### PR TITLE
Fix heavy floor topology: one orchestrator + supervised enum worker

### DIFF
--- a/.github/workflows/bare-exception-zero-tolerance.yml
+++ b/.github/workflows/bare-exception-zero-tolerance.yml
@@ -1,5 +1,8 @@
-name: Bare exception zero tolerance
+name: Bare exception zero tolerance (discrimination)
 
+# Discrimination only. Full corpus R_bare_exceptions runs exclusively under
+# factory-zero-tolerance.yml so heavy floors share one pinned run and one
+# concurrency group (no multi-workflow pending-run cancellation).
 on:
   pull_request:
   push:
@@ -9,12 +12,8 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: sugar-python-heavy-measurement
-  cancel-in-progress: false
-
 jobs:
-  bare-exception-zero-tolerance:
+  bare-exception-discrimination:
     runs-on: [self-hosted, Linux, X64]
     env:
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
@@ -38,7 +37,3 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
-      - name: R_bare_exceptions = 0
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -9,8 +9,9 @@ on:
 permissions:
   contents: read
 
-# Serialize heavy Python measurement on battleaxe self-hosted runners so floors
-# and corpus scans never compete for CPU/timeout budget.
+# ONE orchestrator for heavy kit floors. Do not put other PR workflows in this
+# concurrency group — GitHub keeps only one pending run per group, so six
+# independent workflows cancel each other even with cancel-in-progress: false.
 concurrency:
   group: sugar-python-heavy-measurement
   cancel-in-progress: false
@@ -43,9 +44,12 @@ jobs:
         run: >-
           python -m pip install
           pytest
+          tqdm
           ./implementations/python/sugar-lift-python-source
           ./implementations/python/sugar-source-tree
           ./implementations/python/sugar-lift-py-tests
+      # Heavy supervised enum floors — sequential under this one job so the
+      # complete floor set is always from one pinned run.
       - name: R_native_crashes = 0
         if: always()
         run: >-
@@ -86,11 +90,6 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
-      # Product-completeness axis (#5252). R_silent does not subsume unclassified.
-      # Discrimination proves the instrument trips on planted residue and refuses
-      # missing measurement (never fakes R=0). Live corpus R is measured by
-      # recensus shards and gated via:
-      #   scripts/factory_walk_unclassified_law.py --from-json <shard>
       - name: R_factory_walk_unclassified discrimination
         if: always()
         run: >-
@@ -150,9 +149,6 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
-      # Permanent construction-currency floor (#6115+#6121+#6128). Dual-body
-      # residual keeps main honestly red until sugar-lift-python-source is drained;
-      # sole-path R is reported in the same instrument and must stay 0.
       - name: R_construction_side_doors discrimination
         if: always()
         run: >-

--- a/.github/workflows/native-crash-zero-tolerance.yml
+++ b/.github/workflows/native-crash-zero-tolerance.yml
@@ -1,5 +1,7 @@
-name: Python native-crash floor (R>0 red)
+name: Python native-crash floor (discrimination)
 
+# Discrimination only. Full corpus R_native_crashes runs exclusively under
+# factory-zero-tolerance.yml (one heavy orchestrator).
 on:
   pull_request:
   push:
@@ -9,13 +11,9 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: sugar-python-heavy-measurement
-  cancel-in-progress: false
-
 jobs:
-  python-native-crash-floor:
-    name: python-native-crash-floor
+  native-crash-discrimination:
+    name: native-crash-discrimination
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +32,3 @@ jobs:
           python -m pytest --noconftest
           implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py
           -q
-      - name: R_native_crashes = 0
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py

--- a/.github/workflows/timeout-zero-tolerance.yml
+++ b/.github/workflows/timeout-zero-tolerance.yml
@@ -1,5 +1,7 @@
-name: Timeout zero tolerance
+name: Timeout zero tolerance (discrimination)
 
+# Discrimination only. Full corpus R_timeouts runs exclusively under
+# factory-zero-tolerance.yml (one heavy orchestrator).
 on:
   pull_request:
   push:
@@ -9,12 +11,8 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: sugar-python-heavy-measurement
-  cancel-in-progress: false
-
 jobs:
-  timeout-zero-tolerance:
+  timeout-discrimination:
     runs-on: [self-hosted, Linux, X64]
     env:
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
@@ -38,7 +36,3 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
-      - name: R_timeouts = 0
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -1,0 +1,296 @@
+"""Supervised persistent enumeration worker for CI floors.
+
+Topology:
+  - One long-lived worker process reuses enum caches across healthy files.
+  - Parent records the current file *before* dispatch.
+  - On 30s silence/timeout: kill worker, terminal=timeout for that file, restart.
+  - On signal death: terminal=native-crash for that file, restart.
+  - On lift-error / bare exception: terminal=bare-exception, keep worker.
+  - On completed / typed-gap: keep worker.
+  - Every file gets exactly one terminal row before the scan ends.
+
+Worker invokes the enumeration protocol only (never preconstruction).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Sequence
+
+
+_WORKER = Path(__file__).resolve().parent / "_supervised_enum_worker.py"
+
+
+@dataclass(frozen=True)
+class FileTerminal:
+    """One conserved per-file outcome from the supervised scan."""
+
+    file: str
+    category: str  # completed | typed-gap | bare-exception | timeout | native-crash
+    returncode: int | None
+    signal_name: str | None
+    stderr_tail: str
+    terminal: Mapping[str, Any] | None
+    worker_restarts: int
+
+
+class SupervisedEnumSupervisor:
+    def __init__(
+        self,
+        *,
+        file_timeout: float = 30.0,
+        python: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        if file_timeout > 30:
+            raise ValueError("per-file timeout may not exceed 30 seconds")
+        self.file_timeout = float(file_timeout)
+        self.python = python or sys.executable
+        self.env = dict(env or os.environ)
+        self.env.setdefault("PYTHONFAULTHANDLER", "1")
+        self._proc: subprocess.Popen[str] | None = None
+        self.worker_restarts = 0
+        self._current_file: str | None = None
+
+    @property
+    def current_file(self) -> str | None:
+        return self._current_file
+
+    def start(self) -> None:
+        if self._proc is not None and self._proc.poll() is None:
+            return
+        self._proc = subprocess.Popen(
+            [self.python, str(_WORKER)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=self.env,
+        )
+        ready = self._readline(timeout=30.0)
+        if ready is None:
+            self._kill()
+            raise RuntimeError("supervised enum worker did not become ready")
+        if ready.get("kind") == "bootstrap-error":
+            self._kill()
+            raise RuntimeError(
+                f"supervised enum worker bootstrap failed: {ready.get('message')}"
+            )
+        if ready.get("kind") != "ready":
+            self._kill()
+            raise RuntimeError(f"supervised enum worker bad handshake: {ready!r}")
+
+    def stop(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            if proc.poll() is None and proc.stdin is not None:
+                proc.stdin.write(json.dumps({"kind": "shutdown"}) + "\n")
+                proc.stdin.flush()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._kill()
+            else:
+                self._kill()
+        finally:
+            self._proc = None
+
+    def _kill(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+        except Exception:  # noqa: BLE001
+            pass
+        self._proc = None
+
+    def restart(self) -> None:
+        self._kill()
+        self.worker_restarts += 1
+        self.start()
+
+    def _readline(self, *, timeout: float) -> dict[str, Any] | None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return None
+        # Prefer select when available; fall back to blocking with alarm on POSIX.
+        deadline = time.monotonic() + timeout
+        import select
+
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            readable, _, _ = select.select([proc.stdout], [], [], remaining)
+            if not readable:
+                continue
+            line = proc.stdout.readline()
+            if line == "":
+                # EOF — worker died
+                return None
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+        return None
+
+    def lift_file(self, path: Path, rel: str) -> FileTerminal:
+        """Dispatch one file; may restart the worker on crash/timeout."""
+        self.start()
+        self._current_file = rel
+        proc = self._proc
+        assert proc is not None and proc.stdin is not None
+        request = {"kind": "lift", "path": str(path.resolve()), "rel": rel}
+        try:
+            proc.stdin.write(json.dumps(request) + "\n")
+            proc.stdin.flush()
+        except BrokenPipeError:
+            return self._after_death(rel, note="broken pipe on dispatch")
+
+        response = self._readline(timeout=self.file_timeout)
+        if response is None:
+            # Timeout or EOF.
+            rc = proc.poll()
+            if rc is None:
+                # Still running but silent → timeout.
+                self._kill()
+                self.worker_restarts += 1
+                self.start()
+                return FileTerminal(
+                    file=rel,
+                    category="timeout",
+                    returncode=None,
+                    signal_name=None,
+                    stderr_tail=f"exceeded {self.file_timeout}s",
+                    terminal=None,
+                    worker_restarts=self.worker_restarts,
+                )
+            return self._after_death(rel, note="worker exited during lift")
+
+        kind = response.get("kind")
+        if kind == "lift-result":
+            terminal = response.get("terminal")
+            if not isinstance(terminal, Mapping):
+                return FileTerminal(
+                    file=rel,
+                    category="bare-exception",
+                    returncode=1,
+                    signal_name=None,
+                    stderr_tail="worker returned lift-result without terminal",
+                    terminal=None,
+                    worker_restarts=self.worker_restarts,
+                )
+            outcome = str(terminal.get("outcome") or "")
+            if outcome in {"completed", "typed-gap"}:
+                category = outcome
+            else:
+                category = "bare-exception"
+            return FileTerminal(
+                file=rel,
+                category=category,
+                returncode=0,
+                signal_name=None,
+                stderr_tail="",
+                terminal=dict(terminal),
+                worker_restarts=self.worker_restarts,
+            )
+        if kind == "lift-error":
+            return FileTerminal(
+                file=rel,
+                category="bare-exception",
+                returncode=1,
+                signal_name=None,
+                stderr_tail=(
+                    f"{response.get('error_type')}: {response.get('message')}"
+                )[-2000:],
+                terminal=None,
+                worker_restarts=self.worker_restarts,
+            )
+        return FileTerminal(
+            file=rel,
+            category="bare-exception",
+            returncode=1,
+            signal_name=None,
+            stderr_tail=f"unexpected worker response: {response!r}"[-2000:],
+            terminal=None,
+            worker_restarts=self.worker_restarts,
+        )
+
+    def _after_death(self, rel: str, *, note: str) -> FileTerminal:
+        proc = self._proc
+        rc = proc.poll() if proc is not None else -1
+        stderr = ""
+        if proc is not None and proc.stderr is not None:
+            try:
+                stderr = proc.stderr.read()[-2000:]
+            except Exception:  # noqa: BLE001
+                stderr = ""
+        signal_name = None
+        category = "bare-exception"
+        if rc is not None and rc < 0:
+            category = "native-crash"
+            try:
+                signal_name = signal.Signals(-rc).name
+            except ValueError:
+                signal_name = f"signal-{-rc}"
+        elif rc is None:
+            category = "native-crash"
+            rc = -1
+        self._kill()
+        self.worker_restarts += 1
+        try:
+            self.start()
+        except RuntimeError as error:
+            # Leave supervisor without a worker; next lift_file will retry.
+            stderr = (stderr + f"\nrestart failed: {error}")[-2000:]
+        return FileTerminal(
+            file=rel,
+            category=category,
+            returncode=rc,
+            signal_name=signal_name,
+            stderr_tail=(stderr or note)[-2000:],
+            terminal=None,
+            worker_restarts=self.worker_restarts,
+        )
+
+    def scan(
+        self, paths: Sequence[tuple[Path, str]]
+    ) -> list[FileTerminal]:
+        """Lift every (path, rel); guarantee one terminal row per file."""
+        rows: list[FileTerminal] = []
+        try:
+            self.start()
+            for path, rel in paths:
+                rows.append(self.lift_file(path, rel))
+        finally:
+            self.stop()
+        return rows
+
+
+def scan_paths(
+    paths: Sequence[Path],
+    *,
+    root: Path,
+    file_timeout: float = 30.0,
+) -> list[FileTerminal]:
+    from _enum_floor_runtime import relative_to_root
+
+    pairs = [(path, relative_to_root(path, root)) for path in paths]
+    supervisor = SupervisedEnumSupervisor(file_timeout=file_timeout)
+    return supervisor.scan(pairs)

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Persistent enumeration worker for supervised floor scans.
+
+Protocol (newline-delimited JSON on stdin/stdout):
+
+  parent → worker:  {"kind":"lift","path":"<abs>","rel":"<rel>"}
+  worker → parent:  {"kind":"lift-result","file":"<rel>","terminal":{...}}
+                    or {"kind":"lift-error","file":"<rel>","error_type":"...","message":"..."}
+
+  parent → worker:  {"kind":"ping"}
+  worker → parent:  {"kind":"pong"}
+
+  parent → worker:  {"kind":"shutdown"}
+  worker exits 0
+
+Enumeration door only: path_source → SourceFile → functions → sugar.
+Never restores package preconstruction. Process stays warm across files
+so oracle/module caches survive until the supervisor restarts us.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap() -> str | None:
+    scripts = Path(__file__).resolve().parent
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    try:
+        from _production_lift_child import production_lift_bootstrap_error
+
+        return production_lift_bootstrap_error()
+    except Exception as error:  # noqa: BLE001
+        return f"{type(error).__name__}: {error}"
+
+
+def _lift(path: str, rel: str) -> dict:
+    import os
+
+    # Test-only plants (parent env, never production):
+    #   SUGAR_SUPERVISOR_PLANT_BARE=<rel>     → untyped RuntimeError
+    #   SUGAR_SUPERVISOR_PLANT_TIMEOUT=<rel>  → hang until supervisor kills us
+    plant_bare = os.environ.get("SUGAR_SUPERVISOR_PLANT_BARE")
+    if plant_bare and plant_bare == rel:
+        raise RuntimeError("planted bare exception for supervisor test")
+    plant_timeout = os.environ.get("SUGAR_SUPERVISOR_PLANT_TIMEOUT")
+    if plant_timeout and plant_timeout == rel:
+        import time
+
+        time.sleep(3600)
+
+    from _production_lift_child import production_lift_testimony
+
+    terminal = production_lift_testimony(Path(path), rel)
+    return {"kind": "lift-result", "file": rel, "terminal": terminal}
+
+
+def main() -> int:
+    err = _bootstrap()
+    if err is not None:
+        print(
+            json.dumps(
+                {
+                    "kind": "bootstrap-error",
+                    "message": err,
+                }
+            ),
+            flush=True,
+        )
+        return 2
+    print(json.dumps({"kind": "ready"}), flush=True)
+    for raw in sys.stdin:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError as error:
+            print(
+                json.dumps(
+                    {
+                        "kind": "protocol-error",
+                        "message": f"invalid json: {error}",
+                    }
+                ),
+                flush=True,
+            )
+            continue
+        kind = msg.get("kind")
+        if kind == "shutdown":
+            return 0
+        if kind == "ping":
+            print(json.dumps({"kind": "pong"}), flush=True)
+            continue
+        if kind == "lift":
+            path = str(msg.get("path") or "")
+            rel = str(msg.get("rel") or path)
+            try:
+                print(json.dumps(_lift(path, rel)), flush=True)
+            except BaseException as error:  # noqa: BLE001 -- parent classifies
+                # Untyped failure: emit then re-raise so bare-exception path
+                # can also see nonzero exit if the supervisor cares.
+                print(
+                    json.dumps(
+                        {
+                            "kind": "lift-error",
+                            "file": rel,
+                            "error_type": type(error).__name__,
+                            "message": str(error)[-4000:],
+                        }
+                    ),
+                    flush=True,
+                )
+                # Stay alive after bare exceptions so the supervisor can
+                # continue the census without a restart (typed path already
+                # stays alive). Native crashes never reach here.
+            continue
+        print(
+            json.dumps(
+                {
+                    "kind": "protocol-error",
+                    "message": f"unknown kind {kind!r}",
+                }
+            ),
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 """R_bare_exceptions — permanent baseline-free untyped-failure floor.
 
