### PR TITLE
Ratchet lift refusal vocabulary census after lifter drift

### DIFF
--- a/tools/lift_refusal_vocabulary_census.json
+++ b/tools/lift_refusal_vocabulary_census.json
@@ -2,7 +2,7 @@
   "identity": "path + normalized text digest + duplicate ordinal; line is display only",
   "issue": "#3632",
   "law": "REFUSE is the verifier verb; lift outputs are reduced meaning or typed effects.",
-  "lift_output_backlog": 1829,
+  "lift_output_backlog": 1830,
   "occurrences": [
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/discharge_cli.py:523c0ad6c899be9b:1",
@@ -286,7 +286,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py:3feab243bdcc8dd8:1",
-      "line": 96,
+      "line": 137,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -296,7 +296,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py:55039820e093b03a:1",
-      "line": 658,
+      "line": 694,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py",
       "reason": "line explicitly talks about verifier/prove-side refusal vocabulary",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -306,7 +306,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07a1923e8775da07:1",
-      "line": 2797,
+      "line": 2896,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -316,7 +316,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07a1923e8775da07:2",
-      "line": 2804,
+      "line": 2903,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -326,7 +326,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07e1a59934e7a669:1",
-      "line": 1297,
+      "line": 1404,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -336,7 +336,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:0b3e51e7a8642aee:1",
-      "line": 3282,
+      "line": 3383,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -346,7 +346,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:1",
-      "line": 197,
+      "line": 234,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -356,7 +356,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:2",
-      "line": 267,
+      "line": 304,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -366,7 +366,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:3",
-      "line": 277,
+      "line": 314,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -376,7 +376,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:4",
-      "line": 290,
+      "line": 327,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -386,7 +386,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:5",
-      "line": 2029,
+      "line": 2131,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -395,18 +395,8 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
-      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:29211267c3030dcb:1",
-      "line": 2744,
-      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "def _refused_decorator_name(decorator: ast.expr) -> str:",
-      "wire_marker": "wire-protocol:lift-report-payload"
-    },
-    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:2b1ea1908a30d567:1",
-      "line": 2817,
+      "line": 2916,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -416,7 +406,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:2ff68163ee0743b8:1",
-      "line": 2681,
+      "line": 2805,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -426,7 +416,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:323981772b7a43d0:1",
-      "line": 1978,
+      "line": 2080,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -436,7 +426,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:334c5570dcf7e2e8:1",
-      "line": 2799,
+      "line": 2898,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -446,7 +436,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:334c5570dcf7e2e8:2",
-      "line": 2806,
+      "line": 2905,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -456,7 +446,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:35f0e1bc84c17b0a:1",
-      "line": 893,
+      "line": 991,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -466,7 +456,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:4ae90c55d54449d3:1",
-      "line": 1752,
+      "line": 1856,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -476,7 +466,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:4c469dad29c9f03f:1",
-      "line": 2677,
+      "line": 2801,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -486,7 +476,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5490fb1c72fabb2b:1",
-      "line": 97,
+      "line": 134,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -496,7 +486,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:584c0d7a15b58f1b:1",
-      "line": 1670,
+      "line": 1774,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -506,7 +496,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:595151665adfae36:1",
-      "line": 2827,
+      "line": 2926,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -516,7 +506,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5c9cc4b4a1b3359b:1",
-      "line": 2826,
+      "line": 2925,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -526,7 +516,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5ce72679c0ae1bb8:1",
-      "line": 2811,
+      "line": 2910,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -536,7 +526,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5ce72679c0ae1bb8:2",
-      "line": 2814,
+      "line": 2913,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -546,7 +536,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:1",
-      "line": 196,
+      "line": 233,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -556,7 +546,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:2",
-      "line": 266,
+      "line": 303,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -566,7 +556,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:3",
-      "line": 276,
+      "line": 313,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -576,7 +566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:4",
-      "line": 289,
+      "line": 326,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -586,7 +576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:5",
-      "line": 2028,
+      "line": 2130,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -596,7 +586,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:66bbb74de25b7e5b:1",
-      "line": 969,
+      "line": 1076,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -606,7 +596,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:684cb47145fbde57:1",
-      "line": 2800,
+      "line": 2899,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -616,7 +606,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:684cb47145fbde57:2",
-      "line": 2807,
+      "line": 2906,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -626,7 +616,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:75c22bbaf7c3d3fc:1",
-      "line": 1954,
+      "line": 2058,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -636,7 +626,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:7be2d7840e24c169:1",
-      "line": 1977,
+      "line": 2079,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -645,18 +635,28 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
-      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:7d33419450d7531e:1",
-      "line": 1236,
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:7f0fb93a6285e1d8:1",
+      "line": 1343,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "raise _UnsupportedSyntax(node.slice, \"slice annotations are refused\")",
+      "text": "raise _UnsupportedSyntax(node.slice_, \"slice annotations are refused\")",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:8db97768fd10741a:1",
+      "line": 1038,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "kind=\"bare-raise-refused\",",
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:9619c63bd219f362:1",
-      "line": 830,
+      "line": 928,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -665,8 +665,18 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:98ffb2d0275f8c06:1",
+      "line": 2877,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _contains_refused_control(fn: typed.FunctionDef) -> _UnsupportedSyntax | None:",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:99255915fed3a1a9:1",
-      "line": 894,
+      "line": 992,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -675,8 +685,18 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a024794c032ce929:1",
+      "line": 2878,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "class _RefusedControlScanner(typed.TypedNodeWalker):",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a0d47a5dffe481fa:1",
-      "line": 2819,
+      "line": 2918,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -686,7 +706,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a11cbd91625388f8:1",
-      "line": 1957,
+      "line": 2061,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -696,7 +716,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a851ca28f6008b79:1",
-      "line": 879,
+      "line": 977,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -706,7 +726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:b366f2d9801c38d8:1",
-      "line": 2843,
+      "line": 2942,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -716,7 +736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:b790a90e666402f3:1",
-      "line": 1958,
+      "line": 2062,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -726,7 +746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:b8336f0a06821c80:1",
-      "line": 2669,
+      "line": 2793,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -736,7 +756,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:bbf3f68eab7a9377:1",
-      "line": 217,
+      "line": 254,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -746,7 +766,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:c777fce5f866e1e7:1",
-      "line": 303,
+      "line": 340,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -756,7 +776,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:cb711432aada956b:1",
-      "line": 1956,
+      "line": 2060,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -766,7 +786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:d7268ed408ba6c06:1",
-      "line": 1857,
+      "line": 1961,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -775,18 +795,8 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
-      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:dd64d4d4a1e75d9e:1",
-      "line": 2779,
-      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "class _RefusedControlScanner(ast.NodeVisitor):",
-      "wire_marker": "wire-protocol:lift-report-payload"
-    },
-    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ddc2e8fb8e7e74ec:1",
-      "line": 759,
+      "line": 857,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -796,7 +806,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:dec5ed98ecf87133:1",
-      "line": 2831,
+      "line": 2930,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -806,7 +816,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:df7a728b69570b0e:1",
-      "line": 1979,
+      "line": 2081,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -815,8 +825,18 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:e0829a866a3ac750:1",
+      "line": 2863,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _refused_decorator_name(decorator: typed.expr) -> str:",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:e4f7e69be5a23714:1",
-      "line": 760,
+      "line": 858,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -826,7 +846,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:e8951d7583605aa0:1",
-      "line": 831,
+      "line": 929,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -836,7 +856,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:1",
-      "line": 1403,
+      "line": 1510,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -846,7 +866,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:2",
-      "line": 1431,
+      "line": 1538,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -856,7 +876,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:3",
-      "line": 1459,
+      "line": 1566,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -866,7 +886,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:4",
-      "line": 1487,
+      "line": 1594,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -876,7 +896,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:f07060d3fbacca9d:1",
-      "line": 2829,
+      "line": 2928,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -886,7 +906,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:f24e852621ff01aa:1",
-      "line": 2655,
+      "line": 2779,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -896,7 +916,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:fc33afd15623fb98:1",
-      "line": 1953,
+      "line": 2057,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -905,18 +925,8 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
-      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:fe18e50a53379127:1",
-      "line": 2778,
-      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "def _contains_refused_control(fn: ast.FunctionDef) -> _UnsupportedSyntax | None:",
-      "wire_marker": "wire-protocol:lift-report-payload"
-    },
-    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:fe90dd51ba418fb0:1",
-      "line": 2781,
+      "line": 2880,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -936,7 +946,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:0ea9d3db9fed818c:1",
-      "line": 176,
+      "line": 231,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -946,7 +956,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:a73ac5bc57ddf363:1",
-      "line": 173,
+      "line": 228,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -956,7 +966,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:c4829d099c3b9db1:1",
-      "line": 386,
+      "line": 441,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -966,7 +976,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:eae51ec3ab0e5a96:1",
-      "line": 429,
+      "line": 484,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -976,7 +986,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:001ea710188b8ed0:1",
-      "line": 87,
+      "line": 106,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -986,7 +996,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:17deb40a592c5a31:1",
-      "line": 578,
+      "line": 616,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -996,7 +1006,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:1a797c7d41988438:1",
-      "line": 553,
+      "line": 591,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1006,7 +1016,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:1da299b961b7e825:1",
-      "line": 546,
+      "line": 584,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1016,7 +1026,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:1fa611f28bc092a6:1",
-      "line": 305,
+      "line": 332,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1026,7 +1036,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2ddd026578073f3f:1",
-      "line": 279,
+      "line": 306,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1036,7 +1046,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2ddd026578073f3f:2",
-      "line": 299,
+      "line": 326,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1046,7 +1056,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:1",
-      "line": 207,
+      "line": 234,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1056,7 +1066,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:2",
-      "line": 232,
+      "line": 259,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1066,7 +1076,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:3",
-      "line": 240,
+      "line": 267,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1076,7 +1086,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:4",
-      "line": 302,
+      "line": 329,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1086,7 +1096,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:5",
-      "line": 518,
+      "line": 556,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1096,7 +1106,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:6",
-      "line": 522,
+      "line": 560,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1106,7 +1116,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:7",
-      "line": 536,
+      "line": 574,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1116,7 +1126,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:8",
-      "line": 564,
+      "line": 602,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1126,7 +1136,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:2e32a0c2c39836c7:9",
-      "line": 597,
+      "line": 635,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1136,7 +1146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:3921598abdfe38a5:1",
-      "line": 115,
+      "line": 134,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1146,7 +1156,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:4099dbff86e0398a:1",
-      "line": 241,
+      "line": 268,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1156,7 +1166,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:4c7afb22a128b502:1",
-      "line": 616,
+      "line": 654,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1166,7 +1176,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:581e8b0843d2a6fa:1",
-      "line": 227,
+      "line": 254,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1176,7 +1186,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:5fbdb61c66da49db:1",
-      "line": 515,
+      "line": 553,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1186,7 +1196,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:607a5d1d2276a6b7:1",
-      "line": 551,
+      "line": 589,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1206,7 +1216,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:6f69526b161ffeb3:1",
-      "line": 507,
+      "line": 545,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1216,7 +1226,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:7dc55f1573894024:1",
-      "line": 615,
+      "line": 653,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1226,7 +1236,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:81100d9c41c58e03:1",
-      "line": 555,
+      "line": 593,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1236,7 +1246,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:854914881837510a:1",
-      "line": 188,
+      "line": 215,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1246,7 +1256,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:8d454c63744dcbbb:1",
-      "line": 234,
+      "line": 261,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1256,7 +1266,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:9c3c91a758b8eb13:1",
-      "line": 313,
+      "line": 340,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1266,7 +1276,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:9c80f0465c00eda9:1",
-      "line": 197,
+      "line": 224,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1276,7 +1286,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:a9c747a9ca21e00b:1",
-      "line": 191,
+      "line": 218,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1296,7 +1306,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:bb69f65fb5e49269:1",
-      "line": 592,
+      "line": 630,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1306,7 +1316,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:ce9dd0b0ef6ebb9c:1",
-      "line": 182,
+      "line": 209,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1316,7 +1326,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:d5294bba8743e512:1",
-      "line": 569,
+      "line": 607,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1326,7 +1336,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:e2c37ec878ee0d7c:1",
-      "line": 566,
+      "line": 604,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1336,7 +1346,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:e3aa3615ad864b12:1",
-      "line": 200,
+      "line": 227,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1346,7 +1356,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:e46970d8ae367926:1",
-      "line": 78,
+      "line": 97,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1356,7 +1366,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:e75c195423fbe70b:1",
-      "line": 215,
+      "line": 242,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1366,7 +1376,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:e8e169d94c9ae348:1",
-      "line": 612,
+      "line": 650,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1376,7 +1386,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:facbb170acfca872:1",
-      "line": 56,
+      "line": 75,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -1386,7 +1396,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py:fce9e33f77d61e0f:1",
-      "line": 619,
+      "line": 657,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py",
       "reason": "verify-facing dialect describes what the verifier can discharge",
       "replacement": "rename only with verify schema compatibility if the field crosses RPC",
