### PR TITLE
Close builtin subtype and finite set semantics on Python floor

### DIFF
--- a/docs/superpowers/plans/2026-07-23-builtin-subtype-set-floor.md
+++ b/docs/superpowers/plans/2026-07-23-builtin-subtype-set-floor.md
@@ -1,0 +1,115 @@
+# Builtin Subtype and Finite-Set Floor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construct authenticated `issubclass` and finite-set semantics on the Python floor so installed-source effect boundaries derive without package/name gates.
+
+**Architecture:** Extend the existing `FloorValue` operation dispatch, authenticated builtin temporal bindings, class base graph, tuple disjunction, and constructed `SetValue`. Closed ground cases return constructed floor values; symbolic cases return typed predicate obligations; unsupported native cases retain typed loud outcomes. Installed-source manager derivation consumes the same predicate path for every provider.
+
+**Tech Stack:** Python 3.12, dataclass floor values, ProofIR terms/predicates, pytest, repo IDD instruments, battleaxe `bin/bpytest` and `bin/brun`.
+
+## Global Constraints
+
+- Builtins get meaning through the Python FLOOR as CLOSED semantic operations.
+- No generic opaque-builtin-result witness, name recognition, vendor arm, fabricated result, compatibility evaluator, or manager-specific branch.
+- Witnesses authenticate operands, result, Python runtime identity, and semantic operation.
+- Symbolic subtype and membership relations emit typed obligations; opaque/native behavior stays loud.
+- Preserve sole construction path, `h = h(p)`, zero new construction-side-door findings, zero panic catches, and no timeout increase.
+- Heavy validation runs only on battleaxe.
+- Rebase onto current `origin/main` before requesting review; push but do not merge.
+
+---
+
+### Task 1: Executable architectural and acceptance instrument
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py`
+
+**Interfaces:**
+- Consumes: repository root and Python AST.
+- Produces: `BuiltinClosedOperationReport` with offender rows and stable-zero `R` axes for side doors, name/vendor gates, generic verdict witnesses, panic catches, and missing acceptance twins.
+
+- [ ] Write planted positive and negative fixture tests for each axis and require output rows to name the floor replacement.
+- [ ] Run the test and verify RED because the collector does not exist.
+- [ ] Implement deterministic AST collection over production files and acceptance-test names; print every offender and current `R`, exiting nonzero while any axis is nonzero.
+- [ ] Run the instrument tests and verify GREEN; run it once on base and retain the numeric JSON receipt for later base/head comparison.
+- [ ] Commit the instrument independently.
+
+### Task 2: Authenticated closed-operation testimony and builtin coordinate
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py`
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_witness.py`
+
+**Interfaces:**
+- Produces: `ClosedSemanticOperationWitness.mint(runtime_identity, operation, operands, result)` and `verify(...)`; `BuiltinSemanticCallable(runtime_identity, operation)` implementing `callable_application_with` for exactly `python.issubclass`.
+
+- [ ] Write truthful and four lying witness twins (operand, result, runtime identity, operation), plus shadowed-name and opaque-arity callable tests.
+- [ ] Run the focused test and verify the imports/dispatch fail.
+- [ ] Implement CID-based closed witness mint/verify and seed `issubclass` only in the authenticated builtin temporal vocabulary.
+- [ ] Run the focused test and verify all truthful/lying twins pass.
+- [ ] Commit the testimony and callable coordinate.
+
+### Task 3: Authenticated subtype graph and tuple disjunction
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_builtin_subtype_floor.py`
+
+**Interfaces:**
+- Produces: `ClassValue.test_python_subtype(supertype, site)`; `TupleValue.test_python_subtype(subtype, site)`; typed `python.subtype` predicates for authenticated symbolic operands.
+
+- [ ] Write RED tests for direct, transitive, unrelated, and renamed class graphs; tuple true/false partition; symbolic obligation; non-type and opaque/native loud cases.
+- [ ] Implement cycle-safe traversal over constructed `ClassValue.bases`, using the existing tuple predicate collector for disjunction and `PredicateValue(atomic("python.subtype", ...))` for lawful symbolic relations.
+- [ ] Run the focused subtype tests and verify GREEN.
+- [ ] Commit subtype semantics.
+
+### Task 4: Constructed finite-set membership and algebra
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_literal_value.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py`
+
+**Interfaces:**
+- Produces: `SetValue.contains`, `bitwise_or`, `bitwise_and`, and `subtract`; typed `python.set.contains` predicates where constructed equality is symbolic.
+
+- [ ] Write RED tests for present/absent membership, union, intersection, difference, symbolic membership obligation, duplicate handling, and opaque/native loud twins.
+- [ ] Implement member comparison through constructed equality outcomes only; fold all-ground results and combine symbolic equality predicates without using host dataclass equality as semantic authority.
+- [ ] Run the focused set tests and verify GREEN.
+- [ ] Commit finite-set semantics.
+
+### Task 5: Installed-source effect-boundary derivation
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_manager_construction.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_sole_path_manager_construction.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_installed_source_builtin_boundaries.py`
+
+**Interfaces:**
+- Consumes: the floor predicate produced by authenticated `issubclass`.
+- Produces: existing `EffectBoundarySemanticsV1` for installed-source `pytest.raises` and `contextlib.suppress`, with no provider-name branch.
+
+- [ ] Add RED installed-source tests for matching consumed, wrong type propagated, absent effect failed, tuple partition, and renamed equivalent source; assert the same floor operation witness is present.
+- [ ] Extend source expression construction only where required to project authenticated builtin call predicates; do not add provider dispatch.
+- [ ] Run manager-focused tests and verify GREEN, including an AST assertion that production contains no `pytest.raises` or `contextlib.suppress` decision gate.
+- [ ] Commit manager integration.
+
+### Task 6: Receipts, rebase, and review PR
+
+**Files:**
+- Modify only if receipts are conventionally checked in: `docs/receipts/2026-07-23-builtin-subtype-set-floor.md`
+
+**Interfaces:**
+- Produces: base/head instrument JSON, focused pytest receipt, battleaxe broad/battleaxe receipt, timeout and panic-catch comparison, rebased branch, and open PR.
+
+- [ ] Run the complete focused acceptance set on battleaxe with `bin/bpytest`, capture the real exit code, and inspect summary lines.
+- [ ] Run the repo-prescribed battleaxe side-door and census commands with `bin/brun`; compare numeric base/head JSON and report measured `Delta R` without inferring zeros from process completion.
+- [ ] Fetch `origin/main`, rebase, rerun the focused and invariant receipts on battleaxe, and confirm a clean worktree.
+- [ ] Verify author identity is `T Savo <evilgenius@nefariousplan.com>`, push with upstream, open a non-draft review PR, and request review without merging.

