### PR TITLE
Type audit leaf auxiliary sidecars

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
@@ -27,6 +27,8 @@ from .open_lane_dto import (
 )
 from .plan_atom_dto import PlanAtomDto
 from .recovered_audit_dto import (
+    AuditLeafEnvelopeDto,
+    AuditLeafSourceAuditDto,
     RecoveredAuditDto,
     RecoveredEffectDto,
     RecoveredEffectTreeDto,
@@ -42,6 +44,8 @@ from .source_memento_dto import SourceMementoDto
 from .source_span_dto import SourceSpanDto
 
 __all__ = [
+    "AuditLeafEnvelopeDto",
+    "AuditLeafSourceAuditDto",
     "AssertionFactDto",
     "AssertionSurfaceAuditDto",
     "BodyUniverseDto",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/recovered_audit_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/recovered_audit_dto.py
@@ -72,6 +72,16 @@ _LEAF_PANIC_FIELDS = frozenset(
 )
 _LEAF_EFFECT_FIELDS = frozenset({"locus", "effect", "category", "status", "reason"})
 _LEAF_SUPPRESSED_FIELDS = frozenset({"locus", "reason"})
+_LEAF_ENVELOPE_FIELDS = frozenset({"semanticCore", "auxiliaryRows"})
+_LEAF_AUXILIARY_FIELDS = frozenset({"sourceAudit"})
+_SOURCE_AUDIT_FIELDS = frozenset({"role", "loci", "totals"})
+_SOURCE_AUDIT_ROW_FIELDS = frozenset(
+    {"status", "kind", "name", "source_cid", "locus"}
+)
+_SOURCE_AUDIT_LOCUS_FIELDS = frozenset({"file", "line", "col"})
+_SOURCE_AUDIT_TOTALS_FIELDS = frozenset(
+    {"source_loci", "source_warranted", "source_unresolved"}
+)
 
 _TREE_AUDIT_FIELDS = _LEAF_AUDIT_FIELDS | frozenset({"census"})
 _TREE_CENSUS_FIELDS = frozenset(
@@ -233,6 +243,109 @@ class RecoveredAuditDto:
             panics=panics,
             effects=effects,
             suppressed_descendants=suppressed,
+        )
+
+
+@dataclass(frozen=True)
+class AuditLeafSourceAuditDto:
+    """Closed diagnostic sidecar carried beside the semantic audit core."""
+
+    role: str
+    loci: list[dict[str, Any]]
+    totals: dict[str, int]
+
+    def to_rpc(self) -> dict[str, Any]:
+        return {"role": self.role, "loci": self.loci, "totals": self.totals}
+
+    @classmethod
+    def from_rpc(cls, data: object) -> AuditLeafSourceAuditDto:
+        row = _require_mapping(data, "audit leaf sourceAudit")
+        _reject_unknown(row, set(_SOURCE_AUDIT_FIELDS), "audit leaf sourceAudit")
+        loci = _require_list(row.get("loci"), "audit leaf sourceAudit loci")
+        checked_loci: list[dict[str, Any]] = []
+        for item in loci:
+            locus_row = _require_mapping(item, "audit leaf sourceAudit row")
+            _reject_unknown(
+                locus_row,
+                set(_SOURCE_AUDIT_ROW_FIELDS),
+                "audit leaf sourceAudit row",
+            )
+            place = _require_mapping(
+                locus_row.get("locus"), "audit leaf sourceAudit locus"
+            )
+            _reject_unknown(
+                place,
+                set(_SOURCE_AUDIT_LOCUS_FIELDS),
+                "audit leaf sourceAudit locus",
+            )
+            checked_loci.append(
+                {
+                    "status": _require_str(
+                        locus_row.get("status"), "audit leaf sourceAudit status"
+                    ),
+                    "kind": _require_str(
+                        locus_row.get("kind"), "audit leaf sourceAudit kind"
+                    ),
+                    "name": _require_str(
+                        locus_row.get("name"), "audit leaf sourceAudit name"
+                    ),
+                    "source_cid": _require_str(
+                        locus_row.get("source_cid"),
+                        "audit leaf sourceAudit source_cid",
+                    ),
+                    "locus": {
+                        "file": _require_str(
+                            place.get("file"), "audit leaf sourceAudit locus file"
+                        ),
+                        "line": _require_int(
+                            place.get("line"), "audit leaf sourceAudit locus line"
+                        ),
+                        "col": _require_int(
+                            place.get("col"), "audit leaf sourceAudit locus col"
+                        ),
+                    },
+                }
+            )
+        totals = _require_mapping(row.get("totals"), "audit leaf sourceAudit totals")
+        _reject_unknown(
+            totals, set(_SOURCE_AUDIT_TOTALS_FIELDS), "audit leaf sourceAudit totals"
+        )
+        return cls(
+            role=_require_str(row.get("role"), "audit leaf sourceAudit role"),
+            loci=checked_loci,
+            totals={
+                key: _require_int(totals.get(key), f"audit leaf sourceAudit {key}")
+                for key in _SOURCE_AUDIT_TOTALS_FIELDS
+            },
+        )
+
+
+@dataclass(frozen=True)
+class AuditLeafEnvelopeDto:
+    semantic_core: RecoveredAuditDto
+    source_audit: AuditLeafSourceAuditDto
+
+    def to_rpc(self) -> dict[str, Any]:
+        return {
+            "semanticCore": self.semantic_core.to_rpc(),
+            "auxiliaryRows": {"sourceAudit": self.source_audit.to_rpc()},
+        }
+
+    @classmethod
+    def from_rpc(cls, data: object) -> AuditLeafEnvelopeDto:
+        row = _require_mapping(data, "audit leaf envelope")
+        _reject_unknown(row, set(_LEAF_ENVELOPE_FIELDS), "audit leaf envelope")
+        auxiliary = _require_mapping(
+            row.get("auxiliaryRows"), "audit leaf auxiliaryRows"
+        )
+        _reject_unknown(
+            auxiliary, set(_LEAF_AUXILIARY_FIELDS), "audit leaf auxiliaryRows"
+        )
+        return cls(
+            semantic_core=RecoveredAuditDto.from_rpc(row.get("semanticCore")),
+            source_audit=AuditLeafSourceAuditDto.from_rpc(
+                auxiliary.get("sourceAudit")
+            ),
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1321,6 +1321,8 @@ def _send_enumerate_result(
 
 
 def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
+    from sugar_lift_py_tests.kit_rpc import AuditLeafEnvelopeDto
+
     """Project one construction roll call directly onto the legacy audit wire.
 
     The old wire names remain compatibility spelling only. They are populated
@@ -1412,15 +1414,17 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
     # `kind` and `recoveryOverride` are closed-envelope discriminators required
     # by the current Rust reader. No recovery policy is consulted here; every
     # semantic value is projected from the roll call above.
-    return {
-        "kind": "recovered-construction-audit",
-        "recoveryOverride": True,
-        "status": "failed" if panics else "clean",
-        "panics": panics,
-        "effects": [],
-        "suppressedDescendants": [],
-        "sourceAudit": source_audit,
-    }
+    return AuditLeafEnvelopeDto.from_rpc({
+        "semanticCore": {
+            "kind": "recovered-construction-audit",
+            "recoveryOverride": True,
+            "status": "failed" if panics else "clean",
+            "panics": panics,
+            "effects": [],
+            "suppressedDescendants": [],
+        },
+        "auxiliaryRows": {"sourceAudit": source_audit},
+    }).to_rpc()
 
 
 def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -416,6 +416,7 @@ def frontier_leaf_rpc(full_path: Path, file_rel: str) -> dict:
     (present Blue / absent Yellow), everything the report needs on the CLI side.
     """
     from sugar_lift_py_tests.kit_rpc.recovered_audit_dto import (
+        AuditLeafEnvelopeDto,
         RecoveredAuditDto,
         RecoveredConstructionPanicDto,
     )
@@ -435,6 +436,9 @@ def frontier_leaf_rpc(full_path: Path, file_rel: str) -> dict:
                 gap={"blame": terminal, "kind": node.kind, "reason": reason},
             )
         )
-    leaf = RecoveredAuditDto(panics=panics).to_rpc()
-    leaf["sourceAudit"] = source_audit_from_roll_call(full_path, file_rel)
-    return leaf
+    return AuditLeafEnvelopeDto.from_rpc({
+        "semanticCore": RecoveredAuditDto(panics=panics).to_rpc(),
+        "auxiliaryRows": {
+            "sourceAudit": source_audit_from_roll_call(full_path, file_rel)
+        },
+    }).to_rpc()

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -87,7 +87,7 @@ def test_source_files_scan_finds_the_fixture_file(project: Path) -> None:
     assert files == ["mathy.py"]
 
 
-def _audit_leaf(workspace: Path, file: str = "mathy.py") -> dict:
+def _audit_envelope(workspace: Path, file: str = "mathy.py") -> dict:
     file_key = next(
         node["memento"]
         for node in _enumerate("source_files", workspace)["nodes"]
@@ -104,6 +104,32 @@ def _audit_leaf(workspace: Path, file: str = "mathy.py") -> dict:
         seek=True,
         options={"auditFrontier": True},
     )["nodes"][0]["audit"]
+
+
+def _audit_leaf(workspace: Path, file: str = "mathy.py") -> dict:
+    envelope = _audit_envelope(workspace, file)
+    return {
+        **envelope["semanticCore"],
+        "sourceAudit": envelope["auxiliaryRows"]["sourceAudit"],
+    }
+
+
+def test_audit_leaf_separates_closed_semantic_core_from_typed_auxiliary_rows(
+    project: Path,
+) -> None:
+    leaf = _audit_envelope(project)
+
+    assert set(leaf) == {"semanticCore", "auxiliaryRows"}
+    assert set(leaf["semanticCore"]) == {
+        "kind",
+        "recoveryOverride",
+        "status",
+        "panics",
+        "effects",
+        "suppressedDescendants",
+    }
+    assert set(leaf["auxiliaryRows"]) == {"sourceAudit"}
+    assert leaf["auxiliaryRows"]["sourceAudit"]["role"] == "mathy.py"
 
 
 def _script_roll_call(monkeypatch: pytest.MonkeyPatch, answer: str) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_recovered_audit_schema_golden.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recovered_audit_schema_golden.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.kit_rpc import RecoveredAuditDto, RecoveredFrontierAuditDto
+from sugar_lift_py_tests.kit_rpc import (
+    AuditLeafEnvelopeDto,
+    RecoveredAuditDto,
+    RecoveredFrontierAuditDto,
+)
 
 _FIXTURES = (
     Path(__file__).resolve().parents[4] / "protocol" / "conformance" / "recovered-audit"
@@ -27,14 +31,14 @@ def _load(name: str) -> dict:
 @pytest.mark.parametrize("name", ["leaf-clean.json", "leaf-full.json"])
 def test_leaf_goldens_round_trip_without_loss(name: str) -> None:
     fixture = _load(name)
-    audit = RecoveredAuditDto.from_rpc(fixture)
+    audit = AuditLeafEnvelopeDto.from_rpc(fixture)
     assert audit.to_rpc() == fixture
 
 
 def test_leaf_golden_rejects_unknown_fields() -> None:
     fixture = _load("bad-leaf-unknown-field.json")
     with pytest.raises(ValueError, match="unknown field"):
-        RecoveredAuditDto.from_rpc(fixture)
+        AuditLeafEnvelopeDto.from_rpc(fixture)
 
 
 @pytest.mark.parametrize(

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -1049,6 +1049,53 @@ struct RecoveredAuditLeafWire {
     suppressed_descendants: Vec<SuppressedAuditLocusLeafWire>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SourceAuditLocusWire {
+    file: String,
+    line: u64,
+    col: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct SourceAuditRowWire {
+    status: String,
+    kind: String,
+    name: String,
+    source_cid: String,
+    locus: SourceAuditLocusWire,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct SourceAuditTotalsWire {
+    source_loci: u64,
+    source_warranted: u64,
+    source_unresolved: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SourceAuditWire {
+    role: String,
+    loci: Vec<SourceAuditRowWire>,
+    totals: SourceAuditTotalsWire,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AuditLeafAuxiliaryRowsWire {
+    source_audit: SourceAuditWire,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AuditLeafEnvelopeWire {
+    semantic_core: RecoveredAuditLeafWire,
+    auxiliary_rows: AuditLeafAuxiliaryRowsWire,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RecoveredPanicOwnerIdentity {
@@ -1254,54 +1301,42 @@ pub fn fold_lift_report_response(
             if let Some(payload) = leaf.payload.clone() {
                 facts.push(payload);
             }
-            let mut audit = leaf.audit.ok_or_else(|| EnumerateError::Malformed {
+            let audit = leaf.audit.ok_or_else(|| EnumerateError::Malformed {
                 plugin: conn.surface.clone(),
                 reason: format!(
                     "report leaf {} omitted recovered body",
                     memento_locus_display(&definition.memento)
                 ),
             })?;
+            let decoded = decode_audit_leaf_boundary(&conn.surface, audit)?;
             // The reporter's roll-call partition -- everything the CLI renders
             // (present -> warranted/Blue, absent -> unresolved/Yellow). One
             // source-audit row per leaf; its totals sum into the ledger.
-            if let Some(source_audit) = audit
-                .as_object_mut()
-                .and_then(|object| object.remove("sourceAudit"))
-            {
-                if let Some(totals) = source_audit.get("totals") {
-                    source_loci += totals
-                        .get("source_loci")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0);
-                    source_warranted += totals
-                        .get("source_warranted")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0);
-                    source_unresolved += totals
-                        .get("source_unresolved")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0);
+            let source_audit = decoded.auxiliary_rows.source_audit;
+            source_loci += source_audit.totals.source_loci;
+            source_warranted += source_audit.totals.source_warranted;
+            source_unresolved += source_audit.totals.source_unresolved;
+            // Each unresolved locus (absent -> the minority) becomes a
+            // Yellow un_asserted body the visual renderer paints.
+            for locus in &source_audit.loci {
+                if locus.status == "unresolved" {
+                    un_asserted_loci.push(json!({
+                        "file": locus.locus.file,
+                        "line": locus.locus.line,
+                        "name": locus.name,
+                    }));
                 }
-                // Each unresolved locus (absent -> the minority) becomes a
-                // Yellow un_asserted body the visual renderer paints.
-                if let Some(loci) = source_audit.get("loci").and_then(Value::as_array) {
-                    for locus in loci {
-                        if locus.get("status").and_then(Value::as_str) == Some("unresolved") {
-                            let place = locus.get("locus");
-                            un_asserted_loci.push(json!({
-                                "file": place.and_then(|p| p.get("file")).cloned().unwrap_or(Value::Null),
-                                "line": place.and_then(|p| p.get("line")).cloned().unwrap_or(Value::Null),
-                                "name": locus.get("name").cloned().unwrap_or(Value::Null),
-                            }));
-                        }
-                    }
-                }
-                source_audits.push(source_audit);
             }
-            merge_recovered_audit_leaf(
+            source_audits.push(serde_json::to_value(source_audit).map_err(|error| {
+                EnumerateError::Malformed {
+                    plugin: conn.surface.clone(),
+                    reason: format!("typed source audit does not serialize: {error}"),
+                }
+            })?);
+            merge_recovered_audit_core(
                 &conn.surface,
                 &definition.memento,
-                audit,
+                decoded.semantic_core,
                 &mut panics,
                 &mut effects,
                 &mut suppressed,
@@ -1362,17 +1397,48 @@ fn merge_recovered_audit_leaf(
     effects: &mut Vec<Value>,
     suppressed: &mut Vec<Value>,
 ) -> Result<(), KitError> {
+    let decoded = decode_audit_leaf_boundary(plugin, audit)?;
+    merge_recovered_audit_core(
+        plugin,
+        demanded_body,
+        decoded.semantic_core,
+        panics,
+        effects,
+        suppressed,
+    )
+}
+
+fn decode_audit_leaf_boundary(
+    plugin: &str,
+    audit: Value,
+) -> Result<AuditLeafEnvelopeWire, KitError> {
     let malformed = |reason: String| {
         KitError::from(EnumerateError::Malformed {
             plugin: plugin.to_string(),
             reason,
         })
     };
-    let leaf: RecoveredAuditLeafWire = serde_json::from_value(audit).map_err(|error| {
+    serde_json::from_value(audit).map_err(|error| {
         malformed(format!(
-            "audit leaf does not decode as closed recovered wire schema: {error}"
+            "audit leaf does not decode as closed typed core-plus-sidecar schema: {error}"
         ))
-    })?;
+    })
+}
+
+fn merge_recovered_audit_core(
+    plugin: &str,
+    demanded_body: &SourceMemento,
+    leaf: RecoveredAuditLeafWire,
+    panics: &mut Vec<Value>,
+    effects: &mut Vec<Value>,
+    suppressed: &mut Vec<Value>,
+) -> Result<(), KitError> {
+    let malformed = |reason: String| {
+        KitError::from(EnumerateError::Malformed {
+            plugin: plugin.to_string(),
+            reason,
+        })
+    };
     if leaf.kind != "recovered-construction-audit" || !leaf.recovery_override {
         return Err(malformed(
             "audit leaf is not a recovery-override construction audit".to_string(),
@@ -1957,7 +2023,7 @@ mod tests {
         }
     }
 
-    fn recovered_leaf(panics: Vec<Value>) -> Value {
+    fn recovered_semantic_core(panics: Vec<Value>) -> Value {
         json!({
             "kind": "recovered-construction-audit",
             "recoveryOverride": true,
@@ -1966,6 +2032,85 @@ mod tests {
             "effects": [],
             "suppressedDescendants": [],
         })
+    }
+
+    fn source_audit_leaf() -> Value {
+        json!({
+            "role": "pkg.py",
+            "loci": [{
+                "status": "warranted",
+                "kind": "Module",
+                "name": "<module>",
+                "source_cid": "blake3-512:source",
+                "locus": {"file": "pkg.py", "line": 1, "col": 0},
+            }],
+            "totals": {
+                "source_loci": 1,
+                "source_warranted": 1,
+                "source_unresolved": 0,
+            },
+        })
+    }
+
+    fn recovered_leaf_envelope(core: Value) -> Value {
+        json!({
+            "semanticCore": core,
+            "auxiliaryRows": {"sourceAudit": source_audit_leaf()},
+        })
+    }
+
+    fn recovered_leaf(panics: Vec<Value>) -> Value {
+        recovered_leaf_envelope(recovered_semantic_core(panics))
+    }
+
+    #[test]
+    fn recovered_leaf_with_source_audit_decodes_core_and_sidecar() {
+        let envelope = recovered_leaf(Vec::new());
+        let decoded = decode_audit_leaf_boundary("fixture", envelope)
+            .expect("recovered leaf core and typed sidecar must decode together");
+
+        assert_eq!(decoded.semantic_core.status, "clean");
+        assert_eq!(decoded.auxiliary_rows.source_audit.role, "pkg.py");
+    }
+
+    #[test]
+    fn report_leaf_uses_the_same_typed_boundary() {
+        let envelope = recovered_leaf(Vec::new());
+        let decoded = decode_audit_leaf_boundary("fixture", envelope)
+            .expect("report leaf must use the shared core-plus-sidecar boundary");
+
+        assert_eq!(decoded.semantic_core.kind, "recovered-construction-audit");
+        assert_eq!(decoded.auxiliary_rows.source_audit.totals.source_loci, 1);
+    }
+
+    #[test]
+    fn unknown_semantic_core_field_stays_loud() {
+        let mut core = recovered_semantic_core(Vec::new());
+        core["inventedSemanticField"] = json!(true);
+        let error = decode_audit_leaf_boundary("fixture", recovered_leaf_envelope(core))
+            .expect_err("unknown semantic-core fields must remain closed-world errors");
+
+        assert!(error.to_string().contains("inventedSemanticField"));
+    }
+
+    #[test]
+    fn unknown_auxiliary_row_stays_loud() {
+        let mut envelope = recovered_leaf(Vec::new());
+        envelope["auxiliaryRows"]["inventedDiagnostic"] = json!({});
+        let error = decode_audit_leaf_boundary("fixture", envelope)
+            .expect_err("untyped auxiliary rows must not be silently ignored");
+
+        assert!(error.to_string().contains("inventedDiagnostic"));
+    }
+
+    #[test]
+    fn typed_leaf_sidecar_round_trips_without_loss() {
+        let envelope = recovered_leaf(Vec::new());
+        let decoded = decode_audit_leaf_boundary("fixture", envelope.clone())
+            .expect("typed leaf envelope must decode");
+        let round_trip = serde_json::to_value(decoded).expect("typed leaf envelope must serialize");
+
+        assert_eq!(round_trip, envelope);
     }
 
     fn recovered_panic(demand: &str) -> Value {
@@ -2129,7 +2274,7 @@ mod tests {
     fn recovered_audit_leaf_goldens_round_trip_without_loss() {
         for name in ["leaf-clean.json", "leaf-full.json"] {
             let fixture = recovered_audit_fixture(name);
-            let leaf: RecoveredAuditLeafWire = serde_json::from_value(fixture.clone())
+            let leaf = decode_audit_leaf_boundary("fixture", fixture.clone())
                 .unwrap_or_else(|error| panic!("{name} must decode as leaf wire: {error}"));
             let round_trip = serde_json::to_value(&leaf).expect("closed leaf wire must serialize");
             assert_eq!(
@@ -2142,7 +2287,7 @@ mod tests {
     #[test]
     fn recovered_audit_leaf_golden_rejects_unknown_fields() {
         let fixture = recovered_audit_fixture("bad-leaf-unknown-field.json");
-        let error = serde_json::from_value::<RecoveredAuditLeafWire>(fixture)
+        let error = decode_audit_leaf_boundary("fixture", fixture)
             .expect_err("unknown leaf lane must be rejected");
         assert!(
             error.to_string().contains("inventedLane")

--- a/protocol/conformance/recovered-audit/README.md
+++ b/protocol/conformance/recovered-audit/README.md
@@ -6,10 +6,14 @@ Two closed shapes:
 
 | Prefix | Producer | Consumer | Status vocabulary |
 | --- | --- | --- | --- |
-| `leaf-*` | Python kit leaf (`RecoveredAuditDto`) | Rust fold (`RecoveredAuditLeafWire`) | `clean` \| `failed` |
+| `leaf-*` | Python kit typed envelope | Rust shared leaf boundary (`AuditLeafEnvelopeWire`) | `clean` \| `failed` |
 | `tree-*` | Rust fold (`fold_recovered_audit`) | CLI + wall consumers | `valid-empty` \| `complete` \| `failed` |
 
-Both languages round-trip these fixtures and reject unknown fields. A writer
+Each leaf has exactly two named fields: strict `semanticCore` and strict
+`auxiliaryRows`. The semantic core remains `RecoveredAuditLeafWire`; the typed
+auxiliary channel currently contains `sourceAudit`. Both languages round-trip
+these fixtures and reject unknown fields at the envelope, semantic-core, and
+auxiliary-row levels. A writer
 change the other side cannot parse fails in the PR that introduces it, not on
 the next wall run. Schema generation from one shared definition is the stronger
 end state; these goldens are the first ratchet.

--- a/protocol/conformance/recovered-audit/bad-leaf-unknown-field.json
+++ b/protocol/conformance/recovered-audit/bad-leaf-unknown-field.json
@@ -1,9 +1,22 @@
 {
-  "kind": "recovered-construction-audit",
-  "recoveryOverride": true,
-  "status": "clean",
-  "panics": [],
-  "effects": [],
-  "suppressedDescendants": [],
-  "inventedLane": []
+  "semanticCore": {
+    "kind": "recovered-construction-audit",
+    "recoveryOverride": true,
+    "status": "clean",
+    "panics": [],
+    "effects": [],
+    "suppressedDescendants": [],
+    "inventedLane": []
+  },
+  "auxiliaryRows": {
+    "sourceAudit": {
+      "role": "pkg.py",
+      "loci": [],
+      "totals": {
+        "source_loci": 0,
+        "source_warranted": 0,
+        "source_unresolved": 0
+      }
+    }
+  }
 }

--- a/protocol/conformance/recovered-audit/leaf-clean.json
+++ b/protocol/conformance/recovered-audit/leaf-clean.json
@@ -1,8 +1,21 @@
 {
-  "kind": "recovered-construction-audit",
-  "recoveryOverride": true,
-  "status": "clean",
-  "panics": [],
-  "effects": [],
-  "suppressedDescendants": []
+  "semanticCore": {
+    "kind": "recovered-construction-audit",
+    "recoveryOverride": true,
+    "status": "clean",
+    "panics": [],
+    "effects": [],
+    "suppressedDescendants": []
+  },
+  "auxiliaryRows": {
+    "sourceAudit": {
+      "role": "pkg.py",
+      "loci": [],
+      "totals": {
+        "source_loci": 0,
+        "source_warranted": 0,
+        "source_unresolved": 0
+      }
+    }
+  }
 }

--- a/protocol/conformance/recovered-audit/leaf-full.json
+++ b/protocol/conformance/recovered-audit/leaf-full.json
@@ -1,38 +1,63 @@
 {
-  "kind": "recovered-construction-audit",
-  "recoveryOverride": true,
-  "status": "failed",
-  "panics": [
-    {
-      "kind": "FactoryPanic",
-      "status": "mandatory-panic",
-      "reason": "missing floor construction",
-      "locus": "pkg.py:1:0",
-      "demandedSource": "definition:broken",
-      "terminalGapLocus": "pkg.py:2:4",
-      "gap": {
-        "blame": "pkg.py:2:4",
-        "gap_kind": "Floor",
-        "gap_locus": "pkg.py:2:4",
-        "observed": "Nonlocal",
-        "requested": "value",
-        "fix": "construct the floor arm"
+  "semanticCore": {
+    "kind": "recovered-construction-audit",
+    "recoveryOverride": true,
+    "status": "failed",
+    "panics": [
+      {
+        "kind": "FactoryPanic",
+        "status": "mandatory-panic",
+        "reason": "missing floor construction",
+        "locus": "pkg.py:1:0",
+        "demandedSource": "definition:broken",
+        "terminalGapLocus": "pkg.py:2:4",
+        "gap": {
+          "blame": "pkg.py:2:4",
+          "gap_kind": "Floor",
+          "gap_locus": "pkg.py:2:4",
+          "observed": "Nonlocal",
+          "requested": "value",
+          "fix": "construct the floor arm"
+        }
+      }
+    ],
+    "effects": [
+      {
+        "locus": "pkg.py:7:0",
+        "effect": "GetattrRuntimeEffect",
+        "category": "RuntimeEffect",
+        "status": "runtime-effect",
+        "reason": "getattr runtime boundary: attribute name expression is runtime"
+      }
+    ],
+    "suppressedDescendants": [
+      {
+        "locus": "pkg.py:3:4",
+        "reason": "ancestor FactoryPanic poisoned this source locus"
+      }
+    ]
+  },
+  "auxiliaryRows": {
+    "sourceAudit": {
+      "role": "pkg.py",
+      "loci": [
+        {
+          "status": "unresolved",
+          "kind": "Nonlocal",
+          "name": "Nonlocal",
+          "source_cid": "blake3-512:source",
+          "locus": {
+            "file": "pkg.py",
+            "line": 2,
+            "col": 4
+          }
+        }
+      ],
+      "totals": {
+        "source_loci": 1,
+        "source_warranted": 0,
+        "source_unresolved": 1
       }
     }
-  ],
-  "effects": [
-    {
-      "locus": "pkg.py:7:0",
-      "effect": "GetattrRuntimeEffect",
-      "category": "RuntimeEffect",
-      "status": "runtime-effect",
-      "reason": "getattr runtime boundary: attribute name expression is runtime"
-    }
-  ],
-  "suppressedDescendants": [
-    {
-      "locus": "pkg.py:3:4",
-      "reason": "ancestor FactoryPanic poisoned this source locus"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## What changed

- emit every Python audit leaf as `{semanticCore, auxiliaryRows}`
- decode report and recovered leaves through one strict Rust `AuditLeafEnvelopeWire` boundary
- type and close `sourceAudit` independently from the authenticated semantic core
- remove the ad-hoc `sourceAudit` strip from `tree.rs` (zero strip sites remain)
- add report/recovered, unknown-core, unknown-sidecar, and round-trip twins

## Validation

- `../../bin/bcargo test -p sugar-compiler --lib tree::tests -- --nocapture` — 19 passed
- focused Python producer/schema tests — 7 passed
- `construction_side_door_law.py` — R=0, sole_path=0, auditor_errors=0
- `construction_panic_catch_law.py` — R=0
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope note

The pre-existing full Python golden still exposes the separate `FactoryPanic` versus `ConstructionPanic` vocabulary mismatch already present on main. This PR does not alter that semantic vocabulary; the clean-leaf sidecar round trip and Rust full-envelope goldens are green.

Ready for soundness audit. Not merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Type audit leaf sidecars as a strict envelope with separated `semanticCore` and `auxiliaryRows`
> - Introduces `AuditLeafEnvelopeWire` (Rust) and `AuditLeafEnvelopeDto` (Python) to replace flat audit leaf payloads with a typed envelope containing `semanticCore` and `auxiliaryRows.sourceAudit`.
> - Adds strict typed structs for the `sourceAudit` sidecar (`SourceAuditWire`, `SourceAuditRowWire`, `SourceAuditLocusWire`, `SourceAuditTotalsWire`) with `deny_unknown_fields` at every level in Rust and equivalent strict validation in Python.
> - Updates `fold_lift_report_response` and `merge_recovered_audit_leaf` in [tree.rs](https://github.com/TSavo/sugar/pull/6190/files#diff-1e76daa010a218df51ed5a9f321167e9101bfbc1ef2983cc15a1da0d4fe553eb) to decode the new envelope via `decode_audit_leaf_boundary` and extract typed totals/loci from `auxiliary_rows.source_audit`.
> - Updates `_roll_call_audit_leaf` in [lift_rpc.py](https://github.com/TSavo/sugar/pull/6190/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) and `frontier_leaf_rpc` in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/6190/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) to produce the envelope shape instead of a flat dict.
> - Updates protocol conformance fixtures in `protocol/conformance/recovered-audit/` to match the new envelope schema.
> - Behavioral Change: any audit leaf not conforming to the typed envelope (including unknown fields at envelope, semantic-core, or auxiliary-row levels) is now rejected with a `Malformed` error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 540436b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->