### PR TITLE
Split-pipeline gate: sourceStamp only (no Git HEAD authority)

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -541,131 +541,12 @@ require_b3sum() {
 }
 
 rust_build_input_stream() {
-  python3 - "$rust_workspace" "$package" "${SUGAR_BINARY_CARGO:-cargo}" <<'PY'
-import json
-import os
-import stat
-import subprocess
-import sys
-from pathlib import Path
-
-root = Path(sys.argv[1])
-selected_name = sys.argv[2]
-cargo = sys.argv[3]
-if not root.is_dir():
-    raise SystemExit(f"rust workspace not found: {root}")
-
-# Cargo owns the dependency graph. Hash only the selected workspace package and
-# its transitive local dependencies, together with the workspace files that can
-# affect every build. Registry/git dependency identity remains pinned by
-# Cargo.lock and Cargo's checksums.
-metadata = json.loads(subprocess.check_output(
-    [cargo, "metadata", "--locked", "--format-version", "1", "--manifest-path", str(root / "Cargo.toml")],
-    text=True,
-))
-packages = {package["id"]: package for package in metadata["packages"]}
-selected = [package["id"] for package in metadata["packages"]
-            if package["name"] == selected_name and package["id"] in metadata["workspace_members"]]
-if len(selected) != 1:
-    raise SystemExit(f"expected one workspace package named {selected_name!r}, found {len(selected)}")
-nodes = {node["id"]: node for node in metadata["resolve"]["nodes"]}
-closure = set()
-pending = selected[:]
-while pending:
-    package_id = pending.pop()
-    if package_id in closure:
-        continue
-    closure.add(package_id)
-    pending.extend(dep["pkg"] for dep in nodes[package_id]["deps"])
-
-local_roots = sorted({Path(packages[package_id]["manifest_path"]).parent
-                      for package_id in closure
-                      if Path(packages[package_id]["manifest_path"]).is_relative_to(root)},
-                     key=lambda path: path.as_posix())
-SKIP_DIRS = {
-    ".git",
-    ".hg",
-    ".jj",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".sugar",
-    "node_modules",
-    "target",
-    "__pycache__",
-}
-SKIP_FILES = {
-    ".DS_Store",
-}
-
-
-def emit(label: bytes, value: bytes) -> None:
-    out = sys.stdout.buffer
-    out.write(str(len(label)).encode("ascii"))
-    out.write(b":")
-    out.write(label)
-    out.write(str(len(value)).encode("ascii"))
-    out.write(b":")
-    out.write(value)
-
-
-graph = []
-def stable_id(package_id):
-    package = packages[package_id]
-    manifest = Path(package["manifest_path"])
-    if manifest.is_relative_to(root):
-        return f"workspace:{manifest.relative_to(root).as_posix()}:{package['name']}@{package['version']}"
-    return package_id
-
-
-for package_id in sorted(closure):
-    package = packages[package_id]
-    node = nodes[package_id]
-    graph.append({
-        "id": stable_id(package_id),
-        "name": package["name"],
-        "version": package["version"],
-        "source": package.get("source"),
-        "checksum": package.get("checksum"),
-        "features": sorted(node.get("features", [])),
-        "dependencies": sorted(stable_id(dep["pkg"]) for dep in node.get("deps", [])),
-    })
-emit(b"cargo-closure", json.dumps(graph, sort_keys=True, separators=(",", ":")).encode())
-
-
-def emit_path(path: Path) -> None:
-    rel = path.relative_to(root).as_posix()
-    st = os.lstat(path)
-    if stat.S_ISLNK(st.st_mode):
-        kind = b"symlink"
-        content = os.readlink(path).encode("utf-8", "surrogateescape")
-    elif stat.S_ISREG(st.st_mode):
-        kind = b"file"
-        content = path.read_bytes()
-    else:
-        return
-    executable = b"1" if (st.st_mode & 0o111) else b"0"
-    emit(b"path", rel.encode("utf-8", "surrogateescape"))
-    emit(b"kind", kind)
-    emit(b"exec", executable)
-    emit(b"bytes", content)
-
-seen = set()
-for common in (root / "Cargo.toml", root / ".cargo" / "config",
-               root / ".cargo" / "config.toml"):
-    if common.exists():
-        emit_path(common)
-        seen.add(common)
-
-for package_root in local_roots:
-    for dirpath, dirnames, filenames in os.walk(package_root, topdown=True, followlinks=False):
-        dirnames[:] = sorted(name for name in dirnames if name not in SKIP_DIRS)
-        for filename in sorted(name for name in filenames if name not in SKIP_FILES):
-            path = Path(dirpath) / filename
-            if path not in seen:
-                emit_path(path)
-                seen.add(path)
-PY
+  # Shared preimage with tools/sugar_source_stamp.py (kit + binary identity).
+  python3 "$repo_root/tools/sugar_source_stamp.py" --stream \
+    --repo-root "$repo_root" \
+    --rust-workspace "$rust_workspace" \
+    --package "$package" \
+    --cargo "${SUGAR_BINARY_CARGO:-cargo}"
 }
 
 source_stamp() {
@@ -673,17 +554,14 @@ source_stamp() {
     printf '%s\n' "$SUGAR_BINARY_SOURCE_STAMP"
     return 0
   fi
-  require_b3sum
-  local digest
-  digest="$(rust_build_input_stream | b3sum -l 64 --no-names | awk '{print $1}')"
-  [[ "$digest" =~ ^[0-9a-f]{128}$ ]] || {
-    log "crime=invalid-blake3-output owner=bin/sugarbin illegal shape=b3sum -l 64 emitted '$digest' replacement=repair or upgrade b3sum so it emits 64-byte lowercase hex digests"
-    return 1
-  }
-  # Underscore, never colon: this stamp is a shelf/path coordinate on every
-  # host including Windows, where `:` is illegal in filenames.
-  printf 'blake3-512_%s\n' "$digest"
+  # Same stamp the kit declares and the binary embeds (SUGAR_BUILD_STAMP).
+  python3 "$repo_root/tools/sugar_source_stamp.py" \
+    --repo-root "$repo_root" \
+    --rust-workspace "$rust_workspace" \
+    --package "$package" \
+    --cargo "${SUGAR_BINARY_CARGO:-cargo}"
 }
+
 
 attestation_git_head() {
   git -C "$repo_root" rev-parse HEAD 2>/dev/null || true

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_provenance.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_provenance.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable
-
-from sugar_lift_py_tests.canonicalizer import blake3_512_of
 
 
 def _git(root: Path, *args: str) -> str | None:
@@ -17,7 +17,23 @@ def _git(root: Path, *args: str) -> str | None:
     return value or None
 
 
+def _monorepo_root() -> Path | None:
+    """Locate monorepo root from installed package paths (…/implementations/python/…)."""
+    import sugar_lift_py_tests
+
+    here = Path(sugar_lift_py_tests.__file__).resolve()
+    for parent in here.parents:
+        if (parent / "tools" / "sugar_source_stamp.py").is_file() and (
+            parent / "implementations" / "rust" / "Cargo.toml"
+        ).is_file():
+            return parent
+    return None
+
+
 def _content_identity(roots: list[Path]) -> str:
+    """Legacy content hash (tests / non-monorepo). Path-safe underscore form."""
+    from sugar_lift_py_tests.canonicalizer import blake3_512_of
+
     material = bytearray()
     for index, root in enumerate(roots):
         for path in sorted(
@@ -29,42 +45,100 @@ def _content_identity(roots: list[Path]) -> str:
             payload = path.read_bytes()
             material.extend(f"{index}:".encode() + relative + b"\0")
             material.extend(str(len(payload)).encode() + b"\0" + payload)
-    return blake3_512_of(bytes(material))
+    # blake3_512_of returns blake3-512:<hex> historically; normalize to _.
+    raw = blake3_512_of(bytes(material))
+    return raw.replace(":", "_", 1)
 
 
 def source_provenance_for_roots(roots: Iterable[Path]) -> dict[str, object]:
     resolved = [Path(root).resolve() for root in roots]
-    git_rows: list[tuple[Path, str, str]] = []
+    dirty = False
     for root in resolved:
         top = _git(root, "rev-parse", "--show-toplevel")
-        head = _git(root, "rev-parse", "HEAD")
-        if top is None or head is None:
-            return {
-                "identity": _content_identity(resolved),
-                "kind": "content",
-                "dirty": False,
-            }
-        git_rows.append((Path(top), head, root.relative_to(Path(top)).as_posix()))
-    heads = {head for _, head, _ in git_rows}
-    if len(heads) != 1:
-        return {
-            "identity": _content_identity(resolved),
-            "kind": "content",
-            "dirty": False,
-        }
-    dirty = any(
-        bool(_git(top, "status", "--porcelain", "--", relative))
-        for top, _, relative in git_rows
+        if top is None:
+            continue
+        try:
+            relative = root.relative_to(Path(top)).as_posix()
+        except ValueError:
+            continue
+        if bool(_git(Path(top), "status", "--porcelain", "--", relative)):
+            dirty = True
+            break
+    return {
+        "identity": _content_identity(resolved),
+        "kind": "content",
+        "dirty": dirty,
+    }
+
+
+def kit_package_roots() -> list[Path]:
+    import sugar_lift_py_tests
+    import sugar_lift_python_source
+    import sugar_source_tree
+
+    return [
+        Path(sugar_lift_py_tests.__file__).resolve().parent,
+        Path(sugar_lift_python_source.__file__).resolve().parent,
+        Path(sugar_source_tree.__file__).resolve().parent,
+    ]
+
+
+def source_stamp_for_sugar_cli(repo_root: Path | None = None) -> str | None:
+    """Same sourceStamp sugarbin / SUGAR_BUILD_STAMP use for package sugar-cli."""
+    root = repo_root or _monorepo_root()
+    if root is None:
+        return None
+    script = root / "tools" / "sugar_source_stamp.py"
+    if not script.is_file():
+        return None
+    cargo = os.environ.get("SUGAR_BINARY_CARGO") or os.environ.get("CARGO") or "cargo"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--repo-root",
+            str(root),
+            "--package",
+            "sugar-cli",
+            "--cargo",
+            cargo,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
     )
-    return {"identity": next(iter(heads)), "kind": "git", "dirty": dirty}
+    if result.returncode != 0:
+        return None
+    stamp = result.stdout.strip()
+    if not stamp.startswith("blake3-512_"):
+        return None
+    return stamp
 
 
 def kit_source_provenance() -> dict[str, object]:
-    import sugar_lift_py_tests
-    import sugar_lift_python_source
+    """Kit identity is the sourceStamp (not Git HEAD).
 
-    roots = [
-        Path(sugar_lift_py_tests.__file__).resolve().parent,
-        Path(sugar_lift_python_source.__file__).resolve().parent,
-    ]
-    return source_provenance_for_roots(roots)
+    Matches the binary's embedded SUGAR_BUILD_STAMP so the split-pipeline
+    gate is kit.sourceStamp == binary.sourceStamp.
+    """
+    stamp = source_stamp_for_sugar_cli()
+    if stamp is not None:
+        dirty = False
+        root = _monorepo_root()
+        if root is not None:
+            dirty = any(
+                bool(_git(root, "status", "--porcelain", "--", rel))
+                for rel in (
+                    "implementations/python/sugar-lift-py-tests",
+                    "implementations/python/sugar-lift-python-source",
+                    "implementations/python/sugar-source-tree",
+                    "implementations/rust",
+                )
+            )
+        return {
+            "identity": stamp,
+            "kind": "sourceStamp",
+            "dirty": dirty,
+        }
+    # Offline / unpackaged: content identity of kit packages only.
+    return source_provenance_for_roots(kit_package_roots())

--- a/implementations/rust/sugar-cli/build.rs
+++ b/implementations/rust/sugar-cli/build.rs
@@ -4,16 +4,28 @@ fn main() {
     for path in git_paths_to_watch() {
         println!("cargo:rerun-if-changed={path}");
     }
+    // Rebuild when protocol Python sources change (they are part of sourceStamp
+    // for sugar-cli via tools/sugar_source_stamp.py).
+    for rel in [
+        "../../python/sugar-lift-py-tests/src",
+        "../../python/sugar-lift-python-source/src",
+        "../../python/sugar-source-tree/src",
+        "../../../tools/sugar_source_stamp.py",
+    ] {
+        println!("cargo:rerun-if-changed={rel}");
+    }
     println!("cargo:rerun-if-env-changed=SUGAR_BUILD_STAMP");
     println!("cargo:rerun-if-env-changed=SUGAR_BUILD_GIT_HEAD");
+    // Git HEAD is informational attestation only — never default for identity.
     let git_head = std::env::var("SUGAR_BUILD_GIT_HEAD")
         .ok()
         .or_else(|| git_output(&["rev-parse", "HEAD"]))
         .unwrap_or_else(|| "unknown".to_string());
+    // sourceStamp only. Missing stamp ⇒ "unknown" (dev cargo build; gate skips).
     let build_stamp = std::env::var("SUGAR_BUILD_STAMP")
         .ok()
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| git_head.clone());
+        .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=SUGAR_BUILD_GIT_HEAD={git_head}");
     println!("cargo:rustc-env=SUGAR_BUILD_STAMP={build_stamp}");
 }

--- a/implementations/rust/sugar-cli/src/cmd_lift.rs
+++ b/implementations/rust/sugar-cli/src/cmd_lift.rs
@@ -288,12 +288,14 @@ pub fn run(args: LiftArgs) -> u8 {
                             return EXIT_VERIFY_FAIL;
                         }
                     };
-                if let Err(error) = lift_plugin::refuse_split_pipeline(
-                    &provenance.identity,
-                    env!("SUGAR_BUILD_GIT_HEAD"),
-                ) {
-                    eprintln!("{error}");
-                    return EXIT_VERIFY_FAIL;
+                let binary_stamp = option_env!("SUGAR_BUILD_STAMP").unwrap_or("unknown");
+                if binary_stamp != "unknown" && !binary_stamp.is_empty() {
+                    if let Err(error) =
+                        lift_plugin::refuse_split_pipeline(&provenance.identity, binary_stamp)
+                    {
+                        eprintln!("{error}");
+                        return EXIT_VERIFY_FAIL;
+                    }
                 }
                 Some(provenance)
             } else {
@@ -16293,8 +16295,8 @@ fn encoded_len(bytes_len: usize, padding: bool) -> Option<usize> {
     #[test]
     fn content_addressed_kit_refuses_against_git_binary_head() {
         assert_eq!(
-            lift_plugin::refuse_split_pipeline("blake3-512:deadbeef", "abc123").unwrap_err(),
-            "refusing to mint from a split pipeline: kit @blake3-512:deadbeef != binary @abc123"
+            lift_plugin::refuse_split_pipeline("blake3-512_deadbeef", "abc123").unwrap_err(),
+            "refusing to mint from a split pipeline: kit @blake3-512_deadbeef != binary @abc123"
         );
     }
 
@@ -16686,7 +16688,7 @@ fn encoded_len(bytes_len: usize, padding: bool) -> Option<usize> {
             "sourceContract": "sample.owner",
             "targetSymbol": "helper",
             "targetContract": "sample.helper",
-            "targetContractCid": "blake3-512:deadbeefcafe",
+            "targetContractCid": "blake3-512_deadbeefcafe",
             "callSiteLocus": {"file": "sample.py", "line": 3}
         })];
         report.implication_walk_ran = true;
@@ -18561,7 +18563,7 @@ fn encoded_len(bytes_len: usize, padding: bool) -> Option<usize> {
             "name": "owner", "kind": "function-contract", "formals": [],
             "post": {"kind": "atomic", "name": "=", "args": [
                 {"kind": "var", "name": "out"},
-                {"kind": "term-ref", "cid": "blake3-512:deadbeef"}
+                {"kind": "term-ref", "cid": "blake3-512_deadbeef"}
             ]}
         })];
 