-In-process enum door (path_source → SourceFile → functions → sugar).
-One process for the whole scan — caches stay warm.
-Progress → progress.log; engine JSONL → engine.jsonl; never mixed.
+Supervised persistent enum worker: reuses process across healthy files;
+restarts on native crash / timeout. Enumeration protocol only.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 import subprocess
 import sys
@@ -19,28 +17,17 @@ from typing import Any, Mapping, NamedTuple, Sequence
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _enum_floor_runtime import (  # noqa: E402
-    iter_with_tqdm,
-    open_progress,
     prepare_floor_io,
     production_roots,
     require_python_paths,
-    timed_enum_file,
 )
-
-# Re-export for discrimination tests / external importers.
-__all__ = [
-    "BareExceptionOffender",
-    "bare_exception_offender",
-    "production_roots",
-    "r_bare_exceptions",
-    "require_python_paths",
-]
 from _production_lift_child import (  # noqa: E402
     NON_FAILURE_OUTCOMES,
     OUTCOME_COMPLETED,
     OUTCOME_TYPED_GAP,
     production_lift_bootstrap_error,
 )
+from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
 
 
 class BareExceptionOffender(NamedTuple):
@@ -84,34 +71,18 @@ def r_bare_exceptions(offenders: Sequence[BareExceptionOffender]) -> int:
     return len(offenders)
 
 
