### PR TITLE
fix: conserve byte-identical loop-graph records before decode

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -221,6 +221,28 @@ def _record(preimage, cid_field):
     return seal_loop_record(preimage, cid_field)
 
 
+def _conserve_unique_records(records):
+    """Collapse byte-identical loop-graph records, preserving first order.
+
+    The record streams (state / completed-face / obligation / transform) can
+    re-emit a record with identical content -- e.g. a completed face and a latch
+    obligation that seal to the same bytes, or a binding-state two transforms
+    both reference. A record CID is a content hash, so equal content is the SAME
+    record; the loop-graph decoder keys records by CID and requires each once.
+    Conserving exact duplicates here (as `state_records` already does) satisfies
+    that contract without dropping any distinct record.
+    """
+    seen: set[str] = set()
+    unique = []
+    for record in records:
+        cid = cid_of_json(record)
+        if cid in seen:
+            continue
+        seen.add(cid)
+        unique.append(record)
+    return unique
+
+
 def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectionV1:
     """Construct, decode, project, then publish a loop's guarded post-state."""
     from .nodes import For, While
@@ -576,6 +598,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             "postBindingObligationCids": post_records,
         }, "loopConstructionCid"
     )
+    records = _conserve_unique_records(records)
     construction = decode_loop_construction_v1({"root": root, "records": records})
 
     bindings = {}

--- a/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
@@ -250,3 +250,19 @@ def test_seal_runtime_state_seals_guarded_join_and_stays_loud_on_projected():
     )
     with pytest.raises(BindingStateWireGap, match="multi-face"):
         _seal_runtime_state(multi)
+
+
+def test_conserve_unique_records_collapses_identical_keeps_distinct():
+    # Loop-graph assembly can re-emit a byte-identical record; the decoder keys
+    # records by CID and requires each once. Conservation collapses exact
+    # duplicates (first order preserved) but never a genuinely distinct record.
+    from sugar_source_tree.live_loop_construction import _conserve_unique_records
+
+    a = {"kind": "loop-body-transform", "bodyTransformCid": "cid-a"}
+    b = {"kind": "loop-latch-obligation", "latchObligationCid": "cid-b"}
+    c = {"kind": "loop-body-transform", "bodyTransformCid": "cid-c"}
+
+    # identical re-emissions of a and b collapse to one each, in first order
+    assert _conserve_unique_records([a, b, dict(a), dict(b)]) == [a, b]
+    # distinct records (different content) are all retained
+    assert _conserve_unique_records([a, c, b]) == [a, c, b]


### PR DESCRIPTION
Next crash cluster: `LoopWireError: duplicate loop graph CID` (`core/computation/eval.py`, `tests/io/test_sql.py`).

`construct_live_loop_recurrence` assembles the loop graph from several record streams; some pandas loops re-emit a **byte-identical** record across streams (a completed face and a latch obligation that seal to the same bytes). A record CID is a content hash, so equal CIDs = the same record; the decoder keys records by CID and requires each once. Conserve exact duplicates before decode — the same conservation `state_records` already applies — preserving first order. References resolve by CID to the single entry, so **loop semantics are unchanged**; proven neutral on the bounded-loop control suite (same 9 pass / 3 pre-existing fail, unchanged).

Both files now enumerate with panics == R, 0 dup owners. Twin proves identical records collapse (first order) while distinct records are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate byte-identical loop-graph records before decode in `construct_live_loop_recurrence`
> Adds a `_conserve_unique_records` helper in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6199/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) that collapses duplicate records by CID (via `cid_of_json`), preserving first-occurrence order. `construct_live_loop_recurrence` now calls this before decoding, so duplicate-by-content records are dropped upstream of the decode step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f72594.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->