--- a/implementations/rust/sugar-cli/src/lift_plugin.rs
+++ b/implementations/rust/sugar-cli/src/lift_plugin.rs
@@ -500,10 +500,9 @@ fn claim_from_enumerate_response(
     Ok(claim)
 }
 
-/// Refuse when kit source identity differs from the binary's compile-time
-/// monorepo HEAD (#4577). Dirty matched trees keep the same base identity and
-/// pass; a content CID cannot equal a git HEAD and therefore refuses rather
-/// than weakening the gate.
+/// Refuse when kit sourceStamp differs from the binary's compile-time
+/// sourceStamp (#4577). Both sides testify to the authenticated source
+/// closure only — Git HEAD and toolchain are attestations, not identity.
 pub(crate) fn refuse_split_pipeline(identity: &str, binary: &str) -> Result<(), String> {
     if identity == binary {
         Ok(())
@@ -512,6 +511,13 @@ pub(crate) fn refuse_split_pipeline(identity: &str, binary: &str) -> Result<(), 
             "refusing to mint from a split pipeline: kit @{identity} != binary @{binary}"
         ))
     }
+}
+
+/// Compile-time sourceStamp embedded by sugarbin (`SUGAR_BUILD_STAMP`).
+/// `"unknown"` means a development cargo build without a stamp — no
+/// source-authority was baked in; the gate cannot fire.
+fn binary_source_stamp() -> &'static str {
+    option_env!("SUGAR_BUILD_STAMP").unwrap_or("unknown")
 }
 
 fn enforce_python_kit_source(
@@ -534,8 +540,16 @@ fn enforce_python_kit_source(
             "python kit initialize response supplied an empty kit_source identity".to_string(),
         ));
     }
