### PR TITLE
drain: authenticated source-visible methods and constructors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -231,7 +231,7 @@ def main() -> int:
                 ):
                     source_call_preconstruction[
                         (
-                            "source-visible"
+                            f"source-visible-{row.dispatch_kind}"
                             if isinstance(row, SourceCallPreconstructionRefV1)
                             else row.kind
                         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -108,9 +108,7 @@ class ClassDefinitionValue(FloorValue):
         # tail before this class's methods.  A base method is retained with its
         # original authenticated source frame; nothing is reconstructed here.
         inherited = tuple(
-            method
-            for base in reversed(self._c3_tail())
-            for method in base.methods
+            method for base in reversed(self._c3_tail()) for method in base.methods
         )
         return tuple(
             ObjectMethodValue(
@@ -122,6 +120,7 @@ class ClassDefinitionValue(FloorValue):
                     coordinate.cid
                     for coordinate in method.source_call_frame.formal_coordinates
                 ),
+                method.source_call_frame,
             )
             for method in (*inherited, *self.methods)
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from sugar_lift_py_tests.sugar_body import SugarBody
@@ -22,6 +22,7 @@ class ObjectMethodValue(FloorValue):
     body: SugarBody[Any] | Sugar
     source_call_frame_cid: str | None = None
     formal_coordinate_cids: tuple[str, ...] = ()
+    source_call_frame: object | None = field(default=None, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         from sugar_lift_py_tests.sugar.sugar_base import Sugar

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -365,6 +365,8 @@ class ObjectValue(FloorValue):
         owner: str,
         blame: object,
         ctx: Any | None = None,
+        keywords: tuple[tuple[str, FloorValue], ...] = (),
+        required_frame: object | None = None,
     ) -> Outcome:
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
@@ -374,6 +376,10 @@ class ObjectValue(FloorValue):
         for method in reversed(self.methods):
             if method.name != name:
                 continue
+            if required_frame is not None and (
+                method.source_call_frame_cid != required_frame.frame_cid
+            ):
+                continue
             if not method.parameters:
                 return self._floor_gap(
                     owner=owner,
@@ -382,23 +388,32 @@ class ObjectValue(FloorValue):
                     requested="method self parameter",
                     fix=f"add method binding sugar for `{self.class_name}.{name}`",
                 )
-            expected = len(method.parameters) - 1
-            if len(arguments) != expected:
+            target_name = f"{self.class_name}.{name}"
+            arg_values = (self, *arguments)
+            selected_frame = required_frame or method.source_call_frame
+            if selected_frame is not None:
+                from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+                try:
+                    arg_values = selected_frame.bind_actuals(arg_values, keywords, ctx)
+                except SourceCallBindingGap as exc:
+                    return self._floor_gap(
+                        owner=owner,
+                        blame=blame,
+                        observed=str(exc),
+                        requested="actuals matching authenticated method signature",
+                        fix="preserve exact defaults/variadics or keep the call loud",
+                    )
+            elif keywords or len(arguments) != len(method.parameters) - 1:
                 return self._floor_gap(
                     owner=owner,
                     blame=blame,
                     observed=f"{self.class_name}.{name}",
-                    requested=f"{expected} method arguments",
-                    fix=(
-                        f"add method argument binding sugar for "
-                        f"`{self.class_name}.{name}`"
-                    ),
+                    requested="arguments matching the constructor-bound method",
+                    fix="bind through the authenticated method frame or keep loud",
                 )
-            target_name = f"{self.class_name}.{name}"
-            arg_values = (self, *arguments)
             arg_terms = [
-                value.to_term(owner=f"{owner} method argument")
-                for value in arg_values
+                value.to_term(owner=f"{owner} method argument") for value in arg_values
             ]
             call_value = CallSiteValue(
                 target_name=target_name,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
@@ -16,6 +16,7 @@ class SourceCallPreconstructionRefV1:
     resolved_object_cid: str
     distribution_artifact_cid: str
     source_call_frame_cid: str
+    dispatch_kind: Literal["function", "constructor", "method"] = "function"
     resolution_cid: str = ""
 
     def __post_init__(self) -> None:
@@ -33,6 +34,7 @@ class SourceCallPreconstructionRefV1:
             "resolvedObjectCid": self.resolved_object_cid,
             "distributionArtifactCid": self.distribution_artifact_cid,
             "sourceCallFrameCid": self.source_call_frame_cid,
+            "dispatchKind": self.dispatch_kind,
         }
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -29,6 +29,7 @@ class MethodCallSugar(Sugar):
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
     keywords: tuple = ()  # (name, sugar) pairs, in source order
+    source_call_frame: object = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -67,24 +68,37 @@ class MethodCallSugar(Sugar):
                     receiver, tuple(rest), kw_values + ((name, value),), positional, ctx
                 )
             )
