### PR TITLE
Measure source-derived context managers in census

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
@@ -57,13 +57,20 @@ def run_production_lift_child(path: Path, rel: str) -> int:
     (intentional) but does not stop scanning the rest. Any other exception is
     left to propagate -- that is the bare-exception signal.
     """
-    from sugar_source_tree.tree import SourceFile
     from sugar_source_tree.reporter import CollectingReporter
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from _production_source_file import (
+        corpus_root_from_relative,
+        production_source_file,
+    )
 
     reporter = CollectingReporter()
-    sf = SourceFile.from_path(str(path), reporter=reporter)
+    sf = production_source_file(
+        path,
+        root=corpus_root_from_relative(path, rel),
+        reporter=reporter,
+    )
     typed_gap = False
     for fn in sf.functions():
         try:

--- a/implementations/python/sugar-lift-py-tests/scripts/_production_source_file.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_source_file.py
@@ -1,0 +1,89 @@
+"""The source-derived preconstruction door shared by census floors.
+
+Semantic enumeration in production installs source-derived context-manager
+testimony before asking the typed tree for Sugar.  Every census floor must use
+that same prepared tree; otherwise a real With construction is reverse-
+suppressed into a false loud residual.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def production_source_file(path, *, root, reporter, distribution_index=None):
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.manager_summary_derivation import (
+        populate_source_derived_resource_refs,
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(root)
+    )
+    source_file = SourceFile(
+        path_source(str(path)), reporter=reporter, construction_context=context
+    )
+    populate_source_derived_resource_refs(
+        source_file,
+        root=root,
+        path=path,
+        distribution_index=distribution_index,
+    )
+    _install_unresolved_source_derived_gaps(source_file)
+    return source_file
+
+
+def corpus_root_from_relative(path: Path, relative: str) -> Path:
+    """Invert the parent's exact ``path.relative_to(root)`` operation."""
+    root = path.resolve()
+    for _part in Path(relative).parts:
+        root = root.parent
+    return root
+
+
+def _install_unresolved_source_derived_gaps(source_file) -> None:
+    """Close the census table without pretending unresolved sites resolved.
+
+    Production's final linker table supplies its own typed unresolved rows.
+    Census construction has no linker RPC, so every source-derived use not
+    discharged above receives an exact-coordinate ``no-derived-contract`` gap.
+    This makes absence loud while preserving derived testimony where it exists.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_python_source.canonical import cid_of_json
+    from sugar_source_tree.nodes import With
+
+    context = source_file.unit.construction_context
+    for node in source_file.nodes():
+        if not isinstance(node, With):
+            continue
+        for item in node.items:
+            span = item.context_expr.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                source_file.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            if coordinate in context.source_derived_contract_refs:
+                continue
+            demand_cid = cid_of_json(
+                {
+                    "kind": "source-derived-context-manager-census-demand",
+                    "schemaVersion": "1",
+                    "useSite": coordinate.wire(),
+                }
+            )
+            context.source_derived_contract_refs[coordinate] = (
+                ContextManagerResolutionGapV1(
+                    demand_cid, coordinate, None, "no-derived-contract", ()
+                )
+            )

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -138,6 +138,17 @@ def _collect_file_construction(
     }
 
 
+def _production_source_file(path, *, root, reporter, distribution_index=None):
+    from _production_source_file import production_source_file
+
+    return production_source_file(
+        path,
+        root=root,
+        reporter=reporter,
+        distribution_index=distribution_index,
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("corpus", type=Path)
@@ -148,7 +159,15 @@ def main() -> int:
 
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
+
+    import importlib.metadata
+
+    package_distributions = importlib.metadata.packages_distributions()
+    distribution_index = {
+        package: importlib.metadata.distribution(distributions[0])
+        for package, distributions in package_distributions.items()
+        if len(distributions) == 1
+    }
 
     files = sorted(args.corpus.rglob("*.py"))
     signal.signal(signal.SIGALRM, _timeout)
@@ -179,7 +198,12 @@ def main() -> int:
             def construct_file():
                 nonlocal functions_total, functions_clean
                 reporter = CollectingReporter()
-                source_file = SourceFile.from_path(str(path), reporter=reporter)
+                source_file = _production_source_file(
+                    path,
+                    root=args.corpus,
+                    reporter=reporter,
+                    distribution_index=distribution_index,
+                )
                 for function in source_file.functions():
                     functions_total += 1
                     try:

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -83,12 +83,15 @@ def test_bare_exception_propagates_never_swallowed(tmp_path: Path, monkeypatch) 
     # If construction raises a non-typed-gap exception, the child must let
     # it propagate (so the parent's subprocess exits nonzero = bare exception).
     # We force a bare exception from the production door and assert it escapes.
-    import sugar_source_tree.tree as tree_mod
-
     def _boom(*a, **k):
         raise RuntimeError("planted bare exception in construction")
 
-    monkeypatch.setattr(tree_mod.SourceFile, "from_path", staticmethod(_boom))
+    import sys
+
+    production_source_file = sys.modules.get("_production_source_file")
+    if production_source_file is None:
+        import _production_source_file as production_source_file
+    monkeypatch.setattr(production_source_file, "production_source_file", _boom)
     path = _write(tmp_path, "def a():\n    return 1\n")
     with pytest.raises(RuntimeError, match="planted bare exception"):
         _CHILD.run_production_lift_child(path, "mod.py")

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import csv
+import importlib.metadata
 import importlib.util
 from pathlib import Path
 
@@ -51,3 +53,73 @@ def test_recensus_projects_construction_panic_as_a_loud_counted_gap(
         "message": panic.info.message,
         "gap": panic.info.to_json(),
     }
+
+
+def _distribution(root: Path, source: str) -> importlib.metadata.Distribution:
+    package = root / "arbitrary"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from arbitrary.manager import make_resource\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def test_control_effect_recensus_runs_source_derived_preconstruction(tmp_path) -> None:
+    module = _load("control_effect_recensus")
+    distribution = _distribution(
+        tmp_path,
+        "class RenamedResource:\n"
+        "    def __enter__(self):\n"
+        "        return 9\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_resource():\n"
+        "    return RenamedResource()\n",
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def use_resource():\n"
+        "    with arbitrary.make_resource():\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+    )
+    from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+        WithSourceResourceSugar,
+    )
+    from sugar_source_tree.nodes import With
+    from sugar_source_tree.reporter import CollectingReporter
+
+    source_file = module._production_source_file(
+        path,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+        distribution_index={"arbitrary": distribution},
+    )
+
+    refs = source_file.unit.construction_context.source_derived_contract_refs
+    assert len(refs) == 1
+    assert isinstance(next(iter(refs.values())), SourceDerivedContextManagerRefV1)
+    with_node = next(node for node in source_file.nodes() if isinstance(node, With))
+    assert isinstance(with_node.sugar(), WithSourceResourceSugar)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -116,6 +116,8 @@ class WithConstructionGapKind(str, Enum):
     UNAUTHENTICATED_MEMBER = "unauthenticated-member"
     PAYLOAD_CID_MISMATCH = "payload-cid-mismatch"
     UNSUPPORTED_CM_SCHEMA = "unsupported-cm-schema"
+    NO_DERIVED_CONTRACT = "no-derived-contract"
+    STALE_DERIVED_CONTRACT = "stale-derived-contract"
     UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS = "unsupported-context-manager-semantics"
     MULTIPLE_CONTEXT_MANAGER_ITEMS = "multiple-context-manager-items"
     UNSUPPORTED_WITH_BINDING_TARGET = "unsupported-with-binding-target"


### PR DESCRIPTION
## What changed
- route the control/effect census and all isolated floor children through one source-derived preconstruction helper before semantic enumeration
- preserve real `SourceDerivedContextManagerRefV1` testimony and install content-addressed typed unresolved rows for undischarged With sites
- close the With construction-gap union over `no-derived-contract` and `stale-derived-contract`
- add a renamed source-visible manager discrimination twin and shared-child regressions

## Why
The ordinary census constructed a context-free `SourceFile`, so source-derived managers that production now constructs remained falsely red. This was reverse suppression of a real With drain.

## Validation
- `PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/scripts python3 -m pytest implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py -q --noconftest` (9 passed)
- `construction_side_door_law.py` (`R_construction_side_doors=0`, `auditor_errors=0`)
- `construction_invariant_law.py` (all axes `R=0`)

The full five-floor pandas census must run from the merged main so its corpus CID and commit attribution are authoritative.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Measure source-derived context managers in census by installing resolution gaps for unresolved `with` items
> - Introduces [`_production_source_file.py`](https://github.com/TSavo/sugar/pull/6162/files#diff-f03f9b81225baf8990a8b782116be4c45b825873c76698b81f739c53abca5da9) with a `production_source_file` factory that populates source-derived resource refs and installs `ContextManagerResolutionGapV1` with kind `no-derived-contract` for any `with` item lacking a derived contract.
> - Updates `control_effect_recensus.py` and `_production_lift_child.py` to construct `SourceFile` instances via `production_source_file` instead of `SourceFile.from_path`, passing a computed corpus root and distribution index.
> - Adds `NO_DERIVED_CONTRACT` and `STALE_DERIVED_CONTRACT` members to the `WithConstructionGapKind` enum in `panic.py`.
> - Adds a test verifying that recensus applies source-derived preconstruction and that `With` nodes receive `WithSourceResourceSugar`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eadef2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->