### PR TITLE
fix: key recovered panics by roll-call coordinate, not sealed CID alone

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1364,19 +1364,36 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
 
     demanded_source = f"module:{source_file.unit.source_cid}"
     panics = []
-    nodes_by_cid = {}
+    # Key nodes by the roll-call identity (sealed CID + source coordinate +
+    # kind) -- the SAME identity `MinorityReport` uses. One sealed fragment CID
+    # is shared by equal source text at DISTINCT loci (e.g. `os` at 3:7 and Name
+    # nodes at 197:28 / 206:14 all seal to one CID); those are distinct
+    # obligations the minority counts separately. Keying panics by CID ALONE
+    # would map every occurrence back to one node, emit duplicate owner
+    # identities the Rust reader rejects, AND under-count R by fusing distinct
+    # source sites. Carry the coordinate so each absent node yields its own
+    # terminal locus, exactly matching `report.R`.
+    def _coord_key(node) -> tuple:
+        lc = node.line_col_span()
+        return (node.fragment.seal().cid, lc.start_line, lc.start_col, node.kind)
+
+    nodes_by_key: dict[tuple, Any] = {}
     for node in reporter.registered:
-        nodes_by_cid.setdefault(node.fragment.seal().cid, node)
-    gaps_by_cid = {}
+        nodes_by_key.setdefault(_coord_key(node), node)
+    gaps_by_key: dict[tuple, Any] = {}
     for node, panic in reporter.gaps:
-        cid = node.fragment.seal().cid
-        nodes_by_cid.setdefault(cid, node)
-        gaps_by_cid.setdefault(cid, panic)
-    absent_cids = [entry.cid for entry in report.minority]
-    absent_cids.extend(cid for cid in gaps_by_cid if cid not in absent_cids)
-    for cid in absent_cids:
-        node = nodes_by_cid[cid]
-        panic = gaps_by_cid.get(cid)
+        key = _coord_key(node)
+        nodes_by_key.setdefault(key, node)
+        gaps_by_key.setdefault(key, panic)
+    absent_keys = [
+        (entry.cid, entry.start_line, entry.start_col, entry.kind)
+        for entry in report.minority
+    ]
+    absent_seen = set(absent_keys)
+    absent_keys.extend(key for key in gaps_by_key if key not in absent_seen)
+    for key in absent_keys:
+        node = nodes_by_key[key]
+        panic = gaps_by_key.get(key)
         lc = node.line_col_span()
         locus = f"{file_rel}:{lc.start_line}:{lc.start_col}"
         terminal = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
@@ -122,7 +122,42 @@ def test_census_fingers_exactly_the_unwritten_kinds():
         assert written not in gap_kinds, f"{written} sugar is written; not a gap"
 
 
+def test_shared_cid_at_distinct_loci_stays_distinct_and_located():
+    # Two identical `import os` statements register two ImportAlias nodes with
+    # the SAME sealed fragment CID (equal source text) at DISTINCT loci. The
+    # roll call counts both; the panic producer must too. Keying panics by CID
+    # alone collapses the second locus onto the first node -- mislocating it to
+    # line 1 AND emitting a duplicate owner identity the Rust reader rejects,
+    # which under-reports the real second-site residual.
+    with tempfile.TemporaryDirectory() as root:
+        path = Path(root, "t.py")
+        path.write_text("import os\nimport os\n")
+        leaf = lift_rpc._roll_call_audit_leaf(path, "t.py")
+
+    panics = leaf["semanticCore"]["panics"]
+    owners = [(p["demandedSource"], p["terminalGapLocus"]) for p in panics]
+    assert len(owners) == len(set(owners)), (
+        f"duplicate recovered-panic owner identity: {owners}"
+    )
+
+    alias_lines = sorted(
+        p["terminalGapLocus"]
+        for p in panics
+        if p["terminalGapLocus"].endswith("[ImportAlias]")
+    )
+    assert alias_lines == ["t.py:1:7-1:9[ImportAlias]", "t.py:2:7-2:9[ImportAlias]"], (
+        f"each import alias must keep its own locus, got {alias_lines}"
+    )
+
+    # The panic list conserves the roll-call minority exactly: one row per
+    # absent source site, no fusion, no inflation.
+    assert len(panics) == leaf["auxiliaryRows"]["sourceAudit"]["totals"][
+        "source_unresolved"
+    ], "panic count must equal R (source_unresolved)"
+
+
 if __name__ == "__main__":
     test_unwritten_sugar_makes_the_frontier_fail_loudly()
     test_census_fingers_exactly_the_unwritten_kinds()
+    test_shared_cid_at_distinct_loci_stays_distinct_and_located()
     print("ok: frontier is honest -- unwritten kinds finger, written kinds clear")


### PR DESCRIPTION
## Second census-blocking bug (beneath #6192)

With #6192's `FactoryPanic`→`ConstructionPanic` fix, `sugar.enumerate` got past the first crash and hit the next:

```
sugar.enumerate malformed: duplicate recovered panic owner identity:
  demandedBody = pandas/__init__.py <module>, terminalGapLocus = __init__.py:7:0-7:18[Name]
```

## Root cause: panics keyed by CID, losing coordinate

One sealed fragment CID is shared by **equal source text at distinct loci** — e.g. the `os` ImportAlias at `3:7` and `Name` nodes at `197:28` / `206:14` all seal to one CID (the roll-call comment already notes this: *"equal source text may share a CID at distinct loci"*). The `MinorityReport` correctly keeps them as distinct obligations (keyed by coordinate + CID). But the panic producer did:

```python
absent_cids = [entry.cid for entry in report.minority]   # drops coordinate
...
node = nodes_by_cid[cid]                                  # all occurrences -> ONE node
```

So N distinct source sites sharing a CID collapsed onto one node → **duplicate owner identities** (rejected by the Rust reader) **and every shared-CID site mislocated onto the first node's line**.

Verified on the real artifact — pandas/`__init__.py`: 17 CIDs each shared by 3 distinct source sites (an ImportAlias + two Names). It's an under-report of real residuals, not just a crash.

## Fix
Key panics by the roll-call identity — sealed CID **+ source coordinate + kind** — so each absent node yields its own terminal locus. `panics` now equals `R` (`source_unresolved`) exactly: no fused, no mislocated residual.

## Discrimination test
`import os` ×2 → two `ImportAlias` at one CID, distinct loci:
- **before**: both mislocated to `1:7`, duplicate owner (dupOwners=2)
- **after**: `1:7` and `2:7` distinct, 0 dups, panics == R

Unblocks the pandas census enumerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_roll_call_audit_leaf` to key recovered panics by coordinate, not sealed CID alone
> - Changes panic keying in `_roll_call_audit_leaf` from sealed fragment CID alone to a composite of `(cid, start_line, start_col, kind)`, so identical fragments at different source locations produce distinct panic entries with correct terminal loci.
> - Replaces `nodes_by_cid`/`gaps_by_cid` dicts with `nodes_by_key`/`gaps_by_key` keyed by the composite, and builds the absent set from minority report tuples using the same structure.
> - Adds a regression test that places two identical `import os` statements at different lines and asserts each yields a unique owner identity and distinct locus in `semanticCore.panics`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad93a21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audit results so identical code elements at different source locations remain distinct.
  * Improved missing-item reporting by preserving each unresolved location and its associated details.

* **Tests**
  * Added coverage verifying that duplicate imports produce separate, correctly located audit entries.
  * Confirmed reported audit counts match the number of unresolved items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->