-        from sugar_lift_py_tests.floor import ObjectValue
+        from sugar_lift_py_tests.floor import CallSiteValue, ObjectValue
+
+        if (
+            isinstance(receiver, CallSiteValue)
+            and receiver.body is not None
+            and receiver.source_call_frame_cid is not None
+        ):
+            receiver = receiver.force_floor(
+                ctx,
+                owner="authenticated method receiver",
+                project_callsite=False,
+            )
 
         if isinstance(receiver, ObjectValue):
-            if kw_values:
-                from sugar_source_tree.panic import SugarNotWritten
-
-                raise SugarNotWritten(
-                    owner="MethodCallSugar._collect_kwargs",
-                    observed="source-visible object method called with keywords",
-                    requested="keyword binding through its SourceVisibleCallFrameV1",
-                    fix="extend the sole method call frame binder; never drop keywords",
-                )
             return receiver.call_method_value(
                 self.name,
                 positional,
                 owner="MethodCallSugar",
                 blame=self.site,
                 ctx=ctx,
+                keywords=kw_values,
+                required_frame=self.source_call_frame,
+            )
+        if self.source_call_frame is not None:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="MethodCallSugar._collect_kwargs",
+                observed=type(receiver).__name__,
+                requested="authenticated constructed receiver matching the method frame",
+                fix="preserve receiver identity or keep authenticated dispatch loud",
             )
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
@@ -107,7 +121,7 @@ class MethodCallSugar(Sugar):
                 arg_values=(receiver, *positional, *(v for _, v in kw_values)),
                 parameters=(),
                 term=term,
-                body=None,  # the dig is CUED, not inlined here
+                body=None,
                 site=self.site,
                 runtime_dispatch_receiver=receiver,
             )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -17,7 +17,7 @@ from sugar_lift_py_tests.source_call_resolution import (
     SourceCallPreconstructionGapV1,
     SourceCallPreconstructionRefV1,
 )
