### PR TITLE
drain: symbolic attribute stores carry real constructed operands

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -102,14 +102,38 @@ class ChainedAssignSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
         from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
 
         return self.value.desugar(ctx).and_then(
-            lambda _value: (
-                reduce_body(self.stores, ctx)
+            lambda value: (
+                reduce_body(
+                    tuple(
+                        _PreconstructedStoreSugar(store, value) for store in self.stores
+                    ),
+                    ctx,
+                )
                 if self.stores
                 else Complete(BlockValue((), can_fall_through=True))
             )
         )
+
+
+@dataclass(frozen=True)
+class _PreconstructedStoreSugar(Sugar):
+    """One chained target consuming the statement's already-reduced RHS."""
+
+    store: Sugar
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="chained store projection",
+            reason="the public ChainedAssignSugar twins own RHS-once sequencing",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.store.desugar_store(ctx, self.value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -26,6 +26,8 @@ class AttributeStoreEffectSugar(Sugar):
     _effect_continues_control_flow) -- the block keeps reducing past it.
     """
 
+    receiver: Sugar
+    value: Sugar
     attr: str
     site: object = dataclass_field(compare=False)
 
@@ -42,20 +44,41 @@ class AttributeStoreEffectSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        # Python constructs the RHS before evaluating an assignment target.
+        return self.value.desugar(ctx).and_then(
+            lambda value: self.receiver.desugar(ctx).and_then(
+                lambda receiver: self._store(receiver, value)
+            )
+        )
+
+    def desugar_store(self, ctx: object, value) -> Outcome:
+        """Store an RHS already reduced once by a chained assignment."""
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self._store(receiver, value)
+        )
+
+    def _store(self, receiver, value) -> Outcome:
         from sugar_lift_py_tests.effect import (
             AttributeStoreRuntimeEffect,
-            runtime_effect_evidence,
+            runtime_effect_evidence_from_terms,
         )
-        from sugar_lift_py_tests.ir import make_var
+        from sugar_lift_py_tests.ir import ctor, str_const
 
-        operand = make_var(f"store_target.{self.attr}")
+        operation = ctor(
+            "python:attribute_store",
+            [
+                receiver.to_term(owner="AttributeStoreEffectSugar.receiver"),
+                str_const(self.attr),
+                value.to_term(owner="AttributeStoreEffectSugar.value"),
+            ],
+        )
         return Incomplete(
             AttributeStoreRuntimeEffect(
                 "attribute assignment runtime boundary: attribute store "
                 f"target `.{self.attr}` -- receiver identity belongs to "
                 "Python's runtime __setattr__/descriptor dispatch; "
                 f"attr={self.attr} site={self.site}",
-                **runtime_effect_evidence("py.setattr", operand, self.site),
+                **runtime_effect_evidence_from_terms(operation, operation, self.site),
             )
         )
 
@@ -104,3 +127,8 @@ class SubscriptStoreEffectSugar(Sugar):
                 **runtime_effect_evidence("py.setitem", operand, self.site),
             )
         )
+
+    def desugar_store(self, ctx: object, value) -> Outcome:
+        """Compatibility with chained store sequencing; subscript is separately owned."""
+        del value
+        return self.desugar(ctx)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2277,6 +2277,8 @@ class Assign(Statement):
 
                     stores.append(
                         AttributeStoreEffectSugar(
+                            receiver=target.value.sugar(),
+                            value=value_sugar,
                             attr=target.attr,
                             site=target.fragment,
                         )
@@ -2323,6 +2325,8 @@ class Assign(Statement):
             )
 
             return AttributeStoreEffectSugar(
+                receiver=self.targets[0].value.sugar(),
+                value=self.value.sugar(),
                 attr=self.targets[0].attr,
                 site=self.fragment,
             )
@@ -2419,6 +2423,8 @@ class AugAssign(Statement):
             )
 
             return AttributeStoreEffectSugar(
+                receiver=self.target.value.sugar(),
+                value=self.value.sugar(),
                 attr=self.target.attr,
                 site=self.fragment,
             )
@@ -2496,6 +2502,8 @@ class AnnAssign(Statement):
             )
 
             return AttributeStoreEffectSugar(
+                receiver=self.target.value.sugar(),
+                value=self.value.sugar(),
                 attr=self.target.attr,
                 site=self.fragment,
             )

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -5,13 +5,17 @@ keeps reducing past it (see outcome/incomplete.py::
 _effect_continues_control_flow); the returned value is unaffected."""
 
 import tempfile
+from dataclasses import replace
 
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_py_tests.effect import (
     AttributeStoreRuntimeEffect,
+    RaiseEffect,
     SubscriptStoreRuntimeEffect,
 )
 from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
 from sugar_source_tree.fragment import SourceFragment as TreeSourceFragment
 from sugar_source_tree.tree import SourceFile
 
@@ -26,6 +30,35 @@ def _fn(src):
 def _entries(src):
     outcome = _fn(src).sugar().desugar()
     return outcome.value.record.statements
+
+
+class _CountingSugar(Sugar):
+    def __init__(self, delegate, calls):
+        self.delegate = delegate
+        self.calls = calls
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(cls.__name__, "test probe", "counts one reduction")
+
+    def desugar(self, ctx=None):
+        self.calls.append(1)
+        return self.delegate.desugar(ctx)
+
+
+class _OutcomeSugar(Sugar):
+    def __init__(self, outcome, calls):
+        self.outcome = outcome
+        self.calls = calls
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(cls.__name__, "test probe", "returns pinned outcome")
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.calls.append(1)
+        return self.outcome
 
 
 def test_attribute_store_lifts_a_red_effect_and_the_block_continues():
@@ -71,7 +104,12 @@ def test_attribute_store_witness_site_is_the_tree_fragment():
     witness = red.effect.witness
     assert isinstance(witness.site, TreeSourceFragment)
     assert witness.site.text == "o.a = v"
-    assert "store_target.a" in repr(witness.runtime_operand.term)
+    operand = repr(witness.runtime_operand.term)
+    assert "python:attribute_store" in operand
+    assert "name='o'" in operand
+    assert "value='a'" in operand
+    assert "name='v'" in operand
+    assert "store_target" not in operand
 
 
 def test_subscript_store_witness_names_the_index():
@@ -87,8 +125,9 @@ def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 2
     operands = {repr(e.effect.witness.runtime_operand.term) for e in red}
-    assert any("store_target.a" in o for o in operands)
-    assert any("store_target.b" in o for o in operands)
+    assert any("value='a'" in operand and "name='v'" in operand for operand in operands)
+    assert any("value='b'" in operand and "name='w'" in operand for operand in operands)
+    assert all("store_target" not in operand for operand in operands)
 
 
 def test_symbolic_attribute_store_owns_real_receiver_and_value_children():
@@ -117,6 +156,47 @@ def test_symbolic_attribute_store_witnesses_real_receiver_and_value_terms():
     assert "symbolic_receiver" in operation
     assert "constructed_value" in operation
     assert "payload" in operation
+
+
+def test_chained_attribute_store_reuses_one_constructed_rhs():
+    function = _fn(
+        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "    renamed = symbolic_receiver.payload = constructed_value\n"
+        "    return renamed\n"
+    )
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    sugar = assignment.sugar()
+    calls = []
+    counted = _CountingSugar(sugar.value, calls)
+    rewritten = replace(
+        sugar,
+        value=counted,
+        stores=tuple(replace(store, value=counted) for store in sugar.stores),
+    )
+
+    rewritten.desugar()
+    assert calls == [1]
+
+
+def test_rhs_constructs_before_halted_receiver_and_store_does_not_continue():
+    function = _fn(
+        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "    symbolic_receiver.payload = constructed_value\n"
+    )
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    sugar = assignment.sugar()
+    receiver_calls = []
+    value_calls = []
+    halt = Incomplete(RaiseEffect(exception_name="ArbitraryError"))
+    rewritten = replace(
+        sugar,
+        receiver=_OutcomeSugar(halt, receiver_calls),
+        value=_CountingSugar(sugar.value, value_calls),
+    )
+
+    assert rewritten.desugar() is halt
+    assert value_calls == [1]
+    assert receiver_calls == [1]
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -91,6 +91,34 @@ def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():
     assert any("store_target.b" in o for o in operands)
 
 
+def test_symbolic_attribute_store_owns_real_receiver_and_value_children():
+    function = _fn(
+        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "    symbolic_receiver.payload = constructed_value\n"
+    )
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    sugar = assignment.sugar()
+
+    assert sugar.receiver == assignment.targets[0].value.sugar()
+    assert sugar.value == assignment.value.sugar()
+
+
+def test_symbolic_attribute_store_witnesses_real_receiver_and_value_terms():
+    function = _fn(
+        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "    symbolic_receiver.payload = constructed_value\n"
+    )
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    outcome = assignment.sugar().desugar()
+
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, AttributeStoreRuntimeEffect)
+    operation = repr(outcome.effect.witness.operation)
+    assert "symbolic_receiver" in operation
+    assert "constructed_value" in operation
+    assert "payload" in operation
+
+
 if __name__ == "__main__":
     test_attribute_store_lifts_a_red_effect_and_the_block_continues()
     test_attribute_store_post_out_equals_the_returned_value()


