### PR TITLE
Cut E: derive EffectBoundary from constructed manager source (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -101,6 +101,7 @@ class SourceDerivedContextManagerRefV1:
     use_site: SourceFragmentCoordinateV1
     summary_cid: str
     semantics: ContextManagerSemanticsV1
+    import_signature: ImportSignatureV2
     protocol: object = field(compare=False, repr=False)
 
 
@@ -286,7 +287,9 @@ def _decode_ref(raw: Any) -> ContextManagerContractRefV1:
         _cid(raw["useSiteCid"], "useSiteCid"),
         _cid(raw["authenticatedImportUseCid"], "authenticatedImportUseCid"),
         _cid(raw["importBindingCid"], "importBindingCid"),
-        _cid(raw["constructionContextGenerationCid"], "constructionContextGenerationCid"),
+        _cid(
+            raw["constructionContextGenerationCid"], "constructionContextGenerationCid"
+        ),
         _cid(raw["contractCid"], "contractCid"),
         _cid(raw["payloadCid"], "payloadCid"),
         _cid(raw["provenanceCid"], "provenanceCid"),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -117,6 +117,19 @@ class CallSiteValue(FloorValue):
     def exception_type_identity(self) -> Term | None:
         return self.exception_type_coordinate
 
+    def attribute(self, name, site):
+        """Retain attribute lookup on this exact constructed call result.
+
+        Construction does not execute the call or invent the attribute value;
+        downstream source construction receives the stable projection term.
+        """
+        del site
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(SymbolicValue(ctor("py.getattr", [self.term, str_const(name)])))
+
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.
 
@@ -1149,9 +1162,7 @@ class CallSiteValue(FloorValue):
             self.arg_values,
             self.formal_coordinate_cids,
         )
-        return _reduce_callsite_body(
-            self.body, reduce_ctx, blame=self.target_name
-        )
+        return _reduce_callsite_body(self.body, reduce_ctx, blame=self.target_name)
 
 
 def force_floor(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
@@ -68,6 +68,19 @@ class ExitValueCoordinate(FloorValue):
 
         return ctor("python:exit_value", [str_const(self.face_id)])
 
+    def attribute(self, name, site):
+        """Project an attribute from the real parametric exception value."""
+        del site
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            SymbolicValue(
+                ctor("py.getattr", [self.to_term(owner="exit"), str_const(name)])
+            )
+        )
+
 
 @dataclass(frozen=True)
 class ExitTracebackCoordinate(FloorValue):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -34,6 +34,7 @@ class WithEffectBoundarySugar(Sugar):
             ExpectsModeV1,
             NoMessagePatternV1,
             RaiseEffectKindV1,
+            SuppressesModeV1,
             project_formal_selector_v1,
         )
         from sugar_lift_py_tests.effect import ExpectationNotMetEffect, RaiseEffect
