### PR TITLE
Memoize construction field data; free Node shells

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -57,23 +57,28 @@ def materialize(
 ) -> Node:
     """Typeable -> Typed: THE construction event. Panics on MISSING kind.
 
-    The returned node holds only ``unit``, ``ref``, and its ``reporter``;
-    every field access on it is a fresh query through ``ref.describe()``.
-    The reporter is threaded here so EVERY constructed node carries one and
-    hands it on to the children it later resolves.
-
-    THE construction event IS the registration: a node registers on the roll in
-    its own constructor (``Node.__post_init__``), so being constructed is being
-    on the roster and there is no way to new a node off the roll -- that is what
-    it means to be an AST node. materialize does not register; the constructor
-    does.
+    Constructs a Node shell for this backend ref (source or shadow). Field
+    *data* is memoized on the unit's ConstructionCache — slots resolve once
+    per (ref, reporter, control_context) into a shared row; shells may be
+    built freely over that row. Registration runs in the constructor.
     """
+    from .construction_cache import ConstructionCache
+
+    ctx = control_context or ControlConstructionContextV1()
+    cache = getattr(unit, "construction_cache", None)
+    if cache is None:
+        cache = ConstructionCache()
+        object.__setattr__(unit, "construction_cache", cache)
+    # Ensure the field row exists (filled lazily on first accessor).
+    key = cache.key(ref, reporter, ctx)
+    cache.fields.setdefault(key, {})
+
     cls = ref.resolve_type()
     return cls(
         unit=unit,
         ref=ref,
         reporter=reporter,
-        control_context=control_context or ControlConstructionContextV1(),
+        control_context=ctx,
     )
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -1,0 +1,31 @@
+"""Work memoization for typed construction — field *data*, not Node shells.
+
+Each ``(ref, reporter, control_context)`` site owns a field row. Slots resolve
+at most once into that row on first need. ``materialize`` may construct Node
+shells freely; each shell reads the shared row. Source and shadow backends use
+the same map (different ``ref``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ConstructionCache:
+    """Shared field rows keyed by backend site + reporter + control context."""
+
+    __slots__ = ("fields",)
+
+    def __init__(self) -> None:
+        # key -> {slot_name: resolved value}
+        self.fields: dict[tuple, dict[str, Any]] = {}
+
+    @staticmethod
+    def key(
+        ref: object,
+        reporter: object,
+        control_context: object,
+    ) -> tuple:
+        loop_targets = getattr(control_context, "loop_targets", ())
+        exception_slots = getattr(control_context, "exception_slots", ())
+        return (id(ref), id(reporter), loop_targets, exception_slots)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -19,15 +19,14 @@ Asking "which node is this" is ``isinstance`` on THESE classes — blessed
 and encouraged (design review, #5940 section 6). What is banned is tag
 dispatch on strings.
 
-Equality is identity: each build constructs one node per site, so
-``a is b`` is the sameness question within a ``SourceFile``. There is no
-pool and no interning across files — structural equality across sources
-is a CID question, answered by mementos, not by ``__eq__``.
+Field *data* is memoized once per backend site on the unit (source or
+shadow ref + control context). Node shells may be constructed freely over
+that memo — memoize data, construct the class as often as needed. Structural
+equality across sources is a CID question (mementos), not ``__eq__`` on shells.
 
-Nodes carry their own fields; nothing is ever written onto a
-backend node (no stamping). Synthetic nodes (a future ``assert_with_test``)
-are ordinary instances of these classes with no backend handle at all —
-the backend contract stays read-only.
+Nothing is written onto a backend node (no stamping). Shadow rewrite is the
+same construction door with a different backend: a ShadowNode that already
+carries the rewritten shape, then memoized like any other ref.
 """
 
 from __future__ import annotations
@@ -152,6 +151,8 @@ class SourceUnit:
     # Bound by SourceFile after the backend materializes the Module — the sole
     # structural authority for module-body identity. Never a second parse.
     typed_module: object = field(init=False, default=None)
+    # Field-data memo for materialize (see construction_cache.py).
+    construction_cache: object = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -168,6 +169,7 @@ class SourceUnit:
             ),
         )
         object.__setattr__(self, "typed_module", None)
+        object.__setattr__(self, "construction_cache", None)
 
     def bind_typed_module(self, module: "Module") -> None:
         """Attach the already-materialized Module root (SourceFile only)."""
@@ -462,14 +464,10 @@ class _Splice:
 class Node(Typed):
     """Abstract base of every node. The hierarchy is the grammar.
 
-    A node holds only its ``unit`` and its backend reference ``ref``.
-    Every declared accessor — ``Call.args``, ``FunctionDef.body``, a
-    leaf like ``Name.id`` — is a QUERY: resolved through ``ref`` at the
-    moment of access, never precomputed and never held between calls.
-    The class annotations below each concrete class are the contract the
-    backend must satisfy; an accessor the backend cannot answer panics
-    loudly at that accessor, naming it — never silence, never a bare
-    ``None``.
+    Shell over memoized field *data* on the unit ConstructionCache. Accessors
+    resolve each backend slot at most once per (ref, reporter, control_context)
+    into that shared row; re-reads hit the row. Shells are free to construct.
+    Shadow rewrite uses the same door with a shadow backend ref.
     """
 
     unit: SourceUnit