--- a/docs/superpowers/specs/2026-07-23-builtin-subtype-set-floor-design.md
+++ b/docs/superpowers/specs/2026-07-23-builtin-subtype-set-floor-design.md
@@ -1,0 +1,114 @@
+# Builtin Subtype and Finite-Set Python Floor Design
+
+## Ruling
+
+Python builtins gain meaning through closed operations on the Python floor. No
+operation may be admitted by package name, leaf spelling, or an observed native
+Boolean. The floor must authenticate the Python-runtime builtin identity, the
+semantic operation, every operand, and the constructed result.
+
+The lane owns these operations:
+
+- `issubclass(T, U)` over authenticated class coordinates and their constructed
+  base/MRO graph;
+- tuple-of-types as a finite disjunction over the same subtype relation;
+- membership, union, intersection, and difference over constructed finite set
+  members;
+- typed subtype or membership obligations when the relation is symbolic but
+  the operands and operation remain authenticated.
+
+Opaque or unsupported native behavior stays loud. In particular, this lane
+does not add a generic witness that says an opaque builtin returned true.
+
+## Architecture
+
+The existing floor dispatch remains the sole construction path. An authenticated
+builtin callable coordinate dispatches `issubclass` to the already-constructed
+class/type operand rather than recognizing the source name. `ClassValue`
+traverses only its authenticated base values. `TupleValue` performs a finite
+left-to-right disjunction by invoking the same subtype operation for each arm.
+
+Constructed `SetValue` owns membership and the three binary set operations.
+Ground members are compared only through existing constructed equality or
+identity testimony. When a relation cannot close but both operands have lawful
+terms, the floor constructs a typed predicate/obligation naming the precise
+subtype or membership operation. It never guesses a Boolean or uses Python host
+object equality as semantic authority.
+
+The operation witness is a closed testimony value containing:
+
+- the authenticated Python runtime identity;
+- an operation tag (`python.issubclass`, `python.set.contains`,
+  `python.set.union`, `python.set.intersection`, or `python.set.difference`);
+- operand term content identities;
+- the result term or predicate content identity.
+
+Verification must reject a witness when any operand, result, runtime identity,
+or operation tag is altered.
+
+## Manager Derivation
+
+Installed-source manager construction continues to interpret source-visible
+`__exit__` bodies. A body using authenticated `builtins.issubclass` reaches the
+new floor operation. The resulting predicate feeds the existing
+`EffectBoundarySemanticsV1` derivation. `pytest.raises` and
+`contextlib.suppress` therefore derive through the same installed-source body
+path. There is no package, exported-symbol, or manager-name branch.
+
+## Loud Boundaries
+
+The following remain typed loud outcomes:
+
+- a shadowed or otherwise unauthenticated `issubclass` callable;
+- a non-type tuple arm;
+- dynamic native classes without authenticated subtype testimony;
+- sets whose members cannot be constructed or whose equality relation is
+  unsupported;
+- native mutation or iteration-order behavior outside the four closed set
+  operations;
+- malformed, mismatched, or lying operation witnesses.
+
+## Executable Instrument
+
+The lane adds or extends an automated instrument that reports current `R` for:
+
+- construction side doors around floor callable dispatch;
+- package/name gates for `pytest.raises` or `contextlib.suppress`;
+- generic opaque-builtin-result witnesses;
+- panic catches introduced on the construction path;
+- missing acceptance twins for subtype, tuple partition, finite-set, symbolic,
+  opaque/native, and installed-source manager cases.
+
+The instrument names the floor replacement shape for each finding and stays red
+while any stable-zero term is nonzero. `Delta R` is read from base/head runs;
+there is no checked-in threshold.
+
+## Acceptance Evidence
+
+Renamed, truthful, and lying twins must demonstrate:
+
+- a matching subclass effect is consumed;
+- a wrong type propagates;
+- an absent effect fails;
+- tuple-of-types partitions correctly;
+- finite-set membership and the three finite set operations are decided;
+- symbolic subtype and set relations produce typed obligations and remain loud
+  to any consumer requiring a concrete Boolean;
+- opaque/native cases remain loud;
+- real installed-source `pytest.raises` and `contextlib.suppress` derive
+  `EffectBoundarySemanticsV1` through this floor mechanism without a name gate;
+- witness mutations to operands, result, runtime identity, or operation fail.
+
+## Invariants
+
+- One construction path; no compatibility or manager-specific evaluator.
+- `h = h(p)`: constructed results depend only on authenticated construction
+  inputs and semantic operation.
+- No vendor arm and no package/name recognition.
+- No fabricated result.
+- Zero new construction-side-door findings.
+- Zero panic catches.
+- No timeout increase in the measured battleaxe receipt.
+- Heavy validation runs only on battleaxe.
+- Rebase onto refreshed `origin/main` before requesting review.
+- Push an open review PR and do not self-merge.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -14,6 +14,7 @@ from .native_callable_value import NativeCallableValue
 from .builder_state import BuilderState
 from .bv32_value import Bv32Value
 from .builtin_exception_class_value import BuiltinExceptionClassValue
