### PR TITLE
Restore ConstructionPanic membrane outside the audit path

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -209,5 +209,7 @@ def timed_enum_file(
         return rel, testimony, None, time.perf_counter() - t0
     except TimeoutError as error:
         return rel, None, error, time.perf_counter() - t0
-    except BaseException as error:  # noqa: BLE001 -- floor classification
+    # ConstructionPanic is BaseException: must not be held here. It kills the
+    # process; the supervisor records the in-flight file as a loud terminal.
+    except Exception as error:  # bare Python failures only
         return rel, None, error, time.perf_counter() - t0

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -100,9 +100,10 @@ def main() -> int:
             rel = str(msg.get("rel") or path)
             try:
                 print(json.dumps(_lift(path, rel)), flush=True)
-            except BaseException as error:  # noqa: BLE001 -- parent classifies
-                # Untyped failure: emit then re-raise so bare-exception path
-                # can also see nonzero exit if the supervisor cares.
+            except Exception as error:
+                # Bare Python failures only. ConstructionPanic is BaseException:
+                # it is not caught here — the worker dies; the supervisor records
+                # the active file and restarts a fresh worker.
                 print(
                     json.dumps(
                         {
@@ -114,9 +115,6 @@ def main() -> int:
                     ),
                     flush=True,
                 )
-                # Stay alive after bare exceptions so the supervisor can
-                # continue the census without a restart (typed path already
-                # stays alive). Native crashes never reach here.
             continue
         print(
             json.dumps(

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -135,7 +135,9 @@ def _run_one(path: Path, *, root: Path, file_timeout: int) -> ChildResult:
         return ChildResult(rel, category, offenders, 0, "")
     except TimeoutError as error:
         return ChildResult(rel, "timeout", (), None, str(error))
-    except BaseException as error:  # noqa: BLE001 -- floor classification
+    # ConstructionPanic is BaseException — must not be held here. Let it kill
+    # the process; supervised floors attribute the in-flight file loudly.
+    except Exception as error:
         return ChildResult(
             rel,
             "non-native-red",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2315,18 +2315,10 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
     return True
 
 
-def _serialize_typed_construction_failure(exc: BaseException) -> dict[str, Any] | None:
-    """JSON-RPC data payload for known typed construction failures, else None."""
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+def _serialize_source_call_binding_gap(exc: BaseException) -> dict[str, Any] | None:
+    """JSON-RPC data for SourceCallBindingGap only — never ConstructionPanic."""
     from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
-    if isinstance(exc, ConstructionPanic):
-        return {
-            "kind": "typed-loud",
-            "exception_type": type(exc).__name__,
-            "stage": "dispatch",
-            "diagnostic": exc.info.to_json(),
-        }
     if isinstance(exc, SourceCallBindingGap):
         return {
             "kind": "typed-loud",
@@ -2343,6 +2335,8 @@ def _serialize_typed_construction_failure(exc: BaseException) -> dict[str, Any] 
 
 
 def _serve() -> None:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
     request_count = 0
     while True:
         msg = _recv()
@@ -2363,9 +2357,30 @@ def _serve() -> None:
         request_count += 1
         try:
             keep_serving = _dispatch_request(msg)
+        except ConstructionPanic as panic:
+            # Fatal to this resident: emit a protocol error then die. Never
+            # convert ConstructionPanic into a successful result, None, or
+            # keep-serving soft continue. Parent may use --allow-failed-components
+            # to continue other components after this process exits.
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg.get("id"),
+                    "error": {
+                        "code": -32603,
+                        "message": str(panic),
+                        "data": {
+                            "exception_type": type(panic).__name__,
+                            "stage": "dispatch",
+                            "diagnostic": panic.info.to_json(),
+                        },
+                    },
+                }
+            )
+            raise SystemExit(1) from panic
         except SourceTreePanic as panic:
-            # Typed construction failure: serialize as JSON-RPC error and keep
-            # serving. Never exit 1 unclassified after the client has a typed row.
+            # Tree-gap (not ConstructionPanic): serialize as JSON-RPC error and
+            # keep serving. Never exit 1 unclassified after the client has a row.
             _send(
                 {
                     "jsonrpc": "2.0",
@@ -2389,9 +2404,26 @@ def _serve() -> None:
             )
             _log_resident_profile(request_count, msg.get("method"))
             continue
-        except BaseException as exc:
-            # ConstructionPanic is BaseException; other kit typed gaps may be too.
-            typed = _serialize_typed_construction_failure(exc)
+        except RecursionError as exc:
+            # C-stack overflow: typed frame, keep resident for the next request.
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg.get("id"),
+                    "error": {
+                        "code": -32603,
+                        "message": f"recursion limit exceeded: {exc}",
+                        "data": {
+                            "exception_type": "RecursionError",
+                            "stage": "dispatch",
+                        },
+                    },
+                }
+            )
+            _log_resident_profile(request_count, msg.get("method"))
+            continue
+        except Exception as exc:
+            typed = _serialize_source_call_binding_gap(exc)
             if typed is None:
                 raise
             _send(

--- a/implementations/python/sugar-lift-py-tests/tests/test_lift_rpc_error_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_lift_rpc_error_transport.py
@@ -10,19 +10,23 @@ from sugar_lift_py_tests import lift_rpc
 
 
 def test_rpc_dispatch_returns_construction_panic_as_json_rpc_error(monkeypatch) -> None:
-    """A semantic lift failure must produce a frame, never transport EOF."""
+    """ConstructionPanic: error frame then process death — never soft success."""
     messages: list[dict[str, Any]] = [
         {"jsonrpc": "2.0", "id": 2, "method": "lift", "params": {}},
         {"jsonrpc": "2.0", "id": 3, "method": "shutdown", "params": {}},
     ]
     sent: list[dict[str, Any]] = []
 
+    def _recv():
+        return messages.pop(0) if messages else None
+
     monkeypatch.setattr(lift_rpc, "_configure_transport_logging", lambda: None)
-    monkeypatch.setattr(lift_rpc, "_recv", lambda: messages.pop(0))
+    monkeypatch.setattr(lift_rpc, "_recv", _recv)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
 
-    def panic_lift(msg_id: Any, params: dict[str, Any]) -> None:
-        del msg_id, params
+    def panic_dispatch(msg: dict[str, Any]) -> bool:
+        if msg.get("method") == "shutdown":
+            return False
         construction_panic_gap(
             owner="rpc-fixture",
             blame="fixture.py:1:0",
@@ -30,42 +34,21 @@ def test_rpc_dispatch_returns_construction_panic_as_json_rpc_error(monkeypatch) 
             requested="value",
             fix="return a JSON-RPC error frame",
         )
+        return True
 
-    monkeypatch.setattr(lift_rpc, "_handle_lift", panic_lift)
+    monkeypatch.setattr(lift_rpc, "_dispatch_request", panic_dispatch)
 
     with pytest.raises(SystemExit) as halted:
         lift_rpc.main(["--rpc"])
 
     assert halted.value.code == 1
+    # Shutdown never runs — process dies on ConstructionPanic.
     assert messages == [{"jsonrpc": "2.0", "id": 3, "method": "shutdown", "params": {}}]
-    assert sent == [
-        {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "error": {
-                "code": -32603,
-                "message": (
-                    "CONSTRUCTION PANIC: match(Sugar) { Some => cite_or_effect, "
-                    "None => panic!() }\nwrite more Floor for this Construction: "
-                    "owner=rpc-fixture blame=fixture.py:1:0 observed=missing "
-                    "requested=value fix=return a JSON-RPC error frame"
-                ),
-                "data": {
-                    "exception_type": "ConstructionPanic",
-                    "stage": "dispatch",
-                    "diagnostic": {
-                        "owner": "rpc-fixture",
-                        "blame": "fixture.py:1:0",
-                        "observed": "missing",
-                        "requested": "value",
-                        "fix": "return a JSON-RPC error frame",
-                        "gap_kind": "Floor",
-                        "gap_locus": "Construction",
-                    },
-                },
-            },
-        },
-    ]
+    assert len(sent) == 1
+    assert sent[0]["id"] == 2
+    assert sent[0]["error"]["code"] == -32603
+    assert sent[0]["error"]["data"]["exception_type"] == "ConstructionPanic"
+    assert sent[0]["error"]["data"]["diagnostic"]["owner"] == "rpc-fixture"
     assert "result" not in sent[0]
 
 
@@ -78,23 +61,32 @@ def test_rpc_dispatch_returns_recursion_error_as_json_rpc_error(monkeypatch) -> 
     ]
     sent: list[dict[str, Any]] = []
 
+    def _recv():
+        return messages.pop(0) if messages else None
+
     monkeypatch.setattr(lift_rpc, "_configure_transport_logging", lambda: None)
-    monkeypatch.setattr(lift_rpc, "_recv", lambda: messages.pop(0))
+    monkeypatch.setattr(lift_rpc, "_recv", _recv)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
 
-    def overflow_lift(msg_id: Any, params: dict[str, Any]) -> None:
-        del msg_id, params
+    def overflow_dispatch(msg: dict[str, Any]) -> bool:
+        if msg.get("method") == "shutdown":
+            lift_rpc._send(
+                {"jsonrpc": "2.0", "id": msg.get("id"), "result": {"ok": True}}
+            )
+            return False
         raise RecursionError("maximum recursion depth exceeded")
 
-    monkeypatch.setattr(lift_rpc, "_handle_lift", overflow_lift)
+    monkeypatch.setattr(lift_rpc, "_dispatch_request", overflow_dispatch)
 
     lift_rpc.main(["--rpc"])
 
     assert messages == []
+    assert len(sent) == 2
     assert sent[0]["id"] == 7
     assert sent[0]["error"]["code"] == -32603
     assert sent[0]["error"]["data"]["exception_type"] == "RecursionError"
     assert "recursion limit exceeded" in sent[0]["error"]["message"]
+    assert sent[1] == {"jsonrpc": "2.0", "id": 8, "result": {"ok": True}}
 
 
 def test_rpc_serves_on_main_thread_without_a_big_stack_shell(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
`R_construction_panic_catches_outside_audit` was 5 after the enum rewrite. This restores the membrane without reverting the supervisor/orchestrator topology.

- **No soft `except BaseException`** in `_enum_floor_runtime`, `_supervised_enum_worker`, or `silent_zero_tolerance` — only ordinary `Exception` for bare failures. `ConstructionPanic` kills the process.
- **`lift_rpc`**: remove `isinstance(ConstructionPanic)` soft-return; on panic send a JSON-RPC error then `SystemExit(1)`. Resident does not keep serving as success. Outer multi-component continue remains `--allow-failed-components`.
- Supervisor architecture unchanged: restart after death/timeout; never reinterpret as clean construction.

## Validation
```
construction_panic_catch_law.py  # GREEN R=0
pytest … supervisor + rpc error transport + floors  # 29 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore ConstructionPanic propagation outside the audit path in the lift RPC server
> - Narrows `except BaseException` to `except Exception` in [_enum_floor_runtime.py](https://github.com/TSavo/sugar/pull/6206/files#diff-722768a8db41f7e5bee7a5b826a61b0ebdc49edb27a8ff262303b2d68fd8c709), [_supervised_enum_worker.py](https://github.com/TSavo/sugar/pull/6206/files#diff-bd73831fb5f99a3e5df072ba5fdab2bb261dc43df3d944f9227f2d7dc6f85683), and [silent_zero_tolerance.py](https://github.com/TSavo/sugar/pull/6206/files#diff-017af4b2b643b2bd518a956fda5e334d86d7f52ae29457078d354da18fa34546) so `ConstructionPanic` (a `BaseException`) propagates and terminates the process instead of being swallowed.
> - Updates [lift_rpc.py](https://github.com/TSavo/sugar/pull/6206/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to explicitly handle `ConstructionPanic` in the RPC loop: sends a `-32603` JSON-RPC error frame then exits with `SystemExit(1)`. `RecursionError` also gets a `-32603` error but keeps the server alive.
> - Restricts `_serialize_source_call_binding_gap` to only handle `SourceCallBindingGap`; `ConstructionPanic` is no longer serialized as a typed diagnostic by that helper.
> - Risk: processes that previously recovered from `ConstructionPanic` will now terminate; callers must handle worker restarts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2b5a25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->