@@ -5806,7 +5816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:00715bf7fa7e3989:1",
-      "line": 23469,
+      "line": 23484,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5836,7 +5846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:023060f70eda31cc:1",
-      "line": 26805,
+      "line": 26820,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5886,7 +5896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:06807fc7bec5fc1d:1",
-      "line": 22556,
+      "line": 22571,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5906,7 +5916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:070a0b11e4fc45bf:1",
-      "line": 24690,
+      "line": 24705,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5916,7 +5926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:07516d6f7741ee2e:1",
-      "line": 24812,
+      "line": 24827,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5926,7 +5936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:075668c502065ada:1",
-      "line": 24778,
+      "line": 24793,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5936,7 +5946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:075f606d39c6e391:1",
-      "line": 27331,
+      "line": 27346,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5946,7 +5956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:08c968721dde4a8d:1",
-      "line": 25107,
+      "line": 25122,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5966,7 +5976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0b284fbf6398a4cb:1",
-      "line": 24482,
+      "line": 24497,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5986,7 +5996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0bb173a2cd4f6c05:1",
-      "line": 27032,
+      "line": 27047,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6006,7 +6016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0c3db6963f2b02a2:1",
-      "line": 24716,
+      "line": 24731,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6026,7 +6036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0c8194715a3902ac:1",
-      "line": 25336,
+      "line": 25351,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6036,7 +6046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0f14e7ba67ebe8a4:1",
-      "line": 27140,
+      "line": 27155,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6046,7 +6056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0f94a77703bdfc9d:1",
-      "line": 26896,
+      "line": 26911,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6056,7 +6066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:10059f735b52c5ca:1",
-      "line": 27238,
+      "line": 27253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6066,7 +6076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:109f387df23564d9:1",
-      "line": 22164,
+      "line": 22179,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6136,7 +6146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:130208c002b27c83:1",
-      "line": 25069,
+      "line": 25084,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6156,7 +6166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:14086dd043873bae:1",
-      "line": 24717,
+      "line": 24732,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6256,7 +6266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:156322853641dcae:1",
-      "line": 24363,
+      "line": 24378,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6276,7 +6286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:17c97ab850b80ead:1",
-      "line": 26999,
+      "line": 27014,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6306,7 +6316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:18f47275dc43c9a0:1",
-      "line": 24048,
+      "line": 24063,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6316,7 +6326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:18fe8d58cf2752cf:1",
-      "line": 26686,
+      "line": 26701,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6326,7 +6336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:190e4da1314fc567:1",
-      "line": 26661,
+      "line": 26676,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6336,7 +6346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1a0d750419a333e3:1",
-      "line": 23964,
+      "line": 23979,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6346,7 +6356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1a8a7091a2c86a79:1",
-      "line": 26710,
+      "line": 26725,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6356,7 +6366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1aa1e16daf7b4b70:1",
-      "line": 27183,
+      "line": 27198,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6366,7 +6376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1b68a15408b04149:1",
-      "line": 26760,
+      "line": 26775,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6376,7 +6386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:1",
-      "line": 27795,
+      "line": 27810,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6386,7 +6396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:2",
-      "line": 27825,
+      "line": 27840,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6396,7 +6406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:3",
-      "line": 27893,
+      "line": 27908,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6406,7 +6416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1c061bed085b0bc3:1",
-      "line": 25661,
+      "line": 25676,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6416,7 +6426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1c11f8f22666e7c9:1",
-      "line": 25280,
+      "line": 25295,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6436,7 +6446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1d17be5738840619:1",
-      "line": 25138,
+      "line": 25153,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6446,7 +6456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1d9987aa1f1248d2:1",
-      "line": 27726,
+      "line": 27741,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6576,7 +6586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2332f6d3742487b4:1",
-      "line": 26978,
+      "line": 26993,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6606,7 +6616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:23fdc12df7c53f0f:1",
-      "line": 26932,
+      "line": 26947,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6616,7 +6626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2452451a489656b2:1",
-      "line": 23792,
+      "line": 23807,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6626,7 +6636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:25113e9e5dd84a8f:1",
-      "line": 24336,
+      "line": 24351,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6676,7 +6686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:276e46ed5435d002:1",
-      "line": 27697,
+      "line": 27712,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6686,7 +6696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2795eae4db9bdfee:1",
-      "line": 25035,
+      "line": 25050,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6736,7 +6746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2915f2980123103e:1",
-      "line": 25007,
+      "line": 25022,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6786,7 +6796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2accdc0895e9e669:1",
-      "line": 21117,
+      "line": 21119,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6796,7 +6806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2d6a2a5b71a0b663:1",
-      "line": 23951,
+      "line": 23966,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6826,7 +6836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2e5e4feee4134522:1",
-      "line": 24392,
+      "line": 24407,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6876,7 +6886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3097aa95e17d1856:1",
-      "line": 26687,
+      "line": 26702,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6886,7 +6896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:30c490c5f5efa1a6:1",
-      "line": 26839,
+      "line": 26854,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6906,7 +6916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:315589ac0f502555:1",
-      "line": 27088,
+      "line": 27103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6926,7 +6936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:32041de6dba814ab:1",
-      "line": 24730,
+      "line": 24745,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6966,7 +6976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:339202b9416e3a33:1",
-      "line": 27257,
+      "line": 27272,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6976,7 +6986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:33ed2707c4fcfbef:1",
-      "line": 26692,
+      "line": 26707,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6986,7 +6996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:341be91c6844f3bf:1",
-      "line": 24981,
+      "line": 24996,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6996,7 +7006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:34befd82f6f8ff42:1",
-      "line": 26876,
+      "line": 26891,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7006,7 +7016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:35873b2180a27aef:1",
-      "line": 27190,
+      "line": 27205,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7026,7 +7036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37c5c1d1c57a25eb:1",
-      "line": 27005,
+      "line": 27020,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7046,7 +7056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37d5afe263a0145e:1",
-      "line": 25056,
+      "line": 25071,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7066,7 +7076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3a43a7e8e2e64af4:1",
-      "line": 26904,
+      "line": 26919,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7086,7 +7096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3b639938ea9f6390:1",
-      "line": 25312,
+      "line": 25327,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7096,7 +7106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3baa5fc5fd598c0d:1",
-      "line": 27255,
+      "line": 27270,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7106,7 +7116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3bd536a29fd37e9d:1",
-      "line": 26698,
+      "line": 26713,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7136,7 +7146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3d7a888be1d4b31a:1",
-      "line": 27305,
+      "line": 27320,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7146,7 +7156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:1",
-      "line": 22213,
+      "line": 22228,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7156,7 +7166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:10",
-      "line": 23242,
+      "line": 23257,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7166,7 +7176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:11",
-      "line": 23529,
+      "line": 23544,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7176,7 +7186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:12",
-      "line": 24088,
+      "line": 24103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7186,7 +7196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:13",
-      "line": 24111,
+      "line": 24126,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7196,7 +7206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:14",
-      "line": 27847,
+      "line": 27862,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7206,7 +7216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:15",
-      "line": 27866,
+      "line": 27881,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7216,7 +7226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:2",
-      "line": 22237,
+      "line": 22252,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7226,7 +7236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:3",
-      "line": 22279,
+      "line": 22294,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7236,7 +7246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:4",
-      "line": 22325,
+      "line": 22340,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7246,7 +7256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:5",
-      "line": 22433,
+      "line": 22448,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7256,7 +7266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:6",
-      "line": 22464,
+      "line": 22479,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7266,7 +7276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:7",
-      "line": 22525,
+      "line": 22540,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7276,7 +7286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:8",
-      "line": 23101,
+      "line": 23116,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7286,7 +7296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:9",
-      "line": 23121,
+      "line": 23136,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7296,7 +7306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3e66b2e73573210b:1",
-      "line": 24207,
+      "line": 24222,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7306,7 +7316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3f69a0c862654acb:1",
-      "line": 26979,
+      "line": 26994,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7326,7 +7336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:41518803e7f1d22e:1",
-      "line": 26875,
+      "line": 26890,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7346,7 +7356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:423b67cd8e5f252f:1",
-      "line": 27345,
+      "line": 27360,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7366,7 +7376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:43e8d108b534f26f:1",
-      "line": 27741,
+      "line": 27756,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7396,7 +7406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:48138862d4682b0b:1",
-      "line": 26615,
+      "line": 26630,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7406,7 +7416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:48138862d4682b0b:2",
-      "line": 26650,
+      "line": 26665,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7446,7 +7456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4b658e293164e5eb:1",
-      "line": 27125,
+      "line": 27140,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7456,7 +7466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4b6d488a0d07ccd2:1",
-      "line": 26683,
+      "line": 26698,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7466,7 +7476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c2b7d3cd8239e6e:1",
-      "line": 27236,
+      "line": 27251,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7476,7 +7486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c2f0d3a662a83c4:1",
-      "line": 22554,
+      "line": 22569,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7546,7 +7556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4e5e2357e6d17aa0:1",
-      "line": 24638,
+      "line": 24653,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7566,7 +7576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4fafd457a1ae333a:1",
-      "line": 26706,
+      "line": 26721,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7606,7 +7616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:51143f47a6e30603:1",
-      "line": 25811,
+      "line": 25826,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7626,7 +7636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:51865434a32ef559:1",
-      "line": 26935,
+      "line": 26950,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7636,7 +7646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:52b76da630c76b62:1",
-      "line": 25907,
+      "line": 25922,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7696,7 +7706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:56b258284f9642c8:1",
-      "line": 26954,
+      "line": 26969,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7716,7 +7726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5786e71f09223cfb:1",
-      "line": 27712,
+      "line": 27727,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7746,7 +7756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:595b49ffbabd5f5b:1",
-      "line": 24757,
+      "line": 24772,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7766,7 +7776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5ac33c6e679925b5:1",
-      "line": 27680,
+      "line": 27695,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7786,7 +7796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5bb403bc2c0c8a31:1",
-      "line": 27204,
+      "line": 27219,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7806,7 +7816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c071c74b3d12777:1",
-      "line": 26953,
+      "line": 26968,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7826,7 +7836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c8c3bad631bad37:1",
-      "line": 24546,
+      "line": 24561,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7836,7 +7846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5d2809e5887813e4:1",
-      "line": 24233,
+      "line": 24248,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7856,7 +7866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5fdbd97bf81884d8:1",
-      "line": 27131,
+      "line": 27146,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7876,7 +7886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6050aaede36b36a7:1",
-      "line": 26638,
+      "line": 26653,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7906,7 +7916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:60874978b39adfa4:1",
-      "line": 26682,
+      "line": 26697,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7936,7 +7946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:62c1f77e7b6fa531:1",
-      "line": 26716,
+      "line": 26731,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7956,7 +7966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:64bf9c42441d6213:1",
-      "line": 26138,
+      "line": 26153,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7966,7 +7976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:64d68d8f77c17f16:1",
-      "line": 26672,
+      "line": 26687,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8036,7 +8046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:68b6245dc4813486:1",
-      "line": 27696,
+      "line": 27711,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8046,7 +8056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:692c34495b7680cf:1",
-      "line": 26799,
+      "line": 26814,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8056,7 +8066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69bbb7e52ab40221:1",
-      "line": 27114,
+      "line": 27129,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8066,7 +8076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69d451ac8d3bd3ce:1",
-      "line": 26947,
+      "line": 26962,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8076,7 +8086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69ef7af4b214d979:1",
-      "line": 25016,
+      "line": 25031,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8116,7 +8126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6ae57f6321934965:1",
-      "line": 25779,
+      "line": 25794,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8156,7 +8166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6d3dda9843aa0037:1",
-      "line": 27247,
+      "line": 27262,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8166,7 +8176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e14b3f148ea0ff4:1",
-      "line": 21140,
+      "line": 21142,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8186,7 +8196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e4a242955a2ec48:1",
-      "line": 23921,
+      "line": 23936,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8196,7 +8206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e9f58a481b3aad7:1",
-      "line": 22840,
+      "line": 22855,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8276,7 +8286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:718f849bcfcc5b0b:1",
-      "line": 26671,
+      "line": 26686,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8306,7 +8316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:72321878ae60ef1e:1",
-      "line": 26907,
+      "line": 26922,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8316,7 +8326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:734f917a2131bff9:1",
-      "line": 26664,
+      "line": 26679,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8396,7 +8406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:75a673ba752dd41b:1",
-      "line": 26713,
+      "line": 26728,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8406,7 +8416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76244b46d5d2da2d:1",
-      "line": 26703,
+      "line": 26718,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8416,7 +8426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76590ed1a25eaa1e:1",
-      "line": 24777,
+      "line": 24792,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8426,7 +8436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76ba135bffb8aaa0:1",
-      "line": 25087,
+      "line": 25102,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8456,7 +8466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:77063501e138f18f:1",
-      "line": 26609,
+      "line": 26624,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8466,7 +8476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:771613ec00c7e29f:1",
-      "line": 27755,
+      "line": 27770,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8506,7 +8516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:79051ad91ba65913:1",
-      "line": 27194,
+      "line": 27209,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8516,7 +8526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:796a87e2dd8a70eb:1",
-      "line": 26709,
+      "line": 26724,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8526,7 +8536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:79aa37575ef65eda:1",
-      "line": 25083,
+      "line": 25098,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8566,7 +8576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7affee5384f21d56:1",
-      "line": 27425,
+      "line": 27440,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8596,7 +8606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7c2861be8050c186:1",
-      "line": 27043,
+      "line": 27058,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8616,7 +8626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da128e0c706afdb:1",
-      "line": 23339,
+      "line": 23354,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8626,7 +8636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da1b5483d9ad6cd:1",
-      "line": 26934,
+      "line": 26949,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8646,7 +8656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ec29d9f2347eac0:1",
-      "line": 26702,
+      "line": 26717,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8676,7 +8686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7f000eb0d9eb951d:1",
-      "line": 26599,
+      "line": 26614,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8686,7 +8696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:808bb577e2c06361:1",
-      "line": 25874,
+      "line": 25889,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8706,7 +8716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:80eb2ee38045f801:1",
-      "line": 25019,
+      "line": 25034,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8716,7 +8726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:814324470fc67927:1",
-      "line": 25099,
+      "line": 25114,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8736,7 +8746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:824bb54ba7f20820:1",
-      "line": 23317,
+      "line": 23332,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8746,7 +8756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:827db9276c4fa36d:1",
-      "line": 25802,
+      "line": 25817,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8756,7 +8766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:82b934014b764d2c:1",
-      "line": 27700,
+      "line": 27715,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8796,7 +8806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:87b15a84cf481f08:1",
-      "line": 24056,
+      "line": 24071,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8816,7 +8826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:88dbbb39ee6cfa4c:1",
-      "line": 24679,
+      "line": 24694,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8846,7 +8856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89fe33412c371ae2:1",
-      "line": 26678,
+      "line": 26693,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8856,7 +8866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8a4a1e611861b01a:1",
-      "line": 26976,
+      "line": 26991,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8886,7 +8896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8ac1f27d38bb7b6d:1",
-      "line": 26786,
+      "line": 26801,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8936,7 +8946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8c552c3fc192982d:1",
-      "line": 26846,
+      "line": 26861,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8956,7 +8966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8d256950ad9c8e3d:1",
-      "line": 23981,
+      "line": 23996,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8976,7 +8986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8e7aa9e00f882c2a:1",
-      "line": 26675,
+      "line": 26690,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8996,7 +9006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:902a433fcc62e775:1",
-      "line": 25284,
+      "line": 25299,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9056,7 +9066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:92db2724cf6c2174:1",
-      "line": 26697,
+      "line": 26712,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9096,7 +9106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:968ebe030bdae100:1",
-      "line": 27044,
+      "line": 27059,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9106,7 +9116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:97364d430e50993e:1",
-      "line": 26794,
+      "line": 26809,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9146,7 +9156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:989774411313426b:1",
-      "line": 27163,
+      "line": 27178,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9156,7 +9166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:99cac8ab20136aa1:1",
-      "line": 26912,
+      "line": 26927,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9186,7 +9196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e35a2d5547fe631:1",
-      "line": 26616,
+      "line": 26631,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9196,7 +9206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e5cc7b488c41b38:1",
-      "line": 26684,
+      "line": 26699,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9206,7 +9216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e89d1b9214ea2dc:1",
-      "line": 24871,
+      "line": 24886,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9216,7 +9226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:1",
-      "line": 24886,
+      "line": 24901,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9226,7 +9236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:2",
-      "line": 25042,
+      "line": 25057,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9236,7 +9246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:3",
-      "line": 25076,
+      "line": 25091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9246,7 +9256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:4",
-      "line": 25106,
+      "line": 25121,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9256,7 +9266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:5",
-      "line": 25164,
+      "line": 25179,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9286,7 +9296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a008154800585d78:1",
-      "line": 24976,
+      "line": 24991,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9316,7 +9326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a199c8fed871df78:1",
-      "line": 24816,
+      "line": 24831,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9326,7 +9336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a24878847e5ad418:1",
-      "line": 26970,
+      "line": 26985,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9356,7 +9366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a3ba8f2625938e9d:1",
-      "line": 26708,
+      "line": 26723,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9366,7 +9376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a45c19301663092e:1",
-      "line": 26802,
+      "line": 26817,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9376,7 +9386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a4926de6bb4655ef:1",
-      "line": 24774,
+      "line": 24789,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9396,7 +9406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a574c90d67c2df18:1",
-      "line": 27161,
+      "line": 27176,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9406,7 +9416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a5fa040820524297:1",
-      "line": 27360,
+      "line": 27375,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9416,7 +9426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a5fa040820524297:2",
-      "line": 27387,
+      "line": 27402,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9426,7 +9436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a7043c11ccbadf20:1",
-      "line": 26748,
+      "line": 26763,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9446,7 +9456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a72b68ffa9703bf4:1",
-      "line": 26926,
+      "line": 26941,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9486,7 +9496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8bdb05f2e22e7d3:1",
-      "line": 27094,
+      "line": 27109,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9496,7 +9506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:1",
-      "line": 22182,
+      "line": 22197,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9506,7 +9516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:10",
-      "line": 24206,
+      "line": 24221,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9516,7 +9526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:11",
-      "line": 24232,
+      "line": 24247,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9526,7 +9536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:12",
-      "line": 24275,
+      "line": 24290,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9536,7 +9546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:13",
-      "line": 24303,
+      "line": 24318,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9546,7 +9556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:14",
-      "line": 24335,
+      "line": 24350,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9556,7 +9566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:15",
-      "line": 24362,
+      "line": 24377,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9566,7 +9576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:16",
-      "line": 24391,
+      "line": 24406,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9576,7 +9586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:17",
-      "line": 24424,
+      "line": 24439,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9586,7 +9596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:18",
-      "line": 24481,
+      "line": 24496,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9596,7 +9606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:19",
-      "line": 24516,
+      "line": 24531,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9606,7 +9616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:2",
-      "line": 22351,
+      "line": 22366,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9616,7 +9626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:20",
-      "line": 24545,
+      "line": 24560,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9626,7 +9636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:21",
-      "line": 24579,
+      "line": 24594,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9636,7 +9646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:22",
-      "line": 24610,
+      "line": 24625,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9646,7 +9656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:23",
-      "line": 24637,
+      "line": 24652,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9656,7 +9666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:24",
-      "line": 24678,
+      "line": 24693,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9666,7 +9676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:25",
-      "line": 25653,
+      "line": 25668,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9676,7 +9686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:3",
-      "line": 23059,
+      "line": 23074,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9686,7 +9696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:4",
-      "line": 23180,
+      "line": 23195,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9696,7 +9706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:5",
-      "line": 23443,
+      "line": 23458,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9706,7 +9716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:6",
-      "line": 23468,
+      "line": 23483,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9716,7 +9726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:7",
-      "line": 24047,
+      "line": 24062,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9726,7 +9736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:8",
-      "line": 24142,
+      "line": 24157,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9736,7 +9746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:9",
-      "line": 24176,
+      "line": 24191,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9746,7 +9756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8eee510e8998ded:1",
-      "line": 25175,
+      "line": 25190,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9756,7 +9766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:1",
-      "line": 24909,
+      "line": 24924,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9766,7 +9776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:2",
-      "line": 24931,
+      "line": 24946,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9776,7 +9786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:3",
-      "line": 24958,
+      "line": 24973,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9786,7 +9796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:4",
-      "line": 25305,
+      "line": 25320,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9796,7 +9806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:5",
-      "line": 25335,
+      "line": 25350,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9816,7 +9826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ab15be3fba5b0cd1:1",
-      "line": 27254,
+      "line": 27269,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9826,7 +9836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ab4caa51fd17b486:1",
-      "line": 23444,
+      "line": 23459,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9846,7 +9856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:abdb97e5669a0975:1",
-      "line": 27095,
+      "line": 27110,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9866,7 +9876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ac2f7fea72874fbd:1",
-      "line": 22571,
+      "line": 22586,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9876,7 +9886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ac2f7fea72874fbd:2",
-      "line": 25913,
+      "line": 25928,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9886,7 +9896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:acca0029979f4c13:1",
-      "line": 26797,
+      "line": 26812,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9896,7 +9906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:acedb1ced3aa61ea:1",
-      "line": 26911,
+      "line": 26926,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9916,7 +9926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ae5916805876ac46:1",
-      "line": 23269,
+      "line": 23284,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9976,7 +9986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af910e58b2c77763:1",
-      "line": 23870,
+      "line": 23885,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9986,7 +9996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b04d3d556d773056:1",
-      "line": 27175,
+      "line": 27190,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10036,7 +10046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b2c731d3da6cd11a:1",
-      "line": 27152,
+      "line": 27167,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10046,7 +10056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3241001126a4a9c:1",
-      "line": 26776,
+      "line": 26791,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10056,7 +10066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3241001126a4a9c:2",
-      "line": 26788,
+      "line": 26803,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10086,7 +10096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b432b2e07a83ac87:1",
-      "line": 26168,
+      "line": 26183,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10096,7 +10106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b48b5f3296d119e9:1",
-      "line": 26905,
+      "line": 26920,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10106,7 +10116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b4d76eca871110e7:1",
-      "line": 26676,
+      "line": 26691,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10116,7 +10126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b6318aa7064d9310:1",
-      "line": 24799,
+      "line": 24814,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10136,7 +10146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b6707be7cace8e0e:1",
-      "line": 24851,
+      "line": 24866,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10156,7 +10166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b7df38df0606e289:1",
-      "line": 24611,
+      "line": 24626,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10186,7 +10196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b9722e932f1bb40e:1",
-      "line": 27167,
+      "line": 27182,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10196,7 +10206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ba7cf5bcf797d9c2:1",
-      "line": 24072,
+      "line": 24087,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10226,7 +10236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb523aa660dd4687:1",
-      "line": 21138,
+      "line": 21140,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10246,7 +10256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb970cf4b07065b1:1",
-      "line": 27650,
+      "line": 27665,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10256,7 +10266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bbb47521ef8392a4:1",
-      "line": 25043,
+      "line": 25058,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10276,7 +10286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdc221e9e9c42970:1",
-      "line": 24143,
+      "line": 24158,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10286,7 +10296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:1",
-      "line": 25516,
+      "line": 25531,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10296,7 +10306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:2",
-      "line": 25552,
+      "line": 25567,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10306,7 +10316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:3",
-      "line": 25582,
+      "line": 25597,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10316,7 +10326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:be3064dcdc5f2256:1",
-      "line": 22336,
+      "line": 22351,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10326,7 +10336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:be81b848229b5bcd:1",
-      "line": 22183,
+      "line": 22198,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10376,7 +10386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c0ddc1067d953282:1",
-      "line": 24276,
+      "line": 24291,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10386,7 +10396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c14bd6eb8d20b885:1",
-      "line": 26210,
+      "line": 26225,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10416,7 +10426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c19c266d8e382c09:1",
-      "line": 27200,
+      "line": 27215,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10426,7 +10436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c22e71ad17e3c96c:1",
-      "line": 26610,
+      "line": 26625,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10436,7 +10446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c22e71ad17e3c96c:2",
-      "line": 26645,
+      "line": 26660,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10466,7 +10476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c35e93ca292f8cac:1",
-      "line": 24817,
+      "line": 24832,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10506,7 +10516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c551fd66ec491b8a:1",
-      "line": 25654,
+      "line": 25669,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10526,7 +10536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c581c3d5741e30d2:1",
-      "line": 26779,
+      "line": 26794,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10536,7 +10546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c60d0486ef331dcc:1",
-      "line": 26704,
+      "line": 26719,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10546,7 +10556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c62475395c522d57:1",
-      "line": 25132,
+      "line": 25147,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10576,7 +10586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:1",
-      "line": 25801,
+      "line": 25816,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10586,7 +10596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:2",
-      "line": 25834,
+      "line": 25849,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10596,7 +10606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:3",
-      "line": 26868,
+      "line": 26883,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10606,7 +10616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:4",
-      "line": 26895,
+      "line": 26910,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10616,7 +10626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:5",
-      "line": 26925,
+      "line": 26940,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10626,7 +10636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:6",
-      "line": 26969,
+      "line": 26984,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10636,7 +10646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:7",
-      "line": 27113,
+      "line": 27128,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10666,7 +10676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c7f7b2c61be81a89:1",
-      "line": 25165,
+      "line": 25180,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10686,7 +10696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c9a45d1d9f764cac:1",
-      "line": 25143,
+      "line": 25158,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10766,7 +10776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce5a9317fb3af979:1",
-      "line": 26140,
+      "line": 26155,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10776,7 +10786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce5a9317fb3af979:2",
-      "line": 26212,
+      "line": 26227,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10796,7 +10806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cf0dd1a35f3c7e34:1",
-      "line": 26694,
+      "line": 26709,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10806,7 +10816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cf80a65c884dd0be:1",
-      "line": 24892,
+      "line": 24907,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10846,7 +10856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d12154361fe4d869:1",
-      "line": 27222,
+      "line": 27237,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10856,7 +10866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d1512d6c97bf21bb:1",
-      "line": 24425,
+      "line": 24440,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10866,7 +10876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d18ee531c39bd973:1",
-      "line": 26699,
+      "line": 26714,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10876,7 +10886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d1ae247d480dcbb9:1",
-      "line": 27659,
+      "line": 27674,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10886,7 +10896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d23ddb9678b7afbd:1",
-      "line": 26741,
+      "line": 26756,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10916,7 +10926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d3d0a2aacce4d236:1",
-      "line": 21139,
+      "line": 21141,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10976,7 +10986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d5eab4193775162e:1",
-      "line": 27076,
+      "line": 27091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11006,7 +11016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:1",
-      "line": 24764,
+      "line": 24779,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11016,7 +11026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:2",
-      "line": 26725,
+      "line": 26740,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11026,7 +11036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:3",
-      "line": 27335,
+      "line": 27350,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11036,7 +11046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:4",
-      "line": 27687,
+      "line": 27702,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11056,7 +11066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d72d9e72d4f3a17b:1",
-      "line": 26711,
+      "line": 26726,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11096,7 +11106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d8482b9f8d823ef4:1",
-      "line": 26712,
+      "line": 26727,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11116,7 +11126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d8a4e503703f505e:1",
-      "line": 26901,
+      "line": 26916,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11126,7 +11136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d95de55fab6ad5ad:1",
-      "line": 26696,
+      "line": 26711,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11136,7 +11146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:da49eb6e798c7f5f:1",
-      "line": 25315,
+      "line": 25330,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11146,7 +11156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:da83ec605d06c165:1",
-      "line": 24517,
+      "line": 24532,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11156,7 +11166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:daedfce64925a80d:1",
-      "line": 26908,
+      "line": 26923,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11176,7 +11186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dbb3dec0819eacfc:1",
-      "line": 23394,
+      "line": 23409,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11196,7 +11206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dc67be849666c66e:1",
-      "line": 26701,
+      "line": 26716,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11276,7 +11286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:df7728e04a8a6114:1",
-      "line": 24580,
+      "line": 24595,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11286,7 +11296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dfe42585aa5eda4f:1",
-      "line": 26705,
+      "line": 26720,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11296,7 +11306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e04ef1a953d86622:1",
-      "line": 25493,
+      "line": 25508,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11306,7 +11316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e1112f888f975b87:1",
-      "line": 24251,
+      "line": 24266,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11356,7 +11366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3bbc251d76d2cc1:1",
-      "line": 25077,
+      "line": 25092,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11386,7 +11396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4178bcaf4b76b3d:1",
-      "line": 24177,
+      "line": 24192,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11396,7 +11406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e43a3f4befd820da:1",
-      "line": 27172,
+      "line": 27187,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11416,7 +11426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4782afde62e5c5a:1",
-      "line": 26677,
+      "line": 26692,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11426,7 +11436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4b0b210d7c72ff4:1",
-      "line": 27217,
+      "line": 27232,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11446,7 +11456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5417e4642efa5e7:1",
-      "line": 26869,
+      "line": 26884,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11456,7 +11466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e59b272b3f6baa43:1",
-      "line": 27210,
+      "line": 27225,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11466,7 +11476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e59dc9d3c750862a:1",
-      "line": 26993,
+      "line": 27008,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11506,7 +11516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e60cd4a237068776:1",
-      "line": 26695,
+      "line": 26710,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11516,7 +11526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e6213dbf749b2f84:1",
-      "line": 26767,
+      "line": 26782,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11526,7 +11536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e685278893a1646e:1",
-      "line": 27657,
+      "line": 27672,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11556,7 +11566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e75ffc427ee1b257:1",
-      "line": 24304,
+      "line": 24319,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11566,7 +11576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e8da71b12cfb5a50:1",
-      "line": 27150,
+      "line": 27165,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11596,7 +11606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb423e1709e85420:1",
-      "line": 27230,
+      "line": 27245,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11616,7 +11626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb96318ae36b4913:1",
-      "line": 24798,
+      "line": 24813,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11656,7 +11666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee11ef9a56b0be9f:1",
-      "line": 26688,
+      "line": 26703,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11666,7 +11676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee3fb3104fc6e48d:1",
-      "line": 22575,
+      "line": 22590,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11686,7 +11696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ef7c060e201a3297:1",
-      "line": 24854,
+      "line": 24869,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11736,7 +11746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f1a7449a1c36dab0:1",
-      "line": 24021,
+      "line": 24036,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11766,7 +11776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f252e7eaf9e37429:1",
-      "line": 27296,
+      "line": 27311,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11776,7 +11786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f2a482c55d4b8bfb:1",
-      "line": 24850,
+      "line": 24865,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11806,7 +11816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f35283ed599f5e1e:1",
-      "line": 27715,
+      "line": 27730,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11816,7 +11826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f36013bf14def33f:1",
-      "line": 27347,
+      "line": 27362,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11836,7 +11846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f4078a53a7e6629d:1",
-      "line": 26774,
+      "line": 26789,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11856,7 +11866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f48aa05c03d90298:1",
-      "line": 27304,
+      "line": 27319,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11866,7 +11876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f55d5c58fe2c4b6f:1",
-      "line": 26845,
+      "line": 26860,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11876,7 +11886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f56054e03ade4a1f:1",
-      "line": 27683,
+      "line": 27698,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11936,7 +11946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:faba1e348a75ffc6:1",
-      "line": 25518,
+      "line": 25533,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12016,7 +12026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fb4f3aea8230a6a1:1",
-      "line": 22858,
+      "line": 22873,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -13756,7 +13766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/for_replay.rs:47edf128bfad2082:1",
-      "line": 2322,
+      "line": 2350,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/for_replay.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -19688,11 +19698,11 @@
   "schema": 1,
   "speaker_counts": {
     "emitter-provenance-guard": 3,
-    "lift-output-backlog": 1829,
+    "lift-output-backlog": 1830,
     "provenance-oracle-guard": 53,
     "vendor-language-identifier": 1,
     "verifier-verdict-quote": 40,
     "verify-dialect-boundary": 42
   },