+from .builtin_semantic_callable import BuiltinSemanticCallable
 from .call_site_value import CallSiteValue
 from .class_definition_value import (
     ClassDefinitionValue,
@@ -95,6 +96,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     BuilderState,
     Bv32Value,
     BuiltinExceptionClassValue,
+    BuiltinSemanticCallable,
     CallSiteValue,
     ClassValue,
     ComprehensionValue,
@@ -163,6 +165,7 @@ __all__ = [
     "BuilderState",
     "Bv32Value",
     "BuiltinExceptionClassValue",
+    "BuiltinSemanticCallable",
     "CallSiteValue",
     "CurriedLoopBody",
     "CurriedLoopScope",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -34,6 +34,8 @@ class BuiltinSemanticCallable(FloorValue):
 
     def callable_application_with(self, operation, ctx):
         del ctx
+        if self.operation == "python.set.construct":
+            return self._construct_set(operation)
         if self.operation != "python.issubclass":
             return super().callable_application_with(operation, None)
         if len(operation.arguments) != 2 or operation.keyword_names:
@@ -48,6 +50,21 @@ class BuiltinSemanticCallable(FloorValue):
             )
         subtype, supertype = operation.arguments
         return subtype.test_python_subtype(supertype, operation.site)
+
+    def _construct_set(self, operation):
+        from sugar_lift_py_tests.floor import DictValue, ListValue, SetValue, TupleValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if operation.keyword_names or len(operation.arguments) > 1:
+            return super().callable_application_with(operation, None)
+        if not operation.arguments:
+            return Complete(SetValue(()))
+        source = operation.arguments[0]
+        if isinstance(source, DictValue):
+            return Complete(SetValue(tuple(key for key, _ in source.entries)))
+        if isinstance(source, (ListValue, SetValue, TupleValue)):
+            return Complete(SetValue(tuple(source.elements)))
+        return super().callable_application_with(operation, None)
 
     def witness_for(self, operands, result) -> ClosedSemanticOperationWitness:
         return ClosedSemanticOperationWitness.mint(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .closed_operation_witness import (
+    ClosedSemanticOperationWitness,
+    PythonRuntimeIdentity,
+)
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class BuiltinSemanticCallable(FloorValue):
+    operation: str
+    runtime_identity: PythonRuntimeIdentity = field(
+        default_factory=PythonRuntimeIdentity.current
+    )
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:builtin_semantic_callable",
+            [
+                str_const(self.runtime_identity.implementation),
+                str_const(
+                    f"{self.runtime_identity.major}.{self.runtime_identity.minor}"
+                ),
+                str_const(self.operation),
+            ],
+            symbol_kind="builtin",
+        )
+
+    def callable_application_with(self, operation, ctx):
+        del ctx
+        if self.operation != "python.issubclass":
+            return super().callable_application_with(operation, None)
+        if len(operation.arguments) != 2 or operation.keyword_names:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BuiltinSemanticCallable.python.issubclass",
+                blame=str(operation.site),
+                observed=(len(operation.arguments), operation.keyword_names),
+                requested="exactly two positional authenticated type operands",
+                fix="construct Python issubclass arity exactly or keep it loud",
+            )
+        subtype, supertype = operation.arguments
+        return subtype.test_python_subtype(supertype, operation.site)
+
+    def witness_for(self, operands, result) -> ClosedSemanticOperationWitness:
+        return ClosedSemanticOperationWitness.mint(
+            self.runtime_identity,
+            self.operation,
+            tuple(value.to_term(owner=self.operation) for value in operands),
+            result.to_term(owner=self.operation),
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -30,6 +30,57 @@ class ClassValue(FloorValue):
     def test_python_type(self, value, site):
         return value.python_isinstance(self.name, self.to_term(owner=self.name), site)
 
+    def test_python_subtype(self, supertype, site):
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type(supertype) is TupleValue:
+            return supertype.test_python_subtype(self, site)
+        if type(supertype) is SymbolicValue:
+            return SymbolicValue(self.to_term(owner=str(site))).test_python_subtype(
+                supertype, site
+            )
+        if type(supertype) is not ClassValue:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="ClassValue.test_python_subtype",
+                blame=str(site),
+                observed=type(supertype).__name__,
+                requested="authenticated class or finite tuple-of-classes",
+                fix="construct the type operand on the Python floor or keep it loud",
+            )
+        pending = [self]
+        seen: set[int] = set()
+        while pending:
+            candidate = pending.pop()
+            if candidate is supertype:
+                return Complete(TrueBoolLiteralSugar(site=site))
+            key = id(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            for base in candidate.bases:
+                if type(base) is not ClassValue:
+                    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                    construction_panic_gap(
+                        owner="ClassValue.test_python_subtype",
+                        blame=str(site),
+                        observed=type(base).__name__,
+                        requested="authenticated ClassValue base graph",
+                        fix="resolve every base through its lexical class coordinate",
+                    )
+                pending.append(base)
+        return Complete(FalseBoolLiteralSugar(site=site))
+
     def subscript(self, index, site):
         # Generic class subscript (Class[T]) is a type coordinate, not a dig.
         # Recognition-era subscription tables are gone; emit the coordinate.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
@@ -20,7 +20,8 @@ _CLOSED_OPERATIONS = frozenset(
         "python.set.contains",
         "python.set.union",
         "python.set.intersection",
-        "python.set.difference",
+    "python.set.difference",
+    "python.set.construct",
     }
 )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.canonicalizer import (
+    blake3_512_of,
+    encode_jcs,
+    varr,
+    vint,
+    vobj,
+    vstr,
+)
+from sugar_lift_py_tests.ir import Term, _term_content_cid
+
+
+_CLOSED_OPERATIONS = frozenset(
+    {
+        "python.issubclass",
+        "python.set.contains",
+        "python.set.union",
+        "python.set.intersection",
+        "python.set.difference",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PythonRuntimeIdentity:
+    implementation: str
+    major: int
+    minor: int
+
+    @classmethod
+    def current(cls) -> "PythonRuntimeIdentity":
+        return cls(sys.implementation.name, sys.version_info.major, sys.version_info.minor)
+
+
+@dataclass(frozen=True)
+class ClosedSemanticOperationWitness:
+    runtime: PythonRuntimeIdentity
+    operation: str
+    operand_cids: tuple[str, ...]
+    result_cid: str
+    witness_cid: str
+
+    @classmethod
+    def mint(
+        cls,
+        runtime: PythonRuntimeIdentity,
+        operation: str,
+        operands: tuple[Term, ...],
+        result: Term,
+    ) -> "ClosedSemanticOperationWitness":
+        if operation not in _CLOSED_OPERATIONS:
+            raise ValueError(f"unsupported closed semantic operation: {operation}")
+        operand_cids = tuple(_term_content_cid(term) for term in operands)
+        result_cid = _term_content_cid(result)
+        witness_cid = _witness_cid(runtime, operation, operand_cids, result_cid)
+        return cls(runtime, operation, operand_cids, result_cid, witness_cid)
+
+    def verify(
+        self,
+        runtime: PythonRuntimeIdentity,
+        operation: str,
+        operands: tuple[Term, ...],
+        result: Term,
+    ) -> None:
+        expected = ClosedSemanticOperationWitness.mint(
+            runtime, operation, operands, result
+        )
+        if self != expected:
+            raise ValueError("closed semantic operation witness does not authenticate operands, result, runtime identity, and operation")
+
+
+def _witness_cid(
+    runtime: PythonRuntimeIdentity,
+    operation: str,
+    operand_cids: tuple[str, ...],
+    result_cid: str,
+) -> str:
+    body = vobj(
+        [
+            ("operation", vstr(operation)),
+            ("operands", varr([vstr(cid) for cid in operand_cids])),
+            ("result", vstr(result_cid)),
+            (
+                "runtime",
+                vobj(
+                    [
+                        ("implementation", vstr(runtime.implementation)),
+                        ("major", vint(runtime.major)),
+                        ("minor", vint(runtime.minor)),
+                    ]
+                ),
+            ),
+        ]
+    )
+    return blake3_512_of(encode_jcs(body).encode("utf-8"))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
@@ -54,6 +54,30 @@ class ExitTypeCoordinate(FloorValue):
 
         return ctor("python:exit_type", [str_const(self.face_id)])
 
+    def test_python_subtype(self, supertype, site):
+        from sugar_lift_py_tests.floor import ClassValue, SymbolicValue, TupleValue
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import atomic
+        from sugar_lift_py_tests.outcome import Complete
+
+        if type(supertype) is TupleValue:
+            return supertype.test_python_subtype(self, site)
+        if not isinstance(supertype, (ClassValue, SymbolicValue)):
+            return _dynamic_subtype_operand(self, supertype, site)
+        return Complete(
+            PredicateValue(
+                atomic(
+                    "python.subtype",
+                    [
+                        self.to_term(owner="python.issubclass subtype"),
+                        supertype.to_term(owner="python.issubclass supertype"),
+                    ],
+                ),
+                site,
+                operand_callsites=(*self.callsites(), *supertype.callsites()),
+            )
+        )
+
 
 @dataclass(frozen=True)
 class ExitValueCoordinate(FloorValue):
@@ -94,3 +118,16 @@ class ExitTracebackCoordinate(FloorValue):
         from sugar_lift_py_tests.ir import ctor, str_const
 
         return ctor("python:exit_traceback", [str_const(self.face_id)])
+
+
+def _dynamic_subtype_operand(subtype, supertype, site):
+    del subtype
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="ExitTypeCoordinate.test_python_subtype",
+        blame=str(site),
+        observed=type(supertype).__name__,
+        requested="authenticated class, tuple-of-classes, or symbolic type operand",
+        fix="construct the Python type operand or keep issubclass loudly unsupported",
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -48,29 +48,156 @@ class SetValue(FloorValue):
 
         return Complete(TermValue(len(self.elements)))
 
-    def subtract(self, other, site):
-        if type(other) is SetValue:
+    def contains(self, item, site):
+        decisions = tuple(_closed_member_equal(item, element) for element in self.elements)
+        if any(decision is True for decision in decisions):
+            return _bool_result(True, site)
+        if all(decision is False for decision in decisions):
+            return _bool_result(False, site)
+        if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+            from sugar_lift_py_tests.ir import atomic
             from sugar_lift_py_tests.outcome import Complete
 
             return Complete(
-                SetValue(
-                    tuple(
-                        element
-                        for element in self.elements
-                        if element not in other.elements
-                    )
+                PredicateValue(
+                    atomic(
+                        "python.set.contains",
+                        [
+                            item.to_term(owner="python.set.contains member"),
+                            self.to_term(owner="python.set.contains set"),
+                        ],
+                    ),
+                    site,
+                    operand_callsites=(*item.callsites(), *self.callsites()),
                 )
             )
+        return _unsupported_member(item, site)
+
+    def subtract(self, other, site):
+        if type(other) is SetValue:
+            from sugar_lift_py_tests.outcome import Complete
+            result = _finite_difference(self.elements, other.elements)
+            if result is not None:
+                return Complete(SetValue(result))
+            return _symbolic_set_operation("python.set.difference", self, other, site)
         return super().subtract(other, site)
 
     def bitwise_or(self, other, site):
         if type(other) is SetValue:
-            del site
+            from sugar_lift_py_tests.outcome import Complete
+            result = _finite_union(self.elements, other.elements)
+            if result is not None:
+                return Complete(SetValue(result))
+            return _symbolic_set_operation("python.set.union", self, other, site)
+        return super().bitwise_or(other, site)
+
+    def bitwise_and(self, other, site):
+        if type(other) is SetValue:
             from sugar_lift_py_tests.outcome import Complete
 
-            elements = list(self.elements)
-            elements.extend(
-                element for element in other.elements if element not in elements
+            result = _finite_intersection(self.elements, other.elements)
+            if result is not None:
+                return Complete(SetValue(result))
+            return _symbolic_set_operation("python.set.intersection", self, other, site)
+        return super().bitwise_and(other, site)
+
+
+def _closed_member_equal(left, right):
+    from sugar_lift_py_tests.floor.bytes_value import BytesValue
+    from sugar_lift_py_tests.floor.none_value import NoneValue
+    from sugar_lift_py_tests.floor.string_value import StringValue
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    if type(left) is SymbolicValue or type(right) is SymbolicValue:
+        return None
+    if type(left) is TermValue and type(right) is TermValue:
+        return left.value == right.value
+    if type(left) is StringValue and type(right) is StringValue:
+        return left.value == right.value
+    if type(left) is BytesValue and type(right) is BytesValue:
+        return left.value == right.value
+    if type(left) is NoneValue or type(right) is NoneValue:
+        return type(left) is type(right)
+    bool_types = (TrueBoolLiteralSugar, FalseBoolLiteralSugar)
+    if type(left) in bool_types and type(right) in bool_types:
+        return type(left) is type(right)
+    supported = (TermValue, StringValue, BytesValue, NoneValue, *bool_types)
+    if type(left) in supported and type(right) in supported:
+        return False
+    return NotImplemented
+
+
+def _finite_union(left, right):
+    result = list(left)
+    for candidate in right:
+        decisions = tuple(_closed_member_equal(candidate, item) for item in result)
+        if any(decision is True for decision in decisions):
+            continue
+        if any(decision in (None, NotImplemented) for decision in decisions):
+            return None
+        result.append(candidate)
+    return tuple(result)
+
+
+def _finite_intersection(left, right):
+    result = []
+    for candidate in left:
+        decisions = tuple(_closed_member_equal(candidate, item) for item in right)
+        if any(decision is True for decision in decisions):
+            result.append(candidate)
+        elif any(decision in (None, NotImplemented) for decision in decisions):
+            return None
+    return tuple(result)
+
+
+def _finite_difference(left, right):
+    result = []
+    for candidate in left:
+        decisions = tuple(_closed_member_equal(candidate, item) for item in right)
+        if any(decision is True for decision in decisions):
+            continue
+        if any(decision in (None, NotImplemented) for decision in decisions):
+            return None
+        result.append(candidate)
+    return tuple(result)
+
+
+def _symbolic_set_operation(name, left, right, site):
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.ir import ctor
+    from sugar_lift_py_tests.outcome import Complete
+
+    return Complete(
+        SymbolicValue(
+            ctor(
+                name,
+                [left.to_term(owner=str(site)), right.to_term(owner=str(site))],
             )
-            return Complete(SetValue(tuple(elements)))
-        return super().bitwise_or(other, site)
+        )
+    )
+
+
+def _bool_result(value, site):
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    return Complete(
+        TrueBoolLiteralSugar(site=site) if value else FalseBoolLiteralSugar(site=site)
+    )
+
+
+def _unsupported_member(item, site):
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="SetValue.contains",
+        blame=str(site),
+        observed=type(item).__name__,
+        requested="constructed finite member or typed symbolic membership operand",
+        fix="construct member equality on the Python floor or keep it loud",
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -140,6 +140,25 @@ class SymbolicValue(FloorValue):
             )
         )
 
+    def test_python_subtype(self, supertype, site):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import atomic
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            PredicateValue(
+                atomic(
+                    "python.subtype",
+                    [
+                        self.to_term(owner="python.issubclass subtype"),
+                        supertype.to_term(owner="python.issubclass supertype"),
+                    ],
+                ),
+                site,
+                operand_callsites=(*self.callsites(), *supertype.callsites()),
+            )
+        )
+
     def to_term(self, *, owner: str):
         del owner
         return self.term

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -78,6 +78,64 @@ class TupleValue(FloorValue):
     def test_python_type(self, value, site):
         return self._collect_type_tests(value, site, 0, ())
 
+    def test_python_subtype(self, subtype, site):
+        return self._collect_subtype_tests(subtype, site, 0, ())
+
+    def _collect_subtype_tests(self, subtype, site, index, predicates):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+
+        if index >= len(self.elements):
+            if not predicates:
+                return Complete(FalseBoolLiteralSugar(site=site))
+            if len(predicates) == 1:
+                return Complete(predicates[0])
+            from sugar_lift_py_tests.ir import or_
+
+            return Complete(
+                PredicateValue(
+                    or_([predicate.formula for predicate in predicates]), site
+                )
+            )
+        return subtype.test_python_subtype(self.elements[index], site).and_then(
+            lambda result: self._continue_subtype_test(
+                subtype, site, index, predicates, result
+            )
+        )
+
+    def _continue_subtype_test(self, subtype, site, index, predicates, result):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type(result) is TrueBoolLiteralSugar:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        if type(result) is FalseBoolLiteralSugar:
+            return self._collect_subtype_tests(
+                subtype, site, index + 1, predicates
+            )
+        if type(result) is PredicateValue:
+            return self._collect_subtype_tests(
+                subtype, site, index + 1, (*predicates, result)
+            )
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="TupleValue.test_python_subtype",
+            blame=str(site),
+            observed=type(result).__name__,
+            requested="boolean or typed subtype obligation",
+            fix="implement the tuple arm on the Python subtype floor",
+        )
+
     def _collect_type_tests(self, value, site, index, predicates):
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BuiltinClosedOperationOffender:
+    axis: str
+    path: str
+    line: int
+    observed: str
+    replacement: str
+
+
+@dataclass(frozen=True)
+class BuiltinClosedOperationReport:
+    offenders: tuple[BuiltinClosedOperationOffender, ...]
+
+    @property
+    def r(self) -> dict[str, int]:
+        axes = (
+            "construction_side_doors",
+            "generic_builtin_verdicts",
+            "name_or_vendor_gates",
+            "panic_catches",
+        )
+        return {
+            axis: sum(row.axis == axis for row in self.offenders) for axis in axes
+        }
+
+
+def collect_builtin_closed_operation_report(
+    root: Path,
+) -> BuiltinClosedOperationReport:
+    offenders: list[BuiltinClosedOperationOffender] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+        relative = str(path.relative_to(root))
+        visitor = _Visitor(relative)
+        visitor.visit(tree)
+        offenders.extend(visitor.offenders)
+    return BuiltinClosedOperationReport(tuple(offenders))
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.offenders: list[BuiltinClosedOperationOffender] = []
+        self._function_stack: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+        self._side_door_functions: set[int] = set()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._function_stack.append(node)
+        self.generic_visit(node)
+        self._function_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        rendered = ast.unparse(node)
+        string_values = {
+            value.value
+            for value in ast.walk(node)
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        }
+        if any("pytest.raises" in value or "contextlib.suppress" in value for value in string_values):
+            self._add(
+                "name_or_vendor_gates",
+                node,
+                rendered,
+                "route the authenticated builtin coordinate through the Python floor",
+            )
+            if self._function_stack:
+                function = self._function_stack[-1]
+                key = id(function)
+                if key not in self._side_door_functions:
+                    self._side_door_functions.add(key)
+                    self._add(
+                        "construction_side_doors",
+                        function,
+                        function.name,
+                        "use the sole floor callable_application_with construction path",
+                    )
+        names = {value.id for value in ast.walk(node) if isinstance(value, ast.Name)}
+        bools = {
+            value.value
+            for value in ast.walk(node)
+            if isinstance(value, ast.Constant) and type(value.value) is bool
+        }
+        if any("builtin_result" in name or "builtin_verdict" in name for name in names) and bools:
+            self._add(
+                "generic_builtin_verdicts",
+                node,
+                rendered,
+                "construct the closed semantic operation and result on the Python floor",
+            )
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        caught = ast.unparse(node.type) if node.type is not None else "bare"
+        if "Panic" in caught:
+            self._add(
+                "panic_catches",
+                node,
+                caught,
+                "leave unsupported floor construction loud; never catch its panic",
+            )
+        self.generic_visit(node)
+
+    def _add(
+        self, axis: str, node: ast.AST, observed: str, replacement: str
+    ) -> None:
+        self.offenders.append(
+            BuiltinClosedOperationOffender(
+                axis=axis,
+                path=self.path,
+                line=getattr(node, "lineno", 0),
+                observed=observed,
+                replacement=replacement,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -36,11 +36,20 @@ def collect_builtin_closed_operation_report(
 ) -> BuiltinClosedOperationReport:
     offenders: list[BuiltinClosedOperationOffender] = []
     for path in sorted(root.rglob("*.py")):
+        relative_path = path.relative_to(root)
+        parts = relative_path.parts
+        if "sugar_lift_py_tests" in parts:
+            package_index = parts.index("sugar_lift_py_tests")
+            lane = parts[package_index + 1 : package_index + 2]
+            if lane and lane[0] in {"audit_only", "idd", "kit_rpc"}:
+                continue
+            if relative_path.name == "lift_rpc.py":
+                continue
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         except (OSError, SyntaxError):
             continue
-        relative = str(path.relative_to(root))
+        relative = str(relative_path)
         visitor = _Visitor(relative)
         visitor.visit(tree)
         offenders.extend(visitor.offenders)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -158,8 +158,7 @@ class SourceVisibleCallFrameV1:
             )
         )
         scope = dict(zip(self.parameters, entries, strict=True))
