### PR TITLE
Route grouped raises through except star

### DIFF
--- a/docs/superpowers/plans/2026-07-23-grouped-effects-except-star.md
+++ b/docs/superpowers/plans/2026-07-23-grouped-effects-except-star.md
@@ -1,0 +1,82 @@
+# Grouped Effects and `except*` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construct topology-preserving grouped raise effects and route `except*` by authenticated subtype partition through the one ExitSet effect router.
+
+**Architecture:** Source `Raise` constructs immutable group trees from authenticated builtin group coordinates. The shared effect router partitions and regroups those trees; a distinct `TryStarSugar` sequences residual groups through handlers while ordinary `TrySugar` remains unchanged.
+
+**Tech Stack:** Python typed source tree, Sugar floors/effects, ExitSet routing, pytest.
+
+## Global Constraints
+
+- Preserve group topology and every leaf occurrence identity.
+- Use the merged builtin subtype floor; never match spelling.
+- Keep matched and residual empty partitions explicit.
+- Route through the shared ExitSet effect router only.
+- Keep ordinary `except` and `except*` distinct.
+- Unsupported or symbolic topology stays typed loud.
+- Add no panic catch or construction side door.
+
+---
+
+### Task 1: Immutable grouped effect and authenticated partition
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py`
+
+**Interfaces:**
+- Produces `GroupedRaiseEffect.partition(expected, site) -> GroupedRaisePartition`.
+- `GroupedRaisePartition.matched` and `.residual` are always explicit group roots.
+
+- [ ] Write nested, partial, empty-face, identity, and lying-coordinate tests.
+- [ ] Run them and verify missing grouped-effect imports fail.
+- [ ] Implement recursive floor-based partition without flattening.
+- [ ] Run the focused tests green and commit.
+
+### Task 2: Source-authenticated grouped raise construction
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py`
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Test: `implementations/python/sugar-source-tree/tests/test_try_sugar.py`
+
+**Interfaces:**
+- Consumes authenticated exception-group and leaf coordinates from `SourceUnit`.
+- Produces `Incomplete(GroupedRaiseEffect)` through the ordinary `Raise` Sugar path.
+
+- [ ] Replace the old loud `TryStar` fixture with a red grouped-raise construction test.
+- [ ] Verify it fails because `TryStar`/group construction is absent.
+- [ ] Add recursive group/leaf Sugar construction keyed by authenticated coordinates.
+- [ ] Verify nested topology and leaf occurrence identity; commit.
+
+### Task 3: One-router `except*` sequencing and regrouping
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py`
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py`
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Test: `implementations/python/sugar-source-tree/tests/test_try_sugar.py`
+
+**Interfaces:**
+- Produces `route_except_star(effect, expected, slot_id, site)` from the shared router.
+- `TryStarSugar` passes residuals in handler order and regroups handler effects plus residuals.
+
+- [ ] Add red tests for partial consumption, subsequent handlers, bare re-raise, handler-raised effects, and unmatched propagation.
+- [ ] Verify each fails on the missing `TryStar` construction arm.
+- [ ] Implement residual sequencing and identity-aware regrouping in the shared router.
+- [ ] Run all try/grouped tests green; commit.
+
+### Task 4: Permanent laws, rebase, and review PR
+
+**Files:**
+- Modify only if a truthful planted twin exposes an actual detector gap.
+
+- [ ] Run grouped/try focused tests with the exact three-source `PYTHONPATH`.
+- [ ] Run construction side-door and panic-catch laws; require `R=0` and zero auditor errors.
+- [ ] Fetch and rebase onto current `origin/main`.
+- [ ] Re-run all focused receipts after rebase.
+- [ ] Push the branch and open a non-draft review PR; do not merge.

--- a/docs/superpowers/specs/2026-07-23-grouped-effects-except-star-design.md
+++ b/docs/superpowers/specs/2026-07-23-grouped-effects-except-star-design.md
@@ -1,0 +1,23 @@
+# Grouped Effects and `except*` Design
+
+## Authority and representation
+
+`GroupedRaiseEffect` is an immutable exception-group tree. Every group node retains its authenticated source occurrence identity, message value, and ordered children. Every leaf is the existing `RaiseEffect`, including its authenticated exception coordinate, MRO testimony, raised value, and occurrence identity. An empty subgroup is represented by the same group node with an empty `children` tuple; it is never host `None`.
+
+`Raise` may construct this effect only when its callee has the authenticated builtin exception-group coordinate. Nested group and leaf children are constructed recursively through their ordinary typed Nodes and Sugars. Spelling does not grant group authority, and unsupported/dynamic children stay loud.
+
+## Partition and routing
+
+The shared `effect_router` performs one recursive partition. Each leaf asks the merged #6177 Python floor whether its authenticated raised type is a subtype of the authenticated handler type. The result produces two topology-preserving group trees: matched and residual. Neither face is omitted when empty.
+
+`TryStarSugar` sends only the matched subgroup to its handler slot. The residual subgroup continues to the next handler. Handler-raised effects are retained. After all handlers, the router regroups handler-raised effects with the unmatched residual using group occurrence identities and original child order. A bare re-raise of the matched subgroup plus its complementary residual reconstructs the original tree; it never flattens or selects a leaf.
+
+Ordinary `TrySugar` remains distinct and keeps first-total-match `except` semantics. `TryStarSugar` alone accepts grouped effects and partial partitions. Both use the shared ExitSet effect router and the existing in-flight effect slot.
+
+## Loud boundaries
+
+Dynamic exception-group constructors, missing leaf identity/MRO testimony, symbolic subtype partitions that cannot be represented as guarded group topology, and unsupported non-group effects reaching `except*` remain typed loud. No package, vendor, handler spelling, or observed execution grants authority.
+
+## Acceptance
+
+Tests cover nested topology, partial matching, residual-to-next-handler flow, handler bare re-raise, unmatched propagation, explicit empty faces, leaf occurrence preservation, renamed truthful/lying identity twins, and never-flatten/never-first-leaf discrimination. Permanent construction side-door and panic-catch laws remain zero.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -50,6 +50,7 @@ from .name_error_effect import NameErrorEffect
 from .os_exit_runtime_effect import OSExitRuntimeEffect
 from .power_runtime_effect import PowerRuntimeEffect
 from .raise_effect import RaiseEffect
+from .grouped_raise_effect import GroupedRaiseEffect, GroupedRaisePartition
 from .warning_effect import WarningEffect
 from .expectation_not_met_effect import ExpectationNotMetEffect
 from .loop_control_effect import LoopControlEffect