-from sugar_source_tree.nodes import Call, FunctionDef, Name
+from sugar_source_tree.nodes import Attribute, Call, ClassDef, FunctionDef, Name
 
 from .dependency_artifact import (
     DependencyArtifactAuthenticationError,
@@ -53,9 +53,9 @@ def populate_source_visible_call_frames(
         source_file.unit.source_cid,
         module_identities={},
     )
-    calls = {
-        _span_key(node): node for node in source_file.nodes() if isinstance(node, Call)
-    }
+    calls = tuple(node for node in source_file.nodes() if isinstance(node, Call))
+    calls_by_span = {_span_key(node): node for node in calls}
+    constructor_targets = {}
     packages = (
         importlib.metadata.packages_distributions()
         if distribution_index is None
@@ -65,7 +65,7 @@ def populate_source_visible_call_frames(
     for receipt in receipts:
         raw = receipt.use["useSite"]
         key = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
-        call = calls.get(key)
+        call = calls_by_span.get(key) or _call_for_callee_span(calls, key)
         if call is None:
             continue
         coordinate = _coordinate(call)
@@ -151,11 +151,45 @@ def populate_source_visible_call_frames(
             )
             continue
         context.source_call_frames[coordinate] = frame
+        dispatch_kind = "constructor" if isinstance(target, ClassDef) else "function"
+        if isinstance(target, ClassDef):
+            constructor_targets[coordinate] = target
         context.source_call_resolutions[coordinate] = SourceCallPreconstructionRefV1(
             coordinate,
             resolved.cid,
             graph.distribution_artifact_cid,
             frame.frame_cid,
+            dispatch_kind,
+        )
+
+    for call in calls:
+        if not isinstance(call.func, Attribute) or not isinstance(
+            call.func.value, Call
+        ):
+            continue
+        receiver_coordinate = _coordinate(call.func.value)
+        target = constructor_targets.get(receiver_coordinate)
+        if target is None:
+            continue
+        coordinate = _coordinate(call)
+        frame = _source_method_frame(target, call.func.attr)
+        if frame is None:
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(
+                    "dynamic-call-target",
+                    coordinate,
+                    "authenticated class has no source method",
+                )
+            )
+            continue
+        context.source_call_frames[coordinate] = frame
+        constructor_ref = context.source_call_resolutions[receiver_coordinate]
+        context.source_call_resolutions[coordinate] = SourceCallPreconstructionRefV1(
+            coordinate,
+            constructor_ref.resolved_object_cid,
+            constructor_ref.distribution_artifact_cid,
+            frame.frame_cid,
+            "method",
         )
 
 
@@ -177,6 +211,30 @@ def _unsupported_call(target) -> str | None:
 def _span_key(node):
     span = node.line_col_span()
     return span.start_line, span.start_col, span.end_line, span.end_col
+
+
+def _call_for_callee_span(calls, key):
+    """Project an authenticated imported callee occurrence to its exact Call."""
+    candidates = tuple(call for call in calls if _span_key(call.func) == key)
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _source_method_frame(target: ClassDef, name: str):
+    """Project the exact method frame from the sole-door class construction."""
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    outcome = target.sugar().desugar()
+    if not isinstance(outcome, Complete) or not isinstance(
+        outcome.value, ClassDefinitionValue
+    ):
+        return None
+    matches = tuple(
+        method
+        for method in outcome.value._object_methods()
+        if method.name == name and method.source_call_frame is not None
+    )
+    return matches[-1].source_call_frame if matches else None
 
 
 def _coordinate(node) -> SourceFragmentCoordinateV1:

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -282,3 +282,155 @@ def test_cross_file_frame_preserves_real_variadic_actuals(tmp_path: Path) -> Non
     assert value.arg_values[1].elements == (TermValue(2), TermValue(3))
     assert isinstance(value.arg_values[2], DictValue)
     assert value.arg_values[2].entries == ((StringValue("label"), TermValue(4)),)
+
+
+def test_renamed_source_class_constructor_and_method_use_authenticated_frames(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "class arbitrary_helper:\n"
+        "    def __init__(self, seed=11):\n"
+        "        self.seed = seed\n\n"
+        "    def project(self, value=17, *rest, **options):\n"
+        "        return value\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as Renamed\n"
+        "Renamed(13).project(value=23, label=29)\n",
+    )
+    calls = tuple(node for node in source_file.nodes() if isinstance(node, Call))
+    constructor = next(call for call in calls if not hasattr(call.func, "attr"))
+    method = next(
+        call for call in calls if getattr(call.func, "attr", None) == "project"
+    )
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    constructor_row = context.source_call_resolutions[_coordinate(constructor)]
+    method_row = context.source_call_resolutions[_coordinate(method)]
+    assert isinstance(constructor_row, SourceCallPreconstructionRefV1)
+    assert isinstance(method_row, SourceCallPreconstructionRefV1)
+    assert method_row.resolved_object_cid == constructor_row.resolved_object_cid
+    method_value = method.sugar().desugar().value
+    assert isinstance(method_value, CallSiteValue)
+    method_result = method_value.force_floor(
+        None, owner="renamed authenticated method", project_callsite=False
+    )
+    assert method_result.statements == (ReturnValue(TermValue(23)),)
+
+
+def test_authenticated_class_missing_method_stays_typed_loud(tmp_path: Path) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "class arbitrary_helper:\n" "    def __init__(self):\n" "        pass\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as Renamed\n"
+        "Renamed().missing(23)\n",
+    )
+    method = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Call) and getattr(node.func, "attr", None) == "missing"
+    )
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    row = context.source_call_resolutions[_coordinate(method)]
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "dynamic-call-target"
+    assert _coordinate(method) not in context.source_call_frames
+    with pytest.raises(SugarNotWritten, match="dynamic-call-target"):
+        method.sugar().desugar()
+
+
+def test_assigned_constructed_receiver_uses_its_authenticated_method_frame(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "class arbitrary_helper:\n"
+        "    def __init__(self, seed):\n"
+        "        self.seed = seed\n\n"
+        "    def project(self, value=17, **options):\n"
+        "        return value\n",
+    )
+    path, source_file, _context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as Renamed\n"
+        "def consume():\n"
+        "    receiver = Renamed(13)\n"
+        "    return receiver.project(label=29)\n",
+    )
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    function = next(source_file.functions()).substitute({})
+    method = next(
+        node
+        for node in function.walk()
+        if isinstance(node, Call) and getattr(node.func, "attr", None) == "project"
+    )
+
+    method_value = method.sugar().desugar().value
+    assert isinstance(method_value, CallSiteValue)
+    result = method_value.force_floor(
+        None, owner="assigned authenticated receiver", project_callsite=False
+    )
+    assert result.statements == (ReturnValue(TermValue(17)),)
+
+
+def test_authenticated_constructor_method_follows_local_mro(tmp_path: Path) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "class Ancestor:\n"
+        "    def project(self, value=31):\n"
+        "        return value\n\n"
+        "class arbitrary_helper(Ancestor):\n"
+        "    def __init__(self):\n"
+        "        pass\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as Renamed\n"
+        "Renamed().project()\n",
+    )
+    method = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Call) and getattr(node.func, "attr", None) == "project"
+    )
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    row = context.source_call_resolutions[_coordinate(method)]
+    assert isinstance(row, SourceCallPreconstructionRefV1)
+    result = (
+        method.sugar()
+        .desugar()
+        .value.force_floor(
+            None, owner="authenticated inherited method", project_callsite=False
+        )
+    )
+    assert result.statements == (ReturnValue(TermValue(31)),)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -517,7 +517,10 @@ class Node(Typed):
             return self.control_context.enter_loop(self.owned_loop_target)
         if isinstance(self, ExceptHandler) and field_name == "body":
             return self.control_context.enter_exception(self._effect_slot_id())