-  "total_occurrences": 1968
+  "total_occurrences": 1969
 }


### PR DESCRIPTION
## Summary
- Ratchets `tools/lift_refusal_vocabulary_census.json` so `make check-lift-refusal-vocabulary` matches current lift-side `refus*` sites.
- Root cause: `lifter.py` line/text drift (`ast.*` → `typed.*`, `node.slice` → `node.slice_`) invalidated four digests; one new classified site `kind="bare-raise-refused"` raised lift-output backlog 1829 → 1830.

## Validation
- `make check-lift-refusal-vocabulary` (PASS + self-test PASS)

## Notes
- Identity is path + normalized text digest; line numbers are display-only and were refreshed with `--write-current`.
- No source renames in this PR — census-only pin update for CI core job.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ratchet lift refusal vocabulary census after lifter drift
> Updates [lift_refusal_vocabulary_census.json](https://github.com/TSavo/sugar/pull/6215/files#diff-679d9c70dea0d4d683f60434858a4764a923719253749aa1c59b8f5e596046ab) to reflect changes from a lifter drift pass. Replaces `ast`-based symbol references with `typed`-based counterparts (e.g. `_refused_decorator_name(decorator: typed.expr)`, `typed.FunctionDef _contains_refused_control`, `_RefusedControlScanner(typed.TypedNodeWalker)`), updates snippet text to use `node.slice_` instead of `node.slice`, and increments `lift_output_backlog` to 1830 and `total_occurrences` to 1969. Numerous line offsets and entry hashes are adjusted accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 509d87e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->