### PR TITLE
Project live loop post bindings

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
@@ -146,10 +146,18 @@ def scan_guarded_loop_recurrence(
                 )
             )
     nodes_path = next((path for path in python_files if path.name == "nodes.py"), None)
+    live_projection = any(
+        "project_loop_post_binding(" in path.read_text()
+        for path in python_files
+        if path.name in {"nodes.py", "live_loop_construction.py"}
+    )
     if (
         nodes_path is not None
         and binding_state is not None
-        and "project_loop_post_binding(" not in nodes_path.read_text()
+        and (
+            not live_projection
+            or "construct_live_loop_recurrence(" not in nodes_path.read_text()
+        )
     ):
         findings.append(
             _finding(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py
@@ -20,4 +20,18 @@ class GuardedProjection:
     when_false: BindingProjection
 
 
-BindingProjection: TypeAlias = "Sugar | UnboundProjection | GuardedProjection"
+@dataclass(frozen=True)
+class LoopGuardedCompletedFace:
+    completion_kind: str
+    guard_formula: object
+    state: BindingProjection
+
+
+@dataclass(frozen=True)
+class LoopGuardedProjection:
+    completed_faces: tuple[LoopGuardedCompletedFace, ...]
+
+
+BindingProjection: TypeAlias = (
+    "Sugar | UnboundProjection | GuardedProjection | LoopGuardedProjection"
+)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -8,6 +8,7 @@ from sugar_lift_py_tests.ir import not_
 from sugar_lift_py_tests.outcome import ExitSet, Outcome, outcome_to_exitset
 from sugar_lift_py_tests.sugar.binding_projection import (
     GuardedProjection,
+    LoopGuardedProjection,
     UnboundProjection,
 )
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -18,6 +19,18 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
         return outcome_to_exitset(state.desugar(ctx))
     if isinstance(state, UnboundProjection):
         return ExitSet.halted(NameErrorEffect(name=read_name, site=read_site))
+    if isinstance(state, LoopGuardedProjection):
+        exits = ExitSet(())
+        for face in state.completed_faces:
+            exits = exits.union(
+                read_binding(
+                    face.state,
+                    read_name=read_name,
+                    read_site=read_site,
+                    ctx=ctx,
+                ).guarded(face.guard_formula)
+            )
+        return exits.normalize()
     if not isinstance(state, GuardedProjection):
         raise TypeError(type(state))
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.ir import atomic, ctor, str_const
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class LoopBindingRefSugar(Sugar):
+    target_cid: str
+    binding_coordinate_cid: str
+    completion_kind: str
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "python:loop.post_binding",
+                    [
+                        str_const(self.target_cid),
+                        str_const(self.binding_coordinate_cid),
+                        str_const(self.completion_kind),
+                    ],
+                    symbol_kind="coordinate",
+                )
+            )
+        )
+
+
+@dataclass(frozen=True)
+class LoopRecurrenceSugar(Sugar):
+    target_cid: str
+    loop_construction_cid: str
+    binding_coordinate_cids: tuple[str, ...]
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.floor import InvValue
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        recurrences = []
+        for coordinate_cid in self.binding_coordinate_cids:
+            h = ctor(
+                "python:loop.recurrence",
+                [str_const(self.target_cid), str_const(coordinate_cid)],
+                symbol_kind="coordinate",
+            )
+            step = ctor(
+                "python:loop.step",
+                [h, str_const(self.loop_construction_cid)],
+                symbol_kind="coordinate",
+            )
+            recurrences.append(InvValue(atomic("=", [h, step]), self.site))
+        return Complete(BlockValue(tuple(recurrences), can_fall_through=True))

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
@@ -103,11 +103,11 @@ class ComprehensionSugar:
     ]
 
 
-def test_current_tree_measurement_has_nonempty_denominator() -> None:
+def test_current_tree_measurement_is_stable_zero() -> None:
     root = Path(__file__).parents[2]
     findings = scan_guarded_loop_recurrence(root)
 
-    assert findings
-    assert {f.code for f in findings} == {
-        "missing-source-loop-recurrence-projection",
-    }
+    assert findings == ()
+    assert summarize_guarded_loop_recurrence(findings)[
+        "R_guarded_loop_recurrence"
+    ] == 0

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -85,6 +85,7 @@ class LoopProjectedCompletedFace:
     completion_kind: str
     guard_formula_cid: str
     state: BindingState