@@ -125,6 +126,8 @@ __all__ = [
     "OSExitRuntimeEffect",
     "PowerRuntimeEffect",
     "RaiseEffect",
+    "GroupedRaiseEffect",
+    "GroupedRaisePartition",
     "WarningEffect",
     "ExpectationNotMetEffect",
     "LoopControlEffect",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
@@ -4,6 +4,7 @@ from typing import Literal, Never, NoReturn
 
 from .coverage_gap_effect import CoverageGapEffect
 from .raise_effect import RaiseEffect
+from .grouped_raise_effect import GroupedRaiseEffect
 from .runtime_effect import RuntimeEffect
 from .source_oracle_effect import SourceOracleEffect
 from .warning_effect import WarningEffect
@@ -14,6 +15,7 @@ from .loop_control_effect import LoopControlEffect
 # No-recognizer is panic, not a typed Incomplete arm.
 Effect = (
     RaiseEffect
+    | GroupedRaiseEffect
     | WarningEffect
     | RuntimeEffect
     | CoverageGapEffect
@@ -37,6 +39,7 @@ def require_effect(effect: object) -> Effect:
         effect,
         (
             RaiseEffect,
+            GroupedRaiseEffect,
             WarningEffect,
             RuntimeEffect,
             CoverageGapEffect,
@@ -54,6 +57,8 @@ def require_effect(effect: object) -> Effect:
 
 
 def effect_kind(effect: Effect) -> str:
+    if isinstance(effect, GroupedRaiseEffect):
+        return "GroupedRaiseEffect"
     if isinstance(effect, RaiseEffect):
         return "RaiseEffect"
     if isinstance(effect, WarningEffect):
@@ -72,6 +77,8 @@ def effect_kind(effect: Effect) -> str:
 
 
 def effect_reason(effect: Effect) -> str:
+    if isinstance(effect, GroupedRaiseEffect):
+        return effect.reason
     if isinstance(effect, RaiseEffect):
         return effect.reason
     if isinstance(effect, WarningEffect):
@@ -90,6 +97,8 @@ def effect_reason(effect: Effect) -> str:
 
 
 def effect_status(effect: Effect) -> EffectStatus:
+    if isinstance(effect, GroupedRaiseEffect):
+        return "raise-effect"
     if isinstance(effect, RaiseEffect):
         return "raise-effect"
     if isinstance(effect, WarningEffect):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .raise_effect import RaiseEffect
+
+
+@dataclass(frozen=True)
+class GroupedRaisePartition:
+    matched: "GroupedRaiseEffect"
+    residual: "GroupedRaiseEffect"
+
+
+@dataclass(frozen=True)
+class GroupedRaiseEffect:
+    """One immutable exception-group tree; leaves retain RaiseEffect identity."""
+
+    group_identity: str
+    message: object
+    children: tuple[RaiseEffect | "GroupedRaiseEffect", ...]
+    occurrence: str | None = None
+
+    @property
+    def occurrence_id(self) -> str:
+        return self.occurrence or self.group_identity
+
+    @property
+    def reason(self) -> str:
+        return f"grouped raise {self.group_identity} with {len(self.children)} children"
+
+    def partition(self, expected, site) -> GroupedRaisePartition:
+        matched = []
+        residual = []
+        for child in self.children:
+            if isinstance(child, GroupedRaiseEffect):
+                split = child.partition(expected, site)
+                if split.matched.children:
+                    matched.append(split.matched)
+                if split.residual.children:
+                    residual.append(split.residual)
+                continue
+            if _leaf_matches(child, expected, site):
+                matched.append(child)
+            else:
+                residual.append(child)
+        return GroupedRaisePartition(
+            self.derive(tuple(matched)),
+            self.derive(tuple(residual)),
+        )
+
+    def derive(
+        self, children: tuple[RaiseEffect | "GroupedRaiseEffect", ...]
+    ) -> "GroupedRaiseEffect":
+        return GroupedRaiseEffect(
+            self.group_identity,
+            self.message,
+            children,
+            occurrence=self.occurrence,
+        )
+
+
+def _leaf_matches(effect: RaiseEffect, expected, site) -> bool:
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+    from sugar_source_tree.panic import SugarNotWritten
+
+    raised = effect.raised_value
+    operation = getattr(raised, "test_python_subtype", None)
+    if operation is None:
+        raise SugarNotWritten(
+            owner="GroupedRaiseEffect.partition",
+            observed="group leaf lacks an authenticated subtype floor",
+            requested="RaiseEffect leaf with authenticated exception type testimony",
+            fix="construct every group leaf through the ordinary exception floor",
+        )
+    outcome = operation(expected, site)
+    if not isinstance(outcome, Complete):
+        raise SugarNotWritten(
+            owner="GroupedRaiseEffect.partition",
+            observed="symbolic subtype partition",
+            requested="closed true/false subtype partition for group topology",
+            fix="keep symbolic group partition typed loud",
+        )
+    if isinstance(outcome.value, TrueBoolLiteralSugar):
+        return True
+    if isinstance(outcome.value, FalseBoolLiteralSugar):
+        return False
+    raise SugarNotWritten(
+        owner="GroupedRaiseEffect.partition",
+        observed=type(outcome.value).__name__,
+        requested="closed boolean subtype partition",
+        fix="keep unsupported subtype results typed loud",
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py
@@ -67,6 +67,17 @@ def _leaf_matches(effect: RaiseEffect, expected, site) -> bool:
 
     raised = effect.raised_value
     operation = getattr(raised, "test_python_subtype", None)
+    if operation is None and effect.exception_type_coordinate is not None:
+        from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+            AuthenticatedExceptionTypeValue,
+        )
+
+        raised = AuthenticatedExceptionTypeValue(
+            raised,
+            effect.exception_type_coordinate,
+            effect.exception_type_mro,
+        )
+        operation = raised.test_python_subtype
     if operation is None:
         raise SugarNotWritten(
             owner="GroupedRaiseEffect.partition",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -95,6 +95,67 @@ class RoutedOutcome:
     bindings: tuple = ()  # EffectBinding, ...
 
 
+@dataclass(frozen=True)
+class GroupedRoutedOutcome:
+    matched: object
+    residual: object
+    bindings: tuple = ()
+
+
+def route_except_star(effect, expected, *, slot_id=None, site=None):
+    """Partition one grouped raise through the shared ExitSet effect router."""
+    from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+
+    if not isinstance(effect, GroupedRaiseEffect):
+        return None
+    split = effect.partition(expected, site)
+    bindings = ()
+    if split.matched.children and slot_id is not None:
+        bindings = (
+            EffectBinding(slot_id, "grouped-raise", None, split.matched),
+        )
+    return GroupedRoutedOutcome(split.matched, split.residual, bindings)
+
+
+def regroup_except_star(original, effects):
+    """Regroup handler effects and residuals, restoring original topology when possible."""
+    from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    effects = tuple(effects)
+    if not effects:
+        return None
+
+    def leaves(effect):
+        if isinstance(effect, RaiseEffect):
+            return {effect.occurrence_id}
+        if isinstance(effect, GroupedRaiseEffect):
+            result = set()
+            for child in effect.children:
+                result.update(leaves(child))
+            return result
+        return set()
+
+    original_leaves = leaves(original)
+    supplied = set().union(*(leaves(effect) for effect in effects))
+    if supplied and supplied <= original_leaves:
+        def retain(group):
+            children = []
+            for child in group.children:
+                if isinstance(child, GroupedRaiseEffect):
+                    kept = retain(child)
+                    if kept.children:
+                        children.append(kept)
+                elif child.occurrence_id in supplied:
+                    children.append(child)
+            return group.derive(tuple(children))
+        return retain(original)
+
+    # Newly raised handler effects and the residual remain distinct children.
+    # A residual group stays nested; it is never flattened into its leaves.
+    return original.derive(effects)
+
+
 def _observed_effect(entry):
     if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect):
         return "raise", entry.effect.exception_name, None, entry.effect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
@@ -23,3 +23,30 @@ class AuthenticatedExceptionTypeValue(FloorValue):
 
     def exception_type_mro(self) -> tuple[Term, ...] | None:
         return self.mro
+
+    def test_python_subtype(self, supertype, site):
+        from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+            AuthenticatedExceptionTypeValue,
+        )
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if not isinstance(supertype, AuthenticatedExceptionTypeValue):
+            raise SugarNotWritten(
+                owner="AuthenticatedExceptionTypeValue.test_python_subtype",
+                observed=type(supertype).__name__,
+                requested="authenticated exception type operand",
+                fix="construct the handler type through its lexical coordinate",
+            )
+        return Complete(
+            TrueBoolLiteralSugar(site)
+            if self.identity == supertype.identity
+            or (self.mro is not None and supertype.identity in self.mro)
+            else FalseBoolLiteralSugar(site)
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
@@ -14,6 +14,7 @@ class AuthenticatedExceptionTypeValue(FloorValue):
     value: FloorValue
     identity: Term
     mro: tuple[Term, ...] | None = None
+    class_value: FloorValue | None = None
 
     def to_term(self, *, owner: str):
         return self.value.to_term(owner=owner)
@@ -28,13 +29,7 @@ class AuthenticatedExceptionTypeValue(FloorValue):
         from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
             AuthenticatedExceptionTypeValue,
         )
-        from sugar_lift_py_tests.outcome import Complete
-        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
-            FalseBoolLiteralSugar,
-        )
-        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
-            TrueBoolLiteralSugar,
-        )
+        from sugar_lift_py_tests.floor.class_value import ClassValue
         from sugar_source_tree.panic import SugarNotWritten
 
         if not isinstance(supertype, AuthenticatedExceptionTypeValue):
