### PR TITLE
Construct loop else and halted faces

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
@@ -40,6 +40,27 @@ def scan_guarded_loop_recurrence(
                 name = node.func.id if isinstance(node.func, ast.Name) else None
                 rendered = ast.unparse(node)
                 if (
+                    name == "BindingStateWireGap"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)
+                ):
+                    typed_loud_teeth = {
+                        "live loop else requires exhaustion-path body state production": (
+                            "missing-loop-else-exhaustion-state",
+                            "exhaustion face sequenced through else body state",
+                        ),
+                        "live loop outward halted face requires path-state production": (
+                            "missing-loop-outward-halted-state",
+                            "guarded outward halted face with exact runtime state",
+                        ),
+                    }
+                    named = typed_loud_teeth.get(node.args[0].value)
+                    if named is not None:
+                        findings.append(
+                            _finding(path, root, node.lineno, named[0], named[1])
+                        )
+                if (
                     "py.fold." in rendered
                     and isinstance(node.func, ast.Attribute)
                     and node.func.attr == "_make_call"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sugar_lift_py_tests.floor import SymbolicValue
-from sugar_lift_py_tests.ir import atomic, ctor, str_const
+from sugar_lift_py_tests.ir import atomic, ctor, not_, or_, str_const
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
@@ -41,6 +41,8 @@ class LoopRecurrenceSugar(Sugar):
     target_cid: str
     loop_construction_cid: str
     binding_coordinate_cids: tuple[str, ...]
+    outward_faces: tuple[object, ...]
+    construction: object = field(compare=False)
     site: object = field(compare=False)
 
     @classmethod
@@ -48,7 +50,6 @@ class LoopRecurrenceSugar(Sugar):
         return ()
 
     def desugar(self, ctx=None):
-        del ctx
         from sugar_lift_py_tests.floor import InvValue
         from sugar_lift_py_tests.floor.block_value import BlockValue
 
@@ -65,4 +66,35 @@ class LoopRecurrenceSugar(Sugar):
                 symbol_kind="coordinate",
             )
             recurrences.append(InvValue(atomic("=", [h, step]), self.site))
-        return Complete(BlockValue(tuple(recurrences), can_fall_through=True))
+        recurrence = BlockValue(tuple(recurrences), can_fall_through=True)
+        if not self.outward_faces:
+            return Complete(recurrence)
+
+        from sugar_lift_py_tests.floor import ReturnValue
+        from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted, Incomplete
+
+        halted_guards = [face.guard for face in self.outward_faces]
+        completed_guard = not_(
+            halted_guards[0]
+            if len(halted_guards) == 1
+            else or_(halted_guards)
+        )
+        exits = [Completed(completed_guard, recurrence)]
+        for face in self.outward_faces:
+            outcome = face.statement_sugar.desugar(ctx)
+            if isinstance(outcome, Complete) and isinstance(outcome.value, ReturnValue):
+                exits.append(
+                    Completed(
+                        face.guard,
+                        BlockValue((outcome.value,), can_fall_through=False),
+                    )
+                )
+            elif isinstance(outcome, Incomplete):
+                exits.append(Halted(face.guard, outcome.effect, recurrence))
+            else:
+                from sugar_source_tree.binding_state import BindingStateWireGap
+
+                raise BindingStateWireGap(
+                    "loop outward face did not construct return or raise testimony"
+                )
+        return ExitSet(tuple(exits)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
@@ -53,6 +53,22 @@ value = node_from_cid(completed_face.state_c_id)
     }
 
 
