### PR TITLE
docs: sugarbin shelf hit expectation (CI probe, no Rust FS change)

### DIFF
--- a/docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md
+++ b/docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md
@@ -1,0 +1,16 @@
+# Expectation: sugarbin builds once until Rust FS changes
+
+**Pin:** post-#6208 (`sugarbin` is the only Rust binary door in CI).
+
+## Law
+On a given self-hosted runner, after a stamp has been built and published to
+the filesystem shelf (`~/.cache/sugar/binary-shelf-v2/…`):
+
+- The **next** CI run with **no** change under `implementations/rust` (and no
+  change to sugarbin/toolchain inputs that enter the stamp) must log
+  **`filesystem shelf hit`** for each warmed binary.
+- It must **not** log `filesystem shelf miss` + `Compiling …` for those stamps.
+
+## Probe
+Trigger CI with a non-Rust commit. Inspect prepare “Warm sugarbin shelf”:
+only first-ever stamps on that runner may miss; stable Rust → all hits.


### PR DESCRIPTION
## Purpose
Non-Rust change only — drives a main CI run to prove:

**Same Rust FS stamp → filesystem shelf hit, no recompile.**

Receipt: `docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md`

## Check after merge
On prepare “Warm sugarbin shelf”, for each previously published binary look for:
- `sugarbin: filesystem shelf hit for …`
- **not** `Compiling sugar-cli` / shelf miss for the same stamp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document expected CI sugarbin shelf hit behavior when no Rust filesystem changes occur
> Adds a receipt document at [2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md](https://github.com/TSavo/sugar/pull/6209/files#diff-596e14afb1e307d2f58df433dee19217925a54a1e3d8131e73567ee485675801) describing the expected CI behavior for sugarbin filesystem cache shelf hits in the absence of Rust filesystem changes. The document includes a probe section for verifying this behavior in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 786db2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->