### PR TITLE
drain: authenticated source-visible calls through the sole constructor

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_source_file.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_source_file.py
@@ -11,12 +11,22 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def production_source_file(path, *, root, reporter, distribution_index=None):
+def production_source_file(
+    path,
+    *,
+    root,
+    reporter,
+    distribution_index=None,
+    artifact_graph_cache=None,
+):
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
     from sugar_lift_python_source.manager_summary_derivation import (
         populate_source_derived_resource_refs,
+    )
+    from sugar_lift_python_source.source_call_preconstruction import (
+        populate_source_visible_call_frames,
     )
     from sugar_lift_python_source.source_oracle import path_source
     from sugar_source_tree.tree import SourceFile
@@ -27,11 +37,19 @@ def production_source_file(path, *, root, reporter, distribution_index=None):
     source_file = SourceFile(
         path_source(str(path)), reporter=reporter, construction_context=context
     )
+    populate_source_visible_call_frames(
+        source_file,
+        root=root,
+        path=path,
+        distribution_index=distribution_index,
+        artifact_graph_cache=artifact_graph_cache,
+    )
     populate_source_derived_resource_refs(
         source_file,
         root=root,
         path=path,
         distribution_index=distribution_index,
+        artifact_graph_cache=artifact_graph_cache,
     )
     _install_unresolved_source_derived_gaps(source_file)
     return source_file

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -138,7 +138,14 @@ def _collect_file_construction(
     }
 
 
-def _production_source_file(path, *, root, reporter, distribution_index=None):
+def _production_source_file(
+    path,
+    *,
+    root,
+    reporter,
+    distribution_index=None,
+    artifact_graph_cache=None,
+):
     from _production_source_file import production_source_file
 
     return production_source_file(
@@ -146,6 +153,7 @@ def _production_source_file(path, *, root, reporter, distribution_index=None):
         root=root,
         reporter=reporter,
         distribution_index=distribution_index,
+        artifact_graph_cache=artifact_graph_cache,
     )
 
 
@@ -168,6 +176,7 @@ def main() -> int:
         for package, distributions in package_distributions.items()
         if len(distributions) == 1
     }
+    artifact_graph_cache = {}
 
     files = sorted(args.corpus.rglob("*.py"))
     signal.signal(signal.SIGALRM, _timeout)
@@ -180,6 +189,8 @@ def main() -> int:
     files_completed = 0
     functions_total = 0
     functions_clean = 0
+    source_calls_total = 0
+    source_call_preconstruction = Counter()
     started = time.time()
 
     for index, path in enumerate(files, 1):
@@ -196,14 +207,35 @@ def main() -> int:
                     syntax[(type(node).__name__, node.lineno, node.col_offset)] = labels
 
             def construct_file():
-                nonlocal functions_total, functions_clean
+                nonlocal functions_total, functions_clean, source_calls_total
                 reporter = CollectingReporter()
                 source_file = _production_source_file(
                     path,
                     root=args.corpus,
                     reporter=reporter,
                     distribution_index=distribution_index,
+                    artifact_graph_cache=artifact_graph_cache,
                 )
+                from sugar_lift_py_tests.source_call_resolution import (
+                    SourceCallPreconstructionRefV1,
+                )
+                from sugar_source_tree.nodes import Call
+
+                source_calls_total += sum(
+                    1 for node in source_file.nodes() if isinstance(node, Call)
+                )
+                for (
+                    row
+                ) in (
+                    source_file.unit.construction_context.source_call_resolutions.values()
+                ):
+                    source_call_preconstruction[
+                        (
+                            "source-visible"
+                            if isinstance(row, SourceCallPreconstructionRefV1)
+                            else row.kind
+                        )
+                    ] += 1
                 for function in source_file.functions():
                     functions_total += 1
                     try:
@@ -296,6 +328,12 @@ def main() -> int:
         "R_construction_panics": len(construction_panics),
         "functionsTotal": functions_total,
         "functionsConstructClean": functions_clean,
