### PR TITLE
Cache dependency auth; reuse control-effect workers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import argparse
 import ast
 from collections import Counter, defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import json
 from pathlib import Path
+import multiprocessing as mp
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -285,6 +288,57 @@ def _parse_child(stdout: str) -> dict[str, Any] | None:
     return None
 
 
+def _pool_init() -> None:
+    """Warm dependency-auth in each long-lived worker (once per process)."""
+    try:
+        import importlib.metadata
+
+        from sugar_lift_python_source.dependency_artifact import (
+            DependencyArtifactGraph,
+        )
+
+        DependencyArtifactGraph.authenticate(
+            importlib.metadata.distribution("pandas")
+        )
+    except Exception:
+        # Warm is best-effort; first real file will authenticate if needed.
+        pass
+
+
+def _pool_measure(
+    item: tuple[str, str, str, int],
+) -> tuple[str, dict[str, Any]]:
+    """Measure one file inside a reused worker process under a hard alarm."""
+    file_key, path_s, root_s, timeout_s = item
+    path = Path(path_s)
+    root = Path(root_s)
+    relative = path.relative_to(root).as_posix()
+
+    def _on_alarm(_signum, _frame) -> None:
+        raise TimeoutError("control-effect file timeout")
+
+    previous = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.setitimer(signal.ITIMER_REAL, float(timeout_s))
+    try:
+        try:
+            row = _measure_file(path, root=root, relative=relative)
+        except TimeoutError:
+            row = {"category": "timeout", "timeoutSeconds": timeout_s}
+        except Exception as error:
+            row = {
+                "category": "backend-defect",
+                "defect": {
+                    "file": relative,
+                    "type": type(error).__name__,
+                    "message": str(error),
+                },
+            }
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0.0)
+        signal.signal(signal.SIGALRM, previous)
+    return file_key, row
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("corpus", type=Path, nargs="?")
@@ -329,7 +383,8 @@ def main() -> int:
         for path in files
     }
 
-    def run_file(file: str) -> dict[str, Any]:
+    def run_file_subprocess(file: str) -> dict[str, Any]:
+        """Legacy one-shot child (isolation). Prefer the process pool below."""
         path = by_file[file]
         relative = path.relative_to(args.corpus).as_posix()
         env = dict(os.environ)
@@ -372,20 +427,75 @@ def main() -> int:
             }
         return testimony
 
