### PR TITLE
Restore claim-mass tripwires on post-factory tree path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
             python: true
             z3: false
             b3sum: false
+          - name: claim-mass tripwires
+            target: test-claim-mass-tripwires
+            python: true
+            z3: false
+            b3sum: true
           - name: self attestation
             target: self-attest
             python: false

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ help:
 	@echo "  make check-fleet-claim-contract   CLAIMED lanes must carry fleet:lane (+ kit set)"
 	@echo "  make showcase-bulk-refuse-class   Lane A: prove/durable vacuity parity instrument"
 	@echo "  make test-python-format       Black check for implementations/python"
+	@echo "  make test-claim-mass-tripwires fast per-corpus source-accounting pins (#4266)"
 	@echo "  make test-<lang>              csharp / php / c"
 	@echo "  make test-compiler-warning-de compiler-warning delta-epsilon instrument"
 	@echo ""
@@ -343,6 +344,21 @@ test-python-format:
 	$(PYTHON_KIT_PIP) install --quiet --upgrade pip
 	$(PYTHON_KIT_PIP) install --quiet --no-cache-dir -e implementations/python/sugar-lift-py-tests[test]
 	$(PYTHON_KIT) -m black --check $(PYTHON_FORMAT_PATHS)
+
+# Fast claim-mass tripwires (#4266): datetime, itsdangerous, pandas slice,
+# numpy slice, requests recognition slice. Seconds, not wall-scale. Silent
+# must stay 0; lifted loci cannot disappear without a loud pin update.
+# Post-factory path: SourceFile + Assert.sugar() (sugar-source-tree required).
+.PHONY: test-claim-mass-tripwires
+test-claim-mass-tripwires:
+	$(PYTHON) -m venv $(PYTHON_KIT_VENV)
+	$(PYTHON_KIT_PIP) install --quiet --upgrade pip
+	$(PYTHON_KIT_PIP) install --quiet --no-cache-dir \
+		-e implementations/python/sugar-lift-python-source \
+		-e implementations/python/sugar-source-tree \
+		-e implementations/python/sugar-lift-py-tests[test]
+	cd implementations/python/sugar-lift-py-tests && \
+		$(abspath $(PYTHON_KIT)) -m pytest -q tests/test_claim_mass_tripwires.py
 
 .PHONY: test-php
 test-php:
@@ -649,14 +665,14 @@ test-3809-dod-scoreboard:
 # `coretests-source-audit` is the bulk measuring stick (R = unresolved loci);
 # keep it offline/instrument until R is driven to 0 — a permanent R>0 red in
 # default CI is a gate wearing a scoreboard vest (see docs/analysis/ci-whack-a-mole-*).
-ci: check-lift-refusal-vocabulary check-fleet-claim-contract test-python-format test-showcases self-attest coretests-invariants
+ci: check-lift-refusal-vocabulary check-fleet-claim-contract test-python-format test-claim-mass-tripwires test-showcases self-attest coretests-invariants
 	@echo ""
 	@echo "==== ci: PASS ===="
 
 .PHONY: ci-core
 # The non-showcase portion of the acid test. GitHub Actions runs this beside
 # deterministic showcase shards; `ci` remains the one-command local surface.
