### PR TITLE
fix: recovered-audit decoder accepts ConstructionPanic, not stale FactoryPanic

### DIFF
--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -1008,7 +1008,7 @@ fn enumerate_result_from_response(plugin: &str, response: Value) -> Result<Value
 /// fold adds the demanded SourceMemento and complete owner identity.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct RecoveredFactoryPanicWire {
+struct RecoveredConstructionPanicWire {
     kind: String,
     status: String,
     reason: String,
@@ -1044,7 +1044,7 @@ struct RecoveredAuditLeafWire {
     kind: String,
     recovery_override: bool,
     status: String,
-    panics: Vec<RecoveredFactoryPanicWire>,
+    panics: Vec<RecoveredConstructionPanicWire>,
     effects: Vec<RecoveredEffectLeafWire>,
     suppressed_descendants: Vec<SuppressedAuditLocusLeafWire>,
 }
@@ -1106,7 +1106,7 @@ struct RecoveredPanicOwnerIdentity {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RecoveredFactoryPanicRow {
+struct RecoveredConstructionPanicRow {
     kind: String,
     status: String,
     reason: String,
@@ -1457,9 +1457,9 @@ fn merge_recovered_audit_core(
     }
     let demanded_body = demanded_body.to_json();
     for panic in leaf.panics {
-        if panic.kind != "FactoryPanic" || panic.status != "mandatory-panic" {
+        if panic.kind != "ConstructionPanic" || panic.status != "mandatory-panic" {
             return Err(malformed(
-                "recovered panic row must be a mandatory FactoryPanic".to_string(),
+                "recovered panic row must be a mandatory ConstructionPanic".to_string(),
             ));
         }
         if panic.locus.is_empty() || panic.demanded_source.is_empty() {
@@ -1497,7 +1497,7 @@ fn merge_recovered_audit_core(
                 "duplicate recovered panic owner identity: {owner_identity_value}"
             )));
         }
-        let row = RecoveredFactoryPanicRow {
+        let row = RecoveredConstructionPanicRow {
             kind: panic.kind,
             status: panic.status,
             reason: panic.reason,
@@ -2115,7 +2115,7 @@ mod tests {
 
     fn recovered_panic(demand: &str) -> Value {
         json!({
-            "kind": "FactoryPanic",
+            "kind": "ConstructionPanic",
             "status": "mandatory-panic",
             "reason": "unbound propagated dependency name",
             "locus": "consumer.py:1:0",
@@ -2164,6 +2164,31 @@ mod tests {
         assert_eq!(panics[0]["gap"], panics[1]["gap"]);
         assert_ne!(panics[0]["demandedBody"], panics[1]["demandedBody"]);
         assert_eq!(panics[0]["terminalGapLocus"], "typing.py:753:11");
+    }
+
+    #[test]
+    fn recovered_panic_rejects_stale_factory_panic_kind() {
+        // The producer emits ConstructionPanic since factory retirement (#6028).
+        // A row carrying the stale "FactoryPanic" kind must stay loud, not decode.
+        let mut panics = Vec::new();
+        let mut effects = Vec::new();
+        let mut suppressed = Vec::new();
+        let owner = recovered_owner("consumer.py", "<module>", 1);
+        let mut stale = recovered_panic("pandas._typing.A");
+        stale["kind"] = json!("FactoryPanic");
+
+        let error = merge_recovered_audit_leaf(
+            "fixture",
+            &owner,
+            recovered_leaf(vec![stale]),
+            &mut panics,
+            &mut effects,
+            &mut suppressed,
+        )
+        .expect_err("stale FactoryPanic kind must be rejected");
+
+        assert!(error.to_string().contains("mandatory ConstructionPanic"));
+        assert!(panics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## The census-blocking bug

The pandas wall dispatched on main HEAD died in ~5min at frontier mint:

```
error: lift.path: tree enumeration failed: sugar.enumerate response from python malformed:
recovered panic row must be a mandatory FactoryPanic
```

`WALL_EXIT=2`, `HAS_FRONTIER=0` — the corpus could not even be enumerated, so no census could run.

## Root cause: closed boundary lagging its producers

`tree.rs` recovered-construction-audit leaf decoder required every panic row to carry `kind=="FactoryPanic"` / `status=="mandatory-panic"` — a relic from before factory retirement (#6028). Every Python producer emits `kind=="ConstructionPanic"`:
- `lift_rpc.py:1399`, `recovered_audit_dto.py:111/426`, and the consumer `recovered_frontier.py:30` all agree on `ConstructionPanic`.

The Rust unit-test fixture (`recovered_panic`) hard-coded the same stale `FactoryPanic` kind, so tests stayed green against the wrong value while production enumerate failed on every file.

## Fix
- Decoder now requires `ConstructionPanic` (matches the sole producer; python is the reference).
- Fixture aligned to the real producer shape.
- Stale structs renamed `RecoveredFactoryPanic{Wire,Row}` → `RecoveredConstructionPanic{Wire,Row}` (no factory exists).
- Added discrimination test: a stale `FactoryPanic` kind is now rejected loudly (`panics` stays empty).

Unblocks the authoritative pandas census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix recovered-audit decoder to accept `ConstructionPanic` instead of `FactoryPanic`
> Updates `merge_recovered_audit_core` in [tree.rs](https://github.com/TSavo/sugar/pull/6192/files#diff-1e76daa010a218df51ed5a9f321167e9101bfbc1ef2983cc15a1da0d4fe553eb) to validate that panic rows carry kind `"ConstructionPanic"` rather than the stale `"FactoryPanic"`. Renames `RecoveredFactoryPanicWire` and `RecoveredFactoryPanicRow` to `RecoveredConstructionPanicWire` and `RecoveredConstructionPanicRow` throughout. A new test (`recovered_panic_rejects_stale_factory_panic_kind`) asserts that rows with the old kind are rejected with an error mentioning `"mandatory ConstructionPanic"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b638dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->