### PR TITLE
Measure pandas recensus O(R) lexical revalidation cost

### DIFF
--- a/docs/audits/pandas-recensus-latency-bisect.md
+++ b/docs/audits/pandas-recensus-latency-bisect.md
@@ -1,0 +1,228 @@
+# Pandas construction recensus latency bisect
+
+Date: 2026-07-23  
+Worktree: `pandas-with-recensus-20260723`  
+Corpus: installed `pandas==3.0.3`  
+Probe: `implementations/python/sugar-lift-py-tests/scripts/pandas_recensus_latency_probe.py`
+
+## Symptom
+
+Single production files in the construction recensus spend **~87–160s** wall time
+(e.g. `core/arrays/categorical.py`, `core/arrays/datetimelike.py`) where the
+expectation for a construction pass over one module is **milliseconds–low
+seconds**.
+
+The recensus path is honest: `production_source_file` (source-derived CM refs +
+source-visible call frames) then `function.sugar()` for every function. This
+bisect does **not** recommend skipping that door.
+
+## Method
+
+1. Phased single-file probe with `artifact_graph_cache` shared as recensus does.
+2. Internal counters on `AuthenticatedImportUseV1.revalidate` and
+   `authenticated_import_uses`.
+3. Micro-timers around `DependencyArtifactGraph.authenticate`,
+   `resolve_import_binding`, and `resolve_source_visible_frame`.
+
+Commands (from repo root, local Mac probe — one/two files only):
+
+```bash
+export PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts:\
+implementations/python/sugar-lift-py-tests/src:\
+implementations/python/sugar-source-tree/src:\
+implementations/python/sugar-lift-python-source/src
+
+python3 implementations/python/sugar-lift-py-tests/scripts/pandas_recensus_latency_probe.py \
+  --file core/arrays/categorical.py \
+  --phase-preconstruction \
+  --json /tmp/pandas-latency-categorical-nolog.json
+```
+
+Counter run (preconstruction only, two hot files, warm graph cache across files):
+
+```bash
+# see /tmp/pandas-latency-bisect-summary.json from the bisect session
+```
+
+## Quantified breakdown
+
+### `core/arrays/categorical.py` (3183 lines, 88 functions, 508 Call nodes, 1 With)
+
+| Phase | Seconds | Share |
+| --- | ---: | ---: |
+| `populate_source_visible_call_frames` | **137.3** | **~92%** |
+| `populate_source_derived_resource_refs` | 1.05 | ~0.7% |
+| `SourceFile` materialize | 0.05 | ~0% |
+| install unresolved CM gaps | 0.07 | ~0% |
+| With inventory walk | 0.08 | ~0% |
+| all `function.sugar()` (88) | **10.1** | **~7%** |
+| **total** | **~149** | 100% |
+
+Top function construction times (after preconstruction): max **1.1s**
+(`__init__`), median **16ms**, sum **10.05s**. Construction is not the wall.
+
+Preconstruction-only counter run (shared cache):
+
+| File | preconstruction_s | revalidate_calls | authenticated_import_uses_calls | s/revalidate est. |
+| --- | ---: | ---: | ---: | ---: |
+| `core/arrays/categorical.py` | **121.2** | **125** | **127** | **0.97** |
+| `core/arrays/datetimelike.py` | **159.8** | **169** | **171** | **0.95** |
+
+`auth_uses ≈ revalidate + 2`: the `+2` is the two mint passes
+(`populate_source_visible_call_frames` and `populate_source_derived_resource_refs`
+each call `authenticated_import_use_receipts` once). Every remaining call is
+**one full-module lexical re-scan per import-use receipt** inside
+`resolve_import_binding` → `AuthenticatedImportUseV1.revalidate`.
+
+### Inside the call-frame loop (categorical, warm numbers)
+
+| Substep | Seconds | Notes |
+| --- | ---: | --- |
+| `DependencyArtifactGraph.authenticate(pandas)` | ~22–24 | 2944 files; **once** then cache hit |
+| `DependencyArtifactGraph.authenticate(numpy)` | ~9–10 | 1336 files; **once** then cache hit |
+| `resolve_import_binding` (all matched receipts) | **~100–106** | **uncached**; second full pass still ~97s |
+| `resolve_source_visible_frame` | 0.17 | only 2 receipts reach it |
+| `authenticated_import_use_receipts` mint | 0.87 | once per populate_* |
+
+Matched import-use Call receipts: **134** (categorical). Outcomes:
+
+- `dynamic-export` gaps: **99** (still pay full revalidate)
+- `target-outside-binding` gaps: **24**
+- resolved OK: **2** (then `opaque-call-target` at frame build)
+
+So almost all of the ~100s is spent re-proving lexical import uses that already
+failed export resolution — and re-proving them **again on every receipt**.
+
+### Sample `resolve_import_binding` costs (same symbol paid repeatedly)
+
+| elapsed_ms | result | target |
+| ---: | --- | --- |
+| 1228 | ok | `pandas.core.algorithms.take_nd` |
+| 1098 | dynamic-export | `pandas.core.indexes.range.RangeIndex` |
+| 1029 / 966 / 955 | dynamic-export | `pandas._config.get_option` (×3) |
+| 937 / 929 / 906 | dynamic-export | `pandas.core.construction.sanitize_array` (×3) |
+| ~890 | dynamic-export | `numpy.array` / `numpy.bincount` / … |
+
+Per-receipt cost is dominated by `revalidate()` (~**0.72s** average on this
+machine for categorical's source), not by `resolve_export` (~3.3s total for the
+file).
+
+### Function construction / engine log
+
+- Engine log is **not** on the full recensus path (`run_pandas_recensus_remote.sh`
+  does not set `SUGAR_ENGINE_LOG`). Span overhead is therefore not the live
+  multi-minute wall.
+- When enabled, statement-level `SubstituteStatement` spans are dense; useful for
+  bisection, not the primary multi-minute cost here.
+- Gaps / `SugarNotWritten` do **not** cause pathological retries in the recensus
+  loop (one `function.sugar()` per function; panics are caught and counted).
+
+### Once per file vs once per function
+
+| Work | Frequency |
+| --- | --- |
+| `populate_source_visible_call_frames` | **once per file** |
+| `populate_source_derived_resource_refs` | **once per file** |
+| `artifact_graph_cache` authenticate | **once per distribution** (shared across files) |
+| `AuthenticatedImportUseV1.revalidate` → full `#6090` lexical pass | **once per import-use receipt** inside that file |
+| `function.sugar()` | once per function (~10s total on categorical) |
+
+Cost is **quadratic in the wrong place**: for a file with `R` authenticated
+import-use receipts, the resolution door re-runs the **entire** module lexical
+pass `R` times → **O(R · size(module_lexical_analysis))** per file, with no
+process cache.
+
+## Root cause
+
+### Primary mechanism (dominant)
+
+`resolve_import_binding` always calls `authenticated_use.revalidate()`:
+
+```178:197:implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+    def revalidate(self) -> None:
+        """Re-run #6090 and demand byte identity at the resolution door."""
+        rows, outcomes = authenticated_import_uses(
+            self.root,
+            self.path,
+            self.source,
+            self.source_cid,
+            module_identities=self.module_identities,
+        )
+        ...
+        if outcomes.get(key) != "authenticated-import-use" or self.demand not in rows:
+            raise ValueError(...)
+```
+
+That re-executes the full non-constructing lexical import-use analysis for the
+**whole consumer module** on **every** receipt. Preconstruction then does:
+
+```
+for receipt in receipts:          # R ≈ 125–170 on hot pandas files
+    resolve_import_binding(...)   # each → full authenticated_import_uses
+```
+
+Observed: **R ≈ auth_uses − 2**, **~0.95–0.97s per revalidate**, wall time
+**~120–160s/file** before any function construction.
+
+### Secondary (first file / cold process)
+
+`DependencyArtifactGraph.authenticate` hashes every recorded installed file
+(pandas ~2944, numpy ~1336) — **~30s** cold. Recensus already shares
+`artifact_graph_cache` across files, so this is a one-time process tax, not the
+per-file 87–134s after the first hit.
+
+### Non-causes (ruled out)
+
+| Hypothesis | Verdict |
+| --- | --- |
+| Per-function re-preconstruction | **No** — populate once per file |
+| Gap rethrow / retry storms | **No** — single sugar attempt per function |
+| Engine-log sync I/O on full recensus | **No** — log not enabled |
+| Artifact graph rebuild every file | **No** — cache hits after first authenticate |
+| Function construction itself | **No** — ~10s of ~150s |
+
+## Fix shape (one cut)
+
+**Amortize lexical revalidation at the resolution door** — one general
+capability, not a pandas special case:
+
+1. **Preferred:** cache `authenticated_import_uses(root, path, source, source_cid, …)`
+   process-locally keyed by `(source_cid, path, identity_fingerprint)` with the
+   same content-keyed eviction discipline as `source_tables` (finite LRU).
+   `revalidate()` becomes O(use-site check) after the first call for that module.
+2. **Equivalent batch form:** preconstruction resolves all receipts under one
+   shared revalidation snapshot minted once per file, then only checks demand
+   membership / CID identity per receipt (no N full rescans).
+3. **Keep the law loud:** revalidation must still fail if the demand is not
+   byte-identical to the lexical pass; only the **recompute frequency** changes.
+4. **Optional second cut (smaller):** memoize `resolve_export` /
+   `resolve_import_binding` by
+   `(distribution_artifact_cid, module_name, exported_name)` so repeated
+   `get_option` / `sanitize_array` / `numpy.array` sites do not re-walk export
+   chains after revalidation is fixed (today export is ~3s/file; secondary).
+
+Do **not** “fix” by skipping `production_source_file`, silencing gaps, or
+dropping call-frame preconstruction. Those doors are the measurement.
+
+### Expected delta after primary fix
+
+For categorical-class files: **~R × 0.95s → ~1 lexical pass (~1s)** plus real
+export work (~3s) plus construction (~10s) → **order-of-magnitude drop** from
+~120–160s preconstruction to **low tens of seconds or less** (plus cold
+authenticate once per process). Across a full pandas recensus with thousands of
+import-use receipts, wall time should fall by **minutes to hours**.
+
+## Red instrument
+
+`test_resolve_import_binding_amortizes_lexical_revalidation` in
+`implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py`
+counts `authenticated_import_uses` invocations while resolving **N>1** receipts
+from one consumer module and fails while the count remains **Ω(N)**.
+
+That pin stays red until revalidation is amortized; it is a structural budget,
+not a flaky wall-clock threshold.
+
+## Probe artifact
+
+`pandas_recensus_latency_probe.py` remains the local/battleaxe single-file
+bisection tool (`--phase-preconstruction`, optional `--engine-log`).

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_recensus_latency_probe.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_recensus_latency_probe.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Single-file construction latency bisection for pandas recensus.
+
+Phases:
+  1. production_source_file (preconstruction + SourceFile materialize)
+  2. With inventory walk
+  3. per-function function.sugar()
+
+Engine log (JSONL) is optional via SUGAR_ENGINE_LOG / --engine-log.
+After run, prints top spans by elapsed_ms from the JSONL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from _production_source_file import production_source_file  # noqa: E402
+
+
+def _analyze_engine_log(path: Path, top_n: int = 20) -> dict:
+    """Summarize exit events by sugar/role and list top elapsed spans."""
+    by_sugar: Counter[str] = Counter()
+    by_role: Counter[str] = Counter()
+    by_sugar_role: Counter[str] = Counter()
+    event_counts: Counter[str] = Counter()
+    exits: list[dict] = []
+    heartbeats = 0
+    errors = 0
+    total_exit_ms = 0.0
+    # Nested child time is double-counted if we sum all exits; also report
+    # root-ish sugars of interest.
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event = row.get("event")
+        event_counts[event] += 1
+        if event == "heartbeat":
+            heartbeats += 1
+            continue
+        if event == "error":
+            errors += 1
+        if event not in {"exit", "error", "propagate"}:
+            continue
+        elapsed = float(row.get("elapsed_ms") or 0.0)
+        sugar = row.get("sugar") or "?"
+        role = row.get("role") or "?"
+        by_sugar[sugar] += elapsed
+        by_role[role] += elapsed
+        by_sugar_role[f"{sugar}|{role}"] += elapsed
+        total_exit_ms += elapsed
+        exits.append(
+            {
+                "elapsed_ms": elapsed,
+                "sugar": sugar,
+                "role": role,
+                "site": row.get("site"),
+                "event": event,
+                "error_type": row.get("error_type"),
+            }
+        )
+    exits.sort(key=lambda r: r["elapsed_ms"], reverse=True)
+    return {
+        "logPath": str(path),
+        "eventCounts": dict(event_counts.most_common()),
+        "heartbeats": heartbeats,
+        "errors": errors,
+        "sumExitElapsedMs": round(total_exit_ms, 3),
+        "note": "sumExitElapsedMs double-counts nested spans",
+        "bySugarMs": {k: round(v, 3) for k, v in by_sugar.most_common(30)},
+        "byRoleMs": {k: round(v, 3) for k, v in by_role.most_common(20)},
+        "bySugarRoleMs": {
+            k: round(v, 3) for k, v in by_sugar_role.most_common(30)
+        },
+        "topSpans": exits[:top_n],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--file",
+        required=True,
+        help="relative path under pandas root, e.g. core/arrays/categorical.py",
+    )
+    parser.add_argument("--corpus", type=Path, default=None)
+    parser.add_argument(
+        "--engine-log",
+        type=Path,
+        default=None,
+        help="JSONL path (also sets SUGAR_ENGINE_LOG before imports that log)",
+    )
+    parser.add_argument(
+        "--limit-functions",
+        type=int,
+        default=0,
+        help="if >0, only first N functions",
+    )
+    parser.add_argument(
+        "--skip-sugar",
+        action="store_true",
+        help="only measure production_source_file + inventory",
+    )
+    parser.add_argument(
+        "--phase-preconstruction",
+        action="store_true",
+        help="time SourceFile vs populate_* separately",
+    )
+    parser.add_argument("--json", type=Path, default=None)
+    parser.add_argument("--top-spans", type=int, default=20)
+    args = parser.parse_args()
+
+    if args.engine_log is not None:
+        args.engine_log.parent.mkdir(parents=True, exist_ok=True)
+        if args.engine_log.exists():
+            args.engine_log.unlink()
+        os.environ["SUGAR_ENGINE_LOG"] = str(args.engine_log.resolve())
+        # Re-configure after env is set (module may have already run configure).
+        from sugar_lift_py_tests import engine_log
+
+        engine_log._LIVE_HANDLER = None  # type: ignore[attr-defined]
+        engine_log.configure_live_log(str(args.engine_log.resolve()))
+
+    from sugar_source_tree.nodes import With
+    from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
+    from sugar_source_tree.reporter import CollectingReporter
+
+    if args.corpus is None:
+        import pandas
+
+        args.corpus = Path(pandas.__file__).resolve().parent
+
+    path = (args.corpus / args.file).resolve()
+    if not path.is_file():
+        print(f"missing file: {path}", file=sys.stderr)
+        return 2
+
+    package_distributions = importlib.metadata.packages_distributions()
+    distribution_index = {
+        package: importlib.metadata.distribution(distributions[0])
+        for package, distributions in package_distributions.items()
+        if len(distributions) == 1
+    }
+    artifact_graph_cache: dict = {}
+
+    phases: dict[str, float] = {}
+    t0 = time.perf_counter()
+
+    if args.phase_preconstruction:
+        from sugar_lift_py_tests.context_manager_resolution import (
+            TreeConstructionContextV1,
+        )
+        from sugar_lift_python_source.manager_summary_derivation import (
+            populate_source_derived_resource_refs,
+        )
+        from sugar_lift_python_source.source_call_preconstruction import (
+            populate_source_visible_call_frames,
+        )
+        from sugar_lift_python_source.source_oracle import path_source
+        from sugar_source_tree.tree import SourceFile
+        from _production_source_file import _install_unresolved_source_derived_gaps
+
+        reporter = CollectingReporter()
+        t = time.perf_counter()
+        context = TreeConstructionContextV1.for_source_call_construction(
+            workspace_root=str(args.corpus)
+        )
+        source_file = SourceFile(
+            path_source(str(path)), reporter=reporter, construction_context=context
+        )
+        phases["source_file_materialize_s"] = time.perf_counter() - t
+
+        t = time.perf_counter()
+        populate_source_visible_call_frames(
+            source_file,
+            root=args.corpus,
+            path=path,
+            distribution_index=distribution_index,
+            artifact_graph_cache=artifact_graph_cache,
+        )
+        phases["populate_source_visible_call_frames_s"] = time.perf_counter() - t
+
+        t = time.perf_counter()
+        populate_source_derived_resource_refs(
+            source_file,
+            root=args.corpus,
+            path=path,
+            distribution_index=distribution_index,
+            artifact_graph_cache=artifact_graph_cache,
+        )
+        phases["populate_source_derived_resource_refs_s"] = time.perf_counter() - t
+
+        t = time.perf_counter()
+        _install_unresolved_source_derived_gaps(source_file)
+        phases["install_unresolved_gaps_s"] = time.perf_counter() - t
+        phases["production_source_file_s"] = time.perf_counter() - t0
+    else:
+        reporter = CollectingReporter()
+        source_file = production_source_file(
+            path,
+            root=args.corpus,
+            reporter=reporter,
+            distribution_index=distribution_index,
+            artifact_graph_cache=artifact_graph_cache,
+        )
+        phases["production_source_file_s"] = time.perf_counter() - t0
+
+    t = time.perf_counter()
+    with_items = 0
+    for node in source_file.nodes():
+        if isinstance(node, With):
+            with_items += sum(1 for _ in node.items)
+    phases["with_inventory_s"] = time.perf_counter() - t
+
+    # Cache contents after first file
+    cache_keys = sorted(str(k) for k in artifact_graph_cache.keys())
+
+    fn_times: list[dict] = []
+    clean = 0
+    panics = 0
+    not_written = 0
+    functions = list(source_file.functions())
+    if args.limit_functions > 0:
+        functions = functions[: args.limit_functions]
+
+    if not args.skip_sugar:
+        t_all = time.perf_counter()
+        for function in functions:
+            name = getattr(function, "name", "?")
+            lc = function.line_col_span()
+            tf = time.perf_counter()
+            status = "clean"
+            try:
+                function.sugar()
+                clean += 1
+            except SugarNotWritten:
+                not_written += 1
+                status = "SugarNotWritten"
+            except SourceTreePanic as panic:
+                panics += 1
+                status = type(panic).__name__
+            except Exception as exc:  # noqa: BLE001
+                panics += 1
+                status = type(exc).__name__
+            fn_times.append(
+                {
+                    "name": name,
+                    "line": lc.start_line,
+                    "elapsed_ms": round((time.perf_counter() - tf) * 1000, 3),
+                    "status": status,
+                }
+            )
+        phases["all_function_sugar_s"] = time.perf_counter() - t_all
+
+    phases["total_s"] = time.perf_counter() - t0
+    fn_times_sorted = sorted(fn_times, key=lambda r: r["elapsed_ms"], reverse=True)
+
+    result = {
+        "kind": "pandas-recensus-latency-probe-v1",
+        "file": args.file,
+        "path": str(path),
+        "phasesSeconds": {k: round(v, 4) for k, v in phases.items()},
+        "withItems": with_items,
+        "functionsTotal": len(functions),
+        "functionsClean": clean,
+        "functionsNotWritten": not_written,
+        "functionsPanic": panics,
+        "reporterGaps": len(reporter.gaps),
+        "artifactGraphCacheKeys": cache_keys,
+        "topFunctionsByMs": fn_times_sorted[:30],
+        "functionMsSum": round(sum(r["elapsed_ms"] for r in fn_times), 3),
+        "functionMsMax": fn_times_sorted[0]["elapsed_ms"] if fn_times_sorted else 0,
+        "functionMsMedian": (
+            sorted(r["elapsed_ms"] for r in fn_times)[len(fn_times) // 2]
+            if fn_times
+            else 0
+        ),
+        "engineLog": None,
+    }
+
+    if args.engine_log is not None and args.engine_log.exists():
+        result["engineLog"] = _analyze_engine_log(args.engine_log, args.top_spans)
+        result["engineLogBytes"] = args.engine_log.stat().st_size
+
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    print(rendered, flush=True)
+    if args.json is not None:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+        print(f"wrote {args.json}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -382,3 +382,59 @@ def test_export_transfer_exhaustively_classifies_running_ast_statement_grammar()
     missing, extra = export_statement_coverage()
     assert missing == []
     assert extra == []
+
+
+def test_resolve_import_binding_amortizes_lexical_revalidation(tmp_path: Path) -> None:
+    """Red instrument: resolution must not re-run #6090 once per receipt.
+
+    pandas construction recensus paid ~0.95s × R full-module
+    ``authenticated_import_uses`` revalidations inside ``resolve_import_binding``
+    (R≈125–170 on hot files). Revalidation may stay exact; recompute frequency
+    must be amortized to O(1) per consumer module, not Ω(R).
+
+    See docs/audits/pandas-recensus-latency-bisect.md.
+    """
+    from sugar_lift_py_tests import import_binding as ib
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="def build(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    # N distinct call sites → N authenticated import-use receipts for one module.
+    n_sites = 8
+    lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
+    source = "\n".join(lines) + "\n"
+    path = tmp_path / "consumer_many.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert len(receipts) == n_sites
+    assert set(outcomes.values()) == {"authenticated-import-use"}
+
+    lexical_passes = {"count": 0}
+    original = ib.authenticated_import_uses
+
+    def counting_authenticated_import_uses(*args, **kwargs):
+        lexical_passes["count"] += 1
+        return original(*args, **kwargs)
+
+    ib.authenticated_import_uses = counting_authenticated_import_uses
+    try:
+        for receipt in receipts:
+            resolve_import_binding(receipt, graph=graph)
+    finally:
+        ib.authenticated_import_uses = original
+
+    # One shared revalidation snapshot for the consumer module is enough.
+    # Ω(n_sites) means each resolve re-ran the full lexical pass (the live bug).
+    assert lexical_passes["count"] <= 1, (
+        f"resolve_import_binding re-ran authenticated_import_uses "
+        f"{lexical_passes['count']} times for {n_sites} receipts from one module; "
+        f"amortize revalidation (cache or batch) so this stays O(1) per module"
+    )


### PR DESCRIPTION
## Summary
- Bisect of pandas construction recensus single-file latency (categorical ~120–150s, datetimelike ~160s preconstruction).
- Root cause: `AuthenticatedImportUseV1.revalidate` re-runs full `#6090` `authenticated_import_uses` **once per import-use receipt** inside `resolve_import_binding` (Ω(R) full-module lexical passes; R≈125–170 on hot files, ~0.95s each).
- Adds audit report, single-file latency probe, and red instrument `test_resolve_import_binding_amortizes_lexical_revalidation` (currently fails: 8 passes for 8 receipts).

## Evidence
See `docs/audits/pandas-recensus-latency-bisect.md`.

## Next cut
Amortize lexical revalidation (cache/batch O(1) per consumer module); do not skip production door.

## Test plan
- [x] Local probe phased timings on categorical/datetimelike
- [x] Red instrument fails with count=8 for 8 receipts (`pytest ...::test_resolve_import_binding_amortizes_lexical_revalidation`)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add probe and red test to measure pandas recensus O(R) lexical revalidation cost
> - Adds [`pandas_recensus_latency_probe.py`](https://github.com/TSavo/sugar/pull/6170/files#diff-adf733b376dcad6e6e3ac3a8798ac4040749a1976ec5924965e6a4e759afc89e), a CLI tool that runs phase-separated preconstruction and full `production_source_file` builds against a target Pandas file, emitting structured JSON with per-phase timings, cache keys, reporter gaps, and function-level sugar stats.
> - Adds a `_analyze_engine_log` helper that ingests a JSONL engine log and aggregates elapsed times by sugar/role into top-N spans, usable when the probe is run with engine logging enabled.
> - Adds [`test_resolve_import_binding_amortizes_lexical_revalidation`](https://github.com/TSavo/sugar/pull/6170/files#diff-68396b56ec98eb40b3e42e8659cad1f7e94fe33b7e08c6cb1dfd1d67632f1f37), a red test that asserts `authenticated_import_uses` is called at most once when resolving N receipts from the same consumer module, catching O(N) revalidation regressions.
> - Adds [`pandas-recensus-latency-bisect.md`](https://github.com/TSavo/sugar/pull/6170/files#diff-861ed4f19bd5c04d49f528449cb95d11d2dcef0df6c6a950474916c8bdf13108), an audit report with root cause analysis and proposed fixes for the identified latency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31bd84c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->