### PR TITLE
Authenticate stdlib dependency artifacts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dynamic_unpack_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dynamic_unpack_assign_sugar.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class DynamicUnpackAssignSugar(Sugar):
+    """Construct a valid unpack shape while keeping unknown iteration loud."""
+
+    target_names: tuple[str, ...]
+    value: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="typed dynamic unpack obligation",
+            reason="unknown iterable cardinality and members cannot fabricate bindings",
+        )
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="DynamicUnpackAssignSugar.desugar",
+            observed="runtime-selected unpack members",
+            requested="authenticated finite iterable members and cardinality",
+            fix="construct the iterable members or keep the unpack obligation loud",
+        )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from email.parser import BytesParser
+import importlib.machinery
 import importlib.metadata
 from pathlib import Path, PurePosixPath
 import sys
+import sysconfig
 from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
@@ -341,6 +343,7 @@ PythonObjectResolutionV1 = ResolvedPythonObjectV1 | PythonObjectResolutionGapV1
 
 @dataclass(frozen=True)
 class DependencyArtifactGraph:
+    artifact_kind: Literal["distribution", "stdlib"]
     distribution_name: str
     distribution_version: str
     distribution_artifact_cid: str
@@ -353,22 +356,27 @@ class DependencyArtifactGraph:
             raise DependencyArtifactAuthenticationError(
                 "dependency artifact graph was not minted by SourceOracle intake"
             )
-        metadata_files = [
-            item
-            for item in self.files
-            if item.source_seat.endswith(".dist-info/METADATA")
-        ]
-        if len(metadata_files) != 1:
+        if self.artifact_kind == "distribution":
+            metadata_files = [
+                item
+                for item in self.files
+                if item.source_seat.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_files) != 1:
+                raise DependencyArtifactAuthenticationError(
+                    "distribution graph must retain one METADATA preimage"
+                )
+            metadata = BytesParser().parsebytes(metadata_files[0].content)
+            if (
+                metadata.get("Name") != self.distribution_name
+                or metadata.get("Version") != self.distribution_version
+            ):
+                raise DependencyArtifactAuthenticationError(
+                    "distribution identity does not match its METADATA preimage"
+                )
+        elif self.artifact_kind != "stdlib":
             raise DependencyArtifactAuthenticationError(
-                "distribution graph must retain one METADATA preimage"
-            )
-        metadata = BytesParser().parsebytes(metadata_files[0].content)
-        if (
-            metadata.get("Name") != self.distribution_name
-            or metadata.get("Version") != self.distribution_version
-        ):
-            raise DependencyArtifactAuthenticationError(
-                "distribution identity does not match its METADATA preimage"
+                "dependency artifact graph has an unknown intake kind"
             )
         records = [
             {"path": item.source_seat, "contentCid": item.content_cid}
@@ -380,7 +388,11 @@ class DependencyArtifactGraph:
             )
         expected = cid_of_json(
             {
-                "kind": "python-dependency-artifact",
+                "kind": (
+                    "python-dependency-artifact"
+                    if self.artifact_kind == "distribution"
+                    else "python-stdlib-artifact"
+                ),
                 "schemaVersion": "1",
                 "distributionName": self.distribution_name,
                 "distributionVersion": self.distribution_version,
@@ -500,6 +512,7 @@ class DependencyArtifactGraph:
             ],
         }
         return cls(
+            artifact_kind="distribution",
             distribution_name=name,
             distribution_version=version,
             distribution_artifact_cid=cid_of_json(preimage),
@@ -507,6 +520,119 @@ class DependencyArtifactGraph:
             modules=MappingProxyType(modules),
             _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
         )