@@ -44,9 +39,17 @@ class AuthenticatedExceptionTypeValue(FloorValue):
                 requested="authenticated exception type operand",
                 fix="construct the handler type through its lexical coordinate",
             )
-        return Complete(
-            TrueBoolLiteralSugar(site)
-            if self.identity == supertype.identity
-            or (self.mro is not None and supertype.identity in self.mro)
-            else FalseBoolLiteralSugar(site)
+        leaf_class = self.class_value if self.class_value is not None else self.value
+        handler_class = (
+            supertype.class_value
+            if supertype.class_value is not None
+            else supertype.value
         )
+        if not isinstance(leaf_class, ClassValue):
+            raise SugarNotWritten(
+                owner="AuthenticatedExceptionTypeValue.test_python_subtype",
+                observed=type(leaf_class).__name__,
+                requested="authenticated ClassValue leaf",
+                fix="construct the raised exception through its lexical class graph",
+            )
+        return leaf_class.test_python_subtype(handler_class, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -47,7 +47,7 @@ class ClassValue(FloorValue):
             return SymbolicValue(self.to_term(owner=str(site))).test_python_subtype(
                 supertype, site
             )
-        if type(supertype) is not ClassValue:
+        if not isinstance(supertype, ClassValue):
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
             construction_panic_gap(
@@ -68,7 +68,7 @@ class ClassValue(FloorValue):
                 continue
             seen.add(key)
             for base in candidate.bases:
-                if type(base) is not ClassValue:
+                if not isinstance(base, ClassValue):
                     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
                     construction_panic_gap(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
@@ -11,6 +11,7 @@ class AuthenticatedExceptionTypeSugar(Sugar):
     identity: object
     mro: tuple | None = None
     site: object = dataclass_field(compare=False, default=None)
+    class_value: object | None = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):
@@ -32,6 +33,8 @@ class AuthenticatedExceptionTypeSugar(Sugar):
 
         return self.value.desugar(ctx).and_then(
             lambda value: Complete(
-                AuthenticatedExceptionTypeValue(value, self.identity, self.mro)
+                AuthenticatedExceptionTypeValue(
+                    value, self.identity, self.mro, self.class_value
+                )
             )
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -14,11 +14,12 @@ from sugar_lift_py_tests.outcome import Complete, Outcome
 def is_hard_raise(entry) -> bool:
     """True when entry is a raise Incomplete that halts control flow."""
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
     if not isinstance(entry, Incomplete):
         return False
-    if not isinstance(entry.effect, RaiseEffect):
+    if not isinstance(entry.effect, (RaiseEffect, GroupedRaiseEffect)):
         return False
     return not entry.follow().continues
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
+from sugar_lift_py_tests.outcome import Complete, Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class GroupedRaiseSugar(Sugar):
+    """Construct one authenticated exception-group tree without flattening it."""
+
+    group_identity: str
+    message: Sugar
+    children: tuple[Sugar, ...]
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_source_tree.panic import SugarNotWritten
+
+        message = self.message.desugar(ctx)
+        if not isinstance(message, Complete):
+            return message
+        effects = []
+        for child in self.children:
+            outcome = child.desugar(ctx)
+            if not isinstance(outcome, Incomplete) or not isinstance(
+                outcome.effect, (RaiseEffect, GroupedRaiseEffect)
+            ):
+                raise SugarNotWritten(
+                    owner="GroupedRaiseSugar.desugar",
+                    observed=type(outcome).__name__,
+                    requested="a constructed raise effect for every group child",
+                    fix="keep non-exception group members loud",
+                )
+            effects.append(outcome.effect)
+        occurrence = f"{self.site.filename}:{self.site.line}:{self.site.col}"
+        return Incomplete(
+            GroupedRaiseEffect(
+                self.group_identity,
+                message.value,
+                tuple(effects),
+                occurrence=occurrence,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class TryStarSugar(Sugar):
+    body: tuple
+    handlers: tuple
+    orelse: tuple = ()
+    finalbody: tuple = ()
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+        from sugar_lift_py_tests.effect_router import (
+            regroup_except_star,
+            route_except_star,
+        )
+        from sugar_lift_py_tests.in_flight_effect import bind_in_flight_effect
+        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            exitset_to_outcome,
+            promote_raise_halts,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            _ReducedBlock,
+            reduce_block_to_exitset,
+        )
+        from sugar_source_tree.panic import SugarNotWritten
+
+        body = promote_raise_halts(reduce_block_to_exitset(self.body, ctx))
+        parts = []
+        for exit_ in body.exits:
+            if not isinstance(exit_, Halted):
+                if self.orelse:
+                    else_exits = reduce_block_to_exitset(self.orelse, ctx)
+                    parts.append(ExitSet((exit_,)).sequence(lambda _state: else_exits))
+                else:
+                    parts.append(ExitSet((exit_,)))
+                continue
+            if not isinstance(exit_.effect, GroupedRaiseEffect):
+                raise SugarNotWritten(
+                    owner="TryStarSugar.desugar",
+                    observed=type(exit_.effect).__name__,
+                    requested="GroupedRaiseEffect for except* routing",
+                    fix="keep ordinary except and except* distinct",
+                )
+            original = exit_.effect
+            residual = original
+            handler_effects = []
+            completed_states = []
+            for matcher, handler_body, slot_id in self.handlers:
+                expected = matcher.desugar(ctx)
+                if not isinstance(expected, Complete):
+                    raise SugarNotWritten(
+                        owner="TryStarSugar.desugar",
+                        observed="symbolic except* type",
+                        requested="authenticated subtype partition operand",
+                        fix="keep symbolic subtype partition typed loud",
+                    )
+                routed = route_except_star(
+                    residual, expected.value, slot_id=slot_id, site=self.site
+                )
+                if routed is None or not routed.matched.children:
+                    continue
+                handler_ctx = bind_in_flight_effect(ctx, slot_id, routed.matched)
+                handler_exits = promote_raise_halts(
+                    reduce_block_to_exitset(handler_body, handler_ctx)
+                )
+                if len(handler_exits.exits) != 1:
+                    raise SugarNotWritten(
+                        owner="TryStarSugar.desugar",
+                        observed="symbolically branching except* handler",
+                        requested="one closed handler exit for exact regrouping",
+                        fix="keep unresolved handler regrouping typed loud",
+                    )
+                for handler_exit in handler_exits.exits:
+                    if isinstance(handler_exit, Halted):
+                        handler_effects.append(handler_exit.effect)
+                    elif isinstance(handler_exit, Completed):
+                        completed_states.append(handler_exit.value)
+                residual = routed.residual
+            outgoing = list(handler_effects)
+            if residual.children:
+                outgoing.append(residual)
+            regrouped = regroup_except_star(original, outgoing)
+            state = exit_.state
+            if isinstance(state, _ReducedBlock):
+                entries = list(state.entries)
+                for completed in completed_states:
+                    if isinstance(completed, _ReducedBlock):
+                        entries.extend(completed.entries)
+                from dataclasses import replace
+
+                state = replace(state, entries=tuple(entries))
+            if regrouped is not None:
+                parts.append(ExitSet((Halted(exit_.guard, regrouped, state),)))
+            elif completed_states:
+                parts.append(ExitSet((Completed(exit_.guard, state),)))
+            else:
+                parts.append(ExitSet.completed(state))
+
+        result = parts[0] if parts else ExitSet.completed(None)
+        for part in parts[1:]:
+            result = result.union(part)
+        if self.finalbody:
+            cleanup = reduce_block_to_exitset(self.finalbody, ctx)
+            from sugar_lift_py_tests.floor.return_value import ReturnValue
+            def restores(value):
+                return not (
+                    isinstance(value, _ReducedBlock)
+                    and (
+                        not value.can_fall_through
+                        or any(isinstance(e, ReturnValue) for e in value.entries)
+                    )
+                )
+
+            result = result.and_finally(lambda: cleanup, cleanup_restores=restores)
+        return exitset_to_outcome(result)

--- a/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
@@ -1,0 +1,81 @@
+def _identity(module: str, name: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor("python:exception_type_identity", [str_const(module), str_const(name)])
+
+
+def _typed_value(identity, *mro):
+    from sugar_lift_py_tests.floor import BlockValue, ClassValue
+    from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+        AuthenticatedExceptionTypeValue,
+    )
+
+    return AuthenticatedExceptionTypeValue(
+        ClassValue("Renamed", (), BlockValue(())), identity, tuple(mro) or (identity,)
+    )
+
+
+def _leaf(identity, occurrence: str, *mro):
+    from sugar_lift_py_tests.effect import RaiseEffect
+
+    return RaiseEffect(
+        exception_type_coordinate=identity,
+        exception_type_mro=tuple(mro) or (identity,),
+        occurrence=occurrence,
+        raised_value=_typed_value(identity, *(tuple(mro) or (identity,))),
+    )
+
+
+def test_nested_group_partition_preserves_tree_and_leaf_identities():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+
+    base = _identity("renamed", "Base")
+    child = _identity("renamed", "Child")
+    other = _identity("renamed", "Other")
+    matched_leaf = _leaf(child, "leaf:matched", child, base)
+    residual_leaf = _leaf(other, "leaf:residual")
+    nested = GroupedRaiseEffect("group:nested", "nested", (matched_leaf, residual_leaf))
+    incoming = GroupedRaiseEffect("group:root", "root", (nested,))
+
+    partition = incoming.partition(_typed_value(base), "site")
+
+    assert partition.matched.group_identity == "group:root"
+    assert partition.residual.group_identity == "group:root"
+    assert partition.matched.children[0].group_identity == "group:nested"
+    assert partition.residual.children[0].group_identity == "group:nested"
+    assert partition.matched.children[0].children == (matched_leaf,)
+    assert partition.residual.children[0].children == (residual_leaf,)
+    assert partition.matched.children[0].children[0] is matched_leaf
+    assert partition.residual.children[0].children[0] is residual_leaf
+
+
+def test_partition_keeps_both_empty_faces_explicit():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+
+    wanted = _identity("renamed", "Wanted")
+    other = _identity("renamed", "Other")
+    incoming = GroupedRaiseEffect(
+        "group:root", "root", (_leaf(wanted, "leaf:wanted"),)
+    )
+
+    all_matched = incoming.partition(_typed_value(wanted), "site")
+    none_matched = incoming.partition(_typed_value(other), "site")
+
+    assert all_matched.residual.children == ()
+    assert all_matched.residual.group_identity == "group:root"
+    assert none_matched.matched.children == ()
+    assert none_matched.matched.group_identity == "group:root"
+
+
+def test_equal_spelling_with_lying_identity_does_not_match():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+
+    truthful = _identity("truthful", "RenamedError")
+    lying = _identity("lying", "RenamedError")
+    leaf = _leaf(truthful, "leaf:truthful")
+    incoming = GroupedRaiseEffect("group:root", "root", (leaf,))
+
+    partition = incoming.partition(_typed_value(lying), "site")
+
+    assert partition.matched.children == ()
+    assert partition.residual.children == (leaf,)

--- a/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
@@ -15,14 +15,16 @@ def _typed_value(identity, *mro):
     )
 
 
-def _leaf(identity, occurrence: str, *mro):
+def _leaf(identity, occurrence: str, *mro, raised_value=None):
     from sugar_lift_py_tests.effect import RaiseEffect
 
+    if raised_value is None:
+        raised_value = _typed_value(identity, *(tuple(mro) or (identity,)))
     return RaiseEffect(
         exception_type_coordinate=identity,
         exception_type_mro=tuple(mro) or (identity,),
         occurrence=occurrence,
-        raised_value=_typed_value(identity, *(tuple(mro) or (identity,))),
+        raised_value=raised_value,
     )
 
 
@@ -32,12 +34,18 @@ def test_nested_group_partition_preserves_tree_and_leaf_identities():
     base = _identity("renamed", "Base")
     child = _identity("renamed", "Child")
     other = _identity("renamed", "Other")
-    matched_leaf = _leaf(child, "leaf:matched", child, base)
+    base_type = _typed_value(base)
+    child_type = type(base_type)(
+        type(base_type.value)("Renamed", (base_type.value,), base_type.value.record),
+        child,
+        (child, base),
+    )
+    matched_leaf = _leaf(child, "leaf:matched", child, base, raised_value=child_type)
     residual_leaf = _leaf(other, "leaf:residual")
     nested = GroupedRaiseEffect("group:nested", "nested", (matched_leaf, residual_leaf))
     incoming = GroupedRaiseEffect("group:root", "root", (nested,))
 
-    partition = incoming.partition(_typed_value(base), "site")
+    partition = incoming.partition(base_type, "site")
 
     assert partition.matched.group_identity == "group:root"
     assert partition.residual.group_identity == "group:root"
@@ -54,11 +62,14 @@ def test_partition_keeps_both_empty_faces_explicit():
 
     wanted = _identity("renamed", "Wanted")
     other = _identity("renamed", "Other")
+    wanted_type = _typed_value(wanted)
     incoming = GroupedRaiseEffect(
-        "group:root", "root", (_leaf(wanted, "leaf:wanted"),)
+        "group:root",
+        "root",
+        (_leaf(wanted, "leaf:wanted", raised_value=wanted_type),),
     )
 
-    all_matched = incoming.partition(_typed_value(wanted), "site")
+    all_matched = incoming.partition(wanted_type, "site")
     none_matched = incoming.partition(_typed_value(other), "site")
 
     assert all_matched.residual.children == ()
@@ -79,3 +90,44 @@ def test_equal_spelling_with_lying_identity_does_not_match():
 
     assert partition.matched.children == ()
     assert partition.residual.children == (leaf,)
+
+
+def test_except_star_partition_and_issubclass_share_class_value_floor(monkeypatch):
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
+    from sugar_lift_py_tests.floor import BlockValue, ClassValue
+    from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+        AuthenticatedExceptionTypeValue,
+    )
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+    base_class = ClassValue("RenamedBase", (), BlockValue(()))
+    leaf_class = ClassValue("RenamedLeaf", (base_class,), BlockValue(()))
+    base_identity = _identity("truthful", "Base")
+    leaf_identity = _identity("truthful", "Leaf")
+    base_type = AuthenticatedExceptionTypeValue(base_class, base_identity)
+    leaf_type = AuthenticatedExceptionTypeValue(leaf_class, leaf_identity)
+    calls = []
+    class_floor = ClassValue.test_python_subtype
+
+    def recording_class_floor(self, supertype, site):
+        calls.append((self, supertype))
+        return class_floor(self, supertype, site)
+
+    monkeypatch.setattr(ClassValue, "test_python_subtype", recording_class_floor)
+
+    issubclass = builtin_name_temporal().value_for("issubclass")
+    issubclass.callable_application_with(
+        CallableApplication((leaf_class, base_class), (), "issubclass-site"), None
+    )
+    leaf = RaiseEffect(
+        exception_type_coordinate=leaf_identity,
+        occurrence="leaf:truthful",
+        raised_value=leaf_type,
+    )
+    partition = GroupedRaiseEffect("group:root", "root", (leaf,)).partition(
+        base_type, "except-star-site"
+    )
+
+    assert partition.matched.children == (leaf,)
+    assert calls == [(leaf_class, base_class), (leaf_class, base_class)]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -576,6 +576,22 @@ class SourceUnit:
 
         return tuple(result) if append_definition(definitions[0]) else None
 
+    def is_builtin_exception_group(self, node: "Name") -> bool:
+        """Authenticate exception-group constructors by runtime identity."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        identity = self.exception_type_identity(node)
+        if identity is None:
+            return False
+        return any(
+            identity
+            == ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const(name)],
+            )
+            for name in ("BaseExceptionGroup", "ExceptionGroup")
+        )
+
 
 class Typeable:
     """The interface: you may ask me for my node type.
@@ -4452,6 +4468,77 @@ class Raise(Statement):
         )
         from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
+        def group_call(node):
+            return (
+                isinstance(node, Call)
+                and isinstance(node.func, Name)
+                and self.unit.is_builtin_exception_group(node.func)
+            )
+
+        def leaf_sugar(node):
+            leaf_identity = leaf_mro = leaf_name = None
+            if isinstance(node, Call) and isinstance(node.func, Name):
+                leaf_identity = self.unit.exception_type_identity(node.func)
+                leaf_mro = self.unit.exception_type_mro(node.func)
+                leaf_name = node.func.id
+            elif isinstance(node, Name):
+                leaf_identity = self.unit.exception_type_identity(node)
+                leaf_mro = self.unit.exception_type_mro(node)
+                leaf_name = node.id
+            if leaf_identity is None:
+                raise SugarNotWritten(
+                    owner="Raise._construct_sugar",
+                    observed="exception-group leaf lacks authenticated exception identity",
+                    requested="a source-authenticated exception type",
+                    fix="keep opaque/native group members loud",
+                )
+            value = node.sugar()
+            if isinstance(value, CallSiteSugar):
+                value = replace(
+                    value,
+                    exception_type_coordinate=leaf_identity,
+                    exception_type_mro=leaf_mro,
+                )
+            else:
+                value = AuthenticatedExceptionTypeSugar(
+                    value, leaf_identity, leaf_mro, node.fragment
+                )
+            return RaiseSugar(value, None, leaf_name, node.fragment)
+
+        def grouped_sugar(call):
+            if (
+                len(call.args) != 2
+                or call.keywords
+                or not isinstance(call.args[1], (List, Tuple))
+            ):
+                raise SugarNotWritten(
+                    owner="Raise._construct_sugar",
+                    observed="unsupported native exception-group construction",
+                    requested="ExceptionGroup(message, finite list-or-tuple members)",
+                    fix="keep opaque/native group construction loud",
+                )
+            from sugar_lift_py_tests.sugar.grouped_raise_sugar import GroupedRaiseSugar
+
+            return GroupedRaiseSugar(
+                group_identity=call.fragment.seal().cid,
+                message=call.args[0].sugar(),
+                children=tuple(
+                    grouped_sugar(member) if group_call(member) else leaf_sugar(member)
+                    for member in call.args[1].elts
+                ),
+                site=call.fragment,
+            )
+
+        if group_call(self.exc):
+            if self.cause is not None:
+                raise SugarNotWritten(
+                    owner="Raise._construct_sugar",
+                    observed="exception-group raise with explicit cause",
+                    requested="group cause regroup semantics",
+                    fix="keep unsupported native behavior loud",
+                )
+            return grouped_sugar(self.exc)
+
         identity = None
         mro = None
         type_name = None
@@ -4787,6 +4874,50 @@ class TryStar(Statement):
     def substitute(self, scope):
         """Same block-aware substitute as Try (identical fields)."""
         return Try.substitute(self, scope)
+
+    def _construct_sugar(self):
+        """Construct the distinct except* router with authenticated type operands."""
+        from sugar_lift_py_tests.sugar.authenticated_exception_type_sugar import (
+            AuthenticatedExceptionTypeSugar,
+        )
+        from sugar_lift_py_tests.sugar.try_star_sugar import TryStarSugar
+
+        handlers = []
+        for handler in self.handlers:
+            if handler.type_ is None or not isinstance(handler.type_, Name):
+                raise SugarNotWritten(
+                    owner="TryStar._construct_sugar",
+                    observed="unsupported except* handler type",
+                    requested="one authenticated exception type operand",
+                    fix="keep unsupported native handler behavior loud",
+                )
+            identity = self.unit.exception_type_identity(handler.type_)
+            if identity is None:
+                raise SugarNotWritten(
+                    owner="TryStar._construct_sugar",
+                    observed="except* type lacks authenticated exception identity",
+                    requested="a constructed exception-type coordinate",
+                    fix="resolve the handler type lexically or keep it loud",
+                )
+            handlers.append(
+                (
+                    AuthenticatedExceptionTypeSugar(
+                        handler.type_.sugar(),
+                        identity,
+                        self.unit.exception_type_mro(handler.type_),
+                        handler.type_.fragment,
+                    ),
+                    tuple(stmt.sugar() for stmt in handler.body),
+                    handler._effect_slot_id(),
+                )
+            )
+        return TryStarSugar(
+            body=tuple(stmt.sugar() for stmt in self.body),
+            handlers=tuple(handlers),
+            orelse=tuple(stmt.sugar() for stmt in self.orelse),
+            finalbody=tuple(stmt.sugar() for stmt in self.finalbody),
+            site=self.fragment,
+        )
 
 
 class Assert(Statement):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -155,6 +155,7 @@ class SourceUnit:
     typed_module: object = field(init=False, default=None)
     # Field-data memo for materialize (see construction_cache.py).
     construction_cache: object = field(init=False, default=None)
+    exception_class_values: object = field(init=False, default=None)
     module_direct_bindings: object = field(init=False, default=None)
     function_nodes: Tuple[object, ...] = field(init=False, default=())
     # Memo for exception_type_identity: full-module walk was ~12ms/call on
@@ -177,6 +178,7 @@ class SourceUnit:
         )
         object.__setattr__(self, "typed_module", None)
         object.__setattr__(self, "construction_cache", None)
+        object.__setattr__(self, "exception_class_values", {})
         object.__setattr__(self, "module_direct_bindings", None)
         object.__setattr__(self, "function_nodes", ())
         object.__setattr__(self, "_exception_type_identity_cache", {})
@@ -313,12 +315,8 @@ class SourceUnit:
             ):
                 containing.append(candidate)
         if containing:
-            owner = max(
-                containing, key=lambda item: item.line_col_span().start_line
-            )
-            table = self.function_symtable(
-                owner.name, owner.line_col_span().start_line
-            )
+            owner = max(containing, key=lambda item: item.line_col_span().start_line)
+            table = self.function_symtable(owner.name, owner.line_col_span().start_line)
             try:
                 symbol = table.lookup(call.func.id)
             except KeyError:
@@ -414,8 +412,7 @@ class SourceUnit:
             }
         if statement.kind in ("Import", "ImportFrom"):
             return {
-                alias.asname or alias.name.split(".", 1)[0]
-                for alias in statement.names
+                alias.asname or alias.name.split(".", 1)[0] for alias in statement.names
             }
         return set()
 
@@ -575,6 +572,63 @@ class SourceUnit:
             return True
 
         return tuple(result) if append_definition(definitions[0]) else None
+
+    def exception_class_value(self, node: "Name"):
+        """Project one source-authenticated exception identity into one class graph."""
+        from sugar_lift_py_tests.floor import BlockValue
+        from sugar_lift_py_tests.floor.local_exception_class_value import (
+            LocalExceptionClassValue,
+        )
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+            BUILTIN_EXCEPTION_NAMES,
+            builtin_name_temporal,
+        )
+
+        identity = self.exception_type_identity(node)
+        mro = self.exception_type_mro(node)
+        if identity is None or mro is None:
+            raise SugarNotWritten(
+                owner="SourceUnit.exception_class_value",
+                observed="exception class lacks a closed authenticated base graph",
+                requested="source-authenticated ClassValue ancestry",
+                fix="keep computed, cyclic, or opaque exception ancestry loud",
+            )
+        cache = self.exception_class_values
+        cached = cache.get(identity)
+        if cached is not None:
+            return cached
+
+        for builtin_name in BUILTIN_EXCEPTION_NAMES:
+            builtin_identity = ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const(builtin_name)],
+            )
+            if identity == builtin_identity:
+                value = builtin_name_temporal().value_for(builtin_name)
+                cache[identity] = value
+                return value
+
+        module = self._require_typed_module("SourceUnit.exception_class_value")
+        definitions = [
+            statement
+            for statement in module.body
+            if statement.kind == "ClassDef" and statement.name == node.id
+        ]
+        if len(definitions) != 1:
+            raise SugarNotWritten(
+                owner="SourceUnit.exception_class_value",
+                observed="authenticated identity has no unique source class",
+                requested="one lexical exception class definition",
+                fix="keep ambiguous exception ancestry loud",
+            )
+        definition = definitions[0]
+        bases = tuple(self.exception_class_value(base) for base in definition.bases)
+        value = LocalExceptionClassValue(
+            name=definition.name, bases=bases, record=BlockValue(())
+        )
+        cache[identity] = value
+        return value
 
     def is_builtin_exception_group(self, node: "Name") -> bool:
         """Authenticate exception-group constructors by runtime identity."""