-ci-core: check-lift-refusal-vocabulary check-fleet-claim-contract test-python-format self-attest coretests-invariants
+ci-core: check-lift-refusal-vocabulary check-fleet-claim-contract test-python-format test-claim-mass-tripwires self-attest coretests-invariants
 	@echo ""
 	@echo "==== ci-core: PASS ===="
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_claim_mass_tripwires.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_claim_mass_tripwires.py
@@ -1,0 +1,230 @@
+"""Fast per-corpus claim-mass tripwires (#4266).
+
+These are source-accounting pins, not wall-scale correctness gates. Each case:
+- SHA-256 pins the hermetic vendor fixture
+- requires silent accounting == 0 (every on-disk assert is classified)
+- pins total assertion mass (lifted + refused)
+- pins the complete current lifted-locus list
+
+Post-factory measurement path: ``SourceFile`` + ``Assert.sugar()``.
+Construction success is *lifted*; a loud panic (``SourceTreePanic``,
+``ConstructionPanic``, or any other exception) is *refused*. There is no
+third arm — soft-skip is silent loss and fails the tripwire.
+
+Stated count cannot fall unexplained. Known lifted loci cannot disappear.
+Improvements are allowed only as more-lifted-with-zero-silent plus a loud pin
+update in the same PR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from claim_mass_corpus import ClaimMassPin, DATETIME_PIN
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.nodes import Assert
+from sugar_source_tree.panic import SourceTreePanic
+from sugar_source_tree.tree import SourceFile
+
+VENDOR = Path(__file__).parent / "vendor"
+
+
+PINS = (
+    DATETIME_PIN,
+    ClaimMassPin(
+        name="itsdangerous",
+        relative_path="itsdangerous-2.2.0/test_serializer.py",
+        sha256="e9620d6a6999a77773e3a5733ca71cb81375dafd06ad0f3a5b2bea9404e66c26",
+        assertion_count=22,
+        # Positive ratchet: lines 119 and 121 now construct via Assert.sugar()
+        # (was 20 lifted loci under the factory audit path). Loud pin update
+        # required by the tripwire contract.
+        lifted_loci=(
+            53,
+            66,
+            79,
+            89,
+            93,
+            96,
+            100,
+            111,
+            119,
+            121,
+            129,
+            136,
+            137,
+            143,
+            144,
+            154,
+            165,
+            181,
+            184,
+            192,
+            193,
+            194,
+        ),
+    ),
+    ClaimMassPin(
+        name="pandas",
+        relative_path="pandas-2.3.3/test_frame_equals.py",
+        sha256="00599b73d4a67e0a505743c3f61097ba4b5109190dbc31794b567bcf7d44db11",
+        assertion_count=18,
+        lifted_loci=(
+            15,
+            24,
+            28,
+            29,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            56,
+            61,
+            66,
+            72,
+            77,
+            80,
+            85,
+        ),
+    ),
+    ClaimMassPin(
+        name="numpy",
+        relative_path="numpy-2.3.5/test_exceptions.py",
+        sha256="3fc5007a241556bab6d582572e6771ffa72b21af584fe615be67601f5178ffc2",
+        assertion_count=17,
+        lifted_loci=(
+            23,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            46,
+            47,
+            50,
+            55,
+            58,
+            64,
+        ),
+    ),
+    ClaimMassPin(
+        name="requests",
+        # Whole-package hash still tripwires source drift across the recognition
+        # surface; measurement only walks the files named by lifted_loci because
+        # the rest of the package is not part of this owned slice.
+        relative_path="requests-2.34.2/requests",
+        sha256="eb729075b795436b6b7c7e746b82750b19c128b8f08793b56b61dc2fef2b9ff3",
+        assertion_count=2,
+        lifted_loci=(
+            ("_internal_utils.py", 46),
+            ("cookies.py", 46),
+        ),
+    ),
+)
+
+
+def _source_digest(path: Path, files: list[Path]) -> str:
+    digest = hashlib.sha256()
+    for source_path in files:
+        if path.is_dir():
+            digest.update(source_path.relative_to(path).as_posix().encode())
+            digest.update(b"\0")
+        digest.update(source_path.read_bytes())
+        if path.is_dir():
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _measure_files(path: Path, pin: ClaimMassPin, files: list[Path]) -> list[Path]:
+    """For multi-file pins, only measure files named by the lifted-locus pin.
+
+    The package hash still covers the full tree so unmeasured files cannot
+    drift silently; measurement stays inside the owned slice.
+    """
+    if not path.is_dir():
+        return files
+    named = {
+        locus[0]
+        for locus in pin.lifted_loci
+        if isinstance(locus, tuple) and len(locus) == 2
+    }
+    if not named:
+        return files
+    return [source_path for source_path in files if source_path.name in named]
+
+
+def _classify_assert(assert_node: Assert) -> str:
+    """Return ``lifted`` or ``refused``. Never soft-skip."""
+    try:
+        assert_node.sugar()
+    except (SourceTreePanic, ConstructionPanic):
+        return "refused"
+    except BaseException:
+        # Any other failure is still loud refusal, not silent loss.
+        return "refused"
+    return "lifted"
+
+
+@pytest.mark.parametrize("pin", PINS, ids=lambda pin: pin.name)
+def test_claim_mass_corpus_never_silently_shrinks(pin: ClaimMassPin) -> None:
+    path = VENDOR / pin.relative_path
+    files = sorted(path.rglob("*.py")) if path.is_dir() else [path]
+    assert _source_digest(path, files) == pin.sha256, (
+        f"{pin.name} source drifted; re-pin the source hash, assertion count, "
+        "and lifted loci in the same PR"
+    )
+
+    silent = lifted = refused = 0
+    lifted_loci: list[int | tuple[str, int]] = []
+    for source_path in _measure_files(path, pin, files):
+        try:
+            source_file = SourceFile(path_source(str(source_path)))
+        except BaseException as panic:
+            raise AssertionError(
+                f"{pin.name} failed to parse {source_path} for claim accounting: "
+                f"{type(panic).__name__}: {panic}; "
+                "replacement=restore the owned parse path for this fixture, or "
+                "re-slice the corpus and re-pin loudly in the same PR"
+            ) from panic
+
+        for assert_node in source_file.nodes():
+            if not isinstance(assert_node, Assert):
+                continue
+            line = assert_node.line_col_span().start_line
+            locus: int | tuple[str, int] = (
+                (source_path.relative_to(path).as_posix(), line)
+                if path.is_dir()
+                else line
+            )
+            status = _classify_assert(assert_node)
+            if status == "lifted":
+                lifted += 1
+                lifted_loci.append(locus)
+            elif status == "refused":
+                refused += 1
+            else:
+                silent += 1
+
+    assert (
+        silent == 0
+    ), f"{pin.name} silent accounting must stay exactly 0; observed silent={silent}"
+    assert (lifted + refused, tuple(lifted_loci)) == (
+        pin.assertion_count,
+        pin.lifted_loci,
+    ), (
+        f"{pin.name} claim mass changed: count={lifted + refused}, "
+        f"lifted={tuple(lifted_loci)}; improvements must increase lifted coverage with "
+        "zero silent and update this pin loudly"
+    )


### PR DESCRIPTION
## Summary
- CI `core (claim-mass tripwires)` was red because `tests/test_claim_mass_tripwires.py` was deleted with the factory nuke while `make test-claim-mass-tripwires` still invoked it (`file or directory not found`).
- Restores the #4266 source-accounting pins using the post-factory measurement path: `SourceFile` + `Assert.sugar()`.
- Installs `sugar-source-tree` in the Makefile target so the tree path is available.
- Loud re-pin: itsdangerous lifted loci now include lines 119 and 121 (22/22 constructed).

## Contract
- SHA-256 pins hermetic vendor fixtures
- silent accounting must stay 0
- total assertion mass and exact lifted-locus lists are pinned
- improvements require a loud pin update in the same PR

## Validation
```bash
SUGAR_BIN=… make test-claim-mass-tripwires
# .....  5 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore claim-mass tripwire tests on the post-factory tree path
> - Adds a new `make test-claim-mass-tripwires` target that installs the relevant Python packages and runs [`test_claim_mass_tripwires.py`](https://github.com/TSavo/sugar/pull/6219/files#diff-fd0bd2b97b4b2c03e554a82dab5d47d6edb8c25092a6ae4e46f1e57f9138c91a) via pytest.
> - The parametrized test pins known corpora (itsdangerous, pandas, numpy, a slice of requests, and a datetime module) by source SHA-256 and asserts that `Assert.sugar()` produces the expected lifted loci and assertion counts.
> - Any failure during sugar construction is classified as a loud refusal rather than a silent skip, ensuring claim mass never shrinks without a deliberate pin update.
> - Adds the target to both the `ci` and `ci-core` aggregate targets and to the CI matrix in [`ci.yml`](https://github.com/TSavo/sugar/pull/6219/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8360e2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->