-        if isinstance(self, (FunctionDef, AsyncFunctionDef, ClassDef, Lambda)) and field_name == "body":
+        if (
+            isinstance(self, (FunctionDef, AsyncFunctionDef, ClassDef, Lambda))
+            and field_name == "body"
+        ):
             return ControlConstructionContextV1()
         return self.control_context
 
@@ -824,7 +827,12 @@ class Node(Typed):
                         candidates.append(
                             (
                                 node.fragment,
-                                ("targets", target_index, "projection", projection_index),
+                                (
+                                    "targets",
+                                    target_index,
+                                    "projection",
+                                    projection_index,
+                                ),
                             )
                         )
         target = getattr(self, "target", None)
@@ -1690,9 +1698,7 @@ class FunctionDef(Statement):
                     construction_root = materialize(
                         substituted.unit, substituted.ref, testimony_reporter
                     )
-                    statements = tuple(
-                        stmt.sugar() for stmt in construction_root.body
-                    )
+                    statements = tuple(stmt.sugar() for stmt in construction_root.body)
                     substitution_trace = trace_builder.freeze(testimony_reporter)
                 else:
                     # Every statement still has an immutable runtime snapshot.
@@ -1827,9 +1833,7 @@ class ClassDef(Statement):
                 and len(item.targets) == 1
                 and isinstance(item.targets[0], Name)
             )