@@ -771,8 +825,7 @@ class Node(Typed):
             vocabulary_missing(
                 owner="nodes.Node.span",
                 observed=(
-                    f"{self.kind} with neither a backend position nor any "
-                    "spanned child"
+                    f"{self.kind} with neither a backend position nor any spanned child"
                 ),
                 requested="every node has a source extent",
                 fix="give the adapter an anchor rule for this kind; never invent a span",
@@ -1830,9 +1883,7 @@ class FunctionDef(Statement):
                 for nested in statement.body:
                     append_statement(nested)
                 steps.append(
-                    FinallyStepV1(
-                        tuple(item.sugar() for item in statement.finalbody)
-                    )
+                    FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
                 )
             else:
                 steps.append(OpaqueStepV1(statement.kind))
@@ -2000,9 +2051,7 @@ class FunctionDef(Statement):
 
         lc = stmt.line_col_span()
         site = f"{stmt.unit.filename}:{lc.start_line} {stmt.kind}"
-        with reduction_span(
-            sugar=f"Body.{stmt.kind}", role="construction", site=site
-        ):
+        with reduction_span(sugar=f"Body.{stmt.kind}", role="construction", site=site):
             return stmt.sugar()
 
     def _construct_sugar(self):
@@ -2090,9 +2139,7 @@ class FunctionDef(Statement):
                         role="construction",
                         site=where,
                     ):
