### PR TITLE
Resume pandas census from durable rows

### DIFF
--- a/docs/superpowers/plans/2026-07-23-pandas-census-resume.md
+++ b/docs/superpowers/plans/2026-07-23-pandas-census-resume.md
@@ -1,0 +1,132 @@
+# Pandas Census Resume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist every pandas census result at completion, resume without rerunning durable files, isolate every construction, and reconcile one complete five-floor 1,415-file run.
+
+**Architecture:** A shared checkpoint module owns manifest identity, strict JSONL validation, durable append, resume selection, and row conservation. Each floor retains its own typed classifier and aggregate, but delegates scheduling durability to that module; control/effect gains the same child boundary already used by the other floors.
+
+**Tech Stack:** Python 3.12, subprocess, concurrent futures, append-only JSONL, pytest, battleaxe `bin/bpytest`/`brun`.
+
+## Global Constraints
+
+- The per-file wall bound is at most 30 seconds and is never escalated.
+- A panic or backend defect remains a counted typed row; genuine infrastructure bugs remain fatal.
+- No row may be fabricated for a file that did not finish.
+- All five floors must use one identical non-empty corpus manifest CID.
+- The production run stays pinned to commit `c401588017ae93e9b379a34b0a155830fc710ae7`.
+- Do not merge the PR.
+
+---
+
+### Task 1: Durable checkpoint contract
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/scripts/pandas_census_checkpoint.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py`
+
+**Interfaces:**
+- Produces: `Checkpoint(floor, files, path)`, `pending_files()`, `append(file, result)`, and `rows()`.
+- Enforces: records keyed by `(corpusManifestCid, file)` and strict one-row-per-manifest-file conservation.
+
+- [ ] Write failing tests that load a durable early row after reopening, reject a foreign CID, reject duplicate keys, and reject malformed JSONL.
+- [ ] Run `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py -q` and confirm failures are caused by the absent module/API.
+- [ ] Implement canonical manifest calculation, strict load validation, and append using `flush()` plus `os.fsync()`.
+- [ ] Re-run the focused test and confirm all checkpoint contract tests pass.
+- [ ] Commit the checkpoint unit as `Persist pandas census rows durably`.
+
+### Task 2: Completion-order resumable scheduler and required twins
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/pandas_census_checkpoint.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py`
+
+**Interfaces:**
+- Produces: `run_pending(checkpoint, worker, workers)` that invokes only absent files and appends each returned typed result immediately in completion order.
+
+- [ ] Write the killed-run twin using a subprocess fixture that records invocations, completes file A, blocks on file B, is killed, then resumes; assert A ran once and all final keys exist.
+- [ ] Run the exact twin and confirm it fails because resume scheduling is absent.
+- [ ] Implement pending-only submission and `as_completed` append behavior.
+- [ ] Run the killed-run twin and confirm it passes.
+- [ ] Write the crash-between-good-files twin whose worker returns success, typed native crash, success; assert all three rows persist.
+- [ ] Run the twin and confirm its expected pre-implementation failure.
+- [ ] Add typed worker-exception handling only for declared child terminal results; let parent/infrastructure exceptions propagate.
+- [ ] Run both twins and the full checkpoint test module.
+- [ ] Commit as `Resume pandas census from completed files`.
+
+### Task 3: Integrate fatal, silent, native-crash, and timeout floors
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py`
+- Modify: corresponding `tests/test_*zero_tolerance.py` and `tests/test_corpus_fatal_triage.py`
+
+**Interfaces:**
+- Consumes: shared checkpoint and completion-order scheduler.
+- Produces: `--checkpoint-jsonl PATH` on every floor and final reports aggregated solely from conserved checkpoint rows.
+
+- [ ] Add failing focused tests proving each floor skips a durable row and preserves typed crash/panic/timeout/non-native-red categories.
+- [ ] Run the focused modules and confirm the new assertions fail for missing checkpoint integration.
+- [ ] Route each parent loop through the shared scheduler while preserving existing child classification.
+- [ ] Reject `--file-timeout` values above 30.
+- [ ] Re-run the focused modules and confirm green.
+- [ ] Commit as `Checkpoint isolated pandas census floors`.
+
+### Task 4: Isolate and checkpoint control/effect
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py`
+- Create or modify: `implementations/python/sugar-lift-py-tests/tests/test_control_effect_recensus.py`
+
+**Interfaces:**
+- Consumes: shared checkpoint scheduler.
+- Produces: child JSON testimony sufficient to reconstruct counts, mechanisms, defects, panics, and per-file floor rows; default and maximum timeout 30 seconds.
+
+- [ ] Write failing tests for a planted child signal, ConstructionPanic testimony, backend exception testimony, timeout, and continuation to a later good file.
+- [ ] Run the focused tests and confirm they fail against parent-process construction.
+- [ ] Add child mode and parent classification, returning full per-file aggregate deltas.
+- [ ] Aggregate only checkpoint testimony and emit a floor summary only at complete conservation.
+- [ ] Re-run focused control/effect and panic-collection tests.
+- [ ] Commit as `Isolate control effect census files`.
+
+### Task 5: Harden reconciliation and verify PR scope
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py`
+
+**Interfaces:**
+- Consumes: five complete native floor summaries.
+- Produces: `validated-summary.json` only when floor names, row conservation, non-empty identical manifest CID, and measured states agree.
+
+- [ ] Write failing tests for an incomplete 1,415-file floor, row/file mismatch, and same-CID-but-tampered files.
+- [ ] Run the focused reconciler test and confirm failure.
+- [ ] Implement strict expected-denominator and cross-floor manifest equality validation without synthesizing missing rows.
+- [ ] Run all focused runner/reconciler tests through `bin/bpytest`.
+- [ ] Inspect `git diff --check`, changed-file scope, and 30-second bound searches.
+- [ ] Commit as `Validate complete pandas floor reconciliation`.
+
+### Task 6: Publish the unmerged PR
+
+**Files:**
+- Modify only files already named above if verification exposes a scoped defect.
+
+- [ ] Run the focused Python test set on battleaxe with `bin/bpytest` and retain the receipt.
+- [ ] Confirm commit identity, clean status, base SHA, and branch diff.
+- [ ] Push `agent/pandas-census-resume` and open a PR describing semantics and exact focused validation.
+- [ ] Report the PR number immediately and leave it unmerged.
+
+### Task 7: Commit-pinned five-floor production census
+
+**Files:**
+- Write receipts outside tracked source under one battleaxe run directory.
+
+- [ ] Resolve the battleaxe checkout at the pinned implementation commit and record commit/interpreter/corpus provenance.
+- [ ] Discover the pandas manifest once, prove it has exactly 1,415 files, and initialize five checkpoints against that CID.
+- [ ] Launch the five floors sequentially in detached tmux using the same run directory and 30-second per-file bound.
+- [ ] Monitor numeric progress only; after disconnect/reboot rerun the same command against the same checkpoint without changing commit or receipt root.
+- [ ] Require 1,415 validated rows on every floor, then run `reconcile_pandas_floors.py` to produce `validated-summary.json`.
+- [ ] Read back numeric totals only and report `R_total`, per-class totals, corpus CID, pinned commit, and summary path.

--- a/docs/superpowers/specs/2026-07-23-pandas-census-resume-design.md
+++ b/docs/superpowers/specs/2026-07-23-pandas-census-resume-design.md
@@ -1,0 +1,57 @@
+# Pandas Census Checkpoint and Isolation Design
+
+## Goal
+
+Make one commit-pinned, five-floor pandas census survive interruption and account
+honestly for all 1,415 corpus files without increasing the 30-second per-file
+bound.
+
+## Durable row contract
+
+All five floors use one append-only JSONL checkpoint implementation. Before any
+child starts, the floor computes the complete sorted corpus manifest and its CID.
+Every appended record carries a schema identifier, floor name, manifest CID,
+relative file key, and the floor-specific result. The append is flushed and
+`fsync`ed before the result is considered complete.
+
+On resume, the loader validates every line. A malformed record, wrong floor,
+wrong manifest CID, unknown file, or duplicate file is a loud checkpoint error.
+Validated records are the completed set; only absent manifest files are run.
+There is no synthesized row for an absent file.
+
+## Per-file process boundary
+
+Every file is constructed in a dedicated child process with a maximum wall bound
+of 30 seconds. Normal testimony, ConstructionPanic, BackendDefect or other Python
+failure, timeout, and native signal termination become distinct terminal rows.
+The parent appends the typed terminal row and continues. Parent infrastructure
+failure remains fatal rather than being multiplied into invented per-file rows.
+
+Parallel floors consume futures in completion order so a slow earlier file does
+not prevent already-finished later files from reaching disk. Control/effect moves
+its construction and testimony into child mode; the parent only classifies,
+checkpoints, and aggregates testimony.
+
+## Finalization and reconciliation
+
+A floor report is emitted only by conserving exactly one validated checkpoint row
+for every manifest file. Interrupted checkpoints remain explicit partial state and
+cannot produce a measured final report. The reconciler requires all five expected
+floors, measured summaries, identical non-empty corpus manifests and CIDs, and
+exact row/file conservation before it writes `validated-summary.json`.
+
+The production census is launched in detached tmux on battleaxe from one pinned
+commit. It is resumed from the same receipt directory after incidental disconnect
+or host interruption and is not rebased or restarted when later changes merge.
+
+## Discrimination tests
+
+1. A runner completes and durably appends an early file, is killed while another
+   file is in flight, then resumes. The early file is not executed twice and the
+   final checkpoint accounts for the entire manifest.
+2. Three files run with a child crash planted between two successful files. The
+   checkpoint contains both success rows and the typed crash row, proving the
+   crash did not abort the run.
+3. Foreign-CID, duplicate, malformed, and incomplete checkpoints remain loud.
+4. Reconciliation refuses divergent manifests or any incomplete floor.
+

--- a/docs/superpowers/specs/2026-07-23-pandas-census-resume-design.md
+++ b/docs/superpowers/specs/2026-07-23-pandas-census-resume-design.md
@@ -54,4 +54,3 @@ or host interruption and is not rebased or restarted when later changes merge.
    crash did not abort the run.
 3. Foreign-CID, duplicate, malformed, and incomplete checkpoints remain loud.
 4. Reconciliation refuses divergent manifests or any incomplete floor.
-

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -8,21 +8,13 @@ import ast
 from collections import Counter, defaultdict
 import json
 from pathlib import Path
-import signal
+import os
 import subprocess
 import sys
 import time
 from typing import Any, Callable
 
 from sugar_lift_py_tests.audit_only import collect_construction_panic
-
-
-class FileTimeout(Exception):
-    pass
-
-
-def _timeout(_signum, _frame):
-    raise FileTimeout("per-file construction timeout")
 
 
 def _coordinate(node) -> tuple[str, int, int]:
@@ -157,14 +149,7 @@ def _production_source_file(
     )
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("corpus", type=Path)
-    parser.add_argument("--repo", type=Path, default=Path.cwd())
-    parser.add_argument("--timeout", type=int, default=180)
-    parser.add_argument("--json", type=Path)
-    args = parser.parse_args()
-
+def _measure_file(path: Path, *, root: Path, relative: str) -> dict[str, Any]:
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
 
@@ -176,14 +161,160 @@ def main() -> int:
         for package, distributions in package_distributions.items()
         if len(distributions) == 1
     }
-    artifact_graph_cache = {}
+    source = path.read_text(encoding="utf-8", errors="replace")
+    tree = ast.parse(source, filename=str(path))
+    imports = _import_bindings(tree)
+    syntax: dict[tuple[str, int, int], tuple[str, ...]] = {}
+    for node in ast.walk(tree):
+        labels = _labels(node, imports)
+        if labels:
+            syntax[(type(node).__name__, node.lineno, node.col_offset)] = labels
 
+    functions_total = 0
+    functions_clean = 0
+    source_calls_total = 0
+    source_call_preconstruction: Counter[str] = Counter()
+
+    def construct_file():
+        nonlocal functions_total, functions_clean, source_calls_total
+        reporter = CollectingReporter()
+        source_file = _production_source_file(
+            path,
+            root=root,
+            reporter=reporter,
+            distribution_index=distribution_index,
+            artifact_graph_cache={},
+        )
+        from sugar_lift_py_tests.source_call_resolution import (
+            SourceCallPreconstructionRefV1,
+        )
+        from sugar_source_tree.nodes import Call
+
+        source_calls_total = sum(
+            1 for node in source_file.nodes() if isinstance(node, Call)
+        )
+        for row in source_file.unit.construction_context.source_call_resolutions.values():
+            source_call_preconstruction[
+                (
+                    f"source-visible-{row.dispatch_kind}"
+                    if isinstance(row, SourceCallPreconstructionRefV1)
+                    else row.kind
+                )
+            ] += 1
+        for function in source_file.functions():
+            functions_total += 1
+            try:
+                function.sugar()
+                functions_clean += 1
+            except SugarNotWritten:
+                pass
+        return reporter
+
+    reporter, panic_row = _collect_file_construction(relative, construct_file)
+    if panic_row is not None:
+        return {
+            "category": "construction-panic",
+            "panic": panic_row,
+            "functionsTotal": functions_total,
+            "functionsClean": functions_clean,
+            "sourceCallsTotal": source_calls_total,
+            "sourceCallPreconstruction": dict(source_call_preconstruction),
+        }
+    assert reporter is not None
+    registered = {_coordinate(node) for node in reporter.registered}
+    present = {_coordinate(node) for node in reporter.present}
+    gaps = {_coordinate(node): panic for node, panic in reporter.gaps}
+    counts: dict[str, Counter[str]] = defaultdict(Counter)
+    mechanisms: dict[str, Counter[str]] = defaultdict(Counter)
+    families: Counter[str] = Counter(kind for kind, _line, _col in gaps)
+    for (kind, line, col), labels in syntax.items():
+        key = (kind, line, col)
+        if key in gaps:
+            status = "direct-loud"
+            mechanism = type(gaps[key]).__name__
+        elif key in present:
+            status = "built"
+            mechanism = None
+        elif key in registered:
+            status = "blocked-descendant"
+            mechanism = None
+        else:
+            status = "unregistered"
+            mechanism = None
+        for label in labels:
+            counts[label][status] += 1
+            if mechanism is not None:
+                mechanisms[label][mechanism] += 1
+    return {
+        "category": "completed",
+        "functionsTotal": functions_total,
+        "functionsClean": functions_clean,
+        "sourceCallsTotal": source_calls_total,
+        "sourceCallPreconstruction": dict(source_call_preconstruction),
+        "counts": {label: dict(values) for label, values in counts.items()},
+        "mechanisms": {label: dict(values) for label, values in mechanisms.items()},
+        "families": dict(families),
+    }
+
+
+def _child_main(path: Path, *, root: Path, relative: str) -> int:
+    try:
+        row = _measure_file(path, root=root, relative=relative)
+    except Exception as error:
+        row = {
+            "category": "backend-defect",
+            "defect": {
+                "file": relative,
+                "type": type(error).__name__,
+                "message": str(error),
+            },
+        }
+    print(json.dumps({"kind": "control-effect-row", "result": row}, sort_keys=True))
+    return 0
+
+
+def _parse_child(stdout: str) -> dict[str, Any] | None:
+    for line in reversed(stdout.splitlines()):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and value.get("kind") == "control-effect-row":
+            result = value.get("result")
+            return result if isinstance(result, dict) else None
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("corpus", type=Path, nargs="?")
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--commit")
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--checkpoint-jsonl", type=Path)
+    parser.add_argument("--child-file", type=Path)
+    parser.add_argument("--child-root", type=Path)
+    parser.add_argument("--child-rel")
+    args = parser.parse_args()
+    if args.child_file or args.child_root or args.child_rel:
+        if args.child_file is None or args.child_root is None or args.child_rel is None:
+            parser.error("child mode requires --child-file, --child-root, and --child-rel")
+        return _child_main(
+            args.child_file, root=args.child_root, relative=args.child_rel
+        )
+    if args.corpus is None:
+        parser.error("corpus is required in parent mode")
+    if args.timeout > 30:
+        parser.error("--timeout may not exceed 30 seconds")
     files = sorted(args.corpus.rglob("*.py"))
-    signal.signal(signal.SIGALRM, _timeout)
+    if not files:
+        parser.error("corpus contains no Python files")
     counts: dict[str, Counter] = defaultdict(Counter)
     mechanisms: dict[str, Counter] = defaultdict(Counter)
     families = Counter()
-    defects = []
+    defects: list[dict[str, Any]] = []
     construction_panics: list[dict[str, Any]] = []
     floor_rows: list[dict[str, Any]] = []
     files_completed = 0
@@ -192,134 +323,103 @@ def main() -> int:
     source_calls_total = 0
     source_call_preconstruction = Counter()
     started = time.time()
+    script = Path(__file__).resolve()
+    by_file = {
+        f"{args.corpus.name}/{path.relative_to(args.corpus).as_posix()}": path
+        for path in files
+    }
 
-    for index, path in enumerate(files, 1):
-        relative = str(path.relative_to(args.corpus))
+    def run_file(file: str) -> dict[str, Any]:
+        path = by_file[file]
+        relative = path.relative_to(args.corpus).as_posix()
+        env = dict(os.environ)
+        env["PYTHONFAULTHANDLER"] = "1"
         try:
-            signal.alarm(args.timeout)
-            source = path.read_text(encoding="utf-8", errors="replace")
-            tree = ast.parse(source, filename=str(path))
-            imports = _import_bindings(tree)
-            syntax = {}
-            for node in ast.walk(tree):
-                labels = _labels(node, imports)
-                if labels:
-                    syntax[(type(node).__name__, node.lineno, node.col_offset)] = labels
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--child-file",
+                    str(path),
+                    "--child-root",
+                    str(args.corpus),
+                    "--child-rel",
+                    relative,
+                ],
+                text=True,
+                capture_output=True,
+                timeout=args.timeout,
+                env=env,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return {"category": "timeout", "timeoutSeconds": args.timeout}
+        if completed.returncode < 0:
+            return {
+                "category": "native-crash",
+                "returncode": completed.returncode,
+                "signal": -completed.returncode,
+            }
+        testimony = _parse_child(completed.stdout)
+        if completed.returncode != 0 or testimony is None:
+            return {
+                "category": "backend-defect",
+                "defect": {
+                    "file": relative,
+                    "type": "ChildProtocolError",
+                    "message": completed.stderr[-2000:] or "child emitted no testimony",
+                },
+            }
+        return testimony
 
-            def construct_file():
-                nonlocal functions_total, functions_clean, source_calls_total
-                reporter = CollectingReporter()
-                source_file = _production_source_file(
-                    path,
-                    root=args.corpus,
-                    reporter=reporter,
-                    distribution_index=distribution_index,
-                    artifact_graph_cache=artifact_graph_cache,
-                )
-                from sugar_lift_py_tests.source_call_resolution import (
-                    SourceCallPreconstructionRefV1,
-                )
-                from sugar_source_tree.nodes import Call
+    if args.checkpoint_jsonl is not None:
+        from pandas_census_checkpoint import Checkpoint, run_pending
 
-                source_calls_total += sum(
-                    1 for node in source_file.nodes() if isinstance(node, Call)
-                )
-                for (
-                    row
-                ) in (
-                    source_file.unit.construction_context.source_call_resolutions.values()
-                ):
-                    source_call_preconstruction[
-                        (
-                            f"source-visible-{row.dispatch_kind}"
-                            if isinstance(row, SourceCallPreconstructionRefV1)
-                            else row.kind
-                        )
-                    ] += 1
-                for function in source_file.functions():
-                    functions_total += 1
-                    try:
-                        function.sugar()
-                        functions_clean += 1
-                    except SugarNotWritten:
-                        pass
-                return reporter
+        checkpoint = Checkpoint(
+            floor="control-effect",
+            files=tuple(by_file),
+            path=args.checkpoint_jsonl,
+        )
+        journal_rows = run_pending(
+            checkpoint, run_file, workers=max(1, args.workers)
+        )
+        measured_rows = [(row["file"], row["result"]) for row in journal_rows]
+    else:
+        measured_rows = [(file, run_file(file)) for file in sorted(by_file)]
 
-            reporter, panic_row = _collect_file_construction(relative, construct_file)
-            if panic_row is not None:
-                construction_panics.append(panic_row)
-                families["ConstructionPanic"] += 1
-                print(
-                    f"[{index}/{len(files)}] CONSTRUCTION-PANIC {relative}: "
-                    f"{panic_row['message']}",
-                    flush=True,
-                )
-                floor_rows.append(
-                    {
-                        "file": f"{args.corpus.name}/{relative}",
-                        "category": "construction-panic",
-                    }
-                )
-                continue
-            assert reporter is not None
-
-            registered = {_coordinate(node) for node in reporter.registered}
-            present = {_coordinate(node) for node in reporter.present}
-            gaps = {_coordinate(node): panic for node, panic in reporter.gaps}
-            for kind, _line, _col in gaps:
-                families[kind] += 1
-
-            for (kind, line, col), labels in syntax.items():
-                key = (kind, line, col)
-                if key in gaps:
-                    status = "direct-loud"
-                    mechanism = type(gaps[key]).__name__
-                elif key in present:
-                    status = "built"
-                    mechanism = None
-                elif key in registered:
-                    status = "blocked-descendant"
-                    mechanism = None
-                else:
-                    status = "unregistered"
-                    mechanism = None
-                for label in labels:
-                    counts[label][status] += 1
-                    if mechanism is not None:
-                        mechanisms[label][mechanism] += 1
+    for index, (file, raw) in enumerate(measured_rows, start=1):
+        row = dict(raw)
+        category = str(row.get("category"))
+        floor_rows.append({"file": file, "category": category})
+        functions_total += int(row.get("functionsTotal") or 0)
+        functions_clean += int(row.get("functionsClean") or 0)
+        source_calls_total += int(row.get("sourceCallsTotal") or 0)
+        source_call_preconstruction.update(row.get("sourceCallPreconstruction") or {})
+        for label, values in (row.get("counts") or {}).items():
+            counts[str(label)].update(values)
+        for label, values in (row.get("mechanisms") or {}).items():
+            mechanisms[str(label)].update(values)
+        families.update(row.get("families") or {})
+        if category == "completed":
             files_completed += 1
-            floor_rows.append(
-                {"file": f"{args.corpus.name}/{relative}", "category": "completed"}
-            )
-            if index % 100 == 0:
-                direct = sum(row["direct-loud"] for row in counts.values())
-                print(
-                    f"[{index}/{len(files)}] completed={files_completed} "
-                    f"direct-labelled={direct}",
-                    flush=True,
-                )
-        except Exception as exc:
+        elif category == "construction-panic":
+            panic = row.get("panic")
+            if isinstance(panic, dict):
+                construction_panics.append(panic)
+            families["ConstructionPanic"] += 1
+        else:
+            defect = row.get("defect")
             defects.append(
-                {"file": relative, "type": type(exc).__name__, "message": str(exc)}
+                dict(defect)
+                if isinstance(defect, dict)
+                else {"file": file, "type": category, "message": category}
             )
-            print(
-                f"[{index}/{len(files)}] DEFECT {type(exc).__name__} "
-                f"{relative}: {exc}",
-                flush=True,
-            )
-            floor_rows.append(
-                {
-                    "file": f"{args.corpus.name}/{relative}",
-                    "category": "unmeasurable",
-                    "reason": type(exc).__name__,
-                }
-            )
-        finally:
-            signal.alarm(0)
+        if index % 25 == 0:
+            print(f"measured {index}/{len(files)} files", flush=True)
 
     result = {
         "kind": "control-effect-construction-recensus",
-        "commit": _git_commit(args.repo),
+        "commit": args.commit or _git_commit(args.repo),
         "corpus": str(args.corpus),
         "filesTotal": len(files),
         "filesCompleted": files_completed,
@@ -351,9 +451,7 @@ def main() -> int:
     }
     from pandas_floor_summary import floor_summary
 
-    file_names = sorted(
-        f"{args.corpus.name}/{path.relative_to(args.corpus)}" for path in files
-    )
+    file_names = sorted(by_file)
     result["floorSummary"] = floor_summary(
         floor="control-effect",
         files=file_names,

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -457,17 +457,12 @@ def main() -> int:
         files=file_names,
         rows=floor_rows,
         totals={
-            "R_control_effect": result["R"],
+            "R_control_effect": result["R"] + len(defects),
             "constructionPanics": len(construction_panics),
-            "unmeasurable": len(defects),
+            "backendDefectsOrProcessTerminals": len(defects),
         },
-        measured=(
-            not defects and not construction_panics and files_completed == len(files)
-        ),
-        unmeasurable_reasons=(
-            (["construction-panic"] if construction_panics else [])
-            + (["defect"] if defects else [])
-        ),
+        measured=len(floor_rows) == len(files),
+        unmeasurable_reasons=(),
     )
     rendered = json.dumps(result, indent=2)
     print("=== RESULT JSON ===", flush=True)

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -159,6 +159,8 @@ def _is_fatal_category(category: str) -> bool:
 
 
 def _run_parent(args: argparse.Namespace) -> int:
+    if args.file_timeout > 30:
+        raise ValueError("per-file timeout may not exceed 30 seconds")
     packages = tuple(args.packages) or PACKAGES
     versions = {package: importlib.metadata.version(package) for package in packages}
     all_paths = [
@@ -180,20 +182,19 @@ def _run_parent(args: argparse.Namespace) -> int:
     typed_gap_classes: Counter[str] = Counter()
     typed_gap_owners: Counter[str] = Counter()
     script = Path(__file__).resolve()
+    by_rel = {
+        f"{package}/{path.relative_to(root).as_posix()}": (path, root)
+        for package, root, path in paths
+    }
 
-    for index, (package, root, path) in enumerate(paths, start=1):
+    def measure_unchecked(rel: str) -> dict[str, Any]:
+        path, _root = by_rel[rel]
         try:
             source = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             source = path.read_text(encoding="utf-8", errors="replace")
-        rel = f"{package}/{path.relative_to(root).as_posix()}"
         tree = ast.parse(source, filename=rel)
         assertion_count = sum(isinstance(node, ast.Assert) for node in ast.walk(tree))
-        assertion_counts["files_total"] += 1
-        assertion_counts["assertions_total"] += assertion_count
-        assertion_counts[
-            "files_with_assertions" if assertion_count else "files_without_assertions"
-        ] += 1
         command = [
             sys.executable,
             str(script),
@@ -226,6 +227,46 @@ def _run_parent(args: argparse.Namespace) -> int:
                 timed_out=True,
                 timeout_seconds=args.file_timeout,
             )
+        return {"assertionCount": assertion_count, "terminal": row}
+
+    def measure(rel: str) -> dict[str, Any]:
+        try:
+            return measure_unchecked(rel)
+        except Exception as error:
+            return {
+                "assertionCount": 0,
+                "terminal": {
+                    "file": rel,
+                    "category": "backend-defect",
+                    "reason": f"{type(error).__name__}: {error}",
+                },
+            }
+
+    if args.checkpoint_jsonl:
+        from pandas_census_checkpoint import Checkpoint, run_pending
+
+        checkpoint = Checkpoint(
+            floor="fatal-triage",
+            files=tuple(by_rel),
+            path=Path(args.checkpoint_jsonl),
+        )
+        journal_rows = run_pending(checkpoint, measure, workers=1)
+        measured = [dict(row["result"]) for row in journal_rows]
+    else:
+        measured = [measure(rel) for rel in sorted(by_rel)]
+
+    for index, (rel, measured_row) in enumerate(
+        zip(sorted(by_rel), measured, strict=True), start=1
+    ):
+        assertion_count = int(measured_row["assertionCount"])
+        assertion_counts["files_total"] += 1
+        assertion_counts["assertions_total"] += assertion_count
+        assertion_counts[
+            "files_with_assertions" if assertion_count else "files_without_assertions"
+        ] += 1
+        row = measured_row["terminal"]
+        if not isinstance(row, dict):
+            raise ValueError(f"invalid fatal checkpoint testimony for {rel}")
 
         category = str(row["category"])
         floor_rows.append({"file": rel, "category": category})
@@ -297,6 +338,7 @@ def main() -> int:
         "--file-timeout", type=int, default=DEFAULT_FILE_TIMEOUT_SECONDS
     )
     parser.add_argument("--output")
+    parser.add_argument("--checkpoint-jsonl")
     parser.add_argument("--child-file")
     parser.add_argument("--child-rel")
     args = parser.parse_args()

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -332,8 +332,8 @@ def main() -> int:
                 "nonNativeRed": summary.non_native_red,
                 "timeouts": summary.timeouts,
             },
-            measured=summary.timeouts == 0,
-            unmeasurable_reasons=("timeout",) if summary.timeouts else (),
+            measured=len(summary.rows) == len(files),
+            unmeasurable_reasons=(),
         )
         write_json(args.json, payload)
     print(

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -24,7 +24,7 @@ import sys
 from pathlib import Path as _P
 
 sys.path.insert(0, str(_P(__file__).resolve().parent))
-from typing import NamedTuple, Sequence
+from typing import Any, Mapping, NamedTuple, Sequence
 
 
 class NativeCrashOffender(NamedTuple):
@@ -169,18 +169,63 @@ def audit_paths(
     root: Path,
     file_timeout: int,
     workers: int,
+    checkpoint_path: Path | None = None,
 ) -> AuditSummary:
-    with ThreadPoolExecutor(max_workers=workers) as executor:
+    if file_timeout > 30:
+        raise ValueError("per-file timeout may not exceed 30 seconds")
+    if checkpoint_path is not None:
+        from pandas_census_checkpoint import checkpointed_path_results
+
+        def serialize(row: ChildResult) -> Mapping[str, Any]:
+            return {
+                "category": row.category,
+                "returncode": row.returncode,
+                "stderrTail": row.stderr_tail,
+                "signal": row.offender.signal if row.offender else None,
+            }
+
+        def deserialize(file: str, raw: Mapping[str, Any]) -> ChildResult:
+            returncode = raw.get("returncode")
+            code = int(returncode) if isinstance(returncode, int) else None
+            stderr_tail = str(raw.get("stderrTail") or "")
+            signal_name = raw.get("signal")
+            offender = (
+                NativeCrashOffender(file, code, str(signal_name), stderr_tail)
+                if raw.get("category") == "native-crash"
+                and code is not None
+                and isinstance(signal_name, str)
+                else None
+            )
+            return ChildResult(
+                file, str(raw.get("category")), code, stderr_tail, offender
+            )
+
         rows = list(
-            executor.map(
-                lambda path: _run_isolated(
-                    path,
-                    root=root,
-                    file_timeout=file_timeout,
+            checkpointed_path_results(
+                floor="native-crash",
+                paths=paths,
+                root=root,
+                checkpoint_path=checkpoint_path,
+                worker=lambda path: _run_isolated(
+                    path, root=root, file_timeout=file_timeout
                 ),
-                sorted(paths),
+                serialize=serialize,
+                deserialize=deserialize,
+                workers=workers,
             )
         )
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            rows = list(
+                executor.map(
+                    lambda path: _run_isolated(
+                        path,
+                        root=root,
+                        file_timeout=file_timeout,
+                    ),
+                    sorted(paths),
+                )
+            )
     offenders = tuple(row.offender for row in rows if row.offender is not None)
     for row in rows:
         if row.category == "timeout":
@@ -235,6 +280,7 @@ def main() -> int:
     parser.add_argument("--child-file", type=Path)
     parser.add_argument("--child-rel")
     parser.add_argument("--json", type=Path)
+    parser.add_argument("--checkpoint-jsonl", type=Path)
     args = parser.parse_args()
 
     if args.child_file or args.child_rel:
@@ -262,6 +308,7 @@ def main() -> int:
         root=args.repo_root,
         file_timeout=args.file_timeout,
         workers=max(1, args.workers),
+        checkpoint_path=args.checkpoint_jsonl,
     )
     if args.json is not None:
         from pandas_floor_summary import floor_summary, relative_files, write_json

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_census_checkpoint.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_census_checkpoint.py
@@ -1,0 +1,164 @@
+"""Durable, manifest-bound checkpoints for pandas corpus floors."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence, TypeVar
+
+from pandas_floor_summary import corpus_cid
+
+
+SCHEMA = "pandas-census-checkpoint-row-v1"
+
+
+class CheckpointError(ValueError):
+    """The durable journal does not conserve the declared corpus."""
+
+
+class Checkpoint:
+    def __init__(self, *, floor: str, files: Sequence[str], path: Path) -> None:
+        ordered = tuple(sorted(str(file) for file in files))
+        if not ordered:
+            raise CheckpointError("checkpoint requires a non-empty corpus manifest")
+        if len(set(ordered)) != len(ordered):
+            raise CheckpointError("corpus manifest contains duplicate files")
+        self.floor = floor
+        self.files = ordered
+        self.manifest_cid = corpus_cid(ordered)
+        self.path = path
+        self._by_file: dict[str, dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        raw = self.path.read_bytes()
+        if raw and not raw.endswith(b"\n"):
+            # A process can die after beginning the one in-flight append. Only
+            # that torn tail is discarded; every newline-terminated row stays.
+            end = raw.rfind(b"\n") + 1
+            with self.path.open("r+b") as stream:
+                stream.truncate(end)
+                stream.flush()
+                os.fsync(stream.fileno())
+            raw = raw[:end]
+        for line_number, encoded in enumerate(raw.splitlines(), start=1):
+            try:
+                row = json.loads(encoded)
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise CheckpointError(
+                    f"malformed checkpoint row at line {line_number}"
+                ) from error
+            self._validate_row(row, line_number=line_number)
+            file = str(row["file"])
+            if file in self._by_file:
+                raise CheckpointError(f"duplicate checkpoint row for {file}")
+            self._by_file[file] = row
+
+    def _validate_row(self, row: object, *, line_number: int | None = None) -> None:
+        where = f" at line {line_number}" if line_number is not None else ""
+        if not isinstance(row, dict) or row.get("schema") != SCHEMA:
+            raise CheckpointError(f"invalid checkpoint schema{where}")
+        if row.get("floor") != self.floor:
+            raise CheckpointError(f"checkpoint floor mismatch{where}")
+        if row.get("corpusManifestCid") != self.manifest_cid:
+            raise CheckpointError(f"checkpoint manifest CID mismatch{where}")
+        file = row.get("file")
+        if not isinstance(file, str) or file not in self.files:
+            raise CheckpointError(f"checkpoint names unknown file{where}: {file!r}")
+        if not isinstance(row.get("result"), dict):
+            raise CheckpointError(f"checkpoint result is not an object{where}")
+
+    def pending_files(self) -> tuple[str, ...]:
+        return tuple(file for file in self.files if file not in self._by_file)
+
+    def append(self, file: str, result: Mapping[str, Any]) -> dict[str, Any]:
+        if file in self._by_file:
+            raise CheckpointError(f"duplicate checkpoint row for {file}")
+        row: dict[str, Any] = {
+            "schema": SCHEMA,
+            "floor": self.floor,
+            "corpusManifestCid": self.manifest_cid,
+            "file": file,
+            "result": dict(result),
+        }
+        self._validate_row(row)
+        encoded = (json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n").encode(
+            "utf-8"
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(
+            self.path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644
+        )
+        try:
+            view = memoryview(encoded)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("checkpoint append made no progress")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        self._by_file[file] = row
+        return row
+
+    def rows(self) -> list[dict[str, Any]]:
+        return [self._by_file[file] for file in self.files if file in self._by_file]
+
+
+def run_pending(
+    checkpoint: Checkpoint,
+    worker: Callable[[str], Mapping[str, Any]],
+    *,
+    workers: int,
+) -> list[dict[str, Any]]:
+    pending = checkpoint.pending_files()
+    if not pending:
+        return checkpoint.rows()
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
+        futures = {executor.submit(worker, file): file for file in pending}
+        for future in as_completed(futures):
+            file = futures[future]
+            checkpoint.append(file, future.result())
+    return checkpoint.rows()
+
+
+T = TypeVar("T")
+
+
+def checkpointed_path_results(
+    *,
+    floor: str,
+    paths: Sequence[Path],
+    root: Path,
+    checkpoint_path: Path,
+    worker: Callable[[Path], T],
+    serialize: Callable[[T], Mapping[str, Any]],
+    deserialize: Callable[[str, Mapping[str, Any]], T],
+    workers: int,
+) -> tuple[T, ...]:
+    """Run absent paths and return one typed result for every manifest file."""
+    by_rel = {
+        path.resolve().relative_to(root.resolve()).as_posix(): path
+        for path in sorted(paths)
+    }
+    checkpoint = Checkpoint(
+        floor=floor, files=tuple(by_rel), path=checkpoint_path
+    )
+    rows = run_pending(
+        checkpoint,
+        lambda rel: serialize(worker(by_rel[rel])),
+        workers=workers,
+    )
+    if len(rows) != len(by_rel):
+        raise CheckpointError(
+            f"incomplete {floor} checkpoint: {len(rows)}/{len(by_rel)} rows"
+        )
+    return tuple(
+        deserialize(str(row["file"]), row["result"])
+        for row in rows
+    )

--- a/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
@@ -18,7 +18,9 @@ def _summary(raw: Mapping[str, Any]) -> Mapping[str, Any]:
     return nested if isinstance(nested, Mapping) else raw
 
 
-def reconcile(reports: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+def reconcile(
+    reports: Mapping[str, Mapping[str, Any]], *, expected_files: int | None = None
+) -> dict[str, Any]:
     missing = sorted(set(FLOORS) - set(reports))
     errors: list[str] = [f"missing floor: {name}" for name in missing]
     summaries: dict[str, Mapping[str, Any]] = {}
@@ -43,6 +45,18 @@ def reconcile(reports: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
             errors.append(f"{name}: empty corpus is not a measured zero")
         elif len(rows) != len(files):
             errors.append(f"{name}: per-site row conservation failure")
+        else:
+            row_files = [row.get("file") for row in rows if isinstance(row, Mapping)]
+            if (
+                len(row_files) != len(rows)
+                or any(not isinstance(file, str) for file in row_files)
+                or sorted(str(file) for file in row_files) != sorted(files)
+            ):
+                errors.append(f"{name}: per-site row identity failure")
+            if expected_files is not None and len(files) != expected_files:
+                errors.append(
+                    f"{name}: expected {expected_files} corpus files, got {len(files)}"
+                )
     manifests = {
         str(row.get("corpus", {}).get("manifestCid"))
         for row in summaries.values()
@@ -50,6 +64,13 @@ def reconcile(reports: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
     }
     if len(manifests) != 1 or "None" in manifests:
         errors.append("five floors do not name one identical corpus manifest")
+    file_manifests = {
+        tuple(row.get("corpus", {}).get("files", ()))
+        for row in summaries.values()
+        if isinstance(row.get("corpus"), Mapping)
+    }
+    if len(file_manifests) != 1:
+        errors.append("five floors do not carry one identical corpus file manifest")
     totals = {
         name: dict(row.get("totals", {}))
         for name, row in summaries.items()
@@ -77,12 +98,13 @@ def main() -> int:
     for floor in FLOORS:
         parser.add_argument("--" + floor, type=Path, required=True)
     parser.add_argument("--output", type=Path, default=Path("validated-summary.json"))
+    parser.add_argument("--expected-files", type=int, default=1415)
     args = parser.parse_args()
     reports = {
         floor: json.loads(getattr(args, floor.replace("-", "_")).read_text(encoding="utf-8"))
         for floor in FLOORS
     }
-    result = reconcile(reports)
+    result = reconcile(reports, expected_files=args.expected_files)
     write_json(args.output, result)
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result["verdict"] == "green" else 1

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -385,8 +385,8 @@ def main() -> int:
                 "nonNativeRed": summary.non_native_red,
                 "timeouts": summary.timeouts,
             },
-            measured=not incomplete,
-            unmeasurable_reasons=incomplete,
+            measured=len(summary.rows) == len(files),
+            unmeasurable_reasons=(),
         )
         write_json(args.json, payload)
     print(

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -214,18 +214,67 @@ def audit_paths(
     root: Path,
     file_timeout: int,
     workers: int,
+    checkpoint_path: Path | None = None,
 ) -> AuditSummary:
-    with ThreadPoolExecutor(max_workers=workers) as executor:
+    if file_timeout > 30:
+        raise ValueError("per-file timeout may not exceed 30 seconds")
+    if checkpoint_path is not None:
+        from pandas_census_checkpoint import checkpointed_path_results
+
+        def serialize(row: ChildResult) -> Mapping[str, Any]:
+            return {
+                "category": row.category,
+                "offenders": [offender._asdict() for offender in row.offenders],
+                "returncode": row.returncode,
+                "stderrTail": row.stderr_tail,
+            }
+
+        def deserialize(file: str, raw: Mapping[str, Any]) -> ChildResult:
+            offenders = tuple(
+                SilentOffender(
+                    file=str(offender["file"]),
+                    kind=str(offender["kind"]),
+                    count=int(offender["count"]),
+                    note=str(offender["note"]),
+                )
+                for offender in raw.get("offenders", [])
+                if isinstance(offender, Mapping)
+            )
+            returncode = raw.get("returncode")
+            return ChildResult(
+                file,
+                str(raw.get("category")),
+                offenders,
+                int(returncode) if isinstance(returncode, int) else None,
+                str(raw.get("stderrTail") or ""),
+            )
+
         rows = list(
-            executor.map(
-                lambda path: _run_isolated(
-                    path,
-                    root=root,
-                    file_timeout=file_timeout,
+            checkpointed_path_results(
+                floor="silent",
+                paths=paths,
+                root=root,
+                checkpoint_path=checkpoint_path,
+                worker=lambda path: _run_isolated(
+                    path, root=root, file_timeout=file_timeout
                 ),
-                sorted(paths),
+                serialize=serialize,
+                deserialize=deserialize,
+                workers=workers,
             )
         )
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            rows = list(
+                executor.map(
+                    lambda path: _run_isolated(
+                        path,
+                        root=root,
+                        file_timeout=file_timeout,
+                    ),
+                    sorted(paths),
+                )
+            )
     offenders = tuple(offender for row in rows for offender in row.offenders)
     for row in rows:
         if row.category in {
@@ -288,6 +337,7 @@ def main() -> int:
     parser.add_argument("--child-file", type=Path)
     parser.add_argument("--child-rel")
     parser.add_argument("--json", type=Path)
+    parser.add_argument("--checkpoint-jsonl", type=Path)
     args = parser.parse_args()
 
     if args.child_file or args.child_rel:
@@ -306,6 +356,7 @@ def main() -> int:
         root=args.repo_root,
         file_timeout=args.file_timeout,
         workers=max(1, args.workers),
+        checkpoint_path=args.checkpoint_jsonl,
     )
     incomplete = tuple(
         sorted({row.category for row in summary.rows if row.category != "completed"})

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from typing import Any, Mapping
 
 # Floors share ``_production_lift_child`` (this directory); make it
 # importable whether run standalone, as a child, or spec-loaded by a test.
@@ -110,17 +111,57 @@ def _run_child(path: Path, rel: str) -> int:
 
 
 def audit_paths(
-    paths: Sequence[Path], *, root: Path, file_timeout: int, workers: int
+    paths: Sequence[Path],
+    *,
+    root: Path,
+    file_timeout: int,
+    workers: int,
+    checkpoint_path: Path | None = None,
 ) -> AuditSummary:
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        rows = tuple(
-            executor.map(
-                lambda path: _run_isolated(
-                    path, root=root, file_timeout=file_timeout
+    if file_timeout > 30:
+        raise ValueError("per-file timeout may not exceed 30 seconds")
+    if checkpoint_path is not None:
+        from pandas_census_checkpoint import checkpointed_path_results
+
+        def serialize(row: ChildResult) -> Mapping[str, Any]:
+            return {
+                "category": row.category,
+                "timeoutSeconds": (
+                    row.offender.timeout_seconds if row.offender else None
                 ),
-                sorted(paths),
+            }
+
+        def deserialize(file: str, raw: Mapping[str, Any]) -> ChildResult:
+            seconds = raw.get("timeoutSeconds")
+            offender = (
+                timeout_offender(file=file, timeout_seconds=float(seconds))
+                if raw.get("category") == "timeout" and isinstance(seconds, (int, float))
+                else None
             )
+            return ChildResult(file, str(raw.get("category")), offender)
+
+        rows = checkpointed_path_results(
+            floor="timeout",
+            paths=paths,
+            root=root,
+            checkpoint_path=checkpoint_path,
+            worker=lambda path: _run_isolated(
+                path, root=root, file_timeout=file_timeout
+            ),
+            serialize=serialize,
+            deserialize=deserialize,
+            workers=workers,
         )
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            rows = tuple(
+                executor.map(
+                    lambda path: _run_isolated(
+                        path, root=root, file_timeout=file_timeout
+                    ),
+                    sorted(paths),
+                )
+            )
     return AuditSummary(
         rows=rows,
         offenders=tuple(row.offender for row in rows if row.offender is not None),
@@ -146,6 +187,7 @@ def main() -> int:
     parser.add_argument("--child-file", type=Path)
     parser.add_argument("--child-rel")
     parser.add_argument("--json", type=Path)
+    parser.add_argument("--checkpoint-jsonl", type=Path)
     args = parser.parse_args()
     if args.child_file or args.child_rel:
         if args.child_file is None or args.child_rel is None:
@@ -171,6 +213,7 @@ def main() -> int:
         root=args.repo_root,
         file_timeout=args.file_timeout,
         workers=max(1, args.workers),
+        checkpoint_path=args.checkpoint_jsonl,
     )
     rows = summary.rows
     offenders = summary.offenders

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from pandas_census_checkpoint import Checkpoint, CheckpointError, run_pending  # noqa: E402
+
+
+def test_killed_run_resumes_without_redoing_completed_file(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "rows.jsonl"
+    invocations = tmp_path / "invocations.jsonl"
+    blocked = tmp_path / "blocked"
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            from pathlib import Path
+            import sys
+            import time
+
+            sys.path.insert(0, {str(SCRIPTS)!r})
+            from pandas_census_checkpoint import Checkpoint, run_pending
+
+            checkpoint = Checkpoint(
+                floor="planted",
+                files=("a.py", "b.py", "c.py"),
+                path=Path({str(checkpoint)!r}),
+            )
+            invocations = Path({str(invocations)!r})
+            blocked = Path({str(blocked)!r})
+
+            def worker(file):
+                with invocations.open("a", encoding="utf-8") as stream:
+                    stream.write(json.dumps({{"file": file}}) + "\\n")
+                    stream.flush()
+                if file == "b.py" and not blocked.exists():
+                    blocked.write_text("started", encoding="utf-8")
+                    time.sleep(60)
+                return {{"category": "completed"}}
+
+            run_pending(checkpoint, worker, workers=1)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    process = subprocess.Popen([sys.executable, str(driver)])
+    deadline = time.monotonic() + 10
+    while not blocked.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert blocked.exists(), "planted run never reached the in-flight file"
+    os.kill(process.pid, signal.SIGKILL)
+    process.wait(timeout=5)
+
+    subprocess.run([sys.executable, str(driver)], check=True, timeout=10)
+
+    calls = [json.loads(line)["file"] for line in invocations.read_text().splitlines()]
+    assert calls.count("a.py") == 1
+    assert calls.count("b.py") == 2
+    assert calls.count("c.py") == 1
+    resumed = Checkpoint(
+        floor="planted", files=("a.py", "b.py", "c.py"), path=checkpoint
+    )
+    assert [row["file"] for row in resumed.rows()] == ["a.py", "b.py", "c.py"]
+
+
+def test_crash_between_good_files_is_a_durable_typed_row(tmp_path: Path) -> None:
+    checkpoint = Checkpoint(
+        floor="planted",
+        files=("a.py", "crash.py", "z.py"),
+        path=tmp_path / "rows.jsonl",
+    )
+
+    def worker(file: str) -> dict[str, object]:
+        program = (
+            "import os, signal; os.kill(os.getpid(), signal.SIGABRT)"
+            if file == "crash.py"
+            else "pass"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", program], capture_output=True, check=False
+        )
+        if result.returncode < 0:
+            return {
+                "category": "native-crash",
+                "signal": signal.Signals(-result.returncode).name,
+            }
+        return {"category": "completed"}
+
+    run_pending(checkpoint, worker, workers=1)
+
+    assert [(row["file"], row["result"]["category"]) for row in checkpoint.rows()] == [
+        ("a.py", "completed"),
+        ("crash.py", "native-crash"),
+        ("z.py", "completed"),
+    ]
+
+
+def test_checkpoint_rejects_foreign_manifest_duplicate_and_malformed_rows(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "rows.jsonl"
+    checkpoint = Checkpoint(floor="planted", files=("a.py",), path=path)
+    checkpoint.append("a.py", {"category": "completed"})
+
+    with pytest.raises(CheckpointError, match="manifest CID"):
+        Checkpoint(floor="planted", files=("different.py",), path=path)
+
+    with pytest.raises(CheckpointError, match="duplicate"):
+        checkpoint.append("a.py", {"category": "completed"})
+
+    path.write_text("{not json}\n", encoding="utf-8")
+    with pytest.raises(CheckpointError, match="malformed"):
+        Checkpoint(floor="planted", files=("a.py",), path=path)

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
@@ -99,3 +99,15 @@ def test_different_corpus_identity_cannot_reconcile() -> None:
 
     assert result["measurement"] == "unmeasurable"
     assert "five floors do not name one identical corpus manifest" in result["errors"]
+
+
+def test_expected_denominator_and_exact_file_rows_are_required() -> None:
+    reports = {name: _floor(name) for name in RECONCILE.FLOORS}
+    reports["silent"]["rows"] = [
+        {"file": "renamed/other.py", "category": "completed"}
+    ]
+
+    result = RECONCILE.reconcile(reports, expected_files=1415)
+
+    assert "silent: per-site row identity failure" in result["errors"]
+    assert "silent: expected 1415 corpus files, got 1" in result["errors"]


### PR DESCRIPTION
## What changed

- add one strict append-only JSONL checkpoint contract shared by all five pandas floors
- `fsync` every completed per-file result and resume only absent manifest keys
- recover only a torn final append; reject malformed, duplicate, foreign-floor, foreign-CID, or unknown-file rows
- consume concurrent work in completion order so finished files are durable even behind a slow earlier file
- move control/effect construction into a 30-second child process and preserve ConstructionPanic, backend defect, timeout, and native crash as typed terminal rows
- require exact 1,415-row, identical-file-manifest reconciliation for production output

## Why

Six pandas censuses failed before 1,415/1,415 and discarded all progress because results existed only in parent memory. A disconnect, killed tmux session, or reboot restarted every floor from zero; control/effect also constructed inside the parent process.

## Validation

- RED: checkpoint test initially failed collection because the checkpoint module did not exist
- `bin/bpytest --noconftest implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py -q` — 24 passed
- killed-parent twin proves a durable file is not rerun and only the in-flight file is lost
- real `SIGABRT` twin proves success / crash / success all persist
- battleaxe one-file control/effect smoke completed, then resumed the same checkpoint in 0.003 seconds with identical testimony

## Validation limitation

A broader historical batch had 30 passes and 5 environment failures because the immutable battleaxe Python closure did not expose `sugar_source_tree` to those tests. Those failures were import/bootstrap failures, not runner assertions; they are not represented as green.

This PR is intentionally unmerged. The full census is pinned to this branch commit and runs separately on battleaxe.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume pandas census measurement from durable per-file checkpoints
> - Adds [pandas_census_checkpoint.py](https://github.com/TSavo/sugar/pull/6174/files#diff-3e92167f9d410c02929b6f6056039e6dc3c2e6c5d81d326f953548bae943a262) with a `Checkpoint` class that maintains a manifest-scoped, append-only JSONL journal, and `run_pending`/`checkpointed_path_results` utilities that submit only uncompleted files and persist results immediately on completion.
> - Updates all five census floors (`control_effect_recensus`, `corpus_fatal_triage`, `native_crash_zero_tolerance`, `silent_zero_tolerance`, `timeout_zero_tolerance`) to accept `--checkpoint-jsonl` and skip already-measured files on resume.
> - `control_effect_recensus` now isolates each file in a child process with a 30s hard cap, classifying outcomes as `completed`, `construction-panic`, `backend-defect`, `native-crash`, or `timeout`.
> - `reconcile_pandas_floors` gains stricter validation: per-site row identity (not just count), identical file manifests across all five floors, and a configurable `--expected-files` corpus size (default 1415).
> - `measured` status across floors is now determined by row conservation (`len(rows) == len(files)`) rather than absence of failures.
> - Risk: all floors enforce `--timeout <= 30`; runs with higher values will now error out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 075db62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->