### PR TITLE
Mint via full-tree sugar.enumerate; sourceStamp-only shelf identity

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -680,7 +680,9 @@ source_stamp() {
     log "crime=invalid-blake3-output owner=bin/sugarbin illegal shape=b3sum -l 64 emitted '$digest' replacement=repair or upgrade b3sum so it emits 64-byte lowercase hex digests"
     return 1
   }
-  printf 'blake3-512:%s\n' "$digest"
+  # Underscore, never colon: this stamp is a shelf/path coordinate on every
+  # host including Windows, where `:` is illegal in filenames.
+  printf 'blake3-512_%s\n' "$digest"
 }
 
 attestation_git_head() {
@@ -688,7 +690,20 @@ attestation_git_head() {
 }
 
 stamp_for_filename() {
+  # Defensive: any leftover `:` (legacy blake3-512: form) becomes `_`.
+  # New stamps already use `_` so this is a no-op for them.
   printf '%s\n' "${1//:/_}"
+}
+
+# Hex body of a source stamp. Accepts blake3-512_<hex> (current, path-safe)
+# and legacy blake3-512:<hex>. Never leaves a `:` in the result.
+stamp_digest() {
+  local stamp="$1"
+  case "$stamp" in
+    blake3-512_*) printf '%s\n' "${stamp#blake3-512_}" ;;
+    blake3-512:*) printf '%s\n' "${stamp#blake3-512:}" ;;
+    *) printf '%s\n' "${stamp##*[:_]}" ;;
+  esac
 }
 
 artifact_name() {
@@ -704,43 +719,14 @@ tool_versions() {
 }
 
 build_identity() {
+  # Shelf / artifact identity is ONLY the authenticated source matter:
+  # sourceStamp = blake3 of the cargo package's local dependency FS closure
+  # (rust_build_input_stream). Not monorepo HEAD. Not toolchain strings.
+  # Platform / profile / binary name live in the cell path (artifact_name),
+  # not in this content key — so a docs-only commit cannot bust the shelf.
   local stamp="$1"
-  require_b3sum || return 1
-  # Shelf / artifact identity is FS + toolchain + package + binary by default.
-  # A docs-only monorepo commit must not rebuild every tool (#6210).
-  #
-  # sugar is the exception (#4577): the Python kit reports monorepo HEAD as
-  # kit_source.identity, and mint refuses a split pipeline when that HEAD
-  # differs from the binary's compile-time SUGAR_BUILD_GIT_HEAD. After #6210
-  # removed HEAD from the shelf key, a shelf hit on a newer checkout served a
-  # sugar binary baked with an older HEAD and every surface=python mint
-  # correctly refused. Re-key *only* sugar by monorepo HEAD so kit @HEAD ==
-  # binary @HEAD without reintroducing rebuild storms for discharge_cli etc.
-  # Compile-time monorepo head is still stamped via SUGARBIN_MONOREPO_HEAD.
-  local incremental="0"
-  [[ "$profile" != debug ]] || incremental="1"
-  local monorepo_head=""
-  if [[ "$bin_name" == "sugar" ]]; then
-    monorepo_head="$(attestation_git_head)"
-    [[ -n "$monorepo_head" ]] || monorepo_head="unknown"
-  fi
-  python3 - "$stamp" "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$package" "$bin_name" "$incremental" "$monorepo_head" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512:" $1}'
-import sys
-def emit(label, value):
-    label = label.encode(); value = value.encode()
-    sys.stdout.buffer.write(str(len(label)).encode() + b":" + label)
-    sys.stdout.buffer.write(str(len(value)).encode() + b":" + value)
-labels = ("sourceStamp", "rustcVersionVerbose", "cargoVersionVerbose",
-          "platform", "targetTriple", "profile", "sortedFeatures",
-          "package", "binary", "incremental")
-values = list(sys.argv[1:11])
-for label, value in zip(labels, values):
-    emit(label, value)
-# Optional monorepo HEAD (sugar only). Empty for every other binary so their
-# shelf cells stay stable across docs-only commits.
-if len(sys.argv) > 11 and sys.argv[11]:
-    emit("monorepoHead", sys.argv[11])
-PY
+  [[ -n "$stamp" ]] || { log "build_identity: empty sourceStamp"; return 1; }
+  printf '%s\n' "$stamp"
 }
 
 # Cargo freshness belongs to the source/toolchain/profile family, not to one
@@ -754,7 +740,7 @@ build_family_identity() {
   # Cargo's working target is shared across source stamps. Exact source
   # identity belongs to the finished artifact; Cargo owns incremental
   # freshness inside this toolchain/target/profile family.
-  python3 - "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$incremental" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512:" $1}'
+  python3 - "$rustc_verbose" "$cargo_verbose" "$(platform_key)" "$target_triple" "$profile" "" "$incremental" <<'PY' | b3sum -l 64 --no-names | awk '{print "blake3-512_" $1}'
 import sys
 def emit(label, value):
     label = label.encode(); value = value.encode()
@@ -830,7 +816,8 @@ shelf_tag_for_stamp() {
     printf '%s\n' "$SUGAR_BINARY_SHELF_TAG"
     return 0
   fi
-  local digest="${stamp#*:}"
+  local digest
+  digest="$(stamp_digest "$stamp")"
   printf 'sugar-binary-shelf-v2-%s-%s-%.24s\n' "$(platform_key)" "$profile" "$digest"
 }
 
@@ -953,7 +940,7 @@ publish_if_absent() {
   local repo shelf_tag stamp_short
   repo="$(github_repo)" || { log "gh repo identity unavailable; cannot publish $name"; [[ "${SUGAR_BINARY_REQUIRE_PUBLISH:-0}" != 1 ]] && return 0 || return 1; }
   shelf_tag="$(shelf_tag_for_stamp "$stamp")"
-  stamp_short="${stamp#*:}"; stamp_short="${stamp_short:0:24}"
+  stamp_short="$(stamp_digest "$stamp")"; stamp_short="${stamp_short:0:24}"
   # Ensure the shelf release exists. Concurrent prepares can race create; treat
   # "already exists" (view succeeds after create fails) as success.
   if ! ensure_shelf_release "$shelf_tag" "$repo" "$stamp_short"; then
@@ -1127,10 +1114,8 @@ build_from_source() {
   local build_root="$build_base/$(stamp_for_filename "$family_identity")"
   mkdir -p "$build_root"
   local built="$build_root/$profile/$bin_name"
-  # Pin compile-time monorepo HEAD so the #4577 split-pipeline gate compares
-  # kit source to the checkout that produced this binary. Avoid the obsolete
-  # SUGAR_BUILD_* names in this broker; the makefile maps monorepo head into
-  # the cargo rustc-env slot.
+  # SUGAR_BUILD_STAMP is the authenticated sourceStamp (source matter only).
+  # SUGAR_BUILD_GIT_HEAD remains a version/attestation label, not a shelf key.
   local monorepo_head
   monorepo_head="$(attestation_git_head)"
   [[ -n "$monorepo_head" ]] || monorepo_head="unknown"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -662,7 +662,8 @@ def _kit_declaration_result() -> Dict[str, Any]:
                 {"name": ENUMERATE_RPC_METHOD, "required": False},
                 {"name": BIND_CONTRACT_REFS_RPC_METHOD, "required": False},
                 {"name": BIND_CALL_CONTRACT_REFS_RPC_METHOD, "required": False},
-                {"name": "lift", "required": True},
+                # lift is not a kit method: full-tree construction is sugar.enumerate only
+                # {"name": "lift", "required": True},
                 {"name": "sugar.plugin.lift_implications", "required": False},
                 {"name": "sugar.plugin.resolve_dependency_proofs", "required": False},
                 {"name": "shutdown", "required": False},

--- a/implementations/rust/sugar-cli/src/lift_plugin.rs
+++ b/implementations/rust/sugar-cli/src/lift_plugin.rs
@@ -399,7 +399,34 @@ pub(crate) fn dispatch_lift_path(
     let initialize_response = kit.initialize_response().clone();
     enforce_python_kit_source(surface, &initialize_response)?;
     let before = current_rss_kib();
-    let claim = kit.lift(lift_params).map_err(lift_error_from_kit)?;
+
+    // There is no lift RPC. Full-tree "lift" is enumerate(SourceTree) via
+    // sugar.enumerate. Sending method "lift" is the retired factory door.
+    let claim = if kit.supports_rpc_method("sugar.enumerate") {
+        let root = project_root_for_enumerate(project_root, &lift_params);
+        let response = sugar_compiler::tree::fold_enumerate_source_tree(&kit, root.as_path())
+            .map_err(lift_error_from_kit)?;
+        claim_from_enumerate_response(surface, &lift_params, response)?
+    } else if let Some(method) = manifest.method.as_deref().filter(|m| *m != "lift") {
+        // Consumer plugins (e.g. sugar.plugin.lift_implications) keep an
+        // explicit non-lift method from the manifest. Default/empty/"lift"
+        // is never sent.
+        let _ = method;
+        kit.lift(lift_params).map_err(lift_error_from_kit)?
+    } else {
+        return Err(LiftPluginError::diagnostic(
+            LiftPluginDiagnosticKind::PathExecution,
+            "lift.enumerate",
+            format!(
+                "surface `{surface}` does not advertise sugar.enumerate and has no \
+                 non-lift plugin method; sending JSON-RPC method `lift` is retired \
+                 — kits construct only through sugar.enumerate over SourceTree"
+            ),
+            "Advertise sugar.enumerate on the kit declaration, or set manifest \
+             method to a real plugin method (never `lift`).",
+        ));
+    };
+
     trace_lift_plugin_claim_checkpoint_with_delta(
         "dispatch_lift_path.after_kit_lift",
         &claim,
@@ -413,6 +440,64 @@ pub(crate) fn dispatch_lift_path(
     let mut session = LiftPluginSession::from_claim(claim)?;
     session.initialize_response = Some(initialize_response);
     Ok(session)
+}
+
+/// Workspace root for full-tree enumeration: honor per-plugin workspace_override
+/// on the typed lift request when present.
+fn project_root_for_enumerate(project_root: &Path, lift_params: &LiftRequest) -> PathBuf {
+    // LiftRequest serializes workspace_root; prefer that when set.
+    let wire = lift_params.to_wire_value().ok();
+    if let Some(Value::String(root)) = wire
+        .as_ref()
+        .and_then(|v| v.get("workspace_root"))
+        .or_else(|| wire.as_ref().and_then(|v| v.get("workspaceRoot")))
+    {
+        if !root.is_empty() {
+            return PathBuf::from(root);
+        }
+    }
+    project_root.to_path_buf()
+}
+
+/// Wrap a full-tree enumerate `ir-document` as the DomainClaim mint expects.
+fn claim_from_enumerate_response(
+    surface: &str,
+    lift_params: &LiftRequest,
+    response: Value,
+) -> Result<DomainClaim, LiftPluginError> {
+    use libsugar::core::Term;
+    use sugar_ir_types::Sort;
+
+    let wire = lift_params.to_wire_value().map_err(|error| {
+        LiftPluginError::diagnostic(
+            LiftPluginDiagnosticKind::RequestEncoding,
+            "lift.request",
+            format!("encode lift request: {error}"),
+            "Inspect LiftPluginOptions and build_lift_params.",
+        )
+    })?;
+    let input = Input::Spec(wire);
+    // Same membrane as the old lift-plugin path: Term::Const payload carrying
+    // the wire response. Sort name is opaque for address identity.
+    let response_term = Term::Const {
+        value: response,
+        sort: Sort::Primitive {
+            name: "EnumerateSourceTreeResponse".to_string(),
+        },
+    };
+    let transport = LiftPluginKit::new(surface, Vec::new(), None);
+    let mut claim = transport
+        .claim_from_response_term(&input, response_term)
+        .map_err(|error| {
+            LiftPluginError::diagnostic(
+                LiftPluginDiagnosticKind::PathExecution,
+                "lift.enumerate.claim",
+                error.to_string(),
+                "Full-tree sugar.enumerate response must form a DomainClaim payload.",
+            )
+        })?;
+    claim.from = vec![address(&input)];
+    Ok(claim)
 }
 
 /// Refuse when kit source identity differs from the binary's compile-time

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -1229,6 +1229,62 @@ pub fn fold_recovered_audit(
     }))
 }
 
+/// Enumerate the **entire** source tree and fold function-contract IR.
+///
+/// There is no `lift` RPC. What used to be called "lift" is this walk:
+/// `source_files` → per-file `universe` (all function contracts). Mint and
+/// any other full-tree client must call this (or the typed `Kit::source_files`
+/// API) and must never send JSON-RPC method `"lift"`.
+pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Value, KitError> {
+    let conn = kit.enumerate_conn(workspace_root);
+    let (files, source_gaps) = enumerate_rpc(&conn, Level::SourceFiles, None, false)?;
+    if !source_gaps.is_empty() {
+        return Err(EnumerateError::Malformed {
+            plugin: conn.surface.clone(),
+            reason: format!("source census returned {} gaps", source_gaps.len()),
+        }
+        .into());
+    }
+    let mut ir = Vec::new();
+    let mut source_mementos = Vec::new();
+    let mut diagnostics = Vec::new();
+    for file in files {
+        source_mementos.push(file.memento.to_json());
+        let (nodes, gaps) =
+            enumerate_rpc(&conn, Level::Universe, Some(file.memento.to_json()), false)?;
+        for gap in gaps {
+            let item = gap
+                .memento
+                .as_ref()
+                .and_then(|m| m.source_function_name())
+                .map(|name| Value::String(name.to_string()))
+                .unwrap_or(Value::Null);
+            diagnostics.push(json!({
+                "path": file.memento.file,
+                "reason": gap.reason,
+                "item": item,
+            }));
+        }
+        for node in nodes {
+            if let Some(audit) = node.audit {
+                if looks_like_ir_contract_row(&audit) {
+                    ir.push(audit);
+                }
+            }
+        }
+    }
+    Ok(json!({
+        "kind": "ir-document",
+        "ir": ir,
+        "sourceMementos": source_mementos,
+        "diagnostics": diagnostics,
+        "sourceLedger": {
+            "source_files": source_mementos.len(),
+            "contracts": ir.len(),
+        },
+    }))
+}
+
 /// The lift REPORT as an enumeration client -- lift and mint are just clients
 /// of `sugar.enumerate`, not callers of a `lift` method. Same walk as
 /// `fold_recovered_audit` (SourceFiles -> Functions -> Facts), but each leaf

--- a/tests/sugarbin_artifact_manifest.sh
+++ b/tests/sugarbin_artifact_manifest.sh
@@ -56,7 +56,7 @@ export SUGARBIN_FAKE_CHILD_LOG="$tmp/child.log"
 export SUGAR_BINARY_CARGO="$tmp/bin/cargo"
 export SUGAR_BINARY_TARGET_ROOT="$tmp/target"
 export SUGAR_BINARY_CACHE_DIR="$tmp/cache"
-export SUGAR_BINARY_SOURCE_STAMP="blake3-512:$(printf '1%.0s' {1..128})"
+export SUGAR_BINARY_SOURCE_STAMP="blake3-512_$(printf '1%.0s' {1..128})"
 export SUGAR_BINARY_NO_SHELF=1 SUGAR_BINARY_PUBLISH=0
 
 # SUGAR_BIN is a single-binary override. A differently requested executable
@@ -94,7 +94,8 @@ required = {"schema", "binary", "package", "sourceStamp", "buildIdentity", "plat
             "targetTriple", "profile", "features", "rustc", "cargo", "sha256", "built", "executed"}
 assert set(data) == required
 assert data["binary"] == "sugar" and data["package"] == "sugar-cli"
-assert data["buildIdentity"].startswith("blake3-512:")
+assert data["buildIdentity"].startswith("blake3-512_")
+assert ":" not in data["buildIdentity"], "identity must be path-safe (no colon)"
 assert data["cargo"].startswith("cargo 1.96.0")
 assert "\nrelease: 1.96.0\n" in data["cargo"]
 assert "\nhost: x86_64-unknown-linux-gnu\n" in data["cargo"]

--- a/tests/sugarbin_build_identity_target.sh
+++ b/tests/sugarbin_build_identity_target.sh
@@ -65,7 +65,7 @@ export SUGARBIN_FAKE_CARGO_LOG="$tmp/cargo.log"
 export SUGAR_BINARY_CARGO="$tmp/bin/cargo"
 export SUGAR_BINARY_TARGET_ROOT="$tmp/target"
 export SUGAR_BINARY_CACHE_DIR="$tmp/cache"
-export SUGAR_BINARY_SOURCE_STAMP="blake3-512:$(printf '7%.0s' {1..128})"
+export SUGAR_BINARY_SOURCE_STAMP="blake3-512_$(printf '7%.0s' {1..128})"
 export SUGAR_BINARY_NO_SHELF=1 SUGAR_BINARY_PUBLISH=0
 export SUGARBIN_FAKE_GIT_HEAD="head-before-unrelated-change"
 
@@ -93,12 +93,12 @@ resolved_from_make="$("$repo/bin/sugarbin" --bin sugar)"
 [[ "$($resolved_from_make)" == "fresh:sugar" ]]
 [[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 2 ]]
 
-# #4577: monorepo HEAD is a build input so kit @HEAD == binary @HEAD. An
-# unrelated commit must miss the cache and invoke Cargo for a new identity.
+# cargo.log is already 2 (initial + after target disappeared). An unrelated
+# monorepo HEAD change must NOT invoke Cargo again — identity is sourceStamp only.
 export SUGARBIN_FAKE_GIT_HEAD="head-after-unrelated-change"
 resolved_again="$("$repo/bin/sugarbin" --bin sugar)"
 [[ "$resolved_again" == "$tmp/target/release/sugar" ]]
-[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 3 ]]
+[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 2 ]]
 [[ "$($resolved_again)" == "fresh:sugar" ]]
 
 # BX/CI filesystem shelf: a local artifact contributes an atomic cell, then a
@@ -106,21 +106,23 @@ resolved_again="$("$repo/bin/sugarbin" --bin sugar)"
 export SUGAR_BINARY_NO_SHELF=0 SUGAR_BINARY_PUBLISH=1
 export SUGAR_BINARY_SHELF_ROOT="$tmp/shelf"
 "$repo/bin/sugarbin" --bin sugar >/dev/null
-find "$tmp/shelf" -type f -name 'sugar-*.gz' | grep -q .
+# Cell layout: shelf/<platform>/<profile>/<sourceStamp>/<artifactName>/*.gz
+ls "$tmp/shelf"/*/*/*/*/*.gz >/dev/null 2>&1 \
+  || { echo 'shelf cell missing after publish' >&2; ls -laR "$tmp/shelf" >&2; exit 1; }
 rm "$tmp/target/release/sugar" "$tmp/target/release/sugar.sugarbin.json"
 export SUGAR_BINARY_ALLOW_BUILD=0
 resolved_from_shelf="$("$repo/bin/sugarbin" --bin sugar)"
 [[ "$($resolved_from_shelf)" == "fresh:sugar" ]]
-[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 3 ]]
+[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 2 ]]
 
 # A real source-closure change misses the artifact shelf and calls Cargo, but
 # reuses the same persistent toolchain/profile target so incremental state is
 # available. Cargo, not Make's target existence, owns freshness here.
-export SUGAR_BINARY_SOURCE_STAMP="blake3-512:$(printf '8%.0s' {1..128})"
+export SUGAR_BINARY_SOURCE_STAMP="blake3-512_$(printf '8%.0s' {1..128})"
 export SUGAR_BINARY_NO_SHELF=1 SUGAR_BINARY_PUBLISH=0 SUGAR_BINARY_ALLOW_BUILD=1
 rm "$tmp/target/release/sugar" "$tmp/target/release/sugar.sugarbin.json"
 "$repo/bin/sugarbin" --bin sugar >/dev/null
-[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 4 ]]
+[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 3 ]]
 [[ "$(cut -d'|' -f1 "$tmp/cargo.log" | sort -u | wc -l | tr -d ' ')" == 1 ]]
 
-echo 'PASS: sugarbin Cargo output is isolated by build identity'
+echo 'PASS: sugarbin identity is sourceStamp only (HEAD does not bust the shelf)'


### PR DESCRIPTION
## Summary

- **Mint no longer sends JSON-RPC `lift`.** When the kit advertises `sugar.enumerate`, mint walks the entire source tree (`source_files` → `universe`) and folds an `ir-document`. That is the only construction door. Kits that still only advertise `lift` fail loudly.
- **Sugarbin shelf/build identity is the authenticated `sourceStamp` only** (cargo local dependency FS closure). Monorepo HEAD is not in the key (#6220 reversion). Stamps use `blake3-512_<hex>` (underscore, Windows-safe).

## Validation

- `cargo check -p sugar-cli`
- `bash tests/sugarbin_build_identity_target.sh` → PASS (HEAD does not bust shelf)

## Notes

Sole-construction baseline untouched. `#4577` split-pipeline remains a separate gate (kit content vs binary), not whole-repo HEAD in the shelf key.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mint via `sugar.enumerate` full-tree construction and scope build identity to source stamp only
> - `dispatch_lift_path` in [lift_plugin.rs](https://github.com/TSavo/sugar/pull/6222/files#diff-fe181985bfab2ea39f3380841730d83ced2e2ab58e12142c2dcaa6c4a4d16777) now uses `sugar.enumerate` (via `fold_enumerate_source_tree`) instead of the `lift` RPC when the plugin supports it; missing enumerate support without an explicit alternative now returns a diagnostic error rather than falling back silently.
> - `build_identity` in [sugarbin](https://github.com/TSavo/sugar/pull/6222/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) is redefined as exactly the source stamp, removing prior hashing of toolchain, platform, profile, package, binary, and monorepo HEAD — shelf identity no longer changes when those inputs change.
> - Stamp format changes from `blake3-512:<hex>` to `blake3-512_<hex>` across `source_stamp`, `build_family_identity`, and related helpers, making stamps path-safe on Windows.
> - A new `stamp_digest` helper normalizes both the new underscore and legacy colon stamp formats so callers can extract the hex body uniformly.
> - Risk: `build_identity` is a breaking change for any shelf or cache keyed on the old multi-input hash; existing cached artifacts will not match new identities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e811fe9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source-tree lifting now uses full-tree enumeration when supported, improving claim generation and diagnostics.
  * Added clearer handling for unsupported lifting surfaces and compatible fallback methods.

* **Bug Fixes**
  * Standardized source stamps and artifact identities to a path-safe format.
  * Build and shelf identities now remain stable when unrelated toolchain or platform metadata changes.

* **Compatibility**
  * Legacy source-stamp formats continue to be recognized and normalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->