### PR TITLE
drain: finally routes break/continue through ExitSet

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -53,6 +53,12 @@ def reduce_block_to_exitset(
     for index, head in enumerate(statements):
 
         def reduce_next(state: _ReducedBlock) -> ExitSet[_ReducedBlock]:
+            if not state.can_fall_through:
+                # A terminal Completed face (return, including return from
+                # finally) owns the exit.  It is completed rather than halted,
+                # but its source tail is unreachable and must not be reduced
+                # into a contradictory second post-state.
+                return ExitSet.completed(state)
             outcome = head.desugar(ctx)
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2832,6 +2832,32 @@ class For(Statement):
         produced = []
         current = dict(scope)
         for statement in statements:
+            if (
+                statement.kind == "Try"
+                and not statement.handlers
+                and not statement.orelse
+                and statement.finalbody
+                and len(statement.body) == 1
+                and statement.body[0].kind in ("Break", "Continue")
+                and statement.body[0].control_context.nearest_loop_target().target_cid
+                == self.owned_loop_target.target_cid
+            ):
+                # A concrete loop dissolves before construction, so consume its
+                # owned jump here only after routing the mandatory cleanup.  The
+                # jump has no value to evaluate; ``finally`` therefore precedes
+                # the selected loop edge.  A cleanup halt/return remains in the
+                # produced block and supersedes that edge through ordinary
+                # ExitSet reduction.  Wider Try shapes retain their live
+                # TrySugar router below rather than being linearized here.
+                incoming_action = statement.body[0].kind.lower()
+                cleanup = For._substitute_controlled_suite(
+                    self, statement.finalbody, current
+                )
+                if cleanup is None:
+                    return None
+                cleanup_statements, current, cleanup_action = cleanup
+                produced.extend(cleanup_statements)
+                return produced, current, cleanup_action or incoming_action
             if statement.kind == "Break":
                 return produced, current, "break"
             if statement.kind == "Continue":

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -1,5 +1,5 @@
 """`try` as the STRUCTURAL surface of the effect router: except clauses match
-by exact kind+name (the same rule with-contracts ride), matching handlers
+by authenticated exception identity (the same rule with-contracts ride), matching handlers
 consume the Incomplete, non-matches propagate, else/finally splice, and the
 loud residuals stay loud. Mirror of test_with_contract.py for the native-syntax
 twin."""
@@ -441,6 +441,110 @@ def test_conditional_raise_assign_paths_through_finally_no_residual_halt():
     }
     assert by_value[2].name == "py.truthy"
     assert by_value[1].kind == "not"
