### PR TITLE
docs: remember first-warm sugar shelf stamp after #6210

### DIFF
--- a/docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md
+++ b/docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md
@@ -1,16 +1,44 @@
 # Expectation: sugarbin builds once until Rust FS changes
 
-**Pin:** post-#6208 (`sugarbin` is the only Rust binary door in CI).
+**Pin:** after #6210 (monorepo HEAD removed from shelf `build_identity`).
 
 ## Law
 On a given self-hosted runner, after a stamp has been built and published to
 the filesystem shelf (`~/.cache/sugar/binary-shelf-v2/…`):
 
-- The **next** CI run with **no** change under `implementations/rust` (and no
-  change to sugarbin/toolchain inputs that enter the stamp) must log
+- The **next** CI run with **no** change under the Rust package input closure
+  (and no change to toolchain/platform/profile that enter the stamp) must log
   **`filesystem shelf hit`** for each warmed binary.
 - It must **not** log `filesystem shelf miss` + `Compiling …` for those stamps.
 
+## Remembered first-warm stamp (post-#6210)
+
+From a CI run on main @ `8be473aa9293e9dd57e560d91c0d666dd2d7198e`
+(Merge #6210 / identity-without-git-head). **First** warm after the identity
+formula change — shelf miss + build is expected **once**:
+
+```
+sugarbin: filesystem shelf miss for sugar-linux-x86_64-release-blake3-512_a63effa8ba4cfbd85d383ba6a8e86a02181e29a2fd5e870a52e9fa377fd549a8ed86c2f803a9fe268fa0e8ebd4d1cdf5a0cebeed47b354f53d0af399e489b5df
+sugarbin: building sugar once for this session (set SUGAR_BIN to skip)
+```
+
+**Artifact name (full):**
+`sugar-linux-x86_64-release-blake3-512_a63effa8ba4cfbd85d383ba6a8e86a02181e29a2fd5e870a52e9fa377fd549a8ed86c2f803a9fe268fa0e8ebd4d1cdf5a0cebeed47b354f53d0af399e489b5df`
+
+**Identity digest (shelf cell):**
+`blake3-512:a63effa8ba4cfbd85d383ba6a8e86a02181e29a2fd5e870a52e9fa377fd549a8ed86c2f803a9fe268fa0e8ebd4d1cdf5a0cebeed47b354f53d0af399e489b5df`
+
+### Pass criterion for the next non-Rust push
+Same runner, unchanged Rust inputs → expect:
+
+```
+sugarbin: filesystem shelf hit for sugar-linux-x86_64-release-blake3-512_a63effa8ba4cfbd85d383ba6a8e86a02181e29a2fd5e870a52e9fa377fd549a8ed86c2f803a9fe268fa0e8ebd4d1cdf5a0cebeed47b354f53d0af399e489b5df
+```
+
+If the digest changes without a Rust FS change, identity is still wrong.
+If the digest matches but still **miss**, the shelf is not durable on that runner
+(HOME / `SUGAR_BINARY_SHELF_ROOT` / multi-machine scheduling).
+
 ## Probe
-Trigger CI with a non-Rust commit. Inspect prepare “Warm sugarbin shelf”:
-only first-ever stamps on that runner may miss; stable Rust → all hits.
+Trigger CI with a non-Rust commit. Inspect prepare “Warm sugarbin shelf”.
+EOF


### PR DESCRIPTION
Records stamp `a63effa8…` as the expected shelf cell for the next no-Rust-change CI check.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document remembered first-warm sugar shelf stamp after #6210
> Updates [2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md](https://github.com/TSavo/sugar/pull/6211/files#diff-596e14afb1e307d2f58df433dee19217925a54a1e3d8131e73567ee485675801) to reference PR #6210 instead of #6208 and clarifies the shelf hit condition as "no change under the Rust package input closure" with toolchain/platform/profile as the stamp inputs. Adds a new section with the recorded CI run context, example shelf miss/hit logs, artifact name, identity digest, and a pass criterion for the next non-Rust push.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2d4052.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->