### PR TITLE
feat: seal single-face LoopProjectedBinding carried into a later loop

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -22,6 +22,7 @@ from .binding_state import (
     ConstructedValueTestimonyV1,
     GuardedBinding,
     GuardedBindingStateV1,
+    LoopProjectedBinding,
     UnboundBinding,
     UnboundBindingStateV1,
     _constructed_preimage,
@@ -82,6 +83,20 @@ def _seal_runtime_state(state):
             guard_cid,
             cid_of_json(_state_wire(when_true)),
             cid_of_json(_state_wire(when_false)),
+        )
+    if isinstance(state, LoopProjectedBinding):
+        # A prior loop's post-state carried into a later loop. A single
+        # completion face is TOTAL: a for/while with no break exits only by
+        # NormalExhaustion, so that face's LoopBindingRef IS the unconditional
+        # post-value (the ref itself carries the completion identity). Seal it
+        # directly. A multi-face projection (a loop that can break) is a genuine
+        # multi-way join whose binary-guarded folding is not yet built -- it
+        # stays LOUD rather than guess a fallthrough and bind the wrong value.
+        if len(state.completed_faces) == 1:
+            return _seal_runtime_state(state.completed_faces[0].state)
+        raise BindingStateWireGap(
+            "multi-face loop projected binding sealing is unimplemented; "
+            "stays loud rather than fold a multi-way completion join"
         )
     raise BindingStateWireGap(
         f"live loop state has no authenticated sealed projection: "

--- a/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
@@ -221,10 +221,10 @@ def test_seal_runtime_state_seals_guarded_join_and_stays_loud_on_projected():
     # a constructed Node arm seals to a bound value, not a guard
     assert isinstance(_seal_runtime_state(node_true), BoundBindingStateV1)
 
-    # Bad twin: a LoopProjectedBinding is a real state this projection does not
-    # yet implement -- it must stay LOUD, never silently pass.
+    # A SINGLE-face loop projection is TOTAL (a no-break loop exits only by
+    # NormalExhaustion), so it seals to that one face's state unconditionally.
     target_cid = cid_of_json({"target": "loop"})
-    projected = LoopProjectedBinding(
+    single = LoopProjectedBinding(
         target_cid,
         (
             LoopProjectedCompletedFace(
@@ -232,5 +232,21 @@ def test_seal_runtime_state_seals_guarded_join_and_stays_loud_on_projected():
             ),
         ),
     )
-    with pytest.raises(BindingStateWireGap):
-        _seal_runtime_state(projected)
+    assert _seal_runtime_state(single) == _seal_runtime_state(node_true)
+
+    # Bad twin: a MULTI-face projection (a loop that can break) is a genuine
+    # multi-way completion join whose folding is unbuilt -- it stays LOUD,
+    # never silently folds to a wrong fallthrough value.
+    multi = LoopProjectedBinding(
+        target_cid,
+        (
+            LoopProjectedCompletedFace(
+                target_cid, "BreakExit", cid_of_json({"g": "b"}), node_true
+            ),
+            LoopProjectedCompletedFace(
+                target_cid, "NormalExhaustion", cid_of_json({"g": "x"}), node_false
+            ),
+        ),
+    )
+    with pytest.raises(BindingStateWireGap, match="multi-face"):
+        _seal_runtime_state(multi)


### PR DESCRIPTION
Follow-up to #6196. The focused sweep's next crash cluster was `LoopProjectedBinding` (a prior loop's post-state) carried into a later loop's pre-state — 5 files.

**Evidence over assumption:** every real occurrence is a **single** completion face (`NormalExhaustion`) whose state is a `LoopBindingRef` Node. A no-break loop exits only by exhaustion, so that single face is the **total, unconditional** post-value — seal it directly. A multi-face projection (a loop that can break) is a real multi-way join whose binary-guarded folding is unbuilt; it **stays loud** rather than guess a fallthrough and silently bind the wrong value.

Fixes `internals/managers.py`, `io/pytables.py`, `io/formats/style.py` (panics == R, 0 dup owners). `io/html` and `util/hashing` advance to distinct next bugs (`KeyError: 'retained'`; a read-path `LoopProjectedBinding` site). Twin proves single-face seals to its face state, multi-face stays loud. 19 binding/loop tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal single-face `LoopProjectedBinding` in `_seal_runtime_state`
> - `_seal_runtime_state` in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6197/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) now handles `LoopProjectedBinding` carried into a later loop iteration in the single recursive projection path.
> - When the binding has exactly one completed face, the face's sealed state is returned directly instead of raising.
> - When the binding has multiple completed faces, a `BindingStateWireGap` is raised with a message indicating multi-face sealing is unimplemented, replacing the previous generic error.
> - Tests in [test_guarded_loop_recurrence.py](https://github.com/TSavo/sugar/pull/6197/files#diff-8bd16b1ec0c768ac4f34c61011ea19a06baee84e1b3e29a3eb2548983527b58e) cover both the single-face success path and the multi-face error path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30158e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling for loop projections with a single completion path.
  * Multi-path loop projections now provide a clear error instead of failing with a generic sealing error.
* **Tests**
  * Updated coverage to verify successful sealing for single-face projections and explicit errors for multi-face projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->