+def test_instrument_names_typed_loud_live_loop_face_teeth(tmp_path: Path) -> None:
+    (tmp_path / "live_loop_construction.py").write_text(
+        '''
+raise BindingStateWireGap("live loop else requires exhaustion-path body state production")
+raise BindingStateWireGap("live loop outward halted face requires path-state production")
+'''
+    )
+
+    findings = scan_guarded_loop_recurrence(tmp_path)
+
+    assert {finding.code for finding in findings} == {
+        "missing-loop-else-exhaustion-state",
+        "missing-loop-outward-halted-state",
+    }
+
+
 def test_instrument_reports_numeric_r_and_lawful_projection_is_silent(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -30,6 +30,13 @@ class LiveLoopProjectionV1:
     bindings: BindingMap
 
 
+@dataclass(frozen=True)
+class LiveOutwardHaltedFaceV1:
+    statement_sugar: object
+    guard: object
+    state: tuple[BindingEntryV1, ...]
+
+
 def _formula_cid(formula) -> str:
     import json
 
@@ -65,12 +72,14 @@ def _combine(outer, inner):
     return inner if outer is None else and_([outer, inner])
 
 
-def _control_guards(statements, outer=None):
-    """Return exact owned break/continue guards; reject other halted faces."""
+def _control_guards(statements, scope, outer=None):
+    """Return exact owned control guards, including outward halted faces."""
     from .nodes import Break, Continue, For, If, Raise, Return, While
 
     breaks = []
     continues = []
+    halted = []
+    current = dict(scope)
     for statement in statements:
         if isinstance(statement, Break):
             breaks.append(outer)
@@ -79,27 +88,34 @@ def _control_guards(statements, outer=None):
             continues.append(outer)
             continue
         if isinstance(statement, (Return, Raise)):
-            raise BindingStateWireGap(
-                "live loop outward halted face requires path-state production"
-            )
+            halted.append((statement, outer, current))
+            continue
         if isinstance(statement, If):
             guard = branch_result_guard(
                 branch_result_slot(statement.test), statement.test.fragment
             )
-            b, c = _control_guards(statement.body, _combine(outer, guard))
-            breaks.extend(b)
-            continues.extend(c)
-            b, c = _control_guards(
-                statement.orelse, _combine(outer, not_(guard))
+            b, c, h = _control_guards(
+                statement.body, current, _combine(outer, guard)
             )
             breaks.extend(b)
             continues.extend(c)
-            continue
+            halted.extend(h)
+            b, c, h = _control_guards(
+                statement.orelse, current, _combine(outer, not_(guard))
+            )
+            breaks.extend(b)
+            continues.extend(c)
+            halted.extend(h)
         # A nested loop owns its control effects; its recurrence is constructed
         # independently and is not attributed to this target.
         if isinstance(statement, (For, While)):
             continue
-    return breaks, continues
+        binding = statement.substitution_binding(current)
+        if binding:
+            binding = statement._binding_entries(binding, current)
+            binding = statement.refine_binding_entries(binding, current)
+            current.update(binding)
+    return breaks, continues, halted
 
 
 def _guard_union(guards, fallback):
@@ -130,7 +146,7 @@ def _make_loop_ref(loop, entry, completion_kind):
     )
 
 
-def _make_statement(loop, construction, binding_coordinate_cids):
+def _make_statement(loop, construction, binding_coordinate_cids, outward_faces):
     from .backend import Child, Leaf, materialize
     from .shadow import ShadowNode, _handle_of
 
@@ -144,6 +160,7 @@ def _make_statement(loop, construction, binding_coordinate_cids):
                 ("construction", Leaf(construction)),
                 ("target_cid", Leaf(construction.target.target_cid)),
                 ("binding_coordinate_cids", Leaf(binding_coordinate_cids)),
+                ("outward_faces", Leaf(outward_faces)),
             ),
         ),
         loop.reporter,
@@ -161,15 +178,10 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
 
     if not isinstance(loop, (For, While)) or loop.owned_loop_target is None:
         raise BindingStateWireGap("live loop producer requires an owned For/While")
-    if loop.orelse:
-        raise BindingStateWireGap(
-            "live loop else requires exhaustion-path body state production"
-        )
-
     carried_names = tuple(
         sorted(
             name
-            for name in For._stmts_bound_names(loop.body)
+            for name in For._stmts_bound_names((*loop.body, *loop.orelse))
             if isinstance(scope.get(name), BindingEntryV1)
         )
     )
@@ -181,7 +193,9 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     true_guard = atomic(
         "python.loop.reachable", [str_const(target_cid)]
     )
-    break_guards, continue_guards = _control_guards(loop.body)
+    break_guards, continue_guards, halted_specs = _control_guards(
+        loop.body, scope
+    )
     break_guard = _guard_union(break_guards, true_guard)
     continue_guard = _guard_union(continue_guards, true_guard)
 
@@ -239,8 +253,49 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         face_records.append(face)
         face_snapshots[completion_kind] = (face, state_record, runtime_snapshot)
 
