### PR TITLE
feat: seal branch-joined GuardedBinding into the loop binding-state wire

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -13,12 +13,17 @@ from sugar_lift_py_tests.loop_construction import (
     seal_loop_record,
 )
 
+from .binding_provenance import _state_wire
 from .binding_state import (
     BindingEntryV1,
     BindingMap,
     BindingStateWireGap,
     BoundBindingStateV1,
     ConstructedValueTestimonyV1,
+    GuardedBinding,
+    GuardedBindingStateV1,
+    UnboundBinding,
+    UnboundBindingStateV1,
     _constructed_preimage,
     branch_result_slot,
 )
@@ -46,20 +51,50 @@ def _formula_cid(formula) -> str:
     return cid_of_json(json.loads(encode_jcs(formula_to_value(formula))))
 
 
+def _seal_runtime_state(state):
+    """Seal ONE live BindingState into its authenticated SealedBindingStateV1.
+
+    The single recursive projection for every runtime binding state, not a
+    Node-only special case: a constructed Node mints its value testimony; an
+    unbound name carries its cause; a branch-joined GuardedBinding recurses into
+    both arms and pins them under the same branch-result guard the loop control
+    faces use. A guarded arm's identity is the content CID of its own sealed
+    state, so nested guards/joins address by construction.
+    """
+    from .nodes import Node
+
+    if isinstance(state, Node):
+        constructed = state.sugar()
+        testimony = ConstructedValueTestimonyV1.mint(
+            state.fragment, cid_of_json(_constructed_preimage(constructed))
+        )
+        return BoundBindingStateV1(testimony)
+    if isinstance(state, UnboundBinding):
+        return UnboundBindingStateV1(state.cause.seal().cid)
+    if isinstance(state, GuardedBinding):
+        # `site` is unused in the branch-result term (it carries only
+        # `slot.slot_id`), so the guard formula CID matches the loop control
+        # guard for the same slot; pass the slot itself as the site owner.
+        guard_cid = _formula_cid(branch_result_guard(state.slot, state.slot))
+        when_true = _seal_runtime_state(state.when_true)
+        when_false = _seal_runtime_state(state.when_false)
+        return GuardedBindingStateV1(
+            guard_cid,
+            cid_of_json(_state_wire(when_true)),
+            cid_of_json(_state_wire(when_false)),
+        )
+    raise BindingStateWireGap(
+        f"live loop state has no authenticated sealed projection: "
+        f"{type(state).__name__}"
+    )
+
+
 def _testified(entry: BindingEntryV1) -> BindingEntryV1:
     if entry.constructed_value_testimony is not None:
         return entry
-    from .nodes import Node
-
-    if not isinstance(entry.state, Node):
-        raise BindingStateWireGap(
-            "live loop state lacks constructed Node testimony"
-        )
-    constructed = entry.state.sugar()
-    testimony = ConstructedValueTestimonyV1.mint(
-        entry.state.fragment, cid_of_json(_constructed_preimage(constructed))
-    )
-    return entry.with_testimony(testimony)
+    if isinstance(entry.sealed_state, (UnboundBindingStateV1, GuardedBindingStateV1)):
+        return entry
+    return replace(entry, sealed_state=_seal_runtime_state(entry.state))
 
 
 def _sealed_state(snapshot: tuple[BindingEntryV1, ...]):

--- a/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
@@ -182,3 +182,55 @@ def test_downstream_binding_read_stays_loud_without_exact_guard_formulas():
 
     with pytest.raises(BindingStateWireGap, match="exact guard formula"):
         _construct_binding_projection(projection)