### PR DESCRIPTION
## Outcome

- replaces the fabricated `store_target.payload` operand with `python:attribute_store(real_receiver, attribute, real_rhs)` testimony
- threads the already-constructed RHS through chained stores, so the RHS is constructed once and each target consumes the same value
- preserves Python's RHS-before-attribute-target evaluation order and does not continue a store after a halted target
- leaves subscript/authenticated-object identity semantics in their separately owned lanes

## Instruments

- red twins pin real receiver/RHS children, renamed symbolic receivers, RHS-once chaining, and halt sequencing
- predicted `Epsilon R_Assign`: direct symbolic attribute-store testimony sites become faithfully constructed; exact shared-census delta pending the #6162 production-source base/head receipt

## Focused receipts

- `44 passed` — store-target, Assign-target, AnnAssign/AugAssign, alias/symbolic-attribute twins
- `R_construction_side_doors=0` (`auditor_errors=0`)
- construction invariant: every axis `R=0`
- `R_no_sugar_in_desugar=0` (`auditor_errors=0`)

No vendor/name dispatch, no fabricated `_Var`, and no new construction door.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make symbolic attribute stores carry real receiver and value operands in witness evidence
> - `AttributeStoreEffectSugar` now holds explicit `receiver` and `value` fields and emits a structured `python:attribute_store` IR operation term with those children as witness evidence, replacing the previous synthetic `store_target.<attr>` variable operand.
> - `ChainedAssignSugar.desugar` evaluates the RHS exactly once and distributes the preconstructed value to each store via a new `_PreconstructedStoreSugar` wrapper and the `desugar_store` API.
> - `AttributeStoreEffectSugar.desugar` now evaluates the RHS before the receiver; a halted receiver short-circuits without continuing the store.
> - Behavioral Change: witness operand strings for attribute stores no longer contain `store_target` and instead include explicit receiver and value term details.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aafa6e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->