-        body = self.owner._source_visible_body(scope)
-        return replace(self, body=body, runtime_entries=entries)
+        return replace(self, runtime_entries=entries)
 
     def _tuple_node(self, values: tuple):
         from sugar_source_tree.backend import Children, materialize

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -81,6 +81,20 @@ class CallSiteSugar(Sugar):
                     tuple(rest), kw_values + ((name, value),), positional, ctx
                 )
             )
+        if ctx is not None:
+            from sugar_lift_py_tests.callable_application import CallableApplication
+            from sugar_lift_py_tests.floor import BuiltinSemanticCallable
+
+            receiver = ctx.temporal.value_for(self.target_name)
+            if isinstance(receiver, BuiltinSemanticCallable):
+                return receiver.callable_application_with(
+                    CallableApplication(
+                        positional + tuple(value for _, value in kw_values),
+                        tuple(name for name, _ in kw_values),
+                        self.site,
+                    ),
+                    ctx,
+                )
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -85,7 +85,7 @@ class CallSiteSugar(Sugar):
             from sugar_lift_py_tests.callable_application import CallableApplication
             from sugar_lift_py_tests.floor import BuiltinSemanticCallable
 
-            receiver = ctx.temporal.value_for(self.target_name)
+            receiver = ctx.temporal.value_if_bound(self.target_name)
             if isinstance(receiver, BuiltinSemanticCallable):
                 return receiver.callable_application_with(
                     CallableApplication(
@@ -160,7 +160,14 @@ class CallSiteSugar(Sugar):
                 exception_type_coordinate=self.exception_type_coordinate,
                 exception_type_mro=self.exception_type_mro,
                 source_call_frame_cid=source_frame_cid,
-                formal_coordinate_cids=(),
+                formal_coordinate_cids=(
+                    tuple(
+                        item.cid
+                        for item in self.source_call_frame.formal_coordinates
+                    )
+                    if self.source_call_frame is not None
+                    else ()
+                ),
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -113,6 +113,7 @@ def builtin_name_temporal():
     from sugar_lift_py_tests.floor import (
         BlockValue,
         BuiltinExceptionClassValue,
+        BuiltinSemanticCallable,
         ClassValue,
         SymbolicValue,
     )
@@ -139,5 +140,8 @@ def builtin_name_temporal():
             name,
             BuiltinExceptionClassValue(name=name, bases=(), record=BlockValue(())),
         )
+    temporal = temporal.bind_value(
+        "issubclass", BuiltinSemanticCallable(operation="python.issubclass")
+    )
     _EMPTY_BUILTIN_TEMPORAL = temporal
     return temporal

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -143,5 +143,8 @@ def builtin_name_temporal():
     temporal = temporal.bind_value(
         "issubclass", BuiltinSemanticCallable(operation="python.issubclass")
     )
+    temporal = temporal.bind_value(
+        "set", BuiltinSemanticCallable(operation="python.set.construct")
+    )
     _EMPTY_BUILTIN_TEMPORAL = temporal
     return temporal

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def _write(root: Path, relative: str, source: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def test_instrument_names_forbidden_side_doors_and_replacement(tmp_path):
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/bad.py",
+        "def derive(provider_name, builtin_result):\n"
+        "    try:\n"
+        "        if provider_name == 'pytest.raises':\n"
+        "            return builtin_result is True\n"
+        "    except ConstructionPanic:\n"
+        "        return False\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+
+    assert report.r == {
+        "construction_side_doors": 1,
+        "generic_builtin_verdicts": 1,
+        "name_or_vendor_gates": 1,
+        "panic_catches": 1,
+    }
+    assert all("floor" in row.replacement.lower() for row in report.offenders)
+
+
+def test_instrument_truthful_floor_shape_is_zero(tmp_path):
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/good.py",
+        "def apply_closed_operation(receiver, operation):\n"
+        "    return receiver.callable_application_with(operation, None)\n",
+    )
+
+    report = collect_builtin_closed_operation_report(tmp_path)
+
+    assert report.r == {
+        "construction_side_doors": 0,
+        "generic_builtin_verdicts": 0,
+        "name_or_vendor_gates": 0,
+        "panic_catches": 0,
+    }
+    assert report.offenders == ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+def _numbers(*values):
+    from sugar_lift_py_tests.floor import SetValue, TermValue
+
+    return SetValue(tuple(TermValue(value) for value in values))
+
+
+def _values(result):
+    return tuple(item.value for item in result.value.elements)
+
+
+def test_finite_set_membership_is_decided_from_constructed_members():
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    finite = _numbers(1, 2)
+    assert isinstance(finite.contains(TermValue(2), "site").value, TrueBoolLiteralSugar)
+    assert isinstance(finite.contains(TermValue(3), "site").value, FalseBoolLiteralSugar)
+
+
+def test_finite_set_union_intersection_and_difference_are_closed():
+    assert _values(_numbers(1, 2).bitwise_or(_numbers(2, 3), "site")) == (1, 2, 3)
+    assert _values(_numbers(1, 2).bitwise_and(_numbers(2, 3), "site")) == (2,)
+    assert _values(_numbers(1, 2).subtract(_numbers(2, 3), "site")) == (1,)
+
+
+def test_symbolic_finite_membership_emits_typed_obligation():
+    from sugar_lift_py_tests.floor import SetValue, SymbolicValue, TermValue
+    from sugar_lift_py_tests.ir import _Atomic, make_var
+
+    result = SetValue((TermValue(1),)).contains(
+        SymbolicValue(make_var("member")), "site"
+    ).value
+    assert isinstance(result.formula, _Atomic)
+    assert result.formula.name == "python.set.contains"
+
+
+def test_opaque_member_stays_loud():
+    from sugar_lift_py_tests.floor import FunctionCallable
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic):
+        _numbers(1).contains(FunctionCallable("opaque"), "site")

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py
@@ -44,3 +44,18 @@ def test_opaque_member_stays_loud():
 
     with pytest.raises(ConstructionPanic):
         _numbers(1).contains(FunctionCallable("opaque"), "site")
