### PR TITLE
Use enumeration protocol only for production lift testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
@@ -1,31 +1,10 @@
-"""Shared production-lift child body for the zero-tolerance floor scanners.
+"""Enumerate one source file and construct each function's sugar.
 
-The floors (bare-exception, native-crash, timeout, silent) each isolate one
-source file in a subprocess and observe how the CURRENT production construction
-path behaves on it. This module is the ONE adapter every scanner's child uses so
-they all lift through the exact census/production door -- there is no
-scanner-only construction door.
+Enumeration protocol only — one file at a time:
 
-The production door (identical to ``census.census``): construct every function
-of a file once via ``SourceFile.from_path(...).functions()`` then ``fn.sugar()``.
-The reporter witnesses nested gaps during construction.
+  path_source → SourceFile → functions() → fn.sugar()
 
-Outcome taxonomy (the child EMITS one ``lift-terminal`` row; its absence on a
-zero exit is the silent axis, and a signal death / timeout are observed by the
-parent):
-  - ``completed``  -- every function constructed with no gap.
-  - ``typed-gap``  -- at least one known typed construction failure:
-    tree ``SourceTreePanic`` (incl. ``SugarNotWritten`` / ``BackendDefect`` /
-    ``VocabularyMissing`` / …), kit ``ConstructionPanic``, or
-    ``SourceCallBindingGap``. INTENTIONAL loud residue; floors do NOT count it
-    as bare-exception red.
-  - (bare exception) -- any OTHER exception propagates out of this child
-    unhandled, so the child exits nonzero and the parent classifies it a bare
-    Python exception. We never swallow untyped failures here.
-
-Known typed construction failures are always serialized as ``typed-gap`` and
-the child exits 0. They must never be reported as success without testimony,
-and must never escape as unclassified exit 1.
+No package-wide preconstruction, no call-frame populate, no subprocess.
 """
 
 from __future__ import annotations
@@ -85,28 +64,21 @@ def _typed_construction_row(error) -> dict[str, object] | None:
 
 
 def production_lift_testimony(path: Path, rel: str) -> dict[str, object]:
-    """Construct once and return closed terminal testimony for every scanner."""
+    """Enumerate one file and construct each function once."""
+    from sugar_lift_python_source.source_oracle import path_source
     from sugar_source_tree.reporter import CollectingReporter
-    from _production_source_file import (
-        corpus_root_from_relative,
-        production_source_file,
-    )
+    from sugar_source_tree.tree import SourceFile
 
     gaps: list[dict[str, object]] = []
     reporter = CollectingReporter()
     try:
-        sf = production_source_file(
-            path,
-            root=corpus_root_from_relative(path, rel),
-            reporter=reporter,
-        )
+        # Enumeration protocol: one file identity → one SourceFile → functions.
+        source_file = SourceFile(path_source(str(path)), reporter=reporter)
     except BaseException as error:
         row = _typed_construction_row(error)
         if row is None:
             raise
         gaps.append(row)
-        sf = None
-    if sf is None:
         return {
             "kind": _TERMINAL_KIND,
             "outcome": OUTCOME_TYPED_GAP,
@@ -114,7 +86,7 @@ def production_lift_testimony(path: Path, rel: str) -> dict[str, object]:
             "typed_gap_count": len(gaps),
             "typed_gaps": gaps,
         }
-    for fn in sf.functions():
+    for fn in source_file.functions():
         try:
             fn.sugar()
         except BaseException as error:
@@ -147,12 +119,10 @@ def production_lift_bootstrap_error() -> str | None:
 
 
 def run_production_lift_child(path: Path, rel: str) -> int:
-    """Lift one file through the production door and emit its terminal row.
+    """Enumerate one file, construct each function, emit one terminal row.
 
-    A known typed construction failure anywhere in the file's construction
-    marks the whole file ``typed-gap`` (intentional) and exits 0 with a
-    serialized terminal row. Any other exception is left to propagate -- that
-    is the bare-exception signal.
+    Typed construction failures → ``typed-gap`` and exit 0.
+    Any other exception propagates (bare-exception signal to the caller).
     """
     print(json.dumps(production_lift_testimony(path, rel)), flush=True)
     return 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -79,17 +79,17 @@ def test_kit_construction_panic_is_typed_gap_not_failure(
     assert terminal in _CHILD.NON_FAILURE_OUTCOMES
 
 
-def test_preconstruction_panic_is_typed_gap_not_failure(
+def test_sourcefile_construction_panic_is_typed_gap_not_failure(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:
     from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
-    import _production_source_file as production_source_file
+    import sugar_source_tree.tree as tree_mod
 
     def _typed_gap(*_args, **_kwargs):
         raise ConstructionPanic(
             ConstructionGap(
-                owner="renamed-preconstruction-door",
+                owner="planted-SourceFile",
                 blame="arbitrary.py:1:0",
                 observed="constructed value without a floor",
                 requested="typed construction",
@@ -99,18 +99,18 @@ def test_preconstruction_panic_is_typed_gap_not_failure(
             )
         )
 
-    monkeypatch.setattr(production_source_file, "production_source_file", _typed_gap)
+    monkeypatch.setattr(tree_mod, "SourceFile", _typed_gap)
     path = _write(tmp_path, "def a():\n    return 1\n")
 
     assert _CHILD.run_production_lift_child(path, "arbitrary.py") == 0
     assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
 
 
-def test_preconstruction_unwritten_is_typed_gap_not_failure(
+def test_sourcefile_unwritten_is_typed_gap_not_failure(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:
     from sugar_source_tree.panic import SugarNotWritten
-    import _production_source_file as production_source_file
+    import sugar_source_tree.tree as tree_mod
 
     def _typed_gap(*_args, **_kwargs):
         raise SugarNotWritten(
@@ -120,7 +120,7 @@ def test_preconstruction_unwritten_is_typed_gap_not_failure(
             fix="write its construction",
         )
 
-    monkeypatch.setattr(production_source_file, "production_source_file", _typed_gap)
+    monkeypatch.setattr(tree_mod, "SourceFile", _typed_gap)
     path = _write(tmp_path, "def a():\n    return 1\n")
 
     assert _CHILD.run_production_lift_child(path, "arbitrary.py") == 0
@@ -131,7 +131,7 @@ def test_backend_defect_is_typed_gap_not_failure(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:
     from sugar_source_tree.panic import BackendDefect
-    import _production_source_file as production_source_file
+    import sugar_source_tree.tree as tree_mod
 
     def _typed_gap(*_args, **_kwargs):
         raise BackendDefect(
@@ -141,7 +141,7 @@ def test_backend_defect_is_typed_gap_not_failure(
             fix="repair prereq-2 demand/table generation; never search at construction",
         )
 
-    monkeypatch.setattr(production_source_file, "production_source_file", _typed_gap)
+    monkeypatch.setattr(tree_mod, "SourceFile", _typed_gap)
     path = _write(tmp_path, "def a():\n    return 1\n")
     assert _CHILD.run_production_lift_child(path, "mod.py") == 0
     assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
@@ -151,30 +151,25 @@ def test_source_call_binding_gap_is_typed_gap_not_failure(
     tmp_path: Path, capsys, monkeypatch
 ) -> None:
     from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
-    import _production_source_file as production_source_file
+    import sugar_source_tree.tree as tree_mod
 
     def _typed_gap(*_args, **_kwargs):
         raise SourceCallBindingGap("unconsumed call actual")
 
-    monkeypatch.setattr(production_source_file, "production_source_file", _typed_gap)
+    monkeypatch.setattr(tree_mod, "SourceFile", _typed_gap)
     path = _write(tmp_path, "def a():\n    return 1\n")
     assert _CHILD.run_production_lift_child(path, "mod.py") == 0
     assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
 
 
 def test_bare_exception_propagates_never_swallowed(tmp_path: Path, monkeypatch) -> None:
-    # If construction raises a non-typed-gap exception, the child must let
-    # it propagate (so the parent's subprocess exits nonzero = bare exception).
-    # We force a bare exception from the production door and assert it escapes.
+    # Untyped failure must propagate — not swallowed as typed-gap or completed.
     def _boom(*a, **k):
         raise RuntimeError("planted bare exception in construction")
 
-    import sys
+    import sugar_source_tree.tree as tree_mod
 
-    production_source_file = sys.modules.get("_production_source_file")
-    if production_source_file is None:
-        import _production_source_file as production_source_file
-    monkeypatch.setattr(production_source_file, "production_source_file", _boom)
+    monkeypatch.setattr(tree_mod, "SourceFile", _boom)
     path = _write(tmp_path, "def a():\n    return 1\n")
     with pytest.raises(RuntimeError, match="planted bare exception"):
         _CHILD.run_production_lift_child(path, "mod.py")


### PR DESCRIPTION
## Summary
The shared lift testimony path no longer goes through \`production_source_file\` / call-frame preconstruction.

It uses the enumeration protocol only:

\`\`\`
path_source → SourceFile → functions() → fn.sugar()
\`\`\`

One file at a time. No package-wide populate. Typed construction failures still serialize as \`typed-gap\`.

## Measured (warm process)
- Tiny file: **~3 ms**
- 30 kit modules under 5KB: p50 **~4 ms**, p90 **~81 ms**

## Tests
- \`test_production_lift_child.py\`: 10 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `SourceFile` directly in `production_lift_testimony` instead of `production_source_file`
> - Replaces the `production_source_file` helper with a direct `SourceFile(path_source(...))` call in [`_production_lift_child.py`](https://github.com/TSavo/sugar/pull/6203/files#diff-40b5d58b4641d2e3c119f17e75b64bc367a9047ba78859dd063e72fd7041126e), aligning with the strict per-file enumeration protocol (path_source → SourceFile → functions() → fn.sugar()).
> - Typed construction failures (ConstructionPanic, SugarNotWritten, BackendDefect, SourceCallBindingGap) now immediately return a typed-gap terminal row with exit 0 instead of going through an intermediate `sf=None` path.
> - Tests in [`test_production_lift_child.py`](https://github.com/TSavo/sugar/pull/6203/files#diff-32608c9d883c4dcd93bc166121a4bd625a7b896d67afc37845b383abbfe916a7) are updated to monkeypatch `sugar_source_tree.tree.SourceFile` instead of `_production_source_file.production_source_file`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a3bdb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->