### PR TITLE
fix: route source-derived resource exit by its sealed disposition

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -24,9 +24,6 @@ class WithSourceResourceSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.context_manager_contract import (
-            NeverSuppressesDispositionV1,
-        )
         from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
         from sugar_lift_py_tests.outcome.resource_bindings import (
             EnterResultBinding,
@@ -72,7 +69,8 @@ class WithSourceResourceSugar(Sugar):
                         self.exit_face_id, body_face
                     ).to_facts(site=self.site, guard=body_face.guard)
                     routed = ExitSet((body_face,)).and_exit(
-                        exit_es, disposition=NeverSuppressesDispositionV1()
+                        exit_es,
+                        disposition=self.summary.semantics.exit.disposition,
                     )
                     parts.append(
                         prepend_facts_to_exitset(

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -1,0 +1,69 @@
+"""Disposition routing twins for source-derived resource managers."""
+
+from types import SimpleNamespace
+
+from sugar_lift_py_tests.context_manager_contract import EffectMatcher, Suppresses
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import BlockValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Halted, Incomplete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+    WithSourceResourceSugar,
+)
+
+
+class _FixedSugar(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _CompletedProtocol:
+    def enter_outcome(self, ctx=None):
+        del ctx
+        return Complete(TermValue(2))
+
+    def exit_outcome(self, ctx=None):
+        del ctx
+        return Complete(BlockValue((), can_fall_through=True))
+
+
+def test_summary_suppresses_disposition_consumes_matching_body_halt():
+    disposition = Suppresses(EffectMatcher(kind="raise", name="ValueError"))
+    summary = SimpleNamespace(
+        semantics=SimpleNamespace(exit=SimpleNamespace(disposition=disposition))
+    )
+    sugar = WithSourceResourceSugar(
+        manager=_FixedSugar(Complete(TermValue(1))),
+        protocol=_CompletedProtocol(),
+        summary=summary,
+        body=(
+            _FixedSugar(
+                Incomplete(
+                    RaiseEffect(
+                        exception_name="ValueError", occurrence="resource.py:4:8"
+                    )
+                )
+            ),
+        ),
+        manager_slot_id="manager-slot",
+        enter_slot_id=None,
+        exit_face_id="exit-face",
+        site="resource.py:3:4",
+    )
+
+    exits = sugar.desugar().exits
+
+    assert exits
+    assert not any(
+        isinstance(face, Halted)
+        and getattr(face.effect, "exception_name", None) == "ValueError"
+        for face in exits
+    )


### PR DESCRIPTION
Summary:
- consume the exit disposition carried by the source-derived context-manager summary
- remove the latent hardcoded NeverSuppresses authority
- add a suppression twin proving a matching halted body face is consumed

Evidence:
- 33 focused tests passed
- R_construction_side_doors=0; auditor_errors=0

Predicted epsilon R: no current census movement; this hardens both-face routing for future proven suppression summaries.

Not merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WithSourceResourceSugar.desugar` to route exits using the sealed disposition
> Previously, `WithSourceResourceSugar.desugar` passed a hard-coded `NeverSuppressesDispositionV1` to `ExitSet.and_exit`, ignoring the disposition defined in `summary.semantics.exit.disposition`. This meant body halts were never consumed during exit joining, regardless of the resource's actual semantics.
>
> - [with_source_resource_sugar.py](https://github.com/TSavo/sugar/pull/6158/files#diff-019cb1219f11d2a8455045d2a46e8e9550f902ff5fabf32c95a098bd46143923) now passes `self.summary.semantics.exit.disposition` instead of the hard-coded value.
> - A new test in [test_with_source_resource_sugar.py](https://github.com/TSavo/sugar/pull/6158/files#diff-7c5a63fa7376a0c3fc85faf90a8ffa41026c70ded370958aab0ef45cf81f94a3) verifies that a `Suppresses` disposition correctly consumes a matching `ValueError` body halt.
> - Behavioral Change: resources with a suppressing disposition will now consume matching body halts during exit joining, where previously they never would.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27ce45c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->