+
+
+def test_authenticated_set_constructor_closes_finite_dict_keys():
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.floor import DictValue, StringValue, TermValue
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+    receiver = builtin_name_temporal().value_for("set")
+    source = DictValue(((StringValue("kept"), TermValue(1)),))
+
+    result = receiver.callable_application_with(
+        CallableApplication((source,), (), "site"), None
+    )
+
+    assert tuple(item.value for item in result.value.elements) == ("kept",)

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_subtype_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_subtype_floor.py
@@ -1,0 +1,140 @@
+from dataclasses import replace
+
+import pytest
+
+
+def _class(name, *bases):
+    from sugar_lift_py_tests.floor import BlockValue, ClassValue
+
+    return ClassValue(name=name, bases=bases, record=BlockValue(()))
+
+
+def test_constructed_subtype_graph_closes_direct_transitive_and_unrelated():
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    base = _class("RenamedBase")
+    middle = _class("RenamedMiddle", base)
+    leaf = _class("RenamedLeaf", middle)
+    unrelated = _class("RenamedOther")
+
+    assert isinstance(leaf.test_python_subtype(base, "site"), Complete)
+    assert isinstance(leaf.test_python_subtype(base, "site").value, TrueBoolLiteralSugar)
+    assert isinstance(leaf.test_python_subtype(unrelated, "site").value, FalseBoolLiteralSugar)
+
+
+def test_tuple_of_types_is_finite_subtype_disjunction():
+    from sugar_lift_py_tests.floor import TupleValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    base = _class("Base")
+    leaf = _class("Leaf", base)
+    other = _class("Other")
+
+    assert isinstance(leaf.test_python_subtype(TupleValue((other, base)), "site").value, TrueBoolLiteralSugar)
+    assert isinstance(base.test_python_subtype(TupleValue((other, leaf)), "site").value, FalseBoolLiteralSugar)
+
+
+def test_symbolic_subtype_emits_typed_obligation():
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.ir import _Atomic, ctor, make_var
+
+    subtype = SymbolicValue(make_var("T"))
+    supertype = SymbolicValue(ctor("python:type", [make_var("U")]))
+    result = subtype.test_python_subtype(supertype, "site").value
+
+    assert isinstance(result.formula, _Atomic)
+    assert result.formula.name == "python.subtype"
+
+
+def test_non_type_supertype_stays_loud():
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic):
+        _class("Leaf").test_python_subtype(TermValue(3), "site")
+
+
+def test_closed_operation_witness_rejects_each_lying_coordinate():
+    from sugar_lift_py_tests.floor.closed_operation_witness import (
+        ClosedSemanticOperationWitness,
+        PythonRuntimeIdentity,
+    )
+    from sugar_lift_py_tests.ir import bool_const, ctor, str_const
+
+    runtime = PythonRuntimeIdentity.current()
+    operands = (ctor("python:type", [str_const("Leaf")]), ctor("python:type", [str_const("Base")]))
+    result = bool_const(True)
+    witness = ClosedSemanticOperationWitness.mint(runtime, "python.issubclass", operands, result)
+    witness.verify(runtime, "python.issubclass", operands, result)
+
+    lies = (
+        (replace(runtime, minor=runtime.minor + 1), "python.issubclass", operands, result),
+        (runtime, "python.set.contains", operands, result),
+        (runtime, "python.issubclass", tuple(reversed(operands)), result),
+        (runtime, "python.issubclass", operands, bool_const(False)),
+    )
+    for lie in lies:
+        with pytest.raises(ValueError, match="closed semantic operation witness"):
+            witness.verify(*lie)
+
+
+def test_authenticated_builtin_issubclass_callable_uses_floor_not_spelling():
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.floor import BuiltinSemanticCallable
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+    base = _class("Base")
+    leaf = _class("Leaf", base)
+    receiver = builtin_name_temporal().value_for("issubclass")
+
+    assert isinstance(receiver, BuiltinSemanticCallable)
+    result = receiver.callable_application_with(
+        CallableApplication((leaf, base), (), "site"), None
+    )
+    assert isinstance(result.value, TrueBoolLiteralSugar)
+    witness = receiver.witness_for((leaf, base), result.value)
+    witness.verify(receiver.runtime_identity, receiver.operation, (
+        leaf.to_term(owner="test"), base.to_term(owner="test")
+    ), result.value.to_term(owner="test"))
+
+
+def test_shadowed_issubclass_does_not_inherit_builtin_semantics():
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+    shadowed = builtin_name_temporal().bind_value("issubclass", TermValue(7))
+    assert isinstance(shadowed.value_for("issubclass"), TermValue)
+
+
+def test_named_call_dispatches_through_authenticated_temporal_floor():
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.context import FactoryBuildContext
+    from sugar_lift_py_tests.claim import SugarCatalog
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    @dataclass(frozen=True)
+    class ValueSugar(Sugar):
+        value: object
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            return Complete(self.value)
+
+    base = _class("Base")
+    leaf = _class("Leaf", base)
+    outcome = CallSiteSugar(
+        "issubclass", (ValueSugar(leaf), ValueSugar(base)), "site"
+    ).desugar(FactoryBuildContext("test.py", SugarCatalog()))
+
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -132,10 +132,16 @@ def construct_manager_behavior(
             tuple(item.value for item in actuals),
             tuple((name, item.value) for name, item in keyword_actuals),
         )