+
+
+def test_finally_fallthrough_preserves_break_for_the_matching_loop():
+    """Cleanup runs on break, then the loop alone consumes its owned halt."""
+    v = _val(
+        "def A():\n"
+        "    for item in [1]:\n"
+        "        try:\n"
+        "            break\n"
+        "        finally:\n"
+        "            marker = item\n"
+        "    return marker\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].value == 1
+
+
+def test_finally_fallthrough_preserves_continue_for_the_matching_loop():
+    """Cleanup runs on continue before the matching loop routes its latch."""
+    v = _val(
+        "def A():\n"
+        "    for item in [1]:\n"
+        "        try:\n"
+        "            continue\n"
+        "        finally:\n"
+        "            marker = item\n"
+        "    return marker\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].value == 1
+
+
+def test_finally_raise_supersedes_break_instead_of_fabricating_loop_exit():
+    """A cleanup halt supersedes the incoming break face."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = (
+        _fn(
+            "class ArbitraryCleanupFault(Exception):\n"
+            "    pass\n"
+            "def A():\n"
+            "    for item in [1]:\n"
+            "        try:\n"
+            "            break\n"
+            "        finally:\n"
+            "            raise ArbitraryCleanupFault\n"
+            "    return 11\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, RaiseEffect)
+    assert out.effect.exception_type_coordinate is not None
+    assert out.effect.exception_name == "ArbitraryCleanupFault"
+
+
+def test_finally_return_supersedes_break_exit():
+    """A terminal cleanup completion replaces the incoming break face."""
+    v = _val(
+        "def A():\n"
+        "    for item in [1]:\n"
+        "        try:\n"
+        "            break\n"
+        "        finally:\n"
+        "            return 13\n"
+        "    return 0\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].value == 13
+
+
+def test_trystar_stays_loud_without_grouped_exception_router():
+    """except* has no honest consumer in the single-effect ExitSet router."""
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('group', [ValueError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n"
+        ).sugar()
+
+
+def test_warnings_warn_does_not_fabricate_a_warning_effect_without_a_producer():
+    """The live warning schema has no source producer; the call stays unresolved."""
+    from sugar_lift_py_tests.effect.warning_effect import WarningEffect
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.floor.warning_observation_value import (
+        WarningObservationValue,
+    )
+
+    v = _val(
+        "import warnings\n" "def A():\n" "    warnings.warn('message', UserWarning)\n"
+    )
+    entries = v.record.contribution()
+    calls = [entry for entry in entries if isinstance(entry, CallSiteValue)]
+    assert len(calls) == 1
+    assert calls[0].target_contract_cid is None
+    assert not any(isinstance(entry, WarningObservationValue) for entry in entries)
+    assert not any(
+        isinstance(getattr(entry, "effect", None), WarningEffect) for entry in entries
+    )
 
 
 def test_false_arm_conditional_raise_routes_with_reverse_polarity():


### PR DESCRIPTION
## Outcome

Completes the live `try/finally` control path for concrete loop-owned `break` and `continue` without introducing another control router.

- a concrete loop's owned jump is routed through its mandatory `finally` cleanup before the matching loop consumes it
- cleanup fall-through preserves the exact break/continue edge and projected binding state
- cleanup raise, return, break, or continue supersedes the incoming edge through the existing ExitSet semantics
- terminal `_ReducedBlock(can_fall_through=False)` faces no longer reduce unreachable tail statements into contradictory postconditions
- wider Try shapes remain on live `TrySugar`; unresolved/grouped shapes remain loud

This uses the existing `LoopTargetCoordinateV1`, `LoopControlEffect`, `TrySugar`, and `ExitSet` paths. There is no name/vendor dispatch and no second evaluator or effect door.

## Sings or sleeps

- **Live:** `TrySugar`, authenticated RaiseEffect routing, bare re-raise's handler-owned in-flight slot, and `ExitSet.and_finally` over every Completed/Halted face.
- **Sleeping:** `WarningEffect` has schema/router readers but no source producer. `warnings.warn(...)` remains an unresolved ordinary call edge; this PR does not fabricate a warning observation.
- **Missing:** no grouped-exception consumer exists for `TryStar` / `except*`, so it remains a loud construction gap.

## Twins

- break -> finally cleanup -> matching loop exit, with cleanup binding preserved
- continue -> finally cleanup -> matching loop latch, with cleanup binding preserved
- renamed `ArbitraryCleanupFault` from finally supersedes break with authenticated identity
- return from finally supersedes break and prevents the unreachable tail from adding a second return
- `TryStar` remains loud
- `warnings.warn` produces no fabricated `WarningEffect`
- existing exact nested bare re-raise twins remain green

## Honest pandas census

Matched detached battleaxe pair at base `03b21153` and head `809bfe4e` (the same patch, before final rebase over unrelated CM-only #6159):

- 1,415/1,415 files completed on each side
- 0 defects/timeouts
- base `R=7,848`; head `R=7,848`; **Delta R=0**
- every AST family delta is zero, including `Try 24 -> 24`, `Raise 0 -> 0`, `For 687 -> 687`, and `While 38 -> 38`
- function-clean count is unchanged at 19,727/27,707

This is a semantic correctness repair, not a pandas syntax drain. No census shell is retired; the truthful/lying ExitSet twins are the permanent regression law.

## Verification

- focused control/effect suite after final rebase: `79 passed`
- broad source-tree head: `423 passed, 5 skipped, 13 inherited failures`
- exact current-main broad comparison before final CM-only rebase: `417 passed, 5 skipped, the same 13 failures`
- construction-side-door law: `R_construction_side_doors=0`, every axis/auditor error zero
- `git diff --check`

No Rust wire changed, so no Rust build was required for this Python production-router lane.

Architect review requested for the concrete-loop/finally ownership cut and terminal Completed-face sequencing.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route break/continue through try/finally blocks before loop consumes the control edge
> - `For._substitute_controlled_suite` in [nodes.py](https://github.com/TSavo/sugar/pull/6160/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now detects a `try/finally` wrapping a bare `break` or `continue` and runs the finally suite first, before the loop consumes the control edge.
> - A `raise` or `return` in the finally supersedes the break/continue, so cleanup can redirect control flow.
> - `reduce_block_to_exitset` in [function_universe_sugar.py](https://github.com/TSavo/sugar/pull/6160/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) stops sequencing further statements once a non-fall-through state is reached, preventing unreachable tail statements from producing a contradictory post-state.
> - Five new tests in [test_try_sugar.py](https://github.com/TSavo/sugar/pull/6160/files#diff-e08e75c8aa18050f22f6a4f3eab47a900f9605097a7ac8dc38f92f9c906a7e07) cover finally-before-break, finally-before-continue, raise-supersedes-break, return-supersedes-break, and `try/except*` remaining unrouted.
> - Behavioral Change: loops containing `try/finally` around `break`/`continue` now execute the finally body; previously the cleanup was skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db656e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected loop behavior when `break` or `continue` is used inside `try ... finally` blocks.
  * Ensured cleanup code runs before loop control takes effect.
  * Cleanup actions that raise an exception or return now correctly override the original loop action.
  * Prevented unreachable terminal states from producing contradictory follow-up results.
  * Preserved unresolved handling for unsupported grouped exception syntax and avoided generating warning effects without a source warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->