+
+
+def test_seal_runtime_state_seals_guarded_join_and_stays_loud_on_projected():
+    # A branch-joined GuardedBinding carried into a loop pre-state must seal
+    # through the ONE recursive projection -- not stay loud as a Node-only
+    # special case did (the pandas frame/indexing/blocks loop crashes).
+    from sugar_source_tree.binding_provenance import (
+        BoundBindingStateV1,
+        GuardedBindingStateV1,
+        _state_wire,
+    )
+    from sugar_source_tree.binding_state import GuardedBinding, branch_result_slot
+    from sugar_source_tree.live_loop_construction import (
+        _formula_cid,
+        _seal_runtime_state,
+    )
+    from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
+
+    _a, node_true, _e1 = _entry("def f():\n    y = 1\n")
+    _b, node_false, _e2 = _entry("def f():\n    y = 2\n")
+    _c, test_node, _e3 = _entry("def f():\n    t = 3\n")
+    slot = branch_result_slot(test_node)
+
+    sealed = _seal_runtime_state(GuardedBinding(slot, node_true, node_false))
+    assert isinstance(sealed, GuardedBindingStateV1)
+    # each arm addresses by the content CID of its OWN sealed state (recursion)
+    assert sealed.when_true_state_cid == cid_of_json(
+        _state_wire(_seal_runtime_state(node_true))
+    )
+    assert sealed.when_false_state_cid == cid_of_json(
+        _state_wire(_seal_runtime_state(node_false))
+    )
+    # the guard is the SAME branch-result guard the loop control faces use
+    assert sealed.guard_formula_cid == _formula_cid(
+        branch_result_guard(slot, slot)
+    )
+    # a constructed Node arm seals to a bound value, not a guard
+    assert isinstance(_seal_runtime_state(node_true), BoundBindingStateV1)
+
+    # Bad twin: a LoopProjectedBinding is a real state this projection does not
+    # yet implement -- it must stay LOUD, never silently pass.
+    target_cid = cid_of_json({"target": "loop"})
+    projected = LoopProjectedBinding(
+        target_cid,
+        (
+            LoopProjectedCompletedFace(
+                target_cid, "NormalExhaustion", cid_of_json({"g": "x"}), node_true
+            ),
+        ),
+    )
+    with pytest.raises(BindingStateWireGap):
+        _seal_runtime_state(projected)


### PR DESCRIPTION
## Ranked #1 crash capability from the focused sweep

The focused enumerate sweep (all 1415 pandas files, post-#6192/#6193) showed the enumerate boundary CLEAN (0 duplicate-owner, 0 malformed) but **23 files crash** during construction. The dominant cluster (7+) was:

```
BindingStateWireGap: live loop state lacks constructed Node testimony
```
(frame, indexing, internals/blocks, internals/managers, indexes/base, tools/numeric, arrays/boolean)

## Root cause: Node-only sealing of loop pre-state

A name conditionally assigned in an `If` branch is a `GuardedBinding` (`{slot, when_true, when_false}`, a recursive guarded value tree). Carried into a loop's carried-names pre-state, `_testified` could only seal a raw `Node` and raised. `_snapshot_preimage` even documents it: *"Guarded and pending bound states have no serializable testimony yet… callers that need wire admission must stay loud."* The capability was simply unbuilt.

## Fix: one recursive BindingState sealer

`_seal_runtime_state` — the single projection for every runtime state, not a Node special case:
- **Node** → bound value testimony (`state.sugar()`)
- **UnboundBinding** → cause fragment CID
- **GuardedBinding** → recurse both arms, pin under the **same** `branch_result_guard` the loop control faces use; each arm addressed by the content CID of its own sealed state
- **LoopProjectedBinding** → stays **loud** (nested/sequential-loop projection is a distinct unbuilt capability)

The `guarded` wire variant + `GuardedBindingStateV1` already existed in the decoder; this builds the producer side.

## Verified on the real corpus
The 7 files now enumerate with **panics == R** and **zero duplicate owner identities**. `core/frame.py`: 15,988 panics, 0 dups. Twin test proves the recursive seal (arm CIDs + shared guard) and that an unimplemented state stays loud, never silently passes. 41 existing binding/loop tests unchanged.

Remaining crash after this: `internals/managers.py` advances to the next layer (`LoopProjectedBinding` into a loop) — a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal branch-joined `GuardedBinding` into the loop binding-state wire
> - Adds `_seal_runtime_state` to [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6196/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094), which dispatches on binding state type: `Node` → `BoundBindingStateV1`, `UnboundBinding` → `UnboundBindingStateV1`, `GuardedBinding` → `GuardedBindingStateV1` (recursively sealing each arm), and any unsupported type → `BindingStateWireGap`.
> - Updates `_testified` to delegate to `_seal_runtime_state` instead of only handling `Node` states, so `GuardedBinding` and `UnboundBinding` entries now populate `sealed_state` without raising.
> - Adds a test in [test_guarded_loop_recurrence.py](https://github.com/TSavo/sugar/pull/6196/files#diff-8bd16b1ec0c768ac4f34c61011ea19a06baee84e1b3e29a3eb2548983527b58e) covering `GuardedBinding` sealing and confirming `LoopProjectedBinding` still raises `BindingStateWireGap`.
> - Behavioral Change: `_testified` previously attached only `constructed_value_testimony` for `Node` entries; it now also sets `sealed_state` to `BoundBindingStateV1` for those entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b2feb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->