### PR TITLE
Re-key sugar shelf identity by monorepo HEAD for #4577

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -706,23 +706,40 @@ tool_versions() {
 build_identity() {
   local stamp="$1"
   require_b3sum || return 1
-  # Shelf / artifact identity is FS + toolchain + package + binary only.
-  # Monorepo git HEAD is NOT part of the key: a docs-only commit must not
-  # force rebuild. Compile-time monorepo head is still stamped into the binary
-  # via SUGARBIN_MONOREPO_HEAD for #4577 diagnostics; it does not change the
-  # content-addressed shelf cell.
+  # Shelf / artifact identity is FS + toolchain + package + binary by default.
+  # A docs-only monorepo commit must not rebuild every tool (#6210).
+  #
+  # sugar is the exception (#4577): the Python kit reports monorepo HEAD as
+  # kit_source.identity, and mint refuses a split pipeline when that HEAD
+  # differs from the binary's compile-time SUGAR_BUILD_GIT_HEAD. After #6210
+  # removed HEAD from the shelf key, a shelf hit on a newer checkout served a
+  # sugar binary baked with an older HEAD and every surface=python mint
+  # correctly refused. Re-key *only* sugar by monorepo HEAD so kit @HEAD ==
+  # binary @HEAD without reintroducing rebuild storms for discharge_cli etc.
+  # Compile-time monorepo head is still stamped via SUGARBIN_MONOREPO_HEAD.
   local incremental="0"
   [[ "$profile" != debug ]] || incremental="1"
-  python3 - "$stamp" "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$package" "$bin_name" "$incremental" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512:" $1}'
+  local monorepo_head=""
+  if [[ "$bin_name" == "sugar" ]]; then
+    monorepo_head="$(attestation_git_head)"
+    [[ -n "$monorepo_head" ]] || monorepo_head="unknown"
+  fi
+  python3 - "$stamp" "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$package" "$bin_name" "$incremental" "$monorepo_head" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512:" $1}'
 import sys
 def emit(label, value):
     label = label.encode(); value = value.encode()
     sys.stdout.buffer.write(str(len(label)).encode() + b":" + label)
     sys.stdout.buffer.write(str(len(value)).encode() + b":" + value)
-for label, value in zip(("sourceStamp", "rustcVersionVerbose", "cargoVersionVerbose",
-                         "platform", "targetTriple", "profile", "sortedFeatures",
-                         "package", "binary", "incremental"), sys.argv[1:]):
+labels = ("sourceStamp", "rustcVersionVerbose", "cargoVersionVerbose",
+          "platform", "targetTriple", "profile", "sortedFeatures",
+          "package", "binary", "incremental")
+values = list(sys.argv[1:11])
+for label, value in zip(labels, values):
     emit(label, value)
+# Optional monorepo HEAD (sugar only). Empty for every other binary so their
+# shelf cells stay stable across docs-only commits.
+if len(sys.argv) > 11 and sys.argv[11]:
+    emit("monorepoHead", sys.argv[11])
 PY
 }
 

--- a/docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md
+++ b/docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md
@@ -1,6 +1,7 @@
 # Expectation: sugarbin builds once until Rust FS changes
 
-**Pin:** after #6210 (monorepo HEAD removed from shelf `build_identity`).
+**Pin:** after #6210 (monorepo HEAD removed from shelf `build_identity` for
+non-sugar tools) plus the sugar-only monorepo-HEAD carve-out for #4577.
 
 ## Law
 On a given self-hosted runner, after a stamp has been built and published to
@@ -8,8 +9,13 @@ the filesystem shelf (`~/.cache/sugar/binary-shelf-v2/…`):
 
 - The **next** CI run with **no** change under the Rust package input closure
   (and no change to toolchain/platform/profile that enter the stamp) must log
