### PR TITLE
Keep recursive allocation identity loud

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -377,6 +377,18 @@ def test_non_admitted_class_call_keeps_ordinary_call_construction(tmp_path):
     _outcome_or_panic(path, "boundary")
 
 
+def test_recursive_allocation_occurrence_stays_opaque_without_recursing(tmp_path):
+    path = tmp_path / "recursive_allocation.py"
+    path.write_text(
+        "class Vessel:\n"
+        "    def clone(self):\n"
+        "        item = Vessel()\n"
+        "        return item\n"
+    )
+
+    _outcome_or_panic(path, "clone")
+
+
 def test_custom_setitem_receiver_stays_loud(tmp_path):
     path = tmp_path / "setitem.py"
     path.write_text(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -328,7 +328,20 @@ class SourceUnit:
         bindings = (self.module_direct_bindings or {}).get(call.func.id, ())
         if len(bindings) != 1 or not isinstance(bindings[0], ClassDef):
             return None
-        return bindings[0]
+        definition = bindings[0]
+        # Constructing the allocation definition requires constructing its
+        # methods. A call occurrence inside that same definition therefore
+        # cannot use the definition as already-constructed testimony without a
+        # cycle; it remains an opaque occurrence until recursive allocation has
+        # its own construction rule.
+        definition_span = definition.line_col_span()
+        if (
+            (definition_span.start_line, definition_span.start_col)
+            <= (span.start_line, span.start_col)
+            <= (definition_span.end_line, definition_span.end_col)
+        ):
+            return None
+        return definition
 
     @staticmethod
     def source_class_has_authenticated_default_attribute_behavior(
@@ -827,6 +840,12 @@ class Node(Typed):
 
     def post_binding_scope(self, scope: BindingMap) -> BindingMap:
         """Apply statement-owned invalidations to the one temporal map."""
+        if not any(
+            isinstance(entry, BindingEntryV1)
+            and isinstance(entry.state, ObjectPlaceStateV1)
+            for entry in scope.values()
+        ):
+            return scope
         exposed = {
             state.object_identity_cid
             for call in self.walk()


### PR DESCRIPTION
## What changed

- keeps a source allocation occurrence inside its own still-constructing class definition opaque, preserving occurrence identity without fabricating recursive allocation behavior
- avoids scanning statements for opaque-call invalidation when the temporal scope contains no authenticated object field state
- adds a regression twin proving recursive allocation remains loud/opaque instead of recursing

## Why

#6176 was merged externally while its current-head bare-exception floor still had one branch-caused `RecursionError` in `import_binding.py`. The source call attempted to use its own allocation definition as already-constructed testimony. This follow-up closes only that post-merge floor defect.

## Validation

- focused object identity, temporal binding, Assign/Call, side-door, and panic-catch suite: `91 passed in 11.46s`
- `R_construction_panic_catches_outside_audit = 0`
- `git diff --check origin/main...HEAD`

No timeout increase, panic catch, name gate, fabricated fields, or subscript support is introduced. `obj[key]` remains typed-loud.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent recursive allocation of call occurrences within their own class definition
> - A call occurrence inside a class body no longer resolves to that class's allocation definition; it returns `None` instead, keeping it opaque until a dedicated recursive allocation rule exists.
> - `Node.post_binding_scope` skips processing when the scope contains no `BindingEntryV1` entries with `ObjectPlaceStateV1` state, avoiding unnecessary work.
> - A new acceptance test in [test_object_field_flow_acceptance.py](https://github.com/TSavo/sugar/pull/6182/files#diff-bad61dbc03ee3853336c3bd0e63e5235c30c63a99d532f67269893235c6d28ef) asserts that recursive allocation occurrences stay opaque rather than triggering a construction cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f171a79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->