### PR TITLE
Stop putting monorepo HEAD into sugarbin shelf identity

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -706,16 +706,14 @@ tool_versions() {
 build_identity() {
   local stamp="$1"
   require_b3sum || return 1
-  # sourceStamp is the BLAKE3 package-input closure. Monorepo HEAD is also part
-  # of identity so a shelf/cache hit cannot serve a binary whose compile-time
-  # monorepo HEAD disagrees with the live Python kit identity (#4577 split-
-  # pipeline refuse: kit @HEAD != binary @oldHEAD).
+  # Shelf / artifact identity is FS + toolchain + package + binary only.
+  # Monorepo git HEAD is NOT part of the key: a docs-only commit must not
+  # force rebuild. Compile-time monorepo head is still stamped into the binary
+  # via SUGARBIN_MONOREPO_HEAD for #4577 diagnostics; it does not change the
+  # content-addressed shelf cell.
   local incremental="0"
   [[ "$profile" != debug ]] || incremental="1"
-  local monorepo_head
-  monorepo_head="$(attestation_git_head)"
-  [[ -n "$monorepo_head" ]] || monorepo_head="unknown"
-  python3 - "$stamp" "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$package" "$bin_name" "$incremental" "$monorepo_head" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512:" $1}'
+  python3 - "$stamp" "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$package" "$bin_name" "$incremental" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512:" $1}'
 import sys
 def emit(label, value):
     label = label.encode(); value = value.encode()
@@ -723,7 +721,7 @@ def emit(label, value):
     sys.stdout.buffer.write(str(len(value)).encode() + b":" + value)
 for label, value in zip(("sourceStamp", "rustcVersionVerbose", "cargoVersionVerbose",
                          "platform", "targetTriple", "profile", "sortedFeatures",
-                         "package", "binary", "incremental", "monorepoHead"), sys.argv[1:]):
+                         "package", "binary", "incremental"), sys.argv[1:]):
     emit(label, value)
 PY
 }


### PR DESCRIPTION
## Why CI rebuilds on every push (even same run / no Rust change)

`bin/sugarbin` shelves binaries under `build_identity`, which included **`monorepoHead` = `git rev-parse HEAD`**.

So:
- docs-only commit → new HEAD → new identity → **filesystem shelf miss** → full compile
- prepare and matrix can even disagree if anything about identity drifts; mainly every commit was a cold shelf

## Fix
Remove `monorepoHead` from `build_identity`. Shelf key = rust package input stamp + toolchain/platform/profile + package/binary only.

Compile still records monorepo HEAD via `SUGARBIN_MONOREPO_HEAD` for #4577 diagnostics; it does **not** change the shelf cell.

## Law
**Build once per Rust FS stamp. Never again until Rust inputs change.**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove monorepo HEAD from `build_identity` shelf identity calculation in sugarbin
> The `build_identity` function in [sugarbin](https://github.com/TSavo/sugar/pull/6210/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) no longer includes the monorepo git HEAD when computing the blake3-512 identity hash. Behavioral Change: builds that differ only by repo HEAD will now produce identical shelf identities, meaning they may share cached artifacts across different commits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea532c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->