+    outward_faces = []
+    outward_face_cids = []
+    outward_records = []
+    for statement, guard, halted_scope in halted_specs:
+        live_guard = guard if guard is not None else true_guard
+        projected_entries = tuple(
+            replace(
+                halted_scope.get(name, entry),
+                coordinate=entry.coordinate,
+                sealed_state=BoundBindingStateV1(None),
+            )
+            for name, entry in zip(carried_names, pre_entries, strict=True)
+        )
+        state_record, runtime_snapshot = _sealed_state(projected_entries)
+        if all(
+            prior["stateCid"] != state_record["stateCid"]
+            for prior in state_records
+        ):
+            state_records.append(state_record)
+        runtime_states[state_record["stateCid"]] = runtime_snapshot
+        guard_cid = _formula_cid(live_guard)
+        live_guards[guard_cid] = live_guard
+        statement_sugar = statement.sugar()
+        effect_cid = cid_of_json(_constructed_preimage(statement_sugar))
+        face = _record(
+            {
+                "kind": "loop-outward-halted-face",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "effectCid": effect_cid,
+                "guardFormulaCid": guard_cid,
+                "stateCid": state_record["stateCid"],
+            },
+            "outwardHaltedFaceCid",
+        )
+        outward_records.append(face)
+        outward_face_cids.append(face["outwardHaltedFaceCid"])
+        outward_faces.append(
+            LiveOutwardHaltedFaceV1(statement_sugar, live_guard, runtime_snapshot)
+        )
+
     body_face = face_snapshots["BodyFallthrough"][0]
-    records = [*state_records, *face_records]
+    records = [*state_records, *face_records, *outward_records]
     body_exit_cid = cid_of_json(
         {"loopBodyExitSet": loop.body[0].fragment.seal().cid if loop.body else target_cid}
     )
@@ -361,6 +416,73 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     )
     records.append(exhaustion)
 
+    post_exhaustion_face = face_snapshots["NormalExhaustion"]
+    else_body_cid = None
+    else_obligation_cid = None
+    if loop.orelse:
+        exhaustion_scope = dict(scope)
+        exhaustion_runtime = face_snapshots["NormalExhaustion"][2]
+        for name, entry in zip(carried_names, exhaustion_runtime, strict=True):
+            exhaustion_scope[name] = entry
+        _else_statements, _changed, else_net = loop._substitute_body_tracked(
+            loop.orelse, exhaustion_scope
+        )
+        else_runtime = tuple(
+            replace(else_net[name], coordinate=pre_entry.coordinate)
+            for name, pre_entry in zip(carried_names, pre_entries, strict=True)
+        )
+        else_state, else_runtime = _sealed_state(else_runtime)
+        if all(
+            prior["stateCid"] != else_state["stateCid"]
+            for prior in state_records
+        ):
+            state_records.append(else_state)
+            records.append(else_state)
+        runtime_states[else_state["stateCid"]] = else_runtime
+        else_output = _record(
+            {
+                "kind": "loop-completed-face",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "completionKind": "NormalExhaustion",
+                "guardFormulaCid": _formula_cid(exhaustion_guard),
+                "stateCid": else_state["stateCid"],
+            },
+            "completedFaceCid",
+        )
+        records.append(else_output)
+        face_records.append(else_output)
+        else_body = _record(
+            {
+                "kind": "loop-body-transform",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "inputStateCid": exhaustion_face["stateCid"],
+                "binderTransformCid": successor_cid,
+                "bodySourceFragmentCid": loop.orelse[0].fragment.seal().cid,
+                "bodyExitTemplateCid": cid_of_json(
+                    {"loopElseExitSet": loop.orelse[0].fragment.seal().cid}
+                ),
+            },
+            "bodyTransformCid",
+        )
+        records.append(else_body)
+        else_obligation = _record(
+            {
+                "kind": "loop-else-exhaustion-obligation",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "inputCompletedFaceCid": exhaustion_face["completedFaceCid"],
+                "elseBodyTransformCid": else_body["bodyTransformCid"],
+                "outputCompletedFaceCid": else_output["completedFaceCid"],
+            },
+            "elseExhaustionObligationCid",
+        )
+        records.append(else_obligation)
+        post_exhaustion_face = (else_output, else_state, else_runtime)
+        else_body_cid = else_body["bodyTransformCid"]
+        else_obligation_cid = else_obligation["elseExhaustionObligationCid"]
+
     post_records = []
     completed_post_kinds = (
         ("BreakExit", "NormalExhaustion")
@@ -368,7 +490,11 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         else ("NormalExhaustion",)
     )
     for completion_kind in completed_post_kinds:
-        face, state_record, _snapshot = face_snapshots[completion_kind]
+        face, state_record, _snapshot = (
+            post_exhaustion_face
+            if completion_kind == "NormalExhaustion"
+            else face_snapshots[completion_kind]
+        )
         for entry in pre_entries:
             post = _record(
                 {
@@ -393,9 +519,10 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             "continueLatchObligationCids": continue_obligations,
             "breakExitObligationCids": break_obligations,
             "exhaustionExitObligationCid": exhaustion["exhaustionExitObligationCid"],
-            "elseBodyCid": None, "elseExhaustionObligationCid": None,
+            "elseBodyCid": else_body_cid,
+            "elseExhaustionObligationCid": else_obligation_cid,
             "completedFaceCids": [face["completedFaceCid"] for face in face_records],
-            "outwardHaltedFaceCids": [],
+            "outwardHaltedFaceCids": outward_face_cids,
             "postBindingObligationCids": post_records,
         }, "loopConstructionCid"
     )
@@ -415,9 +542,14 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             loop,
             construction,
             tuple(entry.coordinate.cid for entry in pre_entries),
+            tuple(outward_faces),
         ),
         bindings,
     )
 
 
-__all__ = ["LiveLoopProjectionV1", "construct_live_loop_recurrence"]
+__all__ = [
+    "LiveLoopProjectionV1",
+    "LiveOutwardHaltedFaceV1",
+    "construct_live_loop_recurrence",
+]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6880,6 +6880,7 @@ class LoopRecurrenceStatement(Statement):
     construction: object
     target_cid: str
     binding_coordinate_cids: tuple[str, ...]
+    outward_faces: tuple[object, ...]
     _child_fields = ("loop",)
 
     def substitute(self, scope):
@@ -6895,6 +6896,8 @@ class LoopRecurrenceStatement(Statement):
             self.target_cid,
             self.construction.loop_construction_cid,
             self.binding_coordinate_cids,
+            self.outward_faces,
+            self.construction,
             self.fragment,
         )
 

--- a/implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py
+++ b/implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py
@@ -88,3 +88,132 @@ def arbitrary(limit):
     assert {
         face.completion_kind for face in post_read.state.completed_faces
     } == {"NormalExhaustion"}
+
+
+def test_live_for_else_projects_else_state_only_on_normal_exhaustion():
+    constructed = _function(
+        """
+def arbitrary(items, stop):
+    carried = 0
+    for renamed in items:
+        if renamed == stop:
+            break
+        carried = renamed
+    else:
+        carried = 42
+    return carried
+"""
+    ).sugar()
+
+    loop = constructed.statements[1]
+    graph = loop.construction.wire_graph()
+    root = graph["root"]
+    assert root["elseBodyCid"] is not None
+    assert root["elseExhaustionObligationCid"] is not None
+
+    post = constructed.statements[2].value.state
+    by_kind = {face.completion_kind: face for face in post.completed_faces}
+    assert set(by_kind) == {"BreakExit", "NormalExhaustion"}
+    exhaustion = by_kind["NormalExhaustion"].state
+    assert type(exhaustion).__name__ == "IntLiteralSugar"
+    assert exhaustion.value == 42
+    assert type(by_kind["BreakExit"].state).__name__ == "LoopBindingRefSugar"
+
+
+def test_renamed_else_lying_twin_cannot_run_else_on_break_face():
+    constructed = _function(
+        """
+def arbitrary(items, gate):
+    result = 0
+    for renamed in items:
+        if renamed == gate:
+            break
+    else:
+        result = 9
+    return result
+"""
+    ).sugar()
+
+    post = constructed.statements[2].value.state
+    by_kind = {face.completion_kind: face for face in post.completed_faces}
+    assert by_kind["NormalExhaustion"].state.value == 9
+    assert type(by_kind["BreakExit"].state).__name__ == "LoopBindingRefSugar"
+
+
+def test_live_while_else_uses_false_test_face_before_tail_substitution():
+    constructed = _function(
+        """
+def arbitrary(limit):
+    carried = 0
+    while carried < limit:
+        carried = carried + 1
+    else:
+        carried = 17
+    return carried
+"""
+    ).sugar()
+
+    loop = constructed.statements[1]
+    root = loop.construction.wire_graph()["root"]
+    assert root["elseBodyCid"] is not None
+    post = constructed.statements[2].value.state
+    assert len(post.completed_faces) == 1
+    assert post.completed_faces[0].completion_kind == "NormalExhaustion"
+    assert post.completed_faces[0].state.value == 17
+
+
+def test_guarded_return_in_live_loop_is_an_outward_halted_face():
+    constructed = _function(
+        """
+def arbitrary(items, stop):
+    carried = 0
+    for renamed in items:
+        carried = renamed
+        if renamed == stop:
+            return carried
+    return carried
+"""
+    ).sugar()
+
+    loop = constructed.statements[1]
+    root = loop.construction.wire_graph()["root"]
+    assert len(root["outwardHaltedFaceCids"]) == 1
+    halted_state = loop.outward_faces[0].state[0]
+    assert (
+        halted_state.coordinate.cid
+        == constructed.statements[2]
+        .value.state.completed_faces[0]
+        .state.binding_coordinate_cid
+    )
+    assert type(halted_state.state.sugar()).__name__ != "IntLiteralSugar"
+    exits = loop.desugar()
+    assert type(exits).__name__ == "ExitSet"
+    assert any(
+        type(face).__name__ == "Completed" and not face.value.can_fall_through
+        for face in exits.exits
+    )
+
+
+def test_guarded_raise_in_live_while_is_an_outward_halted_face():
+    constructed = _function(
+        """
+def arbitrary(limit, stop):
+    carried = 0
+    while carried < limit:
+        if carried == stop:
+            raise ValueError(carried)
+        carried = carried + 1
+    return carried
+"""
+    ).sugar()
+
+    loop = constructed.statements[1]
+    root = loop.construction.wire_graph()["root"]
+    assert len(root["outwardHaltedFaceCids"]) == 1
+    exits = loop.desugar()
+    assert type(exits).__name__ == "ExitSet"
+    assert any(
+        type(face).__name__ == "Halted"
+        and type(face.effect).__name__ == "RaiseEffect"
+        for face in exits.exits
+    )