-            and not (
-                isinstance(item, AnnAssign) and isinstance(item.target, Name)
-            )
+            and not (isinstance(item, AnnAssign) and isinstance(item.target, Name))
         )
         if unsupported:
             from sugar_source_tree.panic import SugarNotWritten
@@ -1857,29 +1861,33 @@ class ClassDef(Statement):
             )
             for method in methods
         )
-        fields = tuple(
-            ConstructedClassFieldV1(
-                name,
-                fragment.seal().cid,
-                value.sugar(),
+        fields = (
+            tuple(
+                ConstructedClassFieldV1(
+                    name,
+                    fragment.seal().cid,
+                    value.sugar(),
+                )
+                for name, value, fragment in class_assignments
             )
-            for name, value, fragment in class_assignments
-        ) + tuple(
-            ConstructedClassFieldV1(
-                item.target.id,
-                item.fragment.seal().cid,
-                item.value.sugar(),
+            + tuple(
+                ConstructedClassFieldV1(
+                    item.target.id,
+                    item.fragment.seal().cid,
+                    item.value.sugar(),
+                )
+                for item in annotated_assignments
+                if item.value is not None
             )
-            for item in annotated_assignments
-            if item.value is not None
-        ) + tuple(
-            ConstructedClassFieldV1(
-                item.name,
-                item.fragment.seal().cid,
-                item.sugar(),
+            + tuple(
+                ConstructedClassFieldV1(
+                    item.name,
+                    item.fragment.seal().cid,
+                    item.sugar(),
+                )
+                for item in self.body
+                if isinstance(item, ClassDef)
             )
-            for item in self.body
-            if isinstance(item, ClassDef)
         )
         base_sugars = ()
         if self.bases:
@@ -1889,8 +1897,8 @@ class ClassDef(Statement):
                 if context is not None
                 else None
             )
-            base_sugars = () if table is None else table.get(
-                self.fragment.seal().cid, ()
+            base_sugars = (
+                () if table is None else table.get(self.fragment.seal().cid, ())
             )
         return ClassDefinitionSugar(
             class_name=self.name,
@@ -1902,9 +1910,7 @@ class ClassDef(Statement):
             annotation_cids=tuple(
                 item.fragment.seal().cid for item in annotated_assignments
             ),
-            decorator_cids=tuple(
-                item.fragment.seal().cid for item in self.decorators
-            ),
+            decorator_cids=tuple(item.fragment.seal().cid for item in self.decorators),
             base_sugars=base_sugars,
             base_fragment_cids=tuple(base.fragment.seal().cid for base in self.bases),
             site=self.fragment,
@@ -2173,7 +2179,9 @@ class Assign(Statement):
             return None
 
         starred = [
-            index for index, element in enumerate(target.elts) if isinstance(element, Starred)
+            index
+            for index, element in enumerate(target.elts)
+            if isinstance(element, Starred)
         ]
         if len(starred) > 1:
             return None
@@ -2212,7 +2220,12 @@ class Assign(Statement):
             ShadowNode(
                 "List",
                 self.span,
-                (("elts", Children(tuple(_handle_of(element) for element in elements))),),
+                (
+                    (
+                        "elts",
+                        Children(tuple(_handle_of(element) for element in elements)),
+                    ),
+                ),
             ),
             self.reporter,
         )
@@ -2856,7 +2869,9 @@ class For(Statement):
             unrolled.extend(statements)
             target_names = self._bound_names_in(self.target)
             carried = {
-                key: value for key, value in iteration.items() if key not in target_names
+                key: value
+                for key, value in iteration.items()
+                if key not in target_names
             }
             if action == "break":
                 broke = True
@@ -3972,10 +3987,7 @@ class Try(Statement):
         names = set().union(*(net.keys() for net in nets))
         merged: BindingMap = {}
         for name in sorted(names):
-            states = [
-                net.get(name, _explicit_state(name, scope))
-                for net in nets
-            ]
+            states = [net.get(name, _explicit_state(name, scope)) for net in nets]
             if any(state is _MISSING for state in states):
                 continue
             if all(state is states[0] or state == states[0] for state in states[1:]):
@@ -5319,9 +5331,7 @@ class Call(Expression):
                         f"{source_call_resolution.detail}"
                     ),
                 )
-            if not isinstance(
-                source_call_resolution, SourceCallPreconstructionRefV1
-            ):
+            if not isinstance(source_call_resolution, SourceCallPreconstructionRefV1):
                 from sugar_source_tree.panic import BackendDefect
 
                 raise BackendDefect(
@@ -5363,6 +5373,29 @@ class Call(Expression):
                     ),
                 )
             )