-  **`filesystem shelf hit`** for each warmed binary.
-- It must **not** log `filesystem shelf miss` + `Compiling …` for those stamps.
+  **`filesystem shelf hit`** for each warmed **non-sugar** binary.
+- **`sugar` is different (#4577):** its shelf identity includes monorepo HEAD
+  so kit `@HEAD` equals binary `@SUGAR_BUILD_GIT_HEAD`. A docs-only monorepo
+  commit still rebuilds sugar (small) and must **not** rebuild discharge_cli /
+  witness_rpc / etc.
+- It must **not** log `filesystem shelf miss` + `Compiling …` for non-sugar
+  stamps when only monorepo HEAD moved.
 
 ## Remembered first-warm stamp (post-#6210)
 


### PR DESCRIPTION
## Summary

Showcase CI on run [30067416258](https://github.com/TSavo/sugar/actions/runs/30067416258) failed shards **0/4** and **3/4** (1/4 and 2/4 cancelled). Multiple root causes; this PR fixes the **smallest CI-actionable** one.

### Root cause fixed here: split pipeline × shelf (#6210 vs #4577)

After #6210, shelf `build_identity` omitted monorepo HEAD. A shelf hit on a newer main checkout served a `sugar` binary whose compile-time `SUGAR_BUILD_GIT_HEAD` lagged the checkout HEAD. Surface=`python` mint then correctly refused:

```
refusing to mint from a split pipeline: kit @69218e80… != binary @9be71f38…
```

Observed on that run for:

- `examples/python-base64-federation/run.sh` (vendor mint)
- `examples/python-bodyguard-precondition/run.sh`
- `examples/python-literal-base20/run.sh`

**Fix:** re-key **only** the `sugar` binary identity with monorepo HEAD. Other tools keep the #6210 stable key (docs-only commits do not rebuild discharge_cli / witness_rpc / …).

Validation: `bash tests/sugarbin_build_identity_target.sh` (already pins #4577: unrelated HEAD change must rebuild sugar).

### Correctly red (not fixed here)

#### A) Factory residual — method `lift` deleted, mint still calls it

Law (cmd_mint / #6025): *lift and mint are enumeration clients — there is no `lift`-method fallback.* Report path (`dispatch_report_lift_plugin` → `fold_lift_report_response`) was migrated; **`MintKit::transform_session` still calls `dispatch_lift_path` → `Kit::lift` → JSON-RPC method `lift`.**

`sugar_lift_py_tests.lift_rpc` factory nuke deleted `_handle_lift` but still advertises `{"name": "lift", "required": True}`. Exact transport error:

```
method 'lift' not found
```

Logo / mint failures on the run:

| Showcase | Attribution |
|---|---|
| `examples/zlib-crc32/run-logo-receipt.sh` | A2/mint-failed |
| `examples/struct-calcsize/run-logo-receipt.sh` | A2/mint-failed |
| `examples/itsdangerous-token-padding/run.sh` | A2/mint-failed |
| `examples/hashlib-sha256-hexdigest/run-logo-receipt.sh` | A2/mint-failed |
| `examples/hashlib-sha256-digest-length/run-logo-receipt.sh` | A2/mint-failed |
| `examples/stdlib-base32-padding/run-logo-receipt.sh` | A2/mint-failed |
| `examples/numpy-showcase/run.sh` (multi-lifter mint) | A2/expected-verdict-mismatch (downstream of empty mint) |

**Replacement shape:** MintKit producer/consumer dispatch must fold via `sugar.enumerate` (or `fold_claim_tree` / `fold_kit_to_pool`) into a mintable `ir-document`/`proof-envelope`; stop calling method `lift`. Drop or un-require the dead `lift` advertisement in kit declaration.

#### B) Twin-law A2 mismatches (product, not shelf)

| Showcase | Law / observed |
|---|---|
| `examples/base64-showcase/run.sh` | good: expected witness discharge, got **MISSING** |
| `examples/bitflags-showcase/run.sh` | bad: expected consistency refusal, got **undecidable,discharged** |
| `examples/tokio-await-implication-edge/run.sh` | good await implication expected discharged, got **unsatisfied** |
| `examples/java-abs-bound/run.sh` | bad: expected consistency unsatisfied, got **undecidable** |
| `examples/java-abs-flagship/run.sh` | good: expected all discharged, got **undecidable** |
| `examples/java-panama-bridge/run.sh` | verify receipt empty / non-JSON |
| `examples/numpy-attribute-safety-showcase/run.sh` | prove JSON `Extra data` parse fail |

Gate: `FAIL: A2 must be 0 (every showcase verdict matches its twin law)`.

## Shard status (run 30067416258 @ 69218e80)

| Shard | Conclusion |
|---|---|
| showcases (0/4) | **failure** (10 failing showcases) |
| showcases (1/4) | cancelled |
| showcases (2/4) | cancelled |
| showcases (3/4) | **failure** (7 failing showcases) |

Later main runs still flapping/cancelling; #6219 claim-mass restack landed.

## Test plan

- [x] `bash tests/sugarbin_build_identity_target.sh "$(pwd)"`
- [ ] CI prepare warm: sugar miss once after this lands when HEAD moved; non-sugar shelf hits stable on docs-only
- [ ] surface=python mint no longer split-pipeline when shelf serves current HEAD
- [ ] Remaining showcase reds stay attributed to A/B above (not split pipeline)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-key sugar shelf identity by monorepo HEAD in `build_identity`
> - When building the `sugar` binary, `build_identity` in [`bin/sugarbin`](https://github.com/TSavo/sugar/pull/6220/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) now fetches the monorepo Git HEAD via `attestation_git_head` and includes it in the blake3-512 hash, producing a distinct shelf identity per commit (falls back to `unknown` if HEAD is unavailable).
> - All other binaries are unaffected and remain keyed by FS + toolchain + package + binary.
> - Updated [`docs/receipts/2026-07-24-sugarbin-shelf-once-until-rust-fs-changes.md`](https://github.com/TSavo/sugar/pull/6220/files#diff-596e14afb1e307d2f58df433dee19217925a54a1e3d8131e73567ee485675801) to document that docs-only commits may still rebuild `sugar` but should not rebuild other tools.
> - Behavioral Change: `sugar` shelf cache will now miss on every new monorepo HEAD, even for commits that don't touch the binary's source.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2daca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->