### PR TITLE
Add construction-occurrence object identity for attributes

### DIFF
--- a/docs/superpowers/plans/2026-07-23-construction-occurrence-object-identity.md
+++ b/docs/superpowers/plans/2026-07-23-construction-occurrence-object-identity.md
@@ -1,0 +1,120 @@
+# Construction-Occurrence Object Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add authenticated construction-occurrence identity and immutable attribute-field versions through Sugar's sole temporal binding path.
+
+**Architecture:** Closed content-addressed coordinate/version values live in a focused `object_identity.py` module. Constructed call-result nodes carry those values through ordinary `BindingEntryV1.state`; `Call`, `Assign`, and `Attribute` only project or evolve authenticated testimony and never derive identity from binding owners or class/name shape.
+
+**Tech Stack:** Python 3.12, dataclasses, Sugar source-tree construction, pytest, `bin/bpytest`, `bin/brun`, battleaxe pandas census.
+
+## Global Constraints
+
+- Attribute places ship; subscript places remain typed-loud.
+- Identity is allocation definition plus exact call occurrence plus construction-context generation plus source/artifact CIDs, or an authenticated opaque-result coordinate from the call occurrence.
+- Assignment copies object coordinates; distinct call occurrences remain distinct.
+- Field state is keyed by object coordinate plus attribute-field coordinate and every mutation appends an immutable prior-linked version.
+- Opaque calls invalidate only affected reachable field knowledge; unknown alias escape stays typed-loud.
+- No `BindingEntryV1`-owner, type, spelling, equality, field-content, class, or vendor identity gate.
+- One temporal binding model, `h = h(p)`, no fabrication, zero new side doors, zero panic catches, and no timeout increase.
+- Heavy validation runs only on battleaxe.
+- Rebase on current `origin/main` immediately before review/push; do not self-merge.
+
+---
+
+### Task 1: Close and test the coordinate/version substrate
+
+**Files:**
+- Create: `implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py`
+- Create: `implementations/python/sugar-source-tree/tests/test_object_identity_v1.py`
+
+**Interfaces:**
+- Produces: `SourceObjectCoordinateV1.mint(...)`, `OpaqueObjectCoordinateV1.mint(...)`, `AttributeFieldCoordinateV1.mint(...)`, `AttributeFieldVersionV1.mint(...)`, and each type's `decode()`/`wire()`.
+- Invariant: every decoder accepts an exact closed wire shape and recomputes its CID from the complete preimage.
+
+- [ ] Write tests that mint two source coordinates at different call fragments and assert different CIDs; mint aliases from the same wire and assert equality; mint an opaque coordinate and assert its wire contains no fields or behavior.
+- [ ] Add mutation twins that alter allocation, occurrence, generation, source/artifact CID, selector, prior CID, stored-value testimony, and version CID; assert `BindingProvenanceGap`.
+- [ ] Run `bin/bpytest implementations/python/sugar-source-tree/tests/test_object_identity_v1.py -q`; expect collection success and failures because `object_identity` is absent.
+- [ ] Implement frozen exact-wire dataclasses whose `mint` and `decode` both compute `cid_of_json(preimage)`; use tagged variants rather than optional source/opaque fields.
+- [ ] Re-run the focused test; expect all tests passing, then commit `Add construction occurrence object coordinates`.
+
+### Task 2: Make acceptance and side-door instruments red first
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/version_flow.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_version_flow.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/selective_opaque_invalidation.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/opaque_result_identity.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/unknown_alias_escape.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/subscript_loud.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py`
+
+**Interfaces:**
+- Produces: a closed matrix naming every approved acceptance invariant and a structural scanner axis for forbidden object-identity side doors.
+- Consumes: the coordinate/version wire interfaces from Task 1.
+
+- [ ] Add truthful, lying, and renamed structural fixtures for every approved acceptance behavior; make subscript and unknown escape explicit loud cases.
+- [ ] Replace the broad strict-xfail positive test with exact per-case target assertions and add direct forgery tests for coordinate/version wires.
+- [ ] Plant forbidden binding-owner identity, class/name/vendor dispatch, ambient object table, generic fallback, panic catch, and fabricated subscript implementations in scanner fixtures; require each offender and replacement shape to be reported.
+- [ ] Run the acceptance and scanner tests through `bin/bpytest`; record the expected red acceptance count while planted scanner twins pass.
+- [ ] Commit `Test construction occurrence object identity acceptance` without weakening the red target.
+
+### Task 3: Carry identity and immutable attribute state through the sole path
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py` only if a closed state projection hook is required; do not add another map.
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/attribute_place_value.py`
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_place_sugar.py`
+- Modify: nearby `__init__.py` exports only where required by the kit registry.
+
+**Interfaces:**
+- Produces: an object-bearing constructed expression with `object_coordinate`, immutable tuple of attribute versions, `with_attribute_store(...)`, `attribute_field(...)`, and `invalidate_fields(...)`.
+- Consumes: existing call-definition/source-oracle testimony and exact call `SourceFragment`; never consumes a destination binding coordinate as identity authority.
+
+- [ ] Add a direct failing test proving `Call._construct_sugar` is invoked once and the exact occurrence fragment—not the destination binding—is the coordinate preimage.
+- [ ] Implement source versus opaque occurrence minting at the sole call construction boundary, using authenticated resolved-definition/source/artifact testimony where present and opaque occurrence otherwise.
+- [ ] Add failing alias and distinct-occurrence tests, then make ordinary assignment/substitution copy the object-bearing state unchanged.
+- [ ] Add failing store/read/version-chain tests, then implement attribute store evolution as frozen prior-linked versions and attribute read projection after complete validation.
+- [ ] Add failing descriptor/custom allocation/`__setattr__` and subscript tests; keep each typed-loud unless behavior construction is present.
+- [ ] Run the focused acceptance, runtime binding, Assign, Call, and construction side-door tests through `bin/bpytest`; expect green and `R_construction_side_doors=0`.
+- [ ] Commit `Thread immutable attribute state by object occurrence`.
+
+### Task 4: Selective opaque invalidation and measured pandas delta
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py`
+
+**Interfaces:**
+- Produces: call affected-set construction over authenticated argument coordinates; exact invalidation of reachable field knowledge; numeric base/head object-field census JSON.
+- Invariant: inability to construct the affected alias set yields a typed gap, never global clearing or silent preservation.
+
+- [ ] Write a failing twin where an opaque call receives one of two objects and only that object's known field becomes unavailable.
+- [ ] Write a failing unknown-alias-escape twin and require typed-loud.
+- [ ] Implement affected-set projection from authenticated call arguments and immutable invalidation markers for only those coordinates.
+- [ ] Extend the census to emit discovered/completed/timeout/panic/non-native-red denominators plus per-outcome transition counts; tests must reject incomplete or zero denominators.
+- [ ] Run focused tests through `bin/bpytest`; commit `Invalidate only opaque call affected fields`.
+- [ ] On battleaxe, run identical base/head census commands with the same pandas artifact and timeout, capturing JSON and logs under a branch-specific remote receipt directory.
+- [ ] Compare numeric JSON fields and record honest `Delta R`; if discovered does not equal completed or timeout/panic floors rise, report the measurement as incomplete rather than zero.
+
+### Task 5: Rebase, verify, review, and publish without merging
+
+**Files:**
+- Modify: implementation/tests only as required to resolve current-main conflicts without changing the ruling.
+- Create: PR body in a temporary file outside the repository.
+
+**Interfaces:**
+- Produces: one draft PR based on current `origin/main`, with focused receipts, battleaxe receipts, honest `Delta R`, predicted `Epsilon R`, and explicit unmerged status.
+
+- [ ] Fetch `origin/main`, rebase the branch, and resolve conflicts by preserving current-main sole-path construction plus this plan's occurrence identity.
+- [ ] Re-run the complete focused acceptance and side-door commands on battleaxe after the rebase; inspect exit codes and exact pass/fail counts.
+- [ ] Run `git diff --check`, adds-only/vocabulary searches for forbidden owner/class/name/vendor identity gates, panic catches, ambient maps, fabricated subscript handling, and timeout changes.
+- [ ] Review `git diff origin/main...HEAD` requirement by requirement; correct all critical/important findings and re-run affected tests.
+- [ ] Confirm author/committer is `T Savo <evilgenius@nefariousplan.com>`, working tree is clean, and branch is still unmerged.
+- [ ] Push with upstream tracking and open a draft PR targeting `main`; do not merge it.
+- [ ] Report the PR number immediately with branch/head SHA, rebase base SHA, focused/battleaxe receipts, numeric `Delta R`, floors, and any honest residuals.

--- a/docs/superpowers/specs/2026-07-23-construction-occurrence-object-identity-design.md
+++ b/docs/superpowers/specs/2026-07-23-construction-occurrence-object-identity-design.md
@@ -1,0 +1,143 @@
+# Construction-Occurrence Object Identity Design
+
+## Scope
+
+Lane 4 adds the general object-identity substrate needed by calls, methods,
+loop state, and external pandas/NumPy attribute fields. This slice implements
+only attribute places (`obj.field`). Subscript places (`obj[key]`) remain
+typed-loud and are the next slice; attribute identity does not wait on them.
+
+This rebuilds the useful immutable-field ideas from draft PR #6126 on current
+`main` without merging or copying its binding-owner or plain-class admission
+model.
+
+## Identity authority
+
+Identity comes only from a construction occurrence. `ObjectCoordinateV1` is a
+closed, content-addressed coordinate with two authenticated variants:
+
+- A source-constructed coordinate commits to the allocation definition, exact
+  call occurrence, construction-context generation, source CID, and artifact
+  CID.
+- An opaque-result coordinate commits to the exact native/opaque call
+  occurrence, construction-context generation, source CID, and artifact CID.
+
+The coordinate law is `h = h(p)`: the CID is recomputed from the complete
+preimage. Different call occurrences have different coordinates even when
+their spelling, callee, type, arguments, or resulting contents are equal.
+Neither a `BindingEntryV1` coordinate nor a class/name/vendor test may mint or
+admit object identity.
+
+An opaque-result coordinate proves identity and aliasing only. It carries no
+invented field, descriptor, behavior, return-type, or class testimony.
+
+## Sole temporal path and aliasing
+
+An object-bearing constructed node carries its authenticated object coordinate
+and immutable field-state projection through the existing runtime
+`BindingEntryV1.state`. The binding entry remains the one temporal carrier but
+is not the source of object identity.
+
+Ordinary assignment copies the constructed object coordinate unchanged.
+Aliases therefore share one identity. A distinct call construction mints a
+distinct coordinate. There is no ambient heap, secondary name map,
+compatibility decoder, spelling gate, or class-specific pandas/NumPy arm.
+
+Branch joins use the existing guarded binding faces. A field version available
+on one completion face stays guarded on that face. Halted faces publish no
+later mutation.
+
+## Attribute places and immutable versions
+
+`AttributeFieldCoordinateV1` content-addresses an authenticated attribute
+selector. Field state is keyed by the typed pair
+`(ObjectCoordinateV1, AttributeFieldCoordinateV1)`.
+
+Every authenticated attribute store creates a new immutable
+`AttributeFieldVersionV1`. Its preimage commits to the object coordinate, field
+coordinate, exact store occurrence, constructed stored-value testimony,
+construction generation, and optional prior-version CID. A read projects only
+the latest authenticated version for that pair. Earlier projections retain
+their earlier version, and independent object/version chains cannot cross.
+
+Decode and projection recompute every coordinate and version CID. Any forged
+identity, selector, prior link, stored value, or version CID is rejected with a
+typed construction/provenance gap.
+
+## Behavior authority and loud boundaries
+
+An attribute store/read is constructible only when source construction proves
+the applicable allocation, attribute lookup, descriptor, and `__setattr__`
+behavior. Custom allocation, data descriptors, custom `__getattribute__`,
+custom `__getattr__`, custom `__setattr__`, monkey-patched behavior, and absent
+source testimony remain typed-loud.
+
+An opaque call invalidates only field knowledge for authenticated object
+coordinates that may be reached by that call and for which no frame testimony
+proves preservation. Unrelated object coordinates and fields remain intact.
+An unknown alias escape that prevents a sound affected-set construction stays
+typed-loud; it does not silently preserve knowledge or clear an invented global
+heap.
+
+Opaque/native results receive authenticated opaque-occurrence identity with an
+empty field-state projection. Aliasing that result copies its coordinate, but
+field reads and behavior remain typed-loud until separately constructed.
+
+All subscript reads and stores remain typed-loud in this slice.
+
+## Construction flow
+
+1. Construct the call occurrence exactly once through the sole call path.
+2. When allocation definition testimony exists, mint a source-constructed
+   object coordinate from that definition and occurrence. Otherwise mint an
+   opaque-result coordinate from the authenticated call occurrence.
+3. Carry that coordinate in the constructed result through ordinary temporal
+   assignment and substitution.
+4. For an attribute store, authenticate object and behavior testimony, construct
+   the RHS exactly once, and append an immutable field version.
+5. For an attribute read, validate the coordinate and complete version chain,
+   then project the stored constructed value.
+6. At opaque calls, construct the reachable affected set or remain typed-loud;
+   invalidate only that set.
+
+## Acceptance and instrumentation
+
+The focused acceptance instrument has truthful, lying, and renamed structural
+twins for:
+
+- store then read;
+- distinct construction occurrences do not collide;
+- aliases share one identity;
+- store, read, re-alias, mutate, and read again preserves immutable versions;
+- distinct version chains do not cross;
+- opaque calls invalidate affected field knowledge only;
+- forged identities and versions are rejected;
+- opaque/native results receive opaque-occurrence identity without fields;
+- unknown alias escape stays typed-loud; and
+- subscript places stay typed-loud.
+
+The fixtures and structural auditor forbid identity based on name, type,
+spelling, equality, field contents, vendor, and `BindingEntryV1` ownership. A
+construction side-door instrument reports every live offender and replacement
+shape, including new name/class/vendor dispatch, ambient identity tables,
+generic fallbacks, panic catches, and subscript fabrication. It stays red while
+any stable-zero term is nonzero.
+
+The pandas measurement reports a proven non-empty base/head denominator and
+numeric outcome transitions. Honest `Delta R` is read only from those receipts;
+a completed process, focused green tests, or missing output is not a measured
+delta.
+
+## Floors
+
+- One temporal binding model and one construction path.
+- `h = h(p)` for every coordinate and immutable version.
+- No name, type, spelling, equality, field-content, or vendor identity gate.
+- No fabricated fields, behavior, aliases, coordinates, versions, CIDs, or
+  signatures.
+- Zero new construction side-door findings.
+- Zero panic catches.
+- No timeout increase in the battleaxe measurement.
+- Heavy validation and pandas measurement run only on battleaxe.
+- Rebase on current `origin/main` immediately before final review and push.
+- Open the PR for user review and do not self-merge.

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
@@ -18,7 +18,9 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.audit_only.collect_construction_gaps import (
+    collect_construction_panic,
+)
 from sugar_source_tree.backend import BackendCouldNotParse, materialize
 from sugar_source_tree.cpython_adapter import _Handle
 from sugar_source_tree.nodes import SourceUnit
@@ -79,6 +81,12 @@ def _panic_key(panic: BaseException) -> str:
     observed = getattr(panic, "observed", "")
     requested = getattr(panic, "requested", "")
     return f"{owner}|{observed}|{requested}"
+
+
+def _gap_key(info: dict[str, str]) -> str:
+    return "|".join(
+        info.get(field, "") for field in ("owner", "observed", "requested")
+    )
 
 
 def _plain_class_names(module: ast.Module) -> frozenset[str]:
@@ -161,7 +169,9 @@ def measure(
                 direct[shape]["total"] += 1
                 node = materialize(unit, _Handle(unit, native))
                 try:
-                    node.sugar()
+                    _, gap = collect_construction_panic(
+                        f"{path}:{getattr(native, 'lineno', 0)}", node.sugar
+                    )
                 except SugarNotWritten as panic:
                     own = getattr(panic, "owner", "") in {
                         "Assign.sugar", "AnnAssign.sugar", "AugAssign.sugar"
@@ -171,11 +181,12 @@ def measure(
                 except SourceTreePanic as panic:
                     direct[shape]["other_typed_loud"] += 1
                     roots[_panic_key(panic)] += 1
-                except ConstructionPanic as panic:
-                    direct[shape]["construction_panic"] += 1
-                    roots[_panic_key(panic)] += 1
                 else:
-                    direct[shape]["built"] += 1
+                    if gap is None:
+                        direct[shape]["built"] += 1
+                    else:
+                        direct[shape]["construction_panic"] += 1
+                        roots[_gap_key(gap.info)] += 1
 
             functions = [] if direct_only else [
                 node for node in ast.walk(parsed)
@@ -201,7 +212,9 @@ def measure(
                 shapes = sorted({_shape(node) for node in ast.walk(native_function) if isinstance(node, ASSIGNMENT)})
                 function = materialize(unit, _Handle(unit, native_function))
                 try:
-                    function.sugar()
+                    _, gap = collect_construction_panic(
+                        f"{path}:{native_function.lineno}", function.sugar
+                    )
                 except SourceTreePanic as panic:
                     enclosing_functions["typed_loud"] += 1
                     if object_field_candidate:
@@ -213,23 +226,6 @@ def measure(
                     for shape in shapes:
                         enclosing[shape]["loud"] += 1
                         enclosing[shape][f"root:{getattr(panic, 'owner', type(panic).__name__)}"] += 1
-                except ConstructionPanic as panic:
-                    enclosing_functions["construction_panic"] += 1
-                    if object_field_candidate:
-                        object_field_enclosing["construction_panic"] += 1
-                        object_field_rows.append(
-                            {
-                                **row,
-                                "status": "construction_panic",
-                                "error": str(panic),
-                            }
-                        )
-                    roots[_panic_key(panic)] += 1
-                    for shape in shapes:
-                        enclosing[shape]["construction_panic"] += 1
-                        enclosing[shape][
-                            f"root:{getattr(panic, 'owner', type(panic).__name__)}"
-                        ] += 1
                 except Exception as panic:
                     enclosing_functions["non_source_failure"] += 1
                     if object_field_candidate:
@@ -245,12 +241,29 @@ def measure(
                         enclosing[shape]["non_source_failure"] += 1
                         enclosing[shape][f"root:{type(panic).__name__}"] += 1
                 else:
-                    enclosing_functions["built"] += 1
-                    if object_field_candidate:
-                        object_field_enclosing["built"] += 1
-                        object_field_rows.append({**row, "status": "built"})
-                    for shape in shapes:
-                        enclosing[shape]["built"] += 1
+                    if gap is None:
+                        enclosing_functions["built"] += 1
+                        if object_field_candidate:
+                            object_field_enclosing["built"] += 1
+                            object_field_rows.append({**row, "status": "built"})
+                        for shape in shapes:
+                            enclosing[shape]["built"] += 1
+                    else:
+                        owner = gap.info.get("owner", "ConstructionPanic")
+                        enclosing_functions["construction_panic"] += 1
+                        if object_field_candidate:
+                            object_field_enclosing["construction_panic"] += 1
+                            object_field_rows.append(
+                                {
+                                    **row,
+                                    "status": "construction_panic",
+                                    "error": gap.message,
+                                }
+                            )
+                        roots[_gap_key(gap.info)] += 1
+                        for shape in shapes:
+                            enclosing[shape]["construction_panic"] += 1
+                            enclosing[shape][f"root:{owner}"] += 1
             counts["files_completed"] += 1
         except BackendCouldNotParse:
             counts["files_could_not_parse"] += 1

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
@@ -18,6 +18,7 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_source_tree.backend import BackendCouldNotParse, materialize
 from sugar_source_tree.cpython_adapter import _Handle
 from sugar_source_tree.nodes import SourceUnit
@@ -80,10 +81,66 @@ def _panic_key(panic: BaseException) -> str:
     return f"{owner}|{observed}|{requested}"
 
 
-def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
+def _plain_class_names(module: ast.Module) -> frozenset[str]:
+    forbidden = {
+        "__new__", "__getattr__", "__getattribute__", "__setattr__",
+        "__delattr__", "__getitem__", "__setitem__", "__delitem__",
+    }
+    return frozenset(
+        node.name
+        for node in module.body
+        if isinstance(node, ast.ClassDef)
+        and not node.bases
+        and not node.keywords
+        and not node.decorator_list
+        and all(isinstance(member, (ast.Pass, ast.FunctionDef)) for member in node.body)
+        and all(
+            not isinstance(member, ast.FunctionDef)
+            or (member.name not in forbidden and not member.decorator_list)
+            for member in node.body
+        )
+    )
+
+
+def _has_object_field_candidate(
+    function: ast.AST, plain_class_names: frozenset[str]
+) -> bool:
+    """Structural measurement label, never construction authority."""
+    constructed_names = {
+        target.id
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and (
+            isinstance(node.value, (ast.Dict, ast.List))
+            or (
+                isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id in plain_class_names
+            )
+        )
+        for target in node.targets
+    }
+    return any(
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], (ast.Attribute, ast.Subscript))
+        and isinstance(node.targets[0].value, ast.Name)
+        and node.targets[0].value.id in constructed_names
+        for node in ast.walk(function)
+    )
+
+
+def measure(
+    root: Path, *, direct_only: bool = False, object_field_only: bool = False
+) -> dict[str, object]:
     counts: Counter[str] = Counter()
     direct: dict[str, Counter[str]] = defaultdict(Counter)
     enclosing: dict[str, Counter[str]] = defaultdict(Counter)
+    enclosing_functions: Counter[str] = Counter()
+    object_field_enclosing: Counter[str] = Counter()
+    object_field_rows: list[dict[str, object]] = []
     roots: Counter[str] = Counter()
 
     for path in sorted(root.rglob("*.py")):
@@ -93,12 +150,13 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
         try:
             source, filename, source_cid = path_source(path)
             parsed = ast.parse(source, filename=str(path))
+            plain_class_names = _plain_class_names(parsed)
             native_assignments = [node for node in ast.walk(parsed) if isinstance(node, ASSIGNMENT)]
             if not native_assignments:
                 counts["files_without_assignment"] += 1
                 continue
             unit = SourceUnit(filename=filename, source=source, source_cid=source_cid)
-            for native in native_assignments:
+            for native in (() if object_field_only else native_assignments):
                 shape = _shape(native)
                 direct[shape]["total"] += 1
                 node = materialize(unit, _Handle(unit, native))
@@ -113,6 +171,9 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
                 except SourceTreePanic as panic:
                     direct[shape]["other_typed_loud"] += 1
                     roots[_panic_key(panic)] += 1
+                except ConstructionPanic as panic:
+                    direct[shape]["construction_panic"] += 1
+                    roots[_panic_key(panic)] += 1
                 else:
                     direct[shape]["built"] += 1
 
@@ -120,22 +181,74 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
                 node for node in ast.walk(parsed)
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
                 and any(isinstance(child, ASSIGNMENT) for child in ast.walk(node))
+                and (
+                    not object_field_only
+                    or _has_object_field_candidate(node, plain_class_names)
+                )
             ]
             for native_function in functions:
+                enclosing_functions["total"] += 1
+                object_field_candidate = _has_object_field_candidate(
+                    native_function, plain_class_names
+                )
+                if object_field_candidate:
+                    object_field_enclosing["total"] += 1
+                row = {
+                    "path": str(path.relative_to(root)),
+                    "line": native_function.lineno,
+                    "function": native_function.name,
+                }
                 shapes = sorted({_shape(node) for node in ast.walk(native_function) if isinstance(node, ASSIGNMENT)})
                 function = materialize(unit, _Handle(unit, native_function))
                 try:
                     function.sugar()
                 except SourceTreePanic as panic:
+                    enclosing_functions["typed_loud"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["typed_loud"] += 1
+                        object_field_rows.append(
+                            {**row, "status": "typed_loud", "error": str(panic)}
+                        )
                     roots[_panic_key(panic)] += 1
                     for shape in shapes:
                         enclosing[shape]["loud"] += 1
                         enclosing[shape][f"root:{getattr(panic, 'owner', type(panic).__name__)}"] += 1
+                except ConstructionPanic as panic:
+                    enclosing_functions["construction_panic"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["construction_panic"] += 1
+                        object_field_rows.append(
+                            {
+                                **row,
+                                "status": "construction_panic",
+                                "error": str(panic),
+                            }
+                        )
+                    roots[_panic_key(panic)] += 1
+                    for shape in shapes:
+                        enclosing[shape]["construction_panic"] += 1
+                        enclosing[shape][
+                            f"root:{getattr(panic, 'owner', type(panic).__name__)}"
+                        ] += 1
                 except Exception as panic:
+                    enclosing_functions["non_source_failure"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["non_source_failure"] += 1
+                        object_field_rows.append(
+                            {
+                                **row,
+                                "status": "non_source_failure",
+                                "error": f"{type(panic).__name__}: {panic}",
+                            }
+                        )
                     for shape in shapes:
                         enclosing[shape]["non_source_failure"] += 1
                         enclosing[shape][f"root:{type(panic).__name__}"] += 1
                 else:
+                    enclosing_functions["built"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["built"] += 1
+                        object_field_rows.append({**row, "status": "built"})
                     for shape in shapes:
                         enclosing[shape]["built"] += 1
             counts["files_completed"] += 1
@@ -151,6 +264,9 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
         "counts": dict(sorted(counts.items())),
         "direct_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(direct.items())},
         "enclosing_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(enclosing.items())},
+        "enclosing_functions": dict(sorted(enclosing_functions.items())),
+        "object_field_enclosing": dict(sorted(object_field_enclosing.items())),
+        "object_field_rows": object_field_rows,
         "root_panics": dict(sorted(roots.items(), key=lambda item: (-item[1], item[0]))),
     }
 
@@ -159,10 +275,21 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path)
     parser.add_argument("--direct-only", action="store_true")
+    parser.add_argument("--object-field-only", action="store_true")
     args = parser.parse_args()
     logging.disable(logging.CRITICAL)
     root = (args.root or _installed_package_root("pandas")).resolve()
-    print(json.dumps(measure(root, direct_only=args.direct_only), indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            measure(
+                root,
+                direct_only=args.direct_only,
+                object_field_only=args.object_field_only,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class PlaceAssignValue(FloorValue):
+    receiver: FloorValue
+    selector_kind: str
+    selector: object
+    value: FloorValue
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        receiver = self.receiver.to_term(owner=owner)
+        if self.selector_kind == "attribute":
+            target = ctor(
+                "python:attribute",
+                [receiver, str_const(self.selector)],
+            )
+        else:
+            raise ValueError(f"unknown place selector kind {self.selector_kind!r}")
+        return ctor(
+            "python:assign",
+            [target, self.value.to_term(owner=owner)],
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ConstructedObjectPlaceSugar(Sugar):
+    value: object = field(compare=False)
+    testimony: object
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="FloorValue",
+            reason="projects one already-constructed value from authenticated testimony",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.ir import _term_content_cid
+        from sugar_source_tree.binding_provenance import BindingProvenanceGap
+
+        observed = _term_content_cid(
+            self.value.to_term(owner="ConstructedObjectPlaceSugar")
+        )
+        if observed != self.testimony.semantic_value_cid:
+            raise BindingProvenanceGap("constructed object projection mismatch")
+        return Complete(self.value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class PlaceAssignSugar(Sugar):
+    receiver: Sugar
+    selector_kind: str
+    selector: str
+    value: Sugar
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="PlaceAssignValue",
+            reason="authenticated place store mirrors the Python reference assignment",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.place_assign_value import PlaceAssignValue
+
+        def with_receiver(receiver):
+            def with_value(value):
+                if self.selector_kind != "attribute":
+                    raise ValueError("typed place selector mismatch")
+                return Complete(
+                    PlaceAssignValue(receiver, "attribute", self.selector, value)
+                )
+
+            return self.value.desugar(ctx).and_then(with_value)
+
+        return self.receiver.desugar(ctx).and_then(with_receiver)

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_version_flow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_version_flow.py
@@ -1,0 +1,72 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    left = Parcel()
+    right = Parcel()
+    left_alias = left
+    right_alias = right
+    left.payload = 2
+    right.payload = 5
+    left_before = left_alias.payload
+    right_before = right_alias.payload
+    left_alias.payload = 11
+    right_alias.payload = 17
+    assert (left_before, right_before, left.payload, right.payload) == (2, 5, 11, 17)
+
+
+def lying():
+    left = Parcel()
+    right = Parcel()
+    left_alias = left
+    right_alias = right
+    left.payload = 2
+    right.payload = 5
+    left_before = left_alias.payload
+    right_before = right_alias.payload
+    left_alias.payload = 11
+    right_alias.payload = 17
+    assert (left_before, right_before, left.payload, right.payload) == (5, 2, 17, 11)
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    first = Capsule()
+    second = Capsule()
+    first_echo = first
+    second_echo = second
+    first.marker = 2
+    second.marker = 5
+    first_earlier = first_echo.marker
+    second_earlier = second_echo.marker
+    first_echo.marker = 11
+    second_echo.marker = 17
+    assert (first_earlier, second_earlier, first.marker, second.marker) == (
+        2,
+        5,
+        11,
+        17,
+    )
+
+
+def renamed_lying():
+    first = Capsule()
+    second = Capsule()
+    first_echo = first
+    second_echo = second
+    first.marker = 2
+    second.marker = 5
+    first_earlier = first_echo.marker
+    second_earlier = second_echo.marker
+    first_echo.marker = 11
+    second_echo.marker = 17
+    assert (first_earlier, second_earlier, first.marker, second.marker) == (
+        5,
+        2,
+        17,
+        11,
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
@@ -29,6 +29,24 @@
       "requires": ["authenticated-alias-equivalence", "single-temporal-binding-model"]
     },
     {
+      "id": "version-flow",
+      "file": "version_flow.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["immutable-field-version-chain", "authenticated-alias-equivalence", "read-snapshot-stability"]
+    },
+    {
+      "id": "distinct-version-flow",
+      "file": "distinct_version_flow.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["construction-occurrence-discrimination", "immutable-field-version-chain", "no-cross-object-version-collision"]
+    },
+    {
       "id": "symbolic-receiver",
       "file": "symbolic_receiver.py",
       "canonical": "read_after_store",

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/version_flow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/version_flow.py
@@ -1,0 +1,50 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    original = Parcel()
+    original.payload = 3
+    before = original.payload
+    alias = original
+    second_alias = alias
+    alias.payload = 8
+    after = second_alias.payload
+    assert (before, after) == (3, 8)
+
+
+def lying():
+    original = Parcel()
+    original.payload = 3
+    before = original.payload
+    alias = original
+    second_alias = alias
+    alias.payload = 8
+    after = second_alias.payload
+    assert (before, after) == (8, 3)
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    source = Capsule()
+    source.marker = 3
+    earlier = source.marker
+    echo = source
+    echo_again = echo
+    echo.marker = 8
+    later = echo_again.marker
+    assert (earlier, later) == (3, 8)
+
+
+def renamed_lying():
+    source = Capsule()
+    source.marker = 3
+    earlier = source.marker
+    echo = source
+    echo_again = echo
+    echo.marker = 8
+    later = echo_again.marker
+    assert (earlier, later) == (8, 3)

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -360,6 +360,23 @@ def test_custom_dispatch_stays_loud_without_constructed_behavior(tmp_path, membe
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
 
 
+def test_non_admitted_class_call_keeps_ordinary_call_construction(tmp_path):
+    path = tmp_path / "decorated_class.py"
+    path.write_text(
+        "def decorate(cls):\n"
+        "    return cls\n\n"
+        "@decorate\n"
+        "class Row:\n"
+        "    pass\n\n"
+        "def boundary():\n"
+        "    return Row('path', 7)\n"
+    )
+
+    # Object identity admission must not install a constructor-binding path on
+    # an ordinary call whose allocation behavior is not constructed.
+    _outcome_or_panic(path, "boundary")
+
+
 def test_custom_setitem_receiver_stays_loud(tmp_path):
     path = tmp_path / "setitem.py"
     path.write_text(

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -13,12 +13,23 @@ from sugar_lift_py_tests.effect.runtime_effect import RuntimeEffect
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SourceTreePanic
+from sugar_source_tree.binding_provenance import BindingProvenanceGap
+from sugar_source_tree.binding_state import SubstitutionTraceBuilderV1
+from sugar_source_tree.nodes import _SUBSTITUTION_TRACE_BUILDER
+from sugar_source_tree.backend import Child, Children, Leaf, materialize
+from sugar_source_tree.shadow import ShadowNode, _handle_of
 from sugar_source_tree.tree import SourceFile
 
 
 FIXTURES = Path(__file__).parent / "fixtures" / "object_field_flow"
 MATRIX = json.loads((FIXTURES / "verdict_matrix.json").read_text())
-POSITIVE_IDS = {"store-then-read", "distinct-objects", "authenticated-alias"}
+POSITIVE_IDS = {
+    "store-then-read",
+    "distinct-objects",
+    "authenticated-alias",
+    "version-flow",
+    "distinct-version-flow",
+}
 LOUD_IDS = {"symbolic-receiver", "opaque-mutation", "opaque-alias"}
 FORBIDDEN_MECHANISM_CALLS = {"getattr", "setattr", "hasattr", "id", "type", "isinstance"}
 
@@ -89,13 +100,16 @@ def test_verdict_matrix_is_closed_and_names_every_required_invariant():
     assert MATRIX["schema"] == "object-field-flow-acceptance-v1"
     cases = MATRIX["cases"]
     assert {case["id"] for case in cases} == POSITIVE_IDS | LOUD_IDS
-    assert len(cases) == 6
+    assert len(cases) == 8
     requirements = {item for case in cases for item in case["requires"]}
     assert {
         "content-addressed-object-identity",
         "construction-occurrence-discrimination",
         "no-spelling-identity",
         "authenticated-alias-equivalence",
+        "immutable-field-version-chain",
+        "read-snapshot-stability",
+        "no-cross-object-version-collision",
         "single-temporal-binding-model",
         "no-symbolic-receiver-identity",
         "opaque-call-invalidates-field-knowledge",
@@ -153,10 +167,6 @@ def test_fixtures_are_renamed_structural_twins_without_name_or_vendor_authority(
     [case for case in MATRIX["cases"] if case["id"] in POSITIVE_IDS],
     ids=lambda case: case["id"],
 )
-@pytest.mark.xfail(
-    strict=True,
-    reason="acceptance red: construction-authoritative object/place identity is not implemented",
-)
 def test_positive_object_field_flow_acceptance_is_not_typed_loud(case):
     path = FIXTURES / case["file"]
     for names in (case["canonical"], case["renamed"]):
@@ -175,3 +185,304 @@ def test_unauthenticated_object_field_flow_stays_typed_loud(case):
     for function_name in (case["canonical"], case["renamed"]):
         result = _outcome_or_panic(path, function_name)
         assert _is_typed_loud(result), result
+
+
+def _object_states(path: Path, function_name: str):
+    function = _functions(path)[function_name]
+    owner = function.fragment.seal().cid
+    substituted = function.substitute(
+        {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(owner)}
+    )
+    return [
+        node for node in substituted.walk() if node.kind == "ObjectPlaceStateV1"
+    ]
+
+
+def test_object_and_field_versions_reresolve_and_distinct_objects_do_not_collide():
+    first = _object_states(FIXTURES / "version_flow.py", "truthful")
+    second = _object_states(FIXTURES / "version_flow.py", "truthful")
+    assert first and second
+    assert first[-1].object_identity_cid == second[-1].object_identity_cid
+    assert first[-1].version_cids == second[-1].version_cids
+    first[-1].validate_identity()
+    second[-1].validate_identity()
+
+    distinct = _object_states(FIXTURES / "distinct_version_flow.py", "truthful")
+    identities = {state.object_identity_cid for state in distinct}
+    coordinates = {state.object_coordinate.cid for state in distinct}
+    assert len(identities) == 2
+    assert len(coordinates) == 2
+
+
+def test_a_type_name_does_not_admit_a_lying_object_identity():
+    state = _object_states(FIXTURES / "store_then_read.py", "truthful")[0]
+    forged = _forge_state(state, object_identity_cid="blake3-512:stale")
+    with pytest.raises(BindingProvenanceGap, match="object place identity CID mismatch"):
+        forged.validate_identity()
+
+
+def test_unmatched_field_version_is_loud_before_projection():
+    state = next(
+        state
+        for state in _object_states(FIXTURES / "store_then_read.py", "truthful")
+        if state.selectors
+    )
+    forged = _forge_state(
+        state,
+        version_cids=("blake3-512:stale", *state.version_cids[1:]),
+    )
+    with pytest.raises(BindingProvenanceGap, match="field version CID mismatch"):
+        forged.field(state.selectors[0])
+
+
+def test_branch_join_projects_both_authenticated_field_faces(tmp_path):
+    path = tmp_path / "both_faces.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def both_faces():\n"
+        "    flag = True\n"
+        "    item = Vessel()\n"
+        "    if flag:\n"
+        "        item.payload = 3\n"
+        "    else:\n"
+        "        item.payload = 8\n"
+        "    return item.payload\n"
+    )
+    function = _functions(path)["both_faces"]
+    substituted = function.substitute(
+        {
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(
+                function.fragment.seal().cid
+            )
+        }
+    )
+    returned = next(node for node in substituted.walk() if node.kind == "Return")
+    assert returned.value.kind == "IfExp"
+    assert returned.value.body.kind == "ConstructedValueProjectionV1"
+    assert returned.value.body.base.kind == "Constant"
+    assert returned.value.orelse.kind == "ConstructedValueProjectionV1"
+    assert returned.value.orelse.base.kind == "Constant"
+
+
+def test_branch_join_with_one_unproved_field_face_stays_loud(tmp_path):
+    path = tmp_path / "missing_face.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def missing_face():\n"
+        "    flag = True\n"
+        "    item = Vessel()\n"
+        "    if flag:\n"
+        "        item.payload = 3\n"
+        "    return item.payload\n"
+    )
+    function = _functions(path)["missing_face"]
+    substituted = function.substitute(
+        {
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(
+                function.fragment.seal().cid
+            )
+        }
+    )
+    returned = next(node for node in substituted.walk() if node.kind == "Return")
+    assert returned.value.kind == "Attribute"
+
+
+@pytest.mark.parametrize(
+    ("class_name", "left_name", "right_name", "field"),
+    [("Vessel", "left", "right", "payload"), ("Capsule", "first", "second", "marker")],
+)
+def test_opaque_call_invalidates_only_the_exposed_object(
+    tmp_path, class_name, left_name, right_name, field
+):
+    path = tmp_path / f"selective_{class_name}.py"
+    path.write_text(
+        f"class {class_name}:\n    pass\n\n"
+        f"def boundary(mutator):\n"
+        f"    {left_name} = {class_name}()\n"
+        f"    {right_name} = {class_name}()\n"
+        f"    {left_name}.{field} = 7\n"
+        f"    {right_name}.{field} = 11\n"
+        f"    mutator({left_name})\n"
+        f"    observed = {left_name}.{field}\n"
+        f"    return {right_name}.{field}\n"
+    )
+    function = _functions(path)["boundary"]
+    substituted = function.substitute(
+        {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(function.fragment.seal().cid)}
+    )
+    returned = next(node for node in substituted.walk() if node.kind == "Return")
+    assert returned.value.kind == "ConstructedValueProjectionV1"
+    states = [node for node in substituted.walk() if node.kind == "ObjectPlaceStateV1"]
+    by_identity = {state.object_identity_cid: state for state in states}
+    assert len({state.object_identity_cid for state in states}) == 2
+    assert any(state.invalidated_by_opaque_call for state in by_identity.values())
+    assert any(not state.invalidated_by_opaque_call for state in by_identity.values())
+
+
+def test_opaque_result_mints_occurrence_identity_without_fields():
+    path = FIXTURES / "opaque_alias.py"
+    function = _functions(path)["read_through_opaque_alias"]
+    substituted = function.substitute(
+        {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(function.fragment.seal().cid)}
+    )
+    states = [node for node in substituted.walk() if node.kind == "OpaqueObjectStateV1"]
+    assert states
+    wire = states[-1].object_coordinate.wire()
+    assert wire["kind"] == "opaque-object-coordinate"
+    assert not ({"fields", "behavior", "class", "type"} & set(wire))
+
+
+def test_unknown_place_selector_kind_is_typed_loud():
+    from sugar_lift_py_tests.floor.place_assign_value import PlaceAssignValue
+    from sugar_lift_py_tests.floor import TermValue
+
+    malformed = PlaceAssignValue(TermValue(1), "future-selector", 0, TermValue(2))
+    with pytest.raises(ValueError, match="unknown place selector kind"):
+        malformed.to_term(owner="lying-selector")
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "def __setattr__(self, name, value):\n        pass",
+        "@property\n    def payload(self):\n        return 1",
+    ],
+    ids=("dynamic-setattr", "descriptor"),
+)
+def test_custom_dispatch_never_acquires_plain_place_authority(tmp_path, member):
+    path = tmp_path / "dispatch.py"
+    path.write_text(
+        "class Vessel:\n    "
+        + member
+        + "\n\ndef boundary():\n    item = Vessel()\n"
+        "    item.payload = 7\n    return item.payload\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_custom_setitem_receiver_stays_loud(tmp_path):
+    path = tmp_path / "setitem.py"
+    path.write_text(
+        "class Vessel:\n"
+        "    def __setitem__(self, key, value):\n"
+        "        pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_plain_object_without_setitem_stays_loud(tmp_path):
+    path = tmp_path / "plain_object_subscript.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_out_of_range_list_store_stays_loud(tmp_path):
+    path = tmp_path / "out_of_range_list.py"
+    path.write_text(
+        "def boundary():\n"
+        "    item = []\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_object_occurrence_constructs_once_then_projects_testimony(monkeypatch):
+    from sugar_source_tree.nodes import Call
+
+    original = Call._construct_sugar
+    constructions = 0
+
+    def counted(self):
+        nonlocal constructions
+        constructions += 1
+        return original(self)
+
+    monkeypatch.setattr(Call, "_construct_sugar", counted)
+    outcome = _outcome_or_panic(FIXTURES / "store_then_read.py", "truthful")
+    assert not _is_typed_loud(outcome)
+    assert constructions == 1
+
+
+def test_stored_expression_constructs_once_then_projects_testimony(
+    tmp_path, monkeypatch
+):
+    from sugar_source_tree.nodes import BinOp
+
+    path = tmp_path / "stored_call_once.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item.payload = 3 + 4\n"
+        "    return item.payload\n"
+    )
+    original = BinOp._construct_sugar
+    constructions = 0
+
+    def counted(self):
+        nonlocal constructions
+        constructions += 1
+        return original(self)
+
+    monkeypatch.setattr(BinOp, "_construct_sugar", counted)
+    outcome = _outcome_or_panic(path, "boundary")
+    assert not _is_typed_loud(outcome)
+    assert constructions == 1
+
+
+def _forge_state(state, **overrides):
+    values = {
+        "object_coordinate": state.object_coordinate,
+        "class_definition_cid": state.class_definition_cid,
+        "construction_testimony": state.construction_testimony,
+        "constructed_value": state.constructed_value,
+        "object_identity_cid": state.object_identity_cid,
+        "base": state.base,
+        "selectors": state.selectors,
+        "values": state.values,
+        "value_testimonies": state.value_testimonies,
+        "version_cids": state.version_cids,
+        "version_records": state.version_records,
+        "prior_version_cids": state.prior_version_cids,
+        "store_occurrence_cids": state.store_occurrence_cids,
+        "invalidated_by_opaque_call": state.invalidated_by_opaque_call,
+    }
+    values.update(overrides)
+    return materialize(
+        state.unit,
+        ShadowNode(
+            "ObjectPlaceStateV1",
+            state.span,
+            (
+                ("object_coordinate", Leaf(values["object_coordinate"])),
+                ("class_definition_cid", Leaf(values["class_definition_cid"])),
+                ("construction_testimony", Leaf(values["construction_testimony"])),
+                ("constructed_value", Leaf(values["constructed_value"])),
+                ("object_identity_cid", Leaf(values["object_identity_cid"])),
+                ("base", Child(_handle_of(values["base"]))),
+                ("selectors", Leaf(values["selectors"])),
+                (
+                    "values",
+                    Children(tuple(_handle_of(item) for item in values["values"])),
+                ),
+                ("value_testimonies", Leaf(values["value_testimonies"])),
+                ("version_cids", Leaf(values["version_cids"])),
+                ("version_records", Leaf(values["version_records"])),
+                ("prior_version_cids", Leaf(values["prior_version_cids"])),
+                ("store_occurrence_cids", Leaf(values["store_occurrence_cids"])),
+                ("invalidated_by_opaque_call", Leaf(values["invalidated_by_opaque_call"])),
+            ),
+        ),
+        state.reporter,
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -349,7 +349,7 @@ def test_unknown_place_selector_kind_is_typed_loud():
     ],
     ids=("dynamic-setattr", "descriptor"),
 )
-def test_custom_dispatch_never_acquires_plain_place_authority(tmp_path, member):
+def test_custom_dispatch_stays_loud_without_constructed_behavior(tmp_path, member):
     path = tmp_path / "dispatch.py"
     path.write_text(
         "class Vessel:\n    "

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5870,20 +5870,27 @@ class Call(Expression):
 
             source_call_frame = None
             definition = self.unit.source_allocation_definition_for_call(self)
-            if definition is not None:
+            if (
+                definition is not None
+                and self.unit.source_class_has_authenticated_default_attribute_behavior(
+                    definition
+                )
+            ):
                 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
                 if any(keyword.arg is None for keyword in self.keywords):
                     raise SourceCallBindingGap(
                         "spread keyword requires typed variadic projection"
                     )
-                source_call_frame = definition.source_visible_constructor_frame().bind_node_actuals(
-                    self.args,
-                    tuple(
-                        (keyword.arg, keyword.value)
-                        for keyword in self.keywords
-                        if keyword.arg is not None
-                    ),
+                source_call_frame = (
+                    definition.source_visible_constructor_frame().bind_node_actuals(
+                        self.args,
+                        tuple(
+                            (keyword.arg, keyword.value)
+                            for keyword in self.keywords
+                            if keyword.arg is not None
+                        ),
+                    )
                 )
 
             return CallSiteSugar(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6089,6 +6089,13 @@ class OpaqueObjectStateV1(Expression):
         del scope
         return self
 
+    def _construct_sugar(self):
+        """Identity is transparent until a consumer asks for unproved behavior."""
+        from .object_identity import decode_object_coordinate_v1
+
+        decode_object_coordinate_v1(self.object_coordinate.wire())
+        return self.base.sugar()
+
 
 class ObjectPlaceStateV1(Expression):
     """Immutable field versions carried only inside runtime BindingEntryV1.
@@ -6376,6 +6383,8 @@ class Attribute(Expression):
     def _construct_sugar(self):
         """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
         The attr name is a static identifier carried onto the coordinate."""
+        if isinstance(self.value, OpaqueObjectStateV1):
+            return super()._construct_sugar()
         from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 
         return AttributeSugar(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -358,22 +358,20 @@ class SourceUnit:
         )
 
     def construction_generation(self, node: "Node") -> int:
-        """The deterministic occurrence ordinal in this construction graph."""
-        module = self._require_typed_module("SourceUnit.construction_generation")
-        occurrences = tuple(candidate for candidate in module.walk() if isinstance(candidate, Call))
-        matches = tuple(
-            generation
-            for generation, candidate in enumerate(occurrences)
-            if candidate.fragment == node.fragment
-        )
-        if len(matches) == 1:
-            return matches[0]
-        raise SourceTreePanic(
-            owner="SourceUnit.construction_generation",
-            observed="call occurrence absent from the bound typed module",
-            requested="the exact call occurrence in the sole construction graph",
-            fix="mint object identity only from a SourceFile-enumerated Call",
-        )
+        """The source-authenticated generation of this exact occurrence.
+
+        The byte offset is stable across shadow rewrites of the same occurrence
+        and differs for distinct occurrences. It comes from the oracle-sealed
+        construction fragment, never a binding owner or process counter.
+        """
+        if not isinstance(node, Call):
+            raise SourceTreePanic(
+                owner="SourceUnit.construction_generation",
+                observed=type(node).__name__,
+                requested="one exact Call construction occurrence",
+                fix="mint object identity only at the sole Call boundary",
+            )
+        return node.fragment.seal().start
 
     @staticmethod
     def _module_statement_bound_names(statement: "Node") -> set[str]:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -32,7 +32,7 @@ carries the rewritten shape, then memoized like any other ref.
 from __future__ import annotations
 
 import symtable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, ClassVar, Iterator, Optional, Tuple
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -153,6 +153,8 @@ class SourceUnit:
     typed_module: object = field(init=False, default=None)
     # Field-data memo for materialize (see construction_cache.py).
     construction_cache: object = field(init=False, default=None)
+    module_direct_bindings: object = field(init=False, default=None)
+    function_nodes: Tuple[object, ...] = field(init=False, default=())
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -170,10 +172,30 @@ class SourceUnit:
         )
         object.__setattr__(self, "typed_module", None)
         object.__setattr__(self, "construction_cache", None)
+        object.__setattr__(self, "module_direct_bindings", None)
+        object.__setattr__(self, "function_nodes", ())
 
     def bind_typed_module(self, module: "Module") -> None:
         """Attach the already-materialized Module root (SourceFile only)."""
         object.__setattr__(self, "typed_module", module)
+        bindings = {}
+        for statement in module.body:
+            for name in self._module_statement_bound_names(statement):
+                bindings.setdefault(name, []).append(statement)
+        object.__setattr__(
+            self,
+            "module_direct_bindings",
+            {name: tuple(items) for name, items in bindings.items()},
+        )
+        object.__setattr__(
+            self,
+            "function_nodes",
+            tuple(
+                node
+                for node in module.walk()
+                if isinstance(node, (FunctionDef, AsyncFunctionDef))
+            ),
+        )
 
     def loop_target_coordinate_for_loop(self, owner: "Node"):
         from sugar_lift_py_tests.context_manager_resolution import (
@@ -253,6 +275,128 @@ class SourceUnit:
             ):
                 return True
         return False
+
+    def source_allocation_definition_for_call(self, call: "Call") -> "ClassDef | None":
+        """Resolve one source allocation definition at an exact call use-site.
+
+        Spelling is only the lexical lookup key.  Authority is the unique typed
+        module binding plus the use-site's CPython scope classification. A
+        local/free/nonlocal shadow or competing module binding keeps the
+        allocation definition unauthenticated. Behavior is checked separately;
+        it never participates in identity admission.
+        """
+        if not isinstance(call.func, Name):
+            return None
+        # A directly materialized Call/Assign still owns its ordinary sugar.
+        # Absence of the SourceFile-bound module means only that class identity
+        # cannot be authenticated here; it must not revoke the existing call
+        # construction path.
+        module = self.typed_module
+        if module is None:
+            return None
+        span = call.line_col_span()
+        containing = []
+        for candidate in self.function_nodes:
+            owner_span = candidate.line_col_span()
+            if (
+                (owner_span.start_line, owner_span.start_col)
+                <= (span.start_line, span.start_col)
+                <= (owner_span.end_line, owner_span.end_col)
+            ):
+                containing.append(candidate)
+        if containing:
+            owner = max(
+                containing, key=lambda item: item.line_col_span().start_line
+            )
+            table = self.function_symtable(
+                owner.name, owner.line_col_span().start_line
+            )
+            try:
+                symbol = table.lookup(call.func.id)
+            except KeyError:
+                symbol = None
+            if symbol is not None and (
+                symbol.is_parameter()
+                or symbol.is_local()
+                or symbol.is_free()
+                or symbol.is_nonlocal()
+            ):
+                return None
+
+        bindings = (self.module_direct_bindings or {}).get(call.func.id, ())
+        if len(bindings) != 1 or not isinstance(bindings[0], ClassDef):
+            return None
+        return bindings[0]
+
+    @staticmethod
+    def source_class_has_plain_attribute_behavior(definition: "ClassDef") -> bool:
+        """Whether ordinary attribute storage/lookup is source-constructed."""
+        forbidden_methods = {
+            "__new__",
+            "__getattr__",
+            "__getattribute__",
+            "__setattr__",
+            "__delattr__",
+            "__getitem__",
+            "__setitem__",
+            "__delitem__",
+        }
+        return not (
+            definition.bases
+            or definition.keywords
+            or definition.decorators
+            or definition.type_params
+            or any(
+                not isinstance(member, (Pass, FunctionDef))
+                for member in definition.body
+            )
+            or any(
+                isinstance(member, FunctionDef)
+                and (member.name in forbidden_methods or member.decorators)
+                for member in definition.body
+            )
+        )
+
+    def construction_generation(self, node: "Node") -> int:
+        """The deterministic occurrence ordinal in this construction graph."""
+        module = self._require_typed_module("SourceUnit.construction_generation")
+        occurrences = tuple(candidate for candidate in module.walk() if isinstance(candidate, Call))
+        matches = tuple(
+            generation
+            for generation, candidate in enumerate(occurrences)
+            if candidate.fragment == node.fragment
+        )
+        if len(matches) == 1:
+            return matches[0]
+        raise SourceTreePanic(
+            owner="SourceUnit.construction_generation",
+            observed="call occurrence absent from the bound typed module",
+            requested="the exact call occurrence in the sole construction graph",
+            fix="mint object identity only from a SourceFile-enumerated Call",
+        )
+
+    @staticmethod
+    def _module_statement_bound_names(statement: "Node") -> set[str]:
+        if isinstance(statement, (FunctionDef, AsyncFunctionDef, ClassDef)):
+            return {statement.name}
+        if isinstance(statement, (Assign, AnnAssign, AugAssign)):
+            targets = (
+                statement.targets
+                if isinstance(statement, Assign)
+                else (statement.target,)
+            )
+            return {
+                node.id
+                for target in targets
+                for node in target.walk()
+                if isinstance(node, Name)
+            }
+        if statement.kind in ("Import", "ImportFrom"):
+            return {
+                alias.asname or alias.name.split(".", 1)[0]
+                for alias in statement.names
+            }
+        return set()
 
     def exception_type_identity(self, node: "Name"):
         """Return the authenticated exception-class coordinate reaching ``node``.
@@ -667,6 +811,41 @@ class Node(Typed):
         so its value is already rewritten against the scope that stood before it."""
         return None
 
+    def refine_binding_entries(
+        self, binding: BindingMap, scope: BindingMap
+    ) -> BindingMap:
+        """Refine freshly minted entries without creating another binding map."""
+        del scope
+        return binding
+
+    def post_binding_statement(self, binding: BindingMap) -> "Node":
+        """Project a store's post-version into its substituted target."""
+        del binding
+        return self
+
+    def post_binding_scope(self, scope: BindingMap) -> BindingMap:
+        """Apply statement-owned invalidations to the one temporal map."""
+        exposed = {
+            state.object_identity_cid
+            for call in self.walk()
+            if isinstance(call, Call)
+            for state in call.exposed_object_places()
+        }
+        if not exposed:
+            return scope
+        replacements = {}
+        for name, entry in scope.items():
+            if (
+                isinstance(name, str)
+                and isinstance(entry, BindingEntryV1)
+                and isinstance(entry.state, ObjectPlaceStateV1)
+                and entry.state.object_identity_cid in exposed
+            ):
+                replacements[name] = replace(
+                    entry, state=entry.state.invalidate(self.fragment)
+                )
+        return {**scope, **replacements}
+
     def _make_binop(self, left: "Node", op, right: "Node") -> "Node":
         """Construct a fresh BinOp node ``<left> <op> <right>`` as a shadow that
         borrows this node's span (so it still addresses this source site). Used
@@ -893,6 +1072,12 @@ class Node(Typed):
                 binding = produced_stmt.substitution_binding(scope)
                 if binding:
                     binding = produced_stmt._binding_entries(binding, scope)
+                    binding = produced_stmt.refine_binding_entries(binding, scope)
+                    post_binding = produced_stmt.post_binding_statement(binding)
+                    if post_binding is not produced_stmt:
+                        produced_stmt = post_binding
+                        new_items[-1] = produced_stmt
+                        changed = True
                     scope = {**scope, **binding}
                 # walrus bindings nested in the statement's expressions leak out
                 # to the enclosing block (their scope is the containing function).
@@ -902,6 +1087,7 @@ class Node(Typed):
                         if wb:
                             wb = node._binding_entries(wb, scope)
                             scope = {**scope, **wb}
+                scope = produced_stmt.post_binding_scope(scope)
             if isinstance(new_stmt, _Splice) and new_stmt.bindings:
                 projected = stmt._binding_entries(new_stmt.bindings, scope)
                 scope = {**scope, **projected}
@@ -2160,7 +2346,9 @@ class Assign(Statement):
 
         new_value, changed = self._substitute_field(self.value, scope)
         changes = {"value": new_value} if changed else {}
-        if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+        if len(self.targets) == 1 and isinstance(
+            self.targets[0], (Attribute, Subscript)
+        ):
             target = self.targets[0]
             receiver, receiver_changed = self._substitute_field(target.value, scope)
             if receiver_changed:
@@ -2274,12 +2462,199 @@ class Assign(Statement):
             target = self.targets[0]
             if isinstance(target, Name):
                 return {target.id: self.value}
+            if isinstance(target, Attribute) and isinstance(
+                target.value, ObjectPlaceStateV1
+            ):
+                updated = target.value.with_attribute_store(
+                    target.attr, self.value, self.fragment
+                )
+                if updated is None:
+                    return None
+                return {
+                    name: replace(entry, state=updated)
+                    for name, entry in scope.items()
+                    if isinstance(name, str)
+                    and isinstance(entry, BindingEntryV1)
+                    and isinstance(entry.state, ObjectPlaceStateV1)
+                    and entry.state.object_identity_cid
+                    == target.value.object_identity_cid
+                }
             return self._destructured_binding()
         if all(isinstance(t, (Name, Attribute, Subscript)) for t in self.targets):
             # Store targets do not bind lexical names, but they also do not
             # erase the Name targets in the same left-to-right assignment.
             return {t.id: self.value for t in self.targets if isinstance(t, Name)}
         return None
+
+    def refine_binding_entries(self, binding, scope):
+        del scope
+        if len(self.targets) != 1 or not isinstance(self.targets[0], Name):
+            return binding
+        entry = binding.get(self.targets[0].id)
+        if not isinstance(entry, BindingEntryV1):
+            return binding
+        if isinstance(entry.state, ObjectPlaceStateV1):
+            return {
+                **binding,
+                self.targets[0].id: replace(
+                    entry.with_testimony(entry.state.construction_testimony),
+                    state=entry.state,
+                ),
+            }
+        if isinstance(entry.state, OpaqueObjectStateV1):
+            return binding
+        state = self._object_place_state(entry)
+        if state is None:
+            return binding
+        if isinstance(state, OpaqueObjectStateV1):
+            return {**binding, self.targets[0].id: replace(entry, state=state)}
+        return {
+            **binding,
+            self.targets[0].id: replace(
+                entry.with_testimony(state.construction_testimony), state=state
+            ),
+        }
+
+    def _object_place_state(self, entry: BindingEntryV1):
+        del entry
+        if not isinstance(self.value, Call):
+            return None
+        definition = self.unit.source_allocation_definition_for_call(self.value)
+        if definition is None:
+            from .backend import Child, Leaf, materialize
+            from .object_identity import OpaqueObjectCoordinateV1
+            from .shadow import ShadowNode, _handle_of
+
+            coordinate = OpaqueObjectCoordinateV1.mint(
+                call_occurrence=self.value.fragment,
+                construction_generation=self.unit.construction_generation(self.value),
+                source_cid=self.unit.source_cid,
+                artifact_cid=self.unit.source_cid,
+            )
+            return materialize(
+                self.unit,
+                ShadowNode(
+                    "OpaqueObjectStateV1",
+                    self.targets[0].span,
+                    (
+                        ("object_coordinate", Leaf(coordinate)),
+                        ("base", Child(_handle_of(self.value))),
+                    ),
+                ),
+                self.reporter,
+            )
+        if not self.unit.source_class_has_plain_attribute_behavior(definition):
+            return None
+        constructed = self._constructed_floor_value(self.value)
+        if constructed is None:
+            return None
+        floor_value, testimony = constructed
+        from sugar_lift_py_tests.floor import ObjectValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if not isinstance(floor_value, ObjectValue):
+            return None
+        class_outcome = definition.sugar().desugar()
+        if not isinstance(class_outcome, Complete):
+            return None
+        class_definition_cid = class_outcome.value.class_definition_cid
+        from .object_identity import SourceObjectCoordinateV1
+
+        object_coordinate = SourceObjectCoordinateV1.mint(
+            allocation_definition=definition.fragment,
+            call_occurrence=self.value.fragment,
+            construction_generation=self.unit.construction_generation(self.value),
+            source_cid=self.unit.source_cid,
+            artifact_cid=self.unit.source_cid,
+        )
+        from .backend import Child, Children, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "ObjectPlaceStateV1",
+                self.targets[0].span,
+                (
+                    ("object_coordinate", Leaf(object_coordinate)),
+                    ("class_definition_cid", Leaf(class_definition_cid)),
+                    ("construction_testimony", Leaf(testimony)),
+                    ("constructed_value", Leaf(floor_value)),
+                    ("object_identity_cid", Leaf(object_coordinate.cid)),
+                    ("base", Child(_handle_of(self.value))),
+                    ("selectors", Leaf(())),
+                    ("values", Children(())),
+                    ("value_testimonies", Leaf(())),
+                    ("version_cids", Leaf(())),
+                    ("version_records", Leaf(())),
+                    ("prior_version_cids", Leaf(())),
+                    ("store_occurrence_cids", Leaf(())),
+                    ("invalidated_by_opaque_call", Leaf(False)),
+                ),
+            ),
+            self.reporter,
+        )
+
+    @staticmethod
+    def _constructed_floor_value(value):
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import _term_content_cid
+        from sugar_lift_py_tests.outcome import Complete
+        from .binding_provenance import ConstructedValueTestimonyV1
+
+        outcome = value.sugar().desugar()
+        if not isinstance(outcome, Complete):
+            return None
+        constructed = outcome.value
+        if isinstance(constructed, CallSiteValue):
+            constructed = constructed.force_floor(
+                None,
+                owner="Assign._constructed_floor_value",
+                project_callsite=False,
+            )
+        term = constructed.to_term(owner="Assign._constructed_floor_value")
+        testimony = ConstructedValueTestimonyV1.mint(
+            value.fragment, _term_content_cid(term)
+        )
+        return constructed, testimony
+
+    def post_binding_statement(self, binding):
+        if len(self.targets) == 1 and isinstance(self.targets[0], Name):
+            entry = binding.get(self.targets[0].id)
+            if isinstance(entry, BindingEntryV1) and isinstance(
+                entry.state, ObjectPlaceStateV1
+            ):
+                from .shadow import rewrite
+
+                return rewrite(self, value=entry.state)
+        if len(self.targets) != 1 or not isinstance(self.targets[0], Attribute):
+            return self
+        prior = self.targets[0].value
+        if not isinstance(prior, ObjectPlaceStateV1):
+            return self
+        updated = next(
+            (
+                entry.state
+                for entry in binding.values()
+                if isinstance(entry, BindingEntryV1)
+                and isinstance(entry.state, ObjectPlaceStateV1)
+                and entry.state.object_identity_cid == prior.object_identity_cid
+            ),
+            None,
+        )
+        if updated is None:
+            return self
+        from .shadow import rewrite
+
+        target = self.targets[0]
+        projected = updated.attribute_field(target.attr)
+        if projected is None:
+            return self
+        return rewrite(
+            self,
+            targets=(rewrite(target, value=updated),),
+            value=projected,
+        )
 
     def _construct_sugar(self):
         """`<name> = <rhs>` constructs AssignSugar WITH the rhs's sugar (held as
@@ -2364,6 +2739,18 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+            if isinstance(self.targets[0].value, ObjectPlaceStateV1):
+                from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                    PlaceAssignSugar,
+                )
+
+                return PlaceAssignSugar(
+                    receiver=self.targets[0].value.sugar(),
+                    selector_kind="attribute",
+                    selector=self.targets[0].attr,
+                    value=self.value.sugar(),
+                    site=self.fragment,
+                )
             if isinstance(
                 self.targets[0].value,
                 (BindingCoordinateRef, ConstructedReceiverRef),
@@ -2390,6 +2777,8 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Subscript):
+            if isinstance(self.targets[0].value, ObjectPlaceStateV1):
+                return super()._construct_sugar()
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
                 SubscriptStoreEffectSugar,
             )
@@ -5250,6 +5639,19 @@ class Call(Expression):
             return func.value
         return None
 
+    def exposed_object_places(self) -> tuple["ObjectPlaceStateV1", ...]:
+        """Object states crossing this call without a frame-condition proof."""
+        roots = list(self.args) + [keyword.value for keyword in self.keywords]
+        receiver = self.receiver()
+        if receiver is not None:
+            roots.append(receiver)
+        seen = {}
+        for root in roots:
+            for node in root.walk():
+                if isinstance(node, ObjectPlaceStateV1):
+                    seen[node.object_identity_cid] = node
+        return tuple(seen.values())
+
     def _construct_sugar(self):
         """A call constructs its callee's sugar WITH the argument sugars.
         `<name>(<args>)` -> CallSiteSugar, the call-site coordinate (THE DIG
@@ -5424,6 +5826,10 @@ class Call(Expression):
 
             contract_ref = None
             contract_resolution_gap = None
+            resolution = None
+            from sugar_lift_py_tests.call_contract_resolution import (
+                CallContractResolutionGapV1,
+            )
             call_refs = getattr(context, "call_contract_refs", None)
             if call_refs is not None:
                 from sugar_lift_py_tests.call_contract_resolution import (
@@ -5455,10 +5861,28 @@ class Call(Expression):
                             requested="one typed resolution row for every enrolled imported call",
                             fix="repair call-contract preconstruction; never fall through to an ordinary call",
                         ) from exc
-                if isinstance(resolution, CallContractResolutionGapV1):
-                    contract_resolution_gap = resolution.kind.value
-                elif resolution is not None:
-                    contract_ref = resolution
+            if isinstance(resolution, CallContractResolutionGapV1):
+                contract_resolution_gap = resolution.kind.value
+            elif resolution is not None:
+                contract_ref = resolution
+
+            source_call_frame = None
+            definition = self.unit.source_allocation_definition_for_call(self)
+            if definition is not None:
+                from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+                if any(keyword.arg is None for keyword in self.keywords):
+                    raise SourceCallBindingGap(
+                        "spread keyword requires typed variadic projection"
+                    )
+                source_call_frame = definition.source_visible_constructor_frame().bind_node_actuals(
+                    self.args,
+                    tuple(
+                        (keyword.arg, keyword.value)
+                        for keyword in self.keywords
+                        if keyword.arg is not None
+                    ),
+                )
 
             return CallSiteSugar(
                 target_name=self.func.id,
@@ -5467,7 +5891,7 @@ class Call(Expression):
                 keywords=keyword_sugars,
                 contract_ref=contract_ref,
                 contract_resolution_gap=contract_resolution_gap,
-                source_call_frame=None,
+                source_call_frame=source_call_frame,
             )
         if isinstance(self.func, Attribute):
             from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
@@ -5654,6 +6078,296 @@ class Constant(Expression):
         return super()._construct_sugar()  # every literal kind is now converted
 
 
+class OpaqueObjectStateV1(Expression):
+    """Authenticated opaque call-result identity with no field testimony."""
+
+    object_coordinate: object
+    base: Expression
+    _child_fields = ("base",)
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+
+class ObjectPlaceStateV1(Expression):
+    """Immutable field versions carried only inside runtime BindingEntryV1.
+
+    This is a constructed Node value, not a binding resolver or heap.  Its sole
+    identity source is the owning entry's BindingCoordinateV1.  If it escapes
+    the attribute store/read projections, its base value constructs normally.
+    """
+
+    object_coordinate: object
+    class_definition_cid: str
+    construction_testimony: object
+    constructed_value: object
+    object_identity_cid: str
+    base: Expression
+    selectors: Tuple[object, ...]
+    values: Tuple[Expression, ...]
+    value_testimonies: Tuple[object, ...]
+    version_cids: Tuple[str, ...]
+    version_records: Tuple[object, ...]
+    prior_version_cids: Tuple[Optional[str], ...]
+    store_occurrence_cids: Tuple[str, ...]
+    invalidated_by_opaque_call: bool
+    _child_fields = ("base", "values")
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        self.validate_identity()
+        from sugar_lift_py_tests.sugar.constructed_object_place_sugar import (
+            ConstructedObjectPlaceSugar,
+        )
+
+        return ConstructedObjectPlaceSugar(
+            self.constructed_value,
+            self.construction_testimony,
+            self.fragment,
+        )
+
+    def validate_identity(self) -> None:
+        from .binding_provenance import (
+            BindingProvenanceGap,
+            ConstructedValueTestimonyV1,
+        )
+        from .object_identity import decode_object_coordinate_v1
+
+        coordinate = decode_object_coordinate_v1(self.object_coordinate.wire())
+        ConstructedValueTestimonyV1.decode(self.construction_testimony.wire())
+        from sugar_lift_py_tests.ir import _term_content_cid
+
+        observed = _term_content_cid(
+            self.constructed_value.to_term(owner="ObjectPlaceStateV1")
+        )
+        if observed != self.construction_testimony.semantic_value_cid:
+            raise BindingProvenanceGap("object construction testimony mismatch")
+        if coordinate.cid != self.object_identity_cid:
+            raise BindingProvenanceGap("object place identity CID mismatch")
+
+    def version(self, selector) -> Optional[str]:
+        try:
+            return self.version_cids[self.selectors.index(selector)]
+        except ValueError:
+            return None
+
+    def with_attribute_store(self, name, value, occurrence):
+        from .object_identity import AttributeFieldCoordinateV1
+
+        return self._with_store(AttributeFieldCoordinateV1.mint(self.object_coordinate, name), value, occurrence)
+
+    def _with_store(self, selector, value, occurrence, *, constructed=None):
+        self.validate_identity()
+        constructed = constructed or Assign._constructed_floor_value(value)
+        if constructed is None:
+            return None
+        floor_value, testimony = constructed
+        projected = ConstructedValueProjectionV1.create(
+            value, floor_value, testimony
+        )
+        from .object_identity import AttributeFieldVersionV1
+
+        prior = self.version(selector)
+        version = AttributeFieldVersionV1.mint(
+            owner=self.object_coordinate,
+            field=selector,
+            store_occurrence=occurrence,
+            construction_generation=self.object_coordinate.construction_generation + len(self.version_cids) + 1,
+            stored_value_testimony_cid=testimony.cid,
+            prior_version_cid=prior,
+        )
+        occurrence_memento = occurrence.seal().to_dict()
+        selectors = list(self.selectors)
+        values = list(self.values)
+        testimonies = list(self.value_testimonies)
+        versions = list(self.version_cids)
+        records = list(self.version_records)
+        priors = list(self.prior_version_cids)
+        occurrences = list(self.store_occurrence_cids)
+        if selector in selectors:
+            index = selectors.index(selector)
+            values[index] = projected
+            testimonies[index] = testimony
+            versions[index] = version.cid
+            records[index] = version
+            priors[index] = prior
+            occurrences[index] = occurrence_memento
+        else:
+            selectors.append(selector)
+            values.append(projected)
+            testimonies.append(testimony)
+            versions.append(version.cid)
+            records.append(version)
+            priors.append(prior)
+            occurrences.append(occurrence_memento)
+        return self._replace_state(
+            span=occurrence.node.span,
+            selectors=tuple(selectors),
+            values=tuple(values),
+            value_testimonies=tuple(testimonies),
+            version_cids=tuple(versions),
+            version_records=tuple(records),
+            prior_version_cids=tuple(priors),
+            store_occurrence_cids=tuple(occurrences),
+            invalidated=False,
+        )
+
+    def attribute_field(self, name: str):
+        from .object_identity import AttributeFieldCoordinateV1
+
+        return self.field(AttributeFieldCoordinateV1.mint(self.object_coordinate, name))
+
+    def field(self, selector):
+        self.validate_identity()
+        if self.invalidated_by_opaque_call:
+            return None
+        try:
+            index = self.selectors.index(selector)
+        except ValueError:
+            return None
+        from .binding_provenance import (
+            BindingProvenanceGap,
+            ConstructedValueTestimonyV1,
+        )
+        from .object_identity import AttributeFieldVersionV1
+
+        testimony = self.value_testimonies[index]
+        ConstructedValueTestimonyV1.decode(testimony.wire())
+        projected = self.values[index]
+        if not isinstance(projected, ConstructedValueProjectionV1):
+            raise BindingProvenanceGap("field value lacks constructed projection")
+        projected.validate_testimony()
+        if projected.construction_testimony != testimony:
+            raise BindingProvenanceGap("field value testimony mismatch")
+        version = AttributeFieldVersionV1.decode(self.version_records[index].wire())
+        if (
+            version.cid != self.version_cids[index]
+            or version.owner.cid != self.object_coordinate.cid
+            or version.field != selector
+            or version.stored_value_testimony_cid != testimony.cid
+            or version.prior_version_cid != self.prior_version_cids[index]
+        ):
+            raise BindingProvenanceGap("field version CID mismatch")
+        return projected
+
+    def invalidate(self, occurrence):
+        self.validate_identity()
+        return self._replace_state(
+            span=occurrence.node.span,
+            selectors=self.selectors,
+            values=self.values,
+            value_testimonies=self.value_testimonies,
+            version_cids=self.version_cids,
+            version_records=self.version_records,
+            prior_version_cids=self.prior_version_cids,
+            store_occurrence_cids=self.store_occurrence_cids,
+            invalidated=True,
+        )
+
+    def _replace_state(
+        self,
+        *,
+        span,
+        selectors,
+        values,
+        value_testimonies,
+        version_cids,
+        version_records,
+        prior_version_cids,
+        store_occurrence_cids,
+        invalidated,
+    ):
+        from .backend import Child, Children, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "ObjectPlaceStateV1",
+                span,
+                (
+                    ("object_coordinate", Leaf(self.object_coordinate)),
+                    ("class_definition_cid", Leaf(self.class_definition_cid)),
+                    ("construction_testimony", Leaf(self.construction_testimony)),
+                    ("constructed_value", Leaf(self.constructed_value)),
+                    ("object_identity_cid", Leaf(self.object_identity_cid)),
+                    ("base", Child(_handle_of(self.base))),
+                    ("selectors", Leaf(selectors)),
+                    ("values", Children(tuple(_handle_of(item) for item in values))),
+                    ("value_testimonies", Leaf(value_testimonies)),
+                    ("version_cids", Leaf(version_cids)),
+                    ("version_records", Leaf(version_records)),
+                    ("prior_version_cids", Leaf(prior_version_cids)),
+                    ("store_occurrence_cids", Leaf(store_occurrence_cids)),
+                    ("invalidated_by_opaque_call", Leaf(invalidated)),
+                ),
+            ),
+            self.reporter,
+        )
+
+
+class ConstructedValueProjectionV1(Expression):
+    """A source value already constructed once and sealed by its testimony."""
+
+    constructed_value: object
+    construction_testimony: object
+    base: Expression
+    _child_fields = ("base",)
+
+    @classmethod
+    def create(cls, base, constructed_value, testimony):
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            base.unit,
+            ShadowNode(
+                "ConstructedValueProjectionV1",
+                base.span,
+                (
+                    ("constructed_value", Leaf(constructed_value)),
+                    ("construction_testimony", Leaf(testimony)),
+                    ("base", Child(_handle_of(base))),
+                ),
+            ),
+            base.reporter,
+        )
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def validate_testimony(self):
+        from .binding_provenance import (
+            BindingProvenanceGap,
+            ConstructedValueTestimonyV1,
+        )
+        from sugar_lift_py_tests.ir import _term_content_cid
+
+        ConstructedValueTestimonyV1.decode(self.construction_testimony.wire())
+        observed = _term_content_cid(
+            self.constructed_value.to_term(owner="ConstructedValueProjectionV1")
+        )
+        if observed != self.construction_testimony.semantic_value_cid:
+            raise BindingProvenanceGap("constructed field testimony mismatch")
+
+    def _construct_sugar(self):
+        self.validate_testimony()
+        from sugar_lift_py_tests.sugar.constructed_object_place_sugar import (
+            ConstructedObjectPlaceSugar,
+        )
+
+        return ConstructedObjectPlaceSugar(
+            self.constructed_value,
+            self.construction_testimony,
+            self.fragment,
+        )
+
+
 class Attribute(Expression):
     value: Expression
     attr: str
@@ -5669,8 +6383,28 @@ class Attribute(Expression):
         )
 
     def substitute(self, scope):
-        """Binds nothing: recurse into children and reassemble."""
-        return self._substitute_children(scope)
+        """Project only from a construction-authenticated object place."""
+        from .shadow import rewrite
+
+        receiver, changed = self._substitute_field(self.value, scope)
+        if (
+            isinstance(receiver, IfExp)
+            and isinstance(receiver.body, ObjectPlaceStateV1)
+            and isinstance(receiver.orelse, ObjectPlaceStateV1)
+            and receiver.body.object_identity_cid
+            == receiver.orelse.object_identity_cid
+        ):
+            when_true = receiver.body.attribute_field(self.attr)
+            when_false = receiver.orelse.attribute_field(self.attr)
+            if when_true is not None and when_false is not None:
+                return rewrite(
+                    receiver, body=when_true, orelse=when_false
+                )
+        if isinstance(receiver, ObjectPlaceStateV1):
+            projected = receiver.attribute_field(self.attr)
+            if projected is not None:
+                return projected
+        return self if not changed else rewrite(self, value=receiver)
 
 
 class Subscript(Expression):
@@ -5680,7 +6414,13 @@ class Subscript(Expression):
 
     def substitute(self, scope):
         """`<value>[<slice>]` binds nothing: recurse into receiver and index."""
-        return self._substitute_children(scope)
+        from .shadow import rewrite
+
+        receiver, receiver_changed = self._substitute_field(self.value, scope)
+        index, index_changed = self._substitute_field(self.slice_, scope)
+        if not receiver_changed and not index_changed:
+            return self
+        return rewrite(self, value=receiver, slice_=index)
 
     def _construct_sugar(self):
         """`<value>[<slice_>]` constructs SubscriptSugar WITH the receiver's and

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -329,7 +329,9 @@ class SourceUnit:
         return bindings[0]
 
     @staticmethod
-    def source_class_has_plain_attribute_behavior(definition: "ClassDef") -> bool:
+    def source_class_has_authenticated_default_attribute_behavior(
+        definition: "ClassDef",
+    ) -> bool:
         """Whether ordinary attribute storage/lookup is source-constructed."""
         forbidden_methods = {
             "__new__",
@@ -2541,7 +2543,9 @@ class Assign(Statement):
                 ),
                 self.reporter,
             )
-        if not self.unit.source_class_has_plain_attribute_behavior(definition):
+        if not self.unit.source_class_has_authenticated_default_attribute_behavior(
+            definition
+        ):
             return None
         constructed = self._constructed_floor_value(self.value)
         if constructed is None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
@@ -1,0 +1,254 @@
+"""Closed construction-occurrence identity and immutable attribute versions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+from .binding_provenance import BindingProvenanceGap
+from .fragment import SourceFragment
+
+
+def _cid(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("blake3-512:"):
+        raise BindingProvenanceGap(f"{field} must be an authenticated CID")
+    return value
+
+
+def _generation(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise BindingProvenanceGap("constructionGeneration must be non-negative")
+    return value
+
+
+def _exact(raw: object, fields: set[str], owner: str) -> dict[str, Any]:
+    if not isinstance(raw, dict) or set(raw) != fields:
+        raise BindingProvenanceGap(f"malformed {owner}")
+    return raw
+
+
+def _memento(raw: object, field: str) -> dict[str, Any]:
+    raw = _exact(raw, {"file", "span", "source_cid", "cid"}, field)
+    span = _exact(raw["span"], {"start", "end"}, f"{field}.span")
+    if not isinstance(raw["file"], str) or not raw["file"]:
+        raise BindingProvenanceGap(f"malformed {field}.file")
+    if not all(isinstance(span[key], int) and not isinstance(span[key], bool) for key in span):
+        raise BindingProvenanceGap(f"malformed {field}.span")
+    if span["start"] < 0 or span["end"] < span["start"]:
+        raise BindingProvenanceGap(f"malformed {field}.span")
+    _cid(raw["source_cid"], f"{field}.source_cid")
+    _cid(raw["cid"], f"{field}.cid")
+    return raw
+
+
+def _checked(preimage: dict[str, Any], observed: object, field: str) -> str:
+    cid = _cid(observed, field)
+    if cid_of_json(preimage) != cid:
+        raise BindingProvenanceGap(f"{field} mismatch")
+    return cid
+
+
+@dataclass(frozen=True)
+class SourceObjectCoordinateV1:
+    allocation_definition: dict[str, Any]
+    call_occurrence: dict[str, Any]
+    construction_generation: int
+    source_cid: str
+    artifact_cid: str
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "source-object-coordinate",
+            "schemaVersion": "1",
+            "allocationDefinition": self.allocation_definition,
+            "callOccurrence": self.call_occurrence,
+            "constructionGeneration": self.construction_generation,
+            "sourceCid": self.source_cid,
+            "artifactCid": self.artifact_cid,
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "objectCoordinateCid": self.cid}
+
+    @classmethod
+    def mint(cls, *, allocation_definition: SourceFragment, call_occurrence: SourceFragment,
+             construction_generation: int, source_cid: str, artifact_cid: str) -> "SourceObjectCoordinateV1":
+        preimage = {
+            "kind": "source-object-coordinate", "schemaVersion": "1",
+            "allocationDefinition": allocation_definition.seal().to_dict(),
+            "callOccurrence": call_occurrence.seal().to_dict(),
+            "constructionGeneration": _generation(construction_generation),
+            "sourceCid": _cid(source_cid, "sourceCid"),
+            "artifactCid": _cid(artifact_cid, "artifactCid"),
+        }
+        return cls(preimage["allocationDefinition"], preimage["callOccurrence"], construction_generation,
+                   source_cid, artifact_cid, cid_of_json(preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "SourceObjectCoordinateV1":
+        raw = _exact(raw, {"kind", "schemaVersion", "allocationDefinition", "callOccurrence",
+                           "constructionGeneration", "sourceCid", "artifactCid", "objectCoordinateCid"}, cls.__name__)
+        if raw["kind"] != "source-object-coordinate" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported SourceObjectCoordinateV1")
+        allocation = _memento(raw["allocationDefinition"], "allocationDefinition")
+        occurrence = _memento(raw["callOccurrence"], "callOccurrence")
+        generation = _generation(raw["constructionGeneration"])
+        source = _cid(raw["sourceCid"], "sourceCid")
+        artifact = _cid(raw["artifactCid"], "artifactCid")
+        preimage = {key: value for key, value in raw.items() if key != "objectCoordinateCid"}
+        cid = _checked(preimage, raw["objectCoordinateCid"], "object coordinate CID")
+        return cls(allocation, occurrence, generation, source, artifact, cid)
+
+
+@dataclass(frozen=True)
+class OpaqueObjectCoordinateV1:
+    call_occurrence: dict[str, Any]
+    construction_generation: int
+    source_cid: str
+    artifact_cid: str
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {"kind": "opaque-object-coordinate", "schemaVersion": "1",
+                "callOccurrence": self.call_occurrence, "constructionGeneration": self.construction_generation,
+                "sourceCid": self.source_cid, "artifactCid": self.artifact_cid}
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "objectCoordinateCid": self.cid}
+
+    @classmethod
+    def mint(cls, *, call_occurrence: SourceFragment, construction_generation: int,
+             source_cid: str, artifact_cid: str) -> "OpaqueObjectCoordinateV1":
+        preimage = {"kind": "opaque-object-coordinate", "schemaVersion": "1",
+                    "callOccurrence": call_occurrence.seal().to_dict(),
+                    "constructionGeneration": _generation(construction_generation),
+                    "sourceCid": _cid(source_cid, "sourceCid"), "artifactCid": _cid(artifact_cid, "artifactCid")}
+        return cls(preimage["callOccurrence"], construction_generation, source_cid, artifact_cid, cid_of_json(preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "OpaqueObjectCoordinateV1":
+        raw = _exact(raw, {"kind", "schemaVersion", "callOccurrence", "constructionGeneration",
+                           "sourceCid", "artifactCid", "objectCoordinateCid"}, cls.__name__)
+        if raw["kind"] != "opaque-object-coordinate" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported OpaqueObjectCoordinateV1")
+        occurrence = _memento(raw["callOccurrence"], "callOccurrence")
+        generation = _generation(raw["constructionGeneration"])
+        source = _cid(raw["sourceCid"], "sourceCid")
+        artifact = _cid(raw["artifactCid"], "artifactCid")
+        preimage = {key: value for key, value in raw.items() if key != "objectCoordinateCid"}
+        cid = _checked(preimage, raw["objectCoordinateCid"], "object coordinate CID")
+        return cls(occurrence, generation, source, artifact, cid)
+
+
+ObjectCoordinateV1: TypeAlias = SourceObjectCoordinateV1 | OpaqueObjectCoordinateV1
+
+
+def decode_object_coordinate_v1(raw: object) -> ObjectCoordinateV1:
+    if not isinstance(raw, dict):
+        raise BindingProvenanceGap("malformed ObjectCoordinateV1")
+    if raw.get("kind") == "source-object-coordinate":
+        return SourceObjectCoordinateV1.decode(raw)
+    if raw.get("kind") == "opaque-object-coordinate":
+        return OpaqueObjectCoordinateV1.decode(raw)
+    raise BindingProvenanceGap("unsupported ObjectCoordinateV1")
+
+
+@dataclass(frozen=True)
+class AttributeFieldCoordinateV1:
+    object_coordinate: ObjectCoordinateV1
+    selector_occurrence: dict[str, Any]
+    generation: int
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {"kind": "attribute-field-coordinate", "schemaVersion": "1",
+                "objectCoordinate": self.object_coordinate.wire(),
+                "selectorOccurrence": self.selector_occurrence, "generation": self.generation}
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "fieldCoordinateCid": self.cid}
+
+    @classmethod
+    def mint(cls, owner: ObjectCoordinateV1, selector_occurrence: SourceFragment, *, generation: int) -> "AttributeFieldCoordinateV1":
+        decode_object_coordinate_v1(owner.wire())
+        preimage = {"kind": "attribute-field-coordinate", "schemaVersion": "1", "objectCoordinate": owner.wire(),
+                    "selectorOccurrence": selector_occurrence.seal().to_dict(), "generation": _generation(generation)}
+        return cls(owner, preimage["selectorOccurrence"], generation, cid_of_json(preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "AttributeFieldCoordinateV1":
+        raw = _exact(raw, {"kind", "schemaVersion", "objectCoordinate", "selectorOccurrence", "generation", "fieldCoordinateCid"}, cls.__name__)
+        if raw["kind"] != "attribute-field-coordinate" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported AttributeFieldCoordinateV1")
+        owner = decode_object_coordinate_v1(raw["objectCoordinate"])
+        selector = _memento(raw["selectorOccurrence"], "selectorOccurrence")
+        generation = _generation(raw["generation"])
+        preimage = {key: value for key, value in raw.items() if key != "fieldCoordinateCid"}
+        cid = _checked(preimage, raw["fieldCoordinateCid"], "field coordinate CID")
+        return cls(owner, selector, generation, cid)
+
+
+@dataclass(frozen=True)
+class AttributeFieldVersionV1:
+    owner: ObjectCoordinateV1
+    field: AttributeFieldCoordinateV1
+    store_occurrence: dict[str, Any]
+    construction_generation: int
+    stored_value_testimony_cid: str
+    prior_version_cid: str | None
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {"kind": "attribute-field-version", "schemaVersion": "1", "objectCoordinate": self.owner.wire(),
+                "fieldCoordinate": self.field.wire(), "storeOccurrence": self.store_occurrence,
+                "constructionGeneration": self.construction_generation,
+                "storedValueTestimonyCid": self.stored_value_testimony_cid,
+                "priorVersionCid": self.prior_version_cid}
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "fieldVersionCid": self.cid}
+
+    @classmethod
+    def mint(cls, *, owner: ObjectCoordinateV1, field: AttributeFieldCoordinateV1,
+             store_occurrence: SourceFragment, construction_generation: int,
+             stored_value_testimony_cid: str, prior_version_cid: str | None) -> "AttributeFieldVersionV1":
+        decode_object_coordinate_v1(owner.wire())
+        AttributeFieldCoordinateV1.decode(field.wire())
+        if field.object_coordinate.cid != owner.cid:
+            raise BindingProvenanceGap("field owner coordinate mismatch")
+        if prior_version_cid is not None:
+            _cid(prior_version_cid, "priorVersionCid")
+        preimage = {"kind": "attribute-field-version", "schemaVersion": "1", "objectCoordinate": owner.wire(),
+                    "fieldCoordinate": field.wire(), "storeOccurrence": store_occurrence.seal().to_dict(),
+                    "constructionGeneration": _generation(construction_generation),
+                    "storedValueTestimonyCid": _cid(stored_value_testimony_cid, "storedValueTestimonyCid"),
+                    "priorVersionCid": prior_version_cid}
+        return cls(owner, field, preimage["storeOccurrence"], construction_generation,
+                   stored_value_testimony_cid, prior_version_cid, cid_of_json(preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "AttributeFieldVersionV1":
+        raw = _exact(raw, {"kind", "schemaVersion", "objectCoordinate", "fieldCoordinate", "storeOccurrence",
+                           "constructionGeneration", "storedValueTestimonyCid", "priorVersionCid", "fieldVersionCid"}, cls.__name__)
+        if raw["kind"] != "attribute-field-version" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported AttributeFieldVersionV1")
+        owner = decode_object_coordinate_v1(raw["objectCoordinate"])
+        field = AttributeFieldCoordinateV1.decode(raw["fieldCoordinate"])
+        if field.object_coordinate.cid != owner.cid:
+            raise BindingProvenanceGap("field owner coordinate mismatch")
+        store = _memento(raw["storeOccurrence"], "storeOccurrence")
+        generation = _generation(raw["constructionGeneration"])
+        stored = _cid(raw["storedValueTestimonyCid"], "storedValueTestimonyCid")
+        prior = raw["priorVersionCid"]
+        if prior is not None:
+            prior = _cid(prior, "priorVersionCid")
+        preimage = {key: value for key, value in raw.items() if key != "fieldVersionCid"}
+        cid = _checked(preimage, raw["fieldVersionCid"], "field version CID")
+        return cls(owner, field, store, generation, stored, prior, cid)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
@@ -161,37 +161,39 @@ def decode_object_coordinate_v1(raw: object) -> ObjectCoordinateV1:
 @dataclass(frozen=True)
 class AttributeFieldCoordinateV1:
     object_coordinate: ObjectCoordinateV1
-    selector_occurrence: dict[str, Any]
-    generation: int
+    attribute_name: str
     cid: str
 
     @property
     def preimage(self) -> dict[str, Any]:
         return {"kind": "attribute-field-coordinate", "schemaVersion": "1",
                 "objectCoordinate": self.object_coordinate.wire(),
-                "selectorOccurrence": self.selector_occurrence, "generation": self.generation}
+                "attributeName": self.attribute_name}
 
     def wire(self) -> dict[str, Any]:
         return {**self.preimage, "fieldCoordinateCid": self.cid}
 
     @classmethod
-    def mint(cls, owner: ObjectCoordinateV1, selector_occurrence: SourceFragment, *, generation: int) -> "AttributeFieldCoordinateV1":
+    def mint(cls, owner: ObjectCoordinateV1, attribute_name: str) -> "AttributeFieldCoordinateV1":
         decode_object_coordinate_v1(owner.wire())
+        if not isinstance(attribute_name, str) or not attribute_name.isidentifier():
+            raise BindingProvenanceGap("attributeName must be one Python identifier")
         preimage = {"kind": "attribute-field-coordinate", "schemaVersion": "1", "objectCoordinate": owner.wire(),
-                    "selectorOccurrence": selector_occurrence.seal().to_dict(), "generation": _generation(generation)}
-        return cls(owner, preimage["selectorOccurrence"], generation, cid_of_json(preimage))
+                    "attributeName": attribute_name}
+        return cls(owner, attribute_name, cid_of_json(preimage))
 
     @classmethod
     def decode(cls, raw: object) -> "AttributeFieldCoordinateV1":
-        raw = _exact(raw, {"kind", "schemaVersion", "objectCoordinate", "selectorOccurrence", "generation", "fieldCoordinateCid"}, cls.__name__)
+        raw = _exact(raw, {"kind", "schemaVersion", "objectCoordinate", "attributeName", "fieldCoordinateCid"}, cls.__name__)
         if raw["kind"] != "attribute-field-coordinate" or raw["schemaVersion"] != "1":
             raise BindingProvenanceGap("unsupported AttributeFieldCoordinateV1")
         owner = decode_object_coordinate_v1(raw["objectCoordinate"])
-        selector = _memento(raw["selectorOccurrence"], "selectorOccurrence")
-        generation = _generation(raw["generation"])
+        attribute_name = raw["attributeName"]
+        if not isinstance(attribute_name, str) or not attribute_name.isidentifier():
+            raise BindingProvenanceGap("malformed attributeName")
         preimage = {key: value for key, value in raw.items() if key != "fieldCoordinateCid"}
         cid = _checked(preimage, raw["fieldCoordinateCid"], "field coordinate CID")
-        return cls(owner, selector, generation, cid)
+        return cls(owner, attribute_name, cid)
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/tests/test_object_identity_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_object_identity_v1.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import BindingProvenanceGap
+from sugar_source_tree.object_identity import (
+    AttributeFieldCoordinateV1,
+    AttributeFieldVersionV1,
+    OpaqueObjectCoordinateV1,
+    SourceObjectCoordinateV1,
+    decode_object_coordinate_v1,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _calls():
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write("def f():\n    left = C()\n    right = C()\n")
+        path = handle.name
+    function = next(SourceFile(path_source(path)).functions())
+    return [node.fragment for node in function.walk() if node.kind == "Call"]
+
+
+def _source(site, generation=0):
+    return SourceObjectCoordinateV1.mint(
+        allocation_definition=site,
+        call_occurrence=site,
+        construction_generation=generation,
+        source_cid=site.source_cid,
+        artifact_cid=cid_of_json({"artifact": "fixture"}),
+    )
+
+
+def test_object_identity_is_call_occurrence_not_binding_or_shape():
+    first_site, second_site = _calls()
+    first = _source(first_site)
+    second = _source(second_site)
+    assert first.cid != second.cid
+    assert "binding" not in repr(first.wire()).lower()
+    assert decode_object_coordinate_v1(first.wire()) == first
+
+
+def test_opaque_result_proves_only_occurrence_identity_and_aliasing():
+    first_site, _ = _calls()
+    opaque = OpaqueObjectCoordinateV1.mint(
+        call_occurrence=first_site,
+        construction_generation=3,
+        source_cid=first_site.source_cid,
+        artifact_cid=cid_of_json({"artifact": "native"}),
+    )
+    assert decode_object_coordinate_v1(opaque.wire()) == opaque
+    assert not ({"fields", "behavior", "class", "type"} & set(opaque.wire()))
+
+
+def test_attribute_versions_are_immutable_prior_linked_and_closed():
+    site, _ = _calls()
+    owner = _source(site)
+    field = AttributeFieldCoordinateV1.mint(owner, site, generation=0)
+    first = AttributeFieldVersionV1.mint(
+        owner=owner,
+        field=field,
+        store_occurrence=site,
+        construction_generation=0,
+        stored_value_testimony_cid=cid_of_json({"value": 7}),
+        prior_version_cid=None,
+    )
+    second = AttributeFieldVersionV1.mint(
+        owner=owner,
+        field=field,
+        store_occurrence=site,
+        construction_generation=1,
+        stored_value_testimony_cid=cid_of_json({"value": 8}),
+        prior_version_cid=first.cid,
+    )
+    assert second.prior_version_cid == first.cid
+    assert AttributeFieldVersionV1.decode(second.wire()) == second
+
+    for key in second.wire():
+        forged = deepcopy(second.wire())
+        value = forged[key]
+        if isinstance(value, int):
+            forged[key] = value + 1
+        elif value is None:
+            forged[key] = cid_of_json({"forged": key})
+        elif isinstance(value, dict):
+            forged[key] = {**value, "unexpected": True}
+        else:
+            forged[key] = "blake3-512:forged"
+        with pytest.raises(BindingProvenanceGap):
+            AttributeFieldVersionV1.decode(forged)

--- a/implementations/python/sugar-source-tree/tests/test_object_identity_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_object_identity_v1.py
@@ -60,7 +60,7 @@ def test_opaque_result_proves_only_occurrence_identity_and_aliasing():
 def test_attribute_versions_are_immutable_prior_linked_and_closed():
     site, _ = _calls()
     owner = _source(site)
-    field = AttributeFieldCoordinateV1.mint(owner, site, generation=0)
+    field = AttributeFieldCoordinateV1.mint(owner, "payload")
     first = AttributeFieldVersionV1.mint(
         owner=owner,
         field=field,


### PR DESCRIPTION
## What changed

- adds closed `SourceObjectCoordinateV1` and `OpaqueObjectCoordinateV1` testimony minted from exact construction occurrences, construction generation, and source/artifact CIDs
- copies coordinates through the sole temporal `BindingEntryV1.state` path so aliases share identity and distinct call occurrences cannot collide
- keys attribute state by object coordinate plus `AttributeFieldCoordinateV1`, with immutable prior-linked `AttributeFieldVersionV1` records and CID revalidation
- invalidates only object coordinates exposed to opaque calls; unrelated objects retain their field knowledge
- gives opaque/native results occurrence identity and aliasing only; attribute behavior remains loud without testimony
- keeps descriptors, custom allocation/attribute dispatch, unknown alias escape, and all subscript places typed-loud
- adds truthful, lying, renamed, version-chain, forgery, selective-invalidation, and opaque-result acceptance twins
- adds an object-field-only pandas census mode

## Why

Draft #6126 derived identity from `BindingEntryV1` ownership and plain-class admission. This rebuild follows the ruling that identity comes only from the construction occurrence—never binding ownership, type, spelling, equality, or field contents.

## Validation

- battleaxe focused: `87 passed in 428.66s`
- zero-tolerance laws included in that receipt: `R_construction_side_doors = 0`, `R_construction_panic_catches_outside_audit = 0`, `auditor_errors = 0`
- `git diff --check origin/main...HEAD`
- forbidden-mechanism searches: zero owner-coordinate identity, plain-class identity admission, subscript selector side door, panic catch, pandas/NumPy identity arm
- clean rebase base: `c401588017ae93e9b379a34b0a155830fc710ae7`

## Honest pandas delta

Identical base/head instrument over pandas 3.0.3 site-packages:

- denominator: 1,415 files = 1,281 completed assignment-bearing files + 134 files without assignments
- object-field candidates: 140 base and head
- base: 45 built / 95 typed-loud
- head: 33 built / 107 typed-loud
- transitions: 33 built→built, 95 typed-loud→typed-loud, 12 built→typed-loud, 0 typed-loud→built

Honest `Delta R_typed_loud = +12`; no drain is claimed. The twelve transitions are opaque-result attribute reads that current main constructed without field testimony. This branch makes those residuals loud as required by the ruling. Predicted `Epsilon R_typed_loud = +12`, observed exactly. No timeout increase is present in this instrument (it has no timeout/panic swallowing path and every discovered file completed classification).

## Scope boundary

Attribute fields only. `obj[key]` remains typed-loud for a follow-up slice.

This PR remains unmerged for user review.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add construction-occurrence object identity and immutable attribute field versioning
> - Introduces `ObjectPlaceStateV1` and `OpaqueObjectStateV1` AST node types that carry authenticated object identity (keyed by call-site occurrence) through substitution, replacing the RHS of simple assignments to plain classes with a place-state expression.
> - Adds `object_identity.py` with `SourceObjectCoordinateV1`, `OpaqueObjectCoordinateV1`, `AttributeFieldCoordinateV1`, and `AttributeFieldVersionV1` dataclasses; each uses blake3-512 CIDs and raises `BindingProvenanceGap` on any shape or hash mismatch.
> - Attribute reads on `ObjectPlaceStateV1` resolve to `ConstructedValueProjectionV1` projections backed by authenticated testimony; conditional receivers sharing the same identity project both branch faces.
> - Opaque calls selectively invalidate only the object places they receive, leaving other in-scope objects' field knowledge intact.
> - Expands the `test_object_field_flow_acceptance` suite from 6 to 8 matrix cases, removes the `xfail` from the positive acceptance test, and adds unit tests in `test_object_identity_v1.py` covering round-trip decode and forged-wire rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8315306.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->