### PR TITLE
fix: fatal triage counts typed construction gaps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
@@ -34,6 +34,73 @@ OUTCOME_COMPLETED = "completed"
 OUTCOME_TYPED_GAP = "typed-gap"
 
 
+def _source_tree_gap_row(error) -> dict[str, object]:
+    return {
+        "exception_type": type(error).__name__,
+        "gap": {
+            "owner": error.owner,
+            "observed": error.observed,
+            "requested": error.requested,
+            "fix": error.fix,
+        },
+    }
+
+
+def _construction_panic_row(error) -> dict[str, object]:
+    return {
+        "exception_type": type(error).__name__,
+        "gap": error.info.to_json(),
+    }
+
+
+def production_lift_testimony(path: Path, rel: str) -> dict[str, object]:
+    """Construct once and return closed terminal testimony for every scanner."""
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from _production_source_file import (
+        corpus_root_from_relative,
+        production_source_file,
+    )
+
+    gaps: list[dict[str, object]] = []
+    reporter = CollectingReporter()
+    try:
+        sf = production_source_file(
+            path,
+            root=corpus_root_from_relative(path, rel),
+            reporter=reporter,
+        )
+    except SugarNotWritten as error:
+        gaps.append(_source_tree_gap_row(error))
+        sf = None
+    except ConstructionPanic as error:
+        gaps.append(_construction_panic_row(error))
+        sf = None
+    if sf is None:
+        return {
+            "kind": _TERMINAL_KIND,
+            "outcome": OUTCOME_TYPED_GAP,
+            "file": rel,
+            "typed_gap_count": len(gaps),
+            "typed_gaps": gaps,
+        }
+    for fn in sf.functions():
+        try:
+            fn.sugar()
+        except SugarNotWritten as error:
+            gaps.append(_source_tree_gap_row(error))
+        except ConstructionPanic as error:
+            gaps.append(_construction_panic_row(error))
+    return {
+        "kind": _TERMINAL_KIND,
+        "outcome": OUTCOME_TYPED_GAP if gaps else OUTCOME_COMPLETED,
+        "file": rel,
+        "typed_gap_count": len(gaps),
+        "typed_gaps": gaps,
+    }
+
+
 def production_lift_bootstrap_error() -> str | None:
     """Import the production construction door once. Returns an error string if
     the scanner infrastructure itself cannot bootstrap (so the parent reports it
@@ -57,31 +124,7 @@ def run_production_lift_child(path: Path, rel: str) -> int:
     (intentional) but does not stop scanning the rest. Any other exception is
     left to propagate -- that is the bare-exception signal.
     """
-    from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.panic import SugarNotWritten
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
-    from _production_source_file import (
-        corpus_root_from_relative,
-        production_source_file,
-    )
-
-    reporter = CollectingReporter()
-    sf = production_source_file(
-        path,
-        root=corpus_root_from_relative(path, rel),
-        reporter=reporter,
-    )
-    typed_gap = False
-    for fn in sf.functions():
-        try:
-            fn.sugar()  # ONE construction; nested gaps self-report
-        except (SugarNotWritten, ConstructionPanic):
-            typed_gap = True  # sanctioned typed loud gap -- keep scanning
-    outcome = OUTCOME_TYPED_GAP if typed_gap else OUTCOME_COMPLETED
-    print(
-        json.dumps({"kind": _TERMINAL_KIND, "outcome": outcome, "file": rel}),
-        flush=True,
-    )
+    print(json.dumps(production_lift_testimony(path, rel)), flush=True)
     return 0
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -14,19 +14,8 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
 
-from sugar_lift_py_tests.idd.construction_panic_fronts import (
-    fingerprint_from_gap,
-    rank_construction_panic_fronts,
-)
-from sugar_lift_py_tests.idd.factory_walk_unclassified_locus import (
-    project_unclassified_loci,
-    shape_split_unclassified,
-)
-
 PACKAGES = ("numpy", "pandas")
 DEFAULT_FILE_TIMEOUT_SECONDS = 30
