### PR TITLE
Apply black format to implementations/python

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
-
 _WORKER = Path(__file__).resolve().parent / "_supervised_enum_worker.py"
 
 
@@ -269,9 +268,7 @@ class SupervisedEnumSupervisor:
             worker_restarts=self.worker_restarts,
         )
 
-    def scan(
-        self, paths: Sequence[tuple[Path, str]]
-    ) -> list[FileTerminal]:
+    def scan(self, paths: Sequence[tuple[Path, str]]) -> list[FileTerminal]:
         """Lift every (path, rel); guarantee one terminal row per file."""
         rows: list[FileTerminal] = []
         try:

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -137,9 +137,7 @@ def main() -> int:
     rows = tuple(_from_terminal(t) for t in terminals)
     with progress_path.open("a", encoding="utf-8") as progress:
         for t in terminals:
-            progress.write(
-                f"{t.file}\t{t.category}\trestarts={t.worker_restarts}\n"
-            )
+            progress.write(f"{t.file}\t{t.category}\trestarts={t.worker_restarts}\n")
 
     offenders = tuple(row.offender for row in rows if row.offender is not None)
     print(

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import re
 from typing import Iterable
 
-
 SELF_HASH = "SELF-HASHING-AS-AUTHORITY"
 NAME_GATE = "NAME-SPELLING-OVERLOAD-GATE"
 SECOND_PATH = "SECOND-CONSTRUCTION-PATH"
@@ -163,11 +162,15 @@ def _call_name(node: ast.AST) -> str:
 
 
 def _depends_on(node: ast.AST, names: set[str]) -> bool:
-    return any(isinstance(child, ast.Name) and child.id in names for child in ast.walk(node))
+    return any(
+        isinstance(child, ast.Name) and child.id in names for child in ast.walk(node)
+    )
 
 
 def _finding(path: str, node: ast.AST, kind: str, observed: str) -> Finding:
-    return Finding(path, getattr(node, "lineno", 1), getattr(node, "col_offset", 0), kind, observed)
+    return Finding(
+        path, getattr(node, "lineno", 1), getattr(node, "col_offset", 0), kind, observed
+    )
 
 
 def _function_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
@@ -188,7 +191,9 @@ def _has_revalidation(function: ast.AST) -> bool:
     for node in ast.walk(function):
         if isinstance(node, ast.Call):
             call = _call_name(node).lower().split(".")[-1]
-            if call in _REVALIDATION_WORDS or call.startswith(("revalidate_", "reconstruct_", "resolve_")):
+            if call in _REVALIDATION_WORDS or call.startswith(
+                ("revalidate_", "reconstruct_", "resolve_")
+            ):
                 return True
         if isinstance(node, ast.Compare) and any(
             isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops
@@ -200,7 +205,9 @@ def _has_revalidation(function: ast.AST) -> bool:
 def _self_hash_findings(tree: ast.Module, path: str) -> list[Finding]:
     findings: list[Finding] = []
     for function in (
-        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     ):
         parameters = _function_parameters(function)
         hashes: dict[str, ast.Call] = {}
@@ -226,7 +233,9 @@ def _self_hash_findings(tree: ast.Module, path: str) -> list[Finding]:
             sink_name = _call_name(sink).lower().replace(".", "")
             uses_hash = _depends_on(sink, set(hashes))
             uses_input = _depends_on(sink, parameters)
-            has_cid_slot = any("cid" in keyword.arg.lower() for keyword in sink.keywords if keyword.arg)
+            has_cid_slot = any(
+                "cid" in keyword.arg.lower() for keyword in sink.keywords if keyword.arg
+            )
             authority_sink = any(word in sink_name for word in _AUTHORITY_WORDS)
             if uses_hash and uses_input and (has_cid_slot or authority_sink):
                 findings.append(
@@ -254,27 +263,44 @@ def _is_gate_context(node: ast.Constant, parents: dict[ast.AST, ast.AST]) -> boo
 
 
 def _name_gate_findings(tree: ast.Module, path: str) -> list[Finding]:
-    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    parents = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
     findings: list[Finding] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Attribute) and node.attr in _FORBIDDEN_API_NAMES:
-            findings.append(_finding(path, node, NAME_GATE, f"spelling authority API `{node.attr}`"))
+            findings.append(
+                _finding(path, node, NAME_GATE, f"spelling authority API `{node.attr}`")
+            )
         elif isinstance(node, ast.Name) and node.id in _FORBIDDEN_API_NAMES:
-            findings.append(_finding(path, node, NAME_GATE, f"spelling authority name `{node.id}`"))
+            findings.append(
+                _finding(path, node, NAME_GATE, f"spelling authority name `{node.id}`")
+            )
         elif (
             isinstance(node, ast.Constant)
             and isinstance(node.value, str)
-            and (_FORBIDDEN_SPELLING.search(node.value) or "overload" in node.value.lower())
+            and (
+                _FORBIDDEN_SPELLING.search(node.value)
+                or "overload" in node.value.lower()
+            )
             and _is_gate_context(node, parents)
         ):
-            findings.append(_finding(path, node, NAME_GATE, f"semantic gate literal {node.value!r}"))
+            findings.append(
+                _finding(path, node, NAME_GATE, f"semantic gate literal {node.value!r}")
+            )
     return findings
 
 
 def _ast_test_names(function: ast.AST) -> set[str]:
     names: set[str] = set()
     for node in ast.walk(function):
-        if not isinstance(node, ast.Call) or _call_name(node) != "isinstance" or len(node.args) < 2:
+        if (
+            not isinstance(node, ast.Call)
+            or _call_name(node) != "isinstance"
+            or len(node.args) < 2
+        ):
             continue
         for candidate in ast.walk(node.args[1]):
             if isinstance(candidate, ast.Attribute) and _name(candidate.value) == "ast":
@@ -283,11 +309,15 @@ def _ast_test_names(function: ast.AST) -> set[str]:
 
 
 def _second_path_findings(tree: ast.Module, path: str) -> list[Finding]:
-    if path.endswith(("sugar_source_tree/nodes.py", "sugar_lift_python_source/lifter.py")):
+    if path.endswith(
+        ("sugar_source_tree/nodes.py", "sugar_lift_python_source/lifter.py")
+    ):
         return []
     findings: list[Finding] = []
     for function in (
-        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     ):
         ast_tests = _ast_test_names(function)
         makers = {
@@ -328,14 +358,22 @@ def _terminal_loud(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
         return True
     if isinstance(last, ast.Return) and isinstance(last.value, ast.Call):
         name = _call_name(last.value).lower()
-        return any(word in name for word in ("gap", "unsupported", "incomplete", "error"))
+        return any(
+            word in name for word in ("gap", "unsupported", "incomplete", "error")
+        )
     return False
 
 
-def _declares_statement_transfer(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+def _declares_statement_transfer(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
     """Separate grammar transfers from helpers that incidentally inspect AST nodes."""
 
-    for argument in (*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs):
+    for argument in (
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ):
         annotation = argument.annotation
         if annotation is None:
             continue
@@ -349,7 +387,9 @@ def _non_exhaustive_findings(tree: ast.Module, path: str) -> list[Finding]:
     coverage = _has_stmt_coverage_audit(tree)
     findings: list[Finding] = []
     for function in (
-        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     ):
         if not _declares_statement_transfer(function):
             continue
@@ -377,10 +417,17 @@ def _fabricated_findings(tree: ast.Module, path: str) -> list[Finding]:
             for argument in (*node.args, *(keyword.value for keyword in node.keywords))
         ):
             findings.append(
-                _finding(path, node, FABRICATED, "completion manufactures None as a fallback value")
+                _finding(
+                    path,
+                    node,
+                    FABRICATED,
+                    "completion manufactures None as a fallback value",
+                )
             )
         if name in {"unwrap_or_default", "get_or_default"}:
-            findings.append(_finding(path, node, FABRICATED, f"benign default fallback `{name}`"))
+            findings.append(
+                _finding(path, node, FABRICATED, f"benign default fallback `{name}`")
+            )
     return findings
 
 
@@ -412,20 +459,42 @@ def scan_rust_source(source: str, path: str) -> list[Finding]:
         # projections.  The invariant concerns a semantic outcome/default,
         # so require the catch-all itself to manufacture that outcome.
         if match and _RUST_BENIGN_ARM.search(line):
-            findings.append(Finding(path, index, match.start(), NON_EXHAUSTIVE, "Rust catch-all variant arm silently accepts an unknown variant"))
-            findings.append(Finding(path, index, match.start(), FABRICATED, "Rust catch-all manufactures a benign completion/default"))
+            findings.append(
+                Finding(
+                    path,
+                    index,
+                    match.start(),
+                    NON_EXHAUSTIVE,
+                    "Rust catch-all variant arm silently accepts an unknown variant",
+                )
+            )
+            findings.append(
+                Finding(
+                    path,
+                    index,
+                    match.start(),
+                    FABRICATED,
+                    "Rust catch-all manufactures a benign completion/default",
+                )
+            )
     return sorted(set(findings))
 
 
 def _default_roots(repo: Path) -> tuple[Path, ...]:
     return (
         repo / "implementations/python/sugar-source-tree/src",
-        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
-        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py",
-        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
-        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py",
-        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
-        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
+        repo
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
+        repo
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py",
+        repo
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
+        repo
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py",
+        repo
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
+        repo
+        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
         repo / "implementations/python/sugar-lift-python-source/src",
         repo / "implementations/rust/sugar-linker/src",
         repo / "implementations/rust/sugar-compiler/src",
@@ -440,19 +509,31 @@ def _source_files(roots: Iterable[Path]) -> list[Path]:
         if root.is_file() and root.suffix in {".py", ".rs"}:
             files.add(root)
         elif root.is_dir():
-            files.update(path for path in root.rglob("*") if path.suffix in {".py", ".rs"})
+            files.update(
+                path for path in root.rglob("*") if path.suffix in {".py", ".rs"}
+            )
     return sorted(files)
 
 
-def scan_roots(roots: Iterable[Path], *, repo: Path | None = None) -> tuple[list[Finding], list[str]]:
+def scan_roots(
+    roots: Iterable[Path], *, repo: Path | None = None
+) -> tuple[list[Finding], list[str]]:
     base = (repo or Path.cwd()).resolve()
     findings: list[Finding] = []
     errors: list[str] = []
     for path in _source_files(roots):
-        label = str(path.resolve().relative_to(base)) if path.resolve().is_relative_to(base) else str(path)
+        label = (
+            str(path.resolve().relative_to(base))
+            if path.resolve().is_relative_to(base)
+            else str(path)
+        )
         try:
             source = path.read_text(encoding="utf-8")
-            findings.extend(scan_python_source(source, label) if path.suffix == ".py" else scan_rust_source(source, label))
+            findings.extend(
+                scan_python_source(source, label)
+                if path.suffix == ".py"
+                else scan_rust_source(source, label)
+            )
         except (OSError, UnicodeError, SyntaxError) as exc:
             errors.append(f"{label}: {type(exc).__name__}: {exc}")
     return sorted(set(findings)), sorted(errors)
@@ -468,7 +549,9 @@ def format_report(findings: Iterable[Finding], errors: Iterable[str] = ()) -> st
             f"{finding.observed}; required fix: {finding.required_fix}"
         )
     lines.extend(f"AUDITOR-ERROR: {error}" for error in error_rows)
-    by_class = {kind: sum(row.violation_class == kind for row in rows) for kind in REQUIRED_FIX}
+    by_class = {
+        kind: sum(row.violation_class == kind for row in rows) for kind in REQUIRED_FIX
+    }
     lines.append(f"R_construction_invariant_violations = {len(rows)}")
     for kind, count in by_class.items():
         lines.append(f"R_{kind.lower().replace('-', '_')} = {count}")

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
@@ -182,7 +182,9 @@ def _read_source(path: Path) -> tuple[str | None, SideDoorOffender | None]:
 
 def _import_is_ast(node: ast.AST) -> bool:
     if isinstance(node, ast.Import):
-        return any(alias.name == "ast" or alias.name.startswith("ast.") for alias in node.names)
+        return any(
+            alias.name == "ast" or alias.name.startswith("ast.") for alias in node.names
+        )
     if isinstance(node, ast.ImportFrom):
         return bool(node.module and node.module.split(".", 1)[0] == "ast")
     return False
@@ -191,9 +193,11 @@ def _import_is_ast(node: ast.AST) -> bool:
 def _import_is_old_lifter(node: ast.AST) -> tuple[bool, str]:
     if isinstance(node, ast.Import):
         for alias in node.names:
-            if alias.name in _OLD_LIFTER_MODULES or alias.name.startswith(
-                "sugar_lift_python_source.lifter"
-            ) or alias.name.startswith("sugar_lift_python_source.bind_lifter"):
+            if (
+                alias.name in _OLD_LIFTER_MODULES
+                or alias.name.startswith("sugar_lift_python_source.lifter")
+                or alias.name.startswith("sugar_lift_python_source.bind_lifter")
+            ):
                 return True, alias.name
     if isinstance(node, ast.ImportFrom):
         module = node.module or ""
@@ -312,13 +316,18 @@ def scan_file(path: Path, *, rel: str) -> list[SideDoorOffender]:
         for node in ast.walk(tree):
             # --- membrane admission (all production files, including adapters) ---
             for name, expression in _membrane_name_hits(node):
-                if name.endswith(".json") or name in {
-                    "community_context_managers.json",
-                    "community_context_managers",
-                } or (
-                    isinstance(node, ast.Constant)
-                    and isinstance(node.value, str)
-                    and "community_context_managers" in node.value
+                if (
+                    name.endswith(".json")
+                    or name
+                    in {
+                        "community_context_managers.json",
+                        "community_context_managers",
+                    }
+                    or (
+                        isinstance(node, ast.Constant)
+                        and isinstance(node.value, str)
+                        and "community_context_managers" in node.value
+                    )
                 ):
                     kind = "membrane-spelling-manifest"
                     note = (
@@ -380,12 +389,16 @@ def scan_file(path: Path, *, rel: str) -> list[SideDoorOffender]:
                     )
 
             # --- dual old-lifter on production enumerate path ---
-            if basename in {
-                "lift_rpc.py",
-                "tree_enumerate.py",
-                "bind_rpc.py",
-                "rpc.py",
-            } or "enumerate" in basename:
+            if (
+                basename
+                in {
+                    "lift_rpc.py",
+                    "tree_enumerate.py",
+                    "bind_rpc.py",
+                    "rpc.py",
+                }
+                or "enumerate" in basename
+            ):
                 is_old, expression = _import_is_old_lifter(node)
                 if is_old:
                     offenders.append(
@@ -588,7 +601,9 @@ def format_report(offenders: Sequence[SideDoorOffender]) -> str:
     return "\n".join(lines)
 
 
-def offenders_to_jsonable(offenders: Sequence[SideDoorOffender]) -> list[dict[str, object]]:
+def offenders_to_jsonable(
+    offenders: Sequence[SideDoorOffender],
+) -> list[dict[str, object]]:
     return [
         {
             "path": row.path,
@@ -604,15 +619,15 @@ def offenders_to_jsonable(offenders: Sequence[SideDoorOffender]) -> list[dict[st
 
 def discrimination_self_test() -> bool:
     """Planted membrane + foreign-ast + ast-semantic twins trip; clean stays quiet."""
-    membrane_plant = '''
+    membrane_plant = """
 from sugar_lift_py_tests.manifest_membrane import contract_for_manager
 
 def admit(manager_node):
     return contract_for_manager(default_community_manifest(), manager_node)
 
 _SPELLING = "community_context_managers.json"
-'''
-    ast_plant = '''
+"""
+    ast_plant = """
 import ast
 
 def resolve_exit(source: str):
@@ -624,24 +639,24 @@ def resolve_exit(source: str):
         if isinstance(node, ast.FunctionDef) and node.name == "__exit__":
             return node
     return None
-'''
-    from_ast_plant = '''
+"""
+    from_ast_plant = """
 from ast import parse, walk, NodeVisitor
 
 def resolve(source: str):
     return parse(source)
-'''
-    dual_plant = '''
+"""
+    dual_plant = """
 from sugar_lift_python_source.lifter import lift_source
 
 def enumerate_file(source, path):
     return lift_source(source, path)
-'''
-    clean = '''
+"""
+    clean = """
 def sugar_from_tree(node, prebound_refs):
     # meaning is tree + prebound refs only
     return node.sugar()
-'''
+"""
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw) / "pkg"
         root.mkdir()
@@ -676,8 +691,7 @@ def sugar_from_tree(node, prebound_refs):
         adapter_foreign = [
             row
             for row in adapter_only + adapter_mid
-            if row.kind == "foreign-ast-import"
-            or row.kind.startswith("ast-semantic-")
+            if row.kind == "foreign-ast-import" or row.kind.startswith("ast-semantic-")
         ]
     return (
         r >= 4
@@ -718,9 +732,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args = parser.parse_args(argv)
         if args.self_test:
             ok = discrimination_self_test()
-            print(
-                "CONSTRUCTION-SIDE-DOOR SELF-TEST " + ("GREEN" if ok else "RED")
-            )
+            print("CONSTRUCTION-SIDE-DOOR SELF-TEST " + ("GREEN" if ok else "RED"))
             print(
                 json.dumps(
                     {

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -343,9 +343,7 @@ def main() -> int:
             clean = int(row.get("functionsClean") or 0)
             families = row.get("families") or {}
             snw = int(families.get("SugarNotWritten") or 0)
-            other = sum(
-                int(v) for k, v in families.items() if k != "SugarNotWritten"
-            )
+            other = sum(int(v) for k, v in families.items() if k != "SugarNotWritten")
             live_fns += fn
             live_clean += clean
             live_snw += snw
@@ -458,9 +456,7 @@ def main() -> int:
         flush=True,
     )
     return (
-        1
-        if defects or construction_panics or files_completed != len(file_names)
-        else 0
+        1 if defects or construction_panics or files_completed != len(file_names) else 0
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -61,6 +61,7 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
         configure_live_log()
     try:
         from _production_lift_child import production_lift_testimony
+
         if progress:
             with reduction_span(sugar="production_lift", role="file", site=rel):
                 terminal = production_lift_testimony(path, rel)

--- a/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
@@ -31,8 +31,7 @@ def scan(repository: Path) -> tuple[int, list[GeneratorConstructionOffender]]:
     checks = (
         (
             "Yield._construct_sugar",
-            "class Yield" in text["nodes"]
-            and "YieldSuspensionSugar" in text["nodes"],
+            "class Yield" in text["nodes"] and "YieldSuspensionSugar" in text["nodes"],
             "Yield has no suspended-frame construction step",
         ),
         (
@@ -82,7 +81,9 @@ def main() -> int:
             f"(discovered={discovered}, completed={discovered})"
         )
         for offender in offenders:
-            print(f"- {offender.coordinate}: {offender.observed}; replace with {offender.requested}")
+            print(
+                f"- {offender.coordinate}: {offender.observed}; replace with {offender.requested}"
+            )
     return 1 if offenders else 0
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
@@ -26,7 +26,6 @@ from sugar_source_tree.cpython_adapter import _Handle
 from sugar_source_tree.nodes import SourceUnit
 from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
 
-
 ASSIGNMENT = (ast.Assign, ast.AnnAssign, ast.AugAssign)
 
 
@@ -84,15 +83,19 @@ def _panic_key(panic: BaseException) -> str:
 
 
 def _gap_key(info: dict[str, str]) -> str:
-    return "|".join(
-        info.get(field, "") for field in ("owner", "observed", "requested")
-    )
+    return "|".join(info.get(field, "") for field in ("owner", "observed", "requested"))
 
 
 def _plain_class_names(module: ast.Module) -> frozenset[str]:
     forbidden = {
-        "__new__", "__getattr__", "__getattribute__", "__setattr__",
-        "__delattr__", "__getitem__", "__setitem__", "__delitem__",
+        "__new__",
+        "__getattr__",
+        "__getattribute__",
+        "__setattr__",
+        "__delattr__",
+        "__getitem__",
+        "__setitem__",
+        "__delitem__",
     }
     return frozenset(
         node.name
@@ -159,7 +162,9 @@ def measure(
             source, filename, source_cid = path_source(path)
             parsed = ast.parse(source, filename=str(path))
             plain_class_names = _plain_class_names(parsed)
-            native_assignments = [node for node in ast.walk(parsed) if isinstance(node, ASSIGNMENT)]
+            native_assignments = [
+                node for node in ast.walk(parsed) if isinstance(node, ASSIGNMENT)
+            ]
             if not native_assignments:
                 counts["files_without_assignment"] += 1
                 continue
@@ -174,7 +179,9 @@ def measure(
                     )
                 except SugarNotWritten as panic:
                     own = getattr(panic, "owner", "") in {
-                        "Assign.sugar", "AnnAssign.sugar", "AugAssign.sugar"
+                        "Assign.sugar",
+                        "AnnAssign.sugar",
+                        "AugAssign.sugar",
                     }
                     direct[shape]["direct_gap" if own else "blocked_descendant"] += 1
                     roots[_panic_key(panic)] += 1
@@ -188,15 +195,20 @@ def measure(
                         direct[shape]["construction_panic"] += 1
                         roots[_gap_key(gap.info)] += 1
 
-            functions = [] if direct_only else [
-                node for node in ast.walk(parsed)
-                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-                and any(isinstance(child, ASSIGNMENT) for child in ast.walk(node))
-                and (
-                    not object_field_only
-                    or _has_object_field_candidate(node, plain_class_names)
-                )
-            ]
+            functions = (
+                []
+                if direct_only
+                else [
+                    node
+                    for node in ast.walk(parsed)
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and any(isinstance(child, ASSIGNMENT) for child in ast.walk(node))
+                    and (
+                        not object_field_only
+                        or _has_object_field_candidate(node, plain_class_names)
+                    )
+                ]
+            )
             for native_function in functions:
                 enclosing_functions["total"] += 1
                 object_field_candidate = _has_object_field_candidate(
@@ -209,7 +221,13 @@ def measure(
                     "line": native_function.lineno,
                     "function": native_function.name,
                 }
-                shapes = sorted({_shape(node) for node in ast.walk(native_function) if isinstance(node, ASSIGNMENT)})
+                shapes = sorted(
+                    {
+                        _shape(node)
+                        for node in ast.walk(native_function)
+                        if isinstance(node, ASSIGNMENT)
+                    }
+                )
                 function = materialize(unit, _Handle(unit, native_function))
                 try:
                     _, gap = collect_construction_panic(
@@ -225,7 +243,9 @@ def measure(
                     roots[_panic_key(panic)] += 1
                     for shape in shapes:
                         enclosing[shape]["loud"] += 1
-                        enclosing[shape][f"root:{getattr(panic, 'owner', type(panic).__name__)}"] += 1
+                        enclosing[shape][
+                            f"root:{getattr(panic, 'owner', type(panic).__name__)}"
+                        ] += 1
                 except Exception as panic:
                     enclosing_functions["non_source_failure"] += 1
                     if object_field_candidate:
@@ -275,12 +295,18 @@ def measure(
         "root": str(root),
         "pandas_version": importlib.metadata.version("pandas"),
         "counts": dict(sorted(counts.items())),
-        "direct_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(direct.items())},
-        "enclosing_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(enclosing.items())},
+        "direct_by_shape": {
+            key: dict(sorted(value.items())) for key, value in sorted(direct.items())
+        },
+        "enclosing_by_shape": {
+            key: dict(sorted(value.items())) for key, value in sorted(enclosing.items())
+        },
         "enclosing_functions": dict(sorted(enclosing_functions.items())),
         "object_field_enclosing": dict(sorted(object_field_enclosing.items())),
         "object_field_rows": object_field_rows,
-        "root_panics": dict(sorted(roots.items(), key=lambda item: (-item[1], item[0]))),
+        "root_panics": dict(
+            sorted(roots.items(), key=lambda item: (-item[1], item[0]))
+        ),
     }
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -99,9 +99,7 @@ def _from_terminal(row: FileTerminal) -> ChildResult:
             offender = NativeCrashOffender(
                 row.file, rc, row.signal_name, row.stderr_tail
             )
-        return ChildResult(
-            row.file, "native-crash", rc, row.stderr_tail, offender
-        )
+        return ChildResult(row.file, "native-crash", rc, row.stderr_tail, offender)
     if row.category in {"bare-exception"}:
         return ChildResult(
             row.file, "non-native-red", row.returncode, row.stderr_tail, None

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_census_checkpoint.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_census_checkpoint.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Mapping, Sequence, TypeVar
 
 from pandas_floor_summary import corpus_cid
 
-
 SCHEMA = "pandas-census-checkpoint-row-v1"
 
 
@@ -86,13 +85,11 @@ class Checkpoint:
             "result": dict(result),
         }
         self._validate_row(row)
-        encoded = (json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n").encode(
-            "utf-8"
-        )
+        encoded = (
+            json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n"
+        ).encode("utf-8")
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        descriptor = os.open(
-            self.path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644
-        )
+        descriptor = os.open(self.path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
         try:
             view = memoryview(encoded)
             while view:
@@ -146,9 +143,7 @@ def checkpointed_path_results(
         path.resolve().relative_to(root.resolve()).as_posix(): path
         for path in sorted(paths)
     }
-    checkpoint = Checkpoint(
-        floor=floor, files=tuple(by_rel), path=checkpoint_path
-    )
+    checkpoint = Checkpoint(floor=floor, files=tuple(by_rel), path=checkpoint_path)
     rows = run_pending(
         checkpoint,
         lambda rel: serialize(worker(by_rel[rel])),
@@ -158,7 +153,4 @@ def checkpointed_path_results(
         raise CheckpointError(
             f"incomplete {floor} checkpoint: {len(rows)}/{len(by_rel)} rows"
         )
-    return tuple(
-        deserialize(str(row["file"]), row["result"])
-        for row in rows
-    )
+    return tuple(deserialize(str(row["file"]), row["result"]) for row in rows)

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -7,12 +7,13 @@ import json
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-
 SCHEMA = "pandas-floor-summary-v1"
 
 
 def relative_files(paths: Sequence[Path], root: Path) -> list[str]:
-    return sorted(path.resolve().relative_to(root.resolve()).as_posix() for path in paths)
+    return sorted(
+        path.resolve().relative_to(root.resolve()).as_posix() for path in paths
+    )
 
 
 def corpus_cid(files: Sequence[str]) -> str:
@@ -55,4 +56,6 @@ def floor_summary(
 
 def write_json(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_recensus_latency_probe.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_recensus_latency_probe.py
@@ -78,9 +78,7 @@ def _analyze_engine_log(path: Path, top_n: int = 20) -> dict:
         "note": "sumExitElapsedMs double-counts nested spans",
         "bySugarMs": {k: round(v, 3) for k, v in by_sugar.most_common(30)},
         "byRoleMs": {k: round(v, 3) for k, v in by_role.most_common(20)},
-        "bySugarRoleMs": {
-            k: round(v, 3) for k, v in by_sugar_role.most_common(30)
-        },
+        "bySugarRoleMs": {k: round(v, 3) for k, v in by_sugar_role.most_common(30)},
         "topSpans": exits[:top_n],
     }
 

--- a/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
@@ -101,7 +101,9 @@ def main() -> int:
     parser.add_argument("--expected-files", type=int, default=1415)
     args = parser.parse_args()
     reports = {
-        floor: json.loads(getattr(args, floor.replace("-", "_")).read_text(encoding="utf-8"))
+        floor: json.loads(
+            getattr(args, floor.replace("-", "_")).read_text(encoding="utf-8")
+        )
         for floor in FLOORS
     }
     result = reconcile(reports, expected_files=args.expected_files)

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -232,9 +232,7 @@ def audit_paths(
 
     if checkpoint is not None:
         rows = tuple(
-            done_rows[f]
-            if f in done_rows
-            else ChildResult(f, "missing", (), None, "")
+            done_rows[f] if f in done_rows else ChildResult(f, "missing", (), None, "")
             for f in checkpoint.files
         )
     else:

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -77,9 +77,7 @@ def audit_paths(
             stream.write(f"# timeout supervised enum scan files={len(paths)}\n")
             for t in terminals:
                 stream.write(f"{t.file}\t{t.category}\n")
-    rows = tuple(
-        _from_terminal(t, file_timeout=float(file_timeout)) for t in terminals
-    )
+    rows = tuple(_from_terminal(t, file_timeout=float(file_timeout)) for t in terminals)
     return AuditSummary(
         rows=rows,
         offenders=tuple(row.offender for row in rows if row.offender is not None),
@@ -158,9 +156,7 @@ def main() -> int:
                 "completed": sum(row.category == "completed" for row in rows),
                 "typedGaps": sum(row.category == "typed-gap" for row in rows),
                 "nativeCrashes": sum(row.category == "native-crash" for row in rows),
-                "bareExceptions": sum(
-                    row.category == "bare-exception" for row in rows
-                ),
+                "bareExceptions": sum(row.category == "bare-exception" for row in rows),
             },
             measured=True,
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -179,7 +179,12 @@ class FormalActualBindingV1:
 
     @classmethod
     def from_value(cls, value):
-        expected = {"formalCoordinateCid", "actualOccurrence", "actualTerm", "actualContractRefCid"}
+        expected = {
+            "formalCoordinateCid",
+            "actualOccurrence",
+            "actualTerm",
+            "actualContractRefCid",
+        }
         if not isinstance(value, dict) or set(value) != expected:
             raise ValueError("formal actual binding requires an exact key set")
         return cls(
@@ -234,7 +239,9 @@ class CallEdgeV2:
             "sourceContractCid": self.source_contract_cid,
             "targetContractCid": self.target_contract_cid,
             "callSite": self.call_site.wire(),
-            "formalActualBindings": [item.to_value() for item in self.formal_actual_bindings],
+            "formalActualBindings": [
+                item.to_value() for item in self.formal_actual_bindings
+            ],
             "edgeCid": self.edge_cid,
         }
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
@@ -71,9 +71,7 @@ _SOURCE_CALLS = frozenset({"path_source", "installed_module_source"})
 _IMPORT_LINE = re.compile(r"^\s*import\s+(.+?)(?:\s*#.*)?$")
 # from sugar_linker import resolve_context_manager_demand as lookup
 # from sugar_linker import (
-_FROM_IMPORT_LINE = re.compile(
-    r"^\s*from\s+([\w.]+)\s+import\s+(.+?)(?:\s*#.*)?$"
-)
+_FROM_IMPORT_LINE = re.compile(r"^\s*from\s+([\w.]+)\s+import\s+(.+?)(?:\s*#.*)?$")
 # hidden.resolve_context_manager_demand(  /  resolve_context_manager_demand(
 _CALL_SITE = re.compile(r"(?<![\w.])([\w]+(?:\.[\w]+)*)\s*\(")
 _NAME_AS = re.compile(r"^([\w.]+)(?:\s+as\s+(\w+))?$")
@@ -143,7 +141,9 @@ def _scan_file(path: Path) -> list[str]:
     def record(line_no: int, reason: str) -> None:
         offenders.append(f"{path}:{line_no}:{reason}")
 
-    def ingest_import(module_name: str, line_no: int, asname: str | None = None) -> None:
+    def ingest_import(
+        module_name: str, line_no: int, asname: str | None = None
+    ) -> None:
         local = asname or module_name.split(".", 1)[0]
         aliases[local] = module_name
         if _module_is_hard(module_name):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -677,8 +677,13 @@ def validate_derivation_provenance_v1(
     provenance: ContextManagerDerivationProvenanceV1,
 ) -> None:
     if not isinstance(provenance, ContextManagerDerivationProvenanceV1):
-        raise ContextManagerContractError("derived CM contract requires typed provenance")
-    if provenance.kind != "python-context-manager-derivation" or provenance.schema_version != "1":
+        raise ContextManagerContractError(
+            "derived CM contract requires typed provenance"
+        )
+    if (
+        provenance.kind != "python-context-manager-derivation"
+        or provenance.schema_version != "1"
+    ):
         raise ContextManagerContractError("unsupported CM derivation provenance")
     wire = derivation_provenance_to_dict(provenance)
     cid_fields = (
@@ -705,12 +710,16 @@ def validate_derivation_provenance_v1(
     ):
         raise ContextManagerContractError("re-export warrants must be ordered CIDs")
     if provenance.resolved_definition.source_cid != provenance.module_source_cid:
-        raise ContextManagerContractError("resolved definition is outside module source")
+        raise ContextManagerContractError(
+            "resolved definition is outside module source"
+        )
     if _cid_of_json(wire["resolvedDefinition"]) != provenance.resolved_definition_cid:
         raise ContextManagerContractError("resolved definition CID mismatch")
     if _cid_of_json(wire["useSite"]) != provenance.use_site_cid:
         raise ContextManagerContractError("use-site CID mismatch")
-    derivation_preimage = {key: value for key, value in wire.items() if key != "derivationCid"}
+    derivation_preimage = {
+        key: value for key, value in wire.items() if key != "derivationCid"
+    }
     if _cid_of_json(derivation_preimage) != provenance.derivation_cid:
         raise ContextManagerContractError("derivation CID mismatch")
 
@@ -729,22 +738,31 @@ def seal_derived_context_manager_contract(
     validate_derivation_provenance_v1(provenance)
     payload = semantics_to_value(semantics)
     decoded_payload = json.loads(encode_jcs(payload))
-    if decode_context_manager_semantics_v1(decoded_payload, import_signature) != semantics:
-        raise ContextManagerContractError("context-manager semantics failed canonical validation")
+    if (
+        decode_context_manager_semantics_v1(decoded_payload, import_signature)
+        != semantics
+    ):
+        raise ContextManagerContractError(
+            "context-manager semantics failed canonical validation"
+        )
     payload_cid = blake3_512_of(encode_jcs(payload).encode())
     provenance_wire = derivation_provenance_to_dict(provenance)
     provenance_cid = _cid_of_json(provenance_wire)
     contract_preimage = {
         "kind": "context-manager-contract",
         "schemaVersion": "derived-1",
-        "importSignature": json.loads(encode_jcs(import_signature_to_value(import_signature))),
+        "importSignature": json.loads(
+            encode_jcs(import_signature_to_value(import_signature))
+        ),
         "semantics": decoded_payload,
         "payloadCid": payload_cid,
         "provenance": provenance_wire,
         "provenanceCid": provenance_cid,
     }
     contract_cid = _cid_of_json(contract_preimage)
-    header = _json_value({**contract_preimage, "cid": contract_cid, "contractCid": contract_cid})
+    header = _json_value(
+        {**contract_preimage, "cid": contract_cid, "contractCid": contract_cid}
+    )
     metadata = vobj(
         [
             (
@@ -1116,7 +1134,9 @@ def decode_context_manager_semantics_v1(
 def decode_context_manager_contract(
     canonical_bytes: bytes, member_cid: str
 ) -> DerivedContextManagerContractV1:
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
 
     try:
         raw = json.loads(canonical_bytes)
@@ -1128,8 +1148,12 @@ def decode_context_manager_contract(
     if not all(isinstance(value, dict) for value in (envelope, header, metadata)):
         raise ContextManagerContractError("CM contract layers must be objects")
     if blake3_512_of(encode_jcs(_json_value(envelope)).encode()) != member_cid:
-        raise ContextManagerContractError("member attestation CID does not match envelope")
-    signing = vobj([("header", _json_value(header)), ("metadata", _json_value(metadata))])
+        raise ContextManagerContractError(
+            "member attestation CID does not match envelope"
+        )
+    signing = vobj(
+        [("header", _json_value(header)), ("metadata", _json_value(metadata))]
+    )
     if not ed25519_verify_string(
         envelope.get("signer", ""),
         envelope.get("signature", ""),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -111,9 +111,7 @@ def route_except_star(effect, expected, *, slot_id=None, site=None):
     split = effect.partition(expected, site)
     bindings = ()
     if split.matched.children and slot_id is not None:
-        bindings = (
-            EffectBinding(slot_id, "grouped-raise", None, split.matched),
-        )
+        bindings = (EffectBinding(slot_id, "grouped-raise", None, split.matched),)
     return GroupedRoutedOutcome(split.matched, split.residual, bindings)
 
 
@@ -139,6 +137,7 @@ def regroup_except_star(original, effects):
     original_leaves = leaves(original)
     supplied = set().union(*(leaves(effect) for effect in effects))
     if supplied and supplied <= original_leaves:
+
         def retain(group):
             children = []
             for child in group.children:
@@ -149,6 +148,7 @@ def regroup_except_star(original, effects):
                 elif child.occurrence_id in supplied:
                     children.append(child)
             return group.derive(tuple(children))
+
         return retain(original)
 
     # Newly raised handler effects and the residual remain distinct children.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
@@ -13,15 +13,14 @@ from sugar_lift_py_tests.canonicalizer import (
 )
 from sugar_lift_py_tests.ir import Term, _term_content_cid
 
-
 _CLOSED_OPERATIONS = frozenset(
     {
         "python.issubclass",
         "python.set.contains",
         "python.set.union",
         "python.set.intersection",
-    "python.set.difference",
-    "python.set.construct",
+        "python.set.difference",
+        "python.set.construct",
     }
 )
 
@@ -34,7 +33,9 @@ class PythonRuntimeIdentity:
 
     @classmethod
     def current(cls) -> "PythonRuntimeIdentity":
-        return cls(sys.implementation.name, sys.version_info.major, sys.version_info.minor)
+        return cls(
+            sys.implementation.name, sys.version_info.major, sys.version_info.minor
+        )
 
 
 @dataclass(frozen=True)
@@ -71,7 +72,9 @@ class ClosedSemanticOperationWitness:
             runtime, operation, operands, result
         )
         if self != expected:
-            raise ValueError("closed semantic operation witness does not authenticate operands, result, runtime identity, and operation")
+            raise ValueError(
+                "closed semantic operation witness does not authenticate operands, result, runtime identity, and operation"
+            )
 
 
 def _witness_cid(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -49,7 +49,9 @@ class SetValue(FloorValue):
         return Complete(TermValue(len(self.elements)))
 
     def contains(self, item, site):
-        decisions = tuple(_closed_member_equal(item, element) for element in self.elements)
+        decisions = tuple(
+            _closed_member_equal(item, element) for element in self.elements
+        )
         if any(decision is True for decision in decisions):
             return _bool_result(True, site)
         if all(decision is False for decision in decisions):
@@ -77,6 +79,7 @@ class SetValue(FloorValue):
     def subtract(self, other, site):
         if type(other) is SetValue:
             from sugar_lift_py_tests.outcome import Complete
+
             result = _finite_difference(self.elements, other.elements)
             if result is not None:
                 return Complete(SetValue(result))
@@ -86,6 +89,7 @@ class SetValue(FloorValue):
     def bitwise_or(self, other, site):
         if type(other) is SetValue:
             from sugar_lift_py_tests.outcome import Complete
+
             result = _finite_union(self.elements, other.elements)
             if result is not None:
                 return Complete(SetValue(result))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -119,9 +119,7 @@ class TupleValue(FloorValue):
         if type(result) is TrueBoolLiteralSugar:
             return Complete(TrueBoolLiteralSugar(site=site))
         if type(result) is FalseBoolLiteralSugar:
-            return self._collect_subtype_tests(
-                subtype, site, index + 1, predicates
-            )
+            return self._collect_subtype_tests(subtype, site, index + 1, predicates)
         if type(result) is PredicateValue:
             return self._collect_subtype_tests(
                 subtype, site, index + 1, (*predicates, result)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -26,9 +26,7 @@ class BuiltinClosedOperationReport:
             "name_or_vendor_gates",
             "panic_catches",
         )
-        return {
-            axis: sum(row.axis == axis for row in self.offenders) for axis in axes
-        }
+        return {axis: sum(row.axis == axis for row in self.offenders) for axis in axes}
 
 
 def collect_builtin_closed_operation_report(
@@ -77,7 +75,10 @@ class _Visitor(ast.NodeVisitor):
             for value in ast.walk(node)
             if isinstance(value, ast.Constant) and isinstance(value.value, str)
         }
-        if any("pytest.raises" in value or "contextlib.suppress" in value for value in string_values):
+        if any(
+            "pytest.raises" in value or "contextlib.suppress" in value
+            for value in string_values
+        ):
             self._add(
                 "name_or_vendor_gates",
                 node,
@@ -101,7 +102,10 @@ class _Visitor(ast.NodeVisitor):
             for value in ast.walk(node)
             if isinstance(value, ast.Constant) and type(value.value) is bool
         }
-        if any("builtin_result" in name or "builtin_verdict" in name for name in names) and bools:
+        if (
+            any("builtin_result" in name or "builtin_verdict" in name for name in names)
+            and bools
+        ):
             self._add(
                 "generic_builtin_verdicts",
                 node,
@@ -121,9 +125,7 @@ class _Visitor(ast.NodeVisitor):
             )
         self.generic_visit(node)
 
-    def _add(
-        self, axis: str, node: ast.AST, observed: str, replacement: str
-    ) -> None:
+    def _add(self, axis: str, node: ast.AST, observed: str, replacement: str) -> None:
         self.offenders.append(
             BuiltinClosedOperationOffender(
                 axis=axis,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
@@ -7,7 +7,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 import re
 
-
 _REPLACEMENT = "LoopConstructionV1 plus LoopProjectedBinding"
 
 
@@ -156,7 +155,11 @@ def scan_guarded_loop_recurrence(
             )
             for node in tree.body
         )
-        if legacy or "python:loop.flat_map" not in text or "python:loop.filter_guard" not in text:
+        if (
+            legacy
+            or "python:loop.flat_map" not in text
+            or "python:loop.filter_guard" not in text
+        ):
             findings.append(
                 _finding(
                     comprehension_sugar,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
@@ -29,6 +29,7 @@ class ContextManagerEdgeTransportError(ValueError):
 
 def _json(value) -> Any:
     from sugar_lift_py_tests.canonicalizer import encode_jcs
+
     return json.loads(encode_jcs(value))
 
 
@@ -60,7 +61,9 @@ class ContextManagerEdgeDtoV1:
                 "context-manager edge requires an authenticated derived ref"
             )
         if use_site != reference.use_site:
-            raise ContextManagerEdgeTransportError("context-manager edge use-site mismatch")
+            raise ContextManagerEdgeTransportError(
+                "context-manager edge use-site mismatch"
+            )
         if not _admitted(reference):
             raise ContextManagerEdgeTransportError(
                 "context-manager edge requires admitted closed semantics"
@@ -90,7 +93,9 @@ class ContextManagerEdgeDtoV1:
             "exitTestimonyCid": reference.exit_testimony_cid,
             "demandCid": reference.demand_cid,
             "resolutionCid": reference.resolution_cid,
-            "importSignature": _json(import_signature_to_value(reference.import_signature)),
+            "importSignature": _json(
+                import_signature_to_value(reference.import_signature)
+            ),
             "semantics": _json(semantics_to_value(reference.semantics)),
         }
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/recovered_audit_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/recovered_audit_dto.py
@@ -75,9 +75,7 @@ _LEAF_SUPPRESSED_FIELDS = frozenset({"locus", "reason"})
 _LEAF_ENVELOPE_FIELDS = frozenset({"semanticCore", "auxiliaryRows"})
 _LEAF_AUXILIARY_FIELDS = frozenset({"sourceAudit"})
 _SOURCE_AUDIT_FIELDS = frozenset({"role", "loci", "totals"})
-_SOURCE_AUDIT_ROW_FIELDS = frozenset(
-    {"status", "kind", "name", "source_cid", "locus"}
-)
+_SOURCE_AUDIT_ROW_FIELDS = frozenset({"status", "kind", "name", "source_cid", "locus"})
 _SOURCE_AUDIT_LOCUS_FIELDS = frozenset({"file", "line", "col"})
 _SOURCE_AUDIT_TOTALS_FIELDS = frozenset(
     {"source_loci", "source_warranted", "source_unresolved"}
@@ -343,9 +341,7 @@ class AuditLeafEnvelopeDto:
         )
         return cls(
             semantic_core=RecoveredAuditDto.from_rpc(row.get("semanticCore")),
-            source_audit=AuditLeafSourceAuditDto.from_rpc(
-                auxiliary.get("sourceAudit")
-            ),
+            source_audit=AuditLeafSourceAuditDto.from_rpc(auxiliary.get("sourceAudit")),
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -69,6 +69,8 @@ _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
 _BOUND_CALL_CONTRACT_REFS = None
+
+
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
     """Enroll typed With occurrences without constructing any Sugar.
 
@@ -1364,6 +1366,7 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
 
     demanded_source = f"module:{source_file.unit.source_cid}"
     panics = []
+
     # Key nodes by the roll-call identity (sealed CID + source coordinate +
     # kind) -- the SAME identity `MinorityReport` uses. One sealed fragment CID
     # is shared by equal source text at DISTINCT loci (e.g. `os` at 3:7 and Name
@@ -1431,17 +1434,19 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
     # `kind` and `recoveryOverride` are closed-envelope discriminators required
     # by the current Rust reader. No recovery policy is consulted here; every
     # semantic value is projected from the roll call above.
-    return AuditLeafEnvelopeDto.from_rpc({
-        "semanticCore": {
-            "kind": "recovered-construction-audit",
-            "recoveryOverride": True,
-            "status": "failed" if panics else "clean",
-            "panics": panics,
-            "effects": [],
-            "suppressedDescendants": [],
-        },
-        "auxiliaryRows": {"sourceAudit": source_audit},
-    }).to_rpc()
+    return AuditLeafEnvelopeDto.from_rpc(
+        {
+            "semanticCore": {
+                "kind": "recovered-construction-audit",
+                "recoveryOverride": True,
+                "status": "failed" if panics else "clean",
+                "panics": panics,
+                "effects": [],
+                "suppressedDescendants": [],
+            },
+            "auxiliaryRows": {"sourceAudit": source_audit},
+        }
+    ).to_rpc()
 
 
 def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -111,8 +111,12 @@ def _decode_binding_entry(raw: Any) -> tuple[str, dict[str, Any]]:
     coordinate = _exact(
         raw["coordinate"],
         {
-            "kind", "schemaVersion", "scopeOwnerCid", "bindingSite",
-            "projectionPath", "bindingCoordinateCid",
+            "kind",
+            "schemaVersion",
+            "scopeOwnerCid",
+            "bindingSite",
+            "projectionPath",
+            "bindingCoordinateCid",
         },
         "BindingCoordinateV1",
     )
@@ -131,12 +135,18 @@ def _decode_binding_entry(raw: Any) -> tuple[str, dict[str, Any]]:
         testimony = _exact(
             state["testimony"],
             {
-                "kind", "schemaVersion", "sourceFragmentCid", "semanticValueCid",
+                "kind",
+                "schemaVersion",
+                "sourceFragmentCid",
+                "semanticValueCid",
                 "constructedValueTestimonyCid",
             },
             "ConstructedValueTestimonyV1",
         )
-        if testimony["kind"] != "constructed-value-testimony" or testimony["schemaVersion"] != "1":
+        if (
+            testimony["kind"] != "constructed-value-testimony"
+            or testimony["schemaVersion"] != "1"
+        ):
             raise LoopWireError("unsupported ConstructedValueTestimonyV1")
         _validate_seal(
             testimony,
@@ -215,65 +225,136 @@ _RECORD_CID_FIELDS = {
 
 _EXACT_FIELDS = {
     "loop-completed-face": {
-        "kind", "schemaVersion", "targetCid", "completionKind",
-        "guardFormulaCid", "stateCid", "completedFaceCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "completionKind",
+        "guardFormulaCid",
+        "stateCid",
+        "completedFaceCid",
     },
     "loop-outward-halted-face": {
-        "kind", "schemaVersion", "targetCid", "effectCid", "guardFormulaCid",
-        "stateCid", "outwardHaltedFaceCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "effectCid",
+        "guardFormulaCid",
+        "stateCid",
+        "outwardHaltedFaceCid",
     },
     "loop-binder-transform": {
-        "kind", "schemaVersion", "targetCid", "inputStateCid", "elementValueCid",
-        "outputStateCid", "binderPatternConstructionCid", "binderTransformCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "inputStateCid",
+        "elementValueCid",
+        "outputStateCid",
+        "binderPatternConstructionCid",
+        "binderTransformCid",
     },
     "loop-body-transform": {
-        "kind", "schemaVersion", "targetCid", "inputStateCid", "binderTransformCid",
-        "bodySourceFragmentCid", "bodyExitTemplateCid", "bodyTransformCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "inputStateCid",
+        "binderTransformCid",
+        "bodySourceFragmentCid",
+        "bodyExitTemplateCid",
+        "bodyTransformCid",
     },
     "loop-test-transform": {
-        "kind", "schemaVersion", "targetCid", "inputStateCid",
-        "testValueConstructionCid", "trueGuardFormulaCid", "falseGuardFormulaCid",
-        "haltedFaceCids", "testTransformCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "inputStateCid",
+        "testValueConstructionCid",
+        "trueGuardFormulaCid",
+        "falseGuardFormulaCid",
+        "haltedFaceCids",
+        "testTransformCid",
     },
     "loop-iterator-testimony": {
-        "kind", "schemaVersion", "targetCid", "iterableValueConstructionCid",
-        "iteratorConstructionCid", "nextOperationCid", "exhaustionOperationCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "iterableValueConstructionCid",
+        "iteratorConstructionCid",
+        "nextOperationCid",
+        "exhaustionOperationCid",
         "iteratorTestimonyCid",
     },
     "for-operation": {
-        "kind", "schemaVersion", "targetCid", "nativeLoopTermCid",
-        "binderTransformCid", "iteratorTestimonyCid", "operationCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "nativeLoopTermCid",
+        "binderTransformCid",
+        "iteratorTestimonyCid",
+        "operationCid",
     },
     "while-operation": {
-        "kind", "schemaVersion", "targetCid", "nativeLoopTermCid",
-        "testTransformCid", "operationCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "nativeLoopTermCid",
+        "testTransformCid",
+        "operationCid",
     },
     "loop-latch-obligation": {
-        "kind", "schemaVersion", "targetCid", "inputCompletedFaceCid",
-        "inputStateCid", "operationKind", "successorTransformCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "inputCompletedFaceCid",
+        "inputStateCid",
+        "operationKind",
+        "successorTransformCid",
         "latchObligationCid",
     },
     "loop-continue-latch-obligation": {
-        "kind", "schemaVersion", "targetCid", "continueEffectCid",
-        "inputHaltedFaceCid", "inputStateCid", "successorTransformCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "continueEffectCid",
+        "inputHaltedFaceCid",
+        "inputStateCid",
+        "successorTransformCid",
         "continueLatchObligationCid",
     },
     "loop-break-exit-obligation": {
-        "kind", "schemaVersion", "targetCid", "breakEffectCid",
-        "inputHaltedFaceCid", "outputCompletedFaceCid", "breakExitObligationCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "breakEffectCid",
+        "inputHaltedFaceCid",
+        "outputCompletedFaceCid",
+        "breakExitObligationCid",
     },
     "loop-exhaustion-exit-obligation": {
-        "kind", "schemaVersion", "targetCid", "operationTestimonyCid",
-        "inputStateCid", "outputCompletedFaceCid", "exhaustionExitObligationCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "operationTestimonyCid",
+        "inputStateCid",
+        "outputCompletedFaceCid",
+        "exhaustionExitObligationCid",
     },
     "loop-else-exhaustion-obligation": {
-        "kind", "schemaVersion", "targetCid", "inputCompletedFaceCid",
-        "elseBodyTransformCid", "outputCompletedFaceCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "inputCompletedFaceCid",
+        "elseBodyTransformCid",
+        "outputCompletedFaceCid",
         "elseExhaustionObligationCid",
     },
     "loop-post-binding": {
-        "kind", "schemaVersion", "targetCid", "bindingCoordinateCid",
-        "incomingStateCid", "completedFaceCid", "projectedStateCid",
+        "kind",
+        "schemaVersion",
+        "targetCid",
+        "bindingCoordinateCid",
+        "incomingStateCid",
+        "completedFaceCid",
+        "projectedStateCid",
         "postBindingObligationCid",
     },
 }
@@ -333,11 +414,14 @@ def _decode_record(raw: Any) -> LoopRecordV1:
             for item in value:
                 _require_cid(item, field)
     if kind == "loop-completed-face" and raw["completionKind"] not in {
-        "BodyFallthrough", "NormalExhaustion", "BreakExit"
+        "BodyFallthrough",
+        "NormalExhaustion",
+        "BreakExit",
     }:
         raise LoopWireError("unknown loop completion kind")
     if kind == "loop-latch-obligation" and raw["operationKind"] not in {
-        "ForNext", "WhileTest"
+        "ForNext",
+        "WhileTest",
     }:
         raise LoopWireError("unknown latch operation")
     return LoopRecordV1(kind, cid, deepcopy(raw))
@@ -345,18 +429,33 @@ def _decode_record(raw: Any) -> LoopRecordV1:
 
 def _root(raw: Any) -> dict[str, Any]:
     fields = {
-        "kind", "schemaVersion", "target", "preStateCid", "operation",
-        "bodyTransformCid", "bodyExitTemplateCid", "latchObligationCids",
+        "kind",
+        "schemaVersion",
+        "target",
+        "preStateCid",
+        "operation",
+        "bodyTransformCid",
+        "bodyExitTemplateCid",
+        "latchObligationCids",
         "continueLatchObligationCids",
-        "breakExitObligationCids", "exhaustionExitObligationCid", "elseBodyCid",
+        "breakExitObligationCids",
+        "exhaustionExitObligationCid",
+        "elseBodyCid",
         "elseExhaustionObligationCid",
-        "completedFaceCids", "outwardHaltedFaceCids", "postBindingObligationCids",
+        "completedFaceCids",
+        "outwardHaltedFaceCids",
+        "postBindingObligationCids",
         "loopConstructionCid",
     }
     raw = _exact(raw, fields, "LoopConstructionV1")
     if raw["kind"] != "loop-construction" or raw["schemaVersion"] != "1":
         raise LoopWireError("unsupported LoopConstructionV1")
-    for field in ("preStateCid", "bodyTransformCid", "bodyExitTemplateCid", "exhaustionExitObligationCid"):
+    for field in (
+        "preStateCid",
+        "bodyTransformCid",
+        "bodyExitTemplateCid",
+        "exhaustionExitObligationCid",
+    ):
         _require_cid(raw[field], field)
     if raw["elseBodyCid"] is not None:
         _require_cid(raw["elseBodyCid"], "elseBodyCid")
@@ -364,7 +463,14 @@ def _root(raw: Any) -> dict[str, Any]:
         _require_cid(raw["elseExhaustionObligationCid"], "elseExhaustionObligationCid")
     if (raw["elseBodyCid"] is None) != (raw["elseExhaustionObligationCid"] is None):
         raise LoopWireError("else body and exhaustion obligation must appear together")
-    for field in ("latchObligationCids", "continueLatchObligationCids", "breakExitObligationCids", "completedFaceCids", "outwardHaltedFaceCids", "postBindingObligationCids"):
+    for field in (
+        "latchObligationCids",
+        "continueLatchObligationCids",
+        "breakExitObligationCids",
+        "completedFaceCids",
+        "outwardHaltedFaceCids",
+        "postBindingObligationCids",
+    ):
         if not isinstance(raw[field], list):
             raise LoopWireError(f"{field} must be an array")
         for cid in raw[field]:
@@ -413,7 +519,8 @@ def decode_loop_construction_v1(graph: Any) -> LoopConstructionV1:
     pre_state = state(root["preStateCid"])
     operation_raw = root["operation"]
     if not isinstance(operation_raw, dict) or operation_raw.get("kind") not in {
-        "for-operation", "while-operation"
+        "for-operation",
+        "while-operation",
     }:
         raise LoopWireError("unknown loop operation")
     operation_record = _decode_record(operation_raw)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -290,9 +290,7 @@ class ExitSet(Generic[T]):
                     if _is_true(truth)
                     else true_guard() if _is_false(truth) else not_(truth)
                 )
-                exits.append(
-                    Completed(_and_guards(guard, truth), incoming.state)
-                )
+                exits.append(Completed(_and_guards(guard, truth), incoming.state))
                 exits.append(
                     Halted(
                         _and_guards(guard, falsity),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -175,8 +175,7 @@ class CallSiteSugar(Sugar):
                 source_call_frame_cid=source_frame_cid,
                 formal_coordinate_cids=(
                     tuple(
-                        item.cid
-                        for item in self.source_call_frame.formal_coordinates
+                        item.cid for item in self.source_call_frame.formal_coordinates
                     )
                     if self.source_call_frame is not None
                     else ()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -75,15 +75,19 @@ class ComprehensionSugar(Sugar):
                 ),
                 ctx,
             )
-        return generator.filters[filter_index].desugar(ctx).and_then(
-            lambda guard: self._desugar_filters(
-                generator,
-                filter_index + 1,
-                (*filters, guard),
-                iterable,
-                index,
-                resolved,
-                ctx,
+        return (
+            generator.filters[filter_index]
+            .desugar(ctx)
+            .and_then(
+                lambda guard: self._desugar_filters(
+                    generator,
+                    filter_index + 1,
+                    (*filters, guard),
+                    iterable,
+                    index,
+                    resolved,
+                    ctx,
+                )
             )
         )
 
@@ -111,7 +115,9 @@ class ComprehensionSugar(Sugar):
         )
         body = element_term
         recurrence_rows = []
-        for source_name, binding_coordinate_cid, iterable, filters in reversed(resolved):
+        for source_name, binding_coordinate_cid, iterable, filters in reversed(
+            resolved
+        ):
             coordinate_var = make_var(binding_coordinate_cid)
             body = subst_var_in_term(body, source_name, coordinate_var)
             for guard in reversed(filters):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -242,9 +242,7 @@ class FunctionUniverseSugar(Sugar):
     statements: tuple  # the body statements' sugars, in source order
     site: object = dataclass_field(compare=False, default=None)
     bridge_source_symbol: str | None = None
-    substitution_trace: object | None = dataclass_field(
-        compare=False, default=None
-    )
+    substitution_trace: object | None = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
@@ -92,9 +92,9 @@ class GeneratorWithSugar(Sugar):
             result = ExitSet(tuple(exits)).normalize()
             facts = ()
             if self.enter_slot_id is not None:
-                facts = EnterResultBinding(
-                    self.enter_slot_id, entered.value
-                ).to_facts(site=self.site)
+                facts = EnterResultBinding(self.enter_slot_id, entered.value).to_facts(
+                    site=self.site
+                )
             routed.append(prepend_facts_to_exitset(result, facts))
 
         if not routed:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -75,9 +75,7 @@ class LoopRecurrenceSugar(Sugar):
 
         halted_guards = [face.guard for face in self.outward_faces]
         completed_guard = not_(
-            halted_guards[0]
-            if len(halted_guards) == 1
-            else or_(halted_guards)
+            halted_guards[0] if len(halted_guards) == 1 else or_(halted_guards)
         )
         exits = [Completed(completed_guard, recurrence)]
         for face in self.outward_faces:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
@@ -34,9 +34,7 @@ class PlaceAssignSugar(Sugar):
                 elif self.selector_kind == "subscript":
                     return self.selector.desugar(ctx).and_then(
                         lambda selector: Complete(
-                            PlaceAssignValue(
-                                receiver, "subscript", selector, value
-                            )
+                            PlaceAssignValue(receiver, "subscript", selector, value)
                         )
                     )
                 else:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -114,6 +114,7 @@ class TryStarSugar(Sugar):
         if self.finalbody:
             cleanup = reduce_block_to_exitset(self.finalbody, ctx)
             from sugar_lift_py_tests.floor.return_value import ReturnValue
+
             def restores(value):
                 return not (
                     isinstance(value, _ReducedBlock)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -436,9 +436,11 @@ def frontier_leaf_rpc(full_path: Path, file_rel: str) -> dict:
                 gap={"blame": terminal, "kind": node.kind, "reason": reason},
             )
         )
-    return AuditLeafEnvelopeDto.from_rpc({
-        "semanticCore": RecoveredAuditDto(panics=panics).to_rpc(),
-        "auxiliaryRows": {
-            "sourceAudit": source_audit_from_roll_call(full_path, file_rel)
-        },
-    }).to_rpc()
+    return AuditLeafEnvelopeDto.from_rpc(
+        {
+            "semanticCore": RecoveredAuditDto(panics=panics).to_rpc(),
+            "auxiliaryRows": {
+                "sourceAudit": source_audit_from_roll_call(full_path, file_rel)
+            },
+        }
+    ).to_rpc()

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_finite_set_floor.py
@@ -18,7 +18,9 @@ def test_finite_set_membership_is_decided_from_constructed_members():
 
     finite = _numbers(1, 2)
     assert isinstance(finite.contains(TermValue(2), "site").value, TrueBoolLiteralSugar)
-    assert isinstance(finite.contains(TermValue(3), "site").value, FalseBoolLiteralSugar)
+    assert isinstance(
+        finite.contains(TermValue(3), "site").value, FalseBoolLiteralSugar
+    )
 
 
 def test_finite_set_union_intersection_and_difference_are_closed():
@@ -31,9 +33,11 @@ def test_symbolic_finite_membership_emits_typed_obligation():
     from sugar_lift_py_tests.floor import SetValue, SymbolicValue, TermValue
     from sugar_lift_py_tests.ir import _Atomic, make_var
 
-    result = SetValue((TermValue(1),)).contains(
-        SymbolicValue(make_var("member")), "site"
-    ).value
+    result = (
+        SetValue((TermValue(1),))
+        .contains(SymbolicValue(make_var("member")), "site")
+        .value
+    )
     assert isinstance(result.formula, _Atomic)
     assert result.formula.name == "python.set.contains"
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_subtype_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_subtype_floor.py
@@ -20,8 +20,12 @@ def test_constructed_subtype_graph_closes_direct_transitive_and_unrelated():
     unrelated = _class("RenamedOther")
 
     assert isinstance(leaf.test_python_subtype(base, "site"), Complete)
-    assert isinstance(leaf.test_python_subtype(base, "site").value, TrueBoolLiteralSugar)
-    assert isinstance(leaf.test_python_subtype(unrelated, "site").value, FalseBoolLiteralSugar)
+    assert isinstance(
+        leaf.test_python_subtype(base, "site").value, TrueBoolLiteralSugar
+    )
+    assert isinstance(
+        leaf.test_python_subtype(unrelated, "site").value, FalseBoolLiteralSugar
+    )
 
 
 def test_tuple_of_types_is_finite_subtype_disjunction():
@@ -33,8 +37,14 @@ def test_tuple_of_types_is_finite_subtype_disjunction():
     leaf = _class("Leaf", base)
     other = _class("Other")
 
-    assert isinstance(leaf.test_python_subtype(TupleValue((other, base)), "site").value, TrueBoolLiteralSugar)
-    assert isinstance(base.test_python_subtype(TupleValue((other, leaf)), "site").value, FalseBoolLiteralSugar)
+    assert isinstance(
+        leaf.test_python_subtype(TupleValue((other, base)), "site").value,
+        TrueBoolLiteralSugar,
+    )
+    assert isinstance(
+        base.test_python_subtype(TupleValue((other, leaf)), "site").value,
+        FalseBoolLiteralSugar,
+    )
 
 
 def test_symbolic_subtype_emits_typed_obligation():
@@ -65,13 +75,23 @@ def test_closed_operation_witness_rejects_each_lying_coordinate():
     from sugar_lift_py_tests.ir import bool_const, ctor, str_const
 
     runtime = PythonRuntimeIdentity.current()
-    operands = (ctor("python:type", [str_const("Leaf")]), ctor("python:type", [str_const("Base")]))
+    operands = (
+        ctor("python:type", [str_const("Leaf")]),
+        ctor("python:type", [str_const("Base")]),
+    )
     result = bool_const(True)
-    witness = ClosedSemanticOperationWitness.mint(runtime, "python.issubclass", operands, result)
+    witness = ClosedSemanticOperationWitness.mint(
+        runtime, "python.issubclass", operands, result
+    )
     witness.verify(runtime, "python.issubclass", operands, result)
 
     lies = (
-        (replace(runtime, minor=runtime.minor + 1), "python.issubclass", operands, result),
+        (
+            replace(runtime, minor=runtime.minor + 1),
+            "python.issubclass",
+            operands,
+            result,
+        ),
         (runtime, "python.set.contains", operands, result),
         (runtime, "python.issubclass", tuple(reversed(operands)), result),
         (runtime, "python.issubclass", operands, bool_const(False)),
@@ -97,9 +117,12 @@ def test_authenticated_builtin_issubclass_callable_uses_floor_not_spelling():
     )
     assert isinstance(result.value, TrueBoolLiteralSugar)
     witness = receiver.witness_for((leaf, base), result.value)
-    witness.verify(receiver.runtime_identity, receiver.operation, (
-        leaf.to_term(owner="test"), base.to_term(owner="test")
-    ), result.value.to_term(owner="test"))
+    witness.verify(
+        receiver.runtime_identity,
+        receiver.operation,
+        (leaf.to_term(owner="test"), base.to_term(owner="test")),
+        result.value.to_term(owner="test"),
+    )
 
 
 def test_shadowed_issubclass_does_not_inherit_builtin_semantics():

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py
@@ -5,10 +5,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-
-_SCRIPT = (
-    Path(__file__).parents[1] / "scripts" / "construction_invariant_law.py"
-)
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "construction_invariant_law.py"
 _SPEC = importlib.util.spec_from_file_location("construction_invariant_law", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 LAW = importlib.util.module_from_spec(_SPEC)
@@ -17,38 +14,34 @@ _SPEC.loader.exec_module(LAW)
 
 
 def _classes(source: str) -> set[str]:
-    return {finding.violation_class for finding in LAW.scan_python_source(source, "planted.py")}
+    return {
+        finding.violation_class
+        for finding in LAW.scan_python_source(source, "planted.py")
+    }
 
 
 def test_each_reject_class_has_a_structural_planted_twin() -> None:
-    assert _classes(
-        """
+    assert _classes("""
 def decode(raw):
     content_cid = cid_of_json(raw)
     return AuthenticatedThing(raw=raw, cid=content_cid)
-"""
-    ) == {"SELF-HASHING-AS-AUTHORITY"}
+""") == {"SELF-HASHING-AS-AUTHORITY"}
 
-    assert _classes(
-        """
+    assert _classes("""
 def resolve(symbol):
     if symbol == "pytest.raises":
         return EffectBoundary()
-"""
-    ) == {"NAME-SPELLING-OVERLOAD-GATE"}
+""") == {"NAME-SPELLING-OVERLOAD-GATE"}
 
-    assert _classes(
-        """
+    assert _classes("""
 import ast
 def _expr(node):
     if isinstance(node, ast.Constant):
         return StringValue(node.value)
     return ObjectValue("made", ())
-"""
-    ) == {"SECOND-CONSTRUCTION-PATH"}
+""") == {"SECOND-CONSTRUCTION-PATH"}
 
-    assert _classes(
-        """
+    assert _classes("""
 import ast
 def transfer(statement: ast.stmt, state):
     if isinstance(statement, ast.If):
@@ -56,17 +49,14 @@ def transfer(statement: ast.stmt, state):
     if isinstance(statement, ast.For):
         return state
     return state
-"""
-    ) == {"NON-EXHAUSTIVE-VARIANT-COVERAGE"}
+""") == {"NON-EXHAUSTIVE-VARIANT-COVERAGE"}
 
-    assert _classes(
-        """
+    assert _classes("""
 def desugar(value):
     if value is None:
         return Complete(None)
     return Complete(value)
-"""
-    ) == {"FABRICATED-COMPLETION-FALLBACK"}
+""") == {"FABRICATED-COMPLETION-FALLBACK"}
 
 
 def test_discrimination_negatives_do_not_false_positive() -> None:
@@ -129,7 +119,9 @@ def test_report_names_file_line_class_and_required_fix() -> None:
     assert "R_construction_invariant_violations = 1" in rendered
 
 
-def test_cli_is_red_on_a_planted_violation_and_green_on_clean_source(tmp_path: Path) -> None:
+def test_cli_is_red_on_a_planted_violation_and_green_on_clean_source(
+    tmp_path: Path,
+) -> None:
     planted = tmp_path / "planted.py"
     planted.write_text(
         'def resolve(name):\n    return TABLE.get(name, "pytest.raises")\n',

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
@@ -13,7 +13,6 @@ import importlib.util
 import json
 from pathlib import Path
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "construction_side_door_law.py"
 _SPEC = importlib.util.spec_from_file_location(
@@ -196,9 +195,10 @@ def test_sole_path_packages_are_green() -> None:
     r = _SCANNER.r_construction_side_doors(offenders)
     err = _SCANNER.r_auditor_errors(offenders)
     assert err == 0, _SCANNER.format_report(offenders)
-    assert r == 0, (
-        "sole-path packages must stay at R=0; residual:\n"
-        + _SCANNER.format_report(offenders)
+    assert (
+        r == 0
+    ), "sole-path packages must stay at R=0; residual:\n" + _SCANNER.format_report(
+        offenders
     )
     # Drained sole-path modules must not reintroduce foreign ast.
     sole_foreign = [
@@ -259,9 +259,7 @@ def test_main_json_turns_red_for_planted_side_door(
         "import ast\n\ndef parse_again(source):\n    return ast.parse(source)\n",
         encoding="utf-8",
     )
-    monkeypatch.setattr(
-        _SCANNER, "default_production_roots", lambda _repo=None: (pkg,)
-    )
+    monkeypatch.setattr(_SCANNER, "default_production_roots", lambda _repo=None: (pkg,))
 
     code = _SCANNER.main([])
     assert code == 1
@@ -271,9 +269,7 @@ def test_main_json_turns_red_for_planted_side_door(
     assert summary["R_construction_side_doors"] > 0
     assert summary["R_foreign_ast_import"] > 0
     assert summary["offenders"]
-    assert any(
-        row["axis"] == "foreign-ast-import" for row in summary["offenders"]
-    )
+    assert any(row["axis"] == "foreign-ast-import" for row in summary["offenders"])
 
 
 def test_missing_root_is_auditor_error_not_crash(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
@@ -30,14 +30,27 @@ def _provenance() -> ContextManagerDerivationProvenanceV1:
     definition = SourceFragmentCoordinateV1(_cid("d"), 1, 0, 4, 8)
     use = SourceFragmentCoordinateV1(_cid("u"), 9, 2, 9, 14)
     value = ContextManagerDerivationProvenanceV1(
-        _cid("a"), _cid("b"), _cid("c"), _cid("d"), (_cid("e"),),
-        definition, _cid_of_json(definition.wire()), _cid("f"), _cid("1"),
-        _cid("2"), use, _cid_of_json(use.wire()), _cid("3"), _cid("0"),
+        _cid("a"),
+        _cid("b"),
+        _cid("c"),
+        _cid("d"),
+        (_cid("e"),),
+        definition,
+        _cid_of_json(definition.wire()),
+        _cid("f"),
+        _cid("1"),
+        _cid("2"),
+        use,
+        _cid_of_json(use.wire()),
+        _cid("3"),
+        _cid("0"),
     )
     wire = derivation_provenance_to_dict(value)
     return dataclasses.replace(
         value,
-        derivation_cid=_cid_of_json({k: v for k, v in wire.items() if k != "derivationCid"}),
+        derivation_cid=_cid_of_json(
+            {k: v for k, v in wire.items() if k != "derivationCid"}
+        ),
     )
 
 
@@ -47,8 +60,10 @@ def _seal():
         ExitContractV1(NeverSuppressesDispositionV1(), TotalCompletionV1()),
     )
     return seal_derived_context_manager_contract(
-        import_signature=ImportSignatureV2(()), semantics=semantics,
-        provenance=_provenance(), signer=Signer(bytes(range(32)), "deriver"),
+        import_signature=ImportSignatureV2(()),
+        semantics=semantics,
+        provenance=_provenance(),
+        signer=Signer(bytes(range(32)), "deriver"),
         declared_at="2026-07-22T00:00:00.000Z",
     )
 
@@ -59,12 +74,17 @@ def test_derived_contract_round_trips_construction_provenance():
     assert decoded.provenance.manager_construction_cid == _cid("f")
     assert decoded.provenance.enter_testimony_cid == _cid("1")
     assert decoded.provenance.exit_testimony_cid == _cid("2")
-    assert decoded.contract_cid == json.loads(member.canonical_bytes)["header"]["contractCid"]
+    assert (
+        decoded.contract_cid
+        == json.loads(member.canonical_bytes)["header"]["contractCid"]
+    )
 
 
 def test_legacy_or_extra_authority_field_is_loud():
     member = _seal()
     raw = json.loads(member.canonical_bytes)
     raw["header"]["admissionAuthorityCid"] = _cid("9")
-    with pytest.raises(ContextManagerContractError, match="does not verify|malformed derived"):
+    with pytest.raises(
+        ContextManagerContractError, match="does not verify|malformed derived"
+    ):
         decode_context_manager_contract(json.dumps(raw).encode(), member.cid)

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_edge_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_edge_transport.py
@@ -1,16 +1,22 @@
 import pytest
 
 from sugar_lift_py_tests.context_manager_contract import (
-    EnterResultContractV1, ExitContractV1, ImportSignatureV2,
-    NeverSuppressesDispositionV1, ProtocolResourceSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    ImportSignatureV2,
+    NeverSuppressesDispositionV1,
+    ProtocolResourceSemanticsV1,
 )
 from sugar_lift_py_tests.context_manager_resolution import (
-    ContextManagerContractRefV1, ContextManagerResolutionGapV1,
-    SourceFragmentCoordinateV1, _hash_json,
+    ContextManagerContractRefV1,
+    ContextManagerResolutionGapV1,
+    SourceFragmentCoordinateV1,
+    _hash_json,
 )
 from sugar_lift_py_tests.ir import PrimitiveSort
 from sugar_lift_py_tests.kit_rpc.context_manager_edge_dto import (
-    ContextManagerEdgeDtoV1, ContextManagerEdgeTransportError,
+    ContextManagerEdgeDtoV1,
+    ContextManagerEdgeTransportError,
 )
 from sugar_lift_py_tests.kit_rpc.lift_report_payload_dto import LiftReportPayloadDto
 
@@ -22,14 +28,24 @@ def _cid(char):
 def _ref():
     site = SourceFragmentCoordinateV1(_cid("s"), 3, 9, 3, 18)
     return ContextManagerContractRefV1(
-        resolution_cid=_cid("r"), demand_cid=_cid("d"), use_site=site,
-        use_site_cid=_hash_json(site.wire()), authenticated_import_use_cid=_cid("u"),
-        import_binding_cid=_cid("i"), construction_context_generation_cid=_cid("g"),
-        contract_cid=_cid("m"), payload_cid=_cid("p"), provenance_cid=_cid("v"),
-        distribution_artifact_cid=_cid("a"), dependency_artifact_graph_cid=_cid("b"),
-        module_source_cid=_cid("s"), resolved_definition_cid=_cid("f"),
-        manager_construction_cid=_cid("n"), enter_testimony_cid=_cid("1"),
-        exit_testimony_cid=_cid("2"), import_signature=ImportSignatureV2(()),
+        resolution_cid=_cid("r"),
+        demand_cid=_cid("d"),
+        use_site=site,
+        use_site_cid=_hash_json(site.wire()),
+        authenticated_import_use_cid=_cid("u"),
+        import_binding_cid=_cid("i"),
+        construction_context_generation_cid=_cid("g"),
+        contract_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        provenance_cid=_cid("v"),
+        distribution_artifact_cid=_cid("a"),
+        dependency_artifact_graph_cid=_cid("b"),
+        module_source_cid=_cid("s"),
+        resolved_definition_cid=_cid("f"),
+        manager_construction_cid=_cid("n"),
+        enter_testimony_cid=_cid("1"),
+        exit_testimony_cid=_cid("2"),
+        import_signature=ImportSignatureV2(()),
         semantics=ProtocolResourceSemanticsV1(
             EnterResultContractV1(PrimitiveSort("Value")),
             ExitContractV1(NeverSuppressesDispositionV1()),

--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py
@@ -89,9 +89,7 @@ def test_typed_gap_child_testimony_classifies_nonfatal() -> None:
     assert not _is_fatal_category(row["category"])
 
 
-def test_genuine_python_bug_remains_bare_exception(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_genuine_python_bug_remains_bare_exception(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "bug.py"
     source.write_text("def exercise():\n    return 1\n", encoding="utf-8")
 
@@ -101,9 +99,7 @@ def test_genuine_python_bug_remains_bare_exception(
     import _production_lift_child as production_child
 
     monkeypatch.setattr(production_child, "production_lift_testimony", broken_lift)
-    testimony, returncode = corpus_fatal_triage._child_payload(
-        source, "demo/bug.py"
-    )
+    testimony, returncode = corpus_fatal_triage._child_payload(source, "demo/bug.py")
 
     assert returncode == 3
     assert testimony["outcome"] == "exception"
@@ -123,7 +119,9 @@ def test_genuine_python_bug_remains_bare_exception(
     assert row["category"] == "bare-exception"
 
 
-def test_completed_child_uses_the_same_production_terminal_shape(tmp_path: Path) -> None:
+def test_completed_child_uses_the_same_production_terminal_shape(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "clean.py"
     source.write_text("def identity(value):\n    return value\n", encoding="utf-8")
     testimony, returncode = _child_payload(source, "demo/clean.py")

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
@@ -136,24 +136,26 @@ def test_shared_cid_at_distinct_loci_stays_distinct_and_located():
 
     panics = leaf["semanticCore"]["panics"]
     owners = [(p["demandedSource"], p["terminalGapLocus"]) for p in panics]
-    assert len(owners) == len(set(owners)), (
-        f"duplicate recovered-panic owner identity: {owners}"
-    )
+    assert len(owners) == len(
+        set(owners)
+    ), f"duplicate recovered-panic owner identity: {owners}"
 
     alias_lines = sorted(
         p["terminalGapLocus"]
         for p in panics
         if p["terminalGapLocus"].endswith("[ImportAlias]")
     )
-    assert alias_lines == ["t.py:1:7-1:9[ImportAlias]", "t.py:2:7-2:9[ImportAlias]"], (
-        f"each import alias must keep its own locus, got {alias_lines}"
-    )
+    assert alias_lines == [
+        "t.py:1:7-1:9[ImportAlias]",
+        "t.py:2:7-2:9[ImportAlias]",
+    ], f"each import alias must keep its own locus, got {alias_lines}"
 
     # The panic list conserves the roll-call minority exactly: one row per
     # absent source site, no fusion, no inflation.
-    assert len(panics) == leaf["auxiliaryRows"]["sourceAudit"]["totals"][
-        "source_unresolved"
-    ], "panic count must equal R (source_unresolved)"
+    assert (
+        len(panics)
+        == leaf["auxiliaryRows"]["sourceAudit"]["totals"]["source_unresolved"]
+    ), "panic count must equal R (source_unresolved)"
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 PYTHON_ROOT = Path(__file__).resolve().parents[2]
 PROOF_MODULE = (
     PYTHON_ROOT
@@ -33,11 +32,7 @@ MEASURE_SCRIPT = (
     / "measure_exit_disposition_delta.py"
 )
 WITH_NODES = (
-    PYTHON_ROOT
-    / "sugar-source-tree"
-    / "src"
-    / "sugar_source_tree"
-    / "nodes.py"
+    PYTHON_ROOT / "sugar-source-tree" / "src" / "sugar_source_tree" / "nodes.py"
 )
 PRODUCTION_ROOTS = (
     PYTHON_ROOT / "sugar-lift-py-tests" / "src" / "sugar_lift_py_tests",
@@ -85,8 +80,7 @@ def test_with_construct_sugar_does_not_call_raw_ast_exit_proof():
     with_body = text[start:end] if end != -1 else text[start:]
     hits = [tok for tok in _FORBIDDEN_SIDE_DOOR_TOKENS if tok in with_body]
     assert hits == [], (
-        "With construction reintroduced raw-AST exit disposition tokens: "
-        f"{hits}"
+        "With construction reintroduced raw-AST exit disposition tokens: " f"{hits}"
     )
     assert "exit_disposition_proof" not in with_body
     # No fresh raw-AST greening authority under another name in With.
@@ -105,9 +99,10 @@ def test_production_roots_have_zero_exit_disposition_side_door_imports():
                 tok in text for tok in _FORBIDDEN_SIDE_DOOR_TOKENS
             ):
                 offenders.append(str(path.relative_to(PYTHON_ROOT)))
-    assert offenders == [], (
-        "production still references raw-AST exit disposition side door:\n"
-        + "\n".join(offenders)
+    assert (
+        offenders == []
+    ), "production still references raw-AST exit disposition side door:\n" + "\n".join(
+        offenders
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py
@@ -2,13 +2,14 @@ import importlib.util
 import sys
 from pathlib import Path
 
-
 _REPOSITORY = Path(__file__).resolve().parents[4]
 _SCANNER_PATH = (
     _REPOSITORY
     / "implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py"
 )
-_SPEC = importlib.util.spec_from_file_location("generator_construction_law", _SCANNER_PATH)
+_SPEC = importlib.util.spec_from_file_location(
+    "generator_construction_law", _SCANNER_PATH
+)
 assert _SPEC and _SPEC.loader
 _SCANNER = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = _SCANNER

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
@@ -67,7 +67,9 @@ def test_close_terminates_the_suspended_machine_without_fabricated_return():
 
 def test_opaque_transition_is_typed_loud():
     api = _api()
-    gap = _machine(api.OpaqueStepV1("try-star"),).resume()
+    gap = _machine(
+        api.OpaqueStepV1("try-star"),
+    ).resume()
 
     assert isinstance(gap, api.GeneratorTransitionGapV1)
     assert gap.observed == "try-star"

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
@@ -10,15 +10,13 @@ from sugar_lift_py_tests.idd.guarded_loop_recurrence import (
 
 def test_instrument_names_each_forbidden_symbolic_loop_shape(tmp_path: Path) -> None:
     source = tmp_path / "nodes.py"
-    source.write_text(
-        """
+    source.write_text("""
 def substitution_binding(self, scope):
     return self._make_call(self._make_name(f\"py.fold.{op}\"), (init, self.iter))
 
 def _construct_sugar(self):
     return ForUniversalSugar(target=self.target.id)
-"""
-    )
+""")
 
     findings = scan_guarded_loop_recurrence(tmp_path)
 
@@ -38,12 +36,10 @@ def test_instrument_rejects_ambient_map_and_cid_value_fabrication(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "loop_recurrence.py"
-    source.write_text(
-        """
+    source.write_text("""
 loop_values[target.id] = value
 value = node_from_cid(completed_face.state_c_id)
-"""
-    )
+""")
 
     findings = scan_guarded_loop_recurrence(tmp_path)
 
@@ -54,12 +50,10 @@ value = node_from_cid(completed_face.state_c_id)
 
 
 def test_instrument_names_typed_loud_live_loop_face_teeth(tmp_path: Path) -> None:
-    (tmp_path / "live_loop_construction.py").write_text(
-        '''
+    (tmp_path / "live_loop_construction.py").write_text("""
 raise BindingStateWireGap("live loop else requires exhaustion-path body state production")
 raise BindingStateWireGap("live loop outward halted face requires path-state production")
-'''
-    )
+""")
 
     findings = scan_guarded_loop_recurrence(tmp_path)
 
@@ -72,21 +66,17 @@ raise BindingStateWireGap("live loop outward halted face requires path-state pro
 def test_instrument_reports_numeric_r_and_lawful_projection_is_silent(
     tmp_path: Path,
 ) -> None:
-    (tmp_path / "binding_state.py").write_text(
-        """
+    (tmp_path / "binding_state.py").write_text("""
 class LoopProjectedBinding:
     completed_faces: tuple[LoopProjectedCompletedFace, ...]
 
 BindingState = Node | UnboundBinding | GuardedBinding | LoopProjectedBinding
-"""
-    )
-    (tmp_path / "loop_recurrence.py").write_text(
-        """
+""")
+    (tmp_path / "loop_recurrence.py").write_text("""
 def project_loop_recurrence(loop, scope, trace_builder):
     construction = LoopConstructionV1(...)
     return LoopProjectedBinding(construction.target.target_cid, completed_faces)
-"""
-    )
+""")
 
     findings = scan_guarded_loop_recurrence(tmp_path)
     summary = summarize_guarded_loop_recurrence(findings)
@@ -101,13 +91,11 @@ def project_loop_recurrence(loop, scope, trace_builder):
 
 
 def test_instrument_names_legacy_single_generator_comprehension(tmp_path: Path):
-    (tmp_path / "comprehension_sugar.py").write_text(
-        """
+    (tmp_path / "comprehension_sugar.py").write_text("""
 class ComprehensionSugar:
     target: str
     iterable: object
-"""
-    )
+""")
 
     findings = scan_guarded_loop_recurrence(tmp_path)
 
@@ -124,6 +112,4 @@ def test_current_tree_measurement_is_stable_zero() -> None:
     findings = scan_guarded_loop_recurrence(root)
 
     assert findings == ()
-    assert summarize_guarded_loop_recurrence(findings)[
-        "R_guarded_loop_recurrence"
-    ] == 0
+    assert summarize_guarded_loop_recurrence(findings)["R_guarded_loop_recurrence"] == 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_acceptance_fixture.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_acceptance_fixture.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pytest
 
-
 FIXTURES = Path(__file__).parent / "fixtures" / "loop_construction"
 EXPECTED_CASES = {
     "continue_backedge",
@@ -53,8 +52,7 @@ def test_truth_set_is_complete_and_structural():
     }
     assert all(required_case_fields <= case.keys() for case in manifest["cases"])
     assert all(
-        case["truthfulVerdict"] != case["lyingVerdict"]
-        for case in manifest["cases"]
+        case["truthfulVerdict"] != case["lyingVerdict"] for case in manifest["cases"]
     )
     assert all(
         case["lyingDisposition"] in {"reject", "typed-loud"}

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_wire.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_wire.py
@@ -35,7 +35,11 @@ def _unknown_operation(graph):
 
 
 def _mutate_latch(graph, **changes):
-    latch = next(record for record in graph["records"] if record["kind"] == "loop-latch-obligation")
+    latch = next(
+        record
+        for record in graph["records"]
+        if record["kind"] == "loop-latch-obligation"
+    )
     old_cid = latch["latchObligationCid"]
     latch.update(changes)
     _reseal(latch, "latchObligationCid")
@@ -287,7 +291,9 @@ def test_binding_state_is_content_addressed_and_ordered():
     decoded = decode_binding_state_v1(state)
     assert decoded.state_cid == state["stateCid"]
     stale = copy.deepcopy(state)
-    stale["entries"][0]["state"]["testimony"]["semanticValueCid"] = _cid({"different": 1})
+    stale["entries"][0]["state"]["testimony"]["semanticValueCid"] = _cid(
+        {"different": 1}
+    )
     _reseal(
         stale["entries"][0]["state"]["testimony"],
         "constructedValueTestimonyCid",
@@ -323,10 +329,19 @@ def test_loop_graph_round_trips_and_validates_every_child():
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [
-        (lambda graph: graph["root"].update(loopConstructionCid=_cid({"stale": 1})), "loopConstructionCid mismatch"),
+        (
+            lambda graph: graph["root"].update(loopConstructionCid=_cid({"stale": 1})),
+            "loopConstructionCid mismatch",
+        ),
         (_unknown_operation, "unknown loop record kind"),
-        (lambda graph: _mutate_latch(graph, operationKind="FutureLatch"), "unknown latch operation"),
-        (lambda graph: _mutate_latch(graph, inputStateCid=_cid({"missing": 1})), "missing binding-state"),
+        (
+            lambda graph: _mutate_latch(graph, operationKind="FutureLatch"),
+            "unknown latch operation",
+        ),
+        (
+            lambda graph: _mutate_latch(graph, inputStateCid=_cid({"missing": 1})),
+            "missing binding-state",
+        ),
     ],
 )
 def test_malformed_or_unknown_loop_wire_is_loud(mutation, message):

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -20,7 +20,6 @@ from sugar_source_tree.backend import Child, Children, Leaf, materialize
 from sugar_source_tree.shadow import ShadowNode, _handle_of
 from sugar_source_tree.tree import SourceFile
 
-
 FIXTURES = Path(__file__).parent / "fixtures" / "object_field_flow"
 MATRIX = json.loads((FIXTURES / "verdict_matrix.json").read_text())
 POSITIVE_IDS = {
@@ -31,11 +30,21 @@ POSITIVE_IDS = {
     "distinct-version-flow",
 }
 LOUD_IDS = {"symbolic-receiver", "opaque-mutation", "opaque-alias"}
-FORBIDDEN_MECHANISM_CALLS = {"getattr", "setattr", "hasattr", "id", "type", "isinstance"}
+FORBIDDEN_MECHANISM_CALLS = {
+    "getattr",
+    "setattr",
+    "hasattr",
+    "id",
+    "type",
+    "isinstance",
+}
 
 
 def _functions(path: Path):
-    return {function.name: function for function in SourceFile(path_source(path)).functions()}
+    return {
+        function.name: function
+        for function in SourceFile(path_source(path)).functions()
+    }
 
 
 def _outcome_or_panic(path: Path, function_name: str):
@@ -155,11 +164,13 @@ def test_fixtures_are_renamed_structural_twins_without_name_or_vendor_authority(
     renamed = case["renamed"]
     if isinstance(canonical, dict):
         for verdict in ("truthful", "lying"):
-            assert _normalized_function(module, canonical[verdict]) == _normalized_function(
-                module, renamed[verdict]
-            )
+            assert _normalized_function(
+                module, canonical[verdict]
+            ) == _normalized_function(module, renamed[verdict])
     else:
-        assert _normalized_function(module, canonical) == _normalized_function(module, renamed)
+        assert _normalized_function(module, canonical) == _normalized_function(
+            module, renamed
+        )
 
 
 @pytest.mark.parametrize(
@@ -193,9 +204,7 @@ def _object_states(path: Path, function_name: str):
     substituted = function.substitute(
         {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(owner)}
     )
-    return [
-        node for node in substituted.walk() if node.kind == "ObjectPlaceStateV1"
-    ]
+    return [node for node in substituted.walk() if node.kind == "ObjectPlaceStateV1"]
 
 
 def test_object_and_field_versions_reresolve_and_distinct_objects_do_not_collide():
@@ -217,7 +226,9 @@ def test_object_and_field_versions_reresolve_and_distinct_objects_do_not_collide
 def test_a_type_name_does_not_admit_a_lying_object_identity():
     state = _object_states(FIXTURES / "store_then_read.py", "truthful")[0]
     forged = _forge_state(state, object_identity_cid="blake3-512:stale")
-    with pytest.raises(BindingProvenanceGap, match="object place identity CID mismatch"):
+    with pytest.raises(
+        BindingProvenanceGap, match="object place identity CID mismatch"
+    ):
         forged.validate_identity()
 
 
@@ -308,7 +319,11 @@ def test_opaque_call_invalidates_only_the_exposed_object(
     )
     function = _functions(path)["boundary"]
     substituted = function.substitute(
-        {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(function.fragment.seal().cid)}
+        {
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(
+                function.fragment.seal().cid
+            )
+        }
     )
     returned = next(node for node in substituted.walk() if node.kind == "Return")
     assert returned.value.kind == "ConstructedValueProjectionV1"
@@ -323,7 +338,11 @@ def test_opaque_result_mints_occurrence_identity_without_fields():
     path = FIXTURES / "opaque_alias.py"
     function = _functions(path)["read_through_opaque_alias"]
     substituted = function.substitute(
-        {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(function.fragment.seal().cid)}
+        {
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(
+                function.fragment.seal().cid
+            )
+        }
     )
     states = [node for node in substituted.walk() if node.kind == "OpaqueObjectStateV1"]
     assert states
@@ -352,9 +371,7 @@ def test_unknown_place_selector_kind_is_typed_loud():
 def test_custom_dispatch_stays_loud_without_constructed_behavior(tmp_path, member):
     path = tmp_path / "dispatch.py"
     path.write_text(
-        "class Vessel:\n    "
-        + member
-        + "\n\ndef boundary():\n    item = Vessel()\n"
+        "class Vessel:\n    " + member + "\n\ndef boundary():\n    item = Vessel()\n"
         "    item.payload = 7\n    return item.payload\n"
     )
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
@@ -500,10 +517,7 @@ def test_unhashable_subscript_key_stays_typed_loud(tmp_path):
 def test_out_of_range_list_store_stays_loud(tmp_path):
     path = tmp_path / "out_of_range_list.py"
     path.write_text(
-        "def boundary():\n"
-        "    item = []\n"
-        "    item[0] = 7\n"
-        "    return item[0]\n"
+        "def boundary():\n" "    item = []\n" "    item[0] = 7\n" "    return item[0]\n"
     )
     assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
 
@@ -592,7 +606,10 @@ def _forge_state(state, **overrides):
                 ("version_records", Leaf(values["version_records"])),
                 ("prior_version_cids", Leaf(values["prior_version_cids"])),
                 ("store_occurrence_cids", Leaf(values["store_occurrence_cids"])),
-                ("invalidated_by_opaque_call", Leaf(values["invalidated_by_opaque_call"])),
+                (
+                    "invalidated_by_opaque_call",
+                    Leaf(values["invalidated_by_opaque_call"]),
+                ),
             ),
         ),
         state.reporter,

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py
@@ -11,11 +11,14 @@ import time
 
 import pytest
 
-
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from pandas_census_checkpoint import Checkpoint, CheckpointError, run_pending  # noqa: E402
+from pandas_census_checkpoint import (
+    Checkpoint,
+    CheckpointError,
+    run_pending,
+)  # noqa: E402
 
 
 def test_killed_run_resumes_without_redoing_completed_file(tmp_path: Path) -> None:
@@ -24,8 +27,7 @@ def test_killed_run_resumes_without_redoing_completed_file(tmp_path: Path) -> No
     blocked = tmp_path / "blocked"
     driver = tmp_path / "driver.py"
     driver.write_text(
-        textwrap.dedent(
-            f"""
+        textwrap.dedent(f"""
             import json
             from pathlib import Path
             import sys
@@ -52,8 +54,7 @@ def test_killed_run_resumes_without_redoing_completed_file(tmp_path: Path) -> No
                 return {{"category": "completed"}}
 
             run_pending(checkpoint, worker, workers=1)
-            """
-        ),
+            """),
         encoding="utf-8",
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
@@ -103,9 +103,7 @@ def test_different_corpus_identity_cannot_reconcile() -> None:
 
 def test_expected_denominator_and_exact_file_rows_are_required() -> None:
     reports = {name: _floor(name) for name in RECONCILE.FLOORS}
-    reports["silent"]["rows"] = [
-        {"file": "renamed/other.py", "category": "completed"}
-    ]
+    reports["silent"]["rows"] = [{"file": "renamed/other.py", "category": "completed"}]
 
     result = RECONCILE.reconcile(reports, expected_files=1415)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -8,7 +8,6 @@ import pytest
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
-
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 
 
@@ -61,9 +60,7 @@ def test_unresolved_with_is_typed_gap_on_enum_path(tmp_path: Path) -> None:
     module = _load("control_effect_recensus")
     path = tmp_path / "consumer.py"
     path.write_text(
-        "def use_resource(manager):\n"
-        "    with manager:\n"
-        "        pass\n",
+        "def use_resource(manager):\n" "    with manager:\n" "        pass\n",
         encoding="utf-8",
     )
     row = module._measure_file(path, relative="consumer.py")

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
@@ -29,9 +29,7 @@ def test_source_constructed_false_exit_restores_original_effect():
         ExitSet.completed(TermValue(False)), site="renamed-fixture"
     )
 
-    assert routed.exits == (
-        Halted(true_guard(), original, TermValue("before-exit")),
-    )
+    assert routed.exits == (Halted(true_guard(), original, TermValue("before-exit")),)
 
 
 def test_source_constructed_exit_runs_on_non_exception_transfer():

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -43,9 +43,7 @@ def test_supervised_scan_completes_clean_and_typed_gap(tmp_path: Path) -> None:
     assert rows[1].worker_restarts == 0
 
 
-def test_supervised_timeout_restarts_and_continues(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_supervised_timeout_restarts_and_continues(tmp_path: Path, monkeypatch) -> None:
     # Construction does not execute body sleep(); plant hangs the worker.
     sleeper = _write(tmp_path, "sleep.py", "def a():\n    return 1\n")
     after = _write(tmp_path, "after.py", "def a(z):\n    return z\n")

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/ast_template.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/ast_template.py
@@ -5,6 +5,7 @@ from typing import Any
 
 Json = Any
 
+
 class UnsupportedStatementGrammar(RuntimeError):
     pass
 
@@ -41,8 +42,12 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
-if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+AST_STATEMENT_TYPES = frozenset(
+    getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES
+)
+if {
+    statement.__name__ for statement in AST_STATEMENT_TYPES
+} != AST_STATEMENT_TYPE_NAMES:
     raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
@@ -12,6 +12,8 @@ from .ast_template import function_body_template, function_param_names
 from .canonical import blake3_512_of, cid_of_json, template_cid_of_json
 
 Json = Any
+
+
 class UnsupportedStatementGrammar(RuntimeError):
     pass
 
@@ -48,8 +50,12 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
-if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+AST_STATEMENT_TYPES = frozenset(
+    getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES
+)
+if {
+    statement.__name__ for statement in AST_STATEMENT_TYPES
+} != AST_STATEMENT_TYPE_NAMES:
     raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
 CONTRACT_COMMENT_KIND = "sugar-contract-comment-sugar"

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -535,7 +535,3 @@ def _cannot_raise_during_module_init(statement: ast.AST) -> bool:
         or any(parameter.annotation is not None for parameter in parameters)
         or getattr(statement, "type_params", ())
     )
-
-
-
-

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py
@@ -134,9 +134,7 @@ def harvest_source(source: str, source_path: str) -> HarvestResult:
     return result
 
 
-def _call_edges(
-    stmt: Assert, source_path: str, *, source_contract: str
-) -> list[Json]:
+def _call_edges(stmt: Assert, source_path: str, *, source_contract: str) -> list[Json]:
     """Project the call coordinates already admitted by ``_lift_assert``.
 
     This runs only after the assertion translated successfully, so an edge can
@@ -181,9 +179,7 @@ def _lift_assert(stmt: Assert) -> Json:
 
     op = _CMP.get(test.ops[0].kind)
     if op is None:
-        raise _Unsupported(
-            f"comparison op {test.ops[0].kind} not in whitelist"
-        )
+        raise _Unsupported(f"comparison op {test.ops[0].kind} not in whitelist")
     return _comparison(op, lhs, rhs)
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
@@ -33,6 +33,8 @@ from .ir import (
 )
 
 PANIC_FREEDOM_EFFECT_KIND = "panic-freedom"
+
+
 class UnsupportedStatementGrammar(RuntimeError):
     pass
 
@@ -69,8 +71,12 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
-if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+AST_STATEMENT_TYPES = frozenset(
+    getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES
+)
+if {
+    statement.__name__ for statement in AST_STATEMENT_TYPES
+} != AST_STATEMENT_TYPE_NAMES:
     raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site"
 CLASS_SHAPE_ASSUMPTIONS = [
@@ -557,7 +563,9 @@ class _MethodAttributeScanner(typed.TypedNodeWalker):
         finally:
             self._conditional_depth -= 1
 
-    def _record_assignment_target(self, target: typed.AST, source_node: typed.AST) -> None:
+    def _record_assignment_target(
+        self, target: typed.AST, source_node: typed.AST
+    ) -> None:
         attr = self._instance_attr_name(target)
         if attr is None:
             self.visit(target)
@@ -2455,7 +2463,9 @@ def _method_kind(node: typed.FunctionDef | typed.AsyncFunctionDef) -> str:
     return "instance"
 
 
-def _method_has_unknown_decorator(node: typed.FunctionDef | typed.AsyncFunctionDef) -> bool:
+def _method_has_unknown_decorator(
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
+) -> bool:
     for decorator in node.decorators:
         if _is_transparent_decorator(decorator):
             continue
@@ -2465,7 +2475,9 @@ def _method_has_unknown_decorator(node: typed.FunctionDef | typed.AsyncFunctionD
     return False
 
 
-def _first_parameter_name(node: typed.FunctionDef | typed.AsyncFunctionDef) -> str | None:
+def _first_parameter_name(
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
+) -> str | None:
     positional = [*node.args.posonlyargs, *node.args.args]
     if not positional:
         return None
@@ -2484,7 +2496,9 @@ def _slot_entries(stmt: typed.stmt) -> tuple[list[Json], bool]:
     if not isinstance(stmt, typed.Assign) and type(stmt) in AST_STATEMENT_TYPES:
         return [], False
     if not isinstance(stmt, typed.Assign):
-        raise _UnsupportedSyntax(stmt, f"unknown statement variant: {type(stmt).__name__}")
+        raise _UnsupportedSyntax(
+            stmt, f"unknown statement variant: {type(stmt).__name__}"
+        )
     if not any(
         isinstance(target, typed.Name) and target.id == "__slots__"
         for target in stmt.targets
@@ -2731,7 +2745,9 @@ def _literal_default(
             return ellipsis_const()
         if value is None:
             return none_const()
-    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(
+        node.op, (typed.UAdd, typed.USub)
+    ):
         operand = node.operand
         if isinstance(operand, typed.Constant) and type(operand.value) is int:
             value = operand.value
@@ -2937,7 +2953,9 @@ def _function_locals(fn: typed.FunctionDef, formals: list[str]) -> set[str]:
     return set(formals) | collector.names
 
 
-def _import_bound_name(node: typed.Import | typed.ImportFrom, alias: typed.alias) -> str:
+def _import_bound_name(
+    node: typed.Import | typed.ImportFrom, alias: typed.alias
+) -> str:
     if alias.name == "*":
         raise _UnsupportedSyntax(node, "star imports are refused")
     if alias.asname:
@@ -3070,7 +3088,9 @@ def _lift_guard_membership_compare(
         return None
     equalities = [_atomic("=", [left, option]) for option in options]
     membership = _fold_connective("or", equalities)
-    return _negate_formula(membership) if isinstance(op_node, typed.NotIn) else membership
+    return (
+        _negate_formula(membership) if isinstance(op_node, typed.NotIn) else membership
+    )
 
 
 def _lift_guard_literal_options(node: typed.expr) -> list[Json] | None:
@@ -3115,7 +3135,9 @@ def _lift_guard_term(node: typed.expr) -> Json | None:
                 return None
             return ctor("python:len", operand)
         return None
-    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(
+        node.op, (typed.UAdd, typed.USub)
+    ):
         operand = node.operand
         if isinstance(operand, typed.Constant) and type(operand.value) is int:
             value = operand.value
@@ -3199,7 +3221,9 @@ def _negate_formula(formula: Json) -> Json:
 def _module_global_names(tree: typed.Module) -> set[str]:
     names: set[str] = set()
     for stmt in tree.body:
-        if isinstance(stmt, (typed.FunctionDef, typed.AsyncFunctionDef, typed.ClassDef)):
+        if isinstance(
+            stmt, (typed.FunctionDef, typed.AsyncFunctionDef, typed.ClassDef)
+        ):
             names.add(stmt.name)
         elif isinstance(stmt, typed.Assign):
             for target in stmt.targets:
@@ -3366,7 +3390,9 @@ def _is_type_argument_expr(node: typed.expr | typed.slice_) -> bool:
 
 def _callee_has_subscript_receiver(node: typed.expr) -> bool:
     if isinstance(node, typed.Attribute):
-        return any(isinstance(child, typed.Subscript) for child in typed.walk(node.value))
+        return any(
+            isinstance(child, typed.Subscript) for child in typed.walk(node.value)
+        )
     return False
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -484,6 +484,3 @@ def importlib_library_dir(library_tag: str) -> str | None:
         return str(Path(next(iter(locations))))
     origin = getattr(spec, "origin", None)
     return str(Path(origin).parent) if origin else None
-
-
-

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/typed_node_api.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/typed_node_api.py
@@ -141,9 +141,7 @@ def walk(node: AST):
 
 def parse(source: str, *, filename: str) -> Module:
     """Materialize one authenticated typed module through the sole adapter."""
-    return SourceFile(
-        (source, filename, blake3_512_of(source.encode("utf-8")))
-    ).root
+    return SourceFile((source, filename, blake3_512_of(source.encode("utf-8")))).root
 
 
 def iter_child_nodes(node: AST):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -32,6 +32,8 @@ from .ir import (
 VALUE_PIN_BOUNDARY_KIND = "value-pin-boundary"
 ENUM_PIN_BOUNDARY_KIND = "enum-pin-boundary"
 FINAL_CONFESSION = "typing.Final"
+
+
 class UnsupportedStatementGrammar(RuntimeError):
     pass
 
@@ -68,8 +70,12 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
-if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+AST_STATEMENT_TYPES = frozenset(
+    getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES
+)
+if {
+    statement.__name__ for statement in AST_STATEMENT_TYPES
+} != AST_STATEMENT_TYPE_NAMES:
     raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 
 # Scope boundaries: bindings inside these do not bind module names.
@@ -86,7 +92,9 @@ _SCOPE_BOUNDARY_NODES = (
     typed.GeneratorExp,
 )
 
-_TRY_NODES: tuple = (typed.Try, typed.TryStar) if hasattr(typed, "TryStar") else (typed.Try,)
+_TRY_NODES: tuple = (
+    (typed.Try, typed.TryStar) if hasattr(typed, "TryStar") else (typed.Try,)
+)
 _TYPE_ALIAS_NODE = getattr(typed, "TypeAlias", None)
 
 
@@ -500,7 +508,9 @@ def _is_final_annotation(annotation: typed.expr) -> bool:
 def _is_literal_shaped(node: typed.expr) -> bool:
     if isinstance(node, typed.Constant):
         return True
-    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(
+        node.op, (typed.UAdd, typed.USub)
+    ):
         return isinstance(node.operand, typed.Constant)
     if isinstance(node, (typed.Tuple, typed.List, typed.Set)):
         return all(_is_literal_shaped(element) for element in node.elts)
@@ -545,7 +555,9 @@ def _render_value_term(node: typed.expr) -> Json:
         if value is None:
             return none_const()
         raise _NotAdmissible(f"no IR term shape for {type(value).__name__} constants")
-    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(
+        node.op, (typed.UAdd, typed.USub)
+    ):
         operand = node.operand
         if isinstance(operand, typed.Constant) and type(operand.value) is int:
             value = operand.value
@@ -768,12 +780,20 @@ _DECLARED_NONBINDING_STMT = frozenset(
     )
 )
 
-_BINDING_HANDLED_PATTERN = frozenset((typed.MatchAs, typed.MatchStar, typed.MatchMapping))
+_BINDING_HANDLED_PATTERN = frozenset(
+    (typed.MatchAs, typed.MatchStar, typed.MatchMapping)
+)
 
 _DECLARED_NONBINDING_PATTERN = frozenset(
     # Children are recursed generically in _match_pattern_bindings via
     # iter_child_nodes; these kinds carry no name binding of their own.
-    (typed.MatchValue, typed.MatchSingleton, typed.MatchSequence, typed.MatchClass, typed.MatchOr)
+    (
+        typed.MatchValue,
+        typed.MatchSingleton,
+        typed.MatchSequence,
+        typed.MatchClass,
+        typed.MatchOr,
+    )
 )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_construction_invariant_drains.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_construction_invariant_drains.py
@@ -104,7 +104,9 @@ def test_decorator_spelling_never_confers_transparency_or_stub_authority() -> No
 
     result = lifter.lift_source(source, "spelling_is_not_authority.py")
 
-    refused = {row["function"] for row in result.refusals if row["kind"] == "decorator-refused"}
+    refused = {
+        row["function"] for row in result.refusals if row["kind"] == "decorator-refused"
+    }
     assert any(name and name.endswith(".f") for name in refused)
     assert any(name and name.endswith(".g") for name in refused)
     assert not any(
@@ -113,7 +115,9 @@ def test_decorator_spelling_never_confers_transparency_or_stub_authority() -> No
 
 
 def test_import_alias_does_not_turn_external_default_into_a_literal() -> None:
-    source = "from numpy import nan as renamed\ndef f(value=renamed):\n    return value\n"
+    source = (
+        "from numpy import nan as renamed\ndef f(value=renamed):\n    return value\n"
+    )
 
     result = lifter.lift_source(source, "aliased_external_default.py")
 

--- a/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
@@ -84,9 +84,7 @@ def test_source_lines_matches_parser_split_including_form_feed() -> None:
 def test_public_source_tables_module_has_no_foreign_ast_import() -> None:
     """Construction currency: line tables never import stdlib ast."""
     text = (
-        __import__("pathlib")
-        .Path(source_tables.__file__)
-        .read_text(encoding="utf-8")
+        __import__("pathlib").Path(source_tables.__file__).read_text(encoding="utf-8")
     )
     tree = ast.parse(text)
     for node in ast.walk(tree):

--- a/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
@@ -637,13 +637,10 @@ def test_leaf_harvester_uses_typed_source_tree_for_renamed_call():
 
     assert not hasattr(leaf_assertions, "ast")
     result = leaf_assertions.harvest_source(
-        "def test_arbitrary():\n"
-        "    assert renamed_operation(3) == 7\n",
+        "def test_arbitrary():\n" "    assert renamed_operation(3) == 7\n",
         "renamed_fixture.py",
     )
-    assert [edge["targetSymbol"] for edge in result.call_edges] == [
-        "renamed_operation"
-    ]
+    assert [edge["targetSymbol"] for edge in result.call_edges] == ["renamed_operation"]
     assert result.diagnostics == []
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -43,7 +43,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from .nodes import ControlConstructionContextV1, Node, SourceUnit, Typeable, resolve_kind
+from .nodes import (
+    ControlConstructionContextV1,
+    Node,
+    SourceUnit,
+    Typeable,
+    resolve_kind,
+)
 from .operators import Operator
 from .reporter import NULL_REPORTER, AuditReporter
 from .spans import Span
@@ -109,7 +115,11 @@ class MaybeChild:
         reporter: AuditReporter = NULL_REPORTER,
         control_context: ControlConstructionContextV1 | None = None,
     ) -> Optional[Node]:
-        return None if self.handle is None else materialize(unit, self.handle, reporter, control_context)
+        return (
+            None
+            if self.handle is None
+            else materialize(unit, self.handle, reporter, control_context)
+        )
 
 
 @dataclass(frozen=True)
@@ -124,7 +134,9 @@ class Children:
         reporter: AuditReporter = NULL_REPORTER,
         control_context: ControlConstructionContextV1 | None = None,
     ) -> Tuple[Node, ...]:
-        return tuple(materialize(unit, h, reporter, control_context) for h in self.handles)
+        return tuple(
+            materialize(unit, h, reporter, control_context) for h in self.handles
+        )
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -90,12 +90,19 @@ class BindingCoordinateV1:
         _cid(raw["scopeOwnerCid"], "scopeOwnerCid")
         site = _decode_source_memento(raw["bindingSite"])
         path = raw["projectionPath"]
-        if not isinstance(path, list) or not path or not all(
-            isinstance(part, (str, int)) and not isinstance(part, bool) for part in path
+        if (
+            not isinstance(path, list)
+            or not path
+            or not all(
+                isinstance(part, (str, int)) and not isinstance(part, bool)
+                for part in path
+            )
         ):
             raise BindingProvenanceGap("malformed projectionPath")
         observed = _cid(raw["bindingCoordinateCid"], "bindingCoordinateCid")
-        preimage = {key: value for key, value in raw.items() if key != "bindingCoordinateCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "bindingCoordinateCid"
+        }
         if cid_of_json(preimage) != observed:
             raise BindingProvenanceGap("coordinate CID mismatch")
         return cls(raw["scopeOwnerCid"], site, tuple(path), observed)
@@ -205,7 +212,9 @@ class BindingEntryV1:
     @classmethod
     def decode(cls, raw: object) -> "BindingEntryV1":
         raw = _exact(raw, {"coordinate", "state"}, "BindingEntryV1")
-        return cls(BindingCoordinateV1.decode(raw["coordinate"]), _decode_state(raw["state"]))
+        return cls(
+            BindingCoordinateV1.decode(raw["coordinate"]), _decode_state(raw["state"])
+        )
 
 
 @dataclass(frozen=True)
@@ -305,7 +314,9 @@ class SubstitutionTraceV1:
         _cid(raw["scopeOwnerCid"], "scopeOwnerCid")
         if not isinstance(raw["records"], list):
             raise BindingProvenanceGap("trace records must be an array")
-        records = tuple(SubstitutionTraceRecordV1.decode(item) for item in raw["records"])
+        records = tuple(
+            SubstitutionTraceRecordV1.decode(item) for item in raw["records"]
+        )
         observed = _cid(raw["traceCid"], "traceCid")
         preimage = {key: value for key, value in raw.items() if key != "traceCid"}
         if cid_of_json(preimage) != observed:
@@ -316,7 +327,9 @@ class SubstitutionTraceV1:
 def _decode_source_memento(raw: object) -> dict[str, Any]:
     raw = _exact(raw, {"file", "span", "source_cid", "cid"}, "SourceMemento")
     span = _exact(raw["span"], {"start", "end"}, "SourceMemento span")
-    if not all(isinstance(span[key], int) and not isinstance(span[key], bool) for key in span):
+    if not all(
+        isinstance(span[key], int) and not isinstance(span[key], bool) for key in span
+    ):
         raise BindingProvenanceGap("source span offsets must be integers")
     _cid(raw["source_cid"], "source_cid")
     _cid(raw["cid"], "cid")
@@ -331,7 +344,10 @@ def _state_wire(state: BindingStateV1) -> dict[str, Any]:
             raise BindingProvenanceGap("constructed-value testimony unavailable")
         return {"kind": "bound", "testimony": state.testimony.wire()}
     if isinstance(state, UnboundBindingStateV1):
-        return {"kind": "unbound", "causeFragmentCid": _cid(state.cause_fragment_cid, "causeFragmentCid")}
+        return {
+            "kind": "unbound",
+            "causeFragmentCid": _cid(state.cause_fragment_cid, "causeFragmentCid"),
+        }
     if isinstance(state, GuardedBindingStateV1):
         return {
             "kind": "guarded",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -37,9 +37,7 @@ def mint_binding_coordinate_v1(
     binding_site: SourceFragment,
     projection_path: tuple[str | int, ...],
 ) -> BindingCoordinateV1:
-    return BindingCoordinateV1.mint(
-        scope_owner_cid, binding_site, projection_path
-    )
+    return BindingCoordinateV1.mint(scope_owner_cid, binding_site, projection_path)
 
 
 def mint_constructed_value_testimony_v1(
@@ -122,9 +120,7 @@ class LoopProjectedBinding:
     def __post_init__(self) -> None:
         _require_runtime_cid(self.target_cid, "targetCid")
         if not self.completed_faces:
-            raise BindingStateWireGap(
-                "loop projected binding requires completed faces"
-            )
+            raise BindingStateWireGap("loop projected binding requires completed faces")
         if any(face.target_cid != self.target_cid for face in self.completed_faces):
             raise BindingStateWireGap("loop projected binding target mismatch")
 
@@ -162,9 +158,7 @@ class BindingEntryV1:
         from sugar_source_tree.nodes import Node
 
         if not isinstance(self.state, Node):
-            raise BindingStateWireGap(
-                "binding state is not a constructed bound value"
-            )
+            raise BindingStateWireGap("binding state is not a constructed bound value")
         if self.constructed_value_testimony is None:
             raise BindingStateWireGap("constructed-value testimony unavailable")
         return self.constructed_value_testimony
@@ -431,8 +425,7 @@ def _seal_snapshot(
 ) -> tuple[tuple[str, SealedBindingEntryV1], ...]:
     testified = _testify_snapshot(snapshot, testimony_source)
     return tuple(
-        (name, SealedBindingEntryV1.decode(entry.wire()))
-        for name, entry in testified
+        (name, SealedBindingEntryV1.decode(entry.wire())) for name, entry in testified
     )
 
 
@@ -514,9 +507,9 @@ def _backend_node_preimage(ref: object) -> dict[str, Any]:
             value = {"child": _backend_node_preimage(slot.handle)}
         elif isinstance(slot, MaybeChild):
             value = {
-                "maybeChild": None
-                if slot.handle is None
-                else _backend_node_preimage(slot.handle)
+                "maybeChild": (
+                    None if slot.handle is None else _backend_node_preimage(slot.handle)
+                )
             }
         elif isinstance(slot, Children):
             value = {
@@ -610,7 +603,7 @@ def _snapshot(scope: BindingMap) -> tuple[tuple[str, BindingEntryV1], ...]:
 
 
 def _snapshot_preimage(
-    snapshot: tuple[tuple[str, BindingEntryV1], ...]
+    snapshot: tuple[tuple[str, BindingEntryV1], ...],
 ) -> list[dict[str, Any]]:
     del_names = []
     for _name, entry in snapshot:
@@ -627,9 +620,7 @@ def _snapshot_preimage(
             # yet. They remain present in the in-memory snapshot but cannot mint
             # a state CID; callers that need wire admission must stay loud.
             cell = {"kind": "unserializable"}
-        del_names.append(
-            {"bindingCoordinateCid": entry.coordinate.cid, "cell": cell}
-        )
+        del_names.append({"bindingCoordinateCid": entry.coordinate.cid, "cell": cell})
     return del_names
 
 
@@ -650,9 +641,7 @@ def seal_binding_state_v1(
         if isinstance(entry.sealed_state, BoundBindingStateV1):
             testimony = entry.require_constructed_value_testimony()
             if cid_of_json(testimony.preimage) != testimony.cid:
-                raise BindingStateWireGap(
-                    "constructed-value testimony CID mismatch"
-                )
+                raise BindingStateWireGap("constructed-value testimony CID mismatch")
         entries.append(entry.wire())
     from sugar_lift_py_tests.loop_construction import seal_binding_state_v1 as seal
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -144,9 +144,7 @@ def _control_guards(statements, scope, outer=None):
             guard = branch_result_guard(
                 branch_result_slot(statement.test), statement.test.fragment
             )
-            b, c, h = _control_guards(
-                statement.body, current, _combine(outer, guard)
-            )
+            b, c, h = _control_guards(statement.body, current, _combine(outer, guard))
             breaks.extend(b)
             continues.extend(c)
             halted.extend(h)
@@ -262,22 +260,18 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
 
     target = loop.owned_loop_target.wire()
     target_cid = target["targetCid"]
-    true_guard = atomic(
-        "python.loop.reachable", [str_const(target_cid)]
-    )
-    break_guards, continue_guards, halted_specs = _control_guards(
-        loop.body, scope
-    )
+    true_guard = atomic("python.loop.reachable", [str_const(target_cid)])
+    break_guards, continue_guards, halted_specs = _control_guards(loop.body, scope)
     break_guard = _guard_union(break_guards, true_guard)
     continue_guard = _guard_union(continue_guards, true_guard)
 
     if isinstance(loop, For):
-        exhaustion_guard = atomic(
-            "python.loop.exhausted", [str_const(target_cid)]
-        )
+        exhaustion_guard = atomic("python.loop.exhausted", [str_const(target_cid)])
         operation_kind = "ForNext"
     else:
-        test_guard = branch_result_guard(branch_result_slot(loop.test), loop.test.fragment)
+        test_guard = branch_result_guard(
+            branch_result_slot(loop.test), loop.test.fragment
+        )
         exhaustion_guard = not_(test_guard)
         true_guard = test_guard
         operation_kind = "WhileTest"
@@ -304,8 +298,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         )
         state_record, runtime_snapshot = _sealed_state(projected_entries)
         if all(
-            prior["stateCid"] != state_record["stateCid"]
-            for prior in state_records
+            prior["stateCid"] != state_record["stateCid"] for prior in state_records
         ):
             state_records.append(state_record)
         runtime_states[state_record["stateCid"]] = runtime_snapshot
@@ -340,8 +333,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         )
         state_record, runtime_snapshot = _sealed_state(projected_entries)
         if all(
-            prior["stateCid"] != state_record["stateCid"]
-            for prior in state_records
+            prior["stateCid"] != state_record["stateCid"] for prior in state_records
         ):
             state_records.append(state_record)
         runtime_states[state_record["stateCid"]] = runtime_snapshot
@@ -369,80 +361,101 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     body_face = face_snapshots["BodyFallthrough"][0]
     records = [*state_records, *face_records, *outward_records]
     body_exit_cid = cid_of_json(
-        {"loopBodyExitSet": loop.body[0].fragment.seal().cid if loop.body else target_cid}
+        {
+            "loopBodyExitSet": (
+                loop.body[0].fragment.seal().cid if loop.body else target_cid
+            )
+        }
     )
 
     if isinstance(loop, For):
         binder = _record(
             {
-                "kind": "loop-binder-transform", "schemaVersion": "1",
-                "targetCid": target_cid, "inputStateCid": pre_state["stateCid"],
+                "kind": "loop-binder-transform",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "inputStateCid": pre_state["stateCid"],
                 "elementValueCid": cid_of_json({"iteratorElement": target_cid}),
                 "outputStateCid": pre_state["stateCid"],
                 "binderPatternConstructionCid": loop.target.fragment.seal().cid,
-            }, "binderTransformCid"
+            },
+            "binderTransformCid",
         )
         iterator = _record(
             {
-                "kind": "loop-iterator-testimony", "schemaVersion": "1",
+                "kind": "loop-iterator-testimony",
+                "schemaVersion": "1",
                 "targetCid": target_cid,
                 "iterableValueConstructionCid": loop.iter.fragment.seal().cid,
                 "iteratorConstructionCid": cid_of_json({"iterator": target_cid}),
                 "nextOperationCid": cid_of_json({"next": target_cid}),
                 "exhaustionOperationCid": cid_of_json({"exhaustion": target_cid}),
-            }, "iteratorTestimonyCid"
+            },
+            "iteratorTestimonyCid",
         )
         operation = _record(
             {
-                "kind": "for-operation", "schemaVersion": "1",
+                "kind": "for-operation",
+                "schemaVersion": "1",
                 "targetCid": target_cid,
                 "nativeLoopTermCid": cid_of_json({"native": "python:for"}),
                 "binderTransformCid": binder["binderTransformCid"],
                 "iteratorTestimonyCid": iterator["iteratorTestimonyCid"],
-            }, "operationCid"
+            },
+            "operationCid",
         )
         successor_cid = binder["binderTransformCid"]
         records.extend((binder, iterator, operation))
     else:
         test_transform = _record(
             {
-                "kind": "loop-test-transform", "schemaVersion": "1",
-                "targetCid": target_cid, "inputStateCid": pre_state["stateCid"],
+                "kind": "loop-test-transform",
+                "schemaVersion": "1",
+                "targetCid": target_cid,
+                "inputStateCid": pre_state["stateCid"],
                 "testValueConstructionCid": loop.test.fragment.seal().cid,
                 "trueGuardFormulaCid": _formula_cid(true_guard),
                 "falseGuardFormulaCid": _formula_cid(exhaustion_guard),
                 "haltedFaceCids": [],
-            }, "testTransformCid"
+            },
+            "testTransformCid",
         )
         operation = _record(
             {
-                "kind": "while-operation", "schemaVersion": "1",
+                "kind": "while-operation",
+                "schemaVersion": "1",
                 "targetCid": target_cid,
                 "nativeLoopTermCid": cid_of_json({"native": "python:while"}),
                 "testTransformCid": test_transform["testTransformCid"],
-            }, "operationCid"
+            },
+            "operationCid",
         )
         successor_cid = test_transform["testTransformCid"]
         records.extend((test_transform, operation))
 
     body = _record(
         {
-            "kind": "loop-body-transform", "schemaVersion": "1",
-            "targetCid": target_cid, "inputStateCid": pre_state["stateCid"],
+            "kind": "loop-body-transform",
+            "schemaVersion": "1",
+            "targetCid": target_cid,
+            "inputStateCid": pre_state["stateCid"],
             "binderTransformCid": successor_cid,
             "bodySourceFragmentCid": loop.fragment.seal().cid,
             "bodyExitTemplateCid": body_exit_cid,
-        }, "bodyTransformCid"
+        },
+        "bodyTransformCid",
     )
     latch = _record(
         {
-            "kind": "loop-latch-obligation", "schemaVersion": "1",
+            "kind": "loop-latch-obligation",
+            "schemaVersion": "1",
             "targetCid": target_cid,
             "inputCompletedFaceCid": body_face["completedFaceCid"],
             "inputStateCid": body_face["stateCid"],
             "operationKind": operation_kind,
             "successorTransformCid": successor_cid,
-        }, "latchObligationCid"
+        },
+        "latchObligationCid",
     )
     records.extend((body, latch))
 
@@ -450,13 +463,15 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     if continue_guard is not None:
         obligation = _record(
             {
-                "kind": "loop-continue-latch-obligation", "schemaVersion": "1",
+                "kind": "loop-continue-latch-obligation",
+                "schemaVersion": "1",
                 "targetCid": target_cid,
                 "continueEffectCid": cid_of_json({"continue": target_cid}),
                 "inputHaltedFaceCid": cid_of_json({"continueFace": target_cid}),
                 "inputStateCid": body_face["stateCid"],
                 "successorTransformCid": successor_cid,
-            }, "continueLatchObligationCid"
+            },
+            "continueLatchObligationCid",
         )
         records.append(obligation)
         continue_obligations.append(obligation["continueLatchObligationCid"])
@@ -466,12 +481,14 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         break_face = face_snapshots["BreakExit"][0]
         obligation = _record(
             {
-                "kind": "loop-break-exit-obligation", "schemaVersion": "1",
+                "kind": "loop-break-exit-obligation",
+                "schemaVersion": "1",
                 "targetCid": target_cid,
                 "breakEffectCid": cid_of_json({"break": target_cid}),
                 "inputHaltedFaceCid": cid_of_json({"breakFace": target_cid}),
                 "outputCompletedFaceCid": break_face["completedFaceCid"],
-            }, "breakExitObligationCid"
+            },
+            "breakExitObligationCid",
         )
         records.append(obligation)
         break_obligations.append(obligation["breakExitObligationCid"])
@@ -479,12 +496,14 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     exhaustion_face = face_snapshots["NormalExhaustion"][0]
     exhaustion = _record(
         {
-            "kind": "loop-exhaustion-exit-obligation", "schemaVersion": "1",
+            "kind": "loop-exhaustion-exit-obligation",
+            "schemaVersion": "1",
             "targetCid": target_cid,
             "operationTestimonyCid": operation["operationCid"],
             "inputStateCid": pre_state["stateCid"],
             "outputCompletedFaceCid": exhaustion_face["completedFaceCid"],
-        }, "exhaustionExitObligationCid"
+        },
+        "exhaustionExitObligationCid",
     )
     records.append(exhaustion)
 
@@ -511,10 +530,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             for name, pre_entry in zip(carried_names, pre_entries, strict=True)
         )
         else_state, else_runtime = _sealed_state(else_runtime)
-        if all(
-            prior["stateCid"] != else_state["stateCid"]
-            for prior in state_records
-        ):
+        if all(prior["stateCid"] != else_state["stateCid"] for prior in state_records):
             state_records.append(else_state)
             records.append(else_state)
         runtime_states[else_state["stateCid"]] = else_runtime
@@ -577,22 +593,27 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         for entry in pre_entries:
             post = _record(
                 {
-                    "kind": "loop-post-binding", "schemaVersion": "1",
+                    "kind": "loop-post-binding",
+                    "schemaVersion": "1",
                     "targetCid": target_cid,
                     "bindingCoordinateCid": entry.coordinate.cid,
                     "incomingStateCid": pre_state["stateCid"],
                     "completedFaceCid": face["completedFaceCid"],
                     "projectedStateCid": state_record["stateCid"],
-                }, "postBindingObligationCid"
+                },
+                "postBindingObligationCid",
             )
             records.append(post)
             post_records.append(post["postBindingObligationCid"])
 
     root = _record(
         {
-            "kind": "loop-construction", "schemaVersion": "1",
-            "target": target, "preStateCid": pre_state["stateCid"],
-            "operation": operation, "bodyTransformCid": body["bodyTransformCid"],
+            "kind": "loop-construction",
+            "schemaVersion": "1",
+            "target": target,
+            "preStateCid": pre_state["stateCid"],
+            "operation": operation,
+            "bodyTransformCid": body["bodyTransformCid"],
             "bodyExitTemplateCid": body_exit_cid,
             "latchObligationCids": [latch["latchObligationCid"]],
             "continueLatchObligationCids": continue_obligations,
@@ -603,7 +624,8 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             "completedFaceCids": [face["completedFaceCid"] for face in face_records],
             "outwardHaltedFaceCids": outward_face_cids,
             "postBindingObligationCids": post_records,
-        }, "loopConstructionCid"
+        },
+        "loopConstructionCid",
     )
     records = _conserve_unique_records(records)
     construction = decode_loop_construction_v1({"root": root, "records": records})

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
@@ -64,7 +64,9 @@ def project_loop_post_binding(
                 f"completed face {face.cid} has no authenticated runtime state"
             )
         matches = [
-            entry for entry in snapshot if entry.coordinate.cid == binding_coordinate.cid
+            entry
+            for entry in snapshot
+            if entry.coordinate.cid == binding_coordinate.cid
         ]
         if len(matches) != 1:
             raise BindingStateWireGap(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6786,9 +6786,7 @@ class ObjectPlaceStateV1(Expression):
             ),
             construction_testimony_cid=projected.construction_testimony.cid,
         )
-        return SubscriptFieldCoordinateV1.mint(
-            self.object_coordinate, key_coordinate
-        )
+        return SubscriptFieldCoordinateV1.mint(self.object_coordinate, key_coordinate)
 
     def with_subscript_store(self, key, value, occurrence):
         selector = self._subscript_coordinate(key)
@@ -6802,9 +6800,7 @@ class ObjectPlaceStateV1(Expression):
         if constructed is None:
             return None
         floor_value, testimony = constructed
-        projected = ConstructedValueProjectionV1.create(
-            value, floor_value, testimony
-        )
+        projected = ConstructedValueProjectionV1.create(value, floor_value, testimony)
         from .object_identity import (
             AttributeFieldCoordinateV1,
             AttributeFieldVersionV1,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
@@ -34,7 +34,9 @@ def _memento(raw: object, field: str) -> dict[str, Any]:
     span = _exact(raw["span"], {"start", "end"}, f"{field}.span")
     if not isinstance(raw["file"], str) or not raw["file"]:
         raise BindingProvenanceGap(f"malformed {field}.file")
-    if not all(isinstance(span[key], int) and not isinstance(span[key], bool) for key in span):
+    if not all(
+        isinstance(span[key], int) and not isinstance(span[key], bool) for key in span
+    ):
         raise BindingProvenanceGap(f"malformed {field}.span")
     if span["start"] < 0 or span["end"] < span["start"]:
         raise BindingProvenanceGap(f"malformed {field}.span")
@@ -75,23 +77,49 @@ class SourceObjectCoordinateV1:
         return {**self.preimage, "objectCoordinateCid": self.cid}
 
     @classmethod
-    def mint(cls, *, allocation_definition: SourceFragment, call_occurrence: SourceFragment,
-             construction_generation: int, source_cid: str, artifact_cid: str) -> "SourceObjectCoordinateV1":
+    def mint(
+        cls,
+        *,
+        allocation_definition: SourceFragment,
+        call_occurrence: SourceFragment,
+        construction_generation: int,
+        source_cid: str,
+        artifact_cid: str,
+    ) -> "SourceObjectCoordinateV1":
         preimage = {
-            "kind": "source-object-coordinate", "schemaVersion": "1",
+            "kind": "source-object-coordinate",
+            "schemaVersion": "1",
             "allocationDefinition": allocation_definition.seal().to_dict(),
             "callOccurrence": call_occurrence.seal().to_dict(),
             "constructionGeneration": _generation(construction_generation),
             "sourceCid": _cid(source_cid, "sourceCid"),
             "artifactCid": _cid(artifact_cid, "artifactCid"),
         }
-        return cls(preimage["allocationDefinition"], preimage["callOccurrence"], construction_generation,
-                   source_cid, artifact_cid, cid_of_json(preimage))
+        return cls(
+            preimage["allocationDefinition"],
+            preimage["callOccurrence"],
+            construction_generation,
+            source_cid,
+            artifact_cid,
+            cid_of_json(preimage),
+        )
 
     @classmethod
     def decode(cls, raw: object) -> "SourceObjectCoordinateV1":
-        raw = _exact(raw, {"kind", "schemaVersion", "allocationDefinition", "callOccurrence",
-                           "constructionGeneration", "sourceCid", "artifactCid", "objectCoordinateCid"}, cls.__name__)
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "allocationDefinition",
+                "callOccurrence",
+                "constructionGeneration",
+                "sourceCid",
+                "artifactCid",
+                "objectCoordinateCid",
+            },
+            cls.__name__,
+        )
         if raw["kind"] != "source-object-coordinate" or raw["schemaVersion"] != "1":
             raise BindingProvenanceGap("unsupported SourceObjectCoordinateV1")
         allocation = _memento(raw["allocationDefinition"], "allocationDefinition")
@@ -99,7 +127,9 @@ class SourceObjectCoordinateV1:
         generation = _generation(raw["constructionGeneration"])
         source = _cid(raw["sourceCid"], "sourceCid")
         artifact = _cid(raw["artifactCid"], "artifactCid")
-        preimage = {key: value for key, value in raw.items() if key != "objectCoordinateCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "objectCoordinateCid"
+        }
         cid = _checked(preimage, raw["objectCoordinateCid"], "object coordinate CID")
         return cls(allocation, occurrence, generation, source, artifact, cid)
 
@@ -114,33 +144,67 @@ class OpaqueObjectCoordinateV1:
 
     @property
     def preimage(self) -> dict[str, Any]:
-        return {"kind": "opaque-object-coordinate", "schemaVersion": "1",
-                "callOccurrence": self.call_occurrence, "constructionGeneration": self.construction_generation,
-                "sourceCid": self.source_cid, "artifactCid": self.artifact_cid}
+        return {
+            "kind": "opaque-object-coordinate",
+            "schemaVersion": "1",
+            "callOccurrence": self.call_occurrence,
+            "constructionGeneration": self.construction_generation,
+            "sourceCid": self.source_cid,
+            "artifactCid": self.artifact_cid,
+        }
 
     def wire(self) -> dict[str, Any]:
         return {**self.preimage, "objectCoordinateCid": self.cid}
 
     @classmethod
-    def mint(cls, *, call_occurrence: SourceFragment, construction_generation: int,
-             source_cid: str, artifact_cid: str) -> "OpaqueObjectCoordinateV1":
-        preimage = {"kind": "opaque-object-coordinate", "schemaVersion": "1",
-                    "callOccurrence": call_occurrence.seal().to_dict(),
-                    "constructionGeneration": _generation(construction_generation),
-                    "sourceCid": _cid(source_cid, "sourceCid"), "artifactCid": _cid(artifact_cid, "artifactCid")}
-        return cls(preimage["callOccurrence"], construction_generation, source_cid, artifact_cid, cid_of_json(preimage))
+    def mint(
+        cls,
+        *,
+        call_occurrence: SourceFragment,
+        construction_generation: int,
+        source_cid: str,
+        artifact_cid: str,
+    ) -> "OpaqueObjectCoordinateV1":
+        preimage = {
+            "kind": "opaque-object-coordinate",
+            "schemaVersion": "1",
+            "callOccurrence": call_occurrence.seal().to_dict(),
+            "constructionGeneration": _generation(construction_generation),
+            "sourceCid": _cid(source_cid, "sourceCid"),
+            "artifactCid": _cid(artifact_cid, "artifactCid"),
+        }
+        return cls(
+            preimage["callOccurrence"],
+            construction_generation,
+            source_cid,
+            artifact_cid,
+            cid_of_json(preimage),
+        )
 
     @classmethod
     def decode(cls, raw: object) -> "OpaqueObjectCoordinateV1":
-        raw = _exact(raw, {"kind", "schemaVersion", "callOccurrence", "constructionGeneration",
-                           "sourceCid", "artifactCid", "objectCoordinateCid"}, cls.__name__)
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "callOccurrence",
+                "constructionGeneration",
+                "sourceCid",
+                "artifactCid",
+                "objectCoordinateCid",
+            },
+            cls.__name__,
+        )
         if raw["kind"] != "opaque-object-coordinate" or raw["schemaVersion"] != "1":
             raise BindingProvenanceGap("unsupported OpaqueObjectCoordinateV1")
         occurrence = _memento(raw["callOccurrence"], "callOccurrence")
         generation = _generation(raw["constructionGeneration"])
         source = _cid(raw["sourceCid"], "sourceCid")
         artifact = _cid(raw["artifactCid"], "artifactCid")
-        preimage = {key: value for key, value in raw.items() if key != "objectCoordinateCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "objectCoordinateCid"
+        }
         cid = _checked(preimage, raw["objectCoordinateCid"], "object coordinate CID")
         return cls(occurrence, generation, source, artifact, cid)
 
@@ -166,32 +230,53 @@ class AttributeFieldCoordinateV1:
 
     @property
     def preimage(self) -> dict[str, Any]:
-        return {"kind": "attribute-field-coordinate", "schemaVersion": "1",
-                "objectCoordinate": self.object_coordinate.wire(),
-                "attributeName": self.attribute_name}
+        return {
+            "kind": "attribute-field-coordinate",
+            "schemaVersion": "1",
+            "objectCoordinate": self.object_coordinate.wire(),
+            "attributeName": self.attribute_name,
+        }
 
     def wire(self) -> dict[str, Any]:
         return {**self.preimage, "fieldCoordinateCid": self.cid}
 
     @classmethod
-    def mint(cls, owner: ObjectCoordinateV1, attribute_name: str) -> "AttributeFieldCoordinateV1":
+    def mint(
+        cls, owner: ObjectCoordinateV1, attribute_name: str
+    ) -> "AttributeFieldCoordinateV1":
         decode_object_coordinate_v1(owner.wire())
         if not isinstance(attribute_name, str) or not attribute_name.isidentifier():
             raise BindingProvenanceGap("attributeName must be one Python identifier")
-        preimage = {"kind": "attribute-field-coordinate", "schemaVersion": "1", "objectCoordinate": owner.wire(),
-                    "attributeName": attribute_name}
+        preimage = {
+            "kind": "attribute-field-coordinate",
+            "schemaVersion": "1",
+            "objectCoordinate": owner.wire(),
+            "attributeName": attribute_name,
+        }
         return cls(owner, attribute_name, cid_of_json(preimage))
 
     @classmethod
     def decode(cls, raw: object) -> "AttributeFieldCoordinateV1":
-        raw = _exact(raw, {"kind", "schemaVersion", "objectCoordinate", "attributeName", "fieldCoordinateCid"}, cls.__name__)
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "objectCoordinate",
+                "attributeName",
+                "fieldCoordinateCid",
+            },
+            cls.__name__,
+        )
         if raw["kind"] != "attribute-field-coordinate" or raw["schemaVersion"] != "1":
             raise BindingProvenanceGap("unsupported AttributeFieldCoordinateV1")
         owner = decode_object_coordinate_v1(raw["objectCoordinate"])
         attribute_name = raw["attributeName"]
         if not isinstance(attribute_name, str) or not attribute_name.isidentifier():
             raise BindingProvenanceGap("malformed attributeName")
-        preimage = {key: value for key, value in raw.items() if key != "fieldCoordinateCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "fieldCoordinateCid"
+        }
         cid = _checked(preimage, raw["fieldCoordinateCid"], "field coordinate CID")
         return cls(owner, attribute_name, cid)
 
@@ -221,9 +306,7 @@ class SubscriptKeyCoordinateV1:
         preimage = {
             "kind": "subscript-key-coordinate",
             "schemaVersion": "1",
-            "constructedValueCid": _cid(
-                constructed_value_cid, "constructedValueCid"
-            ),
+            "constructedValueCid": _cid(constructed_value_cid, "constructedValueCid"),
             "constructionTestimonyCid": _cid(
                 construction_testimony_cid, "constructionTestimonyCid"
             ),
@@ -250,10 +333,10 @@ class SubscriptKeyCoordinateV1:
         if raw["kind"] != "subscript-key-coordinate" or raw["schemaVersion"] != "1":
             raise BindingProvenanceGap("unsupported SubscriptKeyCoordinateV1")
         value = _cid(raw["constructedValueCid"], "constructedValueCid")
-        testimony = _cid(
-            raw["constructionTestimonyCid"], "constructionTestimonyCid"
-        )
-        preimage = {key: value for key, value in raw.items() if key != "keyCoordinateCid"}
+        testimony = _cid(raw["constructionTestimonyCid"], "constructionTestimonyCid")
+        preimage = {
+            key: value for key, value in raw.items() if key != "keyCoordinateCid"
+        }
         cid = _checked(preimage, raw["keyCoordinateCid"], "key coordinate CID")
         return cls(value, testimony, cid)
 
@@ -307,7 +390,9 @@ class SubscriptFieldCoordinateV1:
             raise BindingProvenanceGap("unsupported SubscriptFieldCoordinateV1")
         owner = decode_object_coordinate_v1(raw["objectCoordinate"])
         key_coordinate = SubscriptKeyCoordinateV1.decode(raw["keyCoordinate"])
-        preimage = {key: value for key, value in raw.items() if key != "fieldCoordinateCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "fieldCoordinateCid"
+        }
         cid = _checked(preimage, raw["fieldCoordinateCid"], "field coordinate CID")
         return cls(owner, key_coordinate, cid)
 
@@ -324,37 +409,76 @@ class AttributeFieldVersionV1:
 
     @property
     def preimage(self) -> dict[str, Any]:
-        return {"kind": "attribute-field-version", "schemaVersion": "1", "objectCoordinate": self.owner.wire(),
-                "fieldCoordinate": self.field.wire(), "storeOccurrence": self.store_occurrence,
-                "constructionGeneration": self.construction_generation,
-                "storedValueTestimonyCid": self.stored_value_testimony_cid,
-                "priorVersionCid": self.prior_version_cid}
+        return {
+            "kind": "attribute-field-version",
+            "schemaVersion": "1",
+            "objectCoordinate": self.owner.wire(),
+            "fieldCoordinate": self.field.wire(),
+            "storeOccurrence": self.store_occurrence,
+            "constructionGeneration": self.construction_generation,
+            "storedValueTestimonyCid": self.stored_value_testimony_cid,
+            "priorVersionCid": self.prior_version_cid,
+        }
 
     def wire(self) -> dict[str, Any]:
         return {**self.preimage, "fieldVersionCid": self.cid}
 
     @classmethod
-    def mint(cls, *, owner: ObjectCoordinateV1, field: AttributeFieldCoordinateV1,
-             store_occurrence: SourceFragment, construction_generation: int,
-             stored_value_testimony_cid: str, prior_version_cid: str | None) -> "AttributeFieldVersionV1":
+    def mint(
+        cls,
+        *,
+        owner: ObjectCoordinateV1,
+        field: AttributeFieldCoordinateV1,
+        store_occurrence: SourceFragment,
+        construction_generation: int,
+        stored_value_testimony_cid: str,
+        prior_version_cid: str | None,
+    ) -> "AttributeFieldVersionV1":
         decode_object_coordinate_v1(owner.wire())
         AttributeFieldCoordinateV1.decode(field.wire())
         if field.object_coordinate.cid != owner.cid:
             raise BindingProvenanceGap("field owner coordinate mismatch")
         if prior_version_cid is not None:
             _cid(prior_version_cid, "priorVersionCid")
-        preimage = {"kind": "attribute-field-version", "schemaVersion": "1", "objectCoordinate": owner.wire(),
-                    "fieldCoordinate": field.wire(), "storeOccurrence": store_occurrence.seal().to_dict(),
-                    "constructionGeneration": _generation(construction_generation),
-                    "storedValueTestimonyCid": _cid(stored_value_testimony_cid, "storedValueTestimonyCid"),
-                    "priorVersionCid": prior_version_cid}
-        return cls(owner, field, preimage["storeOccurrence"], construction_generation,
-                   stored_value_testimony_cid, prior_version_cid, cid_of_json(preimage))
+        preimage = {
+            "kind": "attribute-field-version",
+            "schemaVersion": "1",
+            "objectCoordinate": owner.wire(),
+            "fieldCoordinate": field.wire(),
+            "storeOccurrence": store_occurrence.seal().to_dict(),
+            "constructionGeneration": _generation(construction_generation),
+            "storedValueTestimonyCid": _cid(
+                stored_value_testimony_cid, "storedValueTestimonyCid"
+            ),
+            "priorVersionCid": prior_version_cid,
+        }
+        return cls(
+            owner,
+            field,
+            preimage["storeOccurrence"],
+            construction_generation,
+            stored_value_testimony_cid,
+            prior_version_cid,
+            cid_of_json(preimage),
+        )
 
     @classmethod
     def decode(cls, raw: object) -> "AttributeFieldVersionV1":
-        raw = _exact(raw, {"kind", "schemaVersion", "objectCoordinate", "fieldCoordinate", "storeOccurrence",
-                           "constructionGeneration", "storedValueTestimonyCid", "priorVersionCid", "fieldVersionCid"}, cls.__name__)
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "objectCoordinate",
+                "fieldCoordinate",
+                "storeOccurrence",
+                "constructionGeneration",
+                "storedValueTestimonyCid",
+                "priorVersionCid",
+                "fieldVersionCid",
+            },
+            cls.__name__,
+        )
         if raw["kind"] != "attribute-field-version" or raw["schemaVersion"] != "1":
             raise BindingProvenanceGap("unsupported AttributeFieldVersionV1")
         owner = decode_object_coordinate_v1(raw["objectCoordinate"])
@@ -367,7 +491,9 @@ class AttributeFieldVersionV1:
         prior = raw["priorVersionCid"]
         if prior is not None:
             prior = _cid(prior, "priorVersionCid")
-        preimage = {key: value for key, value in raw.items() if key != "fieldVersionCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "fieldVersionCid"
+        }
         cid = _checked(preimage, raw["fieldVersionCid"], "field version CID")
         return cls(owner, field, store, generation, stored, prior, cid)
 
@@ -466,6 +592,8 @@ class SubscriptFieldVersionV1:
         prior = raw["priorVersionCid"]
         if prior is not None:
             prior = _cid(prior, "priorVersionCid")
-        preimage = {key: value for key, value in raw.items() if key != "fieldVersionCid"}
+        preimage = {
+            key: value for key, value in raw.items() if key != "fieldVersionCid"
+        }
         cid = _checked(preimage, raw["fieldVersionCid"], "field version CID")
         return cls(owner, field, store, generation, stored, prior, cid)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/shadow.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/shadow.py
@@ -106,6 +106,4 @@ def rewrite(origin: Node, **children: object) -> Node:
     shadow = ShadowNode(desc.kind, desc.raw_span or origin.span, tuple(new_slots))
     # Same materialize door as source backends: shadow ref is another memoized
     # backend identity; field data is interned on the unit, shells are free.
-    return materialize(
-        origin.unit, shadow, origin.reporter, origin.control_context
-    )
+    return materialize(origin.unit, shadow, origin.reporter, origin.control_context)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -84,9 +84,7 @@ class SourceFile:
                     construction_context=construction_context,
                 )
             with reduction_span(sugar="BackendSelect", role="file", site=site):
-                self.backend = (
-                    backend if backend is not None else _default_backend()
-                )
+                self.backend = backend if backend is not None else _default_backend()
             # The reporter enters the whole tree here: the root carries it and
             # hands it to every child it resolves. An audit walk passes a
             # CollectingReporter; everyone else takes the do-nothing default.

--- a/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
@@ -53,7 +53,9 @@ def test_renamed_alias_has_the_same_single_binding_path():
         second["projected_value"].state.fragment.seal().cid
         == first["source_value"].state.fragment.seal().cid
     )
-    assert second["projected_value"].coordinate.cid != first["source_value"].coordinate.cid
+    assert (
+        second["projected_value"].coordinate.cid != first["source_value"].coordinate.cid
+    )
 
 
 def test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces():

--- a/implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py
@@ -81,9 +81,7 @@ def test_trace_round_trip_authenticates_every_preimage():
         assignments[0].value.fragment, cid_of_json({"value": 1})
     )
     entry = BindingEntryV1(coordinate, BoundBindingStateV1(testimony))
-    record = SubstitutionTraceRecordV1.mint(
-        assignments[0].fragment, (), (entry,)
-    )
+    record = SubstitutionTraceRecordV1.mint(assignments[0].fragment, (), (entry,))
     trace = SubstitutionTraceV1.mint(owner, (record,))
     assert SubstitutionTraceV1.decode(trace.wire()) == trace
 
@@ -93,6 +91,4 @@ def test_trace_round_trip_authenticates_every_preimage():
         SubstitutionTraceV1.decode(stale)
 
     with pytest.raises(BindingProvenanceGap, match="coordinate CID mismatch"):
-        BindingCoordinateV1.decode(
-            replace(coordinate, cid="blake3-512:stale").wire()
-        )
+        BindingCoordinateV1.decode(replace(coordinate, cid="blake3-512:stale").wire())

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -277,8 +277,7 @@ def test_nested_arm_composes_already_built_comprehension_kinds(
 
 def test_nested_comprehension_retains_inner_filtered_guard():
     term = _out(
-        "def A(xs, ys, keep):\n"
-        "    return [[y for y in ys if keep(y)] for x in xs]\n"
+        "def A(xs, ys, keep):\n" "    return [[y for y in ys if keep(y)] for x in xs]\n"
     )
     assert term.args[1].body.name == "py.listcomp"
     assert term.args[1].body.args[1].body.name == "python:loop.filter_guard"
@@ -373,9 +372,7 @@ def test_shadowed_range_is_not_unrolled_but_builds_symbolic_coordinate():
 
 
 def test_every_symbolic_filter_becomes_an_ordered_guard():
-    term = _out(
-        "def A(limit):\n" "    return [x for x in [0] if x > 0 if x > limit]\n"
-    )
+    term = _out("def A(limit):\n" "    return [x for x in [0] if x > 0 if x > limit]\n")
     first = term.args[1].body
     assert first.name == "python:loop.filter_guard"
     assert first.args[1].name == "python:loop.filter_guard"

--- a/implementations/python/sugar-source-tree/tests/test_formal_parameter_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_parameter_coordinate.py
@@ -27,7 +27,9 @@ def test_two_renamed_parameter_reads_share_one_authenticated_coordinate() -> Non
 
 
 def test_reassignment_replaces_formal_coordinate_for_later_reads() -> None:
-    function = _function("def transform(items):\n first = items\n items = 3\n return items\n")
+    function = _function(
+        "def transform(items):\n first = items\n items = 3\n return items\n"
+    )
     substituted = function.substitute({})
     refs = [node for node in substituted.walk() if node.kind == "FormalRef"]
     returns = [node for node in substituted.walk() if node.kind == "Return"]

--- a/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
@@ -103,9 +103,7 @@ def test_exceptional_exit_throws_into_machine_and_preserves_both_body_faces():
 
 
 def test_contextmanager_style_try_finally_resumes_cleanup_before_termination():
-    sugar = _with_sugar(
-        "    try:\n        yield 7\n    finally:\n        pass"
-    )
+    sugar = _with_sugar("    try:\n        yield 7\n    finally:\n        pass")
 
     outcome = sugar.desugar()
 

--- a/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_loop_recurrence.py
@@ -87,14 +87,16 @@ def test_break_and_exhaustion_faces_project_exact_runtime_states_by_coordinate()
     }
     runtime_states = {
         state_cid: (
-            break_entry
-            if state_cid
-            == next(
-                face.state_cid
-                for face in construction.completed_faces
-                if face.completion_kind == "BreakExit"
-            )
-            else exhaustion_entry,
+            (
+                break_entry
+                if state_cid
+                == next(
+                    face.state_cid
+                    for face in construction.completed_faces
+                    if face.completion_kind == "BreakExit"
+                )
+                else exhaustion_entry
+            ),
         )
         for state_cid in state_cids
     }
@@ -137,7 +139,9 @@ def test_projection_redecodes_and_rejects_a_spliced_public_dataclass():
     construction = _sample_construction()
     graph = copy.deepcopy(construction.wire_graph())
     face = next(
-        record for record in graph["records"] if record.get("kind") == "loop-completed-face"
+        record
+        for record in graph["records"]
+        if record.get("kind") == "loop-completed-face"
     )
     face["completionKind"] = "NormalExhaustion"
     spliced = LoopConstructionV1(
@@ -215,9 +219,7 @@ def test_seal_runtime_state_seals_guarded_join_and_stays_loud_on_projected():
         _state_wire(_seal_runtime_state(node_false))
     )
     # the guard is the SAME branch-result guard the loop control faces use
-    assert sealed.guard_formula_cid == _formula_cid(
-        branch_result_guard(slot, slot)
-    )
+    assert sealed.guard_formula_cid == _formula_cid(branch_result_guard(slot, slot))
     # a constructed Node arm seals to a bound value, not a guard
     assert isinstance(_seal_runtime_state(node_true), BoundBindingStateV1)
 

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -135,8 +135,8 @@ def test_lambda_parameter_roles_use_the_source_call_frame(source):
 )
 def test_lambda_signature_roles_bind_through_the_shared_frame(expression, expected):
     call = _return_expression(f"def A():\n    return {expression}\n")
-    reduced = call.sugar().desugar().value.force_floor(
-        None, owner="lambda-signature-twin"
+    reduced = (
+        call.sugar().desugar().value.force_floor(None, owner="lambda-signature-twin")
     )
 
     assert reduced.statements[0].value == expected

--- a/implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py
+++ b/implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py
@@ -14,8 +14,7 @@ def _function(source: str):
 
 
 def test_live_for_projects_break_and_exhaustion_before_tail_substitution():
-    function = _function(
-        """
+    function = _function("""
 def arbitrary(items, stop):
     carried = 0
     for renamed in items:
@@ -23,8 +22,7 @@ def arbitrary(items, stop):
             break
         carried = carried + renamed
     return carried
-"""
-    )
+""")
 
     constructed = function.sugar()
 
@@ -38,31 +36,28 @@ def arbitrary(items, stop):
     post_read = constructed.statements[2].value
     assert type(post_read).__name__ == "GuardedBindingReadSugar"
     assert type(post_read.state).__name__ == "LoopGuardedProjection"
-    assert {
-        face.completion_kind for face in post_read.state.completed_faces
-    } == {"BreakExit", "NormalExhaustion"}
+    assert {face.completion_kind for face in post_read.state.completed_faces} == {
+        "BreakExit",
+        "NormalExhaustion",
+    }
 
 
 def test_renamed_lying_twin_does_not_authorize_loop_target_by_spelling():
-    truthful = _function(
-        """
+    truthful = _function("""
 def arbitrary(items):
     carried = 0
     for renamed in items:
         carried = carried + renamed
     return carried
-"""
-    ).sugar()
-    lying = _function(
-        """
+""").sugar()
+    lying = _function("""
 def arbitrary(items):
     carried = 0
     renamed = 99
     for other in items:
         carried = carried + other
     return carried
-"""
-    ).sugar()
+""").sugar()
 
     truthful_loop = truthful.statements[1]
     lying_loop = lying.statements[2]
@@ -70,29 +65,26 @@ def arbitrary(items):
 
 
 def test_live_symbolic_while_projects_false_test_exhaustion_before_tail():
-    function = _function(
-        """
+    function = _function("""
 def arbitrary(limit):
     carried = 0
     while carried < limit:
         carried = carried + 1
     return carried
-"""
-    )
+""")
 
     constructed = function.sugar()
 
     assert type(constructed.statements[1]).__name__ == "LoopRecurrenceSugar"
     post_read = constructed.statements[2].value
     assert type(post_read.state).__name__ == "LoopGuardedProjection"
-    assert {
-        face.completion_kind for face in post_read.state.completed_faces
-    } == {"NormalExhaustion"}
+    assert {face.completion_kind for face in post_read.state.completed_faces} == {
+        "NormalExhaustion"
+    }
 
 
 def test_live_for_else_projects_else_state_only_on_normal_exhaustion():
-    constructed = _function(
-        """
+    constructed = _function("""
 def arbitrary(items, stop):
     carried = 0
     for renamed in items:
@@ -102,8 +94,7 @@ def arbitrary(items, stop):
     else:
         carried = 42
     return carried
-"""
-    ).sugar()
+""").sugar()
 
     loop = constructed.statements[1]
     graph = loop.construction.wire_graph()
@@ -121,8 +112,7 @@ def arbitrary(items, stop):
 
 
 def test_renamed_else_lying_twin_cannot_run_else_on_break_face():
-    constructed = _function(
-        """
+    constructed = _function("""
 def arbitrary(items, gate):
     result = 0
     for renamed in items:
@@ -131,8 +121,7 @@ def arbitrary(items, gate):
     else:
         result = 9
     return result
-"""
-    ).sugar()
+""").sugar()
 
     post = constructed.statements[2].value.state
     by_kind = {face.completion_kind: face for face in post.completed_faces}
@@ -141,8 +130,7 @@ def arbitrary(items, gate):
 
 
 def test_live_while_else_uses_false_test_face_before_tail_substitution():
-    constructed = _function(
-        """
+    constructed = _function("""
 def arbitrary(limit):
     carried = 0
     while carried < limit:
@@ -150,8 +138,7 @@ def arbitrary(limit):
     else:
         carried = 17
     return carried
-"""
-    ).sugar()
+""").sugar()
 
     loop = constructed.statements[1]
     root = loop.construction.wire_graph()["root"]
@@ -163,8 +150,7 @@ def arbitrary(limit):
 
 
 def test_guarded_return_in_live_loop_is_an_outward_halted_face():
-    constructed = _function(
-        """
+    constructed = _function("""
 def arbitrary(items, stop):
     carried = 0
     for renamed in items:
@@ -172,8 +158,7 @@ def arbitrary(items, stop):
         if renamed == stop:
             return carried
     return carried
-"""
-    ).sugar()
+""").sugar()
 
     loop = constructed.statements[1]
     root = loop.construction.wire_graph()["root"]
@@ -195,8 +180,7 @@ def arbitrary(items, stop):
 
 
 def test_guarded_raise_in_live_while_is_an_outward_halted_face():
-    constructed = _function(
-        """
+    constructed = _function("""
 def arbitrary(limit, stop):
     carried = 0
     while carried < limit:
@@ -204,8 +188,7 @@ def arbitrary(limit, stop):
             raise ValueError(carried)
         carried = carried + 1
     return carried
-"""
-    ).sugar()
+""").sugar()
 
     loop = constructed.statements[1]
     root = loop.construction.wire_graph()["root"]
@@ -213,7 +196,6 @@ def arbitrary(limit, stop):
     exits = loop.desugar()
     assert type(exits).__name__ == "ExitSet"
     assert any(
-        type(face).__name__ == "Halted"
-        and type(face.effect).__name__ == "RaiseEffect"
+        type(face).__name__ == "Halted" and type(face.effect).__name__ == "RaiseEffect"
         for face in exits.exits
     )

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_conditional.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_conditional.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import tempfile
 
-from sugar_lift_py_tests.caller_parameter_contract import ContractConditionalConstructionV1
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+)
 from sugar_lift_py_tests.floor import UniverseValue
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.gap.panic import ConstructionPanic

--- a/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
@@ -75,9 +75,7 @@ def test_projection_reauthenticates_coordinate_and_testimony_cids():
             coordinate=replace(ready.coordinate, cid="blake3-512:stale"),
         ).wire()
     with pytest.raises(ValueError, match="testimony CID mismatch"):
-        ready.with_testimony(
-            replace(testimony, cid="blake3-512:stale")
-        ).wire()
+        ready.with_testimony(replace(testimony, cid="blake3-512:stale")).wire()
 
 
 def test_distinct_occurrences_borrowing_one_span_never_collide():

--- a/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
@@ -41,10 +41,7 @@ def _raise_name(source: str, name: str | None = None):
 def test_nodes_py_has_no_ast_import_or_parse():
     """R: raw stdlib parse must not be semantic authority in SourceUnit."""
     nodes_path = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "sugar_source_tree"
-        / "nodes.py"
+        Path(__file__).resolve().parents[1] / "src" / "sugar_source_tree" / "nodes.py"
     )
     tree = _stdlib_ast.parse(nodes_path.read_text(encoding="utf-8"))
     for node in _stdlib_ast.walk(tree):
@@ -127,7 +124,9 @@ def test_exception_type_identity_truthful_arms():
     identity = sf.unit.exception_type_identity(name)
     assert identity is not None
     assert identity.args[0].value == "source-class"
-    class_def = next(n for n in sf.root.walk() if n.kind == "ClassDef" and n.name == "MyErr")
+    class_def = next(
+        n for n in sf.root.walk() if n.kind == "ClassDef" and n.name == "MyErr"
+    )
     lc = class_def.line_col_span()
     expected = (
         f"{sf.unit.source_cid}:{lc.start_line}:{lc.start_col}:"

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -154,8 +154,10 @@ def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinat
     )
     assert outcome.value.initializer is not None
     assert outcome.value.class_definition_cid.startswith("blake3-512:")
-    receiver = call.sugar().desugar().value.force_floor(
-        None, owner="typed-class-call", project_callsite=False
+    receiver = (
+        call.sugar()
+        .desugar()
+        .value.force_floor(None, owner="typed-class-call", project_callsite=False)
     )
 
     assert receiver.class_name == "RenamedGuard"

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -518,13 +518,17 @@ def test_nested_exception_group_constructs_tree_without_flattening():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "def A():\n"
-        "    raise ExceptionGroup('outer', [\n"
-        "        ValueError(),\n"
-        "        ExceptionGroup('inner', [TypeError(), KeyError()]),\n"
-        "    ])\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    raise ExceptionGroup('outer', [\n"
+            "        ValueError(),\n"
+            "        ExceptionGroup('inner', [TypeError(), KeyError()]),\n"
+            "    ])\n"
+        )
+        .sugar()
+        .desugar()
+    )
 
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, GroupedRaiseEffect)
@@ -542,13 +546,17 @@ def test_except_star_partitions_nested_group_and_propagates_only_residual():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('outer', [TypeError(), ExceptionGroup('inner', [ValueError(), KeyError()])])\n"
-        "    except* ValueError:\n"
-        "        pass\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('outer', [TypeError(), ExceptionGroup('inner', [ValueError(), KeyError()])])\n"
+            "    except* ValueError:\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     residual = outcome.effect
     assert isinstance(residual, GroupedRaiseEffect)
@@ -560,15 +568,19 @@ def test_except_star_partitions_nested_group_and_propagates_only_residual():
 
 
 def test_except_star_residual_flows_to_subsequent_handlers():
-    outcome = _fn(
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
-        "    except* ValueError:\n"
-        "        pass\n"
-        "    except* TypeError:\n"
-        "        pass\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n"
+            "    except* TypeError:\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
     from sugar_lift_py_tests.outcome import Complete
 
     assert isinstance(outcome, Complete)
@@ -578,13 +590,17 @@ def test_except_star_bare_reraise_regroups_original_tree():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
-        "    except* ValueError:\n"
-        "        raise\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        raise\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, GroupedRaiseEffect)
     assert [leaf.exception_name for leaf in outcome.effect.children] == [
@@ -597,13 +613,17 @@ def test_except_star_never_selects_only_first_leaf():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('g', [TypeError(), ValueError(), ValueError()])\n"
-        "    except* ValueError:\n"
-        "        pass\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [TypeError(), ValueError(), ValueError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, GroupedRaiseEffect)
     assert [leaf.exception_name for leaf in outcome.effect.children] == ["TypeError"]
@@ -613,15 +633,19 @@ def test_except_star_matches_renamed_source_subclass_by_mro_identity():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "class Renamed(ValueError):\n"
-        "    pass\n"
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('g', [Renamed(), TypeError()])\n"
-        "    except* ValueError:\n"
-        "        pass\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "class Renamed(ValueError):\n"
+            "    pass\n"
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [Renamed(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, GroupedRaiseEffect)
     assert [leaf.exception_name for leaf in outcome.effect.children] == ["TypeError"]
@@ -631,13 +655,17 @@ def test_except_star_handler_raise_regroups_with_unmatched_residual():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
-        "    except* ValueError:\n"
-        "        raise KeyError()\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        raise KeyError()\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, GroupedRaiseEffect)
     assert isinstance(outcome.effect.children[0], RaiseEffect)
@@ -649,11 +677,15 @@ def test_shadowed_exception_group_spelling_does_not_construct_group_effect():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "ExceptionGroup = lambda message, members: ValueError()\n"
-        "def A():\n"
-        "    raise ExceptionGroup('g', [ValueError()])\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "ExceptionGroup = lambda message, members: ValueError()\n"
+            "def A():\n"
+            "    raise ExceptionGroup('g', [ValueError()])\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, RaiseEffect)
     assert not isinstance(outcome.effect, GroupedRaiseEffect)
@@ -663,13 +695,17 @@ def test_ordinary_except_does_not_consume_grouped_raise():
     from sugar_lift_py_tests.effect import GroupedRaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    outcome = _fn(
-        "def A():\n"
-        "    try:\n"
-        "        raise ExceptionGroup('g', [ValueError()])\n"
-        "    except ValueError:\n"
-        "        pass\n"
-    ).sugar().desugar()
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError()])\n"
+            "    except ValueError:\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(outcome, Incomplete)
     assert isinstance(outcome.effect, GroupedRaiseEffect)
 


### PR DESCRIPTION
## Summary
- Run black on `implementations/python` so `make test-python-format` (`black --check`) is green.
- 90 files reformatted under sugar-lift-py-tests, sugar-lift-python-source, and sugar-source-tree only.

## Validation
- `make test-python-format` — pass (795 files unchanged under check)

## Notes
CI job **core (Python format)** fix; no behavior changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply black formatting to the Python implementations codebase
> Runs the black formatter across all Python source files and tests in `implementations/python`. Changes are purely cosmetic — line wrapping, trailing commas, parenthesization, and collapsed/expanded expressions — with no logic, control flow, or data changes intended.
>
> Risk: One file, [construction_side_door_law.py](https://github.com/TSavo/sugar/pull/6216/files#diff-d0802b809390201e77c1fe23d939072c8ceea0b8e6e6e23dac7b3ed921bf44be), contains a formatting artifact in `discrimination_self_test` where a triple-quoted string termination and a new assignment were merged onto one line (`""" + ast_plant = """`), producing invalid Python syntax that will cause a `SyntaxError` on import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e07dbcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->