+            if (
+                source_call_resolution is not None
+                and source_call_resolution.dispatch_kind == "method"
+            ):
+                if not isinstance(self.func, Attribute):
+                    from sugar_source_tree.panic import BackendDefect
+
+                    raise BackendDefect(
+                        owner="Call._construct_sugar",
+                        observed=self.func.kind,
+                        requested="attribute callee for authenticated method dispatch",
+                        fix="bind the method ref to its exact attribute-call occurrence",
+                    )
+                from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+
+                return MethodCallSugar(
+                    receiver=self.func.value.sugar(),
+                    name=self.func.attr,
+                    args=tuple(a.sugar() for a in self.args),
+                    site=self.fragment,
+                    keywords=keyword_sugars,
+                    source_call_frame=bound_frame,
+                )
             return CallSiteSugar(
                 target_name=f"python:resolved-source-call:{bound_frame.frame_cid}",
                 args=tuple(a.sugar() for a in self.args),


### PR DESCRIPTION
## Outcome

Extends the merged ordinary source-call preconstruction phase to authenticated source-visible class constructors and methods. Imported callee occurrences map to the exact constructor Call; direct and temporally-bound constructed receivers dispatch through their authenticated `SourceVisibleCallFrameV1`, including defaults, keywords, variadics, and local MRO projection. Missing methods and receiver/frame mismatches stay typed-loud.

## Instrument

Predicted epsilon: lowers the source-visible method/constructor Call frontier; exact pandas delta is being measured by the corrected shared census.

Floors preserved:
- `R_construction_side_doors=0`
- every construction-invariant axis `R=0`
- `R_no_sugar_in_desugar=0`

## Focused receipts

- 29 source-call + sole-path manager tests passed
- renamed direct constructor/method, assigned receiver, defaults/variadics, local MRO, missing-method loud twins
- changed Python files pass Black

No private evaluator, vendor/name gate, module execution, or fabricated return. Not merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated source-visible dispatch for constructors and methods
> - `SourceCallPreconstructionRefV1` now encodes a `dispatch_kind` (`function`, `constructor`, or `method`), producing distinct CIDs per kind and propagating this to reporting.
> - `populate_source_visible_call_frames` in [source_call_preconstruction.py](https://github.com/TSavo/sugar/pull/6167/files#diff-74b4be0d0a335267f0783561ba4419e3981f34d4d03f9d4d72678b66d4e94cbf) detects constructor calls (callee is a `ClassDef`) and resolves subsequent method calls on the constructed receiver to their exact authenticated method frames.
> - `ObjectValue.call_method_value` now accepts keywords and a `required_frame`, validating and binding call arguments against the authenticated source frame; mismatched or unresolvable calls return a typed floor gap.
> - `Call._construct_sugar` enforces that authenticated method calls have an attribute callee and binds them to a `python:resolved-source-call:{frame_cid}` classification, raising `BackendDefect` on malformed callees.
> - Risk: calls that previously resolved without frame validation may now be rejected with a floor gap if they don't match the authenticated method signature.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c47f56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authenticated constructor and method dispatch, including support for renamed and inherited methods.
  * Added more precise handling of keyword arguments and method binding.
  * Source call records now distinguish functions, constructors, and methods.

* **Bug Fixes**
  * Improved diagnostics for invalid method calls and argument-binding mismatches.
  * Missing authenticated methods now produce clearer, typed errors.

* **Tests**
  * Added coverage for renamed classes, assigned receivers, missing methods, and inherited methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->