### PR TITLE
Amortize export scan and source-visible frame projection

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -10,10 +10,23 @@ this adapter (same residual pattern as ``source_tables_adapter``).
 from __future__ import annotations
 
 import ast
+from dataclasses import replace
 from typing import Any, Literal
 
 from .canonical import blake3_512_of
 from .source_tables import parsed_tree
+
+# Top-level export resolution (empty warrants + empty seen) is pure in
+# (distribution_artifact_cid, module_name, exported_name).  Pandas call-frame
+# preconstruction repeats the same symbol many times per file; re-running the
+# full-module static export walk per receipt was the residual wall after
+# lexical revalidation amortization (see docs/audits/pandas-recensus-latency-bisect.md).
+_EXPORT_RESOLUTION_CACHE: dict[tuple[str, str, str], Any] = {}
+
+
+def clear_export_resolution_cache() -> None:
+    """Drop amortized export resolutions (tests / hermetic process reuse)."""
+    _EXPORT_RESOLUTION_CACHE.clear()
 
 
 def _bind() -> None:
@@ -25,6 +38,7 @@ def _bind() -> None:
         "AuthenticatedModuleSourceV1",
         "DefinitionCoordinateV1",
         "DependencyArtifactGraph",
+        "PythonObjectResolutionGapV1",
         "PythonObjectResolutionV1",
         "ReexportWarrantV1",
         "ResolvedPythonObjectV1",
@@ -33,6 +47,15 @@ def _bind() -> None:
         "_string",
     ):
         g[name] = getattr(da, name)
