### PR TITLE
feat: canonicalize float and bytes constructed-value testimony

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -547,6 +547,17 @@ def _canonical_constructed_value(value: object) -> Any:
 
     if value is None or isinstance(value, (bool, int, str)):
         return value
+    if isinstance(value, float):
+        from decimal import Decimal
+
+        # The one canonical float spelling the system already uses (see
+        # term_value.to_term / ir.real_lit): a fixed-point decimal string, never
+        # a Python float text form. str(float) is the shortest exact decimal
+        # that reparses to the same double; non-finite becomes Infinity / NaN.
+        return {"float": format(Decimal(str(value)), "f")}
+    if isinstance(value, bytes):
+        # Bytes canonicalize by hex, matching bytes_value / sequence_repetition.
+        return {"bytes": value.hex()}
     if isinstance(value, Enum):
         return {
             "enumType": f"{type(value).__module__}.{type(value).__qualname__}",

--- a/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
@@ -168,3 +168,27 @@ def test_loop_projection_rejects_lying_target_and_cid_as_runtime_value():
             guard_cid,
             cid_of_json({"fabricated": "value"}),
         )
+
+
+def test_canonical_constructed_value_seals_float_and_bytes():
+    # Float and bytes literal testimony must enter the closed canonical wire.
+    from sugar_source_tree.binding_state import _canonical_constructed_value
+
+    # Float -> the ONE canonical fixed-point decimal string the system uses
+    # (ir.real_lit), tagged so a float never collides with the str "1.5".
+    assert _canonical_constructed_value(1.5) == {"float": "1.5"}
+    assert _canonical_constructed_value(0.0) == {"float": "0.0"}
+    assert _canonical_constructed_value(-2.25) == {"float": "-2.25"}
+    assert _canonical_constructed_value(1e-05) == {"float": "0.00001"}
+    # Bytes -> hex, matching bytes_value / sequence_repetition.
+    assert _canonical_constructed_value(b"\xde\xad\xbe\xef") == {"bytes": "deadbeef"}
+
+    # Both must be canonical-JSON admissible and deterministic.
+    for value in (1.5, 0.0, b"\x00\xff"):
+        encoded = _canonical_constructed_value(value)
+        assert cid_of_json({"v": encoded}) == cid_of_json({"v": encoded})
+
+    # Bad twin: a value with no canonical spelling stays LOUD, never silently
+    # collapses to a fabricated testimony.
+    with pytest.raises(TypeError, match="unserializable"):
+        _canonical_constructed_value(1 + 2j)


### PR DESCRIPTION
Next crash cluster from the focused sweep: `TypeError: unserializable constructed value float`/`bytes` (6 files).

`_canonical_constructed_value` sealed None/bool/int/str/Enum/fragments/collections/dataclasses but raised on `float` and `bytes`. Sealed both by the conventions **already in the codebase**:
- **float** → `format(Decimal(str(v)), 'f')` — the one canonical fixed-point decimal string (matches `ir.real_lit`; `1e-05`→`0.00001`, non-finite → Infinity/NaN, never a crash), tagged `{"float": ...}` so it can't collide with the string form.
- **bytes** → `.hex()` (matches `bytes_value`/`sequence_repetition`).

Fixes numba `mean_`/`var_`/`window`, `io/sas/sas7bdat`, `io/stata`, `tests/io/test_common` — all enumerate with panics == R, 0 dup owners. Twin proves the canonical forms + JSON admissibility, and that an unspellable value (complex) stays loud. 11 binding tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Canonicalize float and bytes values in `_canonical_constructed_value`
> Adds explicit handling for `float` and `bytes` inputs in [`binding_state.py`](https://github.com/TSavo/sugar/pull/6198/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40). Floats are serialized as fixed-point decimal strings under a `"float"` key (using `Decimal` for determinism); bytes are serialized as hex strings under a `"bytes"` key. Previously, these types would raise `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fda02c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->