### PR TITLE
Construct occurrence-keyed subscript fields

### DIFF
--- a/docs/superpowers/plans/2026-07-23-object-subscript-fields.md
+++ b/docs/superpowers/plans/2026-07-23-object-subscript-fields.md
@@ -1,0 +1,78 @@
+# Object Subscript Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add authenticated `obj[key]` field places to the existing occurrence-keyed immutable object field map.
+
+**Architecture:** Add an authenticated subscript key/field coordinate and version variant, then route Subscript store/read through `ObjectPlaceStateV1._with_store` and `field`. Preserve the single temporal binding map, attribute vocabulary, and every loud boundary.
+
+**Tech Stack:** Python 3.12, frozen dataclasses, JCS/BLAKE3 CIDs, Sugar typed source tree, pytest.
+
+## Global Constraints
+
+- Object identity is the construction occurrence only.
+- Subscript state lives only in `ObjectPlaceStateV1`'s existing versioned field map.
+- No generic field-schema rewrite and no class/name/vendor gate.
+- Opaque, symbolic, unhashable, custom-dispatch, and out-of-range cases remain typed-loud.
+- One temporal binding model, immutable prior-linked versions, selective invalidation, no panic catch, no timeout increase.
+
+---
+
+### Task 1: Red coordinate and acceptance twins
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/tests/test_object_identity_v1.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/subscript_flow.py`
+
+**Interfaces:**
+- Produces: failing expectations for `SubscriptKeyCoordinateV1`, `SubscriptFieldCoordinateV1`, `SubscriptFieldVersionV1`, and supported `obj[key]` flow.
+
+- [ ] Add truthful/lying twins for key separation, aliases, version chains, forgery, and loud residuals.
+- [ ] Run the exact new tests and verify failures are caused by missing subscript coordinate/projection support.
+- [ ] Commit the red acceptance twins.
+
+### Task 2: Authenticated key and field coordinates
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py`
+- Test: `implementations/python/sugar-source-tree/tests/test_object_identity_v1.py`
+
+**Interfaces:**
+- Produces: `SubscriptKeyCoordinateV1.mint/decode`, `SubscriptFieldCoordinateV1.mint/decode`, and `SubscriptFieldVersionV1.mint/decode`.
+
+- [ ] Mint key coordinates only from decoded constructed-value testimony plus the constructed key term CID.
+- [ ] Bind field/version CIDs to the owner object coordinate, key coordinate, store occurrence, generation, value testimony, and prior version.
+- [ ] Reject stale owner, key testimony, key term, and prior-version CIDs.
+- [ ] Run coordinate twins green and commit.
+
+### Task 3: Same-map subscript store and read
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py`
+
+**Interfaces:**
+- Consumes: subscript coordinate/version types from Task 2.
+- Produces: `ObjectPlaceStateV1.with_subscript_store` and `subscript_field`, using existing selector/value/version arrays.
+
+- [ ] Construct key testimony once and admit only supported immutable/hashable key Floor values.
+- [ ] Route single Subscript assignment through `_with_store` and update every alias sharing the object coordinate.
+- [ ] Project Subscript reads by rebuilding the authenticated key coordinate; preserve branch joins and selective invalidation.
+- [ ] Extend place lowering with the closed `subscript` selector kind; unknown kinds stay loud.
+- [ ] Run acceptance twins green and commit.
+
+### Task 4: Loud-boundary and battleaxe verification
+
+**Files:**
+- Modify only tests if a missing discrimination twin is found.
+
+**Interfaces:**
+- Produces: final zero-side-door and focused receipts.
+
+- [ ] Run symbolic/opaque/unhashable/custom-dispatch/out-of-range twins and verify typed loudness.
+- [ ] Run construction side-door and panic-catch laws; require both `R=0` and no auditor errors.
+- [ ] Run the focused object identity, binding, Assign, Call, attribute, and subscript suite on battleaxe.
+- [ ] Rebase on current `origin/main`, rerun focused verification, force-push with lease, and open a ready unmerged PR.

--- a/docs/superpowers/specs/2026-07-23-object-subscript-fields-design.md
+++ b/docs/superpowers/specs/2026-07-23-object-subscript-fields-design.md
@@ -1,0 +1,19 @@
+# Object Subscript Field Coordinates
+
+## Ruling
+
+A supported `obj[key]` place is one field-coordinate variant inside the existing `ObjectPlaceStateV1` version map. Its owner is the construction-occurrence `object_coordinate`; its selector is an authenticated coordinate for the key's constructed value. It never derives object identity from a binding, type, spelling, equality, or field contents.
+
+## Representation
+
+Add `SubscriptFieldCoordinateV1(object_coordinate, key_coordinate, cid)` and `SubscriptFieldVersionV1` beside the attribute variants. The key coordinate cites a decoded `ConstructedValueTestimonyV1` and the constructed key term CID. `ObjectPlaceStateV1.selectors`, values, testimony, version, prior-version, and occurrence arrays remain the sole versioned field map. No generic-field rewrite and no second subscript state exist.
+
+## Construction
+
+`obj[key] = value` constructs the receiver, key, and value exactly once. When the receiver is an authenticated `ObjectPlaceStateV1`, the key has supported immutable/hashable construction testimony, and class subscript dispatch is default and constructed, it mints a subscript field version linked to the prior version for the same owner/key coordinate. `obj[key]` reconstructs the identical key coordinate and projects only the matching authenticated version.
+
+Opaque receivers, symbolic or opaque keys, unhashable keys, custom `__getitem__`/`__setitem__`, out-of-range accesses, forged coordinates/versions, and unknown selector variants remain typed-loud. Opaque calls invalidate only exposed object field knowledge, using the existing invalidation path.
+
+## Acceptance
+
+Truthful/renamed and lying twins cover store/read by key, distinct keys, alias sharing, immutable mutate/read chains, distinct object chains, forgery rejection, selective invalidation, symbolic key loudness, custom dispatch loudness, unhashable/out-of-range loudness, and opaque receiver/key loudness. Attribute behavior and wire vocabulary remain unchanged.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py
@@ -21,6 +21,13 @@ class PlaceAssignValue(FloorValue):
                 "python:attribute",
                 [receiver, str_const(self.selector)],
             )
+        elif self.selector_kind == "subscript":
+            if not isinstance(self.selector, FloorValue):
+                raise ValueError("subscript selector must be one FloorValue")
+            target = ctor(
+                "python:subscript",
+                [receiver, self.selector.to_term(owner=owner)],
+            )
         else:
             raise ValueError(f"unknown place selector kind {self.selector_kind!r}")
         return ctor(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
@@ -10,7 +10,7 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 class PlaceAssignSugar(Sugar):
     receiver: Sugar
     selector_kind: str
-    selector: str
+    selector: object
     value: Sugar
     site: object = field(compare=False)
 
@@ -29,10 +29,20 @@ class PlaceAssignSugar(Sugar):
 
         def with_receiver(receiver):
             def with_value(value):
-                if self.selector_kind != "attribute":
+                if self.selector_kind == "attribute":
+                    selector = self.selector
+                elif self.selector_kind == "subscript":
+                    return self.selector.desugar(ctx).and_then(
+                        lambda selector: Complete(
+                            PlaceAssignValue(
+                                receiver, "subscript", selector, value
+                            )
+                        )
+                    )
+                else:
                     raise ValueError("typed place selector mismatch")
                 return Complete(
-                    PlaceAssignValue(receiver, "attribute", self.selector, value)
+                    PlaceAssignValue(receiver, "attribute", selector, value)
                 )
 
             return self.value.desugar(ctx).and_then(with_value)

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -403,6 +403,20 @@ def test_custom_setitem_receiver_stays_loud(tmp_path):
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
 
 
+def test_custom_getitem_receiver_stays_loud(tmp_path):
+    path = tmp_path / "getitem.py"
+    path.write_text(
+        "class Vessel:\n"
+        "    def __getitem__(self, key):\n"
+        "        return 7\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
 def test_plain_object_subscript_store_then_read_uses_same_field_map(tmp_path):
     path = tmp_path / "plain_object_subscript.py"
     path.write_text(
@@ -416,6 +430,31 @@ def test_plain_object_subscript_store_then_read_uses_same_field_map(tmp_path):
     states = _object_states(path, "boundary")
     assert states[-1].selectors
     assert states[-1].field(states[-1].selectors[0]) is not None
+
+
+def test_subscript_aliases_share_identity_and_immutable_versions(tmp_path):
+    path = tmp_path / "subscript_alias_versions.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    alias = item\n"
+        "    item[0] = 7\n"
+        "    first = alias[0]\n"
+        "    alias[0] = 11\n"
+        "    return item[0]\n"
+    )
+    assert not _is_typed_loud(_outcome_or_panic(path, "boundary"))
+    states = _object_states(path, "boundary")
+    assert {state.object_identity_cid for state in states} == {
+        states[0].object_identity_cid
+    }
+    final = states[-1]
+    assert len(final.selectors) == 1
+    assert len(final.version_cids) == 1
+    assert final.prior_version_cids[0] is not None
+    assert final.prior_version_cids[0] != final.version_cids[0]
+    assert final.field(final.selectors[0]) is not None
 
 
 def test_distinct_constructed_subscript_keys_do_not_collide(tmp_path):
@@ -442,6 +481,18 @@ def test_symbolic_subscript_key_stays_typed_loud(tmp_path):
         "    item = Vessel()\n"
         "    item[key] = 7\n"
         "    return item[key]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_unhashable_subscript_key_stays_typed_loud(tmp_path):
+    path = tmp_path / "unhashable_subscript_key.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[[]] = 7\n"
+        "    return item[[]]\n"
     )
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -403,7 +403,7 @@ def test_custom_setitem_receiver_stays_loud(tmp_path):
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
 
 
-def test_plain_object_without_setitem_stays_loud(tmp_path):
+def test_plain_object_subscript_store_then_read_uses_same_field_map(tmp_path):
     path = tmp_path / "plain_object_subscript.py"
     path.write_text(
         "class Vessel:\n    pass\n\n"
@@ -411,6 +411,37 @@ def test_plain_object_without_setitem_stays_loud(tmp_path):
         "    item = Vessel()\n"
         "    item[0] = 7\n"
         "    return item[0]\n"
+    )
+    assert not _is_typed_loud(_outcome_or_panic(path, "boundary"))
+    states = _object_states(path, "boundary")
+    assert states[-1].selectors
+    assert states[-1].field(states[-1].selectors[0]) is not None
+
+
+def test_distinct_constructed_subscript_keys_do_not_collide(tmp_path):
+    path = tmp_path / "distinct_subscript_keys.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[0] = 7\n"
+        "    item[1] = 11\n"
+        "    return item[0]\n"
+    )
+    assert not _is_typed_loud(_outcome_or_panic(path, "boundary"))
+    state = _object_states(path, "boundary")[-1]
+    assert len(state.selectors) == 2
+    assert len(set(state.version_cids)) == 2
+
+
+def test_symbolic_subscript_key_stays_typed_loud(tmp_path):
+    path = tmp_path / "symbolic_subscript_key.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary(key):\n"
+        "    item = Vessel()\n"
+        "    item[key] = 7\n"
+        "    return item[key]\n"
     )
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2621,8 +2621,17 @@ class Assign(Statement):
         ):
             target = self.targets[0]
             receiver, receiver_changed = self._substitute_field(target.value, scope)
-            if receiver_changed:
-                changes["targets"] = (rewrite(target, value=receiver),)
+            target_changes = {"value": receiver} if receiver_changed else {}
+            if isinstance(target, Subscript):
+                index, index_changed = self._substitute_field(target.slice_, scope)
+                if index_changed:
+                    target_changes["slice_"] = index
+                if isinstance(receiver, ObjectPlaceStateV1):
+                    projected = receiver.subscript_key_projection(index)
+                    if projected is not None:
+                        target_changes["slice_"] = projected
+            if target_changes:
+                changes["targets"] = (rewrite(target, **target_changes),)
         if not changes:
             return self
         return rewrite(self, **changes)
@@ -2737,6 +2746,23 @@ class Assign(Statement):
             ):
                 updated = target.value.with_attribute_store(
                     target.attr, self.value, self.fragment
+                )
+                if updated is None:
+                    return None
+                return {
+                    name: replace(entry, state=updated)
+                    for name, entry in scope.items()
+                    if isinstance(name, str)
+                    and isinstance(entry, BindingEntryV1)
+                    and isinstance(entry.state, ObjectPlaceStateV1)
+                    and entry.state.object_identity_cid
+                    == target.value.object_identity_cid
+                }
+            if isinstance(target, Subscript) and isinstance(
+                target.value, ObjectPlaceStateV1
+            ):
+                updated = target.value.with_subscript_store(
+                    target.slice_, self.value, self.fragment
                 )
                 if updated is None:
                     return None
@@ -2899,7 +2925,9 @@ class Assign(Statement):
                 from .shadow import rewrite
 
                 return rewrite(self, value=entry.state)
-        if len(self.targets) != 1 or not isinstance(self.targets[0], Attribute):
+        if len(self.targets) != 1 or not isinstance(
+            self.targets[0], (Attribute, Subscript)
+        ):
             return self
         prior = self.targets[0].value
         if not isinstance(prior, ObjectPlaceStateV1):
@@ -2919,7 +2947,11 @@ class Assign(Statement):
         from .shadow import rewrite
 
         target = self.targets[0]
-        projected = updated.attribute_field(target.attr)
+        projected = (
+            updated.attribute_field(target.attr)
+            if isinstance(target, Attribute)
+            else updated.subscript_field(target.slice_)
+        )
         if projected is None:
             return self
         return rewrite(
@@ -3065,7 +3097,17 @@ class Assign(Statement):
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Subscript):
             if isinstance(self.targets[0].value, ObjectPlaceStateV1):
-                return super()._construct_sugar()
+                from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                    PlaceAssignSugar,
+                )
+
+                return PlaceAssignSugar(
+                    receiver=self.targets[0].value.sugar(),
+                    selector_kind="subscript",
+                    selector=self.targets[0].slice_.sugar(),
+                    value=self.value.sugar(),
+                    site=self.fragment,
+                )
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
                 SubscriptStoreEffectSugar,
             )
@@ -6684,17 +6726,75 @@ class ObjectPlaceStateV1(Expression):
             occurrence,
         )
 
+    @staticmethod
+    def subscript_key_projection(key):
+        if isinstance(key, ConstructedValueProjectionV1):
+            key.validate_testimony()
+            constructed = (key.constructed_value, key.construction_testimony)
+        else:
+            constructed = Assign._constructed_floor_value(key)
+        if constructed is None:
+            return None
+        floor_value, testimony = constructed
+        from sugar_lift_py_tests.floor import StringValue, TermValue
+
+        supported = isinstance(floor_value, StringValue) or (
+            isinstance(floor_value, TermValue) and type(floor_value.value) is int
+        )
+        if not supported:
+            return None
+        if isinstance(key, ConstructedValueProjectionV1):
+            return key
+        return ConstructedValueProjectionV1.create(key, floor_value, testimony)
+
+    def _subscript_coordinate(self, key):
+        projected = self.subscript_key_projection(key)
+        if projected is None:
+            return None
+        from sugar_lift_py_tests.ir import _term_content_cid
+        from .object_identity import (
+            SubscriptFieldCoordinateV1,
+            SubscriptKeyCoordinateV1,
+        )
+
+        key_coordinate = SubscriptKeyCoordinateV1.mint(
+            constructed_value_cid=_term_content_cid(
+                projected.constructed_value.to_term(owner="subscript-key")
+            ),
+            construction_testimony_cid=projected.construction_testimony.cid,
+        )
+        return SubscriptFieldCoordinateV1.mint(
+            self.object_coordinate, key_coordinate
+        )
+
+    def with_subscript_store(self, key, value, occurrence):
+        selector = self._subscript_coordinate(key)
+        if selector is None:
+            return None
+        return self._with_store(selector, value, occurrence)
+
     def _with_store(self, selector, value, occurrence, *, constructed=None):
         self.validate_identity()
         constructed = constructed or Assign._constructed_floor_value(value)
         if constructed is None:
             return None
         floor_value, testimony = constructed
-        projected = ConstructedValueProjectionV1.create(value, floor_value, testimony)
-        from .object_identity import AttributeFieldVersionV1
+        projected = ConstructedValueProjectionV1.create(
+            value, floor_value, testimony
+        )
+        from .object_identity import (
+            AttributeFieldCoordinateV1,
+            AttributeFieldVersionV1,
+            SubscriptFieldVersionV1,
+        )
 
         prior = self.version(selector)
-        version = AttributeFieldVersionV1.mint(
+        version_type = (
+            AttributeFieldVersionV1
+            if isinstance(selector, AttributeFieldCoordinateV1)
+            else SubscriptFieldVersionV1
+        )
+        version = version_type.mint(
             owner=self.object_coordinate,
             field=selector,
             store_occurrence=occurrence,
@@ -6745,6 +6845,10 @@ class ObjectPlaceStateV1(Expression):
 
         return self.field(AttributeFieldCoordinateV1.mint(self.object_coordinate, name))
 
+    def subscript_field(self, key):
+        selector = self._subscript_coordinate(key)
+        return None if selector is None else self.field(selector)
+
     def field(self, selector):
         self.validate_identity()
         if self.invalidated_by_opaque_call:
@@ -6757,7 +6861,11 @@ class ObjectPlaceStateV1(Expression):
             BindingProvenanceGap,
             ConstructedValueTestimonyV1,
         )
-        from .object_identity import AttributeFieldVersionV1
+        from .object_identity import (
+            AttributeFieldCoordinateV1,
+            AttributeFieldVersionV1,
+            SubscriptFieldVersionV1,
+        )
 
         testimony = self.value_testimonies[index]
         ConstructedValueTestimonyV1.decode(testimony.wire())
@@ -6767,7 +6875,12 @@ class ObjectPlaceStateV1(Expression):
         projected.validate_testimony()
         if projected.construction_testimony != testimony:
             raise BindingProvenanceGap("field value testimony mismatch")
-        version = AttributeFieldVersionV1.decode(self.version_records[index].wire())
+        version_type = (
+            AttributeFieldVersionV1
+            if isinstance(selector, AttributeFieldCoordinateV1)
+            else SubscriptFieldVersionV1
+        )
+        version = version_type.decode(self.version_records[index].wire())
         if (
             version.cid != self.version_cids[index]
             or version.owner.cid != self.object_coordinate.cid
@@ -6941,6 +7054,12 @@ class Subscript(Expression):
 
         receiver, receiver_changed = self._substitute_field(self.value, scope)
         index, index_changed = self._substitute_field(self.slice_, scope)
+        if isinstance(receiver, ObjectPlaceStateV1):
+            projected_key = receiver.subscript_key_projection(index)
+            if projected_key is not None:
+                projected = receiver.subscript_field(projected_key)
+                if projected is not None:
+                    return projected
         if not receiver_changed and not index_changed:
             return self
         return rewrite(self, value=receiver, slice_=index)
@@ -6949,6 +7068,8 @@ class Subscript(Expression):
         """`<value>[<slice_>]` constructs SubscriptSugar WITH the receiver's and
         index's sugars. A Slice index reduces to its own gap through the
         recursion (slice_.sugar()), never silently handled here."""
+        if isinstance(self.value, OpaqueObjectStateV1):
+            return super()._construct_sugar()
         from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
 
         return SubscriptSugar(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
@@ -197,6 +197,122 @@ class AttributeFieldCoordinateV1:
 
 
 @dataclass(frozen=True)
+class SubscriptKeyCoordinateV1:
+    constructed_value_cid: str
+    construction_testimony_cid: str
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "subscript-key-coordinate",
+            "schemaVersion": "1",
+            "constructedValueCid": self.constructed_value_cid,
+            "constructionTestimonyCid": self.construction_testimony_cid,
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "keyCoordinateCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls, *, constructed_value_cid: str, construction_testimony_cid: str
+    ) -> "SubscriptKeyCoordinateV1":
+        preimage = {
+            "kind": "subscript-key-coordinate",
+            "schemaVersion": "1",
+            "constructedValueCid": _cid(
+                constructed_value_cid, "constructedValueCid"
+            ),
+            "constructionTestimonyCid": _cid(
+                construction_testimony_cid, "constructionTestimonyCid"
+            ),
+        }
+        return cls(
+            constructed_value_cid,
+            construction_testimony_cid,
+            cid_of_json(preimage),
+        )
+
+    @classmethod
+    def decode(cls, raw: object) -> "SubscriptKeyCoordinateV1":
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "constructedValueCid",
+                "constructionTestimonyCid",
+                "keyCoordinateCid",
+            },
+            cls.__name__,
+        )
+        if raw["kind"] != "subscript-key-coordinate" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported SubscriptKeyCoordinateV1")
+        value = _cid(raw["constructedValueCid"], "constructedValueCid")
+        testimony = _cid(
+            raw["constructionTestimonyCid"], "constructionTestimonyCid"
+        )
+        preimage = {key: value for key, value in raw.items() if key != "keyCoordinateCid"}
+        cid = _checked(preimage, raw["keyCoordinateCid"], "key coordinate CID")
+        return cls(value, testimony, cid)
+
+
+@dataclass(frozen=True)
+class SubscriptFieldCoordinateV1:
+    object_coordinate: ObjectCoordinateV1
+    key_coordinate: SubscriptKeyCoordinateV1
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "subscript-field-coordinate",
+            "schemaVersion": "1",
+            "objectCoordinate": self.object_coordinate.wire(),
+            "keyCoordinate": self.key_coordinate.wire(),
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "fieldCoordinateCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls, owner: ObjectCoordinateV1, key: SubscriptKeyCoordinateV1
+    ) -> "SubscriptFieldCoordinateV1":
+        decode_object_coordinate_v1(owner.wire())
+        SubscriptKeyCoordinateV1.decode(key.wire())
+        preimage = {
+            "kind": "subscript-field-coordinate",
+            "schemaVersion": "1",
+            "objectCoordinate": owner.wire(),
+            "keyCoordinate": key.wire(),
+        }
+        return cls(owner, key, cid_of_json(preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "SubscriptFieldCoordinateV1":
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "objectCoordinate",
+                "keyCoordinate",
+                "fieldCoordinateCid",
+            },
+            cls.__name__,
+        )
+        if raw["kind"] != "subscript-field-coordinate" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported SubscriptFieldCoordinateV1")
+        owner = decode_object_coordinate_v1(raw["objectCoordinate"])
+        key_coordinate = SubscriptKeyCoordinateV1.decode(raw["keyCoordinate"])
+        preimage = {key: value for key, value in raw.items() if key != "fieldCoordinateCid"}
+        cid = _checked(preimage, raw["fieldCoordinateCid"], "field coordinate CID")
+        return cls(owner, key_coordinate, cid)
+
+
+@dataclass(frozen=True)
 class AttributeFieldVersionV1:
     owner: ObjectCoordinateV1
     field: AttributeFieldCoordinateV1
@@ -243,6 +359,105 @@ class AttributeFieldVersionV1:
             raise BindingProvenanceGap("unsupported AttributeFieldVersionV1")
         owner = decode_object_coordinate_v1(raw["objectCoordinate"])
         field = AttributeFieldCoordinateV1.decode(raw["fieldCoordinate"])
+        if field.object_coordinate.cid != owner.cid:
+            raise BindingProvenanceGap("field owner coordinate mismatch")
+        store = _memento(raw["storeOccurrence"], "storeOccurrence")
+        generation = _generation(raw["constructionGeneration"])
+        stored = _cid(raw["storedValueTestimonyCid"], "storedValueTestimonyCid")
+        prior = raw["priorVersionCid"]
+        if prior is not None:
+            prior = _cid(prior, "priorVersionCid")
+        preimage = {key: value for key, value in raw.items() if key != "fieldVersionCid"}
+        cid = _checked(preimage, raw["fieldVersionCid"], "field version CID")
+        return cls(owner, field, store, generation, stored, prior, cid)
+
+
+@dataclass(frozen=True)
+class SubscriptFieldVersionV1:
+    owner: ObjectCoordinateV1
+    field: SubscriptFieldCoordinateV1
+    store_occurrence: dict[str, Any]
+    construction_generation: int
+    stored_value_testimony_cid: str
+    prior_version_cid: str | None
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "subscript-field-version",
+            "schemaVersion": "1",
+            "objectCoordinate": self.owner.wire(),
+            "fieldCoordinate": self.field.wire(),
+            "storeOccurrence": self.store_occurrence,
+            "constructionGeneration": self.construction_generation,
+            "storedValueTestimonyCid": self.stored_value_testimony_cid,
+            "priorVersionCid": self.prior_version_cid,
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "fieldVersionCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        owner: ObjectCoordinateV1,
+        field: SubscriptFieldCoordinateV1,
+        store_occurrence: SourceFragment,
+        construction_generation: int,
+        stored_value_testimony_cid: str,
+        prior_version_cid: str | None,
+    ) -> "SubscriptFieldVersionV1":
+        decode_object_coordinate_v1(owner.wire())
+        SubscriptFieldCoordinateV1.decode(field.wire())
+        if field.object_coordinate.cid != owner.cid:
+            raise BindingProvenanceGap("field owner coordinate mismatch")
+        if prior_version_cid is not None:
+            _cid(prior_version_cid, "priorVersionCid")
+        preimage = {
+            "kind": "subscript-field-version",
+            "schemaVersion": "1",
+            "objectCoordinate": owner.wire(),
+            "fieldCoordinate": field.wire(),
+            "storeOccurrence": store_occurrence.seal().to_dict(),
+            "constructionGeneration": _generation(construction_generation),
+            "storedValueTestimonyCid": _cid(
+                stored_value_testimony_cid, "storedValueTestimonyCid"
+            ),
+            "priorVersionCid": prior_version_cid,
+        }
+        return cls(
+            owner,
+            field,
+            preimage["storeOccurrence"],
+            construction_generation,
+            stored_value_testimony_cid,
+            prior_version_cid,
+            cid_of_json(preimage),
+        )
+
+    @classmethod
+    def decode(cls, raw: object) -> "SubscriptFieldVersionV1":
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "objectCoordinate",
+                "fieldCoordinate",
+                "storeOccurrence",
+                "constructionGeneration",
+                "storedValueTestimonyCid",
+                "priorVersionCid",
+                "fieldVersionCid",
+            },
+            cls.__name__,
+        )
+        if raw["kind"] != "subscript-field-version" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported SubscriptFieldVersionV1")
+        owner = decode_object_coordinate_v1(raw["objectCoordinate"])
+        field = SubscriptFieldCoordinateV1.decode(raw["fieldCoordinate"])
         if field.object_coordinate.cid != owner.cid:
             raise BindingProvenanceGap("field owner coordinate mismatch")
         store = _memento(raw["storeOccurrence"], "storeOccurrence")

--- a/implementations/python/sugar-source-tree/tests/test_object_identity_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_object_identity_v1.py
@@ -13,6 +13,9 @@ from sugar_source_tree.object_identity import (
     AttributeFieldVersionV1,
     OpaqueObjectCoordinateV1,
     SourceObjectCoordinateV1,
+    SubscriptFieldCoordinateV1,
+    SubscriptFieldVersionV1,
+    SubscriptKeyCoordinateV1,
     decode_object_coordinate_v1,
 )
 from sugar_source_tree.tree import SourceFile
@@ -93,3 +96,43 @@ def test_attribute_versions_are_immutable_prior_linked_and_closed():
             forged[key] = "blake3-512:forged"
         with pytest.raises(BindingProvenanceGap):
             AttributeFieldVersionV1.decode(forged)
+
+
+def test_subscript_versions_key_the_same_object_by_authenticated_key_coordinate():
+    site, _ = _calls()
+    owner = _source(site)
+    zero = SubscriptKeyCoordinateV1.mint(
+        constructed_value_cid=cid_of_json({"key": 0}),
+        construction_testimony_cid=cid_of_json({"testimony": 0}),
+    )
+    one = SubscriptKeyCoordinateV1.mint(
+        constructed_value_cid=cid_of_json({"key": 1}),
+        construction_testimony_cid=cid_of_json({"testimony": 1}),
+    )
+    zero_field = SubscriptFieldCoordinateV1.mint(owner, zero)
+    one_field = SubscriptFieldCoordinateV1.mint(owner, one)
+    assert zero_field.cid != one_field.cid
+
+    first = SubscriptFieldVersionV1.mint(
+        owner=owner,
+        field=zero_field,
+        store_occurrence=site,
+        construction_generation=1,
+        stored_value_testimony_cid=cid_of_json({"value": 7}),
+        prior_version_cid=None,
+    )
+    second = SubscriptFieldVersionV1.mint(
+        owner=owner,
+        field=zero_field,
+        store_occurrence=site,
+        construction_generation=2,
+        stored_value_testimony_cid=cid_of_json({"value": 8}),
+        prior_version_cid=first.cid,
+    )
+    assert second.prior_version_cid == first.cid
+    assert SubscriptFieldVersionV1.decode(second.wire()) == second
+
+    forged = deepcopy(second.wire())
+    forged["fieldCoordinate"] = one_field.wire()
+    with pytest.raises(BindingProvenanceGap):
+        SubscriptFieldVersionV1.decode(forged)


### PR DESCRIPTION
## Summary
- authenticate subscript key and field coordinates under the existing occurrence-derived object coordinate
- store subscript fields in ObjectPlaceStateV1's existing immutable selector/version map
- route constructed integer/string key stores and reads through the same alias-shared temporal binding model
- keep symbolic, unhashable, custom-dispatch, opaque/native, and out-of-range cases typed-loud

## Soundness
- no class-specific identity arm or binding-owner identity
- no duplicate subscript state or generic field-schema rewrite
- forged key/field/version coordinates are rejected by exact decoding and CID checks
- opaque invalidation remains field-selective through the shared ObjectPlaceStateV1 map

## Validation
- focused local: 49 passed
- focused battleaxe: 49 passed
- broader relevant local: 82 passed; 2 unrelated RPC slice tests reproduce red on the independent docstring branch because their subprocess resolves an installed RPC without `lift`
- R_construction_side_doors = 0; auditor_errors = 0
- R_construction_panic_catches_outside_audit = 0

## Honest delta
No pandas/NumPy corpus census was run, so corpus Delta R is unmeasured. In the planted acceptance set, constructed plain-object keyed store/read and distinct-key separation move from typed-loud to constructed; the unsupported-key and custom-dispatch twins remain typed-loud.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct occurrence-keyed subscript fields in `ObjectPlaceStateV1`
> - Adds `SubscriptKeyCoordinateV1`, `SubscriptFieldCoordinateV1`, and `SubscriptFieldVersionV1` to [object_identity.py](https://github.com/TSavo/sugar/pull/6188/files#diff-6c1b2414b1c0f2521f5f7002a4460b90626fe581f656b8388036e2d1e9326128) to represent authenticated `obj[key]` field coordinates and version records in the same versioned field map used by attribute fields.
> - Extends `ObjectPlaceStateV1` with `with_subscript_store`, `subscript_field`, `subscript_key_projection`, and `_subscript_coordinate` to route `obj[key]` stores and reads through the unified field map; unsupported or unhashable keys return `None`.
> - Updates `Assign` and `Subscript` nodes in [nodes.py](https://github.com/TSavo/sugar/pull/6188/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to lower subscript assignments and reads into authenticated projections during substitution and binding.
> - Extends the sugar/lift layer in [place_assign_sugar.py](https://github.com/TSavo/sugar/pull/6188/files#diff-a82c3e0bfd0ee3f67efd36378e3b37e320ffaf0ff71f7546d93f05029e07d1ba) and [place_assign_value.py](https://github.com/TSavo/sugar/pull/6188/files#diff-76e0a768c8fbc54ed1eb997b28054be13af0c3868e88512904f2fea76c262c5a) to desugar and lower subscript-place assignments into `python:subscript` IR.
> - Adds acceptance tests covering store/read round-trips, alias identity, version chaining, key collision avoidance, and loudness for symbolic, unhashable, and custom-`__getitem__` receivers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7762efc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->