### PR TITLE
drain: derive implicit-None ProtocolResource exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
@@ -107,6 +107,21 @@ def some_resource() -> SomeResource:
     return SomeResource()
 
 
+class ImplicitNoneResource:
+    """A renamed resource whose multi-statement exit falls through to None."""
+
+    def __enter__(self) -> ObservationSlot:
+        return ObservationSlot("implicit-none-value")
+
+    def __exit__(self, effect_type, effect, traceback) -> None:
+        first_marker = 1
+        second_marker = 2
+
+
+def implicit_none_resource() -> ImplicitNoneResource:
+    return ImplicitNoneResource()
+
+
 class LyingGuard:
     """A claim cannot override the source-visible NeverSuppresses behavior."""
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -105,12 +105,23 @@ def derive_manager_summary(
 
 
 def _exact_never_suppresses(value: object) -> bool:
+    from sugar_lift_py_tests.floor import GuardedReturn
+    from sugar_lift_py_tests.outcome import Incomplete
     from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
         FalseBoolLiteralSugar,
     )
     from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
 
     if isinstance(value, BlockValue):
+        if value.can_fall_through and not any(
+            isinstance(entry, (ReturnValue, GuardedReturn, Incomplete))
+            for entry in value.statements
+        ):
+            # A source-visible Python function that reaches the end returns
+            # exact None.  The completed block is ordinary construction
+            # testimony; rejecting embedded return/effect faces prevents a
+            # fall-through face from speaking for a different guarded result.
+            return True
         if not value.statements or not isinstance(value.statements[-1], ReturnValue):
             return False
         value = value.statements[-1].value

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -455,6 +455,38 @@ def test_renamed_resource_derives_never_suppresses_from_constructed_protocol(tmp
     assert summary.summary_cid.startswith("blake3-512:")
 
 
+def test_renamed_multistatement_implicit_none_exit_derives_never_suppresses(
+    tmp_path,
+):
+    fixture = (
+        Path(__file__).parents[2]
+        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
+        / "arbitrary_manager_module.py"
+    )
+    graph, resolved, _actual, call_site = _resolved(
+        tmp_path,
+        fixture.read_text(encoding="utf-8"),
+        exported="implicit_none_resource",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="implicit-none-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol)
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        NeverSuppressesDispositionV1,
+        ProtocolResourceSemanticsV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, ProtocolResourceSemanticsV1)
+    assert isinstance(summary.semantics.exit.disposition, NeverSuppressesDispositionV1)
+
+
 def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
     fixture = (
         Path(__file__).parents[2]


### PR DESCRIPTION
Summary:
- derive NeverSuppresses from an already-constructed __exit__ block that falls through to Python None
- reject explicit returns, guarded returns, and embedded incomplete effects
- add a renamed multi-statement manager twin through the sole constructor

Evidence:
- 18 sole-path manager tests passed
- R_construction_side_doors=0
- every construction-invariant axis R=0

Predicted epsilon R: drains only source-visible managers whose remaining direct summary gap is implicit None; blocked loops, opaque calls, generators, and symbolic suppression stay loud. Battleaxe pandas base/head measurement is background telemetry.

Not merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive `NeverSuppresses` exit disposition for implicit-None `__exit__` methods
> - Updates `_exact_never_suppresses` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6159/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to treat block-valued `__exit__` bodies that fall through without any `ReturnValue`, `GuardedReturn`, or `Incomplete` entries as returning exact `None`.
> - Adds a fixture class `ImplicitNoneResource` with a multi-statement `__exit__` that implicitly returns `None` by falling through, used to validate the new derivation path.
> - Adds a test asserting that the derived manager summary for the fixture reports `NeverSuppresses` as the exit disposition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7a1722.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->