### PR TITLE
Correct object place identity documentation

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6142,8 +6142,9 @@ class ObjectPlaceStateV1(Expression):
     """Immutable field versions carried only inside runtime BindingEntryV1.
 
     This is a constructed Node value, not a binding resolver or heap.  Its sole
-    identity source is the owning entry's BindingCoordinateV1.  If it escapes
-    the attribute store/read projections, its base value constructs normally.
+    identity source is ``object_coordinate.cid``, authenticated from the exact
+    construction occurrence.  If it escapes the attribute store/read
+    projections, its base value constructs normally.
     """
 
     object_coordinate: object


### PR DESCRIPTION
## What changed

Corrects the stale `ObjectPlaceStateV1` docstring so it names `object_coordinate.cid`, authenticated from the exact construction occurrence, as the sole identity source.

## Why

The previous text incorrectly restated the rejected #6126 binding-owner identity model and contradicted the shipped occurrence-based implementation.

## Validation

- `git diff --check`
- rejected `BindingCoordinateV1` identity-source wording absent

Documentation only; no runtime behavior changes.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct `ObjectPlaceStateV1` docstring to identify `object_coordinate.cid` as the sole identity source
> Updates the class docstring in [nodes.py](https://github.com/TSavo/sugar/pull/6183/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to accurately state that identity is determined solely by `object_coordinate.cid`, authenticated from the exact construction occurrence. No executable code is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8e399a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->