### PR TITLE
ci: re-ratchet refusal-vocabulary census after #6224

### DIFF
--- a/tools/lift_refusal_vocabulary_census.json
+++ b/tools/lift_refusal_vocabulary_census.json
@@ -2,7 +2,7 @@
   "identity": "path + normalized text digest + duplicate ordinal; line is display only",
   "issue": "#3632",
   "law": "REFUSE is the verifier verb; lift outputs are reduced meaning or typed effects.",
-  "lift_output_backlog": 1830,
+  "lift_output_backlog": 1829,
   "occurrences": [
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/discharge_cli.py:523c0ad6c899be9b:1",
@@ -286,7 +286,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py:3feab243bdcc8dd8:1",
-      "line": 137,
+      "line": 143,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -296,7 +296,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py:55039820e093b03a:1",
-      "line": 694,
+      "line": 700,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py",
       "reason": "line explicitly talks about verifier/prove-side refusal vocabulary",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -306,7 +306,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07a1923e8775da07:1",
-      "line": 2896,
+      "line": 2912,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -316,7 +316,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07a1923e8775da07:2",
-      "line": 2903,
+      "line": 2919,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -326,7 +326,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07e1a59934e7a669:1",
-      "line": 1404,
+      "line": 1412,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -336,7 +336,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:0b3e51e7a8642aee:1",
-      "line": 3383,
+      "line": 3409,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -346,7 +346,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:1",
-      "line": 234,
+      "line": 240,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -356,7 +356,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:2",
-      "line": 304,
+      "line": 310,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -366,7 +366,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:3",
-      "line": 314,
+      "line": 320,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -376,7 +376,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:4",
-      "line": 327,
+      "line": 333,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -386,7 +386,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:262cf0763503ca3b:5",
-      "line": 2131,
+      "line": 2139,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -396,7 +396,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:2b1ea1908a30d567:1",
-      "line": 2916,
+      "line": 2932,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -406,7 +406,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:2ff68163ee0743b8:1",
-      "line": 2805,
+      "line": 2821,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -416,7 +416,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:323981772b7a43d0:1",
-      "line": 2080,
+      "line": 2088,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -426,7 +426,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:334c5570dcf7e2e8:1",
-      "line": 2898,
+      "line": 2914,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -436,7 +436,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:334c5570dcf7e2e8:2",
-      "line": 2905,
+      "line": 2921,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -446,7 +446,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:35f0e1bc84c17b0a:1",
-      "line": 991,
+      "line": 999,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -456,7 +456,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:4ae90c55d54449d3:1",
-      "line": 1856,
+      "line": 1864,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -466,7 +466,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:4c469dad29c9f03f:1",
-      "line": 2801,
+      "line": 2817,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -476,7 +476,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5490fb1c72fabb2b:1",
-      "line": 134,
+      "line": 140,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -486,7 +486,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:584c0d7a15b58f1b:1",
-      "line": 1774,
+      "line": 1782,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -496,7 +496,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:595151665adfae36:1",
-      "line": 2926,
+      "line": 2942,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -506,7 +506,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5c9cc4b4a1b3359b:1",
-      "line": 2925,
+      "line": 2941,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -516,7 +516,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5ce72679c0ae1bb8:1",
-      "line": 2910,
+      "line": 2926,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -526,7 +526,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:5ce72679c0ae1bb8:2",
-      "line": 2913,
+      "line": 2929,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -536,7 +536,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:1",
-      "line": 233,
+      "line": 239,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -546,7 +546,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:2",
-      "line": 303,
+      "line": 309,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -556,7 +556,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:3",
-      "line": 313,
+      "line": 319,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -566,7 +566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:4",
-      "line": 326,
+      "line": 332,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -576,7 +576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:61e064222247ad78:5",
-      "line": 2130,
+      "line": 2138,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -586,7 +586,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:66bbb74de25b7e5b:1",
-      "line": 1076,
+      "line": 1084,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -596,7 +596,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:684cb47145fbde57:1",
-      "line": 2899,
+      "line": 2915,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -606,7 +606,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:684cb47145fbde57:2",
-      "line": 2906,
+      "line": 2922,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -616,7 +616,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:75c22bbaf7c3d3fc:1",
-      "line": 2058,
+      "line": 2066,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -626,7 +626,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:7be2d7840e24c169:1",
-      "line": 2079,
+      "line": 2087,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -636,7 +636,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:7f0fb93a6285e1d8:1",
-      "line": 1343,
+      "line": 1351,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -646,7 +646,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:8db97768fd10741a:1",
-      "line": 1038,
+      "line": 1046,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -656,7 +656,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:9619c63bd219f362:1",
-      "line": 928,
+      "line": 936,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -666,7 +666,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:98ffb2d0275f8c06:1",
-      "line": 2877,
+      "line": 2893,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -676,7 +676,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:99255915fed3a1a9:1",
-      "line": 992,
+      "line": 1000,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -686,7 +686,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a024794c032ce929:1",
-      "line": 2878,
+      "line": 2894,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -696,7 +696,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a0d47a5dffe481fa:1",
-      "line": 2918,
+      "line": 2934,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -706,7 +706,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a11cbd91625388f8:1",
-      "line": 2061,
+      "line": 2069,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -716,7 +716,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:a851ca28f6008b79:1",
-      "line": 977,
+      "line": 985,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -726,7 +726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:b366f2d9801c38d8:1",
-      "line": 2942,
+      "line": 2960,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -736,7 +736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:b790a90e666402f3:1",
-      "line": 2062,
+      "line": 2070,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -746,7 +746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:b8336f0a06821c80:1",
-      "line": 2793,
+      "line": 2809,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -756,7 +756,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:bbf3f68eab7a9377:1",
-      "line": 254,
+      "line": 260,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -766,7 +766,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:c777fce5f866e1e7:1",
-      "line": 340,
+      "line": 346,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -776,7 +776,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:cb711432aada956b:1",
-      "line": 2060,
+      "line": 2068,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -786,7 +786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:d7268ed408ba6c06:1",
-      "line": 1961,
+      "line": 1969,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -796,7 +796,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ddc2e8fb8e7e74ec:1",
-      "line": 857,
+      "line": 865,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -806,7 +806,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:dec5ed98ecf87133:1",
-      "line": 2930,
+      "line": 2946,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -816,7 +816,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:df7a728b69570b0e:1",
-      "line": 2081,
+      "line": 2089,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -826,7 +826,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:e0829a866a3ac750:1",
-      "line": 2863,
+      "line": 2879,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -836,7 +836,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:e4f7e69be5a23714:1",
-      "line": 858,
+      "line": 866,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -846,7 +846,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:e8951d7583605aa0:1",
-      "line": 929,
+      "line": 937,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -856,7 +856,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:1",
-      "line": 1510,
+      "line": 1518,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -866,7 +866,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:2",
-      "line": 1538,
+      "line": 1546,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -876,7 +876,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:3",
-      "line": 1566,
+      "line": 1574,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -886,7 +886,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:ee7431242b841c11:4",
-      "line": 1594,
+      "line": 1602,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -896,7 +896,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:f07060d3fbacca9d:1",
-      "line": 2928,
+      "line": 2944,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -906,7 +906,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:f24e852621ff01aa:1",
-      "line": 2779,
+      "line": 2795,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -916,7 +916,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:fc33afd15623fb98:1",
-      "line": 2057,
+      "line": 2065,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -926,7 +926,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:fe90dd51ba418fb0:1",
-      "line": 2880,
+      "line": 2896,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -946,7 +946,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:0ea9d3db9fed818c:1",
-      "line": 231,
+      "line": 239,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -956,7 +956,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:a73ac5bc57ddf363:1",
-      "line": 228,
+      "line": 236,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -966,7 +966,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:c4829d099c3b9db1:1",
-      "line": 441,
+      "line": 449,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -976,7 +976,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:eae51ec3ab0e5a96:1",
-      "line": 484,
+      "line": 492,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1475,28 +1475,8 @@
       "wire_marker": "not-lift-output"
     },
     {
-      "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:09f770c61a21616c:1",
-      "line": 291,
-      "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "if let Err(error) = lift_plugin::refuse_split_pipeline(",
-      "wire_marker": "internal-only"
-    },
-    {
-      "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:0c6bacd6321e4f06:1",
-      "line": 16297,
-      "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "\"refusing to mint from a split pipeline: kit @blake3-512:deadbeef != binary @abc123\"",
-      "wire_marker": "internal-only"
-    },
-    {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:0f7fb297008cfcc1:1",
-      "line": 16289,
+      "line": 16291,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1506,7 +1486,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:112758a0227f9da3:1",
-      "line": 16277,
+      "line": 16279,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1516,7 +1496,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:177fb6724754cd35:1",
-      "line": 11864,
+      "line": 11866,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1525,18 +1505,18 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:33c5e42d92ab224d:1",
-      "line": 16296,
+      "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:2deef1a575345732:1",
+      "line": 16299,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "lift_plugin::refuse_split_pipeline(\"blake3-512:deadbeef\", \"abc123\").unwrap_err(),",
+      "text": "\"refusing to mint from a split pipeline: kit @blake3-512_deadbeef != binary @abc123\"",
       "wire_marker": "internal-only"
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:3992ca116b5ac1c7:1",
-      "line": 1861,
+      "line": 1863,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1546,7 +1526,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:3992ca116b5ac1c7:2",
-      "line": 2022,
+      "line": 2024,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1556,7 +1536,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:3f1e67de2cb276d1:1",
-      "line": 11870,
+      "line": 11872,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1566,7 +1546,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:4841d56cb6f67dc4:1",
-      "line": 16278,
+      "line": 16280,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1576,7 +1556,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:4b7fffd74e329bfb:1",
-      "line": 11855,
+      "line": 11857,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1586,7 +1566,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:4daf630d0caa2be3:1",
-      "line": 509,
+      "line": 511,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1596,7 +1576,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:6171795fba251ad4:1",
-      "line": 16280,
+      "line": 16282,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1606,7 +1586,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:6b7b6f2af828959a:1",
-      "line": 11883,
+      "line": 11885,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1616,7 +1596,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:6c76640185e571d9:1",
-      "line": 16294,
+      "line": 16296,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1626,7 +1606,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:6d31b8a63e21fa5c:1",
-      "line": 16286,
+      "line": 16288,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1636,7 +1616,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:8e238bc97800d568:1",
-      "line": 11879,
+      "line": 11881,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1646,7 +1626,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:94be325106288ec7:1",
-      "line": 395,
+      "line": 397,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "line explicitly talks about verifier/prove-side refusal vocabulary",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -1656,7 +1636,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:976633debc022a35:1",
-      "line": 9648,
+      "line": 9650,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "line explicitly talks about verifier/prove-side refusal vocabulary",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -1666,7 +1646,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:9fcf97abf8c76316:1",
-      "line": 2011,
+      "line": 2013,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1676,7 +1656,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a3537c5b959e4a72:1",
-      "line": 11878,
+      "line": 11880,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1685,8 +1665,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a463203b3574512a:1",
+      "line": 294,
+      "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "lift_plugin::refuse_split_pipeline(&provenance.identity, binary_stamp)",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a588f37929ff6d61:1",
-      "line": 1855,
+      "line": 1857,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1696,7 +1686,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a588f37929ff6d61:2",
-      "line": 2016,
+      "line": 2018,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1706,7 +1696,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a6e2dd66ac5d07b5:1",
-      "line": 2010,
+      "line": 2012,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1716,7 +1706,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a8bb7875dd6cbfc3:1",
-      "line": 11875,
+      "line": 11877,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1726,7 +1716,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:a8edd464c35e005f:1",
-      "line": 16288,
+      "line": 16290,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1736,7 +1726,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:b53b5452b20da1de:1",
-      "line": 16275,
+      "line": 16277,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1746,7 +1736,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:b63ee49b137e9f6c:1",
-      "line": 1109,
+      "line": 1111,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1756,7 +1746,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:c906d11864ad1cbc:1",
-      "line": 513,
+      "line": 515,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1766,7 +1756,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:cfb9861733b4c49e:1",
-      "line": 516,
+      "line": 518,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1776,7 +1766,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:d3c4edf387dc29ad:1",
-      "line": 11865,
+      "line": 11867,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1786,7 +1776,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:d55db08b9ada68f9:1",
-      "line": 11874,
+      "line": 11876,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1795,8 +1785,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:ecd09f3d8fc36daf:1",
+      "line": 16298,
+      "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "lift_plugin::refuse_split_pipeline(\"blake3-512_deadbeef\", \"abc123\").unwrap_err(),",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:f0d953f65d7d5dd4:1",
-      "line": 11872,
+      "line": 11874,
       "path": "implementations/rust/sugar-cli/src/cmd_lift.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2335,18 +2335,18 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:0a8712119be94642:1",
-      "line": 1170,
+      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:11fdccac1c387af1:1",
+      "line": 1269,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "refuse_split_pipeline(\"blake3-512:deadbeef\", \"abc123\").unwrap_err(),",
+      "text": "refuse_split_pipeline(\"blake3-512_deadbeef\", \"abc123\").unwrap_err(),",
       "wire_marker": "internal-only"
     },
     {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:13c64a3d745b4186:1",
-      "line": 1162,
+      "line": 1261,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2355,33 +2355,23 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:1587b12d034536d9:1",
-      "line": 418,
-      "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "/// Refuse when kit source identity differs from the binary's compile-time",
-      "wire_marker": "internal-only"
-    },
-    {
-      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:4721cf720b3bd759:1",
-      "line": 420,
-      "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "/// pass; a content CID cannot equal a git HEAD and therefore refuses rather",
-      "wire_marker": "internal-only"
-    },
-    {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:57618e949ba4813e:1",
-      "line": 544,
+      "line": 643,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "PathExecutionError::Refused(refusal) => LiftPluginError::Refused(refusal),",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:664ebb998f09a1fc:1",
+      "line": 503,
+      "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// Refuse when kit sourceStamp differs from the binary's compile-time",
       "wire_marker": "internal-only"
     },
     {
@@ -2396,7 +2386,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:7b843b89d524df8c:1",
-      "line": 1161,
+      "line": 1260,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2405,13 +2395,13 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:9265f58b957ea4a9:1",
-      "line": 452,
+      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:8f6e7d8c7475cfc3:1",
+      "line": 1270,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "refuse_split_pipeline(identity, env!(\"SUGAR_BUILD_GIT_HEAD\"))",
+      "text": "\"refusing to mint from a split pipeline: kit @blake3-512_deadbeef != binary @abc123\"",
       "wire_marker": "internal-only"
     },
     {
@@ -2426,7 +2416,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:9a7b0c2383bb9714:1",
-      "line": 1168,
+      "line": 1267,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2436,7 +2426,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:a200f8e72cbdb95a:1",
-      "line": 422,
+      "line": 506,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2446,7 +2436,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:d8be8161e8cd5f2b:1",
-      "line": 427,
+      "line": 511,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2455,23 +2445,23 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:dc24f62662c8c48a:1",
-      "line": 1171,
-      "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "\"refusing to mint from a split pipeline: kit @blake3-512:deadbeef != binary @abc123\"",
-      "wire_marker": "internal-only"
-    },
-    {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:e33168530161c57c:1",
-      "line": 1159,
+      "line": 1258,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "fn split_pipeline_refusal_names_both_commits() {",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:e4f15496db16b4d7:1",
+      "line": 552,
+      "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refuse_split_pipeline(identity, binary).map_err(LiftPluginError::SplitPipeline)?;",
       "wire_marker": "internal-only"
     },
     {
@@ -2486,7 +2476,7 @@
     },
     {
       "key": "implementations/rust/sugar-cli/src/lift_plugin.rs:fccc916eec7e8133:1",
-      "line": 1164,
+      "line": 1263,
       "path": "implementations/rust/sugar-cli/src/lift_plugin.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -19698,11 +19688,11 @@
   "schema": 1,
   "speaker_counts": {
     "emitter-provenance-guard": 3,
-    "lift-output-backlog": 1830,
+    "lift-output-backlog": 1829,
     "provenance-oracle-guard": 53,
     "vendor-language-identifier": 1,
     "verifier-verdict-quote": 40,
     "verify-dialect-boundary": 42
   },
-  "total_occurrences": 1969
+  "total_occurrences": 1968
 }


### PR DESCRIPTION
Sanctioned re-ratchet: #6224's gate change added/moved refusal vocabulary in lift_plugin.rs. Census-only diff; tool compare passes and self-test still trips on planted vocabulary (no suppression).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-ratchet refusal vocabulary census after hash separator format change
> Updates [lift_refusal_vocabulary_census.json](https://github.com/TSavo/sugar/pull/6225/files#diff-679d9c70dea0d4d683f60434858a4764a923719253749aa1c59b8f5e596046ab) to reflect the colon-to-underscore separator change in kit identity strings (e.g. `blake3-512:deadbeef` → `blake3-512_deadbeef`) introduced in #6224. Line numbers, text snippets, and occurrence counts are adjusted to match the current state of `cmd_lift.rs` and `lift_plugin.rs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36c5ddb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vocabulary census records to reflect revised refusal-output classifications and source locations.
  * Corrected occurrence counts and refreshed related Python and Rust entries, including updated error-text formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->