### PR TITLE
fix: bound and memoize fatal construction residue

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_source_file.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_source_file.py
@@ -37,19 +37,23 @@ def production_source_file(
     source_file = SourceFile(
         path_source(str(path)), reporter=reporter, construction_context=context
     )
+    graphs = {} if artifact_graph_cache is None else artifact_graph_cache
+    frames = {}
     populate_source_visible_call_frames(
         source_file,
         root=root,
         path=path,
         distribution_index=distribution_index,
-        artifact_graph_cache=artifact_graph_cache,
+        artifact_graph_cache=graphs,
+        source_frame_cache=frames,
     )
     populate_source_derived_resource_refs(
         source_file,
         root=root,
         path=path,
         distribution_index=distribution_index,
-        artifact_graph_cache=artifact_graph_cache,
+        artifact_graph_cache=graphs,
+        source_frame_cache=frames,
     )
     _install_unresolved_source_derived_gaps(source_file)
     return source_file

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -163,6 +163,10 @@ class TreeConstructionContextV1:
     # subclass definition coordinate.  These are never serialized; the class
     # definition projects their sealed CIDs into its own preimage.
     source_class_bases: dict = field(default_factory=dict)
+    # Source-call frame construction deliberately has no CM enrollment pass.
+    # Its nested With nodes must remain capability-loud, not accuse a missing
+    # row in a table that this context never claimed to populate.
+    contract_enrollment_required: bool = True
 
     @classmethod
     def for_source_call_construction(
@@ -178,6 +182,7 @@ class TreeConstructionContextV1:
             call_contract_refs=call_contract_refs,
             workspace_root=workspace_root,
             source_call_frames={} if source_call_frames is None else source_call_frames,
+            contract_enrollment_required=False,
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
@@ -48,6 +48,7 @@ class SourceCallPreconstructionGapV1:
         "definition-missing",
         "source-body-gap",
         "opaque-call-target",
+        "expansion-bound",
         "non-manager-result",
         "call-binding",
         "dynamic-call-target",

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_source_file.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_source_file.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from _production_source_file import production_source_file  # noqa: E402
+from sugar_source_tree.reporter import CollectingReporter  # noqa: E402
+
+
+def test_preconstruction_phases_share_one_artifact_graph_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sugar_lift_python_source.manager_summary_derivation as summaries
+    import sugar_lift_python_source.source_call_preconstruction as calls
+
+    observed_graphs: list[dict] = []
+    observed_frames: list[dict] = []
+
+    def record_cache(
+        *_args,
+        artifact_graph_cache=None,
+        source_frame_cache=None,
+        **_kwargs,
+    ) -> None:
+        assert artifact_graph_cache is not None
+        assert source_frame_cache is not None
+        observed_graphs.append(artifact_graph_cache)
+        observed_frames.append(source_frame_cache)
+
+    monkeypatch.setattr(calls, "populate_source_visible_call_frames", record_cache)
+    monkeypatch.setattr(summaries, "populate_source_derived_resource_refs", record_cache)
+    source = tmp_path / "arbitrary_consumer.py"
+    source.write_text("def constructed(value):\n    return value\n", encoding="utf-8")
+
+    production_source_file(
+        source,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+    )
+
+    assert len(observed_graphs) == 2
+    assert observed_graphs[0] is observed_graphs[1]
+    assert observed_frames[0] is observed_frames[1]

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -11,23 +11,11 @@ from dataclasses import dataclass, field
 from email.parser import BytesParser
 import importlib.metadata
 from pathlib import Path, PurePosixPath
-import sys
 from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
 from .canonical import blake3_512_of, cid_of_json
 from .source_oracle import SourceUnavailable, dependency_artifact_file
-
-
-def _source_file_cls():
-    """Lazy SourceFile — avoid circular import with source_oracle/tree."""
-    _tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
-    if _tree_src.is_dir() and str(_tree_src) not in sys.path:
-        sys.path.insert(0, str(_tree_src))
-    from sugar_source_tree.backend import BackendCouldNotParse
-    from sugar_source_tree.tree import SourceFile
-
-    return SourceFile, BackendCouldNotParse
 
 
 class DependencyArtifactAuthenticationError(Exception):
@@ -453,15 +441,11 @@ class DependencyArtifactGraph:
             module_name = _module_name(relative)
             if module_name is None:
                 continue
-            SourceFile, BackendCouldNotParse = _source_file_cls()
             try:
                 source = content.decode("utf-8")
-                # Parse gate through SourceFile (typed tree). Export resolution
-                # Export resolution delegated to dependency_export_adapter.
-                SourceFile((source, str(path), content_cid))
-            except (UnicodeError, SyntaxError, BackendCouldNotParse, ValueError) as exc:
+            except UnicodeError as exc:
                 raise DependencyArtifactAuthenticationError(
-                    f"recorded Python module {module_name} is not parseable UTF-8 source"
+                    f"recorded Python module {module_name} is not UTF-8 source"
                 ) from exc
             if module_name in modules:
                 raise DependencyArtifactAuthenticationError(
@@ -664,4 +648,3 @@ def export_statement_coverage():
     from .dependency_export_adapter import export_statement_coverage as _coverage
 
     return _coverage()
-

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -8,7 +8,9 @@ imports and re-exports.  It never imports or executes a target module.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from concurrent.futures import ThreadPoolExecutor
 from email.parser import BytesParser
+from functools import partial
 import importlib.metadata
 from pathlib import Path, PurePosixPath
 from types import MappingProxyType
@@ -418,19 +420,17 @@ class DependencyArtifactGraph:
             )
         authenticated_files: list[AuthenticatedArtifactFileV1] = []
         modules: dict[str, AuthenticatedModuleSourceV1] = {}
-        for recorded in sorted(files, key=lambda item: str(item)):
-            relative = PurePosixPath(str(recorded))
-            if relative.is_absolute():
-                raise DependencyArtifactAuthenticationError(
-                    "distribution manifest contains an absolute file seat"
+        recorded_files = tuple(sorted(files, key=lambda item: str(item)))
+        if recorded_files:
+            workers = min(8, len(recorded_files))
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                authenticated = executor.map(
+                    partial(_authenticate_recorded_file, distribution), recorded_files
                 )
-            path = Path(distribution.locate_file(recorded))
-            try:
-                content, _seat, content_cid = dependency_artifact_file(str(path))
-            except SourceUnavailable as exc:
-                raise DependencyArtifactAuthenticationError(
-                    f"cannot read recorded distribution file {relative}"
-                ) from exc
+                authenticated = tuple(authenticated)
+        else:
+            authenticated = ()
+        for relative, content, content_cid in authenticated:
             authenticated_files.append(
                 AuthenticatedArtifactFileV1(
                     source_seat=relative.as_posix(),
@@ -491,6 +491,23 @@ class DependencyArtifactGraph:
             modules=MappingProxyType(modules),
             _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
         )
+
+
+def _authenticate_recorded_file(distribution, recorded):
+    """Read and hash one independent manifest seat; callers preserve file order."""
+    relative = PurePosixPath(str(recorded))
+    if relative.is_absolute():
+        raise DependencyArtifactAuthenticationError(
+            "distribution manifest contains an absolute file seat"
+        )
+    path = Path(distribution.locate_file(recorded))
+    try:
+        content, _seat, content_cid = dependency_artifact_file(str(path))
+    except SourceUnavailable as exc:
+        raise DependencyArtifactAuthenticationError(
+            f"cannot read recorded distribution file {relative}"
+        ) from exc
+    return relative, content, content_cid
 
 
 def resolve_import_binding(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -10,6 +10,7 @@ this adapter (same residual pattern as ``source_tables_adapter``).
 from __future__ import annotations
 
 import ast
+import functools
 from typing import Any, Literal
 
 from .canonical import blake3_512_of
@@ -52,13 +53,10 @@ def resolve_export(
         return _gap(
             "artifact-module-absent", binding_cid, graph, module_name, exported_name
         )
-    tree = parsed_tree(module.source, module.source_seat)
-    binding = _export_block(tree.body, exported_name, None)
-    dynamic_getattr = any(
-        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == "__getattr__"
-        for node in tree.body
-    )
+    selected = _module_export(module, exported_name)
+    if selected is None:
+        return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
+    binding, dynamic_getattr = selected
     if binding is not None and binding[0] == "definition":
         definition = _definition(module, binding[1])
         return ResolvedPythonObjectV1(
@@ -128,6 +126,22 @@ def resolve_export(
         module_name,
         exported_name,
     )
+
+
+@functools.lru_cache(maxsize=512)
+def _module_export(module, exported_name: str):
+    """Content-keyed finite cache of one module's structural export transfer."""
+    try:
+        tree = parsed_tree(module.source, module.source_seat)
+    except (SyntaxError, ValueError):
+        return None
+    binding = _export_block(tree.body, exported_name, None)
+    dynamic_getattr = any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "__getattr__"
+        for node in tree.body
+    )
+    return binding, dynamic_getattr
 
 
 def _definition(
@@ -276,10 +290,16 @@ def _export_block(statements, name, initial):
 
 
 def _suite_binds_export(statements, name: str) -> bool:
+    return _suite_binds_export_cached(tuple(statements), name)
+
+
+@functools.lru_cache(maxsize=8192)
+def _suite_binds_export_cached(statements: tuple[ast.stmt, ...], name: str) -> bool:
     marker = object()
     return _export_block(statements, name, marker) is not marker
 
 
+@functools.lru_cache(maxsize=4096)
 def _statement_contains_module_init_raise(statement: ast.AST) -> bool:
     stack: list[ast.AST] = [statement]
     while stack:
@@ -440,8 +460,10 @@ def _pattern_binds(pattern: ast.pattern, name: str) -> bool:
     )
 
 
-def _statement_walrus_binds(statement: ast.AST, name: str) -> bool:
-    """Find module-scope named expressions without entering nested scopes/suites."""
+@functools.lru_cache(maxsize=4096)
+def _statement_walrus_bound_names(statement: ast.AST) -> frozenset[str]:
+    """Find all module-scope named-expression bindings in one structural scan."""
+    names: set[str] = set()
     stack = list(ast.iter_child_nodes(statement))
     while stack:
         node = stack.pop()
@@ -451,10 +473,15 @@ def _statement_walrus_binds(statement: ast.AST, name: str) -> bool:
             node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
         ):
             continue
-        if isinstance(node, ast.NamedExpr) and _target_binds(node.target, name):
-            return True
+        if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
         stack.extend(ast.iter_child_nodes(node))
-    return False
+    return frozenset(names)
+
+
+def _statement_walrus_binds(statement: ast.AST, name: str) -> bool:
+    """Test a lexical lookup key against the statement's structural bindings."""
+    return name in _statement_walrus_bound_names(statement)
 
 
 def _cannot_raise_during_module_init(statement: ast.AST) -> bool:
@@ -478,7 +505,3 @@ def _cannot_raise_during_module_init(statement: ast.AST) -> bool:
         or any(parameter.annotation is not None for parameter in parameters)
         or getattr(statement, "type_params", ())
     )
-
-
-
-

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -288,7 +288,14 @@ def resolve_source_visible_frame(
                     "opaque-call-target", resolved.cid, opaque[0]
                 ),
             )
-    frame_result = _construct_source_target_frame(definition_graph, target)
+    try:
+        frame_result = _construct_source_target_frame(definition_graph, target)
+    except SourceCallBindingGap as exc:
+        return _remember_frame_result(
+            frame_cache,
+            resolved.cid,
+            ManagerConstructionGapV1("call-binding", resolved.cid, str(exc)),
+        )
     if isinstance(frame_result, tuple) and frame_result[0] == "gap":
         _tag, kind, detail = frame_result
         return _remember_frame_result(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -215,6 +215,18 @@ def construct_manager_behavior(
     )
 
 
+@dataclass(frozen=True)
+class _SourceDefinitionGraphV1:
+    context: object = field(compare=False)
+    definitions: tuple[Node, ...] = field(compare=False)
+
+
+@dataclass(frozen=True)
+class _SourceFrameGraphV1:
+    frames: tuple[tuple[str, object], ...] = field(compare=False)
+    gap: tuple[str, str] | None = None
+
+
 def resolve_source_visible_frame(
     resolved: ResolvedPythonObjectV1,
     *,
@@ -237,16 +249,18 @@ def resolve_source_visible_frame(
         )
     if frame_cache is not None and resolved.cid in frame_cache:
         return frame_cache[resolved.cid]
-    context = TreeConstructionContextV1.for_source_call_construction()
-    source_file = SourceFile(
-        (module.source, module.source_seat, module.source_cid),
-        construction_context=context,
+    definition_key = (
+        "source-definition-graph-v1",
+        graph.distribution_artifact_cid,
+        resolved.module_name,
+        module.source_cid,
     )
-    definitions = tuple(
-        item
-        for item in source_file.root.body
-        if isinstance(item, (FunctionDef, ClassDef))
-    )
+    definition_graph = None if frame_cache is None else frame_cache.get(definition_key)
+    if definition_graph is None:
+        definition_graph = _construct_source_definition_graph(module)
+        if frame_cache is not None:
+            frame_cache[definition_key] = definition_graph
+    definitions = definition_graph.definitions
     target = next(
         (item for item in definitions if _matches_definition(item, resolved)), None
     )
@@ -274,7 +288,61 @@ def resolve_source_visible_frame(
                     "opaque-call-target", resolved.cid, opaque[0]
                 ),
             )
+    module_key = (
+        "source-frame-graph-v1",
+        graph.distribution_artifact_cid,
+        resolved.module_name,
+        module.source_cid,
+    )
+    frame_graph = None if frame_cache is None else frame_cache.get(module_key)
+    if frame_graph is None:
+        frame_graph = _construct_source_frame_graph(definition_graph)
+        if frame_cache is not None:
+            frame_cache[module_key] = frame_graph
+    if frame_graph.gap is not None:
+        kind, detail = frame_graph.gap
+        return _remember_frame_result(
+            frame_cache,
+            resolved.cid,
+            ManagerConstructionGapV1(kind, resolved.cid, detail),
+        )
+    frame = dict(frame_graph.frames).get(target.name)
+    if frame is None:
+        return _remember_frame_result(
+            frame_cache,
+            resolved.cid,
+            ManagerConstructionGapV1(
+                "definition-missing", resolved.cid, "ordinary source call frame"
+            ),
+        )
+    result = (frame, target)
+    if frame_cache is not None:
+        frame_cache[resolved.cid] = result
+    return result
 
+
+def _construct_source_definition_graph(module) -> _SourceDefinitionGraphV1:
+    """Materialize one authenticated module's direct definitions once."""
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    definitions = tuple(
+        item
+        for item in source_file.root.body
+        if isinstance(item, (FunctionDef, ClassDef))
+    )
+    return _SourceDefinitionGraphV1(context, definitions)
+
+
+def _construct_source_frame_graph(
+    definition_graph: _SourceDefinitionGraphV1,
+) -> _SourceFrameGraphV1:
+    """Construct every direct definition frame once per authenticated module CID."""
+    context = definition_graph.context
+    definitions = definition_graph.definitions
+    definition_names = {item.name for item in definitions}
     frames: dict[str, object] = {}
     reaching_classes: dict[str, ClassDef] = {}
     for item in definitions:
@@ -304,12 +372,9 @@ def resolve_source_visible_frame(
                 if call.func.id not in definition_names
             )
             if opaque:
-                return _remember_frame_result(
-                    frame_cache,
-                    resolved.cid,
-                    ManagerConstructionGapV1(
-                        "opaque-call-target", resolved.cid, opaque[0]
-                    ),
+                return _SourceFrameGraphV1(
+                    (),
+                    ("opaque-call-target", opaque[0]),
                 )
             unresolved = tuple(
                 call.func.id
@@ -326,26 +391,11 @@ def resolve_source_visible_frame(
             pending.remove(function)
             progressed = True
         if not progressed:
-            return _remember_frame_result(
-                frame_cache,
-                resolved.cid,
-                ManagerConstructionGapV1(
-                    "opaque-call-target", resolved.cid, "recursive source call graph"
-                ),
+            return _SourceFrameGraphV1(
+                (),
+                ("opaque-call-target", "recursive source call graph"),
             )
-    frame = frames.get(target.name)
-    if frame is None:
-        return _remember_frame_result(
-            frame_cache,
-            resolved.cid,
-            ManagerConstructionGapV1(
-                "definition-missing", resolved.cid, "ordinary source call frame"
-            ),
-        )
-    result = (frame, target)
-    if frame_cache is not None:
-        frame_cache[resolved.cid] = result
-    return result
+    return _SourceFrameGraphV1(tuple(frames.items()))
 
 
 def _remember_frame_result(frame_cache, resolved_cid, result):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -219,12 +219,8 @@ def construct_manager_behavior(
 class _SourceDefinitionGraphV1:
     context: object = field(compare=False)
     definitions: tuple[Node, ...] = field(compare=False)
-
-
-@dataclass(frozen=True)
-class _SourceFrameGraphV1:
-    frames: tuple[tuple[str, object], ...] = field(compare=False)
-    gap: tuple[str, str] | None = None
+    frames: dict[str, object] = field(default_factory=dict, compare=False)
+    gaps: dict[str, tuple[str, str]] = field(default_factory=dict, compare=False)
 
 
 def resolve_source_visible_frame(
@@ -288,33 +284,15 @@ def resolve_source_visible_frame(
                     "opaque-call-target", resolved.cid, opaque[0]
                 ),
             )
-    module_key = (
-        "source-frame-graph-v1",
-        graph.distribution_artifact_cid,
-        resolved.module_name,
-        module.source_cid,
-    )
-    frame_graph = None if frame_cache is None else frame_cache.get(module_key)
-    if frame_graph is None:
-        frame_graph = _construct_source_frame_graph(definition_graph)
-        if frame_cache is not None:
-            frame_cache[module_key] = frame_graph
-    if frame_graph.gap is not None:
-        kind, detail = frame_graph.gap
+    frame_result = _construct_source_target_frame(definition_graph, target)
+    if isinstance(frame_result, tuple) and frame_result[0] == "gap":
+        _tag, kind, detail = frame_result
         return _remember_frame_result(
             frame_cache,
             resolved.cid,
             ManagerConstructionGapV1(kind, resolved.cid, detail),
         )
-    frame = dict(frame_graph.frames).get(target.name)
-    if frame is None:
-        return _remember_frame_result(
-            frame_cache,
-            resolved.cid,
-            ManagerConstructionGapV1(
-                "definition-missing", resolved.cid, "ordinary source call frame"
-            ),
-        )
+    frame = frame_result
     result = (frame, target)
     if frame_cache is not None:
         frame_cache[resolved.cid] = result
@@ -336,66 +314,56 @@ def _construct_source_definition_graph(module) -> _SourceDefinitionGraphV1:
     return _SourceDefinitionGraphV1(context, definitions)
 
 
-def _construct_source_frame_graph(
-    definition_graph: _SourceDefinitionGraphV1,
-) -> _SourceFrameGraphV1:
-    """Construct every direct definition frame once per authenticated module CID."""
+def _construct_source_target_frame(definition_graph, target):
+    """Construct only the selected definition's authenticated local call closure."""
     context = definition_graph.context
     definitions = definition_graph.definitions
-    definition_names = {item.name for item in definitions}
-    frames: dict[str, object] = {}
-    reaching_classes: dict[str, ClassDef] = {}
-    for item in definitions:
-        if not isinstance(item, ClassDef):
-            continue
-        local_bases = []
-        for base in item.bases:
-            if not isinstance(base, Name) or base.id not in reaching_classes:
-                local_bases = []
-                break
-            local_bases.append(reaching_classes[base.id].sugar())
-        if local_bases and len(local_bases) == len(item.bases):
-            context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
-        reaching_classes[item.name] = item
-    for item in definitions:
-        if isinstance(item, ClassDef):
-            frames[item.name] = item.source_visible_constructor_frame()
+    by_name = {item.name: item for item in definitions}
 
-    pending = [item for item in definitions if isinstance(item, FunctionDef)]
-    while pending:
-        progressed = False
-        for function in tuple(pending):
-            local_calls = tuple(_local_named_calls(function))
-            opaque = tuple(
-                call.func.id
-                for call in local_calls
-                if call.func.id not in definition_names
-            )
-            if opaque:
-                return _SourceFrameGraphV1(
-                    (),
-                    ("opaque-call-target", opaque[0]),
-                )
-            unresolved = tuple(
-                call.func.id
-                for call in local_calls
-                if call.func.id in definition_names and call.func.id not in frames
-            )
-            if unresolved:
-                continue
-            for call in local_calls:
-                nested = frames.get(call.func.id)
-                if nested is not None:
-                    context.source_call_frames[_call_coordinate(call)] = nested
-            frames[function.name] = function.source_visible_call_frame()
-            pending.remove(function)
-            progressed = True
-        if not progressed:
-            return _SourceFrameGraphV1(
-                (),
-                ("opaque-call-target", "recursive source call graph"),
-            )
-    return _SourceFrameGraphV1(tuple(frames.items()))
+    def ensure(item, active: frozenset[str]):
+        cached = definition_graph.frames.get(item.name)
+        if cached is not None:
+            return cached
+        gap = definition_graph.gaps.get(item.name)
+        if gap is not None:
+            return ("gap", *gap)
+        if item.name in active:
+            result = ("opaque-call-target", "recursive source call graph")
+            definition_graph.gaps[item.name] = result
+            return ("gap", *result)
+        active = active | {item.name}
+        if isinstance(item, ClassDef):
+            local_bases = []
+            for base in item.bases:
+                base_definition = by_name.get(base.id) if isinstance(base, Name) else None
+                if not isinstance(base_definition, ClassDef):
+                    local_bases = []
+                    break
+                base_result = ensure(base_definition, active)
+                if isinstance(base_result, tuple) and base_result[0] == "gap":
+                    return base_result
+                local_bases.append(base_definition.sugar())
+            if local_bases and len(local_bases) == len(item.bases):
+                context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
+            frame = item.source_visible_constructor_frame()
+            definition_graph.frames[item.name] = frame
+            return frame
+        local_calls = tuple(_local_named_calls(item))
+        for call in local_calls:
+            dependency = by_name.get(call.func.id)
+            if dependency is None:
+                result = ("opaque-call-target", call.func.id)
+                definition_graph.gaps[item.name] = result
+                return ("gap", *result)
+            nested = ensure(dependency, active)
+            if isinstance(nested, tuple) and nested[0] == "gap":
+                return nested
+            context.source_call_frames[_call_coordinate(call)] = nested
+        frame = item.source_visible_call_frame()
+        definition_graph.frames[item.name] = frame
+        return frame
+
+    return ensure(target, frozenset())
 
 
 def _remember_frame_result(frame_cache, resolved_cid, result):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -111,6 +111,7 @@ def construct_manager_behavior(
     actuals: tuple[ConstructedCallActualV1, ...],
     keyword_actuals: tuple[tuple[str, ConstructedCallActualV1], ...] = (),
     call_site: object | None = None,
+    source_frame_cache: dict | None = None,
 ) -> ConstructedManagerBehaviorV1 | ManagerConstructionGapV1:
     """Construct one resolved callable through SourceFile -> Node -> Sugar only."""
     if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
@@ -123,7 +124,9 @@ def construct_manager_behavior(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
 
-    frame_result = resolve_source_visible_frame(resolved, graph=graph)
+    frame_result = resolve_source_visible_frame(
+        resolved, graph=graph, frame_cache=source_frame_cache
+    )
     if isinstance(frame_result, ManagerConstructionGapV1):
         return frame_result
     frame, _target = frame_result
@@ -216,6 +219,7 @@ def resolve_source_visible_frame(
     resolved: ResolvedPythonObjectV1,
     *,
     graph: DependencyArtifactGraph,
+    frame_cache: dict | None = None,
 ) -> tuple[object, Node] | ManagerConstructionGapV1:
     """Resolve one authenticated definition into the ordinary source frame.
 
@@ -231,6 +235,8 @@ def resolve_source_visible_frame(
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
+    if frame_cache is not None and resolved.cid in frame_cache:
+        return frame_cache[resolved.cid]
     context = TreeConstructionContextV1.for_source_call_construction()
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
@@ -245,8 +251,12 @@ def resolve_source_visible_frame(
         (item for item in definitions if _matches_definition(item, resolved)), None
     )
     if target is None:
-        return ManagerConstructionGapV1(
-            "definition-missing", resolved.cid, "resolved definition coordinate"
+        return _remember_frame_result(
+            frame_cache,
+            resolved.cid,
+            ManagerConstructionGapV1(
+                "definition-missing", resolved.cid, "resolved definition coordinate"
+            ),
         )
 
     definition_names = {item.name for item in definitions}
@@ -257,8 +267,12 @@ def resolve_source_visible_frame(
             if call.func.id not in definition_names
         )
         if opaque:
-            return ManagerConstructionGapV1(
-                "opaque-call-target", resolved.cid, opaque[0]
+            return _remember_frame_result(
+                frame_cache,
+                resolved.cid,
+                ManagerConstructionGapV1(
+                    "opaque-call-target", resolved.cid, opaque[0]
+                ),
             )
 
     frames: dict[str, object] = {}
@@ -290,8 +304,12 @@ def resolve_source_visible_frame(
                 if call.func.id not in definition_names
             )
             if opaque:
-                return ManagerConstructionGapV1(
-                    "opaque-call-target", resolved.cid, opaque[0]
+                return _remember_frame_result(
+                    frame_cache,
+                    resolved.cid,
+                    ManagerConstructionGapV1(
+                        "opaque-call-target", resolved.cid, opaque[0]
+                    ),
                 )
             unresolved = tuple(
                 call.func.id
@@ -308,15 +326,32 @@ def resolve_source_visible_frame(
             pending.remove(function)
             progressed = True
         if not progressed:
-            return ManagerConstructionGapV1(
-                "opaque-call-target", resolved.cid, "recursive source call graph"
+            return _remember_frame_result(
+                frame_cache,
+                resolved.cid,
+                ManagerConstructionGapV1(
+                    "opaque-call-target", resolved.cid, "recursive source call graph"
+                ),
             )
     frame = frames.get(target.name)
     if frame is None:
-        return ManagerConstructionGapV1(
-            "definition-missing", resolved.cid, "ordinary source call frame"
+        return _remember_frame_result(
+            frame_cache,
+            resolved.cid,
+            ManagerConstructionGapV1(
+                "definition-missing", resolved.cid, "ordinary source call frame"
+            ),
         )
-    return frame, target
+    result = (frame, target)
+    if frame_cache is not None:
+        frame_cache[resolved.cid] = result
+    return result
+
+
+def _remember_frame_result(frame_cache, resolved_cid, result):
+    if frame_cache is not None:
+        frame_cache[resolved_cid] = result
+    return result
 
 
 def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -26,6 +26,9 @@ from .canonical import cid_of_json
 from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
 
 
+_SOURCE_DEFINITION_NODE_LIMIT = 4096
+
+
 @dataclass(frozen=True)
 class ConstructedCallActualV1:
     node: Node = field(compare=False)
@@ -97,6 +100,7 @@ class ManagerConstructionGapV1:
         "artifact-mismatch",
         "definition-missing",
         "opaque-call-target",
+        "expansion-bound",
         "non-manager-result",
         "call-binding",
     ]
@@ -331,6 +335,13 @@ def _construct_source_target_frame(definition_graph, target):
             result = ("opaque-call-target", "recursive source call graph")
             definition_graph.gaps[item.name] = result
             return ("gap", *result)
+        if _definition_exceeds_expansion_bound(item):
+            result = (
+                "expansion-bound",
+                f"definition exceeds {_SOURCE_DEFINITION_NODE_LIMIT} constructed nodes",
+            )
+            definition_graph.gaps[item.name] = result
+            return ("gap", *result)
         active = active | {item.name}
         if isinstance(item, ClassDef):
             local_bases = []
@@ -364,6 +375,13 @@ def _construct_source_target_frame(definition_graph, target):
         return frame
 
     return ensure(target, frozenset())
+
+
+def _definition_exceeds_expansion_bound(definition: Node) -> bool:
+    for count, _node in enumerate(definition.walk(), start=1):
+        if count > _SOURCE_DEFINITION_NODE_LIMIT:
+            return True
+    return False
 
 
 def _remember_frame_result(frame_cache, resolved_cid, result):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -383,6 +383,7 @@ def populate_source_derived_resource_refs(
     path,
     distribution_index=None,
     artifact_graph_cache: dict | None = None,
+    source_frame_cache: dict | None = None,
 ) -> None:
     """Preconstruct imported resource managers and freeze exact use-site rows."""
     import importlib.metadata
@@ -464,13 +465,13 @@ def populate_source_derived_resource_refs(
         if len(distributions) != 1:
             _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
             continue
-        distribution = (
-            importlib.metadata.distribution(distributions[0])
-            if distribution_index is None
-            else distribution_index[top_level]
-        )
         graph = graphs.get(top_level)
         if graph is None:
+            distribution = (
+                importlib.metadata.distribution(distributions[0])
+                if distribution_index is None
+                else distribution_index[top_level]
+            )
             graph = DependencyArtifactGraph.authenticate(distribution)
             graphs[top_level] = graph
         resolved = resolve_import_binding(receipt, graph=graph)
@@ -529,6 +530,7 @@ def populate_source_derived_resource_refs(
             actuals=tuple(actuals),
             keyword_actuals=tuple(keyword_actuals),
             call_site=call.fragment,
+            source_frame_cache=source_frame_cache,
         )
         from .manager_construction import ConstructedManagerBehaviorV1
         from .manager_protocol_construction import ConstructedManagerProtocolV1

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -39,6 +39,7 @@ def populate_source_visible_call_frames(
     path: Path,
     distribution_index=None,
     artifact_graph_cache: dict | None = None,
+    source_frame_cache: dict | None = None,
 ) -> None:
     """Populate exact-use source frames and one closed classification row."""
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
@@ -77,13 +78,13 @@ def populate_source_visible_call_frames(
                 SourceCallPreconstructionGapV1(kind, coordinate, top_level)
             )
             continue
-        distribution = (
-            importlib.metadata.distribution(distributions[0])
-            if distribution_index is None
-            else distribution_index[top_level]
-        )
         graph = graphs.get(top_level)
         if graph is None:
+            distribution = (
+                importlib.metadata.distribution(distributions[0])
+                if distribution_index is None
+                else distribution_index[top_level]
+            )
             try:
                 graph = DependencyArtifactGraph.authenticate(distribution)
             except DependencyArtifactAuthenticationError as exc:
@@ -112,7 +113,9 @@ def populate_source_visible_call_frames(
         from sugar_source_tree.panic import SugarNotWritten
 
         try:
-            frame_result = resolve_source_visible_frame(resolved, graph=graph)
+            frame_result = resolve_source_visible_frame(
+                resolved, graph=graph, frame_cache=source_frame_cache
+            )
         except SugarNotWritten as exc:
             context.source_call_resolutions[coordinate] = (
                 SourceCallPreconstructionGapV1("source-body-gap", coordinate, str(exc))

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -348,6 +348,10 @@ def test_final_checked_import_use_rejects_fabricated_definition_coordinate(
         )
     )
     receipt = _demand(tmp_path)
+    assert isinstance(
+        resolve_import_binding(receipt, graph=graph),
+        ResolvedPythonObjectV1,
+    )
     binding_value = receipt.import_binding.to_value()
     binding_value["definitionSite"]["startLine"] = 999
     binding_cid = cid_of_json(binding_value)

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import csv
 import ast
+import threading
+import time
 from dataclasses import replace
 import importlib.metadata
 import json
@@ -220,6 +222,43 @@ def test_walrus_binding_scan_is_reused_for_every_export_name(monkeypatch) -> Non
     after_first = calls
     assert not adapter._statement_walrus_binds(statement, "unrelated")
     assert calls == after_first
+
+
+def test_artifact_file_authentication_preserves_order_under_bounded_overlap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sugar_lift_python_source.dependency_artifact as dependency_artifact
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="def build(value):\n    return value\n",
+    )
+    original = dependency_artifact.dependency_artifact_file
+    lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    def observed(path: str):
+        nonlocal active, maximum_active
+        with lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+        time.sleep(0.01)
+        try:
+            return original(path)
+        finally:
+            with lock:
+                active -= 1
+
+    monkeypatch.setattr(dependency_artifact, "dependency_artifact_file", observed)
+
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    assert maximum_active > 1
+    assert tuple(item.source_seat for item in graph.files) == tuple(
+        sorted(item.source_seat for item in graph.files)
+    )
 
 
 def test_module_init_raise_scan_is_reused_for_every_export_name(monkeypatch) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import csv
+import ast
 from dataclasses import replace
 import importlib.metadata
 import json
@@ -137,6 +138,128 @@ def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
     assert result.kind == "dynamic-export"
     assert result.import_binding_cid.startswith("blake3-512:")
     assert result.distribution_artifact_cid == graph.distribution_artifact_cid
+
+
+def test_unrelated_unparseable_module_does_not_poison_authenticated_export(
+    tmp_path: Path,
+) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="def build(value):\n    return value\n",
+        implementation_source="def broken(:\n",
+    )
+
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "example_pkg"
+    assert graph.modules["example_pkg.implementation"].source_cid.startswith(
+        "blake3-512:"
+    )
+
+
+def test_selected_unparseable_module_is_typed_loud_not_a_raw_parser_crash(
+    tmp_path: Path,
+) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="def build(:\n",
+    )
+
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "opaque-source"
+
+
+def test_repeated_export_resolution_reuses_content_keyed_transfer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sugar_lift_python_source.dependency_export_adapter as adapter
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="def build(value):\n    return value\n",
+        implementation_source="def other(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    demand = _demand(tmp_path)
+    original = adapter._export_block
+    calls = 0
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    adapter._module_export.cache_clear()
+    monkeypatch.setattr(adapter, "_export_block", counted)
+
+    assert isinstance(resolve_import_binding(demand, graph=graph), ResolvedPythonObjectV1)
+    assert isinstance(resolve_import_binding(demand, graph=graph), ResolvedPythonObjectV1)
+    assert calls == 1
+
+
+def test_walrus_binding_scan_is_reused_for_every_export_name(monkeypatch) -> None:
+    import sugar_lift_python_source.dependency_export_adapter as adapter
+
+    statement = ast.parse("payload = [(bound := item) for item in values]").body[0]
+    original = adapter.ast.iter_child_nodes
+    calls = 0
+
+    def counted(node):
+        nonlocal calls
+        calls += 1
+        return original(node)
+
+    monkeypatch.setattr(adapter.ast, "iter_child_nodes", counted)
+    assert adapter._statement_walrus_binds(statement, "bound")
+    after_first = calls
+    assert not adapter._statement_walrus_binds(statement, "unrelated")
+    assert calls == after_first
+
+
+def test_module_init_raise_scan_is_reused_for_every_export_name(monkeypatch) -> None:
+    import sugar_lift_python_source.dependency_export_adapter as adapter
+
+    statement = ast.parse("if enabled:\n    raise RuntimeError()\n").body[0]
+    original = adapter.ast.iter_child_nodes
+    calls = 0
+
+    def counted(node):
+        nonlocal calls
+        calls += 1
+        return original(node)
+
+    adapter._statement_contains_module_init_raise.cache_clear()
+    monkeypatch.setattr(adapter.ast, "iter_child_nodes", counted)
+    assert adapter._statement_contains_module_init_raise(statement)
+    after_first = calls
+    assert adapter._statement_contains_module_init_raise(statement)
+    assert calls == after_first
+
+
+def test_exceptional_suffix_transfer_is_reused(monkeypatch) -> None:
+    import sugar_lift_python_source.dependency_export_adapter as adapter
+
+    statements = tuple(ast.parse("if enabled:\n    exported = build()\n").body)
+    original = adapter._export_block
+    calls = 0
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    adapter._suite_binds_export_cached.cache_clear()
+    monkeypatch.setattr(adapter, "_export_block", counted)
+    assert adapter._suite_binds_export(statements, "exported")
+    after_first = calls
+    assert adapter._suite_binds_export(statements, "exported")
+    assert calls == after_first
 
 
 def test_real_pytest_reexport_resolves_without_manager_name_recognition(

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -132,6 +132,24 @@ def test_opaque_source_call_stays_typed_loud(tmp_path):
     assert result.kind == "opaque-call-target"
 
 
+def test_malformed_nested_source_call_binding_stays_typed_loud(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "def pass_through(value):\n"
+        "    return value\n\n"
+        "def make_guard(expected):\n"
+        "    return pass_through(expected, expected)\n",
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1)
+    assert result.kind == "call-binding"
+    assert result.detail == "unconsumed call actual"
+
+
 def test_renamed_manager_protocol_retains_ordinary_method_call_frames(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -135,6 +135,19 @@ def test_repeated_calls_reuse_one_authenticated_distribution_lookup(
         "arbitrary_helper()\n",
     )
     lookups = 0
+    import sugar_lift_py_tests.import_binding as import_binding
+
+    lexical_passes = 0
+    original_import_uses = import_binding.authenticated_import_uses
+
+    def counted_import_uses(*args, **kwargs):
+        nonlocal lexical_passes
+        lexical_passes += 1
+        return original_import_uses(*args, **kwargs)
+
+    monkeypatch.setattr(
+        import_binding, "authenticated_import_uses", counted_import_uses
+    )
 
     monkeypatch.setattr(
         importlib.metadata,
@@ -153,6 +166,44 @@ def test_repeated_calls_reuse_one_authenticated_distribution_lookup(
     populate_source_visible_call_frames(source_file, root=tmp_path, path=path)
 
     assert lookups == 1
+    # One mint pass plus one independent final-check pass for the whole batch.
+    assert lexical_passes == 2
+
+
+def test_distinct_callees_in_one_module_share_one_constructed_frame_graph(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sugar_lift_python_source.manager_construction as manager_construction
+
+    distribution = _distribution(
+        tmp_path,
+        "def first(value=1):\n    return value\n\n"
+        "def second(value=2):\n    return value\n",
+    )
+    path, source_file, _context = _consumer(
+        tmp_path,
+        "from unprivileged.helpers import first, second\nfirst()\nsecond()\n",
+    )
+    original = manager_construction.SourceFile
+    constructions = 0
+
+    def counted_source_file(*args, **kwargs):
+        nonlocal constructions
+        constructions += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(manager_construction, "SourceFile", counted_source_file)
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+        artifact_graph_cache={},
+        source_frame_cache={},
+    )
+
+    assert constructions == 1
 
 
 def test_source_visible_function_with_opaque_child_stays_typed_loud(

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -206,6 +206,40 @@ def test_distinct_callees_in_one_module_share_one_constructed_frame_graph(
     assert constructions == 1
 
 
+def test_unselected_definition_gap_does_not_expand_into_selected_callee(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def first(value=1):\n    return value\n\n"
+        "class Unselected:\n"
+        "    def noisy(self):\n"
+        "        try:\n"
+        "            return 1\n"
+        "        except Exception:\n"
+        "            return 2\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged.helpers import first\nfirst()\n",
+    )
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+        artifact_graph_cache={},
+        source_frame_cache={},
+    )
+
+    assert len(context.source_call_resolutions) == 1
+    assert isinstance(
+        next(iter(context.source_call_resolutions.values())),
+        SourceCallPreconstructionRefV1,
+    )
+
+
 def test_source_visible_function_with_opaque_child_stays_typed_loud(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -271,6 +271,35 @@ def test_selected_definition_expansion_bound_stays_typed_loud(
     assert row.kind == "expansion-bound"
 
 
+def test_source_callee_with_unresolved_manager_stays_typed_loud(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(manager):\n"
+        "    with manager:\n"
+        "        return 1\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper\n"
+        "arbitrary_helper(object())\n",
+    )
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+        artifact_graph_cache={},
+        source_frame_cache={},
+    )
+
+    row = next(iter(context.source_call_resolutions.values()))
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "source-body-gap"
+
+
 def test_source_visible_function_with_opaque_child_stays_typed_loud(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -240,6 +240,37 @@ def test_unselected_definition_gap_does_not_expand_into_selected_callee(
     )
 
 
+def test_selected_definition_expansion_bound_stays_typed_loud(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sugar_lift_python_source.manager_construction as manager_construction
+
+    distribution = _distribution(
+        tmp_path,
+        "class ArbitraryLarge:\n"
+        "    def first(self):\n        return 1\n"
+        "    def second(self):\n        return 2\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged.helpers import ArbitraryLarge\nArbitraryLarge()\n",
+    )
+    monkeypatch.setattr(manager_construction, "_SOURCE_DEFINITION_NODE_LIMIT", 4)
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+        artifact_graph_cache={},
+        source_frame_cache={},
+    )
+
+    row = next(iter(context.source_call_resolutions.values()))
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "expansion-bound"
+
+
 def test_source_visible_function_with_opaque_child_stays_typed_loud(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -121,6 +121,40 @@ def test_renamed_cross_file_call_installs_source_frame_and_constructs_return(
     assert nested_result.statements == (ReturnValue(TermValue(17)),)
 
 
+def test_repeated_calls_reuse_one_authenticated_distribution_lookup(
+    tmp_path: Path, monkeypatch
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(value=17):\n    return value\n",
+    )
+    path, source_file, _context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper\n"
+        "arbitrary_helper()\n"
+        "arbitrary_helper()\n",
+    )
+    lookups = 0
+
+    monkeypatch.setattr(
+        importlib.metadata,
+        "packages_distributions",
+        lambda: {"unprivileged": ("unprivileged-dist",)},
+    )
+
+    def selected_distribution(name: str):
+        nonlocal lookups
+        lookups += 1
+        assert name == "unprivileged-dist"
+        return distribution
+
+    monkeypatch.setattr(importlib.metadata, "distribution", selected_distribution)
+
+    populate_source_visible_call_frames(source_file, root=tmp_path, path=path)
+
+    assert lookups == 1
+
+
 def test_source_visible_function_with_opaque_child_stays_typed_loud(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -152,6 +152,9 @@ class SourceUnit:
     # Bound by SourceFile after the backend materializes the Module — the sole
     # structural authority for module-body identity. Never a second parse.
     typed_module: object = field(init=False, default=None)
+    _exception_identity_cache: dict[tuple, object | None] = field(
+        init=False, default_factory=dict, compare=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -263,6 +266,24 @@ class SourceUnit:
         Structural authority is the already-materialized typed Module plus the
         unit's CPython ``symtable`` (function scope flags). No second parse.
         """
+        span = node.line_col_span()
+        cache_key = (
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+            node.id,
+        )
+        missing = object()
+        cached = self._exception_identity_cache.get(cache_key, missing)
+        if cached is not missing:
+            return cached
+        result = self._exception_type_identity_uncached(node)
+        self._exception_identity_cache[cache_key] = result
+        return result
+
+    def _exception_type_identity_uncached(self, node: "Name"):
+        """Compute identity from this unit's authenticated typed tree once."""
         from sugar_lift_py_tests.ir import ctor, str_const
         from sugar_lift_py_tests.temporal.builtin_name_bindings import (
             BUILTIN_EXCEPTION_NAMES,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -155,6 +155,15 @@ class SourceUnit:
     _exception_identity_cache: dict[tuple, object | None] = field(
         init=False, default_factory=dict, compare=False, repr=False
     )
+    _function_scope_nodes: tuple = field(
+        init=False, default=(), compare=False, repr=False
+    )
+    _function_scope_nodes_ready: bool = field(
+        init=False, default=False, compare=False, repr=False
+    )
+    _function_symtable_cache: dict[tuple[str, int], object] = field(
+        init=False, default_factory=dict, compare=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -213,6 +222,10 @@ class SourceUnit:
         return module  # type: ignore[return-value]
 
     def function_symtable(self, name: str, lineno: int):
+        key = (name, lineno)
+        cached = self._function_symtable_cache.get(key)
+        if cached is not None:
+            return cached
         matches = []
 
         def visit(table) -> None:
@@ -235,6 +248,7 @@ class SourceUnit:
                 requested="one CPython function symtable selected by type, name, and line",
                 fix="preserve the source function's exact CPython symtable identity",
             )
+        self._function_symtable_cache[key] = matches[0]
         return matches[0]
 
     def is_module_level_function(self, name: str, lineno: int) -> bool:
@@ -291,10 +305,19 @@ class SourceUnit:
 
         module = self._require_typed_module("SourceUnit.exception_type_identity")
         span = node.line_col_span()
+        if not self._function_scope_nodes_ready:
+            object.__setattr__(
+                self,
+                "_function_scope_nodes",
+                tuple(
+                    candidate
+                    for candidate in module.walk()
+                    if candidate.kind in ("FunctionDef", "AsyncFunctionDef")
+                ),
+            )
+            object.__setattr__(self, "_function_scope_nodes_ready", True)
         containing = []
-        for candidate in module.walk():
-            if candidate.kind not in ("FunctionDef", "AsyncFunctionDef"):
-                continue
+        for candidate in self._function_scope_nodes:
             cspan = candidate.line_col_span()
             start = (cspan.start_line, cspan.start_col)
             end = (cspan.end_line, cspan.end_col)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3412,6 +3412,8 @@ class With(Statement):
         derived = context.source_derived_contract_refs.get(coordinate)
         if derived is not None:
             return derived
+        if not context.contract_enrollment_required:
+            return None
         try:
             return context.contract_refs.require(coordinate)
         except ContractRefProtocolError as exc:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -45,6 +45,9 @@ from .operators import (
     ComparisonOperator,
     UnaryOperator,
 )
+
+
+_FUNCTION_CONSTRUCTION_NODE_LIMIT = 1024
 from .panic import (
     backend_defect,
     RuntimeSelectedContextManager,
@@ -1687,6 +1690,18 @@ class FunctionDef(Statement):
         it. A body statement whose sugar is not written yet raises
         SugarNotWritten from its own `.sugar()`, which propagates out here.
         """
+        for count, _node in enumerate(self.walk(), start=1):
+            if count > _FUNCTION_CONSTRUCTION_NODE_LIMIT:
+                raise SugarNotWritten(
+                    owner="FunctionDef._construct_sugar",
+                    observed=(
+                        "authenticated function exceeds the structural "
+                        f"expansion bound of {_FUNCTION_CONSTRUCTION_NODE_LIMIT} nodes"
+                    ),
+                    requested="a bounded substituted function construction",
+                    fix="split the definition or keep its construction typed-loud",
+                )
+
         from sugar_lift_py_tests.engine_log import reduction_span
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             FunctionUniverseSugar,

--- a/implementations/python/sugar-source-tree/tests/test_function_construction_expansion_bound.py
+++ b/implementations/python/sugar-source-tree/tests/test_function_construction_expansion_bound.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def test_renamed_function_expansion_exhaustion_stays_typed_loud(monkeypatch) -> None:
+    import sugar_source_tree.nodes as nodes
+
+    source = "def arbitrary(value):\n    assigned = value\n    return assigned\n"
+    tree = SourceFile((source, "arbitrary_module.py", blake3_512_of(source.encode())))
+    function = next(iter(tree.functions()))
+    monkeypatch.setattr(nodes, "_FUNCTION_CONSTRUCTION_NODE_LIMIT", 4)
+
+    with pytest.raises(SugarNotWritten, match="expansion bound"):
+        function.sugar()

--- a/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
@@ -127,13 +127,36 @@ def test_exception_type_identity_truthful_arms():
     identity = sf.unit.exception_type_identity(name)
     assert identity is not None
     assert identity.args[0].value == "source-class"
-    class_def = next(n for n in sf.root.walk() if n.kind == "ClassDef" and n.name == "MyErr")
+    class_def = next(
+        n for n in sf.root.walk() if n.kind == "ClassDef" and n.name == "MyErr"
+    )
     lc = class_def.line_col_span()
     expected = (
         f"{sf.unit.source_cid}:{lc.start_line}:{lc.start_col}:"
         f"{lc.end_line}:{lc.end_col}"
     )
     assert identity.args[1].value == expected
+
+
+def test_exception_identity_reuses_content_local_structural_testimony(monkeypatch):
+    sf, name = _raise_name("def arbitrary():\n    raise ValueError\n", "ValueError")
+    node_type = type(sf.root).__mro__[1]
+    original = node_type.walk
+    walks = 0
+
+    def counted(self):
+        nonlocal walks
+        if self is sf.root:
+            walks += 1
+        return original(self)
+
+    monkeypatch.setattr(node_type, "walk", counted)
+    first = sf.unit.exception_type_identity(name)
+    assert first is not None
+    assert walks == 1
+    second = sf.unit.exception_type_identity(name)
+    assert second == first
+    assert walks == 1
 
 
 def test_exception_type_identity_lying_arms_stay_loud():

--- a/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
@@ -139,7 +139,16 @@ def test_exception_type_identity_truthful_arms():
 
 
 def test_exception_identity_reuses_content_local_structural_testimony(monkeypatch):
-    sf, name = _raise_name("def arbitrary():\n    raise ValueError\n", "ValueError")
+    sf = _file(
+        "def arbitrary():\n    raise ValueError\n"
+        "def renamed():\n    raise KeyError\n"
+    )
+    names = [
+        node.exc
+        for node in sf.root.walk()
+        if node.kind == "Raise" and node.exc is not None
+    ]
+    assert len(names) == 2
     node_type = type(sf.root).__mro__[1]
     original = node_type.walk
     walks = 0
@@ -151,11 +160,12 @@ def test_exception_identity_reuses_content_local_structural_testimony(monkeypatc
         return original(self)
 
     monkeypatch.setattr(node_type, "walk", counted)
-    first = sf.unit.exception_type_identity(name)
+    first = sf.unit.exception_type_identity(names[0])
     assert first is not None
     assert walks == 1
-    second = sf.unit.exception_type_identity(name)
-    assert second == first
+    second = sf.unit.exception_type_identity(names[1])
+    assert second is not None
+    assert second != first
     assert walks == 1
 
 


### PR DESCRIPTION
## What changed

- shares authenticated dependency-artifact and source-frame caches across the full preconstruction phase
- authenticates artifact seats with bounded overlap while preserving canonical manifest order and content-derived CIDs
- parses only the authenticated module/export selected by a use site instead of eagerly parsing every Python artifact
- constructs only the selected source-call closure and reuses frames/scope analysis by authenticated content
- bounds source-definition and function-substitution expansion; exceeding the bound stays typed loud
- keeps unenrolled nested managers and malformed nested source-call bindings typed loud

No timeout was raised. Memoization keys are authenticated content/CIDs, never names or stale use-site state.

## Profile evidence

- `pandas/core/apply.py`: 29.86s -> about 4s
- `pandas/core/frame.py`: >30s -> typed-loud in the sequential run
- `pandas/core/series.py`: >30s -> construction completes within the bound (a separate `ObjectMethodValue` defect is retained fatal)
- SQLAlchemy artifact graph (531 files): >38s -> 0.164s authentication
- `pandas/tests/io/test_sql.py`: >30s -> typed-loud within the unchanged 30s bound

## Validation

- focused memoization/bound/discrimination twins: 76 passed
- construction side-door law: 14 passed, R=0
- broad source-tree: 432 passed, 5 skipped, same 13 inherited failures as clean main; no new failure
- kit timeout rerun at 30s: `lift_rpc.py` typed-loud in 5s; `function_contract.py` typed-loud in 1s; `proofir/sorts/__init__.py` completed in 3s
- authoritative 238-file sequential rerun is detached on battleaxe; final discovered/completed/category receipt will be posted when complete

Do not merge without review.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound, memoize, and parallelize fatal construction residue in source-call frame resolution
> - Adds `lru_cache`-based memoization across export resolution, walrus-bound name scans, suite export binding checks, and module-init raise scans in [dependency_export_adapter.py](https://github.com/TSavo/sugar/pull/6172/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f).
> - Rewrites `resolve_source_visible_frame` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6172/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to selectively construct only the required definition closure, enforce a 4096-node expansion limit, and cache results via an optional `source_frame_cache`; emits typed `expansion-bound` and `call-binding` gaps on failure.
> - Parallelizes artifact file hashing in `DependencyArtifactGraph.authenticate` using `ThreadPoolExecutor` (up to 8 workers) and drops the parseability gate, accepting any valid UTF-8 module.
> - Propagates a shared `source_frame_cache` through `populate_source_visible_call_frames`, `populate_source_derived_resource_refs`, and `construct_manager_behavior` to reuse constructed frames across call sites within a single invocation.
> - Adds a 1024-node expansion bound to `FunctionDef._construct_sugar` and skips contract enrollment in `With._prebound_manager_resolution` for source-call construction contexts.
> - Risk: unparseable modules no longer abort graph construction and instead resolve to `opaque-source` gaps; the new node limits may cause previously-succeeding constructions to return `expansion-bound` gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fb801d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->