-                        substitution_trace = trace_builder.freeze(
-                            testimony_reporter
-                        )
+                        substitution_trace = trace_builder.freeze(testimony_reporter)
                 else:
                     # Every statement still has an immutable runtime snapshot.
                     # Only a loop consumer demands the sealed state projection;
@@ -4499,10 +4546,15 @@ class Raise(Statement):
                     exception_type_coordinate=leaf_identity,
                     exception_type_mro=leaf_mro,
                 )
-            else:
-                value = AuthenticatedExceptionTypeSugar(
-                    value, leaf_identity, leaf_mro, node.fragment
-                )
+            value = AuthenticatedExceptionTypeSugar(
+                value,
+                leaf_identity,
+                leaf_mro,
+                node.fragment,
+                class_value=self.unit.exception_class_value(
+                    node.func if isinstance(node, Call) else node
+                ),
+            )
             return RaiseSugar(value, None, leaf_name, node.fragment)
 
         def grouped_sugar(call):
@@ -4906,6 +4958,7 @@ class TryStar(Statement):
                         identity,
                         self.unit.exception_type_mro(handler.type_),
                         handler.type_.fragment,
+                        class_value=self.unit.exception_class_value(handler.type_),
                     ),
                     tuple(stmt.sugar() for stmt in handler.body),
                     handler._effect_slot_id(),