+
+
+def _restamp_export_result(result: Any, binding_cid: str) -> Any:
+    """Reuse a cached structural resolution under a new import-binding CID."""
+    if isinstance(result, ResolvedPythonObjectV1):
+        return replace(result, import_binding_cid=binding_cid, cid="")
+    if isinstance(result, PythonObjectResolutionGapV1):
+        return replace(result, import_binding_cid=binding_cid)
+    return result
 
 
 def resolve_export(
@@ -44,6 +67,40 @@ def resolve_export(
     seen: frozenset[tuple[str, str]],
 ) -> PythonObjectResolutionV1:
     _bind()
+    # Only the entry form used by resolve_import_binding is safe to cache:
+    # non-empty warrants/seen encode path context that must not be shared.
+    cacheable = not warrants and not seen
+    cache_key = (
+        graph.distribution_artifact_cid,
+        module_name,
+        exported_name,
+    )
+    if cacheable:
+        hit = _EXPORT_RESOLUTION_CACHE.get(cache_key)
+        if hit is not None:
+            return _restamp_export_result(hit, binding_cid)
+
+    result = _resolve_export_uncached(
+        graph,
+        binding_cid,
+        module_name,
+        exported_name,
+        warrants,
+        seen,
+    )
+    if cacheable:
+        _EXPORT_RESOLUTION_CACHE[cache_key] = result
+    return result
+
+
+def _resolve_export_uncached(
+    graph: DependencyArtifactGraph,
+    binding_cid: str,
+    module_name: str,
+    exported_name: str,
+    warrants: tuple[ReexportWarrantV1, ...],
+    seen: frozenset[tuple[str, str]],
+) -> PythonObjectResolutionV1:
     key = (module_name, exported_name)
     if key in seen:
         return _gap("reexport-cycle", binding_cid, graph, module_name, exported_name)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -212,6 +212,26 @@ def construct_manager_behavior(
     )
 
 
+# Source-visible frames are pure in (artifact, definition coordinate).  The same
+# authenticated definition is projected once per repeated call-site receipt in
+# pandas megamodules; re-materializing SourceFile + class base sugar each time
+# was residual wall after export/revalidation amortization.
+_SOURCE_VISIBLE_FRAME_CACHE: dict[
+    tuple[str, str, str, str, int, int, int, int],
+    tuple[object, Node] | ManagerConstructionGapV1,
+] = {}
+# Keep SourceFile alive for cached (frame, target) node identity.
+_SOURCE_VISIBLE_FRAME_HOLD: dict[
+    tuple[str, str, str, str, int, int, int, int], object
+] = {}
+
+
+def clear_source_visible_frame_cache() -> None:
+    """Drop amortized source-visible frames (tests / hermetic process reuse)."""
+    _SOURCE_VISIBLE_FRAME_CACHE.clear()
+    _SOURCE_VISIBLE_FRAME_HOLD.clear()
+
+
 def resolve_source_visible_frame(
     resolved: ResolvedPythonObjectV1,
     *,
@@ -231,6 +251,39 @@ def resolve_source_visible_frame(
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
+    definition = resolved.definition
+    cache_key = (
+        graph.distribution_artifact_cid,
+        resolved.source_cid,
+        definition.name,
+        definition.kind,
+        definition.start_line,
+        definition.start_col,
+        definition.end_line,
+        definition.end_col,
+    )
+    hit = _SOURCE_VISIBLE_FRAME_CACHE.get(cache_key)
+    if hit is not None:
+        return hit
+
+    result = _resolve_source_visible_frame_uncached(resolved, graph=graph, module=module)
+    if isinstance(result, tuple) and len(result) == 3:
+        frame, target, source_file = result
+        # Hold the SourceFile that owns target/frame node identity.
+        _SOURCE_VISIBLE_FRAME_HOLD[cache_key] = source_file
+        _SOURCE_VISIBLE_FRAME_CACHE[cache_key] = (frame, target)
+        return frame, target
+    assert not isinstance(result, tuple)
+    _SOURCE_VISIBLE_FRAME_CACHE[cache_key] = result
+    return result
+
+
+def _resolve_source_visible_frame_uncached(
+    resolved: ResolvedPythonObjectV1,
+    *,
+    graph: DependencyArtifactGraph,
+    module,
+) -> tuple[object, Node, object] | ManagerConstructionGapV1:
     context = TreeConstructionContextV1.for_source_call_construction()
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
@@ -316,7 +369,7 @@ def resolve_source_visible_frame(
         return ManagerConstructionGapV1(
             "definition-missing", resolved.cid, "ordinary source call frame"
         )
-    return frame, target
+    return frame, target, source_file
 
 
 def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -438,3 +438,118 @@ def test_resolve_import_binding_amortizes_lexical_revalidation(tmp_path: Path) -
         f"{lexical_passes['count']} times for {n_sites} receipts from one module; "
         f"amortize revalidation (cache or batch) so this stays O(1) per module"
     )
+
+
+def test_resolve_export_amortizes_repeated_static_scans(tmp_path: Path) -> None:
+    """Red instrument: same export must not re-walk module AST per receipt.
+
+    After revalidation amortization, megamodule call-frame preconstruction still
+    paid a full static export scan per import-use receipt (many repeats of the
+    same symbol). Structural export resolution is pure in
+    (distribution, module, name); recompute frequency must be O(unique exports).
+    """
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_python_source import dependency_export_adapter as de
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="def build(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    de.clear_export_resolution_cache()
+
+    n_sites = 8
+    lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
+    source = "\n".join(lines) + "\n"
+    path = tmp_path / "consumer_export_many.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert len(receipts) == n_sites
+
+    scans = {"count": 0}
+    original_block = de._export_block
+
+    def counting_export_block(statements, name, initial):
+        scans["count"] += 1
+        return original_block(statements, name, initial)
+
+    de._export_block = counting_export_block
+    try:
+        results = [resolve_import_binding(receipt, graph=graph) for receipt in receipts]
+    finally:
+        de._export_block = original_block
+        de.clear_export_resolution_cache()
+
+    assert all(isinstance(item, ResolvedPythonObjectV1) for item in results)
+    # First receipt: package reexport walk + implementation definition (2).
+    # Further receipts must hit the top-level export cache (no more scans).
+    assert scans["count"] <= 2, (
+        f"resolve_export re-ran _export_block {scans['count']} times for "
+        f"{n_sites} receipts of the same symbol; amortize export resolution"
+    )
+    # Same import binding → same resolved object identity; definition is shared.
+    assert len({item.definition.fragment_cid for item in results}) == 1
+    assert len({item.module_name for item in results}) == 1
+
+
+def test_resolve_source_visible_frame_amortizes_repeated_materialize(
+    tmp_path: Path,
+) -> None:
+    """Red instrument: same definition must not re-SourceFile per receipt.
+
+    ``resolve_source_visible_frame`` materializes the target module and may
+    sugar class bases. Repeating that per call-site receipt dominated
+    megamodule preconstruction after export amortization.
+    """
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_python_source import manager_construction as mc
+    from sugar_lift_python_source.manager_construction import resolve_source_visible_frame
+    from sugar_source_tree.tree import SourceFile
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="def build(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    mc.clear_source_visible_frame_cache()
+
+    n_sites = 6
+    lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
+    source = "\n".join(lines) + "\n"
+    path = tmp_path / "consumer_frame_many.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    resolved = [resolve_import_binding(r, graph=graph) for r in receipts]
+    assert all(isinstance(item, ResolvedPythonObjectV1) for item in resolved)
+
+    materializations = {"count": 0}
+    original_sf = SourceFile
+
+    class CountingSourceFile(original_sf):
+        def __init__(self, *args, **kwargs):
+            materializations["count"] += 1
+            super().__init__(*args, **kwargs)
+
+    mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]
+    try:
+        frames = [
+            resolve_source_visible_frame(item, graph=graph) for item in resolved
+        ]
+    finally:
+        mc.SourceFile = original_sf  # type: ignore[misc, assignment]
+        mc.clear_source_visible_frame_cache()
+
+    assert all(isinstance(item, tuple) for item in frames)
+    assert materializations["count"] <= 1, (
+        f"resolve_source_visible_frame re-materialized SourceFile "
+        f"{materializations['count']} times for {n_sites} receipts of one "
+        f"definition; amortize source-visible frame projection"
+    )


### PR DESCRIPTION
## Summary
- Cache top-level static export resolution by `(distribution_artifact_cid, module, name)` so call-frame preconstruction does not re-walk module AST per import-use receipt.
- Cache `resolve_source_visible_frame` by definition coordinate so repeated receipts do not re-materialize `SourceFile` / re-sugar class bases.
- Red instruments pin O(unique) recompute for both paths (residual wall after #6171 revalidation amortize).

Baseline megamodule probe (pre-fix, battleaxe): `frame.py` call_frames **74s** / total 168s; `series` 14s; `generic` 14s. Median function sugar stays ~4ms.

## Validation
```
python3 -m pytest implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py \
  -k "amortizes or static_reexport_resolves" -v
# 4 passed
```

## Doctrine
Construction doors unchanged. Exact revalidation and export semantics unchanged; only recompute frequency.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Amortize export scan and source-visible frame projection to avoid redundant AST walks
> - `resolve_export` in [dependency_export_adapter.py](https://github.com/TSavo/sugar/pull/6173/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) now caches results keyed by `(distribution_artifact_cid, module_name, exported_name)` when `warrants` and `seen` are empty, skipping repeated AST walks on cache hits.
> - `resolve_source_visible_frame` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6173/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) caches `(frame, target)` tuples and retains the owning `SourceFile` to preserve node identity, avoiding redundant materialization and class-base sugar passes.
> - Both modules expose a `clear_*_cache` function to reset their respective caches within the process.
> - Cached export results are restamped via `_restamp_export_result` to replace binding-specific fields before returning to callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50c6eda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->