### PR TITLE
fix: raise of a formal parameter carries its name through substitution

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4546,6 +4546,10 @@ class Raise(Statement):
             node = node.value
         if node is not None and node.kind == "Name":
             parts.append(node.id)
+        elif node is not None and node.kind == "FormalRef":
+            # After substitution a raised formal name is a FormalRef, not a
+            # Name; its label is the formal's declared name (`raise exc` -> exc).
+            parts.append(node.coordinate.declared_name)
         if not parts:
             return None
         return ".".join(reversed(parts))


### PR DESCRIPTION
`Raise._exception_name` reads the raised exception's label structurally off `self.exc` (Name/Call/Attribute). After substitution a raised formal (`raise exc`) is a `FormalRef`, not a `Name`, so the label came back None and the `RaiseEffect` lost its `exception_name`.

Read the label from a `FormalRef`'s `coordinate.declared_name` too. Flips `test_raise_name_points_at_the_built_value` green (`RaiseEffect.exception_name == 'exc'`); zero regressions. Value-correctness 19→18.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Raise._exception_name` to return the declared name when raising a formal parameter
> When a `Raise` node's `exc` resolves to a `FormalRef` (e.g. after substitution), `_exception_name` previously returned `None` instead of the formal's name. The fix adds a `FormalRef` branch in [nodes.py](https://github.com/TSavo/sugar/pull/6214/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) that appends `node.coordinate.declared_name` to the result parts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fc2f32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exception labeling when raised exceptions originate from substituted formal variables.
  - Exception names now display the correct declared name, including qualified names, for clearer and more accurate diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->