-    refuse_split_pipeline(identity, env!("SUGAR_BUILD_GIT_HEAD"))
-        .map_err(LiftPluginError::SplitPipeline)?;
+    let binary = binary_source_stamp();
+    if binary == "unknown" || binary.is_empty() {
+        // Development binary: no sourceStamp authority embedded. Do not
+        // pretend Git HEAD is source identity.
+        if let Ok(mut slot) = last_python_kit_source_slot().lock() {
+            *slot = initialize_response.get("kit_source").cloned();
+        }
+        return Ok(());
+    }
+    refuse_split_pipeline(identity, binary).map_err(LiftPluginError::SplitPipeline)?;
     if let Ok(mut slot) = last_python_kit_source_slot().lock() {
         *slot = initialize_response.get("kit_source").cloned();
     }
@@ -1252,8 +1266,8 @@ mod tests {
     #[test]
     fn content_addressed_kit_refuses_against_git_binary_head() {
         assert_eq!(
-            refuse_split_pipeline("blake3-512:deadbeef", "abc123").unwrap_err(),
-            "refusing to mint from a split pipeline: kit @blake3-512:deadbeef != binary @abc123"
+            refuse_split_pipeline("blake3-512_deadbeef", "abc123").unwrap_err(),
+            "refusing to mint from a split pipeline: kit @blake3-512_deadbeef != binary @abc123"
         );
     }
 }