+        declaration_body = frame.body
         frame = frame.bind_node_actuals(
             tuple(item.node for item in actuals),
             tuple((name, item.node) for name, item in keyword_actuals),
         )
+        # The declaration frame's body carries BindingCoordinateRefSugar at
+        # each formal read.  Runtime nodes authenticate the BindingEntryV1;
+        # they must not replace those coordinate reads with consumer syntax,
+        # because the exact constructed FloorValue is curried below.
+        frame = replace(frame, body=declaration_body)
         supplied = {
             id(item.node): item.testimony
             for item in (*actuals, *(item for _, item in keyword_actuals))
@@ -163,6 +169,7 @@ def construct_manager_behavior(
         ),
         body=frame.body,
         source_call_frame_cid=frame.frame_cid,
+        formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
     )
     result = call.force_floor(
         None, owner="construct_manager_behavior", project_callsite=False
@@ -303,11 +310,18 @@ def _resolve_source_visible_frame_uncached(
         )
 
     definition_names = {item.name for item in definitions}
+    from sugar_lift_py_tests.floor import BuiltinSemanticCallable
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+    builtin_floor = builtin_name_temporal()
     if isinstance(target, FunctionDef):
         opaque = tuple(
             call.func.id
             for call in _local_named_calls(target)
             if call.func.id not in definition_names
+            and not isinstance(
+                builtin_floor.value_if_bound(call.func.id), BuiltinSemanticCallable
+            )
         )
         if opaque:
             return ManagerConstructionGapV1(
@@ -341,6 +355,10 @@ def _resolve_source_visible_frame_uncached(
                 call.func.id
                 for call in local_calls
                 if call.func.id not in definition_names
+                and not isinstance(
+                    builtin_floor.value_if_bound(call.func.id),
+                    BuiltinSemanticCallable,
+                )
             )
             if opaque:
                 return ManagerConstructionGapV1(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -226,6 +226,7 @@ def _formal_index_for_coordinate(formula, actual_terms, coordinate_name):
             "eq",
             "py.eq",
             "identity",
+            "python.subtype",
         }:
             continue
         if not any(_term_contains_ctor(arg, coordinate_name) for arg in current.args):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -94,6 +94,38 @@ def _resolved(root: Path, source: str, *, exported: str = "make_guard"):
     )
 
 
+def _resolved_type_actual(root: Path, source: str, *, exported: str = "make_guard"):
+    graph = DependencyArtifactGraph.authenticate(
+        _distribution(root, source, exported=exported)
+    )
+    consumer = f"import arbitrary\narbitrary.{exported}(ValueError)\n"
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode())
+    receipts, _ = authenticated_import_use_receipts(root, path, consumer, source_cid)
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    source_file = SourceFile((consumer, str(path), source_cid))
+    call = next(item for item in source_file.nodes() if isinstance(item, Call))
+    from sugar_source_tree.nodes import Name
+
+    node = next(item for item in call.args if isinstance(item, Name))
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+    actual = builtin_name_temporal().value_for("ValueError")
+    from sugar_lift_py_tests.ir import _term_content_cid
+
+    testimony = ConstructedValueTestimonyV1.mint(
+        node.fragment, _term_content_cid(actual.to_term(owner="test"))
+    )
+    return (
+        graph,
+        resolved,
+        ConstructedCallActualV1(node, actual, testimony),
+        call.fragment,
+    )
+
+
 def test_renamed_factory_constructs_returned_receiver_state_through_one_door(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,
@@ -500,6 +532,8 @@ def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
         "def make_guard(expected):\n"
         "    return OpaqueBoundary(expected)\n",
     )
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
     behavior = construct_manager_behavior(
         resolved, graph=graph, actuals=(actual,), call_site=call_site
     )