+        "sourceCallsTotal": source_calls_total,
+        "sourceCallPreconstruction": {
+            **dict(sorted(source_call_preconstruction.items())),
+            "unclassifiedLocalOrDynamic": source_calls_total
+            - sum(source_call_preconstruction.values()),
+        },
         "constructs": {
             label: dict(sorted(statuses.items()))
             for label, statuses in sorted(counts.items())
@@ -326,9 +364,7 @@ def main() -> int:
             "unmeasurable": len(defects),
         },
         measured=(
-            not defects
-            and not construction_panics
-            and files_completed == len(files)
+            not defects and not construction_panics and files_completed == len(files)
         ),
         unmeasurable_reasons=(
             (["construction-panic"] if construction_panics else [])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -153,6 +153,10 @@ class TreeConstructionContextV1:
     workspace_root: str | None = None
     # Mutable frame table held by reference; the context object itself is frozen.
     source_call_frames: dict = field(default_factory=dict)
+    # Closed source-call preconstruction rows at exact use sites.  A frame is
+    # installed only beside a successful authenticated row; every other row is
+    # a typed loud classification consumed by census/linking.
+    source_call_resolutions: dict = field(default_factory=dict)
     source_derived_contract_refs: dict = field(default_factory=dict)
     # Runtime-only, prebound class-base Sugar children keyed by the exact
     # subclass definition coordinate.  These are never serialized; the class

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
@@ -1,0 +1,66 @@
+"""Closed exact-use outcomes for authenticated source-call preconstruction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+from .context_manager_resolution import SourceFragmentCoordinateV1
+
+
+@dataclass(frozen=True)
+class SourceCallPreconstructionRefV1:
+    use_site: SourceFragmentCoordinateV1
+    resolved_object_cid: str
+    distribution_artifact_cid: str
+    source_call_frame_cid: str
+    resolution_cid: str = ""
+
+    def __post_init__(self) -> None:
+        expected = cid_of_json(self.preimage)
+        if self.resolution_cid and self.resolution_cid != expected:
+            raise ValueError("source-call resolution CID does not match its preimage")
+        object.__setattr__(self, "resolution_cid", expected)
+
+    @property
+    def preimage(self):
+        return {
+            "kind": "source-call-preconstruction-ref",
+            "schemaVersion": "1",
+            "useSite": self.use_site.wire(),
+            "resolvedObjectCid": self.resolved_object_cid,
+            "distributionArtifactCid": self.distribution_artifact_cid,
+            "sourceCallFrameCid": self.source_call_frame_cid,
+        }
+
+
+@dataclass(frozen=True)
+class SourceCallPreconstructionGapV1:
+    kind: Literal[
+        "no-distribution",
+        "ambiguous-distribution",
+        "artifact-resolution",
+        "artifact-mismatch",
+        "definition-missing",
+        "source-body-gap",
+        "opaque-call-target",
+        "non-manager-result",
+        "call-binding",
+        "dynamic-call-target",
+    ]
+    use_site: SourceFragmentCoordinateV1
+    detail: str
+
+
+SourceCallPreconstructionV1 = (
+    SourceCallPreconstructionRefV1 | SourceCallPreconstructionGapV1
+)
+
+
+__all__ = [
+    "SourceCallPreconstructionGapV1",
+    "SourceCallPreconstructionRefV1",
+    "SourceCallPreconstructionV1",
+]

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -104,86 +104,10 @@ def construct_manager_behavior(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
 
-    context = TreeConstructionContextV1.for_source_call_construction()
-    source_file = SourceFile(
-        (module.source, module.source_seat, module.source_cid),
-        construction_context=context,
-    )
-    definitions = tuple(
-        item
-        for item in source_file.root.body
-        if isinstance(item, (FunctionDef, ClassDef))
-    )
-    target = next(
-        (item for item in definitions if _matches_definition(item, resolved)), None
-    )
-    if target is None:
-        return ManagerConstructionGapV1(
-            "definition-missing", resolved.cid, "resolved definition coordinate"
-        )
-
-    definition_names = {item.name for item in definitions}
-    if isinstance(target, FunctionDef):
-        opaque = tuple(
-            call.func.id
-            for call in _local_named_calls(target)
-            if call.func.id not in definition_names
-        )
-        if opaque:
-            return ManagerConstructionGapV1(
-                "opaque-call-target", resolved.cid, opaque[0]
-            )
-
-    frames: dict[str, object] = {}
-    # Prebind exact local base occurrences to already-owned class Sugars.  The
-    # ClassDef arm consumes these children through the ordinary door and seals
-    # their definition CIDs; dynamic/imported bases remain loud there.
-    reaching_classes: dict[str, ClassDef] = {}
-    for item in definitions:
-        if not isinstance(item, ClassDef):
-            continue
-        local_bases = []
-        for base in item.bases:
-            if not isinstance(base, Name) or base.id not in reaching_classes:
-                local_bases = []
-                break
-            local_bases.append(reaching_classes[base.id].sugar())
-        if local_bases and len(local_bases) == len(item.bases):
-            context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
-        reaching_classes[item.name] = item
-    for item in definitions:
-        if isinstance(item, ClassDef):
-            frames[item.name] = item.source_visible_constructor_frame()
-
-    pending = [item for item in definitions if isinstance(item, FunctionDef)]
-    while pending:
-        progressed = False
-        for function in tuple(pending):
-            local_calls = tuple(_local_named_calls(function))
-            unresolved = tuple(
-                call.func.id
-                for call in local_calls
-                if call.func.id in definition_names and call.func.id not in frames
-            )
-            if unresolved:
-                continue
-            for call in local_calls:
-                frame = frames.get(call.func.id)
-                if frame is not None:
-                    context.source_call_frames[_call_coordinate(call)] = frame
-            frames[function.name] = function.source_visible_call_frame()
-            pending.remove(function)
-            progressed = True
-        if not progressed:
-            return ManagerConstructionGapV1(
-                "opaque-call-target", resolved.cid, "recursive source call graph"
-            )
-
-    frame = frames.get(target.name)
-    if frame is None:
-        return ManagerConstructionGapV1(
-            "definition-missing", resolved.cid, "ordinary source call frame"
-        )
+    frame_result = resolve_source_visible_frame(resolved, graph=graph)
+    if isinstance(frame_result, ManagerConstructionGapV1):
+        return frame_result
+    frame, _target = frame_result
     try:
         values = frame.bind_actuals(
             tuple(item.value for item in actuals),
@@ -264,6 +188,113 @@ def construct_manager_behavior(
         factory_prefix,
         prefix_cids,
     )
+
+
+def resolve_source_visible_frame(
+    resolved: ResolvedPythonObjectV1,
+    *,
+    graph: DependencyArtifactGraph,
+) -> tuple[object, Node] | ManagerConstructionGapV1:
+    """Resolve one authenticated definition into the ordinary source frame.
+
+    This is orchestration over typed Nodes.  Function/Class bodies still
+    construct only through their existing ``source_visible_*_frame`` arms.
+    """
+    if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
+        return ManagerConstructionGapV1(
+            "artifact-mismatch", resolved.cid, "distribution artifact CID"
+        )
+    module = graph.modules.get(resolved.module_name)
+    if module is None or module.source_cid != resolved.source_cid:
+        return ManagerConstructionGapV1(
+            "artifact-mismatch", resolved.cid, "module source CID"
+        )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    definitions = tuple(
+        item
+        for item in source_file.root.body
+        if isinstance(item, (FunctionDef, ClassDef))
+    )
+    target = next(
+        (item for item in definitions if _matches_definition(item, resolved)), None
+    )
+    if target is None:
+        return ManagerConstructionGapV1(
+            "definition-missing", resolved.cid, "resolved definition coordinate"
+        )
+
+    definition_names = {item.name for item in definitions}
+    if isinstance(target, FunctionDef):
+        opaque = tuple(
+            call.func.id
+            for call in _local_named_calls(target)
+            if call.func.id not in definition_names
+        )
+        if opaque:
+            return ManagerConstructionGapV1(
+                "opaque-call-target", resolved.cid, opaque[0]
+            )
+
+    frames: dict[str, object] = {}
+    reaching_classes: dict[str, ClassDef] = {}
+    for item in definitions:
+        if not isinstance(item, ClassDef):
+            continue
+        local_bases = []
+        for base in item.bases:
+            if not isinstance(base, Name) or base.id not in reaching_classes:
+                local_bases = []
+                break
+            local_bases.append(reaching_classes[base.id].sugar())
+        if local_bases and len(local_bases) == len(item.bases):
+            context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
+        reaching_classes[item.name] = item
+    for item in definitions:
+        if isinstance(item, ClassDef):
+            frames[item.name] = item.source_visible_constructor_frame()
+
+    pending = [item for item in definitions if isinstance(item, FunctionDef)]
+    while pending:
+        progressed = False
+        for function in tuple(pending):
+            local_calls = tuple(_local_named_calls(function))
+            opaque = tuple(
+                call.func.id
+                for call in local_calls
+                if call.func.id not in definition_names
+            )
+            if opaque:
+                return ManagerConstructionGapV1(
+                    "opaque-call-target", resolved.cid, opaque[0]
+                )
+            unresolved = tuple(
+                call.func.id
+                for call in local_calls
+                if call.func.id in definition_names and call.func.id not in frames
+            )
+            if unresolved:
+                continue
+            for call in local_calls:
+                nested = frames.get(call.func.id)
+                if nested is not None:
+                    context.source_call_frames[_call_coordinate(call)] = nested
+            frames[function.name] = function.source_visible_call_frame()
+            pending.remove(function)
+            progressed = True
+        if not progressed:
+            return ManagerConstructionGapV1(
+                "opaque-call-target", resolved.cid, "recursive source call graph"
+            )
+    frame = frames.get(target.name)
+    if frame is None:
+        return ManagerConstructionGapV1(
+            "definition-missing", resolved.cid, "ordinary source call frame"
+        )
+    return frame, target
 
 
 def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -133,7 +133,12 @@ def _exact_never_suppresses(value: object) -> bool:
 
 
 def populate_source_derived_resource_refs(
-    source_file, *, root, path, distribution_index=None
+    source_file,
+    *,
+    root,
+    path,
+    distribution_index=None,
+    artifact_graph_cache: dict | None = None,
 ) -> None:
     """Preconstruct imported resource managers and freeze exact use-site rows."""
     import importlib.metadata
@@ -197,6 +202,7 @@ def populate_source_derived_resource_refs(
         if distribution_index is None
         else {name: (name,) for name in distribution_index}
     )
+    graphs = {} if artifact_graph_cache is None else artifact_graph_cache
     for receipt in receipts:
         raw_site = receipt.use["useSite"]
         key = (
@@ -219,7 +225,10 @@ def populate_source_derived_resource_refs(
             if distribution_index is None
             else distribution_index[top_level]
         )
-        graph = DependencyArtifactGraph.authenticate(distribution)
+        graph = graphs.get(top_level)
+        if graph is None:
+            graph = DependencyArtifactGraph.authenticate(distribution)
+            graphs[top_level] = graph
         resolved = resolve_import_binding(receipt, graph=graph)
         if not isinstance(resolved, ResolvedPythonObjectV1):
             _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -1,0 +1,186 @@
+"""Authenticated ordinary source-call preconstruction.
+
+This phase resolves import occurrences against distribution-recorded source and
+installs exact source-call frames.  It never imports or executes modules, and it
+never grants semantics from a local or package spelling.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+)
+from sugar_lift_py_tests.source_call_resolution import (
+    SourceCallPreconstructionGapV1,
+    SourceCallPreconstructionRefV1,
+)
+from sugar_source_tree.nodes import Call, FunctionDef, Name
+
+from .dependency_artifact import (
+    DependencyArtifactAuthenticationError,
+    DependencyArtifactGraph,
+    PythonObjectResolutionGapV1,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from .manager_construction import (
+    ManagerConstructionGapV1,
+    resolve_source_visible_frame,
+)
+
+
+def populate_source_visible_call_frames(
+    source_file,
+    *,
+    root: Path,
+    path: Path,
+    distribution_index=None,
+    artifact_graph_cache: dict | None = None,
+) -> None:
+    """Populate exact-use source frames and one closed classification row."""
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    context = source_file.unit.construction_context
+    if context is None:
+        return
+    receipts, _outcomes = authenticated_import_use_receipts(
+        Path(root),
+        Path(path),
+        source_file.unit.source,
+        source_file.unit.source_cid,
+        module_identities={},
+    )
+    calls = {
+        _span_key(node): node for node in source_file.nodes() if isinstance(node, Call)
+    }
+    packages = (
+        importlib.metadata.packages_distributions()
+        if distribution_index is None
+        else {name: (name,) for name in distribution_index}
+    )
+    graphs = {} if artifact_graph_cache is None else artifact_graph_cache
+    for receipt in receipts:
+        raw = receipt.use["useSite"]
+        key = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
+        call = calls.get(key)
+        if call is None:
+            continue
+        coordinate = _coordinate(call)
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        distributions = tuple(packages.get(top_level, ()))
+        if len(distributions) != 1:
+            kind = "no-distribution" if not distributions else "ambiguous-distribution"
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(kind, coordinate, top_level)
+            )
+            continue
+        distribution = (
+            importlib.metadata.distribution(distributions[0])
+            if distribution_index is None
+            else distribution_index[top_level]
+        )
+        graph = graphs.get(top_level)
+        if graph is None:
+            try:
+                graph = DependencyArtifactGraph.authenticate(distribution)
+            except DependencyArtifactAuthenticationError as exc:
+                context.source_call_resolutions[coordinate] = (
+                    SourceCallPreconstructionGapV1(
+                        "artifact-resolution", coordinate, str(exc)
+                    )
+                )
+                continue
+            graphs[top_level] = graph
+        resolved = resolve_import_binding(receipt, graph=graph)
+        if isinstance(resolved, PythonObjectResolutionGapV1):
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(
+                    "artifact-resolution", coordinate, resolved.kind
+                )
+            )
+            continue
+        if not isinstance(resolved, ResolvedPythonObjectV1):
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(
+                    "artifact-resolution", coordinate, type(resolved).__name__
+                )
+            )
+            continue
+        from sugar_source_tree.panic import SugarNotWritten
+
+        try:
+            frame_result = resolve_source_visible_frame(resolved, graph=graph)
+        except SugarNotWritten as exc:
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1("source-body-gap", coordinate, str(exc))
+            )
+            continue
+        if isinstance(frame_result, ManagerConstructionGapV1):
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(
+                    frame_result.kind, coordinate, frame_result.detail
+                )
+            )
+            continue
+        frame, target = frame_result
+        opaque = _unsupported_call(target)
+        if opaque is not None:
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(
+                    "dynamic-call-target", coordinate, opaque
+                )
+            )
+            continue
+        from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+        try:
+            frame = frame.bind_node_actuals(
+                call.args,
+                tuple(
+                    (keyword.arg, keyword.value)
+                    for keyword in call.keywords
+                    if keyword.arg is not None
+                ),
+            )
+        except SourceCallBindingGap as exc:
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1("call-binding", coordinate, str(exc))
+            )
+            continue
+        context.source_call_frames[coordinate] = frame
+        context.source_call_resolutions[coordinate] = SourceCallPreconstructionRefV1(
+            coordinate,
+            resolved.cid,
+            graph.distribution_artifact_cid,
+            frame.frame_cid,
+        )
+
+
+def _unsupported_call(target) -> str | None:
+    """Keep method/computed dispatch loud until receiver identity is authenticated."""
+    if not isinstance(target, FunctionDef):
+        return None
+    stack = list(reversed(target.body))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, FunctionDef):
+            continue
+        if isinstance(node, Call) and not isinstance(node.func, Name):
+            return node.func.kind
+        stack.extend(reversed([child for _, _, child in node.children()]))
+    return None
+
+
+def _span_key(node):
+    span = node.line_col_span()
+    return span.start_line, span.start_col, span.end_line, span.end_col
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    start_line, start_col, end_line, end_col = _span_key(node)
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid, start_line, start_col, end_line, end_col
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_call_preconstruction import (
+    SourceCallPreconstructionGapV1,
+    SourceCallPreconstructionRefV1,
+    populate_source_visible_call_frames,
+)
+from sugar_source_tree.nodes import Call
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, implementation: str) -> importlib.metadata.Distribution:
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import arbitrary_helper\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(implementation, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _coordinate(call: Call) -> SourceFragmentCoordinateV1:
+    span = call.line_col_span()
+    return SourceFragmentCoordinateV1(
+        call.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _consumer(root: Path, source: str):
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(root)
+    )
+    source_file = SourceFile(
+        (source, str(path), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    return path, source_file, context
+
+
+def test_renamed_cross_file_call_installs_source_frame_and_constructs_return(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def inner(value):\n"
+        "    return value\n\n"
+        "def arbitrary_helper(value=17):\n"
+        "    return inner(value)\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\n"
+        "renamed()\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    coordinate = _coordinate(call)
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionRefV1)
+    assert row.resolved_object_cid.startswith("blake3-512:")
+    assert row.source_call_frame_cid == context.source_call_frames[coordinate].frame_cid
+    outcome = call.sugar().desugar()
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.body is not None
+    constructed = outcome.value.force_floor(
+        None, owner="renamed cross-file call", project_callsite=False
+    )
+    assert isinstance(constructed, BlockValue)
+    assert constructed.statements == (ReturnValue(TermValue(17)),)
+
+
+def test_source_visible_function_with_opaque_child_stays_typed_loud(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(value):\n"
+        "    return len(value)\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\n"
+        "renamed(17)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    coordinate = _coordinate(call)
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "opaque-call-target"
+    assert coordinate not in context.source_call_frames

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import csv
+from dataclasses import replace
 import importlib.metadata
 from pathlib import Path
+
+import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
@@ -10,12 +13,15 @@ from sugar_lift_py_tests.context_manager_resolution import (
 )
 from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_lift_python_source.source_call_preconstruction import (
+from sugar_lift_py_tests.source_call_resolution import (
     SourceCallPreconstructionGapV1,
     SourceCallPreconstructionRefV1,
+)
+from sugar_lift_python_source.source_call_preconstruction import (
     populate_source_visible_call_frames,
 )
 from sugar_source_tree.nodes import Call
+from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -81,8 +87,7 @@ def test_renamed_cross_file_call_installs_source_frame_and_constructs_return(
     )
     path, source_file, context = _consumer(
         tmp_path,
-        "from unprivileged import arbitrary_helper as renamed\n"
-        "renamed()\n",
+        "from unprivileged import arbitrary_helper as renamed\n" "renamed()\n",
     )
     call = next(node for node in source_file.nodes() if isinstance(node, Call))
 
@@ -105,7 +110,15 @@ def test_renamed_cross_file_call_installs_source_frame_and_constructs_return(
         None, owner="renamed cross-file call", project_callsite=False
     )
     assert isinstance(constructed, BlockValue)
-    assert constructed.statements == (ReturnValue(TermValue(17)),)
+    assert len(constructed.statements) == 1
+    nested = constructed.statements[0]
+    assert isinstance(nested, ReturnValue)
+    assert isinstance(nested.value, CallSiteValue)
+    nested_result = nested.value.force_floor(
+        None, owner="renamed recursive source call", project_callsite=False
+    )
+    assert isinstance(nested_result, BlockValue)
+    assert nested_result.statements == (ReturnValue(TermValue(17)),)
 
 
 def test_source_visible_function_with_opaque_child_stays_typed_loud(
@@ -113,13 +126,11 @@ def test_source_visible_function_with_opaque_child_stays_typed_loud(
 ) -> None:
     distribution = _distribution(
         tmp_path,
-        "def arbitrary_helper(value):\n"
-        "    return len(value)\n",
+        "def arbitrary_helper(value):\n" "    return len(value)\n",
     )
     path, source_file, context = _consumer(
         tmp_path,
-        "from unprivileged import arbitrary_helper as renamed\n"
-        "renamed(17)\n",
+        "from unprivileged import arbitrary_helper as renamed\n" "renamed(17)\n",
     )
     call = next(node for node in source_file.nodes() if isinstance(node, Call))
 
@@ -135,3 +146,139 @@ def test_source_visible_function_with_opaque_child_stays_typed_loud(
     assert isinstance(row, SourceCallPreconstructionGapV1)
     assert row.kind == "opaque-call-target"
     assert coordinate not in context.source_call_frames
+    with pytest.raises(SugarNotWritten, match="opaque-call-target"):
+        call.sugar().desugar()
+
+
+def test_stale_source_frame_cid_is_a_backend_defect(tmp_path: Path) -> None:
+    distribution = _distribution(
+        tmp_path, "def arbitrary_helper(value):\n    return value\n"
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\nrenamed(17)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    coordinate = _coordinate(call)
+    context.source_call_resolutions[coordinate] = replace(
+        context.source_call_resolutions[coordinate],
+        source_call_frame_cid="blake3-512:" + ("00" * 64),
+        resolution_cid="",
+    )
+
+    with pytest.raises(BackendDefect, match="ref/frame mismatch"):
+        call.sugar()
+
+
+def test_invalid_source_call_signature_is_typed_loud(tmp_path: Path) -> None:
+    distribution = _distribution(
+        tmp_path, "def arbitrary_helper(required):\n    return required\n"
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\nrenamed()\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    coordinate = _coordinate(call)
+
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "call-binding"
+    assert coordinate not in context.source_call_frames
+    with pytest.raises(SugarNotWritten, match="call-binding"):
+        call.sugar().desugar()
+
+
+def test_unwritten_source_body_is_a_typed_call_gap(tmp_path: Path) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(value):\n" "    yield value\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\nrenamed(17)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    coordinate = _coordinate(call)
+
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "source-body-gap"
+    assert coordinate not in context.source_call_frames
+    with pytest.raises(SugarNotWritten, match="source-body-gap"):
+        call.sugar().desugar()
+
+
+def test_distribution_without_authenticated_manifest_stays_typed_loud(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path, "def arbitrary_helper(value):\n    return value\n"
+    )
+    (tmp_path / "unprivileged_dist-1.0.dist-info" / "RECORD").unlink()
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\nrenamed(17)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    coordinate = _coordinate(call)
+
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "artifact-resolution"
+    assert coordinate not in context.source_call_frames
+    with pytest.raises(SugarNotWritten, match="artifact-resolution"):
+        call.sugar().desugar()
+
+
+def test_cross_file_frame_preserves_real_variadic_actuals(tmp_path: Path) -> None:
+    from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
+
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(first, *rest, **options):\n" "    return rest\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "import unprivileged\n" "unprivileged.arbitrary_helper(1, 2, 3, label=4)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    value = call.sugar().desugar().value
+    assert isinstance(value, CallSiteValue)
+    assert value.arg_values[0] == TermValue(1)
+    assert isinstance(value.arg_values[1], TupleValue)
+    assert value.arg_values[1].elements == (TermValue(2), TermValue(3))
+    assert isinstance(value.arg_values[2], DictValue)
+    assert value.arg_values[2].entries == ((StringValue("label"), TermValue(4)),)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5232,12 +5232,112 @@ class Call(Expression):
             (kw.arg if kw.arg is not None else "**", kw.value.sugar())
             for kw in self.keywords
         )
+        context = self.unit.construction_context
+        source_call_frame = None
+        source_call_resolution = None
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+
+        if (
+            isinstance(context, TreeConstructionContextV1)
+            and context.source_call_frames
+        ):
+            span = self.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                self.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            source_call_frame = context.source_call_frames.get(coordinate)
+            source_call_resolution = context.source_call_resolutions.get(coordinate)
+        elif isinstance(context, TreeConstructionContextV1):
+            span = self.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                self.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            source_call_resolution = context.source_call_resolutions.get(coordinate)
+        if source_call_resolution is not None:
+            from sugar_lift_py_tests.source_call_resolution import (
+                SourceCallPreconstructionGapV1,
+                SourceCallPreconstructionRefV1,
+            )
+            from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+            if isinstance(source_call_resolution, SourceCallPreconstructionGapV1):
+                return CallSiteSugar(
+                    target_name="python:unresolved-source-call",
+                    args=tuple(a.sugar() for a in self.args),
+                    site=self.fragment,
+                    keywords=keyword_sugars,
+                    contract_resolution_gap=(
+                        f"{source_call_resolution.kind}:"
+                        f"{source_call_resolution.detail}"
+                    ),
+                )
+            if not isinstance(
+                source_call_resolution, SourceCallPreconstructionRefV1
+            ):
+                from sugar_source_tree.panic import BackendDefect
+
+                raise BackendDefect(
+                    owner="Call._construct_sugar",
+                    observed=type(source_call_resolution).__name__,
+                    requested="closed source-call preconstruction result",
+                    fix="emit one typed source-call ref or gap at the exact use site",
+                )
+            if (
+                source_call_frame is None
+                or source_call_frame.frame_cid
+                != source_call_resolution.source_call_frame_cid
+            ):
+                from sugar_source_tree.panic import BackendDefect
+
+                raise BackendDefect(
+                    owner="Call._construct_sugar",
+                    observed="source-call ref/frame mismatch",
+                    requested="byte-identical prebound source frame CID",
+                    fix="re-run authenticated source-call preconstruction",
+                )
+        if source_call_frame is not None:
+            from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+            from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+            if any(keyword.arg is None for keyword in self.keywords):
+                raise SourceCallBindingGap(
+                    "spread keyword requires typed variadic projection"
+                )
+            bound_frame = (
+                source_call_frame
+                if source_call_resolution is not None
+                else source_call_frame.bind_node_actuals(
+                    self.args,
+                    tuple(
+                        (keyword.arg, keyword.value)
+                        for keyword in self.keywords
+                        if keyword.arg is not None
+                    ),
+                )
+            )
+            return CallSiteSugar(
+                target_name=f"python:resolved-source-call:{bound_frame.frame_cid}",
+                args=tuple(a.sugar() for a in self.args),
+                site=self.fragment,
+                keywords=keyword_sugars,
+                source_call_frame=bound_frame,
+            )
         if isinstance(self.func, Name):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
             contract_ref = None
             contract_resolution_gap = None
-            context = self.unit.construction_context
             call_refs = getattr(context, "call_contract_refs", None)
             if call_refs is not None:
                 from sugar_lift_py_tests.call_contract_resolution import (
@@ -5274,43 +5374,6 @@ class Call(Expression):
                 elif resolution is not None:
                     contract_ref = resolution
 
-            source_call_frame = None
-            from sugar_lift_py_tests.context_manager_resolution import (
-                SourceFragmentCoordinateV1,
-                TreeConstructionContextV1,
-            )
-
-            if (
-                isinstance(context, TreeConstructionContextV1)
-                and context.source_call_frames
-            ):
-                span = self.line_col_span()
-                coordinate = SourceFragmentCoordinateV1(
-                    self.unit.source_cid,
-                    span.start_line,
-                    span.start_col,
-                    span.end_line,
-                    span.end_col,
-                )
-                source_call_frame = context.source_call_frames.get(coordinate)
-                if source_call_frame is not None:
-                    from sugar_lift_py_tests.source_call_frame import (
-                        SourceCallBindingGap,
-                    )
-
-                    if any(keyword.arg is None for keyword in self.keywords):
-                        raise SourceCallBindingGap(
-                            "spread keyword requires typed variadic projection"
-                        )
-                    source_call_frame = source_call_frame.bind_node_actuals(
-                        self.args,
-                        tuple(
-                            (keyword.arg, keyword.value)
-                            for keyword in self.keywords
-                            if keyword.arg is not None
-                        ),
-                    )
-
             return CallSiteSugar(
                 target_name=self.func.id,
                 args=tuple(a.sugar() for a in self.args),
@@ -5318,7 +5381,7 @@ class Call(Expression):
                 keywords=keyword_sugars,
                 contract_ref=contract_ref,
                 contract_resolution_gap=contract_resolution_gap,
-                source_call_frame=source_call_frame,
+                source_call_frame=None,
             )
         if isinstance(self.func, Attribute):
             from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar


### PR DESCRIPTION
## Outcome

- generalizes the audited source-manager preconstruction scheduler to ordinary authenticated imported calls
- resolves exact import uses through `DependencyArtifactGraph`, constructs the resolved FunctionDef/ClassDef through the existing typed tree→Sugar door, and installs an immutable exact-use `SourceVisibleCallFrameV1`
- consumes static Name or module-qualified Attribute calls by the authenticated frame CID before syntax dispatch; dynamic attributes retain the ordinary runtime path
- preserves BindingCoordinateV1 formal binding, defaults, positional/keyword variadics, returned values, and recursively source-visible local helpers
- emits closed source-visible/gap classifications from the shared #6162 production census
- shares one artifact graph cache across the production phase; no ambient mutable registry

Opaque/native/dynamic callees receive typed gap rows and no frame. No source execution, private evaluator, package-name rule, or fabricated return was added.

## Focused receipts

- `30 passed` — renamed cross-file/re-export, nested helper, defaults/variadics, opaque child, manager regression, and shared census-door tests
- `R_construction_side_doors=0` (`R_ast_semantic_above_adapter=0`, auditor errors 0)
- construction invariant: every axis `R=0`
- `R_no_sugar_in_desugar=0`

## Measurement

The PR adds the classification fields to the authoritative shared census:

- `sourceCallsTotal`
- `sourceCallPreconstruction.source-visible`
- typed gap counts by reason
- `unclassifiedLocalOrDynamic`

Base/head battleaxe receipts will be attached after the detached corrected censuses complete. This PR remains unmerged for focused sole-path audit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route authenticated source-visible call frames through a sole constructor with typed preconstruction rows
> - Adds [`populate_source_visible_call_frames`](https://github.com/TSavo/sugar/pull/6164/files#diff-74b4be0d0a335267f0783561ba4419e3981f34d4d03f9d4d72678b66d4e94cbf) to precompute bound source-call frames and install a typed outcome row (`SourceCallPreconstructionRefV1` or `SourceCallPreconstructionGapV1`) per call site during `SourceFile` construction.
> - `Call._construct_sugar` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6164/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now consults these precomputed rows, emitting a `python:resolved-source-call:{cid}` construct on success or a `python:unresolved-source-call` gap when no typed row is present.
> - Extracts [`resolve_source_visible_frame`](https://github.com/TSavo/sugar/pull/6164/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) as a reusable helper that authenticates distribution artifacts, builds source-visible frames, and returns structured `ManagerConstructionGapV1` failures (including new `opaque-call-target` gaps for any function in the local call graph, not only the root target).
> - Adds `source_call_resolutions` to `TreeConstructionContextV1` and an optional `artifact_graph_cache` through `production_source_file` and `populate_source_derived_resource_refs` to avoid redundant distribution authentications.
> - `control_effect_recensus` CLI now reports `sourceCallsTotal` and a `sourceCallPreconstruction` breakdown in its JSON output.
> - Risk: `Call` sugar construction raises a backend defect on frame/ref CID mismatch, requiring re-run of authenticated preconstruction to recover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1af189.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated resolution for calls across source files, including renamed imports and nested calls.
  * Added structured outcomes for unresolved, ambiguous, unsupported, or invalid source-call cases.
  * Improved handling of positional, keyword, variadic, and keyword-variadic arguments across file boundaries.

* **Bug Fixes**
  * Improved validation of resolved call targets and detected mismatches between call frames and resolutions.
  * Provides clearer typed errors for opaque targets and invalid call signatures.

* **Performance**
  * Reduced repeated dependency analysis during source processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->