-def _classify_in_process(
-    rel: str,
-    testimony: dict[str, object] | None,
-    error: BaseException | None,
-) -> ChildResult:
-    if error is not None:
-        if isinstance(error, TimeoutError):
-            return ChildResult(rel, "timeout", None)
-        # Typed gaps are caught inside production_lift_testimony; anything else
-        # that escapes is a bare untyped failure.
+def _from_terminal(row: FileTerminal) -> ChildResult:
+    if row.category == "bare-exception":
         return ChildResult(
-            rel,
+            row.file,
             "bare-exception",
             BareExceptionOffender(
-                rel,
-                1,
-                f"{type(error).__name__}: {error}"[-2000:],
+                row.file,
+                row.returncode if row.returncode is not None else 1,
+                row.stderr_tail,
             ),
         )
-    assert testimony is not None
-    outcome = str(testimony.get("outcome") or "")
-    if outcome in NON_FAILURE_OUTCOMES:
-        return ChildResult(rel, outcome, None)
-    return ChildResult(
-        rel,
-        "bare-exception",
-        BareExceptionOffender(rel, 1, f"unexpected outcome {outcome!r}"),
-    )
+    return ChildResult(row.file, row.category, None)
 
 
 def main() -> int:
@@ -130,8 +101,6 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
-    parser.add_argument("--progress-stdout", action="store_true")
-    # Kept for CI flag compatibility; scan is always single-process.
     parser.add_argument("--workers", type=int, default=1)
     args = parser.parse_args()
     del args.workers
@@ -156,30 +125,21 @@ def main() -> int:
         engine_log=args.engine_log,
         progress=args.progress,
     )
