### PR TITLE
fix: a concrete loop whose target cannot destructure stays loud

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3420,6 +3420,25 @@ class For(Statement):
                             )
                             unrolled.extend(else_body)
                         return _Splice(tuple(unrolled), final_target_bindings)
+                if elements is not None:
+                    # A concrete iterable whose target did not destructure its
+                    # elements -- a starred/nested target, or an arity the
+                    # display does not match -- is a runtime binding error, never
+                    # a symbolic universal. It stays loud. (The symbolic-jump
+                    # case set `elements = None` above and falls through.)
+                    raise SugarNotWritten(
+                        owner="For.substitute",
+                        observed=(
+                            f"concrete for-loop target {self.target.kind} does not "
+                            "destructure its elements"
+                        ),
+                        requested="a target that binds every concrete element by name",
+                        fix=(
+                            "use a Name or a flat tuple/list of Names matching the "
+                            "element arity; a starred, nested, or arity-mismatched "
+                            "target stays loud until its destructuring is written"
+                        ),
+                    )
 
             # Symbolic (or unsupported) loop: keep the node, mask the target AND
             # every loop-carried variable (a name the body rebinds), recurse.


### PR DESCRIPTION
A for-loop over a concrete iterable (display/range) whose target does not bind the elements — a starred target (`for a, *b in [(1,2)]`), nested, or arity-mismatched — declined the unroll and fell through to the symbolic branch, silently woven into a `FunctionUniverseSugar` that cannot soundly bind it.

That's a runtime binding error, never a symbolic universal: stay **loud** with `SugarNotWritten`. The symbolic-jump case (sets `elements=None`) still falls through to the real symbolic loop.

Flips `test_starred_target_stays_loud` + `test_arity_mismatch_stays_loud` green; **zero regressions**. Value-correctness reds 21→19. Remaining `for_unroll` reds are the symbolic universal/fold *shape* (separate foundational work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `SugarNotWritten` in `For.substitute` when a concrete loop target cannot destructure
> Previously, a `for` loop with a concrete iterable whose target couldn't destructure its elements (e.g. starred, nested, or arity-mismatched) would silently fall through as symbolic. Now `For.substitute` raises `SugarNotWritten` with a descriptive message in that case, treating it as a runtime binding error. Behavioral Change: loops that previously fell through silently will now raise an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13a73d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->