### PR TITLE
Cut E Part A: derive ProtocolResource With from constructed source (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -95,6 +95,16 @@ ContextManagerResolutionV1 = ContextManagerContractRefV1 | ContextManagerResolut
 
 
 @dataclass(frozen=True)
+class SourceDerivedContextManagerRefV1:
+    """Live protocol testimony plus its immutable h=h(p) summary coordinate."""
+
+    use_site: SourceFragmentCoordinateV1
+    summary_cid: str
+    semantics: ContextManagerSemanticsV1
+    protocol: object = field(compare=False, repr=False)
+
+
+@dataclass(frozen=True)
 class ResolvedContractRefsV1:
     catalog_cid: str
     table_cid: str
@@ -143,6 +153,7 @@ class TreeConstructionContextV1:
     workspace_root: str | None = None
     # Mutable frame table held by reference; the context object itself is frozen.
     source_call_frames: dict = field(default_factory=dict)
+    source_derived_contract_refs: dict = field(default_factory=dict)
 
     @classmethod
     def for_source_call_construction(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1510,6 +1510,13 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 source_file = _TreeSourceFile(
                     identity, construction_context=construction_context
                 )
+                from sugar_lift_python_source.manager_summary_derivation import (
+                    populate_source_derived_resource_refs,
+                )
+
+                populate_source_derived_resource_refs(
+                    source_file, root=root, path=source_path
+                )
                 for function in source_file.functions():
                     function_sugar = function.sugar()
                     rows.extend(
@@ -1729,6 +1736,14 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 tree_file = _TreeSourceFile(
                     identity, construction_context=construction_context
                 )
+                if construction_context is not None:
+                    from sugar_lift_python_source.manager_summary_derivation import (
+                        populate_source_derived_resource_refs,
+                    )
+
+                    populate_source_derived_resource_refs(
+                        tree_file, root=root, path=full_path
+                    )
                 nodes = []
                 for fn in tree_file.functions():
                     lc = fn.line_col_span()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -1,0 +1,117 @@
+"""Source-derived ProtocolResource routing over constructed protocol testimony."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class WithSourceResourceSugar(Sugar):
+    manager: Sugar
+    protocol: object
+    summary: object
+    body: tuple[Sugar, ...]
+    manager_slot_id: str
+    enter_slot_id: str | None
+    exit_face_id: str
+    site: object = field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.context_manager_contract import (
+            NeverSuppressesDispositionV1,
+        )
+        from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+        from sugar_lift_py_tests.outcome.resource_bindings import (
+            EnterResultBinding,
+            ExitFaceBinding,
+            ManagerBinding,
+            prepend_facts_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            promote_raise_halts,
+            sugar_outcome_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        manager_es = sugar_outcome_to_exitset(self.manager.desugar(ctx))
+        parts = []
+        for manager_face in manager_es.exits:
+            if isinstance(manager_face, Halted):
+                parts.append(ExitSet((manager_face,)))
+                continue
+            manager_facts = ManagerBinding(
+                self.manager_slot_id, manager_face.value
+            ).to_facts(site=self.site)
+            enter_es = sugar_outcome_to_exitset(self.protocol.enter_outcome(ctx))
+            for enter_face in enter_es.exits:
+                guard = _and(manager_face.guard, enter_face.guard)
+                if isinstance(enter_face, Halted):
+                    parts.append(ExitSet((Halted(guard, enter_face.effect),)))
+                    continue
+                enter_value = _returned_value(enter_face.value)
+                enter_facts = ()
+                if self.enter_slot_id is not None and enter_value is not None:
+                    enter_facts = EnterResultBinding(
+                        self.enter_slot_id, enter_value
+                    ).to_facts(site=self.site)
+                body_es = promote_raise_halts(
+                    reduce_block_to_exitset(self.body)
+                ).guarded(guard)
+                exit_es = sugar_outcome_to_exitset(self.protocol.exit_outcome(ctx))
+                for body_face in body_es.exits:
+                    face_facts = ExitFaceBinding.from_body_exit(
+                        self.exit_face_id, body_face
+                    ).to_facts(site=self.site, guard=body_face.guard)
+                    routed = ExitSet((body_face,)).and_exit(
+                        exit_es, disposition=NeverSuppressesDispositionV1()
+                    )
+                    parts.append(
+                        prepend_facts_to_exitset(
+                            routed, (*manager_facts, *enter_facts, *face_facts)
+                        )
+                    )
+        if not parts:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="WithSourceResourceSugar.desugar",
+                observed="constructed manager protocol produced no face",
+                requested="one completed or halted source-derived manager face",
+                fix="keep empty protocol testimony loud",
+            )
+        result = parts[0]
+        for part in parts[1:]:
+            result = result.union(part)
+        return result.normalize()
+
+
+def _returned_value(value):
+    from sugar_lift_py_tests.floor import BlockValue, ReturnValue
+
+    if isinstance(value, BlockValue) and value.statements:
+        last = value.statements[-1]
+        if isinstance(last, ReturnValue):
+            return last.value
+    return value
+
+
+def _and(left, right):
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    if left == true_guard():
+        return right
+    if right == true_guard():
+        return left
+    if left == right:
+        return left
+    return and_([left, right])

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1,0 +1,301 @@
+"""Project constructed source-manager testimony into the closed CM schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Literal
+
+from sugar_lift_py_tests.canonicalizer import encode_jcs
+from sugar_lift_py_tests.context_manager_contract import (
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
+    ProtocolResourceSemanticsV1,
+    semantics_to_value,
+)
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+from .canonical import cid_of_json
+from .manager_protocol_construction import ConstructedManagerProtocolV1
+
+
+@dataclass(frozen=True)
+class DerivedManagerSummaryV1:
+    protocol_construction_cid: str
+    enter_testimony_cid: str
+    exit_testimony_cid: str
+    semantics: ProtocolResourceSemanticsV1
+    summary_cid: str
+
+    @property
+    def preimage(self):
+        return {
+            "kind": "source-derived-context-manager-summary",
+            "schemaVersion": "1",
+            "protocolConstructionCid": self.protocol_construction_cid,
+            "enterTestimonyCid": self.enter_testimony_cid,
+            "exitTestimonyCid": self.exit_testimony_cid,
+            "semantics": json.loads(encode_jcs(semantics_to_value(self.semantics))),
+        }
+
+    def __post_init__(self) -> None:
+        if cid_of_json(self.preimage) != self.summary_cid:
+            raise ValueError("derived manager summary CID does not match its preimage")
+
+
+@dataclass(frozen=True)
+class DerivedManagerSummaryGapV1:
+    kind: Literal[
+        "enter-may-halt",
+        "exit-may-halt",
+        "opaque-exit-truthiness",
+    ]
+    protocol_construction_cid: str
+    detail: str
+
+
+def derive_manager_summary(
+    protocol: ConstructedManagerProtocolV1,
+) -> DerivedManagerSummaryV1 | DerivedManagerSummaryGapV1:
+    """Derive only the theorem directly present in constructed outcomes.
+
+    This first arm proves ``NeverSuppresses`` iff every enter face completes
+    and every exit face completes with exact Python ``False`` or ``None``.
+    Symbolic truthiness remains loud; it is never interpreted by target name.
+    """
+    enter = outcome_to_exitset(protocol.enter_outcome())
+    if not enter.exits or any(not isinstance(face, Completed) for face in enter.exits):
+        return DerivedManagerSummaryGapV1(
+            "enter-may-halt", protocol.protocol_construction_cid, "__enter__ ExitSet"
+        )
+    exit_ = outcome_to_exitset(protocol.exit_outcome())
+    if not exit_.exits or any(not isinstance(face, Completed) for face in exit_.exits):
+        return DerivedManagerSummaryGapV1(
+            "exit-may-halt", protocol.protocol_construction_cid, "__exit__ ExitSet"
+        )
+    for face in exit_.exits:
+        if not _exact_never_suppresses(face.value):
+            return DerivedManagerSummaryGapV1(
+                "opaque-exit-truthiness",
+                protocol.protocol_construction_cid,
+                type(face.value).__name__,
+            )
+    semantics = ProtocolResourceSemanticsV1(
+        EnterResultContractV1(PrimitiveSort("Value")),
+        ExitContractV1(NeverSuppressesDispositionV1()),
+    )
+    preimage = {
+        "kind": "source-derived-context-manager-summary",
+        "schemaVersion": "1",
+        "protocolConstructionCid": protocol.protocol_construction_cid,
+        "enterTestimonyCid": protocol.enter_frame_cid,
+        "exitTestimonyCid": protocol.exit_frame_cid,
+        "semantics": json.loads(encode_jcs(semantics_to_value(semantics))),
+    }
+    return DerivedManagerSummaryV1(
+        protocol.protocol_construction_cid,
+        protocol.enter_frame_cid,
+        protocol.exit_frame_cid,
+        semantics,
+        cid_of_json(preimage),
+    )
+
+
+def _exact_never_suppresses(value: object) -> bool:
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+        FalseBoolLiteralSugar,
+    )
+    from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+
+    if isinstance(value, BlockValue):
+        if not value.statements or not isinstance(value.statements[-1], ReturnValue):
+            return False
+        value = value.statements[-1].value
+    if isinstance(value, (FalseBoolLiteralSugar, NoneLiteralSugar)):
+        return True
+    return isinstance(value, TermValue) and (
+        value.value is None or type(value.value) is bool and value.value is False
+    )
+
+
+def populate_source_derived_resource_refs(
+    source_file, *, root, path, distribution_index=None
+) -> None:
+    """Preconstruct imported resource managers and freeze exact use-site rows."""
+    import importlib.metadata
+    from pathlib import Path
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        SourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_py_tests.ir import _term_content_cid
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+    from sugar_source_tree.nodes import Call, With
+
+    from .dependency_artifact import (
+        DependencyArtifactGraph,
+        ResolvedPythonObjectV1,
+        resolve_import_binding,
+    )
+    from .manager_construction import (
+        ConstructedCallActualV1,
+        construct_manager_behavior,
+    )
+    from .manager_protocol_construction import construct_manager_protocol
+
+    context = source_file.root.unit.construction_context
+    if context is None:
+        return
+    receipts, _ = authenticated_import_use_receipts(
+        Path(root),
+        Path(path),
+        source_file.unit.source,
+        source_file.unit.source_cid,
+        module_identities={},
+    )
+    uses = {}
+    for node in source_file.nodes():
+        if not isinstance(node, With):
+            continue
+        for item in node.items:
+            expr = item.context_expr
+            if not isinstance(expr, Call):
+                continue
+            span = expr.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                expr.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            uses[(span.start_line, span.start_col, span.end_line, span.end_col)] = (
+                coordinate,
+                expr,
+                item._exit_face_id(),
+            )
+    packages = (
+        importlib.metadata.packages_distributions()
+        if distribution_index is None
+        else {name: (name,) for name in distribution_index}
+    )
+    for receipt in receipts:
+        raw_site = receipt.use["useSite"]
+        key = (
+            raw_site["startLine"],
+            raw_site["startCol"],
+            raw_site["endLine"],
+            raw_site["endCol"],
+        )
+        selected = uses.get(key)
+        if selected is None:
+            continue
+        coordinate, call, exit_face_id = selected
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        distributions = tuple(packages.get(top_level, ()))
+        if len(distributions) != 1:
+            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            continue
+        distribution = (
+            importlib.metadata.distribution(distributions[0])
+            if distribution_index is None
+            else distribution_index[top_level]
+        )
+        graph = DependencyArtifactGraph.authenticate(distribution)
+        resolved = resolve_import_binding(receipt, graph=graph)
+        if not isinstance(resolved, ResolvedPythonObjectV1):
+            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            continue
+        actuals = []
+        for node in call.args:
+            outcome = node.sugar().desugar()
+            if not isinstance(outcome, Complete):
+                actuals = []
+                break
+            actuals.append(
+                ConstructedCallActualV1(
+                    node,
+                    outcome.value,
+                    ConstructedValueTestimonyV1.mint(
+                        node.fragment,
+                        _term_content_cid(outcome.value.to_term(owner=resolved.cid)),
+                    ),
+                )
+            )
+        keyword_actuals = []
+        if len(actuals) == len(call.args):
+            for keyword in call.keywords:
+                if keyword.arg is None:
+                    keyword_actuals = []
+                    actuals = []
+                    break
+                outcome = keyword.value.sugar().desugar()
+                if not isinstance(outcome, Complete):
+                    keyword_actuals = []
+                    actuals = []
+                    break
+                keyword_actuals.append(
+                    (
+                        keyword.arg,
+                        ConstructedCallActualV1(
+                            keyword.value,
+                            outcome.value,
+                            ConstructedValueTestimonyV1.mint(
+                                keyword.value.fragment,
+                                _term_content_cid(
+                                    outcome.value.to_term(owner=resolved.cid)
+                                ),
+                            ),
+                        ),
+                    )
+                )
+        if len(actuals) != len(call.args):
+            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            continue
+        behavior = construct_manager_behavior(
+            resolved,
+            graph=graph,
+            actuals=tuple(actuals),
+            keyword_actuals=tuple(keyword_actuals),
+            call_site=call.fragment,
+        )
+        from .manager_construction import ConstructedManagerBehaviorV1
+        from .manager_protocol_construction import ConstructedManagerProtocolV1
+
+        if not isinstance(behavior, ConstructedManagerBehaviorV1):
+            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            continue
+        protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
+        if not isinstance(protocol, ConstructedManagerProtocolV1):
+            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            continue
+        summary = derive_manager_summary(protocol)
+        if not isinstance(summary, DerivedManagerSummaryV1):
+            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            continue
+        context.source_derived_contract_refs[coordinate] = (
+            SourceDerivedContextManagerRefV1(
+                coordinate, summary.summary_cid, summary.semantics, protocol
+            )
+        )
+
+
+def _install_derivation_gap(context, coordinate, receipt, kind: str) -> None:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+    )
+
+    context.source_derived_contract_refs[coordinate] = ContextManagerResolutionGapV1(
+        receipt.demand.get("cid", receipt.use["cid"]),
+        coordinate,
+        receipt.target_symbol,
+        kind,
+        (),
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -23,6 +23,12 @@ from sugar_lift_python_source.manager_protocol_construction import (
     ManagerProtocolConstructionGapV1,
     construct_manager_protocol,
 )
+from sugar_lift_python_source.manager_summary_derivation import (
+    DerivedManagerSummaryGapV1,
+    DerivedManagerSummaryV1,
+    derive_manager_summary,
+    populate_source_derived_resource_refs,
+)
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.binding_state import BindingEntryV1
 from sugar_source_tree.nodes import Call, Constant
@@ -224,9 +230,7 @@ def test_fixture_manager_class_bodies_construct_docstrings_and_class_fields():
     )
     source = SourceFile(path_source(str(fixture)))
     classes = {
-        item.name: item
-        for item in source.root.body
-        if isinstance(item, ClassDef)
+        item.name: item for item in source.root.body if isinstance(item, ClassDef)
     }
 
     some_guard = classes["SomeGuard"].sugar().desugar().value
@@ -322,3 +326,161 @@ def test_merged_renamed_some_guard_factory_constructs_through_sole_door(tmp_path
     assert isinstance(protocol, ConstructedManagerProtocolV1)
     assert protocol.enter_outcome() is not None
     assert protocol.exit_outcome() is not None
+
+
+def test_renamed_resource_derives_never_suppresses_from_constructed_protocol(tmp_path):
+    fixture = (
+        Path(__file__).parents[2]
+        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
+        / "arbitrary_manager_module.py"
+    )
+    graph, resolved, _actual, call_site = _resolved(
+        tmp_path, fixture.read_text(encoding="utf-8"), exported="some_resource"
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="resource-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol)
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        NeverSuppressesDispositionV1,
+        ProtocolResourceSemanticsV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, ProtocolResourceSemanticsV1)
+    assert isinstance(summary.semantics.exit.disposition, NeverSuppressesDispositionV1)
+    assert summary.summary_cid.startswith("blake3-512:")
+
+
+def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
+    fixture = (
+        Path(__file__).parents[2]
+        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
+        / "arbitrary_manager_module.py"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, fixture.read_text(encoding="utf-8"), exported="some_manager"
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="boundary-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol)
+
+    assert isinstance(summary, DerivedManagerSummaryGapV1)
+    assert summary.kind in {"enter-may-halt", "opaque-exit-truthiness"}
+
+
+def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):
+    fixture = (
+        Path(__file__).parents[2]
+        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
+        / "arbitrary_manager_module.py"
+    )
+    graph, resolved, _actual, call_site = _resolved(
+        tmp_path, fixture.read_text(encoding="utf-8"), exported="some_resource"
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(), call_site=call_site
+    )
+    protocol = construct_manager_protocol(behavior, exit_face_id="with-resource-face")
+    summary = derive_manager_summary(protocol)
+    assert isinstance(summary, DerivedManagerSummaryV1)
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+        WithSourceResourceSugar,
+    )
+    from sugar_source_tree.nodes import With
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    consumer = (
+        "def use_resource():\n"
+        "    with resource_factory():\n"
+        "        raise ValueError('body')\n"
+    )
+    tree = SourceFile(
+        (consumer, "resource-consumer.py", "blake3-512:" + ("46" * 64)),
+        construction_context=context,
+    )
+    node = next(item for item in tree.nodes() if isinstance(item, With))
+    expr = node.items[0].context_expr
+    span = expr.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    context.source_derived_contract_refs[coordinate] = SourceDerivedContextManagerRefV1(
+        coordinate, summary.summary_cid, summary.semantics, protocol
+    )
+
+    sugar = node.sugar()
+
+    assert isinstance(sugar, WithSourceResourceSugar)
+    assert sugar.protocol is protocol
+    assert sugar.summary.summary_cid == summary.summary_cid
+    from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
+
+    routed = outcome_to_exitset(sugar.desugar())
+    assert routed.exits
+    assert any(isinstance(face, Halted) for face in routed.exits), [
+        (type(face).__name__, repr(face.guard)) for face in routed.exits
+    ]
+
+
+def test_preconstruction_populates_resource_ref_from_authenticated_import(tmp_path):
+    implementation = (
+        "class RenamedResource:\n"
+        "    def __enter__(self):\n"
+        "        return 9\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_resource():\n"
+        "    return RenamedResource()\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="make_resource")
+    consumer = (
+        "import arbitrary\n"
+        "def use_resource():\n"
+        "    with arbitrary.make_resource():\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode("utf-8"))
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile((consumer, str(path), source_cid), construction_context=context)
+
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+    )
+
+    assert len(context.source_derived_contract_refs) == 1
+    assert isinstance(
+        next(iter(context.source_derived_contract_refs.values())),
+        SourceDerivedContextManagerRefV1,
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3197,6 +3197,9 @@ class With(Statement):
             span.end_line,
             span.end_col,
         )
+        derived = context.source_derived_contract_refs.get(coordinate)
+        if derived is not None:
+            return derived
         try:
             return context.contract_refs.require(coordinate)
         except ContractRefProtocolError as exc:
@@ -3237,13 +3240,16 @@ class With(Statement):
         from sugar_lift_py_tests.context_manager_resolution import (
             ContextManagerContractRefV1,
             ContextManagerResolutionGapV1,
+            SourceDerivedContextManagerRefV1,
         )
         from sugar_lift_py_tests.ir import PrimitiveSort
         from .panic import UnsupportedContextManagerSemantics
 
         if isinstance(resolution, ContextManagerResolutionGapV1):
             self._raise_resolution_gap(resolution)
-        if not isinstance(resolution, ContextManagerContractRefV1):
+        if not isinstance(
+            resolution, (ContextManagerContractRefV1, SourceDerivedContextManagerRefV1)
+        ):
             backend_defect(
                 owner="With._construct_sugar",
                 observed=f"unexpected resolution value {type(resolution).__name__}",
@@ -3327,6 +3333,30 @@ class With(Statement):
             )
             from sugar_lift_py_tests.kit_rpc import ContextManagerEdgeDtoV1
             from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+
+            from sugar_lift_py_tests.context_manager_resolution import (
+                SourceDerivedContextManagerRefV1,
+            )
+
+            if isinstance(resolved_ref, SourceDerivedContextManagerRefV1):
+                from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+                    WithSourceResourceSugar,
+                )
+
+                manager_slot = item._manager_slot_id()
+                enter_slot = (
+                    f"{manager_slot}#enter_result" if as_name is not None else None
+                )
+                return WithSourceResourceSugar(
+                    manager=item.context_expr.sugar(),
+                    protocol=resolved_ref.protocol,
+                    summary=resolved_ref,
+                    body=tuple(stmt.sugar() for stmt in self.body),
+                    manager_slot_id=manager_slot,
+                    enter_slot_id=enter_slot,
+                    exit_face_id=item._exit_face_id(),
+                    site=self.fragment,
+                )
 
             if isinstance(resolved_ref.semantics, EffectBoundarySemanticsV1):
                 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (


### PR DESCRIPTION
## Outcome

Derives the closed ProtocolResource/NeverSuppresses summary only when constructed source testimony proves total __enter__ and every completed __exit__ return is exact False/None. The summary CID is h=h(p) over the Cut D protocol and enter/exit testimony. Symbolic/opaque truthiness remains typed-loud.

The preconstruction pass resolves authenticated import uses through DependencyArtifactGraph, constructs the manager through Cut C+D, and installs an immutable per-use source-derived row in TreeConstructionContextV1. WithSourceResourceSugar evaluates the manager once, runs constructed enter, routes every body ExitSet face through constructed exit, and NeverSuppresses restores body halts.

EffectBoundary remains excluded: SomeGuard is loud because enter may halt and exit truthiness ends in an unauthenticated body-less issubclass call; installed pytest.raises remains loud on opaque set.

## Focused evidence

- 29 focused manager/With tests passed
- #6101 fixture truth-set: 12 passed
- R_construction_invariant_violations=0
- R_second_construction_path=0
- R_non_exhaustive_variant_coverage=0
- R_construction_side_doors=0
- R_ast_semantic_above_adapter=0
- auditor_errors=0

Pandas base/head census is background telemetry; exact numeric delta will be added from completed battleaxe receipts. Do not merge before hard both-faces audit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive `ProtocolResource` from constructed source for `with`-statement sugar
> - Adds `derive_manager_summary` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6157/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to compute a stable `DerivedManagerSummaryV1` (with CID validation) from a `ConstructedManagerProtocolV1`, or a `DerivedManagerSummaryGapV1` when derivation is not possible.
> - Adds `populate_source_derived_resource_refs` to authenticate import receipts, match `With(Call(...))` sites, construct manager protocols, derive summaries, and install `SourceDerivedContextManagerRefV1` entries into the construction context before AST traversal.
> - Introduces `WithSourceResourceSugar` in [with_source_resource_sugar.py](https://github.com/TSavo/sugar/pull/6157/files#diff-019cb1219f11d2a8455045d2a46e8e9550f902ff5fabf32c95a098bd46143923), which desugars source-derived `with` statements into `ExitSet`s carrying `ManagerBinding`, optional `EnterResultBinding`, and `ExitFaceBinding` facts routed through a never-suppresses disposition.
> - Updates `nodes.With` in [nodes.py](https://github.com/TSavo/sugar/pull/6157/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to short-circuit prebinding via `source_derived_contract_refs` and construct `WithSourceResourceSugar` when a source-derived ref is present.
> - Behavioral Change: `with` statements resolved to source-derived manager protocols now follow the `WithSourceResourceSugar` desugar path instead of `WithResourceSugar`/`EffectBoundary`, changing how body exits and facts are routed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b30ce72.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->