### PR TITLE
ci: run Python R-floor zero-tolerance gates on self-hosted bx runner

### DIFF
--- a/.github/workflows/bare-exception-zero-tolerance.yml
+++ b/.github/workflows/bare-exception-zero-tolerance.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   bare-exception-zero-tolerance:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     env:
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
     steps:

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   python-sole-construction-floors:
     name: python-sole-construction-floors
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/native-crash-zero-tolerance.yml
+++ b/.github/workflows/native-crash-zero-tolerance.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   python-native-crash-floor:
     name: python-native-crash-floor
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/timeout-zero-tolerance.yml
+++ b/.github/workflows/timeout-zero-tolerance.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   timeout-zero-tolerance:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     env:
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
     steps:


### PR DESCRIPTION
Four heavy R-floor zero-tolerance gates (`factory`, `bare-exception`, `timeout`, `native-crash`) were pinned to `ubuntu-latest` while every heavy sibling (`pandas-wall`, `numpy-wall`, `ci` build) already runs on `[self-hosted, Linux, X64]`. 2-core hosted boxes can't carry the floor measurement; R-floor gates belong on bx. Flip all four.

No step changes — same lift-kit install, same floor scripts; the self-hosted runner already runs `setup-python` for `pandas-wall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run on designated self-hosted Linux x64 build environments.
  * Existing validation steps and commands remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run Python R-floor zero-tolerance CI gates on self-hosted Linux X64 runner
> Switches four zero-tolerance workflow jobs from `ubuntu-latest` to a self-hosted `[self-hosted, Linux, X64]` runner matrix. Affected workflows: bare-exception, factory, native-crash, and timeout zero-tolerance gates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef9fb98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->