### PR TITLE
Key Rust CI cache to Rust sources on the runner disk

### DIFF
--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -1,9 +1,15 @@
 name: Set up Sugar Rust build
-description: Install the pinned toolchain and either seed or consume the exact-commit build cache.
+description: >
+  Install the pinned toolchain and restore/save the Rust build using a
+  content-addressed key of Rust sources on the runner filesystem — never
+  github.sha and never the GitHub Actions cache service for the object store.
 
 inputs:
   mode:
-    description: "seed may build/save; consume requires an exact cache hit"
+    description: >
+      restore = warm target if this source key exists (seed jobs);
+      save = write target into the source-keyed local slot (after build);
+      consume = require a hit for this source key (matrix jobs)
     required: true
   components:
     description: Additional rustup components
@@ -13,40 +19,116 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Validate cache ownership mode
+    - name: Validate mode
       shell: bash
       env:
         MODE: ${{ inputs.mode }}
       run: |
+        # seed → restore (warm if present). save must be a separate step after build.
         case "$MODE" in
-          seed|consume) ;;
-          *) echo "::error::invalid Rust cache mode: $MODE (expected seed or consume)"; exit 2 ;;
+          restore|seed) echo "EFFECTIVE_MODE=restore" >>"$GITHUB_ENV" ;;
+          save)         echo "EFFECTIVE_MODE=save" >>"$GITHUB_ENV" ;;
+          consume)      echo "EFFECTIVE_MODE=consume" >>"$GITHUB_ENV" ;;
+          *)
+            echo "::error::invalid Rust cache mode: $MODE (expected restore|save|consume|seed)"
+            exit 2
+            ;;
         esac
 
     - name: Set up Rust 1.96.0
+      if: env.EFFECTIVE_MODE != 'save'
       uses: dtolnay/rust-toolchain@1.96.0
       with:
         components: ${{ inputs.components }}
 
-    - name: Seed exact-commit Rust build cache
-      if: inputs.mode == 'seed'
-      uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          implementations/rust/target
-        key: ${{ runner.os }}-cargo-v3-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-v3-${{ hashFiles('**/Cargo.lock') }}-
+    - name: Compute Rust source content key
+      id: rustsrc
+      shell: bash
+      run: tools/ci-rust-source-key.sh
 
-    - name: Consume exact-commit Rust build cache
-      if: inputs.mode == 'consume'
-      uses: actions/cache/restore@v5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          implementations/rust/target
-        key: ${{ runner.os }}-cargo-v3-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
-        fail-on-cache-miss: true
+    - name: Resolve local source-keyed slot
+      id: slot
+      shell: bash
+      env:
+        KEY: ${{ steps.rustsrc.outputs.key }}
+      run: |
+        set -euo pipefail
+        CACHE_ROOT="${SUGAR_RUST_CACHE_ROOT:-${HOME}/.cache/sugar-rust-build}"
+        SLOT="${CACHE_ROOT}/${KEY}"
+        mkdir -p "$CACHE_ROOT"
+        echo "cache_root=${CACHE_ROOT}" >>"$GITHUB_OUTPUT"
+        echo "slot=${SLOT}" >>"$GITHUB_OUTPUT"
+        echo "key=${KEY}" >>"$GITHUB_OUTPUT"
+        echo "Rust source key: ${KEY}"
+        echo "Local slot: ${SLOT}"
+
+    - name: Restore Rust build from source-keyed local cache
+      if: env.EFFECTIVE_MODE == 'restore' || env.EFFECTIVE_MODE == 'consume'
+      shell: bash
+      env:
+        MODE: ${{ env.EFFECTIVE_MODE }}
+        SLOT: ${{ steps.slot.outputs.slot }}
+        KEY: ${{ steps.slot.outputs.key }}
+      run: |
+        set -euo pipefail
+        if [[ -d "${SLOT}/target" && -f "${SLOT}/RUST_SOURCE_KEY" ]]; then
+          stored="$(cat "${SLOT}/RUST_SOURCE_KEY")"
+          if [[ "$stored" != "$KEY" ]]; then
+            echo "::error::slot key mismatch stored=${stored} want=${KEY}"
+            exit 1
+          fi
+          echo "Local source-keyed Rust cache HIT"
+          rm -rf implementations/rust/target
+          # Copy only — never hardlink: cargo must not mutate the durable slot.
+          cp -a "${SLOT}/target" implementations/rust/target
+          if [[ -d "${SLOT}/cargo-registry" ]]; then
+            mkdir -p "${HOME}/.cargo"
+            rm -rf "${HOME}/.cargo/registry"
+            cp -a "${SLOT}/cargo-registry" "${HOME}/.cargo/registry"
+          fi
+          if [[ -d "${SLOT}/cargo-git" ]]; then
+            mkdir -p "${HOME}/.cargo"
+            rm -rf "${HOME}/.cargo/git"
+            cp -a "${SLOT}/cargo-git" "${HOME}/.cargo/git"
+          fi
+          echo "hit=true" >>"$GITHUB_OUTPUT"
+        else
+          echo "Local source-keyed Rust cache MISS"
+          if [[ "$MODE" == "consume" ]]; then
+            echo "::error::consume requires a seed/save for this Rust source key on this runner"
+            echo "::error::key=${KEY}"
+            echo "::error::slot=${SLOT}"
+            exit 1
+          fi
+        fi
+
+    - name: Save Rust build into source-keyed local cache
+      if: env.EFFECTIVE_MODE == 'save'
+      shell: bash
+      env:
+        SLOT: ${{ steps.slot.outputs.slot }}
+        KEY: ${{ steps.slot.outputs.key }}
+      run: |
+        set -euo pipefail
+        if [[ ! -d implementations/rust/target ]]; then
+          echo "save: no implementations/rust/target — skip (nothing to stamp)"
+          exit 0
+        fi
+        tmp="${SLOT}.tmp.$$"
+        rm -rf "$tmp"
+        mkdir -p "$tmp"
+        echo "Copying target into durable slot (this can take a few minutes)…"
+        cp -a implementations/rust/target "$tmp/target"
+        if [[ -d "${HOME}/.cargo/registry" ]]; then
+          cp -a "${HOME}/.cargo/registry" "$tmp/cargo-registry"
+        fi
+        if [[ -d "${HOME}/.cargo/git" ]]; then
+          cp -a "${HOME}/.cargo/git" "$tmp/cargo-git"
+        fi
+        printf '%s\n' "$KEY" >"$tmp/RUST_SOURCE_KEY"
+        date -u +%Y-%m-%dT%H:%M:%SZ >"$tmp/SAVED_AT"
+        rm -rf "${SLOT}"
+        mv "$tmp" "${SLOT}"
+        echo "Saved source-keyed Rust cache"
+        echo "key=${KEY}"
+        echo "slot=${SLOT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Rust build owner
+      - name: Restore Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
-          mode: seed
+          mode: restore
 
       - name: Check apt installed-package fast path
         run: tools/test-ci-apt-install.sh