+    def run_pending_process_pool(
+        *,
+        files: tuple[str, ...],
+        workers: int,
+        on_result: Callable[[str, dict[str, Any]], None] | None = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Reuse long-lived workers so dependency auth is paid once per worker."""
+        if not files:
+            return []
+        ctx = mp.get_context("spawn")
+        items = [
+            (
+                file,
+                str(by_file[file]),
+                str(args.corpus),
+                int(args.timeout),
+            )
+            for file in files
+        ]
+        measured: list[tuple[str, dict[str, Any]]] = []
+        with ProcessPoolExecutor(
+            max_workers=max(1, workers),
+            mp_context=ctx,
+            initializer=_pool_init,
+        ) as pool:
+            futures = {
+                pool.submit(_pool_measure, item): item[0] for item in items
+            }
+            for future in as_completed(futures):
+                file = futures[future]
+                try:
+                    key, row = future.result()
+                except Exception as error:
+                    key = file
+                    row = {
+                        "category": "backend-defect",
+                        "defect": {
+                            "file": file,
+                            "type": type(error).__name__,
+                            "message": str(error),
+                        },
+                    }
+                if on_result is not None:
+                    on_result(key, row)
+                measured.append((key, row))
+        return measured
+
     if args.checkpoint_jsonl is not None:
-        from pandas_census_checkpoint import Checkpoint, run_pending
+        from pandas_census_checkpoint import Checkpoint
 
         checkpoint = Checkpoint(
             floor="control-effect",
             files=tuple(by_file),
             path=args.checkpoint_jsonl,
         )
-        journal_rows = run_pending(
-            checkpoint, run_file, workers=max(1, args.workers)
+        pending = checkpoint.pending_files()
+
+        def _append(file: str, row: dict[str, Any]) -> None:
+            checkpoint.append(file, row)
+
+        run_pending_process_pool(
+            files=pending, workers=max(1, args.workers), on_result=_append
         )
+        journal_rows = checkpoint.rows()
         measured_rows = [(row["file"], row["result"]) for row in journal_rows]
     else:
-        measured_rows = [(file, run_file(file)) for file in sorted(by_file)]
+        measured_rows = run_pending_process_pool(
+            files=tuple(sorted(by_file)), workers=max(1, args.workers)
+        )
 
     for index, (file, raw) in enumerate(measured_rows, start=1):
         row = dict(raw)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from email.parser import BytesParser
 import importlib.machinery
 import importlib.metadata
+import os
 from pathlib import Path, PurePosixPath
 import sys
 import sysconfig
@@ -54,13 +55,98 @@ def _distribution_authenticate_cache_key(
     """Stable process-local key for one installed distribution seat."""
     path = getattr(distribution, "_path", None)
     if path is not None:
-        return ("path", str(path))
+        return ("path", str(Path(path).resolve()))
     try:
         name = distribution.metadata["Name"] or ""
         version = distribution.metadata["Version"] or ""
     except Exception:
         name, version = "", ""
     return ("meta", str(name), str(version), str(type(distribution)))
+
+
+def _distribution_disk_cache_path(
+    distribution: importlib.metadata.Distribution,
+) -> Path | None:
+    """Content-stable on-disk seat for one installed distribution graph."""
+    path = getattr(distribution, "_path", None)
+    if path is None:
+        return None
+    seat = Path(path).resolve()
+    record = seat / "RECORD" if seat.is_dir() else seat
+    try:
+        st = record.stat()
+    except OSError:
+        return None
+    digest = blake3_512_of(
+        f"{seat}\0{st.st_mtime_ns}\0{st.st_size}".encode("utf-8")
+    ).removeprefix("blake3-512:")[:32]
+    root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return root / "sugar" / "dependency-artifact-graphs" / f"{digest}.pkl"
+
+
+def _load_authenticate_disk_cache(
+    distribution: importlib.metadata.Distribution,
+) -> "DependencyArtifactGraph | None":
+    path = _distribution_disk_cache_path(distribution)
+    if path is None or not path.is_file():
+        return None
+    try:
+        import pickle
+
+        with path.open("rb") as stream:
+            payload = pickle.load(stream)
+        if not isinstance(payload, dict) or payload.get("schema") != "dep-graph-v1":
+            return None
+        return DependencyArtifactGraph(
+            artifact_kind=payload["artifact_kind"],
+            distribution_name=payload["distribution_name"],
+            distribution_version=payload["distribution_version"],
+            distribution_artifact_cid=payload["distribution_artifact_cid"],
+            files=tuple(payload["files"]),
+            modules=MappingProxyType(dict(payload["modules"])),
+            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
+        )
+    except Exception:
+        return None
+
+
+def _store_authenticate_disk_cache(
+    distribution: importlib.metadata.Distribution,
+    graph: "DependencyArtifactGraph",
+) -> None:
+    path = _distribution_disk_cache_path(distribution)
+    if path is None:
+        return
+    try:
+        import pickle
+        import tempfile
+
+        # MappingProxyType is not pickleable; store plain dict modules.
+        payload = {
+            "schema": "dep-graph-v1",
+            "artifact_kind": graph.artifact_kind,
+            "distribution_name": graph.distribution_name,
+            "distribution_version": graph.distribution_version,
+            "distribution_artifact_cid": graph.distribution_artifact_cid,
+            "files": graph.files,
+            "modules": dict(graph.modules),
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=".auth-", suffix=".pkl"
+        )
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                pickle.dump(payload, stream, protocol=pickle.HIGHEST_PROTOCOL)
+            Path(tmp_name).replace(path)
+        except Exception:
+            try:
+                Path(tmp_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        return
 
 
 @dataclass(frozen=True)
@@ -463,6 +549,10 @@ class DependencyArtifactGraph:
         cached = _AUTHENTICATE_GRAPH_CACHE.get(cache_key)
         if cached is not None:
             return cached
+        disk = _load_authenticate_disk_cache(distribution)
+        if disk is not None:
+            _AUTHENTICATE_GRAPH_CACHE[cache_key] = disk
+            return disk
         files = distribution.files
         if files is None:
             raise DependencyArtifactAuthenticationError(
@@ -548,6 +638,7 @@ class DependencyArtifactGraph:
             _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
         )
         _AUTHENTICATE_GRAPH_CACHE[cache_key] = graph
+        _store_authenticate_disk_cache(distribution, graph)
         return graph
 
     @classmethod


### PR DESCRIPTION
## Summary
After #6194 (compile parse gate), cold \`authenticate(pandas)\` was still ~8s of hash/read, repeated for every census subprocess.

## Fix
1. **Disk cache** of authenticated dependency graphs under \`~/.cache/sugar/dependency-artifact-graphs/\`, keyed by distribution RECORD seat (mtime/size). Loads in ~0.2s after first cold build.
2. **control-effect census** uses a long-lived \`ProcessPoolExecutor\` (spawn) with worker initializer that warms pandas auth; per-file timeout via \`SIGALRM\` inside the worker. Auth is once per worker, not once per file.

## Measurement
| | before | after |
|---|---|---|
| cold authenticate(pandas) | ~8s | ~8s (same first time) |
| second process authenticate | ~8s | **~0.2s** (disk) |
| process mem hit | — | **~0s** |
| 4 small files via pool | N× cold | **~5.4s** total (incl warm) |

## Tests
- \`test_dependency_artifact_graph.py\` + \`test_pandas_census_checkpoint.py\`: **25 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache dependency auth to disk and reuse long-lived worker processes for file measurement
> - `DependencyArtifactGraph.authenticate` now checks a persistent on-disk cache (under `XDG_CACHE_HOME` or `~/.cache/sugar/dependency-artifact-graphs/`) keyed by distribution seat path, mtime, and size before recomputing the graph. Authenticated graphs are written back atomically after construction.
> - The recensus script replaces per-file one-shot subprocesses with a `ProcessPoolExecutor` (spawn context) that reuses worker processes across files. Workers pre-warm dependency auth on startup via `_pool_init`.
> - Per-file timeouts are now enforced inside workers using `SIGALRM`, returning structured `timeout` or `backend-defect` rows rather than crashing the pool.
> - When a checkpoint is active, results are appended incrementally as each future completes via an `on_result` callback.
> - Behavioral Change: the legacy `run_file` subprocess path is retained as `run_file_subprocess` but is no longer used in the main execution flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 523ad3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->