@@ -6194,8 +6247,7 @@ class Call(Expression):
                     site=self.fragment,
                     keywords=keyword_sugars,
                     contract_resolution_gap=(
-                        f"{source_call_resolution.kind}:"
-                        f"{source_call_resolution.detail}"
+                        f"{source_call_resolution.kind}:{source_call_resolution.detail}"
                     ),
                 )
             if not isinstance(source_call_resolution, SourceCallPreconstructionRefV1):
@@ -6279,6 +6331,7 @@ class Call(Expression):
             from sugar_lift_py_tests.call_contract_resolution import (
                 CallContractResolutionGapV1,
             )
+
             call_refs = getattr(context, "call_contract_refs", None)
             if call_refs is not None:
                 from sugar_lift_py_tests.call_contract_resolution import (
@@ -6622,7 +6675,11 @@ class ObjectPlaceStateV1(Expression):
     def with_attribute_store(self, name, value, occurrence):
         from .object_identity import AttributeFieldCoordinateV1
 
-        return self._with_store(AttributeFieldCoordinateV1.mint(self.object_coordinate, name), value, occurrence)
+        return self._with_store(
+            AttributeFieldCoordinateV1.mint(self.object_coordinate, name),
+            value,
+            occurrence,
+        )
 
     def _with_store(self, selector, value, occurrence, *, constructed=None):
         self.validate_identity()
@@ -6630,9 +6687,7 @@ class ObjectPlaceStateV1(Expression):
         if constructed is None:
             return None
         floor_value, testimony = constructed
-        projected = ConstructedValueProjectionV1.create(
-            value, floor_value, testimony
-        )
+        projected = ConstructedValueProjectionV1.create(value, floor_value, testimony)
         from .object_identity import AttributeFieldVersionV1
 
         prior = self.version(selector)
@@ -6640,7 +6695,9 @@ class ObjectPlaceStateV1(Expression):
             owner=self.object_coordinate,
             field=selector,
             store_occurrence=occurrence,
-            construction_generation=self.object_coordinate.construction_generation + len(self.version_cids) + 1,
+            construction_generation=self.object_coordinate.construction_generation
+            + len(self.version_cids)
+            + 1,
             stored_value_testimony_cid=testimony.cid,
             prior_version_cid=prior,
         )
@@ -6857,15 +6914,12 @@ class Attribute(Expression):
             isinstance(receiver, IfExp)
             and isinstance(receiver.body, ObjectPlaceStateV1)
             and isinstance(receiver.orelse, ObjectPlaceStateV1)