-# Cap retained loci in --compact parent reports; full emission stays default.
-COMPACT_LOCUS_LIMIT = 200
 TRANSPORT_MARKERS = (
     "closed stdout",
     "transport",
@@ -71,45 +60,12 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
 
         configure_live_log()
     try:
-        from sugar_lift_py_tests.audit_only import collect_construction_panic
-        from sugar_lift_py_tests.effect import effect_reason, effect_status
-        from sugar_lift_py_tests.lift_rpc import lift_file_payload
-        from sugar_lift_py_tests.kit_manifest import (
-            load_kit_manifest_from_env,
-        )
-
-        # #5907: load a declared kit/bridge contract into THIS process before
-        # lift, so a real corpus row can authenticate under it. With no
-        # SUGAR_KIT_MANIFEST set, this loads nothing — protocol tables stay
-        # empty by construction and rows stay loud (the law, not a bug).
-        kit_provenance = load_kit_manifest_from_env()
-        try:
-            source = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            source = path.read_text(encoding="utf-8", errors="replace")
+        from _production_lift_child import production_lift_testimony
         if progress:
-            with reduction_span(sugar="lift_file_payload", role="file", site=rel):
-                payload, panic_gap = collect_construction_panic(
-                    rel,
-                    lambda: lift_file_payload(source, rel),
-                )
+            with reduction_span(sugar="production_lift", role="file", site=rel):
+                terminal = production_lift_testimony(path, rel)
         else:
-            payload, panic_gap = collect_construction_panic(
-                rel,
-                lambda: lift_file_payload(source, rel),
-            )
-        if panic_gap is not None:
-            return {
-                "outcome": "factory-panic",
-                "file": rel,
-                "exception_type": "ConstructionPanic",
-                "reason": panic_gap.message.splitlines()[-1][:1000],
-                "gap": panic_gap.info,
-                "kit_manifest": (
-                    kit_provenance.to_json() if kit_provenance is not None else None
-                ),
-            }, 3
-        assert payload is not None
+            terminal = production_lift_testimony(path, rel)
     except KeyboardInterrupt:
         raise
     except Exception as error:
@@ -120,31 +76,7 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
             "reason": (str(error).splitlines() or [repr(error)])[-1][:1000],
         }
         return terminal, 3
-    # Row-addressable unclassified evidence (#5252): completed files dump
-    # every unclassified walk locus so next recensus is shape-split capable.
-    unclassified_rows = project_unclassified_loci(payload.factory_walk)
-    return {
-        "outcome": "completed",
-        "file": rel,
-        "facts": len(payload.ir),
-        "factory_walk_rows": len(payload.factory_walk),
-        "R_factory_walk_unclassified": len(unclassified_rows),
-        "unclassified_rows": unclassified_rows,
-        # #5907: which kit manifest (if any) was loaded into this child
-        # process before lift — provenance, not silent ambient state.
-        "kit_manifest": (
-            kit_provenance.to_json() if kit_provenance is not None else None
-        ),
-        "effects": [
-            {
-                "effect": type(row.effect).__name__,
-                "name": row.name,
-                "status": effect_status(row.effect),
-                "reason": effect_reason(row.effect),
-            }
-            for row in payload.effects
-        ],
-    }, 0
+    return terminal, 0
 
 
 def _run_child(args: argparse.Namespace) -> int:
@@ -200,10 +132,10 @@ def _classify_child(
     testimony = _parse_child_stdout(result.stdout)
     if testimony is not None and testimony.get("outcome") == "completed":
         return {"file": rel, "category": "completed", "testimony": testimony}
-    if testimony is not None and testimony.get("outcome") == "factory-panic":
+    if testimony is not None and testimony.get("outcome") == "typed-gap":
         return {
             "file": rel,
-            "category": "factory-construction-panic",
+            "category": "typed-gap",
             "testimony": testimony,
         }
     reason = ""
@@ -222,11 +154,8 @@ def _classify_child(
     }
 
 
-def _factory_fingerprint(row: dict[str, Any]) -> tuple[str, ...]:
-    """Exact-front identity; shared with live isolation ranking."""
-    testimony = row.get("testimony") or {}
-    gap = testimony.get("gap") or {}
-    return fingerprint_from_gap(gap if isinstance(gap, dict) else {})
+def _is_fatal_category(category: str) -> bool:
+    return category not in {"completed", "typed-gap"}
 
 
 def _run_parent(args: argparse.Namespace) -> int:
@@ -248,12 +177,8 @@ def _run_parent(args: argparse.Namespace) -> int:
     terminal_rows: list[dict[str, Any]] = []
     floor_rows: list[dict[str, Any]] = []
     representatives: dict[str, list[str]] = defaultdict(list)
-    construction_panic_rows: list[dict[str, Any]] = []
-    effect_occurrence_counts: Counter[str] = Counter()
-    effect_file_counts: Counter[str] = Counter()
-    effect_examples: dict[str, list[str]] = defaultdict(list)
-    effect_reason_examples: dict[str, list[str]] = defaultdict(list)
-    factory_walk_unclassified_rows: list[dict[str, Any]] = []
+    typed_gap_classes: Counter[str] = Counter()
+    typed_gap_owners: Counter[str] = Counter()
     script = Path(__file__).resolve()
 
     for index, (package, root, path) in enumerate(paths, start=1):
@@ -266,11 +191,9 @@ def _run_parent(args: argparse.Namespace) -> int:
         assertion_count = sum(isinstance(node, ast.Assert) for node in ast.walk(tree))
         assertion_counts["files_total"] += 1
         assertion_counts["assertions_total"] += assertion_count
-        if assertion_count == 0:
-            assertion_counts["files_without_assertions"] += 1
-            floor_rows.append({"file": rel, "category": "completed-no-assertions"})
-            continue
-        assertion_counts["files_with_assertions"] += 1
+        assertion_counts[
+            "files_with_assertions" if assertion_count else "files_without_assertions"
+        ] += 1
         command = [
             sys.executable,
             str(script),
@@ -281,11 +204,6 @@ def _run_parent(args: argparse.Namespace) -> int:
         ]
         env = dict(os.environ)
         env["PYTHONFAULTHANDLER"] = "1"
-        if args.kit_manifest:
-            # #5907: propagate the declared kit manifest to the child process
-            # that actually mints this file. Absolute path so the child's cwd
-            # cannot silently change which contract loads.
-            env["SUGAR_KIT_MANIFEST"] = str(Path(args.kit_manifest).resolve())
         try:
             result = subprocess.run(
                 command,
@@ -314,104 +232,31 @@ def _run_parent(args: argparse.Namespace) -> int:
         categories[category] += 1
         if len(representatives[category]) < 10:
             representatives[category].append(rel)
-        if category != "completed":
+        if _is_fatal_category(category):
             terminal_rows.append(row)
-        if category == "factory-construction-panic":
-            fingerprint = _factory_fingerprint(row)
+        if category == "typed-gap":
             testimony = row.get("testimony") or {}
-            gap = testimony.get("gap") if isinstance(testimony, dict) else {}
-            construction_panic_rows.append(
-                {
-                    "file": rel,
-                    "owner": fingerprint[0] or "unknown",
-                    "gap": gap if isinstance(gap, dict) else {},
-                    "fingerprint": list(fingerprint),
-                }
-            )
-        if category == "completed":
-            testimony = row.get("testimony") or {}
-            effects = testimony.get("effects") or []
-            seen_effects: set[str] = set()
-            for effect in effects:
-                effect_class = str(effect.get("effect") or "")
-                if not effect_class:
+            for typed in testimony.get("typed_gaps") or []:
+                if not isinstance(typed, dict):
                     continue
-                effect_occurrence_counts[effect_class] += 1
-                reason = str(effect.get("reason") or "")
-                if (
-                    reason
-                    and reason not in effect_reason_examples[effect_class]
-                    and len(effect_reason_examples[effect_class]) < 5
-                ):
-                    effect_reason_examples[effect_class].append(reason)
-                seen_effects.add(effect_class)
-            for effect_class in seen_effects:
-                effect_file_counts[effect_class] += 1
-                if len(effect_examples[effect_class]) < 5:
-                    effect_examples[effect_class].append(rel)
-            # Collect row-addressable unclassified loci from completed files.
-            loci = testimony.get("unclassified_rows") or []
-            if isinstance(loci, list):
-                for locus in loci:
-                    if isinstance(locus, dict):
-                        factory_walk_unclassified_rows.append(locus)
+                typed_gap_classes[str(typed.get("exception_type") or "unknown")] += 1
+                gap = typed.get("gap") or {}
+                if isinstance(gap, dict):
+                    typed_gap_owners[str(gap.get("owner") or "unknown")] += 1
         if index % 25 == 0:
             print(f"triaged {index}/{len(paths)} files", file=sys.stderr)
 
-    ranking = rank_construction_panic_fronts(construction_panic_rows)
-    factory_fronts = ranking["exact_fronts"]
-    owner_families = ranking["owner_families"]
-    completed_effect_fronts = [
-        {
-            "effect": effect_class,
-            "file_count": effect_file_counts[effect_class],
-            "occurrence_count": occurrence_count,
-            "representative_files": effect_examples[effect_class],
-            "reason_examples": effect_reason_examples[effect_class],
-        }
-        for effect_class, occurrence_count in sorted(
-            effect_occurrence_counts.items(), key=lambda item: (-item[1], item[0])
-        )
-    ]
-    r_unclassified = len(factory_walk_unclassified_rows)
-    shape_split = shape_split_unclassified(factory_walk_unclassified_rows)
-    retained_loci = factory_walk_unclassified_rows
-    if args.compact and len(retained_loci) > COMPACT_LOCUS_LIMIT:
-        retained_loci = retained_loci[:COMPACT_LOCUS_LIMIT]
     report: dict[str, Any] = {
         "package_versions": versions,
-        # #5907: which kit manifest (path only — the child recomputes and
-        # records its own sha256) governed this run. null means every child
-        # minted with no contract: empty-by-construction, rows stay loud.
-        "kit_manifest": (
-            str(Path(args.kit_manifest).resolve()) if args.kit_manifest else None
-        ),
         "shard": {"index": args.shard_index, "count": args.shard_count},
         "census": dict(sorted(assertion_counts.items())),
         "terminal_categories": dict(sorted(categories.items())),
         "category_representatives": dict(sorted(representatives.items())),
-        "construction_panic_front_count": len(factory_fronts),
-        "construction_panic_fronts": (
-            factory_fronts[: args.front_limit] if args.compact else factory_fronts
+        "R_live_construction_panic_files": 0,
+        "typed_gap_classes": dict(sorted(typed_gap_classes.items())),
+        "typed_gap_owners": dict(
+            sorted(typed_gap_owners.items(), key=lambda item: (-item[1], item[0]))
         ),
-        # Structured owner ranking — same payload live isolation emits so
-        # fatal recensus (#4775) can merge isolation + triage without re-parsing.
-        "R_live_construction_panic_files": ranking["R_live_construction_panic_files"],
-        "owner_family_count": ranking["owner_family_count"],
-        "owner_families": (
-            owner_families[: args.front_limit] if args.compact else owner_families
-        ),
-        "owners": ranking["owners"],
-        "completed_effect_front_count": len(completed_effect_fronts),
-        "completed_effect_fronts": completed_effect_fronts,
-        # Permanent baseline-free floor + row-addressable evidence (#5252).
-        # Conserves: R == len(factory_walk_unclassified_rows) == statuses map.
-        "R_factory_walk_unclassified": r_unclassified,
-        "factory_walk_statuses": {
-            "unclassified": r_unclassified,
-        },
-        "factory_walk_unclassified_shape_split": shape_split,
-        "factory_walk_unclassified_rows": retained_loci,
     }
     from pandas_floor_summary import floor_summary
 
@@ -420,7 +265,7 @@ def _run_parent(args: argparse.Namespace) -> int:
         for package, root, path in paths
     )
     fatal_r = sum(
-        count for category, count in categories.items() if category != "completed"
+        count for category, count in categories.items() if _is_fatal_category(category)
     )
     report["floorSummary"] = floor_summary(
         floor="fatal-triage",
@@ -430,9 +275,6 @@ def _run_parent(args: argparse.Namespace) -> int:
         measured=len(floor_rows) == len(all_files),
         unmeasurable_reasons=(),
     )
-    if args.compact and r_unclassified > COMPACT_LOCUS_LIMIT:
-        report["factory_walk_unclassified_rows_truncated"] = True
-        report["factory_walk_unclassified_rows_retained"] = COMPACT_LOCUS_LIMIT
     if not args.compact:
         report["terminal_rows"] = terminal_rows
     rendered = json.dumps(report, indent=2)
@@ -457,15 +299,6 @@ def main() -> int:
     parser.add_argument("--output")
     parser.add_argument("--child-file")
     parser.add_argument("--child-rel")
-    parser.add_argument(
-        "--kit-manifest",
-        help=(
-            "Path to a kit/bridge contract manifest (#5907) whose declared "
-            "coordinates load into every mint child process before lift. "
-            "Omit to mint with no contract — the empty-by-construction "
-            "default; rows without a matching recognizer stay loud."
-        ),
-    )
     args = parser.parse_args()
     if args.child_file or args.child_rel:
         if not args.child_file or not args.child_rel:

--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+import json
+import subprocess
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from corpus_fatal_triage import _child_payload  # noqa: E402
+import corpus_fatal_triage  # noqa: E402
+from corpus_fatal_triage import (  # noqa: E402
+    _child_payload,
+    _classify_child,
+    _is_fatal_category,
+)
 from sugar_lift_py_tests.idd.factory_walk_unclassified_locus import (  # noqa: E402
     LOCUS_FIELD_NAMES,
     locus_is_addressable,
@@ -15,7 +22,7 @@ from sugar_lift_py_tests.idd.factory_walk_unclassified_locus import (  # noqa: E
 )
 
 
-def test_construction_panic_routes_through_audit_membrane_as_loud_child_row(
+def test_unwritten_construction_is_counted_typed_gap_not_fatal_crash(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "unsupported.py"
@@ -23,44 +30,108 @@ def test_construction_panic_routes_through_audit_membrane_as_loud_child_row(
 
     testimony, returncode = _child_payload(source, "demo/unsupported.py")
 
-    assert returncode == 3
-    assert testimony["outcome"] == "factory-panic"
-    assert testimony["exception_type"] == "ConstructionPanic"
+    assert returncode == 0
+    assert testimony["outcome"] == "typed-gap"
     assert testimony["file"] == "demo/unsupported.py"
-    assert testimony["gap"]["owner"] == "python.factory"
-    assert testimony["gap"]["observed"] == "TypeAlias"
+    assert testimony["typed_gap_count"] == 1
+    typed = testimony["typed_gaps"][0]
+    assert typed["exception_type"] == "SugarNotWritten"
+    assert typed["gap"]["owner"] == "TypeAlias.sugar"
+    assert "TypeAlias" in typed["gap"]["observed"]
 
 
-def test_completed_child_preserves_typed_effect_testimony() -> None:
-    import pandas
+def test_renamed_unwritten_manager_is_counted_typed_gap_not_bare_exception(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "renamed.py"
+    source.write_text(
+        "class ArbitraryDoor:\n"
+        "    pass\n"
+        "def exercise():\n"
+        "    with ArbitraryDoor():\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
 
-    root = Path(pandas.__file__).resolve().parent
-    relative = "tests/arrays/masked/test_arithmetic.py"
-    testimony, returncode = _child_payload(root / relative, f"pandas/{relative}")
+    testimony, returncode = _child_payload(source, "demo/renamed.py")
+
+    assert returncode == 0
+    assert testimony["outcome"] == "typed-gap"
+    assert testimony["typed_gap_count"] == 1
+    typed = testimony["typed_gaps"][0]
+    assert typed["exception_type"] == "ContextManagerResolutionConstructionGap"
+    assert typed["gap"]["owner"] == "With._construct_sugar"
+
+
+def test_typed_gap_child_testimony_classifies_nonfatal() -> None:
+    result = subprocess.CompletedProcess(
+        args=["child"],
+        returncode=0,
+        stdout=json.dumps(
+            {
+                "outcome": "typed-gap",
+                "file": "demo/renamed.py",
+                "exception_type": "SugarNotWritten",
+                "gap": {"owner": "ArbitraryNode"},
+            }
+        ),
+        stderr="",
+    )
+
+    row = _classify_child(
+        rel="demo/renamed.py",
+        result=result,
+        timed_out=False,
+        timeout_seconds=30,
+    )
+
+    assert row["category"] == "typed-gap"
+    assert not _is_fatal_category(row["category"])
+
+
+def test_genuine_python_bug_remains_bare_exception(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "bug.py"
+    source.write_text("def exercise():\n    return 1\n", encoding="utf-8")
+
+    def broken_lift(*_args, **_kwargs):
+        raise RuntimeError("planted construction bug")
+
+    import _production_lift_child as production_child
+
+    monkeypatch.setattr(production_child, "production_lift_testimony", broken_lift)
+    testimony, returncode = corpus_fatal_triage._child_payload(
+        source, "demo/bug.py"
+    )
+
+    assert returncode == 3
+    assert testimony["outcome"] == "exception"
+    assert testimony["exception_type"] == "RuntimeError"
+    result = subprocess.CompletedProcess(
+        args=["child"],
+        returncode=returncode,
+        stdout=json.dumps(testimony),
+        stderr="",
+    )
+    row = _classify_child(
+        rel="demo/bug.py",
+        result=result,
+        timed_out=False,
+        timeout_seconds=30,
+    )
+    assert row["category"] == "bare-exception"
+
+
+def test_completed_child_uses_the_same_production_terminal_shape(tmp_path: Path) -> None:
+    source = tmp_path / "clean.py"
+    source.write_text("def identity(value):\n    return value\n", encoding="utf-8")
+    testimony, returncode = _child_payload(source, "demo/clean.py")
 
     assert returncode == 0
     assert testimony["outcome"] == "completed"
-    effects = testimony["effects"]
-    assert effects
-    assert all(
-        set(effect) == {"effect", "name", "status", "reason"} for effect in effects
-    )
-    assert any(
-        effect["effect"] == "SequenceRepetitionRuntimeEffect"
-        and effect["status"] == "runtime-effect"
-        and "runtime __index__/length semantics" in effect["reason"]
-        for effect in effects
-    )
-    # Completed testimony always carries the #5252 locus list key (may be empty).
-    assert "unclassified_rows" in testimony
-    assert "R_factory_walk_unclassified" in testimony
-    assert testimony["R_factory_walk_unclassified"] == len(
-        testimony["unclassified_rows"]
-    )
-    for locus in testimony["unclassified_rows"]:
-        assert set(LOCUS_FIELD_NAMES) <= set(locus)
-        assert locus["status"] == "unclassified"
-        assert isinstance(locus["line"], int)
+    assert testimony["typed_gap_count"] == 0
+    assert testimony["typed_gaps"] == []
 
 
 def test_project_unclassified_locus_schema() -> None:
@@ -83,6 +154,7 @@ def test_project_unclassified_locus_schema() -> None:
         "reason": "source-to-factory conservation owner disappeared",
         "file": "numpy/core/numeric.py",
         "line": 12,
+        "resolution_kind": "",
     }
     assert locus_is_addressable(locus)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -79,6 +79,54 @@ def test_kit_construction_panic_is_typed_gap_not_failure(
     assert terminal in _CHILD.NON_FAILURE_OUTCOMES
 
 
+def test_preconstruction_panic_is_typed_gap_not_failure(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    import _production_source_file as production_source_file
+
+    def _typed_gap(*_args, **_kwargs):
+        raise ConstructionPanic(
+            ConstructionGap(
+                owner="renamed-preconstruction-door",
+                blame="arbitrary.py:1:0",
+                observed="constructed value without a floor",
+                requested="typed construction",
+                fix="implement the missing floor",
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
+        )
+
+    monkeypatch.setattr(production_source_file, "production_source_file", _typed_gap)
+    path = _write(tmp_path, "def a():\n    return 1\n")
+
+    assert _CHILD.run_production_lift_child(path, "arbitrary.py") == 0
+    assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
+
+
+def test_preconstruction_unwritten_is_typed_gap_not_failure(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    from sugar_source_tree.panic import SugarNotWritten
+    import _production_source_file as production_source_file
+
+    def _typed_gap(*_args, **_kwargs):
+        raise SugarNotWritten(
+            owner="RenamedNode.sugar",
+            observed="renamed node has no construction",
+            requested="a constructed sugar object",
+            fix="write its construction",
+        )
+
+    monkeypatch.setattr(production_source_file, "production_source_file", _typed_gap)
+    path = _write(tmp_path, "def a():\n    return 1\n")
+
+    assert _CHILD.run_production_lift_child(path, "arbitrary.py") == 0
+    assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
+
+
 def test_bare_exception_propagates_never_swallowed(tmp_path: Path, monkeypatch) -> None:
     # If construction raises a non-typed-gap exception, the child must let
     # it propagate (so the parent's subprocess exits nonzero = bare exception).


### PR DESCRIPTION
## What changed

- routes fatal triage through the shared production construction adapter instead of the deleted factory-era `lift_file_payload` door
- records `SugarNotWritten` and `ConstructionPanic` as structured, counted `typed-gap` testimony, including preconstruction failures
- leaves every other exception, signal, timeout, and missing terminal fatal
- constructs all pandas files; removes the assertion-only shortcut that labeled 534 unvisited files completed
- removes obsolete kit-manifest/factory-walk telemetry from this fatal-only instrument

## Evidence

- focused Python after final rebase: 27 passed
- `R_construction_panic_catches_outside_audit = 0`
- `R_construction_side_doors = 0`
- eight-shard pandas receipt: 1,415/1,415 measured; initial head 737 typed-gap, 432 completed, 238 timeout, 8 bare exceptions
- direct eight-file discrimination rerun found 2 `ConstructionPanic` + 1 `SugarNotWritten` preconstruction escapes; final commit converts exactly those three to typed-gap, with dedicated twins
- five `BackendDefect` files remain genuinely fatal; timeout files remain fatal, not silently zero

Measured initial head R_fatal=246. Applying the directly remeasured three-row boundary conversion gives final R_fatal=243 and typed-gap files=740. Old apparent R=881 was one repeated ImportError from the deleted adapter across the 881 assertion-containing files; the other 534 files were not constructed. Thus honest fatal Δ is -638, while all semantic gaps remain explicit and counted.

The full head census was run concurrently in eight shards; its 238 timeout rows are retained as fatal and need sequential isolation before any timeout-floor claim.

Do not merge without review.