### PR TITLE
Bisect Construct phases; skip freeze project without testimony

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -294,6 +294,14 @@ class SubstitutionTraceBuilderV1:
     def freeze(
         self, testimony_source: "ConstructionTestimonyReporterV1 | None" = None
     ) -> SealedSubstitutionTraceV1 | RuntimeSubstitutionTraceV1:
+        """Publish the substitution trace.
+
+        Without a testimony reporter (no loop consumer), keep the runtime
+        trace and skip sealing/hashing every binding — measured exclusive
+        cost of unconditional project() was ~1.2s on pandas asserters for
+        functions that never need sealed wire. Sealed projections run only
+        when a loop testimony reporter is provided.
+        """
         if self._frozen:
             raise ValueError("SubstitutionTraceBuilderV1 is frozen")
         self._frozen = True
@@ -304,6 +312,8 @@ class SubstitutionTraceBuilderV1:
                 for record in self._records
             ),
         )
+        if testimony_source is None:
+            return runtime
         try:
             return runtime.project()
         except BindingProvenanceGap:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1826,6 +1826,17 @@ class FunctionDef(Statement):
             self.reporter,
         )
 
+    def _sugar_body_statement(self, stmt: "Node") -> object:
+        """Sugar one body statement under a Construct-body kind span."""
+        from sugar_lift_py_tests.engine_log import reduction_span
+
+        lc = stmt.line_col_span()
+        site = f"{stmt.unit.filename}:{lc.start_line} {stmt.kind}"
+        with reduction_span(
+            sugar=f"Body.{stmt.kind}", role="construction", site=site
+        ):
+            return stmt.sugar()
+
     def _construct_sugar(self):
         """`def <name>(<formals>): <body>` constructs FunctionUniverseSugar WITH
         each body statement's own sugar — the recursion, child-before-parent.
@@ -1888,21 +1899,50 @@ class FunctionDef(Statement):
                 from .binding_state import ConstructionTestimonyReporterV1
 
                 if loop_trace_required:
-                    testimony_reporter = ConstructionTestimonyReporterV1(
-                        self.reporter, trace_builder
-                    )
-                    construction_root = materialize(
-                        substituted.unit, substituted.ref, testimony_reporter
-                    )
-                    statements = tuple(stmt.sugar() for stmt in construction_root.body)
-                    substitution_trace = trace_builder.freeze(testimony_reporter)
+                    with reduction_span(
+                        sugar="Construct.rematerialize",
+                        role="construction",
+                        site=where,
+                    ):
+                        testimony_reporter = ConstructionTestimonyReporterV1(
+                            self.reporter, trace_builder
+                        )
+                        construction_root = materialize(
+                            substituted.unit, substituted.ref, testimony_reporter
+                        )
+                    body_stmts = construction_root.body
+                    with reduction_span(
+                        sugar="Construct.body", role="construction", site=where
+                    ):
+                        statements = tuple(
+                            self._sugar_body_statement(stmt) for stmt in body_stmts
+                        )
+                    with reduction_span(
+                        sugar="Construct.freeze_trace",
+                        role="construction",
+                        site=where,
+                    ):
+                        substitution_trace = trace_builder.freeze(
+                            testimony_reporter
+                        )
                 else:
                     # Every statement still has an immutable runtime snapshot.
                     # Only a loop consumer demands the sealed state projection;
-                    # ordinary functions retain the trace without re-hashing all
-                    # constructed ProofIR content merely for coexistence.
-                    statements = tuple(stmt.sugar() for stmt in substituted.body)
-                    substitution_trace = trace_builder.freeze()
+                    # ordinary functions retain the runtime trace without
+                    # sealing/hashing every binding (see freeze()).
+                    with reduction_span(
+                        sugar="Construct.body", role="construction", site=where
+                    ):
+                        statements = tuple(
+                            self._sugar_body_statement(stmt)
+                            for stmt in substituted.body
+                        )
+                    with reduction_span(
+                        sugar="Construct.freeze_trace",
+                        role="construction",
+                        site=where,
+                    ):
+                        substitution_trace = trace_builder.freeze()
                 bridge_source_symbol = None
                 context = self.unit.construction_context
                 workspace_root = getattr(context, "workspace_root", None)


### PR DESCRIPTION
## Summary
- Instrument `Construct.body` / `Construct.freeze_trace` / `Construct.rematerialize` and `Body.{kind}` reduction spans so exclusive heatmaps attribute construction cost to real owners instead of a single inflated Construct blob.
- Skip `SubstitutionTraceBuilderV1.freeze()` sealing/`project()` when no loop testimony reporter is provided (non-loop functions keep the runtime trace). Sealed projections still run for loop consumers that need wire testimony.

## Measurement (pandas `_testing/asserters.py`)
| span | before | after |
|---|---|---|
| `Construct.freeze_trace` exclusive | ~1.2s (n=34) | ~15ms (n=27) |
| freeze spans under 1ms | — | 26/27 (max ~12ms, loop path) |

Fail set vs clean main: identical (13 known reds). Focused loop/binding suite: 45 passed.

## Test plan
- [x] Dual-suite fail compare vs main (13 == 13)
- [x] `pytest` loop construction + binding_state tests (45 pass)
- [x] Remeasure asserters with `SUGAR_ENGINE_LOG` exclusive heat

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip `freeze` projection in `SubstitutionTraceBuilderV1` when no testimony source is provided
> - `SubstitutionTraceBuilderV1.freeze()` in [binding_state.py](https://github.com/TSavo/sugar/pull/6181/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) now returns a `RuntimeSubstitutionTraceV1` immediately when `testimony_source` is `None`, skipping sealing/hashing work that was previously attempted unconditionally.
> - `FunctionDef._construct_sugar()` in [nodes.py](https://github.com/TSavo/sugar/pull/6181/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) is refactored to wrap rematerialization, body sugaring, and trace freezing in structured `reduction_span` segments (`Construct.rematerialize`, `Construct.body`, `Construct.freeze_trace`).
> - A new `_sugar_body_statement` helper wraps each body statement's sugar call in a per-statement `Body.<kind>` reduction span with role and site metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1effdfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->