### PR TITLE
fix: loop-else carried names + single-face LoopProjectedBinding read path

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -682,6 +682,15 @@ def binding_state_read_node(
         return state
     if isinstance(state, (UnboundBinding, GuardedBinding)):
         return make_read(state)
+    if isinstance(state, LoopProjectedBinding):
+        # A single completion face is the TOTAL post-value (a no-break loop
+        # exits only by NormalExhaustion), so read straight through it. A
+        # multi-face join stays loud rather than silently pick one arm.
+        if len(state.completed_faces) == 1:
+            return binding_state_read_node(
+                state.completed_faces[0].state, make_read=make_read
+            )
+        raise TypeError(type(state))
     raise TypeError(type(state))
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -500,7 +500,14 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             loop.orelse, exhaustion_scope
         )
         else_runtime = tuple(
-            replace(else_net[name], coordinate=pre_entry.coordinate)
+            # `else_net` holds only the names the else body REBOUND. A carried
+            # name the else clause never touches keeps its loop-exhaustion value
+            # (the state entering the else, already in `exhaustion_scope`), not a
+            # KeyError.
+            replace(
+                else_net.get(name, exhaustion_scope[name]),
+                coordinate=pre_entry.coordinate,
+            )
             for name, pre_entry in zip(carried_names, pre_entries, strict=True)
         )
         else_state, else_runtime = _sealed_state(else_runtime)

--- a/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
@@ -266,3 +266,37 @@ def test_conserve_unique_records_collapses_identical_keeps_distinct():
     assert _conserve_unique_records([a, b, dict(a), dict(b)]) == [a, b]
     # distinct records (different content) are all retained
     assert _conserve_unique_records([a, c, b]) == [a, c, b]
+
+
+def test_binding_state_read_node_reads_through_single_face_projection():
+    # A single-face LoopProjectedBinding is the TOTAL post-value; the read path
+    # must read straight through it (regression: pandas core/util/hashing).
+    # A multi-face join stays loud rather than silently pick one arm.
+    from sugar_source_tree.binding_state import binding_state_read_node
+
+    _a, node, _e = _entry("def f():\n    y = 1\n")
+    target_cid = cid_of_json({"target": "loop"})
+    single = LoopProjectedBinding(
+        target_cid,
+        (
+            LoopProjectedCompletedFace(
+                target_cid, "NormalExhaustion", cid_of_json({"g": "x"}), node
+            ),
+        ),
+    )
+    sentinel = object()
+    assert binding_state_read_node(single, make_read=lambda s: sentinel) is node
+
+    multi = LoopProjectedBinding(
+        target_cid,
+        (
+            LoopProjectedCompletedFace(
+                target_cid, "BreakExit", cid_of_json({"g": "b"}), node
+            ),
+            LoopProjectedCompletedFace(
+                target_cid, "NormalExhaustion", cid_of_json({"g": "x"}), node
+            ),
+        ),
+    )
+    with pytest.raises(TypeError):
+        binding_state_read_node(multi, make_read=lambda s: sentinel)

--- a/implementations/python/sugar-source-tree/tests/test_loop_control_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_control_construction.py
@@ -214,3 +214,25 @@ def test_nested_continue_is_consumed_only_by_the_inner_bounded_loop():
         .value.post()
     )
     assert post.args[1].value == 22
+
+
+def test_loop_else_preserves_a_carried_name_it_never_rebinds():
+    # A name carried through the loop (rebound in the body) that the else clause
+    # does NOT touch keeps its loop-exhaustion value. The else-net holds only
+    # names the else REBOUND, so it must fall back to the exhaustion state, not
+    # KeyError (regression: pandas io/html, io/excel/_xlsxwriter, _version).
+    post = (
+        _function(
+            "def arbitrary():\n"
+            "    total = 0\n"
+            "    for i in (1, 2):\n"
+            "        total = total + i\n"
+            "    else:\n"
+            "        seen = True\n"
+            "    return total\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
+    assert post.args[1].value == 3


### PR DESCRIPTION
The last enumerate crashes from the focused sweep:

1. **else-net KeyError** (`io/html`, `io/excel/_xlsxwriter`, `_version`): the loop-else projection did `else_net[name]` for every carried name, but `else_net` holds only names the else clause **rebound**. A carried name the else never touches keeps its loop-exhaustion value (already in `exhaustion_scope`) — fall back to it. Also greens the previously-red `test_bounded_while_continue_routes_to_test_backedge`.
2. **LoopProjectedBinding read path** (`core/util/hashing`): `binding_state_read_node` raised on a `LoopProjectedBinding`. Mirror the #6197 seal path — single face = total post-value, read straight through; multi-face stays loud.

All four enumerate with panics == R, 0 dup owners. Twins prove both. Remaining reds are the tracked #6200 bounded-loop correctness bug (separate axis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix loop-else carried name lookup and `LoopProjectedBinding` single-face read path
> - `binding_state_read_node` in [binding_state.py](https://github.com/TSavo/sugar/pull/6201/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) now reads through a `LoopProjectedBinding` with exactly one completed face, returning the underlying node directly; multi-face projections still raise `TypeError`.
> - `construct_live_loop_recurrence` in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6201/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) uses `else_net.get(name, exhaustion_scope[name])` so carried names not rebound in the else clause fall back to their loop-exhaustion value instead of raising `KeyError`.
> - Regression tests are added for both fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d91431.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->