+    guard_formula: object | None = None
 
     def __post_init__(self) -> None:
         _require_runtime_cid(self.target_cid, "targetCid")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -1,0 +1,423 @@
+"""Sole-path production of guarded LoopConstructionV1 post-bindings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
+from sugar_lift_py_tests.ir import and_, atomic, not_, or_, str_const
+from sugar_lift_py_tests.loop_construction import (
+    decode_loop_construction_v1,
+    seal_binding_state_v1,
+    seal_loop_record,
+)
+
+from .binding_state import (
+    BindingEntryV1,
+    BindingMap,
+    BindingStateWireGap,
+    BoundBindingStateV1,
+    ConstructedValueTestimonyV1,
+    _constructed_preimage,
+    branch_result_slot,
+)
+
+
+@dataclass(frozen=True)
+class LiveLoopProjectionV1:
+    statement: object
+    bindings: BindingMap
+
+
+def _formula_cid(formula) -> str:
+    import json
+
+    from sugar_lift_py_tests.canonicalizer import encode_jcs
+    from sugar_lift_py_tests.ir import formula_to_value
+
+    return cid_of_json(json.loads(encode_jcs(formula_to_value(formula))))
+
+
+def _testified(entry: BindingEntryV1) -> BindingEntryV1:
+    if entry.constructed_value_testimony is not None:
+        return entry
+    from .nodes import Node
+
+    if not isinstance(entry.state, Node):
+        raise BindingStateWireGap(
+            "live loop state lacks constructed Node testimony"
+        )
+    constructed = entry.state.sugar()
+    testimony = ConstructedValueTestimonyV1.mint(
+        entry.state.fragment, cid_of_json(_constructed_preimage(constructed))
+    )
+    return entry.with_testimony(testimony)
+
+
+def _sealed_state(snapshot: tuple[BindingEntryV1, ...]):
+    testified = tuple(_testified(entry) for entry in snapshot)
+    raw = seal_binding_state_v1(tuple(entry.wire() for entry in testified))
+    return raw, testified
+
+
+def _combine(outer, inner):
+    return inner if outer is None else and_([outer, inner])
+
+
+def _control_guards(statements, outer=None):
+    """Return exact owned break/continue guards; reject other halted faces."""
+    from .nodes import Break, Continue, For, If, Raise, Return, While
+
+    breaks = []
+    continues = []
+    for statement in statements:
+        if isinstance(statement, Break):
+            breaks.append(outer)
+            continue
+        if isinstance(statement, Continue):
+            continues.append(outer)
+            continue
+        if isinstance(statement, (Return, Raise)):
+            raise BindingStateWireGap(
+                "live loop outward halted face requires path-state production"
+            )
+        if isinstance(statement, If):
+            guard = branch_result_guard(
+                branch_result_slot(statement.test), statement.test.fragment
+            )
+            b, c = _control_guards(statement.body, _combine(outer, guard))
+            breaks.extend(b)
+            continues.extend(c)
+            b, c = _control_guards(
+                statement.orelse, _combine(outer, not_(guard))
+            )
+            breaks.extend(b)
+            continues.extend(c)
+            continue
+        # A nested loop owns its control effects; its recurrence is constructed
+        # independently and is not attributed to this target.
+        if isinstance(statement, (For, While)):
+            continue
+    return breaks, continues
+
+
+def _guard_union(guards, fallback):
+    concrete = [guard for guard in guards if guard is not None]
+    if any(guard is None for guard in guards):
+        return fallback
+    if not concrete:
+        return None
+    return concrete[0] if len(concrete) == 1 else or_(concrete)
+
+
+def _make_loop_ref(loop, entry, completion_kind):
+    from .backend import Leaf, materialize
+    from .shadow import ShadowNode
+
+    return materialize(
+        loop.unit,
+        ShadowNode(
+            "LoopBindingRef",
+            loop.span,
+            (
+                ("target_cid", Leaf(loop.owned_loop_target.target_cid)),
+                ("binding_coordinate_cid", Leaf(entry.coordinate.cid)),
+                ("completion_kind", Leaf(completion_kind)),
+            ),
+        ),
+        loop.reporter,
+    )
+
+
+def _make_statement(loop, construction, binding_coordinate_cids):
+    from .backend import Child, Leaf, materialize
+    from .shadow import ShadowNode, _handle_of
+
+    return materialize(
+        loop.unit,
+        ShadowNode(
+            "LoopRecurrenceStatement",
+            loop.span,
+            (
+                ("loop", Child(_handle_of(loop))),
+                ("construction", Leaf(construction)),
+                ("target_cid", Leaf(construction.target.target_cid)),
+                ("binding_coordinate_cids", Leaf(binding_coordinate_cids)),
+            ),
+        ),
+        loop.reporter,
+    )
+
+
+def _record(preimage, cid_field):
+    return seal_loop_record(preimage, cid_field)
+
+
+def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectionV1:
+    """Construct, decode, project, then publish a loop's guarded post-state."""
+    from .nodes import For, While
+    from .loop_recurrence import project_loop_post_binding
+
+    if not isinstance(loop, (For, While)) or loop.owned_loop_target is None:
+        raise BindingStateWireGap("live loop producer requires an owned For/While")
+    if loop.orelse:
+        raise BindingStateWireGap(
+            "live loop else requires exhaustion-path body state production"
+        )
+
+    carried_names = tuple(
+        sorted(
+            name
+            for name in For._stmts_bound_names(loop.body)
+            if isinstance(scope.get(name), BindingEntryV1)
+        )
+    )
+    pre_entries = tuple(scope[name] for name in carried_names)
+    pre_state, pre_runtime = _sealed_state(pre_entries)
+
+    target = loop.owned_loop_target.wire()
+    target_cid = target["targetCid"]
+    true_guard = atomic(
+        "python.loop.reachable", [str_const(target_cid)]
+    )
+    break_guards, continue_guards = _control_guards(loop.body)
+    break_guard = _guard_union(break_guards, true_guard)
+    continue_guard = _guard_union(continue_guards, true_guard)
+
+    if isinstance(loop, For):
+        exhaustion_guard = atomic(
+            "python.loop.exhausted", [str_const(target_cid)]
+        )
+        operation_kind = "ForNext"
+    else:
+        test_guard = branch_result_guard(branch_result_slot(loop.test), loop.test.fragment)
+        exhaustion_guard = not_(test_guard)
+        true_guard = test_guard
+        operation_kind = "WhileTest"
+
+    completed_specs = []
+    if break_guard is not None:
+        completed_specs.append(("BreakExit", break_guard))
+    completed_specs.append(("BodyFallthrough", true_guard))
+    completed_specs.append(("NormalExhaustion", exhaustion_guard))
+
+    state_records = [pre_state]
+    runtime_states = {pre_state["stateCid"]: pre_runtime}
+    face_records = []
+    face_snapshots = {}
+    live_guards = {}
+    for completion_kind, guard in completed_specs:
+        projected_entries = tuple(
+            replace(
+                entry,
+                state=_make_loop_ref(loop, entry, completion_kind),
+                sealed_state=BoundBindingStateV1(None),
+            )
+            for entry in pre_entries
+        )
+        state_record, runtime_snapshot = _sealed_state(projected_entries)
+        if all(
+            prior["stateCid"] != state_record["stateCid"]
+            for prior in state_records
+        ):
+            state_records.append(state_record)
+        runtime_states[state_record["stateCid"]] = runtime_snapshot
+        guard_cid = _formula_cid(guard)
+        live_guards[guard_cid] = guard
+        face = _record(
+            {
+                "kind": "loop-completed-face",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "completionKind": completion_kind,
+                "guardFormulaCid": guard_cid,
+                "stateCid": state_record["stateCid"],
+            },
+            "completedFaceCid",
+        )
+        face_records.append(face)
+        face_snapshots[completion_kind] = (face, state_record, runtime_snapshot)
+
+    body_face = face_snapshots["BodyFallthrough"][0]
+    records = [*state_records, *face_records]
+    body_exit_cid = cid_of_json(
+        {"loopBodyExitSet": loop.body[0].fragment.seal().cid if loop.body else target_cid}
+    )
+
+    if isinstance(loop, For):
+        binder = _record(
+            {
+                "kind": "loop-binder-transform", "schemaVersion": "1",
+                "targetCid": target_cid, "inputStateCid": pre_state["stateCid"],
+                "elementValueCid": cid_of_json({"iteratorElement": target_cid}),
+                "outputStateCid": pre_state["stateCid"],
+                "binderPatternConstructionCid": loop.target.fragment.seal().cid,
+            }, "binderTransformCid"
+        )
+        iterator = _record(
+            {
+                "kind": "loop-iterator-testimony", "schemaVersion": "1",
+                "targetCid": target_cid,
+                "iterableValueConstructionCid": loop.iter.fragment.seal().cid,
+                "iteratorConstructionCid": cid_of_json({"iterator": target_cid}),
+                "nextOperationCid": cid_of_json({"next": target_cid}),
+                "exhaustionOperationCid": cid_of_json({"exhaustion": target_cid}),
+            }, "iteratorTestimonyCid"
+        )
+        operation = _record(
+            {
+                "kind": "for-operation", "schemaVersion": "1",
+                "targetCid": target_cid,
+                "nativeLoopTermCid": cid_of_json({"native": "python:for"}),
+                "binderTransformCid": binder["binderTransformCid"],
+                "iteratorTestimonyCid": iterator["iteratorTestimonyCid"],
+            }, "operationCid"
+        )
+        successor_cid = binder["binderTransformCid"]
+        records.extend((binder, iterator, operation))
+    else:
+        test_transform = _record(
+            {
+                "kind": "loop-test-transform", "schemaVersion": "1",
+                "targetCid": target_cid, "inputStateCid": pre_state["stateCid"],
+                "testValueConstructionCid": loop.test.fragment.seal().cid,
+                "trueGuardFormulaCid": _formula_cid(true_guard),
+                "falseGuardFormulaCid": _formula_cid(exhaustion_guard),
+                "haltedFaceCids": [],
+            }, "testTransformCid"
+        )
+        operation = _record(
+            {
+                "kind": "while-operation", "schemaVersion": "1",
+                "targetCid": target_cid,
+                "nativeLoopTermCid": cid_of_json({"native": "python:while"}),
+                "testTransformCid": test_transform["testTransformCid"],
+            }, "operationCid"
+        )
+        successor_cid = test_transform["testTransformCid"]
+        records.extend((test_transform, operation))
+
+    body = _record(
+        {
+            "kind": "loop-body-transform", "schemaVersion": "1",
+            "targetCid": target_cid, "inputStateCid": pre_state["stateCid"],
+            "binderTransformCid": successor_cid,
+            "bodySourceFragmentCid": loop.fragment.seal().cid,
+            "bodyExitTemplateCid": body_exit_cid,
+        }, "bodyTransformCid"
+    )
+    latch = _record(
+        {
+            "kind": "loop-latch-obligation", "schemaVersion": "1",
+            "targetCid": target_cid,
+            "inputCompletedFaceCid": body_face["completedFaceCid"],
+            "inputStateCid": body_face["stateCid"],
+            "operationKind": operation_kind,
+            "successorTransformCid": successor_cid,
+        }, "latchObligationCid"
+    )
+    records.extend((body, latch))
+
+    continue_obligations = []
+    if continue_guard is not None:
+        obligation = _record(
+            {
+                "kind": "loop-continue-latch-obligation", "schemaVersion": "1",
+                "targetCid": target_cid,
+                "continueEffectCid": cid_of_json({"continue": target_cid}),
+                "inputHaltedFaceCid": cid_of_json({"continueFace": target_cid}),
+                "inputStateCid": body_face["stateCid"],
+                "successorTransformCid": successor_cid,
+            }, "continueLatchObligationCid"
+        )
+        records.append(obligation)
+        continue_obligations.append(obligation["continueLatchObligationCid"])
+
+    break_obligations = []
+    if "BreakExit" in face_snapshots:
+        break_face = face_snapshots["BreakExit"][0]
+        obligation = _record(
+            {
+                "kind": "loop-break-exit-obligation", "schemaVersion": "1",
+                "targetCid": target_cid,
+                "breakEffectCid": cid_of_json({"break": target_cid}),
+                "inputHaltedFaceCid": cid_of_json({"breakFace": target_cid}),
+                "outputCompletedFaceCid": break_face["completedFaceCid"],
+            }, "breakExitObligationCid"
+        )
+        records.append(obligation)
+        break_obligations.append(obligation["breakExitObligationCid"])
+
+    exhaustion_face = face_snapshots["NormalExhaustion"][0]
+    exhaustion = _record(
+        {
+            "kind": "loop-exhaustion-exit-obligation", "schemaVersion": "1",
+            "targetCid": target_cid,
+            "operationTestimonyCid": operation["operationCid"],
+            "inputStateCid": pre_state["stateCid"],
+            "outputCompletedFaceCid": exhaustion_face["completedFaceCid"],
+        }, "exhaustionExitObligationCid"
+    )
+    records.append(exhaustion)
+
+    post_records = []
+    completed_post_kinds = (
+        ("BreakExit", "NormalExhaustion")
+        if "BreakExit" in face_snapshots
+        else ("NormalExhaustion",)
+    )
+    for completion_kind in completed_post_kinds:
+        face, state_record, _snapshot = face_snapshots[completion_kind]
+        for entry in pre_entries:
+            post = _record(
+                {
+                    "kind": "loop-post-binding", "schemaVersion": "1",
+                    "targetCid": target_cid,
+                    "bindingCoordinateCid": entry.coordinate.cid,
+                    "incomingStateCid": pre_state["stateCid"],
+                    "completedFaceCid": face["completedFaceCid"],
+                    "projectedStateCid": state_record["stateCid"],
+                }, "postBindingObligationCid"
+            )
+            records.append(post)
+            post_records.append(post["postBindingObligationCid"])
+
+    root = _record(
+        {
+            "kind": "loop-construction", "schemaVersion": "1",
+            "target": target, "preStateCid": pre_state["stateCid"],
+            "operation": operation, "bodyTransformCid": body["bodyTransformCid"],
+            "bodyExitTemplateCid": body_exit_cid,
+            "latchObligationCids": [latch["latchObligationCid"]],
+            "continueLatchObligationCids": continue_obligations,
+            "breakExitObligationCids": break_obligations,
+            "exhaustionExitObligationCid": exhaustion["exhaustionExitObligationCid"],
+            "elseBodyCid": None, "elseExhaustionObligationCid": None,
+            "completedFaceCids": [face["completedFaceCid"] for face in face_records],
+            "outwardHaltedFaceCids": [],
+            "postBindingObligationCids": post_records,
+        }, "loopConstructionCid"
+    )
+    construction = decode_loop_construction_v1({"root": root, "records": records})
+
+    bindings = {}
+    for name, entry in zip(carried_names, pre_entries, strict=True):
+        projected = project_loop_post_binding(
+            construction=construction,
+            binding_coordinate=entry.coordinate,
+            runtime_states=runtime_states,
+            live_guards=live_guards,
+        )
+        bindings[name] = replace(entry, state=projected, sealed_state=None)
+    return LiveLoopProjectionV1(
+        _make_statement(
+            loop,
+            construction,
+            tuple(entry.coordinate.cid for entry in pre_entries),
+        ),
+        bindings,
+    )
+
+
+__all__ = ["LiveLoopProjectionV1", "construct_live_loop_recurrence"]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
@@ -23,6 +23,7 @@ def project_loop_post_binding(
     construction: LoopConstructionV1,
     binding_coordinate: BindingCoordinateV1,
     runtime_states: Mapping[str, tuple[BindingEntryV1, ...]],
+    live_guards: Mapping[str, object] | None = None,
 ) -> LoopProjectedBinding:
     """Project one coordinate through every exact completed loop face.
 
@@ -41,8 +42,16 @@ def project_loop_post_binding(
         for record in construction.wire_graph()["records"]
         if record.get("kind") == "loop-completed-face"
     }
+    post_face_cids = {
+        record["completedFaceCid"]
+        for record in construction.wire_graph()["records"]
+        if record.get("kind") == "loop-post-binding"
+        and record["bindingCoordinateCid"] == binding_coordinate.cid
+    }
     projected_faces = []
     for face in construction.completed_faces:
+        if face.cid not in post_face_cids:
+            continue
         record = records.get(face.cid)
         if record is None:
             raise BindingStateWireGap("completed face missing from loop graph")
@@ -67,6 +76,11 @@ def project_loop_post_binding(
                 completion_kind=face.completion_kind,
                 guard_formula_cid=record["guardFormulaCid"],
                 state=matches[0].state,
+                guard_formula=(
+                    None
+                    if live_guards is None
+                    else live_guards.get(record["guardFormulaCid"])
+                ),
             )
         )
     return LoopProjectedBinding(target_cid, tuple(projected_faces))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1078,6 +1078,15 @@ class Node(Typed):
                 site=f"{stmt.unit.filename}:{lc.start_line} {stmt.kind}",
             ):
                 new_stmt = stmt.substitute(scope)
+                live_loop_bindings = None
+                if isinstance(new_stmt, (For, While)):
+                    from .live_loop_construction import (
+                        construct_live_loop_recurrence,
+                    )
+
+                    live_loop = construct_live_loop_recurrence(new_stmt, scope)
+                    new_stmt = live_loop.statement
+                    live_loop_bindings = live_loop.bindings
             if new_stmt is not stmt:
                 changed = True
             # A statement may EXPAND into several: a `for` over a concrete
@@ -1090,7 +1099,11 @@ class Node(Typed):
             )
             for produced_stmt in produced:
                 new_items.append(produced_stmt)
-                binding = produced_stmt.substitution_binding(scope)
+                binding = (
+                    live_loop_bindings
+                    if live_loop_bindings is not None
+                    else produced_stmt.substitution_binding(scope)
+                )
                 if binding:
                     binding = produced_stmt._binding_entries(binding, scope)
                     binding = produced_stmt.refine_binding_entries(binding, scope)
@@ -6729,6 +6742,56 @@ class BindingCoordinateRef(Expression):
         return BindingCoordinateRefSugar(self.coordinate, self.fragment)
 
 
+class LoopBindingRef(Expression):
+    """Construction-owned reference to one guarded loop post-binding face."""
+
+    target_cid: str
+    binding_coordinate_cid: str
+    completion_kind: str
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.loop_recurrence_sugar import (
+            LoopBindingRefSugar,
+        )
+
+        return LoopBindingRefSugar(
+            self.target_cid,
+            self.binding_coordinate_cid,
+            self.completion_kind,
+            self.fragment,
+        )
+
+
+class LoopRecurrenceStatement(Statement):
+    """A decoded live LoopConstructionV1 enrolled in the source statement list."""
+
+    loop: Statement
+    construction: object
+    target_cid: str
+    binding_coordinate_cids: tuple[str, ...]
+    _child_fields = ("loop",)
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.loop_recurrence_sugar import (
+            LoopRecurrenceSugar,
+        )
+
+        return LoopRecurrenceSugar(
+            self.target_cid,
+            self.construction.loop_construction_cid,
+            self.binding_coordinate_cids,
+            self.fragment,
+        )
+
+
 class ConstructedReceiverRef(Expression):
     """Typed projection of the receiver constructed by this exact class call."""
 
@@ -6770,6 +6833,8 @@ class BranchResultRef(Expression):
 def _construct_binding_projection(state):
     from sugar_lift_py_tests.sugar.binding_projection import (
         GuardedProjection,
+        LoopGuardedCompletedFace,
+        LoopGuardedProjection,
         UnboundProjection,
     )
 
@@ -6785,9 +6850,20 @@ def _construct_binding_projection(state):
             _construct_binding_projection(state.when_false),
         )
     if isinstance(state, LoopProjectedBinding):
-        raise BindingStateWireGap(
-            "loop projected binding has CID-only guards; exact guard formula "
-            "testimony is required before downstream construction"
+        if any(face.guard_formula is None for face in state.completed_faces):
+            raise BindingStateWireGap(
+                "loop projected binding has CID-only guards; exact guard formula "
+                "testimony is required before downstream construction"
+            )
+        return LoopGuardedProjection(
+            tuple(
+                LoopGuardedCompletedFace(
+                    face.completion_kind,
+                    face.guard_formula,
+                    _construct_binding_projection(face.state),
+                )
+                for face in state.completed_faces
+            )
         )
     raise TypeError(type(state))
 

--- a/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
@@ -109,12 +109,8 @@ def test_break_and_exhaustion_faces_project_exact_runtime_states_by_coordinate()
     assert projected.target_cid == construction.target.target_cid
     assert [face.completion_kind for face in projected.completed_faces] == [
         "BreakExit",
-        "BodyFallthrough",
-        "NormalExhaustion",
     ]
     assert projected.completed_faces[0].state is break_state
-    assert projected.completed_faces[1].state is exhaustion_state
-    assert projected.completed_faces[2].state is exhaustion_state
 
 
 def test_projection_is_typed_loud_for_missing_state_or_coordinate():

--- a/implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py
+++ b/implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def test_live_for_projects_break_and_exhaustion_before_tail_substitution():
+    function = _function(
+        """
+def arbitrary(items, stop):
+    carried = 0
+    for renamed in items:
+        if renamed == stop:
+            break
+        carried = carried + renamed
+    return carried
+"""
+    )
+
+    constructed = function.sugar()
+
+    assert type(constructed.statements[1]).__name__ == "LoopRecurrenceSugar"
+    recurrence = constructed.statements[1].desugar().value
+    assert len(recurrence.inv_contribution()) == 1
+    equation = recurrence.inv_contribution()[0]
+    assert equation.name == "="
+    assert equation.args[1].name == "python:loop.step"
+    assert equation.args[1].args[0] == equation.args[0]
+    post_read = constructed.statements[2].value
+    assert type(post_read).__name__ == "GuardedBindingReadSugar"
+    assert type(post_read.state).__name__ == "LoopGuardedProjection"
+    assert {
+        face.completion_kind for face in post_read.state.completed_faces
+    } == {"BreakExit", "NormalExhaustion"}
+
+
+def test_renamed_lying_twin_does_not_authorize_loop_target_by_spelling():
+    truthful = _function(
+        """
+def arbitrary(items):
+    carried = 0
+    for renamed in items:
+        carried = carried + renamed
+    return carried
+"""
+    ).sugar()
+    lying = _function(
+        """
+def arbitrary(items):
+    carried = 0
+    renamed = 99
+    for other in items:
+        carried = carried + other
+    return carried
+"""
+    ).sugar()
+
+    truthful_loop = truthful.statements[1]
+    lying_loop = lying.statements[2]
+    assert truthful_loop.target_cid != lying_loop.target_cid
+
+
+def test_live_symbolic_while_projects_false_test_exhaustion_before_tail():
+    function = _function(
+        """
+def arbitrary(limit):
+    carried = 0
+    while carried < limit:
+        carried = carried + 1
+    return carried
+"""
+    )
+
+    constructed = function.sugar()
+
+    assert type(constructed.statements[1]).__name__ == "LoopRecurrenceSugar"
+    post_read = constructed.statements[2].value
+    assert type(post_read.state).__name__ == "LoopGuardedProjection"
+    assert {
+        face.completion_kind for face in post_read.state.completed_faces
+    } == {"NormalExhaustion"}

--- a/implementations/python/sugar-source-tree/tests/test_loop_control_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_control_construction.py
@@ -173,8 +173,9 @@ def test_symbolic_break_never_fabricates_a_whole_iterable_universal():
         "            break\n"
         "        assert renamed != stop\n"
     )
-    with pytest.raises(SugarNotWritten, match="For"):
-        function.sugar()
+    constructed = function.sugar()
+    assert type(constructed.statements[0]).__name__ == "LoopRecurrenceSugar"
+    assert "ForUniversalSugar" not in repr(constructed)
 
 
 def test_nested_break_is_consumed_only_by_the_inner_bounded_loop():


### PR DESCRIPTION
## Summary
- construct real For/While LoopConstructionV1 recurrences in the live source sequencing path
- publish exact guarded LoopProjectedBinding faces through BindingEntryV1 before downstream substitution
- keep unsupported else/outward-halt shapes typed-loud and preserve symbolic/unbounded loops without whole-iterable universals

## Validation
- 35 passed: live projection, recurrence, wire/acceptance, and IDD twins
- 4 passed: nested comprehension flat-map and filter-guard twins
- R_guarded_loop_recurrence: 1 -> 0 (Delta -1)
- R_construction_side_doors = 0; auditor_errors = 0
- R_construction_panic_catches_outside_audit = 0

## Census
- For baseline supplied by the lane: 638
- Head For census: not claimed; no complete conserved pandas head census was available in this run, so corpus Delta For remains unmeasured

Open and unmerged.