### PR TITLE
fix: Assign store obligations preserve both branch faces

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -75,6 +75,9 @@ def reduce_block_to_exitset(
                 exits = []
                 for entry in faces.contribution():
                     if isinstance(entry, Incomplete):
+                        if entry.follow().continues:
+                            entries.append(entry)
+                            continue
                         from sugar_lift_py_tests.ir import and_
 
                         guard = (

--- a/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
@@ -1,0 +1,78 @@
+"""Assign aliases and symbolic attribute stores use the sole construction paths."""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _runtime_entries(function):
+    trace = function.sugar().substitution_trace
+    return [dict(record.post_bindings) for record in trace.records]
+
+
+def test_alias_copies_the_authenticated_live_value_without_parallel_identity():
+    function = _function(
+        "def arbitrary():\n"
+        "    original = 7\n"
+        "    renamed = original\n"
+        "    return renamed\n"
+    )
+    first, second, *_ = _runtime_entries(function)
+
+    assert second["renamed"].state.ref is first["original"].state.ref
+    assert (
+        second["renamed"].state.fragment.seal().cid
+        == first["original"].state.fragment.seal().cid
+    )
+    assert second["renamed"].coordinate.cid != first["original"].coordinate.cid
+
+
+def test_renamed_alias_has_the_same_single_binding_path():
+    function = _function(
+        "def arbitrary():\n"
+        "    source_value = 7\n"
+        "    projected_value = source_value\n"
+        "    return projected_value\n"
+    )
+    first, second, *_ = _runtime_entries(function)
+
+    assert second["projected_value"].state.ref is first["source_value"].state.ref
+    assert (
+        second["projected_value"].state.fragment.seal().cid
+        == first["source_value"].state.fragment.seal().cid
+    )
+    assert second["projected_value"].coordinate.cid != first["source_value"].coordinate.cid
+
+
+def test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces():
+    function = _function(
+        "def arbitrary(predicate, symbolic_receiver, constructed_value):\n"
+        "    if predicate:\n"
+        "        symbolic_receiver.payload = constructed_value\n"
+        "    return constructed_value\n"
+    )
+    outcome = function.sugar().desugar()
+    assert isinstance(outcome, Complete)
+    record = outcome.value.record.statements
+    stores = [
+        entry
+        for entry in record
+        if isinstance(entry, Incomplete)
+        and isinstance(entry.effect, AttributeStoreRuntimeEffect)
+    ]
+
+    assert len(stores) == 1
+    assert len(stores[0].branch_conditions) == 1
+    assert any(type(entry).__name__ == "ReturnValue" for entry in record)


### PR DESCRIPTION
## Outcome

- proves `b = a` uses the sole runtime BindingEntry path: the alias shares the authenticated backend/source value while its target owns a distinct occurrence coordinate
- keeps a continuing symbolic attribute-store obligation as guarded red testimony inside `if` instead of falsely halting that face
- preserves the complementary face and the common tail; no last-writer-wins join

## Instrument receipts

- focused Assign/store tests: `27 passed`
- `R_construction_side_doors=0` (all axes 0, auditor errors 0)
- `R_construction_invariant_violations=0` (all axes 0)

Predicted epsilon: lowers enclosing Assign residue where a continuing store occurs under a branch; exact pandas delta waits on the corrected shared census.

## Ownership

This slice does not touch `nodes.py`, authenticated object state, subscript stores, or post-version hooks owned by #6126. The follow-up symbolic attribute-store testimony arm is held until that shared `Assign._construct_sugar` seam is coordinated.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `reduce_block_to_exitset` to preserve both branch faces in conditional store obligations
> - In [`reduce_block_to_exitset`](https://github.com/TSavo/sugar/pull/6161/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b), `Incomplete` entries whose `follow().continues` is `true` are now appended directly to the entries set instead of being converted into `Halted` guarded exits.
> - Adds tests in [`test_assign_alias_symbolic_attribute.py`](https://github.com/TSavo/sugar/pull/6161/files#diff-991067fda04fca1f74481600385c217e82adcbcd3749ce889a49a789714ecd6a) covering alias copy semantics and the new conditional store behavior, including a test asserting that a symbolic attribute store in one branch yields exactly one `Incomplete` entry with the correct guard face and a return among the record entries.
> - Behavioral Change: `ExitSet` and `ReducedBlock` composition changes for `Incomplete` entries that continue — previously these became `Halted` exits, now they remain as-is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dd9de8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->