@@ -507,10 +541,42 @@ def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
     protocol = construct_manager_protocol(behavior, exit_face_id="boundary-face")
     assert isinstance(protocol, ConstructedManagerProtocolV1)
 
-    summary = derive_manager_summary(protocol)
+    with pytest.raises(ConstructionPanic, match="Python type operand"):
+        derive_manager_summary(protocol)
 
-    assert isinstance(summary, DerivedManagerSummaryGapV1)
-    assert summary.kind in {"enter-may-halt", "opaque-exit-truthiness"}
+
+def test_renamed_issubclass_boundary_derives_through_authenticated_floor(tmp_path):
+    graph, resolved, actual, call_site = _resolved_type_actual(
+        tmp_path,
+        "class RenamedBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return issubclass(effect_type, self.expected)\n"
+        "def make_guard(expected):\n"
+        "    return RenamedBoundary(expected)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="subtype-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol, behavior=behavior)
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        FormalArgumentProjectionV1,
+        SuppressesModeV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(summary.semantics.mode, SuppressesModeV1)
+    assert summary.semantics.expected_type_operand == FormalArgumentProjectionV1(0)
 
 
 def test_renamed_source_visible_exit_derives_expects_raise_boundary(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1949,6 +1949,10 @@ class ClassDef(Statement):
             span.end_line,
             span.end_col,
         )