@@ -55,6 +55,11 @@ jobs:
           for b in sugar sugar-ir-smt-lib sugar-ir-lean sugar-ir-coq sugar-ir-maude sugar-walk-rpc rust_test_assertions_rpc witness_rpc discharge_cli; do
             bin/sugarbin --profile debug --bin "$b" >/dev/null
           done
+
+      - name: Save Rust build (source-keyed local cache)
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          mode: save
 
   core:
     name: core (${{ matrix.name }})
@@ -103,7 +108,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Consume shared Rust build
+      - name: Consume shared Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
           mode: consume
@@ -158,7 +163,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Consume shared Rust build
+      - name: Consume shared Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
           mode: consume

--- a/.github/workflows/datetime-claim-twins.yml
+++ b/.github/workflows/datetime-claim-twins.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Reuse or seed the commit's Rust build
+      - name: Restore Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
-          mode: seed
+          mode: restore
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -40,6 +40,11 @@ jobs:
             -e implementations/python/sugar-lift-python-source \
             -e 'implementations/python/sugar-lift-py-tests[test]'
           bin/sugarbin --profile release >/dev/null
+
+      - name: Save Rust build (source-keyed local cache)
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          mode: save
 
       - name: Run focused twins and retain red telemetry
         id: twins

--- a/.github/workflows/examples-gate.yml
+++ b/.github/workflows/examples-gate.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Reuse or seed the commit's Rust build
+      - name: Restore Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
-          mode: seed
+          mode: restore
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -54,3 +54,9 @@ jobs:
         env:
           CI: '1'
           USE_BCARGO: '0'
+
+      - name: Save Rust build (source-keyed local cache)
+        if: always()
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          mode: save

--- a/.github/workflows/numpy-wall.yml
+++ b/.github/workflows/numpy-wall.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Reuse or seed the commit's Rust build
+      - name: Restore Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
-          mode: seed
+          mode: restore
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -128,6 +128,12 @@ jobs:
             --body-file .sugar/numpy-wall/ledger-comment.md
           gh issue comment 4263 --repo "$GITHUB_REPOSITORY" \
             --body-file .sugar/numpy-wall/ledger-comment.md
+
+      - name: Save Rust build (source-keyed local cache)
+        if: always()
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          mode: save
 
       - name: Upload NumPy wall artifacts
         if: always()

--- a/.github/workflows/pandas-wall.yml
+++ b/.github/workflows/pandas-wall.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Reuse or seed the commit's Rust build
+      - name: Restore Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
-          mode: seed
+          mode: restore
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -166,6 +166,12 @@ jobs:
             --body-file .sugar/pandas-wall/ledger-comment.md
           gh issue comment 4263 --repo "$GITHUB_REPOSITORY" \
             --body-file .sugar/pandas-wall/ledger-comment.md
