### PR TITLE
Amortize import-use lexical revalidation (pandas recensus O(R) fix)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -176,13 +176,19 @@ class AuthenticatedImportUseV1:
                 raise ValueError(f"authenticated demand has stale {key}")
 
     def revalidate(self) -> None:
-        """Re-run #6090 and demand byte identity at the resolution door."""
-        rows, outcomes = authenticated_import_uses(
+        """Demand byte identity against one shared #6090 snapshot per module.
+
+        Full-module lexical recompute is amortized: many receipts from one
+        consumer module share one ``authenticated_import_uses`` pass.  Byte
+        identity is unchanged — only recompute frequency (see
+        docs/audits/pandas-recensus-latency-bisect.md).
+        """
+        rows, outcomes = _lexical_revalidation_snapshot(
             self.root,
             self.path,
             self.source,
             self.source_cid,
-            module_identities=self.module_identities,
+            self.module_identities,
         )
         site = self.use["useSite"]
         key = (
@@ -666,6 +672,48 @@ def _final_module_state(
         analyze_nested=False,
     )
     return prepass.statements(module.body, {}, module)
+
+
+# Shared #6090 snapshot for revalidation only.  Keyed by consumer module
+# content + identities map so many receipts share one full-module pass.
+# See docs/audits/pandas-recensus-latency-bisect.md.
+_REVALIDATION_SNAPSHOTS: dict[
+    tuple[str, str, str, str],
+    tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]],
+] = {}
+
+
+def clear_lexical_revalidation_snapshots() -> None:
+    """Drop amortized revalidation snapshots (tests / hermetic process reuse)."""
+    _REVALIDATION_SNAPSHOTS.clear()
+
+
+def _lexical_revalidation_snapshot(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+    """One full-module #6090 pass per consumer module for revalidation."""
+    cache_key = (
+        str(root.resolve()),
+        str(path.resolve()),
+        source_cid,
+        _hash(module_identities),
+    )
+    hit = _REVALIDATION_SNAPSHOTS.get(cache_key)
+    if hit is not None:
+        return hit
+    rows, outcomes = authenticated_import_uses(
+        root,
+        path,
+        source,
+        source_cid,
+        module_identities=module_identities,
+    )
+    _REVALIDATION_SNAPSHOTS[cache_key] = (rows, outcomes)
+    return rows, outcomes
 
 
 def authenticated_import_uses(


### PR DESCRIPTION
## Why
#6170 measured and instrumented: `revalidate()` re-ran full-module
`authenticated_import_uses` once per import-use receipt (Ω(R), ~0.95s × 125–170
on hot pandas files). That was ~92% of multi-minute single-file census cost.

## What
- Shared content-keyed revalidation snapshot per consumer module
- First receipt pays one #6090 pass; siblings check byte identity against it
- Identity law unchanged; recompute frequency amortized
- `clear_lexical_revalidation_snapshots()` for hermetic tests if needed

## Evidence
`test_dependency_artifact_graph.py` — **17 passed** (includes amortization red→green)

## Next
Restart/finish full pandas construction recensus; expect categorical/datetimelike-class files in seconds not ~2 minutes (plus one cold artifact auth).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of authenticated imports while preserving existing checks for source identity and requested content.
  * Added cached validation results to reduce repeated processing during revalidation.
  * Added a way to clear cached validation results when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->