-            and receiver.body.object_identity_cid
-            == receiver.orelse.object_identity_cid
+            and receiver.body.object_identity_cid == receiver.orelse.object_identity_cid
         ):
             when_true = receiver.body.attribute_field(self.attr)
             when_false = receiver.orelse.attribute_field(self.attr)
             if when_true is not None and when_false is not None:
-                return rewrite(
-                    receiver, body=when_true, orelse=when_false
-                )
+                return rewrite(receiver, body=when_true, orelse=when_false)
         if isinstance(receiver, ObjectPlaceStateV1):
             projected = receiver.attribute_field(self.attr)
             if projected is not None:

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -514,16 +514,164 @@ def test_finally_return_supersedes_break_exit():
     assert v.post().args[1].value == 13
 
 
-def test_trystar_stays_loud_without_grouped_exception_router():
-    """except* has no honest consumer in the single-effect ExitSet router."""
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A():\n"
-            "    try:\n"
-            "        raise ExceptionGroup('group', [ValueError()])\n"
-            "    except* ValueError:\n"
-            "        pass\n"
-        ).sugar()
+def test_nested_exception_group_constructs_tree_without_flattening():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "def A():\n"
+        "    raise ExceptionGroup('outer', [\n"
+        "        ValueError(),\n"
+        "        ExceptionGroup('inner', [TypeError(), KeyError()]),\n"
+        "    ])\n"
+    ).sugar().desugar()
+
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert len(outcome.effect.children) == 2
+    assert isinstance(outcome.effect.children[0], RaiseEffect)
+    nested = outcome.effect.children[1]
+    assert isinstance(nested, GroupedRaiseEffect)
+    assert len(nested.children) == 2
+    assert all(isinstance(item, RaiseEffect) for item in nested.children)
+    occurrences = tuple(item.occurrence_id for item in nested.children)
+    assert occurrences[0] != occurrences[1]
+
+
+def test_except_star_partitions_nested_group_and_propagates_only_residual():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('outer', [TypeError(), ExceptionGroup('inner', [ValueError(), KeyError()])])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    residual = outcome.effect
+    assert isinstance(residual, GroupedRaiseEffect)
+    assert isinstance(residual.children[0], RaiseEffect)
+    assert residual.children[0].exception_name == "TypeError"
+    nested = residual.children[1]
+    assert isinstance(nested, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in nested.children] == ["KeyError"]
+
+
+def test_except_star_residual_flows_to_subsequent_handlers():
+    outcome = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+        "    except* TypeError:\n"
+        "        pass\n"
+    ).sugar().desugar()
+    from sugar_lift_py_tests.outcome import Complete
+
+    assert isinstance(outcome, Complete)
+
+
+def test_except_star_bare_reraise_regroups_original_tree():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        raise\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in outcome.effect.children] == [
+        "ValueError",
+        "TypeError",
+    ]
+
+
+def test_except_star_never_selects_only_first_leaf():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [TypeError(), ValueError(), ValueError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in outcome.effect.children] == ["TypeError"]
+
+
+def test_except_star_matches_renamed_source_subclass_by_mro_identity():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "class Renamed(ValueError):\n"
+        "    pass\n"
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [Renamed(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in outcome.effect.children] == ["TypeError"]
+
+
+def test_except_star_handler_raise_regroups_with_unmatched_residual():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        raise KeyError()\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert isinstance(outcome.effect.children[0], RaiseEffect)
+    assert outcome.effect.children[0].exception_name == "KeyError"
+    assert isinstance(outcome.effect.children[1], GroupedRaiseEffect)
+
+
+def test_shadowed_exception_group_spelling_does_not_construct_group_effect():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "ExceptionGroup = lambda message, members: ValueError()\n"
+        "def A():\n"
+        "    raise ExceptionGroup('g', [ValueError()])\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, RaiseEffect)
+    assert not isinstance(outcome.effect, GroupedRaiseEffect)
+
+
+def test_ordinary_except_does_not_consume_grouped_raise():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError()])\n"
+        "    except ValueError:\n"
+        "        pass\n"
+    ).sugar().desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
 
 
 def test_warnings_warn_does_not_fabricate_a_warning_effect_without_a_producer():
@@ -696,7 +844,7 @@ def test_bare_except_catches_arbitrary_raise():
     assert v.post().args[1].name == "z"
 
 
-def test_except_star_stays_loud():
+def test_except_star_rejects_ordinary_raise_effect():
     with pytest.raises(SugarNotWritten):
         _fn(
             "def A(z):\n"
@@ -705,7 +853,7 @@ def test_except_star_stays_loud():
             "    except* ValueError:\n"
             "        pass\n"
             "    return z\n"
-        ).sugar()
+        ).sugar().desugar()
 
 
 def test_non_name_except_type_stays_loud():


### PR DESCRIPTION
## What changed

- add `GroupedRaiseEffect` with immutable exception-group tree topology and leaf occurrence identity
- partition grouped raises through authenticated subtype/MRO floor operations with explicit empty matched and residual groups
- construct finite builtin exception groups only from source-authenticated builtin identity
- route `except*` through the shared effect router, passing only matched subgroups and flowing residuals across handlers
- regroup bare re-raises, handler-raised effects, and unmatched residuals without flattening
- keep ordinary `except` and `except*` distinct and unsupported/symbolic cases loud

## Validation

- `49 passed` — grouped floor plus complete try/except* source suite
- `R_construction_side_doors = 0` (`sole_path=0`, `auditor_errors=0`)
- `R_construction_panic_catches_outside_audit = 0`
- `git diff --check origin/main...HEAD`

## Delta R

Foundational mechanism lane: measured `Delta R = 0`; no downstream pre-census was claimed.

Rebased onto current `origin/main` (`f85c3cbb1`). This PR is intentionally unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route grouped raises through `except*` with topology-preserving partition and regroup
> - Adds `GroupedRaiseEffect` to represent `ExceptionGroup` raises as a tree of children, and `GroupedRaisePartition` to hold matched/residual subtrees after partitioning.
> - Implements `route_except_star` in the effect router to partition a grouped raise effect by handler type using floor-based subtype checks via `AuthenticatedExceptionTypeValue`.
> - Implements `regroup_except_star` to reconstruct the original group topology after handler execution: bare re-raises restore the original tree; handler-raised effects and residual groups are merged as new children.
> - `TryStarSugar.desugar` iterates handlers, partitions residual effects per handler, binds matched subgroups to handler slots, and sequences orelse/finally; ordinary `except` semantics remain separate.
> - `Raise._construct_sugar` and `TryStar._construct_sugar` in the source tree now authenticate exception types with identity, MRO, and a `ClassValue` graph; shadowed `ExceptionGroup` names and unsupported group patterns raise `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b568558.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->