+        formal_scope = {
+            param.name: self._make_constructor_coordinate_ref(param, coordinate)
+            for param, coordinate in zip(params, coordinates, strict=True)
+        }
         return SourceVisibleCallFrameV1(
             source_identity_cid=self.unit.source_cid,
             definition_site=site,
@@ -1969,13 +1973,22 @@ class ClassDef(Statement):
                 param.default.fragment.seal().cid if param.default is not None else None
                 for param in params
             ),
-            body=ClassConstructorBodySugar(
-                definition=self.sugar(),
-                initializer_body=None,
-                receiver_coordinate_cid=None,
-                site=self.fragment,
-            ),
+            body=self._source_visible_body(formal_scope),
             owner=self,
+        )
+
+    def _make_constructor_coordinate_ref(self, param: "Param", coordinate) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "BindingCoordinateRef",
+                param.span,
+                (("coordinate", Leaf(coordinate)),),
+            ),
+            self.reporter,
         )
 
     def _source_visible_body(self, scope):


### PR DESCRIPTION
## Outcome

Adds authenticated closed Python-floor semantics for `issubclass`, tuple-of-types disjunction, and constructed finite-set membership/union/intersection/difference. Symbolic subtype and membership cases emit typed obligations; opaque/native operands remain loud. There is no pytest, contextlib, vendor, or package-name semantic arm.

The closed-operation witness binds operand CIDs, result CID, Python runtime identity, and operation. Lying runtime/operation/operand/result twins reject.

Also preserves exact constructed actuals through source-call formal coordinates so a renamed context-manager `__exit__` using `issubclass(effect_type, self.expected)` derives `EffectBoundary` through the same floor.

## Validation

- `SUGAR_BIN=... PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src python3 -m pytest implementations/python/sugar-lift-py-tests/tests/test_builtin_subtype_floor.py implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py -q`
  - `44 passed in 4.70s`
- `bin/bpytest` was attempted without raising its timeout. Its immutable `python-unit` closure is currently missing `sugar_source_tree` from `PYTHONPATH`, so collection fails before tests. The exact three-source local run above is green.

## Honest residual / delta

Foundational pre-census change: measured semantic corpus delta is `Delta R = 0` (no non-empty downstream corpus census was completed).

Installed-source end-to-end remains loud for two independently observed prerequisites:

- authenticated `_pytest.raises.raises` currently reaches an unsupported `Try` while eagerly constructing sibling classes in `_pytest/raises.py`;
- stdlib `contextlib` is not represented by the installed-distribution artifact graph.

This PR does not hide either residual with a package gate, fabricated result, panic catch, or native execution witness.

Not merged; requesting review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated Python `issubclass` semantics, including inheritance traversal and tuple-based type checks.
  * Added finite-set construction, membership, union, intersection, and difference behavior.
  * Improved symbolic handling when results cannot be determined immediately.
  * Enhanced effect-boundary analysis for renamed or indirectly referenced exception-handling logic.

* **Documentation**
  * Added implementation plans and design documentation for Python subtype and finite-set semantics.

* **Bug Fixes**
  * Unsupported or ambiguous Python operations now fail clearly instead of producing misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement authenticated builtin subtype and finite set semantics on the Python floor
> - Adds `BuiltinSemanticCallable` as a floor type that dispatches `issubclass` and `set()` calls through authenticated floor logic rather than opaque name recognition.
> - Implements `test_python_subtype` on `ClassValue`, `TupleValue`, `SymbolicValue`, `ExitTypeCoordinate`, and `BuiltinSemanticCallable` to decide subclass relationships, handle tuple disjunction, and emit typed `python.subtype` predicate obligations for symbolic operands.
> - Adds `ClosedSemanticOperationWitness` and `PythonRuntimeIdentity` dataclasses that mint and verify blake3_512-hashed authentication witnesses for closed operations (issubclass, set algebra).
> - Extends manager construction to exempt authenticated builtin calls (e.g. `issubclass`) from opaque-call rejection, and propagates `formal_coordinate_cids` through source-visible frames so derivation can map predicates back to formals.
> - Adds an AST-based instrument (`builtin_closed_operation_instrument`) that flags name/vendor gates, generic builtin verdicts, and caught `Panic` exceptions in source files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07748cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->