### PR DESCRIPTION
## Summary
- sequence For/While normal-exhaustion through the live else-body state before publishing LoopProjectedBinding
- construct source-authenticated guarded Return/Raise outward halted faces with path-specific BindingEntryV1 snapshots
- preserve break as a completed exit that bypasses else and keep downstream substitution on the guarded post-state

## Measured delta
- R_guarded_loop_recurrence: 2 -> 0 (Delta R -2)
- removed teeth: missing-loop-else-exhaustion-state; missing-loop-outward-halted-state

## Validation
- local focused: 26 passed
- battleaxe focused: 14 passed in 3.34s
- post-rebase focused: 14 passed
- R_construction_side_doors = 0; auditor_errors = 0
- R_construction_panic_catches_outside_audit = 0

Open and unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct loop else and halted outward faces in live loop recurrence
> - [`construct_live_loop_recurrence`](https://github.com/TSavo/sugar/pull/6187/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) now supports `for`/`while` `else` clauses, recording `elseBodyCid` and `elseExhaustionObligationCid` and associating else state with `NormalExhaustion`; previously, loops with `else` were rejected.
> - Guarded `return`/`raise` statements inside loop bodies are now captured as `LiveOutwardHaltedFaceV1` objects with their guards and path-state, rather than raising an error.
> - [`LoopRecurrenceSugar.desugar`](https://github.com/TSavo/sugar/pull/6187/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now emits an `ExitSet` with guarded `Completed`/`Halted` exits when `outward_faces` are present, instead of always returning a fall-through `Complete` block.
> - [`scan_guarded_loop_recurrence`](https://github.com/TSavo/sugar/pull/6187/files#diff-20cb5b4468f864e9b4eac5db9aa3cf32a713ec84b5afa16f0428504a3f773f00) detects `BindingStateWireGap` raises with specific messages and emits `missing-loop-else-exhaustion-state` and `missing-loop-outward-halted-state` findings.
> - Behavioral Change: loops with `else` or guarded outward exits that previously errored will now produce structured IR outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6f4de2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved live-loop control-flow handling for guarded returns, raises, breaks, continues, and `for`/`while ... else` branches.
  * Added accurate loop exit and completion tracking for outward halted paths.
  * Improved state projection when loops terminate normally or through alternate exits.

* **Bug Fixes**
  * Added clearer detection and reporting for missing loop exhaustion and outward halted states.

* **Tests**
  * Added coverage for loop post-projection, guarded exits, and else-branch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->