+
+    @classmethod
+    def authenticate_stdlib_module(cls, module_name: str) -> "DependencyArtifactGraph":
+        """Authenticate source reached through the running Python's stdlib root."""
+        if not module_name or not all(
+            part.isidentifier() for part in module_name.split(".")
+        ):
+            raise DependencyArtifactAuthenticationError("invalid stdlib module name")
+        root = Path(sysconfig.get_path("stdlib")).resolve()
+        top_level = module_name.split(".", 1)[0]
+        spec = importlib.machinery.PathFinder.find_spec(top_level, [str(root)])
+        if spec is None or spec.origin is None:
+            raise DependencyArtifactAuthenticationError(
+                "module has no source in the authenticated stdlib root"
+            )
+        return cls.authenticate_stdlib_path(
+            top_level, Path(spec.origin), stdlib_root=root
+        )
+
+    @classmethod
+    def authenticate_stdlib_path(
+        cls, module_name: str, path: Path, *, stdlib_root: Path
+    ) -> "DependencyArtifactGraph":
+        """Content-address one stdlib module/package after root containment."""
+        root = stdlib_root.resolve()
+        source_path = path.resolve()
+        if (
+            not source_path.is_relative_to(root)
+            or any(
+                part in {"site-packages", "dist-packages"} for part in source_path.parts
+            )
+            or source_path.suffix != ".py"
+        ):
+            raise DependencyArtifactAuthenticationError(
+                "module source is outside the authenticated stdlib root"
+            )
+        paths = (
+            sorted(source_path.parent.rglob("*.py"))
+            if source_path.name == "__init__.py"
+            else [source_path]
+        )
+        authenticated_files: list[AuthenticatedArtifactFileV1] = []
+        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        for candidate in paths:
+            relative = PurePosixPath(candidate.relative_to(root).as_posix())
+            SourceFile, BackendCouldNotParse = _source_file_cls()
+            try:
+                content, _seat, content_cid = dependency_artifact_file(str(candidate))
+                source = content.decode("utf-8")
+                SourceFile((source, str(candidate), content_cid))
+            except (SourceUnavailable, UnicodeError, SyntaxError, ValueError) as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"cannot authenticate stdlib source {relative}"
+                ) from exc
+            except BackendCouldNotParse as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"cannot authenticate stdlib source {relative}"
+                ) from exc
+            authenticated_files.append(
+                AuthenticatedArtifactFileV1(relative.as_posix(), content_cid, content)
+            )
+            projected_name = _module_name(relative)
+            if projected_name is not None:
+                modules[projected_name] = AuthenticatedModuleSourceV1(
+                    projected_name, relative.as_posix(), content_cid, source
+                )
+        if module_name not in modules:
+            raise DependencyArtifactAuthenticationError(
+                "requested stdlib module is not projected from authenticated source"
+            )
+        runtime_version = sys.implementation.cache_tag or sys.version.split()[0]
+        name = f"{sys.implementation.name}-stdlib"
+        records = [
+            {"path": item.source_seat, "contentCid": item.content_cid}
+            for item in authenticated_files
+        ]
+        preimage = {
+            "kind": "python-stdlib-artifact",
+            "schemaVersion": "1",
+            "distributionName": name,
+            "distributionVersion": runtime_version,
+            "files": records,
+        }
+        return cls(
+            artifact_kind="stdlib",
+            distribution_name=name,
+            distribution_version=runtime_version,
+            distribution_artifact_cid=cid_of_json(preimage),
+            files=tuple(authenticated_files),
+            modules=MappingProxyType(modules),
+            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
+        )
+
+
+def authenticate_dependency_top_level(
+    top_level: str,
+    *,
+    distribution_index: Mapping[str, importlib.metadata.Distribution] | None = None,
+) -> DependencyArtifactGraph:
+    """Authenticate a distribution or stdlib module through one graph door."""
+    if distribution_index is not None and top_level in distribution_index:
+        return DependencyArtifactGraph.authenticate(distribution_index[top_level])
+    packages = importlib.metadata.packages_distributions()
+    distributions = tuple(packages.get(top_level, ()))
+    if len(distributions) == 1:
+        return DependencyArtifactGraph.authenticate(
+            importlib.metadata.distribution(distributions[0])
+        )
+    if distributions:
+        raise DependencyArtifactAuthenticationError(
+            "top-level module belongs to multiple installed distributions"
+        )
+    return DependencyArtifactGraph.authenticate_stdlib_module(top_level)
 
 
 def resolve_import_binding(
@@ -582,8 +708,6 @@ def resolve_import_binding(
     )
 
 
-
-
 def _binding_target(
     value: Mapping[str, Any],
 ) -> tuple[str, tuple[str, ...], str | None]:
@@ -606,6 +730,7 @@ def _binding_target(
         raise ValueError("invalid exported path")
     return _string(module_name, "module name"), tuple(path), source_cid
 
+
 def _module_name(path: PurePosixPath) -> str | None:
     if path.suffix != ".py":
         return None
@@ -617,6 +742,7 @@ def _module_name(path: PurePosixPath) -> str | None:
     if not parts or not all(part.isidentifier() for part in parts):
         return None
     return ".".join(parts)
+
 
 def _gap(
     kind: Any,
@@ -633,20 +759,24 @@ def _gap(
         exported_name=exported_name,
     )
 
+
 def _require_exact_keys(value: Any, expected: set[str], label: str) -> None:
     if not isinstance(value, dict) or set(value) != expected:
         raise ValueError(f"{label} has an invalid key set")
+
 
 def _string(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"{label} must be a nonempty string")
     return value
 
+
 def _cid(value: Any, label: str) -> str:
     value = _string(value, label)
     if not value.startswith("blake3-512:"):
         raise ValueError(f"{label} must be a content CID")
     return value
+
 
 def _nonnegative_int(value: Any, label: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
@@ -664,4 +794,3 @@ def export_statement_coverage():
     from .dependency_export_adapter import export_statement_coverage as _coverage
 
     return _coverage()
-

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -273,7 +273,9 @@ def resolve_source_visible_frame(
     if hit is not None:
         return hit
 
-    result = _resolve_source_visible_frame_uncached(resolved, graph=graph, module=module)
+    result = _resolve_source_visible_frame_uncached(
+        resolved, graph=graph, module=module
+    )
     if isinstance(result, tuple) and len(result) == 3:
         frame, target, source_file = result
         # Hold the SourceFile that owns target/frame node identity.
@@ -308,6 +310,32 @@ def _resolve_source_visible_frame_uncached(
         return ManagerConstructionGapV1(
             "definition-missing", resolved.cid, "resolved definition coordinate"
         )
+
+    definitions_by_name = {item.name: item for item in definitions}
+    reachable_names = {target.name}
+    pending_names = [target.name]
+    while pending_names:
+        current = definitions_by_name[pending_names.pop()]
+        dependencies = []
+        if isinstance(current, ClassDef):
+            dependencies.extend(
+                base.id for base in current.bases if isinstance(base, Name)
+            )
+            functions = tuple(
+                item for item in current.body if isinstance(item, FunctionDef)
+            )
+        else:
+            functions = (current,)
+        dependencies.extend(
+            call.func.id
+            for function in functions
+            for call in _local_named_calls(function)
+        )
+        for name in dependencies:
+            if name in definitions_by_name and name not in reachable_names:
+                reachable_names.add(name)
+                pending_names.append(name)
+    definitions = tuple(item for item in definitions if item.name in reachable_names)
 
     definition_names = {item.name for item in definitions}
     from sugar_lift_py_tests.floor import BuiltinSemanticCallable

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -386,11 +386,9 @@ def populate_source_derived_resource_refs(
     artifact_graph_cache: dict | None = None,
 ) -> None:
     """Preconstruct imported resource managers and freeze exact use-site rows."""
-    import importlib.metadata
     from pathlib import Path
 
     from sugar_lift_py_tests.context_manager_resolution import (
-        ContextManagerResolutionGapV1,
         SourceDerivedContextManagerRefV1,
         SourceFragmentCoordinateV1,
     )
@@ -401,7 +399,6 @@ def populate_source_derived_resource_refs(
     from sugar_source_tree.nodes import Call, With
 
     from .dependency_artifact import (
-        DependencyArtifactGraph,
         ResolvedPythonObjectV1,
         resolve_import_binding,
     )
@@ -442,11 +439,6 @@ def populate_source_derived_resource_refs(
                 expr,
                 item._exit_face_id(),
             )
-    packages = (
-        importlib.metadata.packages_distributions()
-        if distribution_index is None
-        else {name: (name,) for name in distribution_index}
-    )
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
     for receipt in receipts:
         raw_site = receipt.use["useSite"]
@@ -461,18 +453,22 @@ def populate_source_derived_resource_refs(
             continue
         coordinate, call, exit_face_id = selected
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-        distributions = tuple(packages.get(top_level, ()))
-        if len(distributions) != 1:
-            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
-            continue
-        distribution = (
-            importlib.metadata.distribution(distributions[0])
-            if distribution_index is None
-            else distribution_index[top_level]
-        )
         graph = graphs.get(top_level)
         if graph is None:
-            graph = DependencyArtifactGraph.authenticate(distribution)
+            from .dependency_artifact import (
+                DependencyArtifactAuthenticationError,
+                authenticate_dependency_top_level,
+            )
+
+            try:
+                graph = authenticate_dependency_top_level(
+                    top_level, distribution_index=distribution_index
+                )
+            except DependencyArtifactAuthenticationError:
+                _install_derivation_gap(
+                    context, coordinate, receipt, "no-derived-contract"
+                )
+                continue
             graphs[top_level] = graph
         resolved = resolve_import_binding(receipt, graph=graph)
         if not isinstance(resolved, ResolvedPythonObjectV1):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -7,7 +7,6 @@ never grants semantics from a local or package spelling.
 
 from __future__ import annotations
 
-import importlib.metadata
 from pathlib import Path
 
 from sugar_lift_py_tests.context_manager_resolution import (
@@ -21,7 +20,6 @@ from sugar_source_tree.nodes import Attribute, Call, ClassDef, FunctionDef, Name
 
 from .dependency_artifact import (
     DependencyArtifactAuthenticationError,
-    DependencyArtifactGraph,
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
     resolve_import_binding,
@@ -56,11 +54,6 @@ def populate_source_visible_call_frames(
     calls = tuple(node for node in source_file.nodes() if isinstance(node, Call))
     calls_by_span = {_span_key(node): node for node in calls}
     constructor_targets = {}
-    packages = (
-        importlib.metadata.packages_distributions()
-        if distribution_index is None
-        else {name: (name,) for name in distribution_index}
-    )
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
     for receipt in receipts:
         raw = receipt.use["useSite"]
@@ -70,22 +63,14 @@ def populate_source_visible_call_frames(
             continue
         coordinate = _coordinate(call)
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-        distributions = tuple(packages.get(top_level, ()))
-        if len(distributions) != 1:
-            kind = "no-distribution" if not distributions else "ambiguous-distribution"
-            context.source_call_resolutions[coordinate] = (
-                SourceCallPreconstructionGapV1(kind, coordinate, top_level)
-            )
-            continue
-        distribution = (
-            importlib.metadata.distribution(distributions[0])
-            if distribution_index is None
-            else distribution_index[top_level]
-        )
         graph = graphs.get(top_level)
         if graph is None:
             try:
-                graph = DependencyArtifactGraph.authenticate(distribution)
+                from .dependency_artifact import authenticate_dependency_top_level
+
+                graph = authenticate_dependency_top_level(
+                    top_level, distribution_index=distribution_index
+                )
             except DependencyArtifactAuthenticationError as exc:
                 context.source_call_resolutions[coordinate] = (
                     SourceCallPreconstructionGapV1(

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -125,7 +125,7 @@ def test_resolved_python_object_round_trips_with_identical_cid(tmp_path: Path) -
 def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
     distribution = _install_distribution(
         tmp_path,
-        package_source=("def __getattr__(name):\n" "    return object()\n"),
+        package_source=("def __getattr__(name):\n    return object()\n"),
         implementation_source="def build(value):\n    return value\n",
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
@@ -155,6 +155,47 @@ def test_real_pytest_reexport_resolves_without_manager_name_recognition(
     assert result.module_name != "pytest"
     assert result.reexport_warrants
     assert result.definition.source_cid == result.source_cid
+
+
+def test_stdlib_module_resolves_renamed_export_through_dependency_graph(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("contextlib")
+    demand = _demand(
+        tmp_path,
+        "from contextlib import suppress as RenamedBoundary\n"
+        "RenamedBoundary(ValueError)\n",
+    )
+
+    result = resolve_import_binding(demand, graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.kind == "class"
+    assert result.definition.name == "suppress"
+    assert result.module_name == "contextlib"
+    assert graph.modules["contextlib"].source_cid == result.source_cid
+
+
+def test_same_spelled_non_stdlib_module_cannot_mint_stdlib_graph(
+    tmp_path: Path,
+) -> None:
+    impostor = tmp_path / "contextlib.py"
+    impostor.write_text("class suppress:\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError, match="authenticated stdlib root"
+    ):
+        DependencyArtifactGraph.authenticate_stdlib_path(
+            "contextlib", impostor, stdlib_root=Path(sys.base_prefix) / "lib"
+        )
+
+
+def test_any_source_visible_stdlib_module_uses_the_same_graph_intake() -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("typing")
+
+    assert graph.artifact_kind == "stdlib"
+    assert "typing" in graph.modules
+    assert graph.distribution_artifact_cid.startswith("blake3-512:")
 
 
 def test_fabricated_artifact_file_wrapper_is_loud(tmp_path: Path) -> None:
@@ -507,7 +548,9 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
     """
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
     from sugar_lift_python_source import manager_construction as mc
-    from sugar_lift_python_source.manager_construction import resolve_source_visible_frame
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame,
+    )
     from sugar_source_tree.tree import SourceFile
 
     distribution = _install_distribution(
@@ -540,9 +583,7 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
 
     mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]
     try:
-        frames = [
-            resolve_source_visible_frame(item, graph=graph) for item in resolved
-        ]
+        frames = [resolve_source_visible_frame(item, graph=graph) for item in resolved]
     finally:
         mc.SourceFile = original_sf  # type: ignore[misc, assignment]
         mc.clear_source_visible_frame_cache()

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -284,7 +284,7 @@ def test_fixture_manager_class_bodies_construct_docstrings_and_class_fields():
 def test_nested_class_member_constructs_as_exact_class_field_through_same_door():
     source = SourceFile(
         (
-            "class Outer:\n" "    class Inner:\n" "        marker = 17\n",
+            "class Outer:\n    class Inner:\n        marker = 17\n",
             "nested-class.py",
             "blake3-512:" + ("34" * 64),
         )
@@ -922,6 +922,37 @@ def test_installed_source_boundary_with_opaque_builtin_verdict_stays_loud(tmp_pa
     resolution = next(iter(context.source_derived_contract_refs.values()))
     assert isinstance(resolution, ContextManagerResolutionGapV1)
     assert resolution.kind == "no-derived-contract"
+
+
+def test_installed_stdlib_suppress_reaches_grouped_unpack_after_graph_authentication(
+    tmp_path,
+):
+    consumer = (
+        "import contextlib as renamed_stdlib\n"
+        "def use_boundary():\n"
+        "    with renamed_stdlib.suppress(ValueError):\n"
+        "        raise ValueError('boom')\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    graphs = {}
+    from sugar_source_tree.panic import SugarNotWritten
+
+    with pytest.raises(SugarNotWritten, match="DynamicUnpackAssignSugar"):
+        populate_source_derived_resource_refs(
+            tree, root=tmp_path, path=path, artifact_graph_cache=graphs
+        )
+
+    graph = graphs["contextlib"]
+    assert graph.artifact_kind == "stdlib"
+    assert "contextlib" in graph.modules
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -313,12 +313,8 @@ class SourceUnit:
             ):
                 containing.append(candidate)
         if containing:
-            owner = max(
-                containing, key=lambda item: item.line_col_span().start_line
-            )
-            table = self.function_symtable(
-                owner.name, owner.line_col_span().start_line
-            )
+            owner = max(containing, key=lambda item: item.line_col_span().start_line)
+            table = self.function_symtable(owner.name, owner.line_col_span().start_line)
             try:
                 symbol = table.lookup(call.func.id)
             except KeyError:
@@ -414,8 +410,7 @@ class SourceUnit:
             }
         if statement.kind in ("Import", "ImportFrom"):
             return {
-                alias.asname or alias.name.split(".", 1)[0]
-                for alias in statement.names
+                alias.asname or alias.name.split(".", 1)[0] for alias in statement.names
             }
         return set()
 
@@ -755,8 +750,7 @@ class Node(Typed):
             vocabulary_missing(
                 owner="nodes.Node.span",
                 observed=(
-                    f"{self.kind} with neither a backend position nor any "
-                    "spanned child"
+                    f"{self.kind} with neither a backend position nor any spanned child"
                 ),
                 requested="every node has a source extent",
                 fix="give the adapter an anchor rule for this kind; never invent a span",
@@ -1814,9 +1808,7 @@ class FunctionDef(Statement):
                 for nested in statement.body:
                     append_statement(nested)
                 steps.append(
-                    FinallyStepV1(
-                        tuple(item.sugar() for item in statement.finalbody)
-                    )
+                    FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
                 )
             else:
                 steps.append(OpaqueStepV1(statement.kind))
@@ -1984,9 +1976,7 @@ class FunctionDef(Statement):
 
         lc = stmt.line_col_span()
         site = f"{stmt.unit.filename}:{lc.start_line} {stmt.kind}"
-        with reduction_span(
-            sugar=f"Body.{stmt.kind}", role="construction", site=site
-        ):
+        with reduction_span(sugar=f"Body.{stmt.kind}", role="construction", site=site):
             return stmt.sugar()
 
     def _construct_sugar(self):
@@ -2074,9 +2064,7 @@ class FunctionDef(Statement):
                         role="construction",
                         site=where,
                     ):
-                        substitution_trace = trace_builder.freeze(
-                            testimony_reporter
-                        )
+                        substitution_trace = trace_builder.freeze(testimony_reporter)
                 else:
                     # Every statement still has an immutable runtime snapshot.
                     # Only a loop consumer demands the sealed state projection;
@@ -2885,6 +2873,21 @@ class Assign(Statement):
         if len(self.targets) == 1 and isinstance(self.targets[0], (Tuple_, List)):
             bindings = self._destructured_binding()
             if bindings is None:
+                target = self.targets[0]
+                if (
+                    not isinstance(self.value, (Tuple_, List))
+                    and target.elts
+                    and all(isinstance(item, Name) for item in target.elts)
+                ):
+                    from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
+                        DynamicUnpackAssignSugar,
+                    )
+
+                    return DynamicUnpackAssignSugar(
+                        tuple(item.id for item in target.elts),
+                        self.value.sugar(),
+                        self.fragment,
+                    )
                 return super()._construct_sugar()
             from sugar_lift_py_tests.sugar.assign_sugar import MultiAssignSugar
 
@@ -3236,9 +3239,7 @@ class For(Statement):
         except SourceTreePanic:
             pass
 
-        with reduction_span(
-            sugar="For.substitute", role="temporal", site=where
-        ):
+        with reduction_span(sugar="For.substitute", role="temporal", site=where):
             new_iter, iter_changed = self._substitute_field(self.iter, scope)
             subst_iter = new_iter if iter_changed else self.iter
 
@@ -3249,15 +3250,11 @@ class For(Statement):
             with reduction_span(
                 sugar="For.concrete_elements", role="temporal", site=where
             ):
-                elements = (
-                    self._concrete_elements(subst_iter) if concrete else None
-                )
+                elements = self._concrete_elements(subst_iter) if concrete else None
             if elements is not None and len(elements) > self._UNROLL_FUEL:
                 elements = None  # past the unroll budget: the fold/universal stands
             if elements is not None:
-                with reduction_span(
-                    sugar="For.unroll", role="temporal", site=where
-                ):
+                with reduction_span(sugar="For.unroll", role="temporal", site=where):
                     bindings = [self._target_bindings(e) for e in elements]
                     if all(b is not None for b in bindings):
                         if self._body_has_owned_loop_control():
@@ -3271,9 +3268,7 @@ class For(Statement):
                             # by concrete unrolling and must remain a real loop
                             # below.
                             elements = None
-                    if elements is not None and all(
-                        b is not None for b in bindings
-                    ):
+                    if elements is not None and all(b is not None for b in bindings):
                         target_names = self._bound_names_in(self.target)
                         unrolled: list = []
                         carried = dict(
@@ -3283,9 +3278,7 @@ class For(Statement):
                         for element_bindings in bindings:
                             final_target_bindings = element_bindings
                             iter_scope = {**carried, **element_bindings}
-                            new_body, _c = self._substitute_body(
-                                self.body, iter_scope
-                            )
+                            new_body, _c = self._substitute_body(self.body, iter_scope)
                             unrolled.extend(new_body)
                             # thread this iteration's bindings forward (the
                             # carried fold), never the loop target's own names
@@ -3318,9 +3311,7 @@ class For(Statement):
             # substitution_binding can read the fold; the pre-loop value seeds
             # it from the outer scope. A symbolic loop is not a dead unroll --
             # it is the universal / fold over the hole.
-            with reduction_span(
-                sugar="For.symbolic", role="temporal", site=where
-            ):
+            with reduction_span(sugar="For.symbolic", role="temporal", site=where):
                 bound = self._bound_names_in(self.target) | For._stmts_bound_names(
                     self.body
                 )
@@ -6063,8 +6054,7 @@ class Call(Expression):
                     site=self.fragment,
                     keywords=keyword_sugars,
                     contract_resolution_gap=(
-                        f"{source_call_resolution.kind}:"
-                        f"{source_call_resolution.detail}"
+                        f"{source_call_resolution.kind}:{source_call_resolution.detail}"
                     ),
                 )
             if not isinstance(source_call_resolution, SourceCallPreconstructionRefV1):
@@ -6148,6 +6138,7 @@ class Call(Expression):
             from sugar_lift_py_tests.call_contract_resolution import (
                 CallContractResolutionGapV1,
             )
+
             call_refs = getattr(context, "call_contract_refs", None)
             if call_refs is not None:
                 from sugar_lift_py_tests.call_contract_resolution import (
@@ -6491,7 +6482,11 @@ class ObjectPlaceStateV1(Expression):
     def with_attribute_store(self, name, value, occurrence):
         from .object_identity import AttributeFieldCoordinateV1
 
-        return self._with_store(AttributeFieldCoordinateV1.mint(self.object_coordinate, name), value, occurrence)
+        return self._with_store(
+            AttributeFieldCoordinateV1.mint(self.object_coordinate, name),
+            value,
+            occurrence,
+        )
 
     def _with_store(self, selector, value, occurrence, *, constructed=None):
         self.validate_identity()
@@ -6499,9 +6494,7 @@ class ObjectPlaceStateV1(Expression):
         if constructed is None:
             return None
         floor_value, testimony = constructed
-        projected = ConstructedValueProjectionV1.create(
-            value, floor_value, testimony
-        )
+        projected = ConstructedValueProjectionV1.create(value, floor_value, testimony)
         from .object_identity import AttributeFieldVersionV1
 
         prior = self.version(selector)
@@ -6509,7 +6502,9 @@ class ObjectPlaceStateV1(Expression):
             owner=self.object_coordinate,
             field=selector,
             store_occurrence=occurrence,
-            construction_generation=self.object_coordinate.construction_generation + len(self.version_cids) + 1,
+            construction_generation=self.object_coordinate.construction_generation
+            + len(self.version_cids)
+            + 1,
             stored_value_testimony_cid=testimony.cid,
             prior_version_cid=prior,
         )
@@ -6726,15 +6721,12 @@ class Attribute(Expression):
             isinstance(receiver, IfExp)
             and isinstance(receiver.body, ObjectPlaceStateV1)
             and isinstance(receiver.orelse, ObjectPlaceStateV1)
-            and receiver.body.object_identity_cid
-            == receiver.orelse.object_identity_cid
+            and receiver.body.object_identity_cid == receiver.orelse.object_identity_cid
         ):
             when_true = receiver.body.attribute_field(self.attr)
             when_false = receiver.orelse.attribute_field(self.attr)
             if when_true is not None and when_false is not None:
-                return rewrite(
-                    receiver, body=when_true, orelse=when_false
-                )
+                return rewrite(receiver, body=when_true, orelse=when_false)
         if isinstance(receiver, ObjectPlaceStateV1):
             projected = receiver.attribute_field(self.attr)
             if projected is not None:

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -118,20 +118,22 @@ def test_mixed_chain_preserves_each_store_face_in_source_order():
 
 def test_nested_tuple_target_binds_each_structural_projection():
     post = _post(
-        "def A():\n"
-        "    (a, (b, c)), d = (1, (2, 3)), 4\n"
-        "    return a + b + c + d\n"
+        "def A():\n    (a, (b, c)), d = (1, (2, 3)), 4\n    return a + b + c + d\n"
     )
     assert post.args[1].value == 10
 
 
 def test_nested_tuple_projection_pairing_discriminates():
-    left = _post(
-        "def A():\n    (a, (b, c)) = (1, (2, 4))\n    return b - c\n"
-    ).args[1].value
-    right = _post(
-        "def A():\n    (a, (b, c)) = (1, (4, 2))\n    return b - c\n"
-    ).args[1].value
+    left = (
+        _post("def A():\n    (a, (b, c)) = (1, (2, 4))\n    return b - c\n")
+        .args[1]
+        .value
+    )
+    right = (
+        _post("def A():\n    (a, (b, c)) = (1, (4, 2))\n    return b - c\n")
+        .args[1]
+        .value
+    )
     assert (left, right) == (-2, 2)
 
 
@@ -161,11 +163,15 @@ def test_arity_mismatch_stays_loud():
         _fn("def A():\n    a, b = (1, 2, 3)\n    return a\n").sugar()
 
 
-def test_non_display_rhs_stays_loud():
-    # The rhs is a Name, not a Tuple/List display -- no shape to destructure
-    # against, so the tuple target is not threaded.
+def test_non_display_rhs_constructs_but_stays_typed_loud_when_reached():
+    # Construction must be total enough for an unreachable branch to coexist
+    # with a closed guard. If execution reaches the dynamic unpack, its unknown
+    # iteration/cardinality semantics remain loud rather than fabricating binds.
+    function = _fn("def A(p):\n    a, b = p\n    return a\n")
+    sugar = function.sugar()
+
     with pytest.raises(SugarNotWritten):
-        _fn("def A(p):\n    a, b = p\n    return a\n").sugar()
+        sugar.desugar()
 
 
 def test_mixed_chained_targets_stay_loud():


### PR DESCRIPTION
## What changed

- authenticate source-visible stdlib modules into `DependencyArtifactGraph` using the running interpreter stdlib root, runtime identity, retained bytes, and content CIDs
- route manager and source-call preconstruction through one distribution-or-stdlib graph intake
- restrict manager construction to the source-definition dependency closure
- construct dynamic unpack syntax explicitly while keeping runtime-selected members typed-loud

## Why

`packages_distributions()` has no owner for stdlib modules, so `typing` and `contextlib` were rejected before the ordinary dependency artifact path. This admits them without module-name gates or fabricated definitions.

## Honest frontier

- renamed `contextlib.suppress` now resolves to its authenticated installed class and reaches the ExceptionGroup `split()` unpack; that runtime-selected unpack remains loud pending grouped-effect semantics
- `typing` is now an authenticated stdlib artifact; `typing.Pattern` remains a dynamic assignment/export rather than an authenticated class definition, so pytest.raises remains loud at that type operand
- #6184 separately delegates grouped subtype partitioning to the single #6177 `ClassValue` floor

## Validation

- `90 passed` across dependency artifact graph, manager construction, assignment targets, construction side-door law, and panic-catch law
- no corpus census or timeout increase


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate stdlib dependency artifacts alongside distribution artifacts
> - Adds `DependencyArtifactGraph.authenticate_stdlib_module` and `authenticate_stdlib_path` classmethods to content-address stdlib modules from the sysconfig stdlib root, rejecting non-stdlib paths and modules without source.
> - Introduces `authenticate_dependency_top_level` helper that resolves a top-level module name by checking installed distributions first and falling back to stdlib authentication.
> - Updates `populate_source_visible_call_frames` and `populate_source_derived_resource_refs` to use the new unified helper, recording authentication failures as gaps rather than raising.
> - Adds `DynamicUnpackAssignSugar` for tuple/list unpack assignments with a non-display RHS; constructing the sugar succeeds but calling `desugar()` raises `SugarNotWritten` because runtime-selected unpack members cannot be authenticated.
> - `DependencyArtifactGraph` gains an `artifact_kind` field (`'distribution'` or `'stdlib'`) that controls the CID preimage `kind` string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1634763.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->