-    progress = open_progress(
-        progress_path,
-        header=(
-            f"# bare-exception floor (in-process enum)\n"
-            f"# engine_log={engine_path.resolve()}\n"
-            f"# files={len(paths)}\n"
-        ),
+    progress_path.write_text(
+        f"# bare-exception supervised enum scan\n"
+        f"# engine={engine_path}\n"
+        f"# files={len(paths)}\n",
+        encoding="utf-8",
     )
-    rows: list[ChildResult] = []
-    try:
-        for path in iter_with_tqdm(
-            paths,
-            progress=progress,
-            desc="bare-exception",
-            progress_stdout=args.progress_stdout,
-        ):
-            rel, testimony, error, file_s = timed_enum_file(
-                path, root=args.repo_root, file_timeout=args.file_timeout
+    terminals = scan_paths(
+        paths, root=args.repo_root, file_timeout=float(args.file_timeout)
+    )
+    rows = tuple(_from_terminal(t) for t in terminals)
+    with progress_path.open("a", encoding="utf-8") as progress:
+        for t in terminals:
+            progress.write(
+                f"{t.file}\t{t.category}\trestarts={t.worker_restarts}\n"
             )
-            row = _classify_in_process(rel, testimony, error)
-            rows.append(row)
-            del file_s  # timed for future postfix hooks; bar shows rate already
-    finally:
-        progress.close()
 
     offenders = tuple(row.offender for row in rows if row.offender is not None)
     print(
@@ -188,6 +148,7 @@ def main() -> int:
         f"completed={sum(row.category == OUTCOME_COMPLETED for row in rows)} "
         f"typed_gaps={sum(row.category == OUTCOME_TYPED_GAP for row in rows)} "
         f"timeouts={sum(row.category == 'timeout' for row in rows)} "
+        f"native_crashes={sum(row.category == 'native-crash' for row in rows)} "
         f"bare={len(offenders)} "
         f"progress={progress_path} engine={engine_path}"
     )

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """R_native_crashes — permanent baseline-free corpus process floor.
 
-In-process enum scan. A true signal death still kills the whole process (CI
-goes red). Per-file signal isolation is retired — process restarts destroy
-enum caches. Classification helpers remain for discrimination tests.
+Supervised persistent enum worker. A signal death is attributed to the file
+currently in flight; the worker restarts and the census continues so every
+file still gets a terminal row.
 """
 
 from __future__ import annotations
@@ -13,20 +13,17 @@ import os
 from pathlib import Path
 import signal
 import sys
-from typing import Any, NamedTuple, Sequence
+from typing import NamedTuple, Sequence
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _enum_floor_runtime import (  # noqa: E402
-    iter_with_tqdm,
-    open_progress,
     prepare_floor_io,
     production_roots,
-    relative_to_root,
     require_python_paths,
-    timed_enum_file,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
+from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
 
 
 class NativeCrashOffender(NamedTuple):
@@ -79,7 +76,7 @@ def format_report(offenders: Sequence[NativeCrashOffender]) -> str:
     lines = [
         f"R_native_crashes = {r_native_crashes(offenders)}",
         (
-            "Replacement: corpus enumeration terminates with completed testimony, "
+            "Replacement: corpus children terminate with completed testimony, "
             "typed gap, bare-exception row, or loud timeout; never signal."
         ),
         "",
@@ -92,22 +89,24 @@ def format_report(offenders: Sequence[NativeCrashOffender]) -> str:
     return "\n".join(lines)
 
 
-def _run_one(path: Path, *, root: Path, file_timeout: int) -> ChildResult:
-    rel, _testimony, error, _s = timed_enum_file(
-        path, root=root, file_timeout=file_timeout
-    )
-    if isinstance(error, TimeoutError):
-        return ChildResult(rel, "timeout", None, str(error), None)
-    if error is not None:
-        return ChildResult(
-            rel,
-            "non-native-red",
-            1,
-            f"{type(error).__name__}: {error}"[-2000:],
-            None,
+def _from_terminal(row: FileTerminal) -> ChildResult:
+    if row.category == "native-crash":
+        rc = row.returncode if row.returncode is not None else -1
+        offender = native_crash_offender(
+            file=row.file, returncode=rc, stderr=row.stderr_tail
         )
-    # Process survived this file — no per-file native crash without isolation.
-    return ChildResult(rel, "completed", 0, "", None)
+        if offender is None and row.signal_name:
+            offender = NativeCrashOffender(
+                row.file, rc, row.signal_name, row.stderr_tail
+            )
+        return ChildResult(
+            row.file, "native-crash", rc, row.stderr_tail, offender
+        )
+    if row.category in {"bare-exception"}:
+        return ChildResult(
+            row.file, "non-native-red", row.returncode, row.stderr_tail, None
+        )
+    return ChildResult(row.file, row.category, row.returncode, row.stderr_tail, None)
 
 
 def audit_paths(
@@ -120,92 +119,21 @@ def audit_paths(
     progress_path: Path | None = None,
     progress_stdout: bool = False,
 ) -> AuditSummary:
-    del workers
+    del workers, checkpoint_path, progress_stdout
     if file_timeout > 30:
         raise ValueError("per-file timeout may not exceed 30 seconds")
-
-    pending = list(sorted(paths))
-    done_rows: dict[str, ChildResult] = {}
-    checkpoint = None
-    if checkpoint_path is not None:
-        from pandas_census_checkpoint import Checkpoint
-
-        files = tuple(relative_to_root(p, root) for p in pending)
-        by_rel = {relative_to_root(p, root): p for p in pending}
-        checkpoint = Checkpoint(
-            floor="native-crash", files=files, path=checkpoint_path
-        )
-        for row in checkpoint.rows():
-            raw = row["result"]
-            file = str(row["file"])
-            returncode = raw.get("returncode")
-            code = int(returncode) if isinstance(returncode, int) else None
-            stderr_tail = str(raw.get("stderrTail") or "")
-            signal_name = raw.get("signal")
-            offender = (
-                NativeCrashOffender(file, code, str(signal_name), stderr_tail)
-                if raw.get("category") == "native-crash"
-                and code is not None
-                and isinstance(signal_name, str)
-                else None
-            )
-            done_rows[file] = ChildResult(
-                file, str(raw.get("category")), code, stderr_tail, offender
-            )
-        pending = [by_rel[r] for r in checkpoint.pending_files()]
-
-    progress_stream = None
+    terminals = scan_paths(paths, root=root, file_timeout=float(file_timeout))
     if progress_path is not None:
-        progress_stream = open_progress(
-            progress_path,
-            header=(
-                f"# native-crash floor (in-process enum)\n"
-                f"# files={len(paths)} pending={len(pending)}\n"
-            ),
-        )
-    try:
-        iterator: Any = pending
-        if progress_stream is not None:
-            iterator = iter_with_tqdm(
-                pending,
-                progress=progress_stream,
-                total=len(paths),
-                initial=len(paths) - len(pending),
-                desc="native-crash",
-                progress_stdout=progress_stdout,
-            )
-        for path in iterator:
-            row = _run_one(path, root=root, file_timeout=file_timeout)
-            if checkpoint is not None:
-                checkpoint.append(
-                    row.file,
-                    {
-                        "category": row.category,
-                        "returncode": row.returncode,
-                        "stderrTail": row.stderr_tail,
-                        "signal": row.offender.signal if row.offender else None,
-                    },
-                )
-            done_rows[row.file] = row
-    finally:
-        if progress_stream is not None:
-            progress_stream.close()
-
-    if checkpoint is not None:
-        rows = tuple(
-            done_rows[f]
-            if f in done_rows
-            else ChildResult(f, "missing", None, "", None)
-            for f in checkpoint.files
-        )
-    else:
-        rows = tuple(
-            done_rows[relative_to_root(p, root)] for p in sorted(paths)
-        )
+        progress_path.parent.mkdir(parents=True, exist_ok=True)
+        with progress_path.open("w", encoding="utf-8") as stream:
+            stream.write(f"# native-crash supervised enum scan files={len(paths)}\n")
+            for t in terminals:
+                stream.write(f"{t.file}\t{t.category}\n")
+    rows = tuple(_from_terminal(t) for t in terminals)
     offenders = tuple(row.offender for row in rows if row.offender is not None)
     return AuditSummary(
         discovered=len(rows),
-        completed=sum(row.category == "completed" for row in rows),
+        completed=sum(row.category in {"completed", "typed-gap"} for row in rows),
         timeouts=sum(row.category == "timeout" for row in rows),
         non_native_red=sum(row.category == "non-native-red" for row in rows),
         offenders=offenders,
@@ -263,10 +191,7 @@ def main() -> int:
         paths,
         root=args.repo_root,
         file_timeout=args.file_timeout,
-        workers=1,
-        checkpoint_path=args.checkpoint_jsonl,
         progress_path=progress_path,
-        progress_stdout=args.progress_stdout,
     )
     if args.json is not None:
         from pandas_floor_summary import floor_summary, relative_files, write_json

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -1,30 +1,26 @@
 #!/usr/bin/env python3
 """R_timeouts — permanent baseline-free bounded-termination floor.
 
-In-process enum door. Per-file wall clock via SIGALRM (same process — caches
-stay warm). Progress and engine logs never mix.
+Supervised persistent enum worker. A file exceeding the wall clock kills only
+that worker (caches restart); the file is a timeout offender and the scan continues.
 """
 
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 import sys
-from typing import Any, Mapping, NamedTuple, Sequence
+from typing import NamedTuple, Sequence
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _enum_floor_runtime import (  # noqa: E402
-    iter_with_tqdm,
-    open_progress,
     prepare_floor_io,
     production_roots,
-    relative_to_root,
     require_python_paths,
-    timed_enum_file,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
+from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
 
 
 class TimeoutOffender(NamedTuple):
@@ -51,19 +47,14 @@ def r_timeouts(offenders: Sequence[TimeoutOffender]) -> int:
     return len(offenders)
 
 
-def _run_one(path: Path, *, root: Path, file_timeout: int) -> ChildResult:
-    rel, _testimony, error, _s = timed_enum_file(
-        path, root=root, file_timeout=file_timeout
-    )
-    if isinstance(error, TimeoutError):
+def _from_terminal(row: FileTerminal, *, file_timeout: float) -> ChildResult:
+    if row.category == "timeout":
         return ChildResult(
-            rel,
+            row.file,
             "timeout",
-            timeout_offender(file=rel, timeout_seconds=float(file_timeout)),
+            timeout_offender(file=row.file, timeout_seconds=file_timeout),
         )
-    if error is not None:
-        return ChildResult(rel, "non-native-red", None)
-    return ChildResult(rel, "completed", None)
+    return ChildResult(row.file, row.category, None)
 
 
 def audit_paths(
@@ -76,88 +67,22 @@ def audit_paths(
     progress_path: Path | None = None,
     progress_stdout: bool = False,
 ) -> AuditSummary:
-    del workers  # always single-process
+    del workers, checkpoint_path, progress_stdout
     if file_timeout > 30:
         raise ValueError("per-file timeout may not exceed 30 seconds")
-
-    pending = list(sorted(paths))
-    done_rows: dict[str, ChildResult] = {}
-
-    if checkpoint_path is not None:
-        from pandas_census_checkpoint import Checkpoint
-
-        files = tuple(relative_to_root(p, root) for p in pending)
-        by_rel = {relative_to_root(p, root): p for p in pending}
-        checkpoint = Checkpoint(
-            floor="timeout", files=files, path=checkpoint_path
-        )
-        for row in checkpoint.rows():
-            raw = row["result"]
-            file = str(row["file"])
-            seconds = raw.get("timeoutSeconds")
-            offender = (
-                timeout_offender(file=file, timeout_seconds=float(seconds))
-                if raw.get("category") == "timeout"
-                and isinstance(seconds, (int, float))
-                else None
-            )
-            done_rows[file] = ChildResult(file, str(raw.get("category")), offender)
-        pending_rels = list(checkpoint.pending_files())
-        pending = [by_rel[r] for r in pending_rels]
-    else:
-        checkpoint = None
-        by_rel = {}
-
-    progress_stream = None
+    terminals = scan_paths(paths, root=root, file_timeout=float(file_timeout))
     if progress_path is not None:
-        progress_stream = open_progress(
-            progress_path,
-            header=(
-                f"# timeout floor (in-process enum)\n"
-                f"# files={len(paths)} pending={len(pending)}\n"
-            ),
-        )
-
-    try:
-        iterator: Sequence[Path] | Any = pending
-        if progress_stream is not None:
-            iterator = iter_with_tqdm(
-                pending,
-                progress=progress_stream,
-                total=len(paths),
-                initial=len(paths) - len(pending),
-                desc="timeout",
-                progress_stdout=progress_stdout,
-            )
-        for path in iterator:
-            row = _run_one(path, root=root, file_timeout=file_timeout)
-            if checkpoint is not None:
-                checkpoint.append(
-                    row.file,
-                    {
-                        "category": row.category,
-                        "timeoutSeconds": (
-                            row.offender.timeout_seconds if row.offender else None
-                        ),
-                    },
-                )
-            done_rows[row.file] = row
-    finally:
-        if progress_stream is not None:
-            progress_stream.close()
-
-    if checkpoint is not None:
-        ordered = tuple(
-            done_rows[f] if f in done_rows else ChildResult(f, "missing", None)
-            for f in checkpoint.files
-        )
-    else:
-        ordered = tuple(
-            done_rows[relative_to_root(p, root)] for p in sorted(paths)
-        )
+        progress_path.parent.mkdir(parents=True, exist_ok=True)
+        with progress_path.open("w", encoding="utf-8") as stream:
+            stream.write(f"# timeout supervised enum scan files={len(paths)}\n")
+            for t in terminals:
+                stream.write(f"{t.file}\t{t.category}\n")
+    rows = tuple(
+        _from_terminal(t, file_timeout=float(file_timeout)) for t in terminals
+    )
     return AuditSummary(
-        rows=ordered,
-        offenders=tuple(row.offender for row in ordered if row.offender is not None),
+        rows=rows,
+        offenders=tuple(row.offender for row in rows if row.offender is not None),
     )
 
 
@@ -207,10 +132,7 @@ def main() -> int:
         paths,
         root=args.repo_root,
         file_timeout=args.file_timeout,
-        workers=1,
-        checkpoint_path=args.checkpoint_jsonl,
         progress_path=progress_path,
-        progress_stdout=args.progress_stdout,
     )
     rows = summary.rows
     offenders = summary.offenders
@@ -234,8 +156,11 @@ def main() -> int:
             totals={
                 "R_timeouts": len(offenders),
                 "completed": sum(row.category == "completed" for row in rows),
+                "typedGaps": sum(row.category == "typed-gap" for row in rows),
                 "nativeCrashes": sum(row.category == "native-crash" for row in rows),
-                "nonNativeRed": sum(row.category == "non-native-red" for row in rows),
+                "bareExceptions": sum(
+                    row.category == "bare-exception" for row in rows
+                ),
             },
             measured=True,
         )
@@ -244,7 +169,7 @@ def main() -> int:
         "TIMEOUT SURFACE: "
         f"discovered={len(rows)} "
         f"completed={sum(row.category == 'completed' for row in rows)} "
-        f"non_native_red={sum(row.category == 'non-native-red' for row in rows)} "
+        f"typed_gaps={sum(row.category == 'typed-gap' for row in rows)} "
         f"timeouts={len(offenders)} "
         f"progress={progress_path} engine={engine_path}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -1,0 +1,68 @@
+"""Supervised persistent enum worker: reuse, timeout kill, crash restart."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import textwrap
+
+import pytest
+
+import sys
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SPEC = importlib.util.spec_from_file_location(
+    "_supervised_enum_supervisor",
+    _SCRIPTS / "_supervised_enum_supervisor.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SUP = importlib.util.module_from_spec(_SPEC)
+sys.modules["_supervised_enum_supervisor"] = _SUP
+_SPEC.loader.exec_module(_SUP)
+
+
+def _write(tmp: Path, name: str, source: str) -> Path:
+    path = tmp / name
+    path.write_text(textwrap.dedent(source), encoding="utf-8")
+    return path
+
+
+def test_supervised_scan_completes_clean_and_typed_gap(tmp_path: Path) -> None:
+    clean = _write(tmp_path, "clean.py", "def a(z):\n    return z\n")
+    gap = _write(
+        tmp_path,
+        "gap.py",
+        "def a():\n    with open('x'):\n        pass\n",
+    )
+    rows = _SUP.scan_paths([clean, gap], root=tmp_path, file_timeout=30.0)
+    assert [r.file for r in rows] == ["clean.py", "gap.py"]
+    assert rows[0].category == "completed"
+    assert rows[1].category == "typed-gap"
+    # Healthy files share a worker — zero restarts expected for this pair.
+    assert rows[0].worker_restarts == 0
+    assert rows[1].worker_restarts == 0
+
+
+def test_supervised_timeout_restarts_and_continues(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Construction does not execute body sleep(); plant hangs the worker.
+    sleeper = _write(tmp_path, "sleep.py", "def a():\n    return 1\n")
+    after = _write(tmp_path, "after.py", "def a(z):\n    return z\n")
+    monkeypatch.setenv("SUGAR_SUPERVISOR_PLANT_TIMEOUT", "sleep.py")
+    rows = _SUP.scan_paths([sleeper, after], root=tmp_path, file_timeout=1.0)
+    assert rows[0].file == "sleep.py"
+    assert rows[0].category == "timeout"
+    assert rows[0].worker_restarts >= 1
+    assert rows[1].file == "after.py"
+    assert rows[1].category == "completed"
+
+
+def test_supervised_bare_exception_keeps_going(tmp_path: Path, monkeypatch) -> None:
+    bad = _write(tmp_path, "bad.py", "def a():\n    return 1\n")
+    good = _write(tmp_path, "good.py", "def a(z):\n    return z\n")
+    monkeypatch.setenv("SUGAR_SUPERVISOR_PLANT_BARE", "bad.py")
+    rows = _SUP.scan_paths([bad, good], root=tmp_path, file_timeout=30.0)
+    assert rows[0].category == "bare-exception"
+    assert "planted bare" in rows[0].stderr_tail
+    assert rows[1].category == "completed"

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -1,0 +1,47 @@
+"""Heavy Python measurement: one orchestrator, not six workflows in one group.
+
+GitHub concurrency keeps only one running + one pending per group. Multiple
+PR workflows sharing `sugar-python-heavy-measurement` cancel each other even
+with cancel-in-progress: false. Corpus floors must run under one orchestrator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+GROUP = "sugar-python-heavy-measurement"
+
+# PR-triggered floor scanners that used to fight for the group.
+STANDALONE_FLOOR_WORKFLOWS = (
+    "bare-exception-zero-tolerance.yml",
+    "timeout-zero-tolerance.yml",
+    "native-crash-zero-tolerance.yml",
+)
+
+ORCHESTRATOR = "factory-zero-tolerance.yml"
+
+
+def test_standalone_floor_workflows_do_not_claim_heavy_concurrency_group() -> None:
+    for name in STANDALONE_FLOOR_WORKFLOWS:
+        text = (WORKFLOWS / name).read_text()
+        assert GROUP not in text, (
+            f"{name} must not use {GROUP}; full corpus floors run only under "
+            f"{ORCHESTRATOR}"
+        )
+        # Discrimination only — no full-corpus script invocation.
+        assert "zero_tolerance.py\n" not in text or "discrimination" in text.lower()
+
+
+def test_orchestrator_owns_heavy_group_and_runs_corpus_floors() -> None:
+    text = (WORKFLOWS / ORCHESTRATOR).read_text()
+    assert f"group: {GROUP}" in text
+    assert "cancel-in-progress: false" in text
+    for script in (
+        "native_crash_zero_tolerance.py",
+        "bare_exception_zero_tolerance.py",
+        "timeout_zero_tolerance.py",
+        "silent_zero_tolerance.py",
+    ):
+        assert script in text, f"{ORCHESTRATOR} must invoke {script}"


### PR DESCRIPTION
## Summary
Two measurement-topology fixes after #6204:

1. **Concurrency**: Full corpus bare/timeout/native floors run **only** under `factory-zero-tolerance.yml` (sole-construction). Standalone workflows are **discrimination-only** and no longer claim `sugar-python-heavy-measurement`. That stops GitHub’s one-pending-run replacement from cancelling floors mid-set.

2. **Supervised enum worker**: Persistent worker reuses enum caches across healthy files. Parent records the in-flight file; on **native crash** or **30s timeout** it kills/restarts the worker, attributes the row to that file, and continues until every file has a terminal. Door remains `path_source → SourceFile → functions → sugar` (no `_production_source_file`).

Typed-loud child/RPC serialization from #6204 is unchanged.

## Validation
```
pytest --noconftest \
  tests/test_heavy_measurement_concurrency_topology.py \
  tests/test_python_sole_construction_ci.py \
  implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py \
  …floor discrimination…  # 18+ passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix heavy floor topology to use one orchestrator with a supervised enum worker
> - PR workflow files for bare exceptions, native crashes, and timeouts are stripped down to discrimination-only pytest jobs and no longer claim the shared heavy measurement concurrency group or invoke full-corpus scripts.
> - [`factory-zero-tolerance.yml`](.github/workflows/factory-zero-tolerance.yml) becomes the sole orchestrator for the heavy concurrency group and now installs `tqdm` before running floors.
> - Introduces [`_supervised_enum_worker.py`](implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py), a persistent subprocess that handles multiple lift requests per session over a newline-delimited JSON protocol with clean shutdown and crash reporting.
> - Introduces [`_supervised_enum_supervisor.py`](implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py), which manages the worker lifecycle: per-file timeout enforcement, restart on death, and native crash/bare exception classification via `FileTerminal` rows.
> - All three full-corpus scanners (`bare_exception_zero_tolerance.py`, `native_crash_zero_tolerance.py`, `timeout_zero_tolerance.py`) are reworked to enumerate files through the supervised worker instead of running enumeration in-process, removing checkpointing logic.
> - Behavioral Change: `completed` in the native-crash scanner now includes `typed-gap` outcomes; timeout summary JSON gains `typedGaps`, `nativeCrashes`, and `bareExceptions` fields and drops `nonNativeRed`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a94c42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->