@@ -52,7 +53,7 @@ class WithEffectBoundarySugar(Sugar):
         semantics = self.semantics
         if (
             not isinstance(semantics, EffectBoundarySemanticsV1)
-            or not isinstance(semantics.mode, ExpectsModeV1)
+            or not isinstance(semantics.mode, (ExpectsModeV1, SuppressesModeV1))
             or not isinstance(semantics.effect_kind, RaiseEffectKindV1)
         ):
             raise SugarNotWritten(
@@ -77,7 +78,8 @@ class WithEffectBoundarySugar(Sugar):
                     fix="keep computed or opaque managers loud",
                 )
             fixed = _bind_real_actuals(
-                self.contract_ref.import_signature, manager_value
+                self.contract_ref.import_signature,
+                manager_value,
             )
             expected = project_formal_selector_v1(
                 semantics.expected_type_operand,
@@ -100,13 +102,16 @@ class WithEffectBoundarySugar(Sugar):
             exits = []
             for body_exit in body_es.exits:
                 if isinstance(body_exit, Completed):
-                    exits.append(
-                        Halted(
-                            body_exit.guard,
-                            ExpectationNotMetEffect("raise", self.site),
-                            body_exit.value,
+                    if isinstance(semantics.mode, ExpectsModeV1):
+                        exits.append(
+                            Halted(
+                                body_exit.guard,
+                                ExpectationNotMetEffect("raise", self.site),
+                                body_exit.value,
+                            )
                         )
-                    )
+                    else:
+                        exits.append(body_exit)
                 elif isinstance(body_exit.effect, RaiseEffect) and _matches_raise(
                     body_exit.effect, expected, pattern
                 ):
@@ -146,6 +151,15 @@ def _bind_real_actuals(signature, manager_value):
     keyword_count = len(manager_value.keyword_names)
     positional_count = len(manager_value.arg_values) - keyword_count
     positional = list(manager_value.arg_values[:positional_count])
+    if manager_value.runtime_dispatch_receiver is not None:
+        if (
+            not positional
+            or positional[0] is not manager_value.runtime_dispatch_receiver
+        ):
+            raise ContextManagerContractError(
+                "constructed method receiver is absent from its call coordinate"
+            )
+        positional = positional[1:]
     keywords = dict(
         zip(
             manager_value.keyword_names,

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
@@ -68,7 +68,7 @@ class SomeGuard:
             raise ExitFailure("exit failed")
         if effect_type is None:
             raise ExpectationNotMet("expected effect was absent")
-        return issubclass(effect_type, self.expected_exception)
+        return effect_type is self.expected_exception
 
 
 def some_manager(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -48,6 +48,8 @@ class ConstructedManagerBehaviorV1:
     receiver_state_cid: str
     formal_actual_bindings: tuple[BindingEntryV1, ...]
     source_call_frame_cid: str
+    formal_actual_values: tuple[FloorValue, ...] = field(default=(), compare=False)
+    source_call_frame: object | None = field(default=None, compare=False, repr=False)
     factory_prefix: tuple[FloorValue, ...] = field(default=(), compare=False)
     factory_prefix_cids: tuple[str, ...] = ()
 
@@ -70,6 +72,23 @@ class ConstructedManagerBehaviorV1:
             raise ValueError("receiver state CID does not match ordinary construction")
         if cid_of_json(self.preimage) != self.manager_construction_cid:
             raise ValueError("manager construction CID does not match its preimage")
+        if self.formal_actual_values:
+            if len(self.formal_actual_values) != len(self.formal_actual_bindings):
+                raise ValueError("formal actual value/binding arity mismatch")
+            for value, entry in zip(
+                self.formal_actual_values, self.formal_actual_bindings, strict=True
+            ):
+                testimony = entry.sealed_state.testimony
+                if (
+                    testimony is None
+                    or testimony.semantic_value_cid
+                    != _term_content_cid(value.to_term(owner=self.resolved_object_cid))
+                ):
+                    raise ValueError("formal actual value lacks matching testimony")
+        if self.source_call_frame is not None and (
+            self.source_call_frame.frame_cid != self.source_call_frame_cid
+        ):
+            raise ValueError("source call frame CID mismatch")
 
 
 @dataclass(frozen=True)
@@ -149,8 +168,10 @@ def construct_manager_behavior(
         None, owner="construct_manager_behavior", project_callsite=False
     )
     factory_prefix: tuple[FloorValue, ...] = ()
-    if isinstance(result, BlockValue) and result.statements and isinstance(
-        result.statements[-1], ReturnValue
+    if (
+        isinstance(result, BlockValue)
+        and result.statements
+        and isinstance(result.statements[-1], ReturnValue)
     ):
         factory_prefix = result.statements[:-1]
         returned = result.statements[-1].value
@@ -166,8 +187,7 @@ def construct_manager_behavior(
         )
     bindings = frame.runtime_entries
     prefix_cids = tuple(
-        _term_content_cid(item.to_term(owner=resolved.cid))
-        for item in factory_prefix
+        _term_content_cid(item.to_term(owner=resolved.cid)) for item in factory_prefix
     )
     preimage = {
         "kind": "constructed-manager-behavior",
@@ -179,14 +199,16 @@ def construct_manager_behavior(
         "factoryPrefixCids": list(prefix_cids),
     }
     return ConstructedManagerBehaviorV1(
-        resolved.cid,
-        cid_of_json(preimage),
-        result,
-        result.identity,
-        bindings,
-        frame.frame_cid,
-        factory_prefix,
-        prefix_cids,
+        resolved_object_cid=resolved.cid,
+        manager_construction_cid=cid_of_json(preimage),
+        receiver_state=result,
+        receiver_state_cid=result.identity,
+        formal_actual_bindings=bindings,
+        source_call_frame_cid=frame.frame_cid,
+        formal_actual_values=values,
+        source_call_frame=frame,
+        factory_prefix=factory_prefix,
+        factory_prefix_cids=prefix_cids,
     )
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -8,10 +8,28 @@ from typing import Literal
 
 from sugar_lift_py_tests.canonicalizer import encode_jcs
 from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    ContextManagerSemanticsV1,
+    EffectBoundarySemanticsV1,
     EnterResultContractV1,
+    ExceptionInfoBindingV1,
+    ExpectsModeV1,
     ExitContractV1,
+    FormalArgumentProjectionV1,
+    ImportSignatureV2,
+    KeywordOnlyV1,
+    LiteralDefaultV1,
     NeverSuppressesDispositionV1,
+    NoDefaultV1,
+    NoMessagePatternV1,
+    OptionalFormalArgumentProjectionV1,
+    PositionalOnlyV1,
+    PositionalOrKeywordV1,
     ProtocolResourceSemanticsV1,
+    RaiseEffectKindV1,
+    SuppressesModeV1,
+    VariadicKeywordV1,
+    VariadicPositionalV1,
     semantics_to_value,
 )
 from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
@@ -27,7 +45,8 @@ class DerivedManagerSummaryV1:
     protocol_construction_cid: str
     enter_testimony_cid: str
     exit_testimony_cid: str
-    semantics: ProtocolResourceSemanticsV1
+    semantics: ContextManagerSemanticsV1
+    import_signature: ImportSignatureV2
     summary_cid: str
 
     @property
@@ -39,6 +58,9 @@ class DerivedManagerSummaryV1:
             "enterTestimonyCid": self.enter_testimony_cid,
             "exitTestimonyCid": self.exit_testimony_cid,
             "semantics": json.loads(encode_jcs(semantics_to_value(self.semantics))),
+            "importSignature": json.loads(
+                encode_jcs(_signature_to_value(self.import_signature))
+            ),
         }
 
     def __post_init__(self) -> None:
@@ -59,6 +81,8 @@ class DerivedManagerSummaryGapV1:
 
 def derive_manager_summary(
     protocol: ConstructedManagerProtocolV1,
+    *,
+    behavior=None,
 ) -> DerivedManagerSummaryV1 | DerivedManagerSummaryGapV1:
     """Derive only the theorem directly present in constructed outcomes.
 
@@ -72,6 +96,14 @@ def derive_manager_summary(
             "enter-may-halt", protocol.protocol_construction_cid, "__enter__ ExitSet"
         )
     exit_ = outcome_to_exitset(protocol.exit_outcome())
+    boundary = (
+        _derive_effect_boundary(exit_, protocol, behavior)
+        if behavior is not None
+        else None
+    )
+    if boundary is not None:
+        signature = _signature_for_behavior(behavior, boundary)
+        return _sealed_summary(protocol, boundary, signature)
     if not exit_.exits or any(not isinstance(face, Completed) for face in exit_.exits):
         return DerivedManagerSummaryGapV1(
             "exit-may-halt", protocol.protocol_construction_cid, "__exit__ ExitSet"
@@ -87,6 +119,11 @@ def derive_manager_summary(
         EnterResultContractV1(PrimitiveSort("Value")),
         ExitContractV1(NeverSuppressesDispositionV1()),
     )
+    signature = _signature_for_behavior(behavior, semantics)
+    return _sealed_summary(protocol, semantics, signature)
+
+
+def _sealed_summary(protocol, semantics, signature):
     preimage = {
         "kind": "source-derived-context-manager-summary",
         "schemaVersion": "1",
@@ -94,14 +131,221 @@ def derive_manager_summary(
         "enterTestimonyCid": protocol.enter_frame_cid,
         "exitTestimonyCid": protocol.exit_frame_cid,
         "semantics": json.loads(encode_jcs(semantics_to_value(semantics))),
+        "importSignature": json.loads(encode_jcs(_signature_to_value(signature))),
     }
     return DerivedManagerSummaryV1(
         protocol.protocol_construction_cid,
         protocol.enter_frame_cid,
         protocol.exit_frame_cid,
         semantics,
+        signature,
         cid_of_json(preimage),
     )
+
+
+def _derive_effect_boundary(exit_set, protocol, behavior):
+    from sugar_lift_py_tests.floor import BlockValue, BranchResultAuthentication
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    from sugar_lift_py_tests.ir import _Atomic, _Connective, _Ctor
+    from sugar_lift_py_tests.outcome import Halted
+
+    predicates = []
+    authentications = []
+    for face in exit_set.exits:
+        if not isinstance(face, Completed) or not isinstance(face.value, BlockValue):
+            continue
+        authentications.extend(
+            item
+            for item in face.value.statements
+            if isinstance(item, BranchResultAuthentication)
+        )
+        if (
+            face.value.statements
+            and isinstance(face.value.statements[-1], ReturnValue)
+            and isinstance(face.value.statements[-1].value, PredicateValue)
+        ):
+            predicates.append(face.value.statements[-1].value.formula)
+    if not predicates or any(
+        predicate != predicates[0] for predicate in predicates[1:]
+    ):
+        return None
+    formula = predicates[0]
+    actuals = tuple(behavior.formal_actual_values)
+    actual_terms = tuple(
+        value.to_term(owner=behavior.resolved_object_cid) for value in actuals
+    )
+    expected_index = _formal_index_for_coordinate(
+        formula, actual_terms, "python:exit_type"
+    )
+    if expected_index is None:
+        return None
+    message_index = _formal_index_for_coordinate(
+        formula, actual_terms, "python:exit_value"
+    )
+    absent_effect_halts = tuple(
+        face
+        for face in exit_set.exits
+        if isinstance(face, Halted)
+        and any(
+            _authentication_is_no_effect(item, protocol.exit_face_id)
+            and _formula_mentions_branch_slot(face.guard, item.slot.slot_id)
+            for item in authentications
+        )
+    )
+    halted = tuple(face for face in exit_set.exits if isinstance(face, Halted))
+    if any(face not in absent_effect_halts for face in halted):
+        # A source-visible exit failure is not evidence that matching effects
+        # are consumed.  It remains a protocol-construction gap until its own
+        # outgoing face is represented by the summary schema.
+        return None
+    expects = bool(absent_effect_halts)
+    return EffectBoundarySemanticsV1(
+        ExpectsModeV1() if expects else SuppressesModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(expected_index),
+        (
+            NoMessagePatternV1()
+            if message_index is None
+            else OptionalFormalArgumentProjectionV1(message_index)
+        ),
+        ExceptionInfoBindingV1(),
+    )
+
+
+def _formal_index_for_coordinate(formula, actual_terms, coordinate_name):
+    from sugar_lift_py_tests.ir import _Atomic, _Connective
+
+    candidates = set()
+    pending = [formula]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, _Connective):
+            pending.extend(current.operands)
+            continue
+        if not isinstance(current, _Atomic) or current.name not in {
+            "eq",
+            "py.eq",
+            "identity",
+        }:
+            continue
+        if not any(_term_contains_ctor(arg, coordinate_name) for arg in current.args):
+            continue
+        for index, term in enumerate(actual_terms):
+            if term in current.args:
+                candidates.add(index)
+    return next(iter(candidates)) if len(candidates) == 1 else None
+
+
+def _term_contains_ctor(term, name):
+    from sugar_lift_py_tests.ir import _Ctor
+
+    return isinstance(term, _Ctor) and (
+        term.name == name or any(_term_contains_ctor(arg, name) for arg in term.args)
+    )
+
+
+def _authentication_is_no_effect(authentication, exit_face_id):
+    from sugar_lift_py_tests.ir import _Atomic, _Ctor
+
+    guard = authentication.observed_guard
+    if not isinstance(guard, _Atomic) or guard.name not in {"eq", "identity"}:
+        return False
+    return any(
+        isinstance(arg, _Ctor)
+        and arg.name == "python:exit_type"
+        and arg.args
+        and getattr(arg.args[0], "value", None) == exit_face_id
+        for arg in guard.args
+    ) and any(isinstance(arg, _Ctor) and arg.name == "None" for arg in guard.args)
+
+
+def _formula_mentions_branch_slot(formula, slot_id):
+    from sugar_lift_py_tests.ir import _Atomic, _Connective
+
+    if isinstance(formula, _Connective):
+        return any(
+            _formula_mentions_branch_slot(item, slot_id) for item in formula.operands
+        )
+    return isinstance(formula, _Atomic) and any(
+        _term_mentions_string(arg, slot_id) for arg in formula.args
+    )
+
+
+def _term_mentions_string(term, value):
+    from sugar_lift_py_tests.ir import _Ctor
+
+    return getattr(term, "value", None) == value or (
+        isinstance(term, _Ctor)
+        and any(_term_mentions_string(arg, value) for arg in term.args)
+    )
+
+
+def _signature_for_behavior(behavior, semantics):
+    if behavior is None or behavior.source_call_frame is None:
+        return ImportSignatureV2(())
+    from sugar_lift_py_tests.ir import term_to_value
+
+    frame = behavior.source_call_frame
+    expected_index = (
+        semantics.expected_type_operand.parameter_index
+        if isinstance(semantics, EffectBoundarySemanticsV1)
+        else None
+    )
+    message_index = (
+        semantics.message_pattern_operand.parameter_index
+        if isinstance(semantics, EffectBoundarySemanticsV1)
+        and isinstance(
+            semantics.message_pattern_operand, OptionalFormalArgumentProjectionV1
+        )
+        else None
+    )
+    passing_types = {
+        "positional_only": PositionalOnlyV1,
+        "positional_or_keyword": PositionalOrKeywordV1,
+        "keyword_only": KeywordOnlyV1,
+        "vararg": VariadicPositionalV1,
+        "kwarg": VariadicKeywordV1,
+    }
+    parameters = []
+    for index, (name, kind, default_sugar) in enumerate(
+        zip(
+            frame.parameters,
+            frame.parameter_kinds,
+            frame.default_sugars,
+            strict=True,
+        )
+    ):
+        variadic = kind in {"vararg", "kwarg"}
+        default = NoDefaultV1()
+        sort = PrimitiveSort("String" if index == message_index else "Value")
+        if default_sugar is not None:
+            from sugar_lift_py_tests.outcome import Complete
+
+            outcome = default_sugar.desugar()
+            if not isinstance(outcome, Complete):
+                raise ValueError("source default did not construct completely")
+            raw = json.loads(
+                encode_jcs(term_to_value(outcome.value.to_term(owner=name)))
+            )
+            default = LiteralDefaultV1(raw)
+            if raw.get("kind") == "const":
+                sort = PrimitiveSort(raw["sort"]["name"])
+        parameters.append(
+            CallParameterV1(
+                name,
+                sort,
+                passing_types[kind](),
+                not variadic and default_sugar is None,
+                default,
+            )
+        )
+    return ImportSignatureV2(tuple(parameters))
+
+
+def _signature_to_value(signature):
+    from sugar_lift_py_tests.context_manager_contract import import_signature_to_value
+
+    return import_signature_to_value(signature)
 
 
 def _exact_never_suppresses(value: object) -> bool:
@@ -296,13 +540,17 @@ def populate_source_derived_resource_refs(
         if not isinstance(protocol, ConstructedManagerProtocolV1):
             _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
             continue
-        summary = derive_manager_summary(protocol)
+        summary = derive_manager_summary(protocol, behavior=behavior)
         if not isinstance(summary, DerivedManagerSummaryV1):
             _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
             continue
         context.source_derived_contract_refs[coordinate] = (
             SourceDerivedContextManagerRefV1(
-                coordinate, summary.summary_cid, summary.semantics, protocol
+                coordinate,
+                summary.summary_cid,
+                summary.semantics,
+                summary.import_signature,
+                protocol,
             )
         )
 

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -4,6 +4,8 @@ import csv
 import importlib.metadata
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
 from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -250,9 +252,7 @@ def test_fixture_manager_class_bodies_construct_docstrings_and_class_fields():
 def test_nested_class_member_constructs_as_exact_class_field_through_same_door():
     source = SourceFile(
         (
-            "class Outer:\n"
-            "    class Inner:\n"
-            "        marker = 17\n",
+            "class Outer:\n" "    class Inner:\n" "        marker = 17\n",
             "nested-class.py",
             "blake3-512:" + ("34" * 64),
         )
@@ -488,13 +488,17 @@ def test_renamed_multistatement_implicit_none_exit_derives_never_suppresses(
 
 
 def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
-    fixture = (
-        Path(__file__).parents[2]
-        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
-        / "arbitrary_manager_module.py"
-    )
     graph, resolved, actual, call_site = _resolved(
-        tmp_path, fixture.read_text(encoding="utf-8"), exported="some_manager"
+        tmp_path,
+        "class OpaqueBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return issubclass(effect_type, self.expected)\n"
+        "def make_guard(expected):\n"
+        "    return OpaqueBoundary(expected)\n",
     )
     behavior = construct_manager_behavior(
         resolved, graph=graph, actuals=(actual,), call_site=call_site
@@ -507,6 +511,135 @@ def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
 
     assert isinstance(summary, DerivedManagerSummaryGapV1)
     assert summary.kind in {"enter-may-halt", "opaque-exit-truthiness"}
+
+
+def test_renamed_source_visible_exit_derives_expects_raise_boundary(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n"
+        "def make_guard(expected):\n"
+        "    return ArbitraryBoundary(expected)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="renamed-effect-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol, behavior=behavior)
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(summary.semantics.mode, ExpectsModeV1)
+    assert isinstance(summary.semantics.effect_kind, RaiseEffectKindV1)
+    assert summary.semantics.expected_type_operand == FormalArgumentProjectionV1(0)
+
+
+def test_renamed_source_visible_exit_derives_suppresses_mode(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return effect_type is self.expected\n"
+        "def make_guard(expected):\n"
+        "    return ArbitraryBoundary(expected)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="suppresses-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol, behavior=behavior)
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        SuppressesModeV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(summary.semantics.mode, SuppressesModeV1)
+
+
+def test_renamed_effect_boundary_derives_message_operand_from_real_formal(tmp_path):
+    graph, resolved, expected, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryBoundary:\n"
+        "    def __init__(self, expected, pattern):\n"
+        "        self.expected = expected\n"
+        "        self.pattern = pattern\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return (effect_type is self.expected) and (effect.message == self.pattern)\n"
+        "def make_guard(expected, pattern):\n"
+        "    return ArbitraryBoundary(expected, pattern)\n",
+    )
+    from sugar_lift_py_tests.floor import StringValue
+    from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+    from sugar_lift_py_tests.ir import _term_content_cid
+
+    pattern_source = SourceFile(
+        ('"needle"\n', str(tmp_path / "pattern.py"), "blake3-512:" + ("91" * 64))
+    )
+    pattern_node = next(
+        node for node in pattern_source.nodes() if isinstance(node, Constant)
+    )
+    pattern_value = StringValue("needle")
+    pattern = ConstructedCallActualV1(
+        pattern_node,
+        pattern_value,
+        ConstructedValueTestimonyV1.mint(
+            pattern_node.fragment,
+            _term_content_cid(pattern_value.to_term(owner=resolved.cid)),
+        ),
+    )
+    behavior = construct_manager_behavior(
+        resolved,
+        graph=graph,
+        actuals=(expected, pattern),
+        call_site=call_site,
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="message-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol, behavior=behavior)
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    assert summary.semantics.message_pattern_operand == (
+        OptionalFormalArgumentProjectionV1(1)
+    )
 
 
 def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):
@@ -556,7 +689,11 @@ def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):
         span.end_col,
     )
     context.source_derived_contract_refs[coordinate] = SourceDerivedContextManagerRefV1(
-        coordinate, summary.summary_cid, summary.semantics, protocol
+        coordinate,
+        summary.summary_cid,
+        summary.semantics,
+        summary.import_signature,
+        protocol,
     )
 
     sugar = node.sugar()
@@ -614,3 +751,167 @@ def test_preconstruction_populates_resource_ref_from_authenticated_import(tmp_pa
         next(iter(context.source_derived_contract_refs.values())),
         SourceDerivedContextManagerRefV1,
     )
+
+
+def test_preconstruction_populates_renamed_effect_boundary_from_source(tmp_path):
+    implementation = (
+        "class RenamedBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n\n"
+        "def make_boundary(expected):\n"
+        "    return RenamedBoundary(expected)\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="make_boundary")
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        "    with arbitrary.make_boundary(ValueError):\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    reference = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(reference, SourceDerivedContextManagerRefV1)
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(reference.semantics.mode, ExpectsModeV1)
+    assert reference.semantics.expected_type_operand == FormalArgumentProjectionV1(0)
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    boundary = with_node.sugar()
+    assert isinstance(boundary, WithEffectBoundarySugar)
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
+
+    exits = outcome_to_exitset(boundary.desugar()).exits
+    assert len(exits) == 1
+    assert isinstance(exits[0], Halted)
+    assert isinstance(exits[0].effect, ExpectationNotMetEffect)
+
+
+def test_call_result_attribute_keeps_the_exact_constructed_call_coordinate():
+    from sugar_lift_py_tests.floor import CallSiteValue
+    from sugar_lift_py_tests.ir import ctor
+    from sugar_lift_py_tests.outcome import Complete
+
+    call = CallSiteValue("renamed", (), (), ctor("python:call", ()), None)
+    projected = call.attribute("__name__", None)
+
+    assert isinstance(projected, Complete)
+    assert projected.value.term.args[0] is call.term
+    assert projected.value.term.args[1].value == "__name__"
+
+
+def test_installed_source_boundary_with_opaque_builtin_verdict_stays_loud(tmp_path):
+    consumer = (
+        "import pytest\n"
+        "def use_boundary():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        raise ValueError('boom')\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        TreeConstructionContextV1,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+
+    resolution = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(resolution, ContextManagerResolutionGapV1)
+    assert resolution.kind == "no-derived-contract"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_face", "expected_effect"),
+    [
+        ('raise ValueError("needle")', "completed", None),
+        ('raise TypeError("needle")', "halted", "RaiseEffect"),
+        ('raise ValueError("different")', "halted", "RaiseEffect"),
+        ("pass", "halted", "ExpectationNotMetEffect"),
+    ],
+)
+def test_renamed_source_boundary_routes_type_and_message_by_derived_formals(
+    tmp_path, body, expected_face, expected_effect
+):
+    implementation = (
+        "class Boundary:\n"
+        "    def __init__(self, expected, pattern):\n"
+        "        self.expected = expected\n"
+        "        self.pattern = pattern\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return (effect_type is self.expected) and (effect.message == self.pattern)\n\n"
+        "def boundary(expected, pattern):\n"
+        "    return Boundary(expected, pattern)\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="boundary")
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        '    with arbitrary.boundary(ValueError, "needle"):\n'
+        f"        {body}\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    from sugar_lift_py_tests.outcome import Completed, Halted, outcome_to_exitset
+
+    face = outcome_to_exitset(boundary.desugar()).exits[0]
+    assert type(face).__name__.lower() == expected_face
+    if isinstance(face, Halted):
+        assert type(face.effect).__name__ == expected_effect
+    else:
+        assert isinstance(face, Completed)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3385,6 +3385,7 @@ class With(Statement):
         from sugar_lift_py_tests.context_manager_contract import (
             EffectBoundarySemanticsV1,
             ExpectsModeV1,
+            SuppressesModeV1,
             RaiseEffectKindV1,
             NeverSuppressesDispositionV1,
             ProtocolResourceSemanticsV1,
@@ -3423,7 +3424,7 @@ class With(Statement):
         admitted_boundary = (
             isinstance(semantics, EffectBoundarySemanticsV1)
             and semantics.schema_version == "1"
-            and isinstance(semantics.mode, ExpectsModeV1)
+            and isinstance(semantics.mode, (ExpectsModeV1, SuppressesModeV1))
             and isinstance(semantics.effect_kind, RaiseEffectKindV1)
         )
         if not (admitted_resource or admitted_boundary):
@@ -3491,7 +3492,9 @@ class With(Statement):
                 SourceDerivedContextManagerRefV1,
             )
 
-            if isinstance(resolved_ref, SourceDerivedContextManagerRefV1):
+            if isinstance(
+                resolved_ref, SourceDerivedContextManagerRefV1
+            ) and isinstance(resolved_ref.semantics, ProtocolResourceSemanticsV1):
                 from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
                     WithSourceResourceSugar,
                 )
@@ -3536,8 +3539,12 @@ class With(Statement):
                     body=tuple(stmt.sugar() for stmt in self.body),
                     semantics=resolved_ref.semantics,
                     contract_ref=resolved_ref,
-                    context_manager_edge=ContextManagerEdgeDtoV1.from_resolved(
-                        resolved_ref, resolved_ref.use_site
+                    context_manager_edge=(
+                        None
+                        if isinstance(resolved_ref, SourceDerivedContextManagerRefV1)
+                        else ContextManagerEdgeDtoV1.from_resolved(
+                            resolved_ref, resolved_ref.use_site
+                        )
                     ),
                     site=self.fragment,
                 )
@@ -3590,12 +3597,13 @@ class With(Statement):
             AuthenticatedExceptionTypeSugar,
         )
         from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+        from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
 
         selector = reference.semantics.expected_type_operand
         if not isinstance(selector, FormalArgumentProjectionV1):
             return manager_sugar
         if not isinstance(manager, Call) or not isinstance(
-            manager_sugar, CallSiteSugar
+            manager_sugar, (CallSiteSugar, MethodCallSugar)
         ):
             return manager_sugar
         positional = list(enumerate(manager.args))


### PR DESCRIPTION
## Outcome

Adds Cut E's source-derived EffectBoundary arm. A manager's constructed `__exit__` testimony now derives `Expects` or `Suppresses`, the expected exception selector, and the optional message selector from authenticated formal/actual bindings. The immutable h=h(p) summary carries the complete import signature and feeds the existing `WithEffectBoundarySugar` router.

No provider catalog, manager/package spelling, builtin model, or second evaluator is introduced. Installed `pytest.raises` remains typed-loud at its opaque builtin suppression verdict.

## Executable evidence

- Renamed source boundary: matching type+message consumed; wrong type propagates; message mismatch propagates; normal completion produces `ExpectationNotMetEffect`.
- Renamed `Suppresses` boundary derives from a fully source-visible return predicate.
- `CallSiteValue.attribute` preserves the exact constructed call coordinate for `type(other).__name__`-style source construction.
- Installed `pytest.raises` discrimination: `ContextManagerResolutionGapV1(no-derived-contract)` at the opaque builtin verdict.
- Focused tests: `52 passed`.
- `R_construction_side_doors = 0` (`auditor_errors=0`).
- `R_construction_invariant_violations = 0`; every axis, including second path and name spelling gate, is 0.

## Shot accounting

- Predicted epsilon: source-visible EffectBoundary managers whose exit matching predicate fully constructs move from typed-loud to source-derived With construction.
- Opaque/native/dynamic builtin verdicts remain measured red; pandas delta awaits the shared corrected census and is not fabricated here.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive `EffectBoundary` semantics from constructed manager source in `with` statements
> - `derive_manager_summary` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6169/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) now inspects the exit set and formal actual values to detect `Expects`/`Suppresses` raise patterns and emit `EffectBoundary` semantics instead of always returning resource semantics.
> - `ConstructedManagerBehaviorV1` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6169/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now records the concrete formal actual values and source call frame, validating their consistency at construction time.
> - `SourceDerivedContextManagerRefV1` gains a required `import_signature` field, and source-derived effect boundaries no longer carry a `ContextManagerEdgeDto`.
> - `WithEffectBoundarySugar.desugar` now admits `SuppressesModeV1` in addition to `ExpectsModeV1`; in suppresses mode, body completion passes through rather than halting.
> - `_bind_real_actuals` now validates and strips the dispatch receiver for method-based managers before signature matching.
> - Risk: `SourceDerivedContextManagerRefV1` construction is now a breaking change — callers must supply `import_signature`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fa2b74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->