+
+      - name: Save Rust build (source-keyed local cache)
+        if: always()
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          mode: save
 
       - name: Upload pandas wall artifacts
         if: always()

--- a/.github/workflows/restored-suite-scoreboard.yml
+++ b/.github/workflows/restored-suite-scoreboard.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Reuse or seed the commit's Rust build
+      - name: Restore Rust build (source-keyed local cache)
         uses: ./.github/actions/setup-rust-cache
         with:
-          mode: seed
+          mode: restore
 
       - name: Set up Python 3.12.13
         uses: actions/setup-python@v6
@@ -72,6 +72,11 @@ jobs:
             -e 'implementations/python/sugar-lift-py-tests[test]' \
             -e implementations/python/sugar-lift-python-source
           bin/sugarbin --profile release >/dev/null
+
+      - name: Save Rust build (source-keyed local cache)
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          mode: save
 
       - name: Run restored suite and retain red telemetry
         id: suite

--- a/tools/ci-rust-source-key.sh
+++ b/tools/ci-rust-source-key.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Content-address the Rust workspace (and build drivers) for CI cache keys.
+# Key material is only local filesystem content — never github.sha / ref / run id.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$root"
+
+toolchain="1.96.0"
+hash_list="$(mktemp)"
+trap 'rm -f "$hash_list"' EXIT
+
+{
+  printf 'toolchain:%s\n' "$toolchain"
+
+  (
+    cd implementations/rust
+    find . \
+      \( -path './target' -o -path '*/target/*' \) -prune -o \
+      -type f \( \
+        -name '*.rs' -o \
+        -name 'Cargo.toml' -o \
+        -name 'Cargo.lock' -o \
+        -name 'build.rs' -o \
+        -name '*.toml' \
+      \) -print
+  ) | LC_ALL=C sort | while IFS= read -r rel; do
+    # rel is like ./sugar-cli/src/main.rs
+    path="implementations/rust/${rel#./}"
+    printf '%s  ' "$path"
+    # portable content hash of file bytes
+    sha256sum -- "$path" | awk '{print $1}'
+  done
+
+  for extra in \
+    bin/sugarbin \
+    bin/lib/sugar-exec.sh \
+    .github/actions/setup-rust-cache/action.yml \
+    tools/ci-rust-source-key.sh
+  do
+    if [[ -f "$extra" ]]; then
+      printf '%s  ' "$extra"
+      sha256sum -- "$extra" | awk '{print $1}'
+    fi
+  done
+} >"$hash_list"
+
+key="$(sha256sum "$hash_list" | awk '{print $1}')"
+echo "Rust source cache key: ${key}" >&2
+echo "manifest_lines: $(wc -l <"$hash_list")" >&2
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "key=${key}" >>"$GITHUB_OUTPUT"
+fi
+# Always print for non-GHA use
+echo "key=${key}"


### PR DESCRIPTION
## Summary
The shared Rust build was keyed with `github.sha`, so every commit was a primary-key miss and looked like a full rebuild.

Now:
- **Key** = content hash of `implementations/rust` sources (+ toolchain pin + sugarbin) via `tools/ci-rust-source-key.sh`
- **Store** = runner local disk `~/.cache/sugar-rust-build/<key>` — **not** Actions cache, **not** commit SHA
- **prepare**: restore → build → save
- **matrix**: consume (require hit for this source key)

Same Rust tree across commits reuses the build; only real source changes rebuild.

## Note
Local cache is per-runner. Self-hosted fleets need shared disk or sticky scheduling for cross-machine hits.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key Rust CI cache to Rust source content on the runner disk
> - Replaces the GitHub Actions remote cache (keyed by commit SHA/`Cargo.lock`) with a local, content-addressed cache stored on the runner filesystem under `~/.cache/sugar-rust-build`.
> - Adds [`tools/ci-rust-source-key.sh`](https://github.com/TSavo/sugar/pull/6207/files#diff-eaa6dcf8330017ecd02d8bc595200c70b35065d24f114e4092b3f1f3575a89f5) to compute a deterministic SHA-256 key from Rust source files, Cargo manifests, and the pinned toolchain version.
> - The [`setup-rust-cache`](https://github.com/TSavo/sugar/pull/6207/files#diff-eaa6dcf8330017ecd02d8bc595200c70b35065d24f114e4092b3f1f3575a89f5) composite action gains four modes: `restore` (warm cache if present), `save` (persist build to slot), `consume` (fail job on cache miss), and `seed` (alias for `restore`).
> - The `prepare` job in [`ci.yml`](https://github.com/TSavo/sugar/pull/6207/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) runs `restore` then `save`; downstream matrix jobs use `consume` and fail fast if the slot is absent.
> - All other workflows (`datetime-claim-twins`, `examples-gate`, `numpy-wall`, `pandas-wall`, `restored-suite-scoreboard`) follow the same restore-then-save pattern.
> - Risk: `consume` mode causes a hard job failure if the cache slot is missing on the runner, so any runner without a prior `save` will break downstream jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87a86ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->