### PR TITLE
Keep With resolution coordinates stable through substitution

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -123,3 +123,37 @@ def test_control_effect_recensus_runs_source_derived_preconstruction(tmp_path) -
     assert isinstance(next(iter(refs.values())), SourceDerivedContextManagerRefV1)
     with_node = next(node for node in source_file.nodes() if isinstance(node, With))
     assert isinstance(with_node.sugar(), WithSourceResourceSugar)
+
+
+def test_unresolved_with_keeps_its_enrolled_coordinate_after_substitution(
+    tmp_path,
+) -> None:
+    module = _load("control_effect_recensus")
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "def use_resource(manager):\n"
+        "    with manager:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+
+    from sugar_source_tree.panic import (
+        BackendDefect,
+        ContextManagerResolutionConstructionGap,
+    )
+    from sugar_source_tree.reporter import CollectingReporter
+
+    source_file = module._production_source_file(
+        path, root=tmp_path, reporter=CollectingReporter(), distribution_index={}
+    )
+    function = next(source_file.functions())
+
+    with pytest.raises(ContextManagerResolutionConstructionGap):
+        function.sugar()
+    # The wrong behavior is a BackendDefect for a missing row at a rewritten
+    # span.  Reaching the typed resolution gap proves the original use-site
+    # coordinate survived temporal substitution.
+    assert not any(
+        isinstance(panic, BackendDefect)
+        for _node, panic in source_file.reporter.gaps
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1232,11 +1232,48 @@ class WithItem(Node):
     _child_fields = ("context_expr", "optional_vars")
 
     def substitute(self, scope):
-        """Substitute the context expr; optional_vars is a binding site."""
-        from .shadow import rewrite
+        """Substitute the manager while retaining its enrolled source locus.
+
+        A formal/temporal projection borrows the definition's span.  Contract
+        resolution is keyed by this With occurrence, so that rewritten span
+        must never replace the original manager use-site coordinate.
+        """
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode, rewrite
 
         new_ctx, d = self._substitute_field(self.context_expr, scope)
-        return self if not d else rewrite(self, context_expr=new_ctx)
+        rewritten = self if not d else rewrite(self, context_expr=new_ctx)
+        if hasattr(self, "manager_use_site_start_line"):
+            return rewritten
+        span = self.context_expr.line_col_span()
+        desc = rewritten.ref.describe()
+        return materialize(
+            self.unit,
+            ShadowNode(
+                desc.kind,
+                desc.raw_span or self.span,
+                (
+                    *desc.slots,
+                    ("manager_use_site_start_line", Leaf(span.start_line)),
+                    ("manager_use_site_start_col", Leaf(span.start_col)),
+                    ("manager_use_site_end_line", Leaf(span.end_line)),
+                    ("manager_use_site_end_col", Leaf(span.end_col)),
+                ),
+            ),
+            self.reporter,
+        )
+
+    def _manager_use_site_span(self):
+        """The immutable source occurrence used by preconstruction enrollment."""
+        if hasattr(self, "manager_use_site_start_line"):
+            return (
+                self.manager_use_site_start_line,
+                self.manager_use_site_start_col,
+                self.manager_use_site_end_line,
+                self.manager_use_site_end_col,
+            )
+        span = self.context_expr.line_col_span()
+        return span.start_line, span.start_col, span.end_line, span.end_col
 
     def _manager_slot_id(self) -> str:
         """Stable once-eval manager identity for this with-item."""
@@ -3290,13 +3327,13 @@ class With(Statement):
                 requested="the immutable prereq-2 contract-ref table",
                 fix="inject the decoded typed table before SourceFile construction",
             )
-        span = item.context_expr.line_col_span()
+        start_line, start_col, end_line, end_col = item._manager_use_site_span()
         coordinate = SourceFragmentCoordinateV1(
             self.unit.source_cid,
-            span.start_line,
-            span.start_col,
-            span.end_line,
-            span.end_col,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
         )
         derived = context.source_derived_contract_refs.get(coordinate)
         if derived is not None:


### PR DESCRIPTION
## What changed
- mint and retain the original manager use-site span on `WithItem` during temporal substitution
- resolve preconstructed CM testimony by that immutable occurrence rather than a substituted child span
- add the parameter-to-`FormalRef` discrimination twin that previously produced a missing-row `BackendDefect`

## Census defect
The first source-derived five-floor run found real `BackendDefect` rows in pandas (`io/json/_json.py`, `io/parsers/readers.py`, `io/sql.py`, `io/stata.py`): parameter manager expressions rewrote to `FormalRef` at the declaration span, so the enrolled With occurrence could not be found. This made the floor unmeasurable.

## Validation
- focused With/source-derived/recensus: 34 passed
- `R_construction_side_doors=0`, `auditor_errors=0`
- construction-invariant auditor: every axis R=0

The full census was stopped rather than publishing an invalid partial summary. It restarts after this fix reaches main.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `With` resolution coordinates to remain stable after substitution
> - `WithItem.substitute` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6165/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now persists the pre-substitution `context_expr` span as immutable `manager_use_site_*` fields on a `ShadowNode`, preserving the original use-site coordinates across formal/temporal projection.
> - A new `WithItem._manager_use_site_span` helper reads those persisted fields when present, falling back to the live AST span otherwise.
> - `With._prebound_manager_resolution` now calls `_manager_use_site_span` instead of reading `context_expr.line_col_span` directly, so contract resolution is always keyed to the original with-site occurrence.
> - A new test in [`test_recensus_panic_collection.py`](https://github.com/TSavo/sugar/pull/6165/files#diff-4ae95f3eb7ec62a0f5b1b052a6ed60801932afc953bacaf26eec9dd5734617df) asserts that unresolved with-items raise `ContextManagerResolutionConstructionGap` and do not emit a `BackendDefect` due to rewritten spans.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab10296.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->