@@ -499,7 +497,7 @@ class Node(Typed):
         # THE construction event IS the registration. Registering here, in the
         # constructor, means calling ``cls(...)`` at all is showing up on the
         # roll -- there is no way to new a node without it. (register only
-        # records the reference; the node's fields stay lazy through ref.)
+        # records the reference; field *data* is memoized on the unit cache.)
         self.reporter.register(self)
         if isinstance(self, (For, AsyncFor, While)):
             object.__setattr__(
@@ -529,18 +527,28 @@ class Node(Typed):
         KIND_REGISTRY[cls.__name__] = cls
 
     def __getattr__(self, name: str):
-        # Every annotated field is a query into the backend, answered per
-        # access. Unknown names — including an accessor the backend's
-        # answer does not cover — panic loudly, naming the accessor.
+        # Field data is memoized on the unit once per site; this shell exposes it.
         if name.startswith("_"):
             raise AttributeError(name)
+        from .construction_cache import ConstructionCache
+
+        cache = self.unit.construction_cache
+        if cache is None:
+            cache = ConstructionCache()
+            object.__setattr__(self.unit, "construction_cache", cache)
+        key = cache.key(self.ref, self.reporter, self.control_context)
+        row = cache.fields.setdefault(key, {})
+        if name in row:
+            return row[name]
         for slot_name, slot in self.ref.describe().slots:
             if slot_name == name:
-                return slot.resolve(
+                value = slot.resolve(
                     self.unit,
                     self.reporter,
                     self._child_control_context(slot_name),
                 )
+                row[name] = value
+                return value
         if name in _declared_fields(type(self)):
             vocabulary_missing(
                 owner="nodes.Node.__getattr__",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/shadow.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/shadow.py
@@ -104,8 +104,8 @@ def rewrite(origin: Node, **children: object) -> Node:
         else:  # an optional single child given as a Node was handled above
             new_slots.append((name, MaybeChild(_handle_of(replacement))))
     shadow = ShadowNode(desc.kind, desc.raw_span or origin.span, tuple(new_slots))
-    # A rewrite inherits the origin's audit channel: the shadow tree reports
-    # its gaps to the same reporter the source tree did.
+    # Same materialize door as source backends: shadow ref is another memoized
+    # backend identity; field data is interned on the unit, shells are free.
     return materialize(
         origin.unit, shadow, origin.reporter, origin.control_context
     )


### PR DESCRIPTION
## Summary
- Memoize field *data* once per `(ref, reporter, control_context)` on a unit `ConstructionCache`
- `materialize` builds Node shells freely over that shared row (memoize data, not the class instance)
- Shadow rewrite documents the same door: `ShadowNode` is another memoized backend ref

## Why
Accessor re-resolve on every `getattr` paid O(accesses) with accesses growing superlinearly on real pandas bodies. Data memo keeps correctness-by-construction work at the construction boundary without interning shell identity as the cache.

## Validation
- `pytest implementations/python/sugar-source-tree/tests/` — **430 passed**, 5 skipped
- Fail set identical to clean `origin/main` (13 pre-existing reds in this environment; zero new failures)

## Full pandas lift (measured earlier this session)
- Completes end-to-end (no restart-from-zero); wall ~5–6 min on this host for 1421 files (not the optimistic 100s sample of easy files first)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize Node field data per construction site and free Node shells
> - Adds `ConstructionCache` in [construction_cache.py](https://github.com/TSavo/sugar/pull/6179/files#diff-fec1dbfe7718a35848f37642330b8df50429df86eae284a72524c6bf8352972f), a dict-backed store keyed by `(id(ref), id(reporter), loop_targets, exception_slots)` that holds resolved slot values per backend site.
> - `Node.__getattr__` in [nodes.py](https://github.com/TSavo/sugar/pull/6179/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now resolves each declared field at most once per `(ref, reporter, control_context)` site, storing the result in the unit's `ConstructionCache` for all subsequent accesses.
> - `SourceUnit` gains a `construction_cache` field (default `None`) initialized in `__post_init__`, and `materialize` in [backend.py](https://github.com/TSavo/sugar/pull/6179/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8) creates or reuses this cache and pre-registers an empty field row before returning the `Node`.
> - Behavioral Change: field resolution via `Node.__getattr__` is now shared across all `Node` instances that share the same site key on a `SourceUnit`, so side-effectful slot resolvers will only run once.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f4e4af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->