### PR TITLE
Construct generators as suspended control machines

### DIFF
--- a/docs/superpowers/plans/2026-07-23-generator-construction-v1.md
+++ b/docs/superpowers/plans/2026-07-23-generator-construction-v1.md
@@ -1,0 +1,127 @@
+# GeneratorConstructionV1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construct Python generators as suspended machines and derive generator context-manager behavior mechanically from their typed transitions.
+
+**Architecture:** `FunctionDef` authenticates generator shape from its already-materialized source children and produces a `SourceVisibleCallFrameV1` whose call allocates one `GeneratorConstructionV1`. The machine owns resume/send/throw/close transitions and `With` consumes those transitions directly, preserving `ExitSet` faces and leaving unsupported transitions typed-loud.
+
+**Tech Stack:** Python 3.12+, immutable dataclasses, existing source-tree construction, `ExitSet`, pytest, battleaxe `bcargo`/`brun` validation.
+
+## Global Constraints
+
+- One construction path; no second evaluator and no `ast.*` switch.
+- No contextlib, warning, decorator, callable, or manager name gate.
+- Preserve `h = h(p)`, both guarded faces, and exhaustive-or-typed-LOUD behavior.
+- No fabricated values, new side-door findings, panic catches, or timeout increase.
+- Rebase on current `origin/main`, publish as T Savo, and do not merge.
+
+---
+
+### Task 1: Red Generator Construction Instrument and Transition Twins
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py`
+
+**Interfaces:**
+- Consumes: repository Python production roots and existing `ExitSet`/effect types.
+- Produces: numeric `R_generator_construction`, a proven non-empty discovered denominator, and executable API requirements for `GeneratorConstructionV1`, `YieldEffect`, transition requests, termination, and typed transition gaps.
+
+- [ ] **Step 1: Write the failing instrument and minimal allocation/resume twins**
+
+The scanner must discover generator definitions from source structure, report generator call paths that still reduce through eager `SourceVisibleFunctionBodySugar`, and flag production references to contextlib/warning names in the new generator path. The API test imports `GeneratorConstructionV1`, allocates a renamed one-yield frame, resumes it, and asserts the exact yielded value plus successor coordinate.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `python3 -m pytest --noconftest implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py -q`
+
+Expected: FAIL because `generator_construction` and `YieldEffect` do not exist and `R_generator_construction > 0`.
+
+- [ ] **Step 3: Record baseline JSON**
+
+Run: `python3 implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py --json > /tmp/generator-construction-base.json`
+
+Expected: nonzero `discovered`, nonzero `R_generator_construction`, and exit 1.
+
+### Task 2: Suspended Machine and Mechanical With Derivation
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py`
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py`
+- Test: `implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py`
+
+**Interfaces:**
+- Consumes: `SourceVisibleCallFrameV1`, source-materialized statement Sugars, binding entries, and `ExitSet`.
+- Produces: `GeneratorConstructionV1.allocate`, `resume`, `send`, `throw`, `close`; `YieldEffect(value, resume_coordinate)`; typed termination and transition-gap results; mechanical `With` routing.
+
+- [ ] **Step 1: Implement allocation and resume minimally**
+
+Add immutable typed construction/transition dataclasses. Allocation hashes the source frame CID, call-site coordinate, and bound binding coordinates into the instance coordinate. Resume reduces only to the first source-owned `Yield` boundary and carries the remaining suspended frame plus binding state.
+
+- [ ] **Step 2: Verify allocation/resume GREEN**
+
+Run the focused `test_generator_construction_v1.py` allocation and resume tests; expect PASS.
+
+- [ ] **Step 3: Add failing send/throw/close and loud-boundary twins**
+
+Tests require send to bind the prior yield expression result before continuing, throw to introduce the exact incoming typed effect and preserve completed/halted faces, close to inject generator termination mechanics, and second-yield/premature-return/opaque frames to return typed loud gaps.
+
+- [ ] **Step 4: Implement send/throw/close through the same transition reducer**
+
+All four public methods create a typed transition request and invoke one reducer. No method reparses source, switches on `ast.*`, or recognizes names. Unsupported statement/control shapes return `GeneratorTransitionGapV1` with owner, observed shape, requested transition, and replacement architecture.
+
+- [ ] **Step 5: Verify transition GREEN**
+
+Run: `python3 -m pytest --noconftest implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py -q`
+
+Expected: every allocation/resume/send/throw/close and loud-boundary twin passes.
+
+- [ ] **Step 6: Add failing renamed generator-manager integration twins**
+
+Parse source containing an arbitrarily renamed generator manager without decorators. Assert enter binds the first yielded term, normal exit requires termination, exceptional exit throws the incoming effect and retains both `ExitSet` faces, and lying/two-yield/premature/opaque variants remain loud.
+
+- [ ] **Step 7: Implement mechanical With consumption**
+
+When the manager expression constructs `GeneratorConstructionV1`, `WithResourceSugar` uses resume for enter, resumes on completed body faces, throws each halted body's exact effect, and combines transition results via `ExitSet`. Existing non-generator authenticated resource behavior remains unchanged.
+
+- [ ] **Step 8: Verify integration GREEN**
+
+Run: `python3 -m pytest --noconftest implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py -q`
+
+Expected: renamed truthful/lying and all loud boundary twins pass.
+
+### Task 3: Floors, Battleaxe, Rebase, and Publication
+
+**Files:**
+- Modify: only files exposed by red/green cycles above.
+- Receipt: `/tmp/generator-construction-head.json`
+
+**Interfaces:**
+- Consumes: completed construction path and baseline JSON.
+- Produces: comparable `Delta R`, structural floor receipts, rebased verified commit, and open GitHub PR.
+
+- [ ] **Step 1: Run focused structural floors**
+
+Run the generator law, construction side-door law, construction panic-catch law, source constructor-door tests, and exact generator/context-manager twins. Require zero new side doors and zero panic catches.
+
+- [ ] **Step 2: Run battleaxe validation**
+
+Use repository battleaxe wrappers for the focused Python suite and the authoritative generator/pandas census. Run children sequentially if concurrency times out; do not count `non_native_red` as green and do not increase timeout configuration.
+
+- [ ] **Step 3: Record head JSON and calculate Delta R**
+
+Run the same scanner command and discovery scope used for `/tmp/generator-construction-base.json`, write `/tmp/generator-construction-head.json`, assert `discovered == completed > 0`, and subtract numeric `R_generator_construction` fields. If receipts are incomparable, report `Delta R` as unmeasured.
+
+- [ ] **Step 4: Refresh and rebase**
+
+Run `git fetch origin main`, rebase `agent/generator-construction-v1` onto `origin/main`, resolve only lane-owned conflicts, and rerun focused structural and battleaxe validation.
+
+- [ ] **Step 5: Commit and publish without merging**
+
+Commit with `T Savo <evilgenius@nefariousplan.com>`, push with upstream (or force-with-lease after rebase), open a ready-for-review PR against `main`, and report its number, rebased tip, validations, honest `Delta R`, and unmerged status.

--- a/docs/superpowers/specs/2026-07-23-generator-construction-v1-design.md
+++ b/docs/superpowers/specs/2026-07-23-generator-construction-v1-design.md
@@ -1,0 +1,79 @@
+# GeneratorConstructionV1 Suspended-Machine Design
+
+## Ruling
+
+A Python generator is a suspended control machine, not an eager function
+return. The lift has one generator construction path and derives generator
+context-manager behavior mechanically from that construction. No decorator,
+module, function, manager, or warning name grants generator or context-manager
+semantics.
+
+## Construction
+
+`GeneratorConstructionV1` is the sole construction artifact for a generator
+call. Allocation creates one stable instance coordinate and records the
+suspended frame, its binding state, and its current resume coordinate. Calling
+the generator function returns that instance construction without reducing the
+body as an eager function body.
+
+The suspended machine exposes four transitions: resume, send, throw, and close.
+Each transition consumes the current resume coordinate and returns an
+exhaustive typed result:
+
+- `YieldEffect(value, resume_coordinate)` suspends with the exact constructed
+  yielded value and successor coordinate;
+- termination carries the generator return/termination face;
+- halted body faces propagate with their guards and binding state intact;
+- a transition the construction cannot prove becomes a typed loud residual.
+
+No transition performs a second source evaluation or switches on `ast.*`.
+Coordinates and transition terms are derived from source-authenticated
+construction, so `h = h(p)` and renamed definitions construct identically.
+
+## Mechanical Context-Manager Derivation
+
+A `with` manager whose constructed value is a `GeneratorConstructionV1`
+instance is routed by the following mechanics:
+
+1. `__enter__` resumes the instance once. The first `YieldEffect` supplies the
+   entered value and therefore the `as` binding.
+2. Normal `__exit__` resumes from that yield and requires termination.
+3. Exceptional `__exit__` throws the incoming effect into the suspended frame.
+   Every completed and halted result remains in the resulting `ExitSet`; both
+   suppression and propagation faces are preserved when guarded.
+4. A second yield during exit, termination before the first yield, or an opaque
+   transition remains typed and loud.
+
+This is a construction consumer, not a context-manager recognizer. A renamed
+generator manager behaves identically because no `contextlib`, `warning`,
+decorator, or callable name is inspected.
+
+## Instrument and Acceptance Evidence
+
+Before implementation, an automated instrument discovers every current
+generator-construction residual and forbidden side door, reports the current
+non-empty denominator and `R`, stays red while stable-zero terms are nonzero,
+and names `GeneratorConstructionV1` as the replacement shape.
+
+Focused truthful and lying twins cover:
+
+- renamed generator allocation and first-yield `as` binding;
+- normal exit requiring termination;
+- exceptional exit throwing the original effect and retaining both `ExitSet`
+  faces;
+- two yields, premature return, and opaque transition staying typed-loud;
+- resume, send, throw, and close transitions;
+- structural sole-path, no `ast.*` switch, no name gate, no fabricated value,
+  zero new side-door findings, and zero panic catches.
+
+Battleaxe validation records before/after receipts with identical discovery
+scope. `Delta R` is reported only from comparable numeric fields with a proven
+non-empty denominator; otherwise it is reported as unmeasured. Timeout budget
+must not increase.
+
+## Scope Boundary
+
+This lane introduces only generator construction and the mechanical
+generator-manager consumer. Generator expressions, async generators, unrelated
+context-manager authorities, and warning-specific semantics are excluded unless
+they pass through the same construction without additional recognition.

--- a/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""R_generator_construction: suspended-machine construction floor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GeneratorConstructionOffender:
+    coordinate: str
+    observed: str
+    requested: str = "GeneratorConstructionV1 suspended-machine construction"
+
+
+def scan(repository: Path) -> tuple[int, list[GeneratorConstructionOffender]]:
+    roots = {
+        "nodes": repository
+        / "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+        "frame": repository
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py",
+        "call": repository
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py",
+        "with": repository
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+    }
+    text = {name: path.read_text() for name, path in roots.items()}
+    checks = (
+        (
+            "Yield._construct_sugar",
+            "class Yield" in text["nodes"]
+            and "YieldSuspensionSugar" in text["nodes"],
+            "Yield has no suspended-frame construction step",
+        ),
+        (
+            "FunctionDef.source_visible_call_frame",
+            "generator_steps" in text["frame"],
+            "source call frame cannot carry constructed generator steps",
+        ),
+        (
+            "CallSiteSugar.source_call_frame",
+            "GeneratorConstructionV1" in text["call"],
+            "source generator calls still share the eager body-return arm",
+        ),
+        (
+            "GeneratorWithSugar.generator_manager",
+            "GeneratorConstructionV1" in text["with"]
+            and "contextlib" not in text["with"]
+            and "warning" not in text["with"],
+            "With has no name-independent generator-machine consumer",
+        ),
+    )
+    offenders = [
+        GeneratorConstructionOffender(coordinate, observed)
+        for coordinate, satisfied, observed in checks
+        if not satisfied
+    ]
+    return len(checks), offenders
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, default=Path(__file__).parents[4])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    discovered, offenders = scan(args.repository.resolve())
+    summary = {
+        "instrument": "R_generator_construction",
+        "discovered": discovered,
+        "completed": discovered,
+        "R_generator_construction": len(offenders),
+        "offenders": [asdict(item) for item in offenders],
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            f"R_generator_construction = {len(offenders)} "
+            f"(discovered={discovered}, completed={discovered})"
+        )
+        for offender in offenders:
+            print(f"- {offender.coordinate}: {offender.observed}; replace with {offender.requested}")
+    return 1 if offenders else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -1,0 +1,196 @@
+"""Typed suspended-generator construction and transition algebra."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+from .effect import Effect, require_effect
+from .outcome import ExitSet
+
+
+@dataclass(frozen=True)
+class YieldStepV1:
+    value: object
+
+
+@dataclass(frozen=True)
+class ReturnStepV1:
+    value: object | None = None
+
+
+@dataclass(frozen=True)
+class OpaqueStepV1:
+    observed: str
+
+
+@dataclass(frozen=True)
+class FinallyStepV1:
+    statements: tuple[object, ...]
+
+
+GeneratorStepV1 = YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | FinallyStepV1
+
+
+@dataclass(frozen=True)
+class ResumeBindingV1:
+    resume_coordinate: str
+    resume_value: object
+
+
+@dataclass(frozen=True)
+class GeneratorTerminationV1:
+    return_value: object | None
+    binding_state: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class GeneratorTransitionGapV1:
+    owner: str
+    observed: str
+    requested: str
+    fix: str = "construct the transition in GeneratorConstructionV1"
+
+
+@dataclass(frozen=True)
+class YieldEffect:
+    value: object
+    resume_coordinate: str
+    machine: "GeneratorConstructionV1"
+
+
+@dataclass(frozen=True)
+class GeneratorConstructionV1:
+    """One allocated generator instance and its suspended frame state."""
+
+    allocation_coordinate: str
+    frame_coordinate: str
+    binding_state: tuple[object, ...]
+    steps: tuple[GeneratorStepV1, ...]
+    instance_coordinate: str
+    cursor: int = 0
+    suspended_resume_coordinate: str | None = None
+
+    @classmethod
+    def allocate(
+        cls,
+        *,
+        allocation_coordinate: str,
+        frame_coordinate: str,
+        binding_state: tuple[object, ...],
+        steps: tuple[GeneratorStepV1, ...],
+    ) -> "GeneratorConstructionV1":
+        instance_coordinate = cid_of_json(
+            {
+                "kind": "python-generator-instance",
+                "schemaVersion": "1",
+                "allocationCoordinate": allocation_coordinate,
+                "frameCoordinate": frame_coordinate,
+                "bindingState": [repr(item) for item in binding_state],
+            }
+        )
+        return cls(
+            allocation_coordinate=allocation_coordinate,
+            frame_coordinate=frame_coordinate,
+            binding_state=binding_state,
+            steps=tuple(steps),
+            instance_coordinate=instance_coordinate,
+        )
+
+    def resume(self):
+        return self._transition("resume")
+
+    def send(self, value: object):
+        if self.suspended_resume_coordinate is None:
+            return self._gap("send", "generator is not suspended at a yield")
+        machine = replace(
+            self,
+            binding_state=(
+                *self.binding_state,
+                ResumeBindingV1(self.suspended_resume_coordinate, value),
+            ),
+            suspended_resume_coordinate=None,
+        )
+        return machine._transition("send")
+
+    def throw(self, effect: Effect) -> ExitSet:
+        require_effect(effect)
+        incoming = ExitSet.halted(effect, state=self)
+        if self.cursor < len(self.steps) and isinstance(
+            self.steps[self.cursor], FinallyStepV1
+        ):
+            step = self.steps[self.cursor]
+            return incoming.and_finally(lambda: self._reduce_finally(step))
+        return incoming
+
+    def close(self):
+        if self.cursor < len(self.steps) and isinstance(
+            self.steps[self.cursor], FinallyStepV1
+        ):
+            cleanup = self._reduce_finally(self.steps[self.cursor])
+            return cleanup.sequence(
+                lambda state: ExitSet.completed(
+                    GeneratorTerminationV1(None, self.binding_state)
+                )
+            )
+        return GeneratorTerminationV1(None, self.binding_state)
+
+    def _transition(self, requested: str):
+        if self.cursor >= len(self.steps):
+            return GeneratorTerminationV1(None, self.binding_state)
+        step = self.steps[self.cursor]
+        if isinstance(step, OpaqueStepV1):
+            return self._gap(requested, step.observed)
+        if isinstance(step, FinallyStepV1):
+            cleanup = self._reduce_finally(step)
+            from sugar_lift_py_tests.outcome import Completed, Halted
+
+            if any(isinstance(exit_, Halted) for exit_ in cleanup.exits):
+                return cleanup
+            machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
+        if isinstance(step, ReturnStepV1):
+            value = self._reduce_value(step.value, requested)
+            if isinstance(value, GeneratorTransitionGapV1):
+                return value
+            return GeneratorTerminationV1(value, self.binding_state)
+        value = self._reduce_value(step.value, requested)
+        if isinstance(value, GeneratorTransitionGapV1):
+            return value
+        resume_coordinate = f"{self.instance_coordinate}:resume:{self.cursor + 1}"
+        machine = replace(
+            self,
+            cursor=self.cursor + 1,
+            suspended_resume_coordinate=resume_coordinate,
+        )
+        return YieldEffect(value, resume_coordinate, machine)
+
+    def _reduce_value(self, value: object, requested: str):
+        if value is None:
+            return None
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+        if not isinstance(value, Sugar):
+            return value
+        outcome = value.desugar()
+        if isinstance(outcome, Complete):
+            return outcome.value
+        return self._gap(requested, type(outcome).__name__)
+
+    @staticmethod
+    def _reduce_finally(step: FinallyStepV1) -> ExitSet:
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        return reduce_block_to_exitset(step.statements)
+
+    @staticmethod
+    def _gap(requested: str, observed: str) -> GeneratorTransitionGapV1:
+        return GeneratorTransitionGapV1(
+            owner="GeneratorConstructionV1.transition",
+            observed=observed,
+            requested=requested,
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -28,6 +28,8 @@ class SourceVisibleCallFrameV1:
     runtime_entries: tuple[BindingEntryV1, ...] = field(
         default=(), compare=False, repr=False
     )
+    generator_steps: tuple | None = field(default=None, compare=False, repr=False)
+    generator_step_fragment_cids: tuple[str, ...] = ()
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -41,6 +43,7 @@ class SourceVisibleCallFrameV1:
             "formalCoordinates": [item.wire() for item in self.formal_coordinates],
             "parameterKinds": list(self.parameter_kinds),
             "defaultFragmentCids": list(self.default_fragment_cids),
+            "generatorStepFragmentCids": list(self.generator_step_fragment_cids),
         }
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
 
@@ -158,7 +161,16 @@ class SourceVisibleCallFrameV1:
             )
         )
         scope = dict(zip(self.parameters, entries, strict=True))
-        return replace(self, runtime_entries=entries)
+        generator_steps = (
+            None
+            if self.generator_steps is None
+            else self.owner._source_visible_generator_steps(scope)
+        )
+        return replace(
+            self,
+            runtime_entries=entries,
+            generator_steps=generator_steps,
+        )
 
     def _tuple_node(self, values: tuple):
         from sugar_source_tree.backend import Children, materialize

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -144,6 +144,19 @@ class CallSiteSugar(Sugar):
             # including keyword/default actuals. They must not be appended a
             # second time below.
             kw_values = ()
+            if self.source_call_frame.generator_steps is not None:
+                from sugar_lift_py_tests.generator_construction import (
+                    GeneratorConstructionV1,
+                )
+
+                return Complete(
+                    GeneratorConstructionV1.allocate(
+                        allocation_coordinate=str(self.site),
+                        frame_coordinate=self.source_call_frame.frame_cid,
+                        binding_state=self.source_call_frame.runtime_entries,
+                        steps=self.source_call_frame.generator_steps,
+                    )
+                )
         return Complete(
             CallSiteValue(
                 target_name=self.target_name,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
@@ -1,0 +1,116 @@
+"""Mechanical context-manager consumption of GeneratorConstructionV1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    GeneratorTerminationV1,
+    GeneratorTransitionGapV1,
+    YieldEffect,
+)
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class GeneratorWithSugar(Sugar):
+    manager: Sugar
+    body: tuple[Sugar, ...]
+    enter_slot_id: str | None
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ExitSet",
+            reason="generator manager mechanics route already-constructed body faces",
+        )
+
+    def desugar(self, ctx=None) -> Outcome:
+        from sugar_lift_py_tests.outcome.resource_bindings import (
+            EnterResultBinding,
+            prepend_facts_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            exitset_to_outcome,
+            sugar_outcome_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        manager_es = sugar_outcome_to_exitset(self.manager.desugar(ctx))
+        routed = []
+        for manager_exit in manager_es.exits:
+            if isinstance(manager_exit, Halted):
+                routed.append(ExitSet((manager_exit,)))
+                continue
+            machine = manager_exit.value
+            if not isinstance(machine, GeneratorConstructionV1):
+                self._loud(
+                    "manager did not construct GeneratorConstructionV1",
+                    "opaque generator transition",
+                )
+            entered = machine.resume()
+            if isinstance(entered, GeneratorTerminationV1):
+                self._loud(
+                    "generator terminated before first yield",
+                    "terminated before first yield",
+                )
+            if isinstance(entered, GeneratorTransitionGapV1):
+                self._loud(entered.observed, "opaque generator transition")
+            if not isinstance(entered, YieldEffect):
+                self._loud(type(entered).__name__, "opaque generator transition")
+
+            body_es = reduce_block_to_exitset(self.body, ctx).guarded(
+                manager_exit.guard
+            )
+            exits = []
+            for body_exit in body_es.exits:
+                if isinstance(body_exit, Halted):
+                    thrown = entered.machine.throw(body_exit.effect).guarded(
+                        body_exit.guard
+                    )
+                    exits.extend(thrown.exits)
+                    continue
+                after = entered.machine.resume()
+                if isinstance(after, ExitSet):
+                    exits.extend(after.guarded(body_exit.guard).exits)
+                    continue
+                if isinstance(after, YieldEffect):
+                    self._loud("generator yielded during exit", "second yield")
+                if isinstance(after, GeneratorTransitionGapV1):
+                    self._loud(after.observed, "opaque generator transition")
+                if not isinstance(after, GeneratorTerminationV1):
+                    self._loud(type(after).__name__, "opaque generator transition")
+                exits.append(Completed(body_exit.guard, body_exit.value))
+            result = ExitSet(tuple(exits)).normalize()
+            facts = ()
+            if self.enter_slot_id is not None:
+                facts = EnterResultBinding(
+                    self.enter_slot_id, entered.value
+                ).to_facts(site=self.site)
+            routed.append(prepend_facts_to_exitset(result, facts))
+
+        if not routed:
+            return exitset_to_outcome(ExitSet(()))
+        result = routed[0]
+        for part in routed[1:]:
+            result = result.union(part)
+        return exitset_to_outcome(result)
+
+    @staticmethod
+    def _loud(observed: str, label: str):
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="GeneratorWithSugar.desugar",
+            observed=f"{label}: {observed}",
+            requested="an exhaustive GeneratorConstructionV1 transition",
+            fix="construct the transition or retain this typed loud boundary",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/yield_suspension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/yield_suspension_sugar.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class YieldSuspensionSugar(Sugar):
+    """A source yield boundary; only GeneratorConstructionV1 may consume it."""
+
+    value: Sugar | None
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="YieldEffect",
+            reason="yield is consumed only by GeneratorConstructionV1",
+        )
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="YieldSuspensionSugar.desugar",
+            observed="yield suspension reached eager expression reduction",
+            requested="GeneratorConstructionV1 transition consumption",
+            fix="keep generator bodies suspended and resume through their instance coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_REPOSITORY = Path(__file__).resolve().parents[4]
+_SCANNER_PATH = (
+    _REPOSITORY
+    / "implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py"
+)
+_SPEC = importlib.util.spec_from_file_location("generator_construction_law", _SCANNER_PATH)
+assert _SPEC and _SPEC.loader
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SCANNER
+_SPEC.loader.exec_module(_SCANNER)
+
+
+def test_current_repository_has_one_suspended_generator_construction_path():
+    discovered, offenders = _SCANNER.scan(_REPOSITORY)
+
+    assert discovered > 0
+    assert not offenders, "\n".join(
+        f"{item.coordinate}: {item.observed} -> {item.requested}" for item in offenders
+    )
+
+
+def test_scanner_flags_all_four_planted_eager_or_name_gated_shapes(tmp_path):
+    files = {
+        "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py": "class Yield: pass",
+        "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py": "class SourceVisibleCallFrameV1: pass",
+        "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py": "source_body.desugar()",
+        "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py": "if contextlib.contextmanager: warning",
+    }
+    for relative, content in files.items():
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+    discovered, offenders = _SCANNER.scan(tmp_path)
+
+    assert discovered == 4
+    assert len(offenders) == 4

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
@@ -1,0 +1,131 @@
+import importlib.util
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.ir import num
+from sugar_lift_py_tests.outcome import Halted
+
+
+def _api():
+    from sugar_lift_py_tests import generator_construction
+
+    return generator_construction
+
+
+def _machine(*steps):
+    return _api().GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:renamed_manager:1",
+        frame_coordinate="frame:renamed_manager",
+        binding_state=("bound:x",),
+        steps=steps,
+    )
+
+
+def test_call_allocates_suspended_machine_and_resume_yields_exact_value():
+    api = _api()
+    machine = _machine(api.YieldStepV1(num(7)), api.ReturnStepV1(num(9)))
+
+    assert machine.binding_state == ("bound:x",)
+    yielded = machine.resume()
+
+    assert isinstance(yielded, api.YieldEffect)
+    assert yielded.value == num(7)
+    assert yielded.resume_coordinate == f"{machine.instance_coordinate}:resume:1"
+
+
+def test_send_continues_from_the_same_resume_coordinate_to_termination():
+    api = _api()
+    yielded = _machine(api.YieldStepV1(num(7)), api.ReturnStepV1(num(9))).resume()
+
+    terminated = yielded.machine.send(num(11))
+
+    assert isinstance(terminated, api.GeneratorTerminationV1)
+    assert terminated.return_value == num(9)
+    assert terminated.binding_state[-1].resume_value == num(11)
+
+
+def test_throw_routes_the_exact_incoming_effect_as_a_halted_face():
+    api = _api()
+    yielded = _machine(api.YieldStepV1(num(7)), api.ReturnStepV1(num(9))).resume()
+    incoming = RaiseEffect(exception_name="RenamedError", occurrence="body:3")
+
+    exits = yielded.machine.throw(incoming)
+
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].effect is incoming
+
+
+def test_close_terminates_the_suspended_machine_without_fabricated_return():
+    api = _api()
+    yielded = _machine(api.YieldStepV1(num(7)), api.ReturnStepV1(num(9))).resume()
+
+    terminated = yielded.machine.close()
+
+    assert isinstance(terminated, api.GeneratorTerminationV1)
+    assert terminated.return_value is None
+
+
+def test_opaque_transition_is_typed_loud():
+    api = _api()
+    gap = _machine(api.OpaqueStepV1("try-star"),).resume()
+
+    assert isinstance(gap, api.GeneratorTransitionGapV1)
+    assert gap.observed == "try-star"
+    assert gap.requested == "resume"
+
+
+def test_instance_coordinate_depends_on_allocation_frame_and_binding_state():
+    api = _api()
+    left = _machine(api.YieldStepV1(num(7)))
+    renamed_same = _machine(api.YieldStepV1(num(7)))
+    other = api.GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:other:1",
+        frame_coordinate="frame:renamed_manager",
+        binding_state=("bound:x",),
+        steps=(api.YieldStepV1(num(7)),),
+    )
+
+    assert left.instance_coordinate == renamed_same.instance_coordinate
+    assert left.instance_coordinate != other.instance_coordinate
+
+
+def test_generator_construction_module_is_the_named_replacement_shape():
+    assert importlib.util.find_spec("sugar_lift_py_tests.generator_construction")
+
+
+def test_throw_runs_constructed_finally_and_restores_exact_incoming_effect():
+    api = _api()
+    from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+    yielded = _machine(
+        api.YieldStepV1(num(7)),
+        api.FinallyStepV1((InertSugar(site="cleanup"),)),
+        api.ReturnStepV1(),
+    ).resume()
+    incoming = RaiseEffect(exception_name="RenamedError", occurrence="body:8")
+
+    exits = yielded.machine.throw(incoming)
+
+    halted = [exit_ for exit_ in exits.exits if isinstance(exit_, Halted)]
+    assert len(halted) == 1
+    assert halted[0].effect is incoming
+
+
+def test_close_runs_constructed_finally_and_returns_termination_face():
+    api = _api()
+    from sugar_lift_py_tests.outcome import Completed, ExitSet
+    from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+    yielded = _machine(
+        api.YieldStepV1(num(7)),
+        api.FinallyStepV1((InertSugar(site="cleanup"),)),
+        api.ReturnStepV1(num(9)),
+    ).resume()
+
+    exits = yielded.machine.close()
+
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    assert isinstance(exits.exits[0].value, api.GeneratorTerminationV1)
+    assert exits.exits[0].value.return_value is None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1659,8 +1659,14 @@ class FunctionDef(Statement):
         )
 
         substituted_body, _ = self._substitute_body(self.body, formal_scope)
+        generator_steps = self._source_visible_generator_steps_from(substituted_body)
         body = SourceVisibleFunctionBodySugar(
-            tuple(statement.sugar() for statement in substituted_body), self.fragment
+            (
+                ()
+                if generator_steps is not None
+                else tuple(statement.sugar() for statement in substituted_body)
+            ),
+            self.fragment,
         )
         return SourceVisibleCallFrameV1(
             source_identity_cid=self.unit.source_cid,
@@ -1684,6 +1690,14 @@ class FunctionDef(Statement):
             ),
             body=body,
             owner=self,
+            generator_steps=generator_steps,
+            generator_step_fragment_cids=(
+                ()
+                if generator_steps is None
+                else tuple(
+                    statement.fragment.seal().cid for statement in substituted_body
+                )
+            ),
         )
 
     def _source_visible_body(self, scope):
@@ -1692,8 +1706,80 @@ class FunctionDef(Statement):
         )
 
         substituted_body, _ = self._substitute_body(self.body, scope)
+        if self._source_visible_generator_steps_from(substituted_body) is not None:
+            return SourceVisibleFunctionBodySugar((), self.fragment)
         return SourceVisibleFunctionBodySugar(
             tuple(statement.sugar() for statement in substituted_body), self.fragment
+        )
+
+    def _source_visible_generator_steps(self, scope):
+        substituted_body, _ = self._substitute_body(self.body, scope)
+        return self._source_visible_generator_steps_from(substituted_body)
+
+    def _source_visible_generator_steps_from(self, body):
+        if not self._owns_yield(body):
+            return None
+        from sugar_lift_py_tests.generator_construction import (
+            FinallyStepV1,
+            OpaqueStepV1,
+            ReturnStepV1,
+            YieldStepV1,
+        )
+
+        steps = []
+
+        def append_statement(statement):
+            if isinstance(statement, Expr) and isinstance(statement.value, Yield):
+                value = statement.value.value
+                steps.append(YieldStepV1(None if value is None else value.sugar()))
+            elif isinstance(statement, Return):
+                steps.append(
+                    ReturnStepV1(
+                        None if statement.value is None else statement.value.sugar()
+                    )
+                )
+            elif (
+                isinstance(statement, Try)
+                and not statement.handlers
+                and not statement.orelse
+                and statement.finalbody
+                and self._owns_yield(statement.body)
+            ):
+                for nested in statement.body:
+                    append_statement(nested)
+                steps.append(
+                    FinallyStepV1(
+                        tuple(item.sugar() for item in statement.finalbody)
+                    )
+                )
+            else:
+                steps.append(OpaqueStepV1(statement.kind))
+
+        for statement in body:
+            append_statement(statement)
+        if not steps or not isinstance(steps[-1], ReturnStepV1):
+            steps.append(ReturnStepV1())
+        return tuple(steps)
+
+    @staticmethod
+    def _owns_yield(body) -> bool:
+        def visit(node) -> bool:
+            if isinstance(node, (FunctionDef, AsyncFunctionDef, Lambda)):
+                return False
+            if isinstance(node, Yield):
+                return True
+            for field in getattr(node, "_child_fields", ()):
+                value = getattr(node, field)
+                if isinstance(value, Node) and visit(value):
+                    return True
+                if isinstance(value, tuple) and any(
+                    visit(item) for item in value if isinstance(item, Node)
+                ):
+                    return True
+            return False
+
+        return any(
+            isinstance(statement, Yield) or visit(statement) for statement in body
         )
 
     def _make_coordinate_ref(self, param: "Param", coordinate) -> "Node":
@@ -3775,6 +3861,35 @@ class With(Statement):
         self.reporter.report_gap(self, panic)
         raise panic
 
+    def _generator_manager_frame(self, item: WithItem):
+        if not isinstance(item.context_expr, Call):
+            return None
+        context = self.unit.construction_context
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+
+        if not isinstance(context, TreeConstructionContextV1):
+            return None
+        span = item.context_expr.line_col_span()
+        coordinate = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+        frame = context.source_call_frames.get(coordinate)
+        if frame is None or frame.generator_steps is None:
+            return None
+        return frame
+
+    def _generator_manager_sugar(self, item: WithItem):
+        if self._generator_manager_frame(item) is None:
+            return None
+        return item.context_expr.sugar()
+
     def _require_narrow_cm_ref(self, item: WithItem):
         resolution = self._prebound_manager_resolution(item)
         if resolution is None:
@@ -3875,6 +3990,24 @@ class With(Statement):
                 self.reporter.report_gap(self, panic)
                 raise panic
             as_name = item.optional_vars.id
+
+        generator_manager = self._generator_manager_sugar(item)
+        if generator_manager is not None:
+            from sugar_lift_py_tests.sugar.generator_with_sugar import (
+                GeneratorWithSugar,
+            )
+
+            enter_slot = (
+                f"{item._manager_slot_id()}#enter_result"
+                if as_name is not None
+                else None
+            )
+            return GeneratorWithSugar(
+                manager=generator_manager,
+                body=tuple(stmt.sugar() for stmt in self.body),
+                enter_slot_id=enter_slot,
+                site=self.fragment,
+            )
 
         resolved_ref = self._require_narrow_cm_ref(item)
         if resolved_ref is not None:
@@ -4068,7 +4201,8 @@ class With(Statement):
                 return self if not changed else rewrite(self, **changed)
             item = items[0]
             if item.optional_vars is not None and item.optional_vars.kind == "Name":
-                self._require_narrow_cm_ref(item)
+                if self._generator_manager_frame(item) is None:
+                    self._require_narrow_cm_ref(item)
                 enter_slot = f"{item._manager_slot_id()}#enter_result"
                 body_scope[item.optional_vars.id] = item._make_observation_ref(
                     enter_slot, ENTER_RESULT
@@ -4100,7 +4234,8 @@ class With(Statement):
             item = self.items[0]
             if item.optional_vars is None or item.optional_vars.kind != "Name":
                 return None
-            self._require_narrow_cm_ref(item)
+            if self._generator_manager_frame(item) is None:
+                self._require_narrow_cm_ref(item)
             enter_slot = f"{item._manager_slot_id()}#enter_result"
             return {
                 item.optional_vars.id: item._make_observation_ref(
@@ -5589,6 +5724,16 @@ class Yield(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.yield_suspension_sugar import (
+            YieldSuspensionSugar,
+        )
+
+        return YieldSuspensionSugar(
+            value=None if self.value is None else self.value.sugar(),
+            site=self.fragment,
+        )
 
 
 class YieldFrom(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
@@ -1,0 +1,115 @@
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.ir import ctor, eq, num, str_const
+from sugar_source_tree.nodes import Call, FunctionDef, With
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_file(source: str, context) -> SourceFile:
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    return SourceFile(
+        (source, "renamed_generator_manager.py", blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _with_sugar(
+    manager_body: str,
+    with_body: str = "    assert entered == 7",
+    *,
+    bind_entered: bool = True,
+):
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "def arbitrarily_renamed():\n"
+        f"{manager_body}\n\n"
+        f"with arbitrarily_renamed(){' as entered' if bind_entered else ''}:\n"
+        f"{with_body}\n",
+        context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    with_node = next(node for node in source.nodes() if isinstance(node, With))
+    manager_call = with_node.items[0].context_expr
+    assert isinstance(manager_call, Call)
+    context.source_call_frames[_coordinate(manager_call)] = (
+        function.source_visible_call_frame()
+    )
+    return with_node.substitute({}).sugar()
+
+
+def test_renamed_generator_manager_enters_at_first_yield_without_name_authority():
+    sugar = _with_sugar("    yield 7")
+
+    assert type(sugar).__name__ == "GeneratorWithSugar"
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+    assert outcome.value.statements[0].formula == eq(
+        ctor("enter_result_value", [str_const(sugar.enter_slot_id)]), num(7)
+    )
+
+
+def test_second_yield_stays_typed_loud_on_normal_exit():
+    sugar = _with_sugar("    yield 7\n    yield 8")
+
+    with pytest.raises(SugarNotWritten, match="second yield"):
+        sugar.desugar()
+
+
+def test_premature_return_stays_typed_loud_on_enter():
+    sugar = _with_sugar("    return 7\n    yield 8")
+
+    with pytest.raises(SugarNotWritten, match="terminated before first yield"):
+        sugar.desugar()
+
+
+def test_opaque_transition_stays_typed_loud():
+    sugar = _with_sugar("    if opaque:\n        yield 7")
+
+    with pytest.raises(SugarNotWritten, match="opaque generator transition"):
+        sugar.desugar()
+
+
+def test_exceptional_exit_throws_into_machine_and_preserves_both_body_faces():
+    sugar = _with_sugar(
+        "    yield 7",
+        "    if condition:\n        raise RenamedError",
+        bind_entered=False,
+    )
+
+    outcome = sugar.desugar()
+
+    assert isinstance(outcome, Complete)
+    contributions = outcome.value.statements
+    assert any(type(item).__name__ == "Incomplete" for item in contributions)
+    assert outcome.value.can_fall_through
+
+
+def test_contextmanager_style_try_finally_resumes_cleanup_before_termination():
+    sugar = _with_sugar(
+        "    try:\n        yield 7\n    finally:\n        pass"
+    )
+
+    outcome = sugar.desugar()
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.statements[0].formula == eq(
+        ctor("enter_result_value", [str_const(sugar.enter_slot_id)]), num(7)
+    )

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -145,10 +145,11 @@ def test_lambda_signature_roles_bind_through_the_shared_frame(expression, expect
 def test_lambda_preserves_child_panic_role():
     expression = _return_expression("def A():\n    return lambda x: (yield x)\n")
 
+    suspension = expression.sugar()
     with pytest.raises(SugarNotWritten) as caught:
-        expression.sugar()
+        suspension.body.desugar()
 
-    assert caught.value.owner == "Yield.sugar"
+    assert caught.value.owner == "YieldSuspensionSugar.desugar"
 
 
 def test_inline_lambda_call_constructs_callable_then_ordinary_computed_call():

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -16,6 +16,11 @@ from sugar_lift_py_tests.floor import (
     TupleValue,
 )
 from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    GeneratorTerminationV1,
+    YieldEffect,
+)
 from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -66,6 +71,31 @@ def test_source_visible_zero_parameter_call_carries_the_ordinary_body() -> None:
     assert len(constructed.statements) == 1
     assert isinstance(constructed.statements[0], ReturnValue)
     assert constructed.statements[0].value == TermValue(7)
+
+
+def test_renamed_generator_call_allocates_without_eager_body_reduction() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "def arbitrarily_renamed():\n"
+        "    yield 7\n"
+        "    return 9\n\n"
+        "arbitrarily_renamed()\n",
+        context=context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
+
+    outcome = call.sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, GeneratorConstructionV1)
+    yielded = outcome.value.resume()
+    assert isinstance(yielded, YieldEffect)
+    assert yielded.value == TermValue(7)
+    terminated = yielded.machine.resume()
+    assert isinstance(terminated, GeneratorTerminationV1)
+    assert terminated.return_value == TermValue(9)
 
 
 def test_parameterized_source_frame_projects_the_exact_actual_by_coordinate() -> None:


### PR DESCRIPTION
## What changed

- introduce one `GeneratorConstructionV1` allocation/instance coordinate with suspended frame and binding state
- model first yield, resume/send/throw/close, termination, cleanup, propagated halted faces, and typed loud transition gaps
- derive generator context-manager enter/normal-exit/exceptional-exit mechanically from the constructed machine
- keep renamed managers identical without `contextlib`, warning, decorator, callable, or manager name recognition
- add a measured generator-construction law plus truthful/lying and loud-boundary twins

## Why

A generator call allocates a suspended control machine; it is not an eager function return. Generator-backed context managers must consume that machine directly so first yield supplies the entered value, normal exit requires termination, and exceptional exit throws the exact incoming effect back into the generator.

## Validation

- battleaxe focused generator/context-manager + construction floors: `61 passed`
- local identical focused set: `61 passed`
- neighboring side-door/panic-catch/With floors: `42 passed`
- `R_generator_construction`: base `4/4`, head `0/4`, honest `Delta R = -4`
- zero new construction side-door findings and zero panic-catch findings

The broader battleaxe `make test-python` target was attempted but stalled before tests in `sccache rustc -vV` under `bin/sugarbin`; it is not reported green and no timeout was increased.

This PR is intentionally left unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct generator calls as suspended control machines instead of eager body reduction
> - Generator function calls now allocate a `GeneratorConstructionV1` suspended machine (via [`CallSiteSugar`](https://github.com/TSavo/sugar/pull/6178/files#diff-d7d594636ed207e69db76dd7b89c48760b0d3de93da23981143b3c45da88a3c7)) instead of eagerly reducing the function body.
> - [`FunctionDef`](https://github.com/TSavo/sugar/pull/6178/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) detects yield-owning functions and precomputes typed `GeneratorStepV1` sequences (yield, return, finally, opaque), storing them on `SourceVisibleCallFrameV1`; non-generator functions are unaffected.
> - `with` statements whose manager constructs a generator now route through [`GeneratorWithSugar`](https://github.com/TSavo/sugar/pull/6178/files#diff-01b4662b5aadf841bae1a42bc95a607d48f8251b41ee131cd3a424dfb89577f8), performing mechanical resume/throw/close transitions without relying on `contextlib` or decorator names.
> - Yield expressions now construct [`YieldSuspensionSugar`](https://github.com/TSavo/sugar/pull/6178/files#diff-009cb1db682928b0433173a099df966a3864ce5e17fc0dcd8cb7f5b3a4fccab4), which raises a loud `SugarNotWritten` if reached by eager reduction outside a generator transition.
> - Risk: generator function bodies no longer participate in eager `SourceVisibleFunctionBodySugar` reduction; any code path that previously relied on eager generator body evaluation will now receive a suspended machine instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d47f9a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->