### PR TITLE
linker: strengthen ParameterContractResolutionV1 + ClosedCallerUniverseV1 CID

### DIFF
--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -304,10 +304,114 @@ pub struct ClosedCallerUniverseV1 {
     pub callers: Vec<AuthenticatedCallerV1>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl ClosedCallerUniverseV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": "closed-caller-universe",
+            "schemaVersion": "1",
+            "closed": self.closed,
+            "hasExternalCallers": self.has_external_callers,
+            "callers": self.callers,
+        })
+    }
+
+    /// The canonical CID of the exact closed caller universe that authorized a
+    /// resolution. A ClosedCallers-basis resolution carries this so a consumer
+    /// can prove WHICH universe discharged the demand, not merely that the
+    /// two-field correspondence held.
+    pub fn cid(&self) -> Cid {
+        canonical_json_cid(&self.preimage())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolutionBasisV1 {
+    #[serde(rename = "declared-demand")]
+    DeclaredDemand,
+    #[serde(rename = "closed-callers")]
+    ClosedCallers,
+}
+
+impl ResolutionBasisV1 {
+    fn wire(self) -> &'static str {
+        match self {
+            ResolutionBasisV1::DeclaredDemand => "declared-demand",
+            ResolutionBasisV1::ClosedCallers => "closed-callers",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ParameterContractResolutionV1 {
+    pub kind: String,
+    pub schema_version: String,
     pub demand_cid: Cid,
     pub candidate_cid: Cid,
+    pub contract_cid: Cid,
+    pub basis: ResolutionBasisV1,
+    pub caller_universe_cid: Option<Cid>,
+    pub resolution_cid: Cid,
+}
+
+impl ParameterContractResolutionV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "demandCid": self.demand_cid,
+            "candidateCid": self.candidate_cid,
+            "contractCid": self.contract_cid,
+            "basis": self.basis.wire(),
+            "callerUniverseCid": self.caller_universe_cid,
+        })
+    }
+
+    pub fn mint(
+        demand_cid: Cid,
+        candidate_cid: Cid,
+        contract_cid: Cid,
+        basis: ResolutionBasisV1,
+        caller_universe_cid: Option<Cid>,
+    ) -> Self {
+        let mut resolution = Self {
+            kind: "parameter-contract-resolution".into(),
+            schema_version: "1".into(),
+            demand_cid,
+            candidate_cid,
+            contract_cid,
+            basis,
+            caller_universe_cid,
+            resolution_cid: Cid::from("pending"),
+        };
+        resolution.resolution_cid = canonical_json_cid(&resolution.preimage());
+        resolution
+    }
+
+    /// Re-derive the resolution CID and reject any stale or basis-inconsistent
+    /// row. A declared-demand resolution never carries a caller universe; a
+    /// closed-callers resolution always does.
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        if self.kind != "parameter-contract-resolution"
+            || self.schema_version != "1"
+            || canonical_json_cid(&self.preimage()) != self.resolution_cid
+        {
+            return Err(ParameterResolutionGapV1::StaleResolution);
+        }
+        match self.basis {
+            ResolutionBasisV1::DeclaredDemand => {
+                if self.caller_universe_cid.is_some() {
+                    return Err(ParameterResolutionGapV1::StaleResolution);
+                }
+            }
+            ResolutionBasisV1::ClosedCallers => {
+                if self.caller_universe_cid.is_none() {
+                    return Err(ParameterResolutionGapV1::StaleResolution);
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -325,6 +429,7 @@ pub enum ParameterResolutionGapV1 {
     NoIncomingCaller,
     OpenCallerUniverse,
     DisagreeingCallers,
+    StaleResolution,
 }
 
 pub fn discharge_parameter_candidate(
@@ -346,10 +451,13 @@ pub fn discharge_parameter_candidate(
         .declared_demand_cids
         .contains(&candidate.demand.demand_cid)
     {
-        return Ok(ParameterContractResolutionV1 {
-            demand_cid: candidate.demand.demand_cid.clone(),
-            candidate_cid: candidate.candidate_cid.clone(),
-        });
+        return Ok(ParameterContractResolutionV1::mint(
+            candidate.demand.demand_cid.clone(),
+            candidate.candidate_cid.clone(),
+            callee.contract_cid.clone(),
+            ResolutionBasisV1::DeclaredDemand,
+            None,
+        ));
     }
     if !universe.closed || universe.has_external_callers {
         return Err(ParameterResolutionGapV1::OpenCallerUniverse);
@@ -388,8 +496,11 @@ pub fn discharge_parameter_candidate(
             return Err(ParameterResolutionGapV1::DisagreeingCallers);
         }
     }
-    Ok(ParameterContractResolutionV1 {
-        demand_cid: candidate.demand.demand_cid.clone(),
-        candidate_cid: candidate.candidate_cid.clone(),
-    })
+    Ok(ParameterContractResolutionV1::mint(
+        candidate.demand.demand_cid.clone(),
+        candidate.candidate_cid.clone(),
+        callee.contract_cid.clone(),
+        ResolutionBasisV1::ClosedCallers,
+        Some(universe.cid()),
+    ))
 }

--- a/implementations/rust/sugar-linker/tests/caller_parameter_contract.rs
+++ b/implementations/rust/sugar-linker/tests/caller_parameter_contract.rs
@@ -6,8 +6,8 @@ use sugar_linker::caller_parameter::{
     discharge_parameter_candidate, AuthenticatedCallerV1, CallEdgeV2, ClosedCallerUniverseV1,
     ContractConditionalConstructionV1, FormalActualBindingV1, FormalParameterCoordinateV1,
     FormalParameterDeclarationV1, ParameterContractDemandV1, ParameterKindV1,
-    ParameterOwnedContractV1, ParameterResolutionGapV1, SourceFragmentCoordinateV1,
-    ValueOccurrenceCoordinateV1,
+    ParameterContractResolutionV1, ParameterOwnedContractV1, ParameterResolutionGapV1,
+    ResolutionBasisV1, SourceFragmentCoordinateV1, ValueOccurrenceCoordinateV1,
 };
 use sugar_linker::{canonical_json_cid, Cid};
 
@@ -304,5 +304,96 @@ fn unverified_actual_contract_reference_stays_loud() {
     assert_eq!(
         gap,
         ParameterResolutionGapV1::UnauthenticatedActualContractRef
+    );
+}
+
+#[test]
+fn closed_callers_resolution_carries_basis_and_authorizing_universe_cid() {
+    let f = fixture();
+    let universe = ClosedCallerUniverseV1 {
+        closed: true,
+        has_external_callers: false,
+        callers: vec![AuthenticatedCallerV1 {
+            caller_contract_cid: f.edge.source_contract_cid.clone(),
+            caller_contract_decl: f.caller_contract_decl.clone(),
+            edge: f.edge.clone(),
+        }],
+    };
+    let resolved =
+        discharge_parameter_candidate(&f.candidate, &f.contract, &universe).unwrap();
+    assert_eq!(resolved.basis, ResolutionBasisV1::ClosedCallers);
+    assert_eq!(resolved.contract_cid, f.contract.contract_cid);
+    assert_eq!(resolved.caller_universe_cid, Some(universe.cid()));
+    // The resolution CID is self-authenticating and validates.
+    resolved.validate().unwrap();
+    // The carried universe CID names the EXACT universe that authorized it.
+    assert_eq!(resolved.caller_universe_cid.unwrap(), universe.cid());
+}
+
+#[test]
+fn declared_demand_resolution_carries_no_caller_universe() {
+    let mut f = fixture();
+    f.contract
+        .declared_demand_cids
+        .insert(f.candidate.demand.demand_cid.clone());
+    f.contract.semantic_decl["declaredDemandCids"] =
+        serde_json::to_value(&f.contract.declared_demand_cids).unwrap();
+    f.contract.contract_cid = canonical_json_cid(&f.contract.semantic_decl);
+    let resolved = discharge_parameter_candidate(
+        &f.candidate,
+        &f.contract,
+        &ClosedCallerUniverseV1 {
+            closed: false,
+            has_external_callers: true,
+            callers: vec![],
+        },
+    )
+    .unwrap();
+    assert_eq!(resolved.basis, ResolutionBasisV1::DeclaredDemand);
+    assert_eq!(resolved.caller_universe_cid, None);
+    assert_eq!(resolved.contract_cid, f.contract.contract_cid);
+    resolved.validate().unwrap();
+}
+
+#[test]
+fn resolution_round_trips_and_stale_cid_is_rejected() {
+    let f = fixture();
+    let universe = ClosedCallerUniverseV1 {
+        closed: true,
+        has_external_callers: false,
+        callers: vec![AuthenticatedCallerV1 {
+            caller_contract_cid: f.edge.source_contract_cid.clone(),
+            caller_contract_decl: f.caller_contract_decl.clone(),
+            edge: f.edge.clone(),
+        }],
+    };
+    let resolved =
+        discharge_parameter_candidate(&f.candidate, &f.contract, &universe).unwrap();
+    let wire = serde_json::to_value(&resolved).unwrap();
+    let round_trip: ParameterContractResolutionV1 = serde_json::from_value(wire).unwrap();
+    assert_eq!(round_trip, resolved);
+    round_trip.validate().unwrap();
+
+    // A tampered demand CID (leaving resolution_cid stale) is rejected.
+    let mut tampered = resolved.clone();
+    tampered.demand_cid = Cid::from("forged-demand");
+    assert_eq!(
+        tampered.validate().unwrap_err(),
+        ParameterResolutionGapV1::StaleResolution
+    );
+
+    // A closed-callers basis with no caller universe is basis-inconsistent.
+    let mut orphaned = ParameterContractResolutionV1::mint(
+        resolved.demand_cid.clone(),
+        resolved.candidate_cid.clone(),
+        resolved.contract_cid.clone(),
+        ResolutionBasisV1::ClosedCallers,
+        None,
+    );
+    // mint recomputes the CID, so the CID is fresh but the basis invariant fails.
+    orphaned.caller_universe_cid = None;
+    assert_eq!(
+        orphaned.validate().unwrap_err(),
+        ParameterResolutionGapV1::StaleResolution
     );
 }


### PR DESCRIPTION
Phase-2 schema foundation for caller-parameter discharge (owner's design: 'strengthen the resolution schema before production wire use'). `ParameterContractResolutionV1` gains `contractCid, basis (declared-demand|closed-callers), callerUniverseCid?, resolutionCid` with a self-computed CID + validate() enforcing the basis invariant; `ClosedCallerUniverseV1` gains a canonical CID (names which universe authorized a resolution); new `StaleResolution` gap. `discharge_parameter_candidate` mints the strengthened row on both branches. Confined to sugar-linker; workspace compiles; 11 linker tests pass; Python floor/census/mint byte-unchanged (post() still panic-armed). The two-phase enumeration continuation on top of this is the next build.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strengthen `ParameterContractResolutionV1` and `ClosedCallerUniverseV1` with canonical CIDs and self-authentication
> - `ParameterContractResolutionV1` is extended with `kind`, `schema_version`, `contract_cid`, `basis`, `caller_universe_cid`, and `resolution_cid` fields, making resolutions self-describing and self-authenticating.
> - A new `ResolutionBasisV1` enum distinguishes `DeclaredDemand` vs `ClosedCallers` resolution paths in typed and serialized form.
> - `ClosedCallerUniverseV1` gains a `cid()` method that returns a deterministic canonical CID for the universe state; this CID is embedded in closed-callers resolutions.
> - `ParameterContractResolutionV1::mint()` constructs a fully populated resolution with a computed `resolution_cid`; `validate()` recomputes and verifies it, returning the new `StaleResolution` gap variant on mismatch.
> - `discharge_parameter_candidate` now uses `mint()` on success, returning a fully populated resolution in both resolution-basis cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cc5694.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->