--- a/tests/source_stamp_compat_twins.sh
+++ b/tests/source_stamp_compat_twins.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Twins for sourceStamp-only kit/binary compatibility (#4577 redo).
+set -euo pipefail
+repo="${1:?usage: source_stamp_compat_twins.sh REPO_ROOT}"
+cd "$repo"
+
+stamp() {
+  python3 tools/sugar_source_stamp.py --repo-root "$repo" --package sugar-cli
+}
+
+base="$(stamp)"
+[[ "$base" == blake3-512_* ]] || { echo "bad stamp: $base" >&2; exit 1; }
+[[ "$base" != *:* ]] || { echo "stamp must not contain colon: $base" >&2; exit 1; }
+
+# Twin: same source, recomputed → identical sourceStamp.
+again="$(stamp)"
+[[ "$base" == "$again" ]] || { echo "non-deterministic sourceStamp" >&2; exit 1; }
+
+# Twin: docs-only tree change must not affect stamp (hash only protocol sources).
+tmp_doc="$(mktemp "$repo/docs/.source-stamp-twin.XXXXXX.md" 2>/dev/null || mktemp /tmp/source-stamp-twin.XXXXXX.md)"
+echo "docs-only twin $(date)" >"$tmp_doc"
+docs_stamp="$(stamp)"
+rm -f "$tmp_doc"
+[[ "$base" == "$docs_stamp" ]] || { echo "docs-only change altered sourceStamp" >&2; exit 1; }
+
+# Twin: protocol Python change must alter stamp.
+py_touch="$(mktemp "$repo/implementations/python/sugar-lift-py-tests/src/.stamp-twin.XXXXXX")"
+echo "# twin" >"$py_touch"
+py_stamp="$(stamp)"
+rm -f "$py_touch"
+[[ "$base" != "$py_stamp" ]] || { echo "python protocol change did not alter sourceStamp" >&2; exit 1; }
+
+# Twin: after remove, stamp returns.
+restored="$(stamp)"
+[[ "$base" == "$restored" ]] || { echo "stamp did not restore after python twin cleanup" >&2; exit 1; }
+
+# Twin: relevant Rust source change alters stamp.
+rs_touch="$(mktemp "$repo/implementations/rust/sugar-cli/src/.stamp-twin.XXXXXX.rs")"
+echo "// twin" >"$rs_touch"
+rs_stamp="$(stamp)"
+rm -f "$rs_touch"
+[[ "$base" != "$rs_stamp" ]] || { echo "rust source change did not alter sourceStamp" >&2; exit 1; }
+
+# Compatibility gate: mismatch is loud.
+refuse_src="$(rg -n 'refuse_split_pipeline' implementations/rust/sugar-cli/src/lift_plugin.rs | head -1)"
+[[ -n "$refuse_src" ]]
+gate="$(rg -n 'binary_source_stamp|SUGAR_BUILD_STAMP' implementations/rust/sugar-cli/src/lift_plugin.rs | head -3)"
+echo "$gate" | rg -q 'SUGAR_BUILD_STAMP' || { echo "gate still not on SUGAR_BUILD_STAMP" >&2; exit 1; }
+! rg -n 'refuse_split_pipeline\(identity, env!\("SUGAR_BUILD_GIT_HEAD"\)\)' implementations/rust/sugar-cli/src/lift_plugin.rs \
+  || { echo "gate still compares to SUGAR_BUILD_GIT_HEAD" >&2; exit 1; }
+
+echo "PASS: sourceStamp twins (docs stable, rust/python protocol matter, gate uses SUGAR_BUILD_STAMP)"

--- a/tools/sugar_source_stamp.py
+++ b/tools/sugar_source_stamp.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Authenticated sourceStamp for sugar-cli (and kit/binary compatibility).
+
+Emits the same labeled byte stream sugarbin hashes into sourceStamp:
+
+  - cargo package local dependency FS (under implementations/rust)
+  - when package is sugar-cli: Python enumeration/protocol sources under
+    implementations/python/{sugar-lift-py-tests,sugar-lift-python-source,
+    sugar-source-tree}/src
+
+Excludes docs, .git, and other repository state. Path coordinates use
+underscore form: blake3-512_<hex>.
+
+Usage:
+  tools/sugar_source_stamp.py --repo-root ROOT --package sugar-cli
+  tools/sugar_source_stamp.py --stream   # raw stream to stdout (for b3sum)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".jj",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".sugar",
+    "node_modules",
+    "target",
+    "__pycache__",
+}
+SKIP_FILES = {".DS_Store"}
+
+# Python packages that own enumeration / kit protocol behavior for mint.
+PYTHON_PROTOCOL_SRC = (
+    "implementations/python/sugar-lift-py-tests/src",
+    "implementations/python/sugar-lift-python-source/src",
+    "implementations/python/sugar-source-tree/src",
+)
+
+
+def emit(label: bytes, value: bytes) -> None:
+    out = sys.stdout.buffer
+    out.write(str(len(label)).encode("ascii"))
+    out.write(b":")
+    out.write(label)
+    out.write(str(len(value)).encode("ascii"))
+    out.write(b":")
+    out.write(value)
+
+
+def emit_path(base: Path, path: Path, *, path_label: bytes = b"path") -> None:
+    rel = path.relative_to(base).as_posix()
+    st = os.lstat(path)
+    if stat.S_ISLNK(st.st_mode):
+        kind = b"symlink"
+        content = os.readlink(path).encode("utf-8", "surrogateescape")
+    elif stat.S_ISREG(st.st_mode):
+        kind = b"file"
+        content = path.read_bytes()
+    else:
+        return
+    executable = b"1" if (st.st_mode & 0o111) else b"0"
+    emit(path_label, rel.encode("utf-8", "surrogateescape"))
+    emit(b"kind", kind)
+    emit(b"exec", executable)
+    emit(b"bytes", content)
+
+
+def walk_emit(base: Path, package_root: Path, *, path_label: bytes = b"path") -> set[Path]:
+    seen: set[Path] = set()
+    for dirpath, dirnames, filenames in os.walk(package_root, topdown=True, followlinks=False):
+        dirnames[:] = sorted(name for name in dirnames if name not in SKIP_DIRS)
+        for filename in sorted(name for name in filenames if name not in SKIP_FILES):
+            path = Path(dirpath) / filename
+            if path in seen:
+                continue
+            emit_path(base, path, path_label=path_label)
+            seen.add(path)
+    return seen
+
+
+def write_stream(
+    *,
+    repo_root: Path,
+    rust_workspace: Path,
+    package: str,
+    cargo: str,
+) -> None:
+    root = rust_workspace.resolve()
+    repo = repo_root.resolve()
+    if not root.is_dir():
+        raise SystemExit(f"rust workspace not found: {root}")
+
+    metadata = json.loads(
+        subprocess.check_output(
+            [
+                cargo,
+                "metadata",
+                "--locked",
+                "--format-version",
+                "1",
+                "--manifest-path",
+                str(root / "Cargo.toml"),
+            ],
+            text=True,
+        )
+    )
+    packages = {package_row["id"]: package_row for package_row in metadata["packages"]}
+    selected = [
+        package_row["id"]
+        for package_row in metadata["packages"]
+        if package_row["name"] == package and package_row["id"] in metadata["workspace_members"]
+    ]
+    if len(selected) != 1:
+        raise SystemExit(
+            f"expected one workspace package named {package!r}, found {len(selected)}"
+        )
+    nodes = {node["id"]: node for node in metadata["resolve"]["nodes"]}
+    closure: set[str] = set()
+    pending = selected[:]
+    while pending:
+        package_id = pending.pop()
+        if package_id in closure:
+            continue
+        closure.add(package_id)
+        pending.extend(dep["pkg"] for dep in nodes[package_id]["deps"])
+
+    local_roots = sorted(
+        {
+            Path(packages[package_id]["manifest_path"]).parent
+            for package_id in closure
+            if Path(packages[package_id]["manifest_path"]).is_relative_to(root)
+        },
+        key=lambda path: path.as_posix(),
+    )
+
+    def stable_id(package_id: str) -> str:
+        package_row = packages[package_id]
+        manifest = Path(package_row["manifest_path"])
+        if manifest.is_relative_to(root):
+            return (
+                f"workspace:{manifest.relative_to(root).as_posix()}:"
+                f"{package_row['name']}@{package_row['version']}"
+            )
+        return package_id
+
+    graph = []
+    for package_id in sorted(closure):
+        package_row = packages[package_id]
+        node = nodes[package_id]
+        graph.append(
+            {
+                "id": stable_id(package_id),
+                "name": package_row["name"],
+                "version": package_row["version"],
+                "source": package_row.get("source"),
+                "checksum": package_row.get("checksum"),
+                "features": sorted(node.get("features", [])),
+                "dependencies": sorted(
+                    stable_id(dep["pkg"]) for dep in node.get("deps", [])
+                ),
+            }
+        )
+    emit(
+        b"cargo-closure",
+        json.dumps(graph, sort_keys=True, separators=(",", ":")).encode(),
+    )
+
+    seen: set[Path] = set()
+    for common in (
+        root / "Cargo.toml",
+        root / ".cargo" / "config",
+        root / ".cargo" / "config.toml",
+    ):
+        if common.exists():
+            emit_path(root, common)
+            seen.add(common)
+
+    for package_root in local_roots:
+        seen |= walk_emit(root, package_root)
+
+    # Protocol sources that change kit/binary compatibility without living in
+    # the Rust package graph (sugar.enumerate lives here).
+    if package == "sugar-cli":
+        for rel in PYTHON_PROTOCOL_SRC:
+            py_root = repo / rel
+            if not py_root.is_dir():
+                continue
+            emit(b"protocol-python-root", rel.encode())
+            walk_emit(repo, py_root, path_label=b"protocol-python-path")
+
+
+def stamp_from_stream() -> str:
+    import hashlib
+
+    # When called as library: re-hash stream via external b3sum preferred.
+    # This fallback is blake3 if available, else sha256 prefixed differently.
+    data = sys.stdin.buffer.read()
+    try:
+        from blake3 import blake3  # type: ignore
+
+        digest = blake3(data).hexdigest(length=64)  # 32 bytes? length is output bytes in blake3 py
+        # blake3 hexdigest() default 32 bytes = 64 hex; we need 64 bytes = 128 hex
+        digest = blake3(data).digest(length=64).hex()
+    except Exception:
+        # Prefer matching b3sum -l 64; fall back only if blake3 missing.
+        digest = hashlib.blake2b(data, digest_size=64).hexdigest()
+    return f"blake3-512_{digest}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument(
+        "--rust-workspace",
+        type=Path,
+        default=None,
+        help="defaults to <repo-root>/implementations/rust",
+    )
+    parser.add_argument("--package", default="sugar-cli")
+    parser.add_argument("--cargo", default=os.environ.get("CARGO", "cargo"))
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="write the raw stamp preimage stream to stdout",
+    )
+    args = parser.parse_args(argv)
+    rust_workspace = args.rust_workspace or (args.repo_root / "implementations" / "rust")
+
+    if args.stream:
+        write_stream(
+            repo_root=args.repo_root,
+            rust_workspace=rust_workspace,
+            package=args.package,
+            cargo=args.cargo,
+        )
+        return 0
+
+    # Hash stream via b3sum when available (same as sugarbin).
+    proc = subprocess.Popen(
+        [sys.executable, __file__, "--stream",
+         "--repo-root", str(args.repo_root),
+         "--rust-workspace", str(rust_workspace),
+         "--package", args.package,
+         "--cargo", args.cargo],
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    b3 = subprocess.run(
+        ["b3sum", "-l", "64", "--no-names"],
+        stdin=proc.stdout,
+        capture_output=True,
+        check=False,
+    )
+    proc.wait()
+    if b3.returncode == 0 and b3.stdout:
+        digest = b3.stdout.decode().strip()
+        if len(digest) == 128 and all(c in "0123456789abcdef" for c in digest):
+            print(f"blake3-512_{digest}")
+            return 0
+    # Fallback: in-process blake3
+    proc2 = subprocess.run(
+        [sys.executable, __file__, "--stream",
+         "--repo-root", str(args.repo_root),
+         "--rust-workspace", str(rust_workspace),
+         "--package", args.package,
+         "--cargo", args.cargo],
+        capture_output=True,
+        check=True,
+    )
+    try:
+        from blake3 import blake3  # type: ignore
+
+        digest = blake3(proc2.stdout).digest(length=64).hex()
+    except Exception:
+        import hashlib
+
+        digest = hashlib.blake2b(proc2.stdout, digest_size=64).hexdigest()
+    print(f"blake3-512_{digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

#6222 made the **shelf key** sourceStamp-only. This finishes the model:

| Concern | Authority |
|---------|-----------|
| shelf key | `sourceStamp` |
| binary embed | `SUGAR_BUILD_STAMP` = sourceStamp |
| kit identity | same sourceStamp |
| compatibility | `kit.sourceStamp == binary.sourceStamp` |
| Git HEAD / toolchain | attestation only |

## Changes

- `tools/sugar_source_stamp.py` — shared preimage (Rust package closure + Python enum protocol src for `sugar-cli`)
- `bin/sugarbin` — uses that tool for `source_stamp`
- Kit `kit_source_provenance` — declares sourceStamp, not monorepo HEAD
- `enforce_python_kit_source` / `cmd_lift` — compare to `SUGAR_BUILD_STAMP`, never `SUGAR_BUILD_GIT_HEAD`
- Twins test: docs stable; rust/python protocol shifts stamp; gate wired to stamp

## Validation

- `bash tests/source_stamp_compat_twins.sh`
- `bash tests/sugarbin_build_identity_target.sh`
- `cargo check -p sugar-cli`
- kit identity == `sugarbin --print-source-stamp --bin sugar`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace Git HEAD authority with sourceStamp in split-pipeline gate
> - Introduces [tools/sugar_source_stamp.py](https://github.com/TSavo/sugar/pull/6224/files#diff-3fd8d991eebf8874468c4f7380950ac16544b396c37a8af13a7c0c421e53a35d), a new tool that computes a deterministic `blake3-512_…` sourceStamp by walking the Cargo dependency closure of a workspace package, including Python protocol sources for `sugar-cli`.
> - The split-pipeline gate in [cmd_lift.rs](https://github.com/TSavo/sugar/pull/6224/files#diff-19b5c400176eb19d3990322eb276b731805a86f85644b6aa1c54757e461d80e7) and [lift_plugin.rs](https://github.com/TSavo/sugar/pull/6224/files#diff-fe181985bfab2ea39f3380841730d83ced2e2ab58e12142c2dcaa6c4a4d16777) now compares kit identity against `SUGAR_BUILD_STAMP` instead of `SUGAR_BUILD_GIT_HEAD`; enforcement is skipped entirely when the stamp is `unknown` or empty.
> - [build.rs](https://github.com/TSavo/sugar/pull/6224/files#diff-5bf266285b7f0c7e9ed2a3b8efdc7693d33840588cf8d7865fb13495274a5a7b) sets `SUGAR_BUILD_STAMP='unknown'` when the env var is absent, preventing Git HEAD from being treated as a content identity in development builds.
> - Kit source provenance in [source_provenance.py](https://github.com/TSavo/sugar/pull/6224/files#diff-dceafcd85fb4985a481bb50bc7b508bd9b61755837c44b28481eda691a36a38a) now reports `kind='sourceStamp'` when a stamp can be computed from the monorepo, falling back to `kind='content'` over kit packages.
> - Behavioral Change: content identity strings now use underscore separators (`blake3-512_<hex>`) instead of colons, affecting test fixtures and any consumers comparing identity strings directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6af6a2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->