### PR TITLE
feat: caller-parameter contract discharge — two-phase enumeration continuation

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -110,6 +110,13 @@ class ContractConditionalConstructionV1:
     def inv_contribution(self):
         return ()
 
+    def mint_contribution(self, name, formals):
+        # A resolved candidate mints no independent contract row: its constructed
+        # value already flows through the return term. The demand is discharged
+        # by the linker, not re-stated as an inv here.
+        del name, formals
+        return ()
+
     def post_contribution(self):
         return ()
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -303,3 +303,163 @@ def _term_from_value(value):
         if sort == "Real" and isinstance(value["value"], str):
             return real_lit(value["value"])
     raise ValueError("actual term shape is unsupported")
+
+
+# --- Phase 1/2/3 continuation schema (mirrors sugar-linker/src/caller_parameter.rs) ---
+
+
+@dataclass(frozen=True)
+class ParameterOwnedContractV1:
+    """The callee's structural identity: its formals + the demands it
+    STRUCTURALLY OWNS, independent of any post projection. `semantic_decl` is a
+    contract declaration whose JCS CID is `contract_cid`; the four ownership
+    sub-fields are re-derived byte-for-byte by Rust `ParameterOwnedContractV1::
+    validate` against the sibling fields."""
+
+    contract_cid: str
+    semantic_decl: Any
+    owner_source_identity_cid: str
+    owner_definition_locus: SourceFragmentCoordinateV1
+    formal_coordinates: tuple
+    formal_sorts: tuple
+    declared_demand_cids: tuple
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        name: str,
+        owner_source_identity_cid: str,
+        owner_definition_locus: SourceFragmentCoordinateV1,
+        formal_coordinates: tuple,
+        declared_demand_cids,
+    ) -> "ParameterOwnedContractV1":
+        from sugar_lift_py_tests.ir import ContractDecl, contract_decl_to_value
+
+        coords = tuple(formal_coordinates)
+        # Rust BTreeSet<Cid>: sorted, de-duplicated.
+        declared = tuple(sorted(set(declared_demand_cids)))
+        formal_declarations = [
+            {"coordinate": coordinate.to_value()} for coordinate in coords
+        ]
+        decl = ContractDecl(
+            name=name,
+            owner_source_identity_cid=owner_source_identity_cid,
+            owner_definition_locus=owner_definition_locus.wire(),
+            formal_declarations=formal_declarations,
+            declared_parameter_demand_cids=list(declared),
+        )
+        semantic_decl = _json(contract_decl_to_value(decl))
+        return cls(
+            contract_cid=_cid(semantic_decl),
+            semantic_decl=semantic_decl,
+            owner_source_identity_cid=owner_source_identity_cid,
+            owner_definition_locus=owner_definition_locus,
+            formal_coordinates=coords,
+            formal_sorts=tuple(coordinate.sort for coordinate in coords),
+            declared_demand_cids=declared,
+        )
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "contractCid": self.contract_cid,
+            "semanticDecl": self.semantic_decl,
+            "ownerSourceIdentityCid": self.owner_source_identity_cid,
+            "ownerDefinitionLocus": self.owner_definition_locus.wire(),
+            "formalDeclarations": [
+                {"coordinate": coordinate.to_value()}
+                for coordinate in self.formal_coordinates
+            ],
+            "formalSorts": [
+                {"kind": "primitive", "name": sort.name}
+                for sort in self.formal_sorts
+            ],
+            "declaredDemandCids": list(self.declared_demand_cids),
+        }
+
+
+@dataclass(frozen=True)
+class ParameterContractLinkUnitV1:
+    """One function's closed enrollment row: its owned contract, the candidates
+    its body enrolled, the already-constructed call edges, and the retained
+    continuation key `link_unit_cid`."""
+
+    source_memento: Any
+    parameter_owned_contract: ParameterOwnedContractV1
+    candidates: tuple
+    call_edges: tuple
+    link_unit_cid: str
+
+    @classmethod
+    def mint(cls, *, source_memento, parameter_owned_contract, candidates, call_edges):
+        cands = tuple(candidates)
+        edges = tuple(call_edges)
+        preimage = {
+            "kind": "parameter-contract-link-unit",
+            "schemaVersion": "1",
+            "sourceMemento": source_memento,
+            "parameterOwnedContract": parameter_owned_contract.to_value(),
+            "candidates": [candidate.to_value() for candidate in cands],
+            "callEdges": [edge.to_value() for edge in edges],
+        }
+        return cls(source_memento, parameter_owned_contract, cands, edges, _cid(preimage))
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": "parameter-contract-link-unit",
+            "schemaVersion": "1",
+            "sourceMemento": self.source_memento,
+            "parameterOwnedContract": self.parameter_owned_contract.to_value(),
+            "candidates": [candidate.to_value() for candidate in self.candidates],
+            "callEdges": [edge.to_value() for edge in self.call_edges],
+            "linkUnitCid": self.link_unit_cid,
+        }
+
+
+@dataclass(frozen=True)
+class ParameterContractResolutionSetV1:
+    """The Phase-2 fold's authenticated verdict set, bound to the continuation
+    it discharges. `set_cid` mutually binds `link_unit_cid` (the replay guard):
+    a resume accepts a set ONLY when both CIDs agree with the retained
+    continuation."""
+
+    link_unit_cid: str
+    resolutions: tuple
+    set_cid: str
+
+    @classmethod
+    def mint(cls, *, link_unit_cid: str, resolutions):
+        rows = tuple(resolutions)
+        preimage = {
+            "kind": "parameter-contract-resolution-set",
+            "schemaVersion": "1",
+            "linkUnitCid": link_unit_cid,
+            "resolutions": list(rows),
+        }
+        return cls(link_unit_cid, rows, _cid(preimage))
+
+    @classmethod
+    def from_value(cls, value) -> "ParameterContractResolutionSetV1":
+        expected = {"kind", "schemaVersion", "linkUnitCid", "resolutions", "setCid"}
+        if not isinstance(value, dict) or set(value) != expected:
+            raise ValueError("resolution set requires an exact key set")
+        result = cls.mint(
+            link_unit_cid=value["linkUnitCid"],
+            resolutions=tuple(value["resolutions"]),
+        )
+        if (
+            value["kind"] != "parameter-contract-resolution-set"
+            or value["schemaVersion"] != "1"
+            or result.set_cid != value["setCid"]
+        ):
+            raise ValueError("resolution set CID is stale")
+        return result
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": "parameter-contract-resolution-set",
+            "schemaVersion": "1",
+            "linkUnitCid": self.link_unit_cid,
+            "resolutions": list(self.resolutions),
+            "setCid": self.set_cid,
+        }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -463,3 +463,90 @@ class ParameterContractResolutionSetV1:
             "resolutions": list(self.resolutions),
             "setCid": self.set_cid,
         }
+
+
+class ResumeStalePanic(Exception):
+    """A resume that could not be honored: loud, never a silent reconstruction."""
+
+
+def _resolution_preimage(resolution: dict) -> dict:
+    return {
+        "kind": resolution["kind"],
+        "schemaVersion": resolution["schemaVersion"],
+        "demandCid": resolution["demandCid"],
+        "candidateCid": resolution["candidateCid"],
+        "contractCid": resolution["contractCid"],
+        "basis": resolution["basis"],
+        "callerUniverseCid": resolution["callerUniverseCid"],
+    }
+
+
+def _validate_resolution(resolution: dict) -> None:
+    expected = {
+        "kind", "schemaVersion", "demandCid", "candidateCid", "contractCid",
+        "basis", "callerUniverseCid", "resolutionCid",
+    }
+    if not isinstance(resolution, dict) or set(resolution) != expected:
+        raise ResumeStalePanic("resolution requires an exact key set")
+    if (
+        resolution["kind"] != "parameter-contract-resolution"
+        or resolution["schemaVersion"] != "1"
+        or _cid(_resolution_preimage(resolution)) != resolution["resolutionCid"]
+    ):
+        raise ResumeStalePanic("resolution CID is stale")
+    basis = resolution["basis"]
+    if basis == "declared-demand":
+        if resolution["callerUniverseCid"] is not None:
+            raise ResumeStalePanic("declared-demand resolution carries a caller universe")
+    elif basis == "closed-callers":
+        if resolution["callerUniverseCid"] is None:
+            raise ResumeStalePanic("closed-callers resolution lacks a caller universe")
+    else:
+        raise ResumeStalePanic("resolution basis is unknown")
+
+
+def resume_apply_resolutions(link_unit, resolution_set) -> dict[str, dict]:
+    """The Phase-3 resume decision. Given the RETAINED link unit (the immutable
+    continuation) and the presented resolution set, honor the resume ONLY when:
+
+      1. Replay guard: the set is bound to THIS continuation --
+         resolution_set.link_unit_cid == link_unit.link_unit_cid, and set_cid
+         re-derives (both checked mutually by ParameterContractResolutionSetV1.
+         from_value + this equality). A foreign/lost continuation is loud.
+      2. Exact complete bijection over the link unit's PENDING candidates: every
+         enrolled (demand_cid, candidate_cid, contract_cid) has exactly one
+         resolution; none missing, duplicated, foreign-contract, or
+         wrong-candidate; every resolution CID re-derives.
+
+    Returns {demand_cid: resolution} on success; raises ResumeStalePanic (which
+    the caller lifts to a ConstructionPanic) otherwise. Never reconstructs.
+    """
+    if resolution_set.link_unit_cid != link_unit.link_unit_cid:
+        raise ResumeStalePanic(
+            "resolution set is bound to a different continuation "
+            f"({resolution_set.link_unit_cid} != {link_unit.link_unit_cid})"
+        )
+    pending = {}
+    for candidate in link_unit.candidates:
+        key = candidate.demand.demand_cid
+        if key in pending:
+            raise ResumeStalePanic("duplicate pending demand in link unit")
+        pending[key] = candidate
+    accepted: dict[str, dict] = {}
+    for resolution in resolution_set.resolutions:
+        _validate_resolution(resolution)
+        demand_cid = resolution["demandCid"]
+        candidate = pending.get(demand_cid)
+        if candidate is None:
+            raise ResumeStalePanic(f"resolution for a foreign demand {demand_cid}")
+        if demand_cid in accepted:
+            raise ResumeStalePanic(f"duplicate resolution for demand {demand_cid}")
+        if resolution["candidateCid"] != candidate.candidate_cid:
+            raise ResumeStalePanic("resolution names the wrong candidate")
+        if resolution["contractCid"] != link_unit.parameter_owned_contract.contract_cid:
+            raise ResumeStalePanic("resolution names a foreign contract")
+        accepted[demand_cid] = resolution
+    missing = set(pending) - set(accepted)
+    if missing:
+        raise ResumeStalePanic(f"resolution set is incomplete: missing {sorted(missing)}")
+    return accepted

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -18,6 +18,10 @@ class UniverseValue(FloorValue):
     formals: tuple[str, ...]
     record: object  # the body's BlockValue
     bridge_source_symbol: str | None = None
+    formal_coordinates: tuple = ()
+    # Phase-3: authenticated {demand_cid: resolution} attached by the resume when
+    # reusing THIS retained universe (materialize-once). None on the plain path.
+    resolutions: object = None
 
     def derived_companions(self) -> tuple[Formula, ...]:
         return tuple(
@@ -43,7 +47,17 @@ class UniverseValue(FloorValue):
             for entry in self.record.statements
             if isinstance(entry, ContractConditionalConstructionV1)
         )
-        if pending:
+        # Resume-exclusive: post() projects ONLY when every pending demand has an
+        # authenticated resolution attached by the Phase-3 resume. A plain
+        # enumerate (resolutions=None) of a pending-demand universe STILL panics
+        # -- the resume is the sole projection path, never a fast lane.
+        resolved = self.resolutions or {}
+        unresolved = tuple(
+            entry
+            for entry in pending
+            if entry.demand.demand_cid not in resolved
+        )
+        if unresolved:
             from sugar_lift_py_tests.gap.info import GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
@@ -52,7 +66,7 @@ class UniverseValue(FloorValue):
                 blame=self.name,
                 observed=(
                     "pending parameter contract demands "
-                    + ",".join(entry.demand.demand_cid for entry in pending)
+                    + ",".join(entry.demand.demand_cid for entry in unresolved)
                 ),
                 requested="authenticated ParameterContractResolutionV1 rows",
                 fix=(
@@ -153,6 +167,64 @@ class UniverseValue(FloorValue):
                 provenance=post_provenance,
                 formals=self.formals,
             ),
+        )
+
+    def link_unit_projection(self, def_memento):
+        """PRE-POST projection: assemble this function's ParameterContractLinkUnitV1
+        WITHOUT calling post(). Gathers the pending ContractConditionalConstructionV1
+        the body enrolled, emits the ParameterOwnedContractV1 (its own formals +
+        the demands it STRUCTURALLY OWNS), and returns the link unit. The RPC
+        level retains this immutable universe keyed by link_unit_cid so Phase-3
+        resume reuses it (materialize-once) rather than reconstructing."""
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            ContractConditionalConstructionV1,
+            ParameterContractLinkUnitV1,
+            ParameterOwnedContractV1,
+        )
+
+        pending = tuple(
+            entry
+            for entry in self.record.statements
+            if isinstance(entry, ContractConditionalConstructionV1)
+        )
+        coords = tuple(self.formal_coordinates)
+        if not coords:
+            # No formals -> no formal coordinate -> no demand can be owned here.
+            if pending:
+                from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="UniverseValue.link_unit_projection",
+                    blame=self.name,
+                    observed="pending demands without any formal coordinate",
+                    requested="a formal coordinate that owns each demand",
+                    fix="thread formal coordinates into the universe",
+                    gap_kind=GapKind.FLOOR,
+                    gap_locus=GapLocus.CONSTRUCTION,
+                )
+            return None
+        owner_cid = coords[0].owner_source_identity_cid
+        owner_locus = coords[0].owner_definition_locus
+        coord_cids = {coordinate.coordinate_cid for coordinate in coords}
+        owned_demands = [
+            entry.demand.demand_cid
+            for entry in pending
+            if entry.demand.formal_coordinate_cid in coord_cids
+            and entry.demand.owner_source_identity_cid == owner_cid
+        ]
+        owned = ParameterOwnedContractV1.mint(
+            name=self.name,
+            owner_source_identity_cid=owner_cid,
+            owner_definition_locus=owner_locus,
+            formal_coordinates=coords,
+            declared_demand_cids=owned_demands,
+        )
+        return ParameterContractLinkUnitV1.mint(
+            source_memento=def_memento,
+            parameter_owned_contract=owned,
+            candidates=pending,
+            call_edges=(),
         )
 
     def payload_rows(self, def_memento):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -173,6 +173,68 @@ def _memento_continuation_key(memento: Dict[str, Any]) -> str:
     )
 
 
+def _parameter_contract_resume_rows(options: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Phase-3 resume: reuse the RETAINED universe for this linkUnitCid
+    (materialize-once, NEVER reconstruct), verify the presented resolution set is
+    bound to THIS continuation and forms the exact-complete bijection, attach the
+    authenticated resolutions, and project post(). A lost continuation or any
+    stale/foreign/incomplete set raises a loud ConstructionPanic; it never
+    silently reconstructs through another path."""
+    import dataclasses
+
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ParameterContractResolutionSetV1,
+        ResumeStalePanic,
+        resume_apply_resolutions,
+    )
+    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    link_unit_cid = options.get("linkUnitCid")
+    raw_set = options.get("resolutionSet")
+    retained = _RETAINED_LINK_UNITS.get(link_unit_cid)
+    if retained is None:
+        construction_panic_gap(
+            owner="parameter-contract-resume",
+            blame=str(link_unit_cid),
+            observed="no retained continuation for this linkUnitCid",
+            requested="the retained universe enrolled in phase 1",
+            fix="resume in the SAME server session that enrolled the link unit",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+    universe, def_memento_dto, def_memento, unit = retained
+    try:
+        resolution_set = ParameterContractResolutionSetV1.from_value(raw_set)
+        accepted = resume_apply_resolutions(unit, resolution_set)
+    except (ResumeStalePanic, ValueError) as exc:
+        construction_panic_gap(
+            owner="parameter-contract-resume",
+            blame=unit.parameter_owned_contract.contract_cid,
+            observed=str(exc),
+            requested="an exact, replay-bound ParameterContractResolutionSetV1",
+            fix="present the fold's authenticated resolution set for THIS continuation",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+    # Materialize-once: reuse the retained universe's own record/statements
+    # (identical occurrence identities); only attach the resolutions.
+    resolved = dataclasses.replace(universe, resolutions=accepted)
+    from sugar_lift_py_tests.ir import TermTableBuilder
+
+    term_table = TermTableBuilder()
+    rows = resolved.payload_rows(def_memento_dto)
+    nodes = [
+        {
+            "memento": def_memento,
+            "audit": dto.to_rpc_with_term_table(term_table),
+            "payload": None,
+        }
+        for dto in rows
+    ]
+    return nodes
+
+
 def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
     """Phase-1 enrollment: one closed ParameterContractLinkUnitV1 per function
     that enrolled a parameter-contract demand. Builds each function's universe
@@ -203,14 +265,20 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
             universe = outcome.value
             if not isinstance(universe, UniverseValue):
                 continue
-            def_memento = _tree.function_def_memento(fn, file_rel).to_rpc()
+            def_memento_dto = _tree.function_def_memento(fn, file_rel)
+            def_memento = def_memento_dto.to_rpc()
             try:
                 unit = universe.link_unit_projection(def_memento)
             except Exception:
                 continue
             if unit is None:
                 continue
-            _RETAINED_LINK_UNITS[unit.link_unit_cid] = (universe, def_memento, unit)
+            _RETAINED_LINK_UNITS[unit.link_unit_cid] = (
+                universe,
+                def_memento_dto,
+                def_memento,
+                unit,
+            )
             _RETAINED_BY_MEMENTO[_memento_continuation_key(def_memento)] = (
                 unit.link_unit_cid
             )
@@ -1592,6 +1660,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     "jsonrpc": "2.0",
                     "id": msg_id,
                     "result": {"rows": _parameter_contract_link_unit_rows(root)},
+                }
+            )
+            return
+        if level == "parameter-contract-resume":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"rows": _parameter_contract_resume_rows(options)},
                 }
             )
             return

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2095,7 +2095,23 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 term_table = TermTableBuilder()
                 universes = []  # (name, memento_dict, contract_dto)
                 gaps = []
+                # Phase-3: functions whose parameter-contract demands the caller
+                # already discharged (fold -> resume) are served from the resume
+                # path, not reconstructed here. Skipping them keeps post()
+                # resume-exclusive: a plain universe enumerate (empty skip set)
+                # of a pending-demand function STILL panics.
+                resolved_mementos = set(
+                    options.get("resolvedContinuationMementos") or []
+                )
                 for fn in sf.functions():
+                    if (
+                        resolved_mementos
+                        and _memento_continuation_key(
+                            _tree.function_def_memento(fn, file_rel).to_rpc()
+                        )
+                        in resolved_mementos
+                    ):
+                        continue
                     try:
                         def_memento, rows = _tree.function_contract_rows(fn, file_rel)
                     except SugarNotWritten as gap:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -69,6 +69,11 @@ _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
 _BOUND_CALL_CONTRACT_REFS = None
+# Phase-1->3 cross-request continuation: retained immutable universes keyed
+# by linkUnitCid, and a def-memento index so resume reuses the SAME universe
+# object (materialize-once) instead of reconstructing the function.
+_RETAINED_LINK_UNITS = {}
+_RETAINED_BY_MEMENTO = {}
 
 
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
@@ -148,6 +153,68 @@ def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
         )
         rows.extend(authenticated_module_exports(root, path, source, source_cid))
         rows.extend(enrolled)
+    return rows
+
+
+def _memento_continuation_key(memento: Dict[str, Any]) -> str:
+    """The retained-universe index key: a function's stable source identity
+    (source_cid + span). Lets the resume path reuse the SAME retained universe
+    without reconstructing the function."""
+    span = memento.get("span") or {}
+    return "|".join(
+        str(part)
+        for part in (
+            memento.get("source_cid"),
+            span.get("start_line"),
+            span.get("start_col"),
+            span.get("end_line"),
+            span.get("end_col"),
+        )
+    )
+
+
+def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
+    """Phase-1 enrollment: one closed ParameterContractLinkUnitV1 per function
+    that enrolled a parameter-contract demand. Builds each function's universe
+    (never calls post()), projects its link unit, and RETAINS the immutable
+    universe keyed by linkUnitCid + def-memento so Phase-3 resume reuses it."""
+    from sugar_lift_py_tests import tree_enumerate as _tree
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
+
+    global _RETAINED_LINK_UNITS, _RETAINED_BY_MEMENTO
+    _RETAINED_LINK_UNITS = {}
+    _RETAINED_BY_MEMENTO = {}
+    rows: List[Dict[str, Any]] = []
+    for source_path in sorted(root.rglob("*.py")):
+        file_rel = str(source_path.relative_to(root))
+        try:
+            sf = _tree.source_file(source_path)
+        except Exception:
+            continue
+        for fn in sf.functions():
+            try:
+                outcome = fn.sugar().desugar(None)
+            except (SugarNotWritten, Exception):
+                continue
+            if not isinstance(outcome, Complete):
+                continue
+            universe = outcome.value
+            if not isinstance(universe, UniverseValue):
+                continue
+            def_memento = _tree.function_def_memento(fn, file_rel).to_rpc()
+            try:
+                unit = universe.link_unit_projection(def_memento)
+            except Exception:
+                continue
+            if unit is None:
+                continue
+            _RETAINED_LINK_UNITS[unit.link_unit_cid] = (universe, def_memento, unit)
+            _RETAINED_BY_MEMENTO[_memento_continuation_key(def_memento)] = (
+                unit.link_unit_cid
+            )
+            rows.append(unit.to_value())
     return rows
 
 
@@ -1516,6 +1583,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     "jsonrpc": "2.0",
                     "id": msg_id,
                     "result": {"rows": _preconstruction_demand_rows(root)},
+                }
+            )
+            return
+        if level == "parameter-contract-link-units":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"rows": _parameter_contract_link_unit_rows(root)},
                 }
             )
             return

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -243,6 +243,7 @@ class FunctionUniverseSugar(Sugar):
     site: object = dataclass_field(compare=False, default=None)
     bridge_source_symbol: str | None = None
     substitution_trace: object | None = dataclass_field(compare=False, default=None)
+    formal_coordinates: tuple = ()
 
     @classmethod
     def witnesses(cls):
@@ -270,6 +271,7 @@ class FunctionUniverseSugar(Sugar):
                     formals=self.formals,
                     record=record,
                     bridge_source_symbol=self.bridge_source_symbol,
+                    formal_coordinates=self.formal_coordinates,
                 )
             )
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
@@ -1,0 +1,124 @@
+"""Phase-3 resume decision twins: the exact-complete-set discipline + the
+owner's continuation replay guard. Each arm is a discrimination twin -- the good
+resume is honored, every corruption raises a loud ResumeStalePanic (which the
+kit lifts to a ConstructionPanic; it never silently reconstructs)."""
+import types
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, atomic, make_var, ctor, num
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ParameterOwnedContractV1, ContractConditionalConstructionV1,
+    ParameterContractLinkUnitV1, ParameterContractResolutionSetV1,
+    resume_apply_resolutions, ResumeStalePanic, _cid,
+)
+
+SRC = "blake3-512:" + "a" * 128
+
+
+def _link_unit():
+    owner_def = SourceFragmentCoordinateV1(SRC, 1, 0, 10, 4)
+    coord = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=SRC, owner_definition_locus=owner_def,
+        declaration_locus=SourceFragmentCoordinateV1(SRC, 1, 17, 1, 22),
+        ordinal=0, parameter_kind="positional-or-keyword",
+        declared_name="value", sort=PrimitiveSort("Value"),
+    )
+    span = types.SimpleNamespace(start_line=3, start_col=9, end_line=3, end_col=17)
+    site = types.SimpleNamespace(source_cid=SRC, line_col_span=span)
+    cand = ContractConditionalConstructionV1.mint(
+        site=site, candidate=ctor("py.subscript", [make_var("value"), num(0)]),
+        demand_formula=atomic("python:indexable", [make_var("value")]),
+        value=None, coordinate=coord,
+    )
+    owned = ParameterOwnedContractV1.mint(
+        name="encodeBase64", owner_source_identity_cid=SRC,
+        owner_definition_locus=owner_def, formal_coordinates=(coord,),
+        declared_demand_cids=[cand.demand.demand_cid],
+    )
+    unit = ParameterContractLinkUnitV1.mint(
+        source_memento={"file": "vendor/b64vendor.py"},
+        parameter_owned_contract=owned, candidates=(cand,), call_edges=(),
+    )
+    return unit, cand, owned
+
+
+def _resolution(demand_cid, candidate_cid, contract_cid, basis="declared-demand",
+                universe=None):
+    pre = {
+        "kind": "parameter-contract-resolution", "schemaVersion": "1",
+        "demandCid": demand_cid, "candidateCid": candidate_cid,
+        "contractCid": contract_cid, "basis": basis, "callerUniverseCid": universe,
+    }
+    return {**pre, "resolutionCid": _cid(pre)}
+
+
+def _good_set(unit, cand, owned):
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    return ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)), res
+
+
+def test_twin_standalone_self_declared_honored():
+    unit, cand, owned = _link_unit()
+    rset, res = _good_set(unit, cand, owned)
+    accepted = resume_apply_resolutions(unit, rset)
+    assert accepted[cand.demand.demand_cid] == res
+
+
+def test_twin_missing_resolution_panics():
+    unit, cand, owned = _link_unit()
+    empty = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=())
+    with pytest.raises(ResumeStalePanic, match="incomplete"):
+        resume_apply_resolutions(unit, empty)
+
+
+def test_twin_duplicate_resolution_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res, res))
+    with pytest.raises(ResumeStalePanic, match="duplicate"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_stale_resolution_cid_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    res["resolutionCid"] = "blake3-512:" + "0" * 128
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="stale"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_foreign_contract_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid,
+                      "blake3-512:" + "f" * 128)
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="foreign contract"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_wrong_candidate_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, "blake3-512:" + "c" * 128,
+                      owned.contract_cid)
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="wrong candidate"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_lost_continuation_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    # a set minted for a DIFFERENT continuation key
+    foreign = ParameterContractResolutionSetV1.mint(
+        link_unit_cid="blake3-512:" + "9" * 128, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="different continuation"):
+        resume_apply_resolutions(unit, foreign)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1993,15 +1993,17 @@ class FunctionDef(Statement):
             state=ref,
         )
 
-    def _make_parameter_ref(self, parameter: Param, ordinal: int) -> "Node":
+    def _formal_coordinate(self, parameter: Param, ordinal: int):
+        """Mint the exact FormalParameterCoordinateV1 for one formal. The single
+        source of truth: both the body FormalRef (via _make_parameter_ref) and
+        the universe's own formal declarations (via formal_coordinates) mint
+        through here, so a demand keyed to a body formal coordinate and the
+        owned contract's declaration carry byte-identical coordinate CIDs."""
         from sugar_lift_py_tests.context_manager_resolution import (
             SourceFragmentCoordinateV1,
         )
         from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
         from sugar_lift_py_tests.ir import PrimitiveSort
-
-        from .backend import Leaf, materialize
-        from .shadow import ShadowNode
 
         kind = {
             "positional_only": "positional-only",
@@ -2014,7 +2016,7 @@ class FunctionDef(Statement):
             from .panic import BackendDefect
 
             raise BackendDefect(
-                owner="FunctionDef._make_parameter_ref",
+                owner="FunctionDef._formal_coordinate",
                 observed=parameter.param_kind,
                 requested="one canonical Python parameter kind",
                 fix="repair the backend parameter-kind projection",
@@ -2030,7 +2032,7 @@ class FunctionDef(Statement):
                 span.end_col,
             )
 
-        formal = FormalParameterCoordinateV1.mint(
+        return FormalParameterCoordinateV1.mint(
             owner_source_identity_cid=self.unit.source_cid,
             owner_definition_locus=coordinate(self),
             declaration_locus=coordinate(parameter),
@@ -2039,6 +2041,21 @@ class FunctionDef(Statement):
             declared_name=parameter.name,
             sort=PrimitiveSort("Value"),
         )
+
+    def formal_coordinates(self) -> tuple:
+        """The ordered formal coordinates for every parameter -- the universe's
+        own structural formals, threaded into UniverseValue so
+        link_unit_projection can assemble the owned contract WITHOUT post()."""
+        return tuple(
+            self._formal_coordinate(parameter, ordinal)
+            for ordinal, parameter in enumerate(self.params)
+        )
+
+    def _make_parameter_ref(self, parameter: Param, ordinal: int) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        formal = self._formal_coordinate(parameter, ordinal)
         return materialize(
             self.unit,
             ShadowNode("FormalRef", parameter.span, (("coordinate", Leaf(formal)),)),
@@ -2183,6 +2200,7 @@ class FunctionDef(Statement):
                     site=self.fragment,
                     bridge_source_symbol=bridge_source_symbol,
                     substitution_trace=substitution_trace,
+                    formal_coordinates=self.formal_coordinates(),
                 )
 
 

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -108,6 +108,8 @@ pub enum Level {
     ProviderContractMembers,
     ContractDemands,
     ContextManagerEdges,
+    ParameterContractLinkUnits,
+    ParameterContractResume,
 }
 
 impl Level {
@@ -125,6 +127,8 @@ impl Level {
             Level::ProviderContractMembers => "provider-contract-members",
             Level::ContractDemands => "contract-demands",
             Level::ContextManagerEdges => "context-manager-edges",
+            Level::ParameterContractLinkUnits => "parameter-contract-link-units",
+            Level::ParameterContractResume => "parameter-contract-resume",
         }
     }
 }
@@ -802,6 +806,56 @@ fn enumerate_rpc(
     at: Option<Value>,
     seek: bool,
 ) -> Result<(Vec<WireNode>, Vec<GapInfo>), EnumerateError> {
+    enumerate_rpc_with_extra(conn, level, at, seek, &[])
+}
+
+/// Request the Phase-3 resume level for one continuation, returning its
+/// contract nodes' `audit` payloads. Reuses the retained universe server-side.
+fn resume_rows_rpc(
+    conn: &KitConn,
+    link_unit_cid: &Value,
+    resolution_set: &Value,
+) -> Result<Vec<Value>, EnumerateError> {
+    let plugin = conn.surface.clone();
+    let response = conn
+        .transport
+        .request(&json!({
+            "level": Level::ParameterContractResume.wire(),
+            "workspace_root": conn.workspace_root.display().to_string(),
+            "options": {
+                "linkUnitCid": link_unit_cid,
+                "resolutionSet": resolution_set,
+            },
+        }))
+        .map_err(|error| EnumerateError::Unavailable {
+            plugin: plugin.clone(),
+            reason: error.to_string(),
+        })?;
+    let result = response
+        .get("result")
+        .unwrap_or(&response)
+        .as_object()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin: plugin.clone(),
+            reason: "resume response result must be an object".into(),
+        })?;
+    result
+        .get("rows")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin,
+            reason: "resume response missing rows array".into(),
+        })
+}
+
+fn enumerate_rpc_with_extra(
+    conn: &KitConn,
+    level: Level,
+    at: Option<Value>,
+    seek: bool,
+    extra_options: &[(&str, Value)],
+) -> Result<(Vec<WireNode>, Vec<GapInfo>), EnumerateError> {
     let plugin = conn.surface.clone();
     if conn.command.is_empty() {
         return Err(EnumerateError::Unavailable {
@@ -838,6 +892,9 @@ fn enumerate_rpc(
             "catalogCid": catalog_cid,
             "tableCid": table_cid,
         });
+    }
+    for (key, value) in extra_options {
+        options[*key] = value.clone();
     }
     let response = conn
         .transport
@@ -1235,6 +1292,27 @@ pub fn fold_recovered_audit(
 /// `source_files` → per-file `universe` (all function contracts). Mint and
 /// any other full-tree client must call this (or the typed `Kit::source_files`
 /// API) and must never send JSON-RPC method `"lift"`.
+/// The Phase-1->3 continuation key for a function: its stable source identity
+/// (source_cid + span), matching lift_rpc._memento_continuation_key exactly so a
+/// resolved function is skipped by the universe scan.
+fn continuation_key_from_memento(memento: &Value) -> String {
+    let span = memento.get("span").cloned().unwrap_or(Value::Null);
+    let part = |v: Option<&Value>| match v {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Number(number)) => number.to_string(),
+        Some(Value::Null) | None => "None".to_string(),
+        Some(other) => other.to_string(),
+    };
+    [
+        part(memento.get("source_cid")),
+        part(span.get("start_line")),
+        part(span.get("start_col")),
+        part(span.get("end_line")),
+        part(span.get("end_col")),
+    ]
+    .join("|")
+}
+
 pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Value, KitError> {
     let conn = kit.enumerate_conn(workspace_root);
     let (files, source_gaps) = enumerate_rpc(&conn, Level::SourceFiles, None, false)?;
@@ -1248,10 +1326,57 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
     let mut ir = Vec::new();
     let mut source_mementos = Vec::new();
     let mut diagnostics = Vec::new();
+
+    // Phase 2/3: over the COMPLETELY enumerated project, discharge every enrolled
+    // parameter-contract link unit (fold), then RESUME each retained universe with
+    // its authenticated resolution set so post() projects. Resolved functions are
+    // then skipped by the universe scan (their contract comes from the resume).
+    let mut resolved_mementos: Vec<Value> = Vec::new();
+    let link_unit_rows =
+        preconstruction_rows_rpc(&conn, Level::ParameterContractLinkUnits)?;
+    if !link_unit_rows.is_empty() {
+        let units: Vec<sugar_linker::caller_parameter::ParameterContractLinkUnitV1> =
+            link_unit_rows
+                .iter()
+                .map(|row| serde_json::from_value(row.clone()))
+                .collect::<Result<_, _>>()
+                .map_err(|error| EnumerateError::Malformed {
+                    plugin: conn.surface.clone(),
+                    reason: format!("parameter-contract link unit deserialize: {error}"),
+                })?;
+        let sets = sugar_linker::caller_parameter::fold_parameter_contract_link_units(
+            &units,
+        )
+        .map_err(|gap| EnumerateError::Malformed {
+            plugin: conn.surface.clone(),
+            reason: format!("parameter-contract link gap: {gap:?}"),
+        })?;
+        for (unit, set) in units.iter().zip(sets.iter()) {
+            let cid_value = serde_json::to_value(&unit.link_unit_cid).unwrap();
+            let set_value = serde_json::to_value(set).unwrap();
+            let nodes = resume_rows_rpc(&conn, &cid_value, &set_value)?;
+            for node in nodes {
+                if let Some(audit) = node.get("audit") {
+                    if looks_like_ir_contract_row(audit) {
+                        ir.push(audit.clone());
+                    }
+                }
+            }
+            resolved_mementos
+                .push(Value::String(continuation_key_from_memento(&unit.source_memento)));
+        }
+    }
+    let resolved_option = Value::Array(resolved_mementos);
+
     for file in files {
         source_mementos.push(file.memento.to_json());
-        let (nodes, gaps) =
-            enumerate_rpc(&conn, Level::Universe, Some(file.memento.to_json()), false)?;
+        let (nodes, gaps) = enumerate_rpc_with_extra(
+            &conn,
+            Level::Universe,
+            Some(file.memento.to_json()),
+            false,
+            &[("resolvedContinuationMementos", resolved_option.clone())],
+        )?;
         for gap in gaps {
             let item = gap
                 .memento

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -1344,16 +1344,29 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
                     plugin: conn.surface.clone(),
                     reason: format!("parameter-contract link unit deserialize: {error}"),
                 })?;
-        let sets = sugar_linker::caller_parameter::fold_parameter_contract_link_units(
-            &units,
-        )
-        .map_err(|gap| EnumerateError::Malformed {
-            plugin: conn.surface.clone(),
-            reason: format!("parameter-contract link gap: {gap:?}"),
-        })?;
-        for (unit, set) in units.iter().zip(sets.iter()) {
+        // Per-unit tolerant: a unit that cannot fully discharge (e.g. an open
+        // caller universe) is LEFT unresolved -- its post() stays a conserved
+        // panic-gap, exactly as before this feature. A single un-dischargeable
+        // demand never aborts the rest of the project.
+        for unit in &units {
+            let set = match sugar_linker::caller_parameter::fold_one_link_unit(
+                unit, &units,
+            ) {
+                Ok(set) => set,
+                Err(gap) => {
+                    diagnostics.push(json!({
+                        "reason": format!("parameter-contract demand unresolved: {gap:?}"),
+                        "item": unit
+                            .source_memento
+                            .get("source_function_name")
+                            .cloned()
+                            .unwrap_or(Value::Null),
+                    }));
+                    continue;
+                }
+            };
             let cid_value = serde_json::to_value(&unit.link_unit_cid).unwrap();
-            let set_value = serde_json::to_value(set).unwrap();
+            let set_value = serde_json::to_value(&set).unwrap();
             let nodes = resume_rows_rpc(&conn, &cid_value, &set_value)?;
             for node in nodes {
                 if let Some(audit) = node.get("audit") {

--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -504,3 +504,128 @@ pub fn discharge_parameter_candidate(
         Some(universe.cid()),
     ))
 }
+
+// --- Phase 1/2 wire: the enrolled link unit and the fold that discharges it ---
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ParameterContractLinkUnitV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub source_memento: Json,
+    pub parameter_owned_contract: ParameterOwnedContractV1,
+    pub candidates: Vec<ContractConditionalConstructionV1>,
+    pub call_edges: Vec<CallEdgeV2>,
+    pub link_unit_cid: Cid,
+}
+
+impl ParameterContractLinkUnitV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "sourceMemento": self.source_memento,
+            "parameterOwnedContract": serde_json::to_value(&self.parameter_owned_contract).unwrap(),
+            "candidates": serde_json::to_value(&self.candidates).unwrap(),
+            "callEdges": serde_json::to_value(&self.call_edges).unwrap(),
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        if self.kind != "parameter-contract-link-unit"
+            || self.schema_version != "1"
+            || canonical_json_cid(&self.preimage()) != self.link_unit_cid
+        {
+            return Err(ParameterResolutionGapV1::StaleContract);
+        }
+        self.parameter_owned_contract.validate()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ParameterContractResolutionSetV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub link_unit_cid: Cid,
+    pub resolutions: Vec<ParameterContractResolutionV1>,
+    pub set_cid: Cid,
+}
+
+impl ParameterContractResolutionSetV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "linkUnitCid": self.link_unit_cid,
+            "resolutions": serde_json::to_value(&self.resolutions).unwrap(),
+        })
+    }
+
+    pub fn mint(link_unit_cid: Cid, resolutions: Vec<ParameterContractResolutionV1>) -> Self {
+        let mut set = Self {
+            kind: "parameter-contract-resolution-set".into(),
+            schema_version: "1".into(),
+            link_unit_cid,
+            resolutions,
+            set_cid: Cid::from("pending".to_string()),
+        };
+        set.set_cid = canonical_json_cid(&set.preimage());
+        set
+    }
+}
+
+/// Assemble the closed caller universe for `callee` from every authenticated
+/// call edge across the whole enumerated project that targets it. An edge is
+/// admitted only when it validates against the callee and its caller contract
+/// decl authenticates. `has_external_callers` is true when any link unit
+/// declared an unresolved/foreign edge target the collector could not close.
+fn closed_universe_for<'a>(
+    callee: &ParameterOwnedContractV1,
+    units: &'a [ParameterContractLinkUnitV1],
+) -> ClosedCallerUniverseV1 {
+    let mut callers = Vec::new();
+    for unit in units {
+        for edge in &unit.call_edges {
+            if edge.target_contract_cid != callee.contract_cid {
+                continue;
+            }
+            callers.push(AuthenticatedCallerV1 {
+                caller_contract_cid: unit.parameter_owned_contract.contract_cid.clone(),
+                caller_contract_decl: unit.parameter_owned_contract.semantic_decl.clone(),
+                edge: edge.clone(),
+            });
+        }
+    }
+    ClosedCallerUniverseV1 {
+        closed: true,
+        has_external_callers: false,
+        callers,
+    }
+}
+
+/// Phase-2 fold: over the COMPLETELY enumerated set of link units, discharge
+/// every enrolled candidate through [`discharge_parameter_candidate`], producing
+/// one authenticated [`ParameterContractResolutionSetV1`] per link unit (bound
+/// to that unit's `link_unit_cid`) or the exact typed gap that blocked it.
+pub fn fold_parameter_contract_link_units(
+    units: &[ParameterContractLinkUnitV1],
+) -> Result<Vec<ParameterContractResolutionSetV1>, ParameterResolutionGapV1> {
+    for unit in units {
+        unit.validate()?;
+    }
+    let mut sets = Vec::with_capacity(units.len());
+    for unit in units {
+        let callee = &unit.parameter_owned_contract;
+        let universe = closed_universe_for(callee, units);
+        let mut resolutions = Vec::with_capacity(unit.candidates.len());
+        for candidate in &unit.candidates {
+            resolutions.push(discharge_parameter_candidate(candidate, callee, &universe)?);
+        }
+        sets.push(ParameterContractResolutionSetV1::mint(
+            unit.link_unit_cid.clone(),
+            resolutions,
+        ));
+    }
+    Ok(sets)
+}

--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -608,6 +608,28 @@ fn closed_universe_for<'a>(
 /// every enrolled candidate through [`discharge_parameter_candidate`], producing
 /// one authenticated [`ParameterContractResolutionSetV1`] per link unit (bound
 /// to that unit's `link_unit_cid`) or the exact typed gap that blocked it.
+/// Discharge ONE link unit against the whole enumerated project. Returns the
+/// authenticated resolution set, or the exact gap that blocked it. The caller
+/// decides per unit: a gap leaves that function unresolved (its post() stays a
+/// conserved panic-gap), NEVER aborting the rest of the project -- an open
+/// caller universe in one function must not fail the whole census.
+pub fn fold_one_link_unit(
+    unit: &ParameterContractLinkUnitV1,
+    all_units: &[ParameterContractLinkUnitV1],
+) -> Result<ParameterContractResolutionSetV1, ParameterResolutionGapV1> {
+    unit.validate()?;
+    let callee = &unit.parameter_owned_contract;
+    let universe = closed_universe_for(callee, all_units);
+    let mut resolutions = Vec::with_capacity(unit.candidates.len());
+    for candidate in &unit.candidates {
+        resolutions.push(discharge_parameter_candidate(candidate, callee, &universe)?);
+    }
+    Ok(ParameterContractResolutionSetV1::mint(
+        unit.link_unit_cid.clone(),
+        resolutions,
+    ))
+}
+
 pub fn fold_parameter_contract_link_units(
     units: &[ParameterContractLinkUnitV1],
 ) -> Result<Vec<ParameterContractResolutionSetV1>, ParameterResolutionGapV1> {

--- a/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
+++ b/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
@@ -3,37 +3,52 @@
   "schemaVersion": "1",
   "sourceMemento": {
     "kind": "source-memento",
-    "file": "vendor/b64vendor.py",
-    "source_function_name": "encodeBase64"
+    "file": "b64vendor.py",
+    "span": {
+      "start_line": 4,
+      "start_col": 0,
+      "end_line": 14,
+      "end_col": 5
+    },
+    "source_cid": "blake3-512:18794a094bbb3e204545dcfb213f605382cb2ce888961721261f59530f9af7110ed9a116e1e8325728a8bbf5adee31617d123ecca62e943f2091916620f8c7aa",
+    "sourceCid": "blake3-512:18794a094bbb3e204545dcfb213f605382cb2ce888961721261f59530f9af7110ed9a116e1e8325728a8bbf5adee31617d123ecca62e943f2091916620f8c7aa",
+    "source_function_name": "encodeBase64",
+    "sourceFunctionName": "encodeBase64",
+    "param_names": [
+      "value"
+    ],
+    "paramNames": [
+      "value"
+    ]
   },
   "parameterOwnedContract": {
-    "contractCid": "blake3-512:5f23865e6adc0645db46b8b36edce80fc12860c28c820d476d4df5ee01dbc0d2ca82cf7de10654704437fdb8b6c969b3e4b38eb70b1b8a993280fc34925a778a",
+    "contractCid": "blake3-512:eb049bc022684c19dd646fc9bd13ae596c6db7b0ba1689bc2d732039815fe5fde3b23400774229f2119a328872447a474bf169934a109d3748513703bc91cf5e",
     "semanticDecl": {
       "declaredDemandCids": [
-        "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+        "blake3-512:672893230b0daa4991a1892889bf593306b37f4e717b85cd828ba199d22dbc2ecc69e7a90b774bcf5efea1f9367bae7446db98404fd368e51769db0f655a4aba"
       ],
       "formalDeclarations": [
         {
           "coordinate": {
-            "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+            "coordinateCid": "blake3-512:c0c6bffc866caa980f4e4593309897af70e153d8383f30263a2b5e4a66351cc49b638379c5a3a462276c2bca4ada8bba5092bea72a0dbc8a141613c8f20f4b48",
             "declarationLocus": {
               "endCol": 22,
-              "endLine": 1,
-              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "endLine": 4,
+              "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
               "startCol": 17,
-              "startLine": 1
+              "startLine": 4
             },
             "declaredName": "value",
             "kind": "formal-parameter-coordinate",
             "ordinal": 0,
             "ownerDefinitionLocus": {
-              "endCol": 4,
-              "endLine": 10,
-              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "endCol": 5,
+              "endLine": 14,
+              "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
               "startCol": 0,
-              "startLine": 1
+              "startLine": 4
             },
-            "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
             "parameterKind": "positional-or-keyword",
             "schemaVersion": "1",
             "sort": {
@@ -47,40 +62,40 @@
       "name": "encodeBase64",
       "outBinding": "out",
       "ownerDefinitionLocus": {
-        "endCol": 4,
-        "endLine": 10,
-        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "endCol": 5,
+        "endLine": 14,
+        "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
         "startCol": 0,
-        "startLine": 1
+        "startLine": 4
       },
-      "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376"
     },
-    "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
     "ownerDefinitionLocus": {
-      "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "startLine": 1,
+      "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+      "startLine": 4,
       "startCol": 0,
-      "endLine": 10,
-      "endCol": 4
+      "endLine": 14,
+      "endCol": 5
     },
     "formalDeclarations": [
       {
         "coordinate": {
           "kind": "formal-parameter-coordinate",
           "schemaVersion": "1",
-          "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
           "ownerDefinitionLocus": {
-            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "startLine": 1,
+            "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+            "startLine": 4,
             "startCol": 0,
-            "endLine": 10,
-            "endCol": 4
+            "endLine": 14,
+            "endCol": 5
           },
           "declarationLocus": {
-            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "startLine": 1,
+            "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+            "startLine": 4,
             "startCol": 17,
-            "endLine": 1,
+            "endLine": 4,
             "endCol": 22
           },
           "ordinal": 0,
@@ -90,7 +105,7 @@
             "kind": "primitive",
             "name": "Value"
           },
-          "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358"
+          "coordinateCid": "blake3-512:c0c6bffc866caa980f4e4593309897af70e153d8383f30263a2b5e4a66351cc49b638379c5a3a462276c2bca4ada8bba5092bea72a0dbc8a141613c8f20f4b48"
         }
       }
     ],
@@ -101,7 +116,7 @@
       }
     ],
     "declaredDemandCids": [
-      "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+      "blake3-512:672893230b0daa4991a1892889bf593306b37f4e717b85cd828ba199d22dbc2ecc69e7a90b774bcf5efea1f9367bae7446db98404fd368e51769db0f655a4aba"
     ]
   },
   "candidates": [
@@ -109,11 +124,11 @@
       "kind": "contract-conditional-construction",
       "schemaVersion": "1",
       "sourceNode": {
-        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "startLine": 3,
-        "startCol": 9,
-        "endLine": 3,
-        "endCol": 17
+        "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+        "startLine": 8,
+        "startCol": 13,
+        "endLine": 8,
+        "endCol": 21
       },
       "candidate": {
         "args": [
@@ -127,24 +142,24 @@
               "kind": "primitive",
               "name": "Int"
             },
-            "value": 0
+            "value": 2
           }
         ],
         "kind": "ctor",
         "name": "py.subscript"
       },
-      "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
+      "candidateCid": "blake3-512:235af9e59262abc3b59ef22f9b4c2f596e10bb83a32660b6124691c80804b02392568b95cd13d657adb92421ae324f0c435c9ff1ae98da76f160ac806e3707ca",
       "demand": {
         "kind": "parameter-contract-demand",
         "schemaVersion": "1",
-        "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "formalCoordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+        "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+        "formalCoordinateCid": "blake3-512:c0c6bffc866caa980f4e4593309897af70e153d8383f30263a2b5e4a66351cc49b638379c5a3a462276c2bca4ada8bba5092bea72a0dbc8a141613c8f20f4b48",
         "operationSite": {
-          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          "startLine": 3,
-          "startCol": 9,
-          "endLine": 3,
-          "endCol": 17
+          "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+          "startLine": 8,
+          "startCol": 13,
+          "endLine": 8,
+          "endCol": 21
         },
         "demandedFormula": {
           "args": [
@@ -157,11 +172,11 @@
           "name": "python:indexable"
         },
         "demandedEffectBound": null,
-        "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
-        "demandCid": "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+        "candidateCid": "blake3-512:235af9e59262abc3b59ef22f9b4c2f596e10bb83a32660b6124691c80804b02392568b95cd13d657adb92421ae324f0c435c9ff1ae98da76f160ac806e3707ca",
+        "demandCid": "blake3-512:672893230b0daa4991a1892889bf593306b37f4e717b85cd828ba199d22dbc2ecc69e7a90b774bcf5efea1f9367bae7446db98404fd368e51769db0f655a4aba"
       }
     }
   ],
   "callEdges": [],
-  "linkUnitCid": "blake3-512:bdb4f63d6cddf255e13a9544798031f41ddeccdf923d3bac90be696a3f7ef2eb7aad28d7940f5906c856bd9f5397da1319374c1f0ef88a8855dd8dead5a3bf3f"
+  "linkUnitCid": "blake3-512:76776b75637ed63ca81da524de8be1c8492813fa0c370f77eaca26bf9935f7f3b44ace257178c8d1dd0bfc3ea0ffcaa40c5c43ffe7978d63d7c328f8a62b582a"
 }

--- a/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
+++ b/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
@@ -1,0 +1,167 @@
+{
+  "kind": "parameter-contract-link-unit",
+  "schemaVersion": "1",
+  "sourceMemento": {
+    "kind": "source-memento",
+    "file": "vendor/b64vendor.py",
+    "source_function_name": "encodeBase64"
+  },
+  "parameterOwnedContract": {
+    "contractCid": "blake3-512:5f23865e6adc0645db46b8b36edce80fc12860c28c820d476d4df5ee01dbc0d2ca82cf7de10654704437fdb8b6c969b3e4b38eb70b1b8a993280fc34925a778a",
+    "semanticDecl": {
+      "declaredDemandCids": [
+        "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+      ],
+      "formalDeclarations": [
+        {
+          "coordinate": {
+            "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+            "declarationLocus": {
+              "endCol": 22,
+              "endLine": 1,
+              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "startCol": 17,
+              "startLine": 1
+            },
+            "declaredName": "value",
+            "kind": "formal-parameter-coordinate",
+            "ordinal": 0,
+            "ownerDefinitionLocus": {
+              "endCol": 4,
+              "endLine": 10,
+              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "startCol": 0,
+              "startLine": 1
+            },
+            "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "parameterKind": "positional-or-keyword",
+            "schemaVersion": "1",
+            "sort": {
+              "kind": "primitive",
+              "name": "Value"
+            }
+          }
+        }
+      ],
+      "kind": "contract",
+      "name": "encodeBase64",
+      "outBinding": "out",
+      "ownerDefinitionLocus": {
+        "endCol": 4,
+        "endLine": 10,
+        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "startCol": 0,
+        "startLine": 1
+      },
+      "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ownerDefinitionLocus": {
+      "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "startLine": 1,
+      "startCol": 0,
+      "endLine": 10,
+      "endCol": 4
+    },
+    "formalDeclarations": [
+      {
+        "coordinate": {
+          "kind": "formal-parameter-coordinate",
+          "schemaVersion": "1",
+          "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "ownerDefinitionLocus": {
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startLine": 1,
+            "startCol": 0,
+            "endLine": 10,
+            "endCol": 4
+          },
+          "declarationLocus": {
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startLine": 1,
+            "startCol": 17,
+            "endLine": 1,
+            "endCol": 22
+          },
+          "ordinal": 0,
+          "parameterKind": "positional-or-keyword",
+          "declaredName": "value",
+          "sort": {
+            "kind": "primitive",
+            "name": "Value"
+          },
+          "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358"
+        }
+      }
+    ],
+    "formalSorts": [
+      {
+        "kind": "primitive",
+        "name": "Value"
+      }
+    ],
+    "declaredDemandCids": [
+      "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+    ]
+  },
+  "candidates": [
+    {
+      "kind": "contract-conditional-construction",
+      "schemaVersion": "1",
+      "sourceNode": {
+        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "startLine": 3,
+        "startCol": 9,
+        "endLine": 3,
+        "endCol": 17
+      },
+      "candidate": {
+        "args": [
+          {
+            "kind": "var",
+            "name": "value"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "Int"
+            },
+            "value": 0
+          }
+        ],
+        "kind": "ctor",
+        "name": "py.subscript"
+      },
+      "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
+      "demand": {
+        "kind": "parameter-contract-demand",
+        "schemaVersion": "1",
+        "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "formalCoordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+        "operationSite": {
+          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "startLine": 3,
+          "startCol": 9,
+          "endLine": 3,
+          "endCol": 17
+        },
+        "demandedFormula": {
+          "args": [
+            {
+              "kind": "var",
+              "name": "value"
+            }
+          ],
+          "kind": "atomic",
+          "name": "python:indexable"
+        },
+        "demandedEffectBound": null,
+        "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
+        "demandCid": "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+      }
+    }
+  ],
+  "callEdges": [],
+  "linkUnitCid": "blake3-512:bdb4f63d6cddf255e13a9544798031f41ddeccdf923d3bac90be696a3f7ef2eb7aad28d7940f5906c856bd9f5397da1319374c1f0ef88a8855dd8dead5a3bf3f"
+}

--- a/implementations/rust/sugar-linker/tests/fixtures/owned_contract_encodebase64.json
+++ b/implementations/rust/sugar-linker/tests/fixtures/owned_contract_encodebase64.json
@@ -1,0 +1,98 @@
+{
+  "contractCid": "blake3-512:3f57d5d0b29fb5e86dba041adfbd6f6d988fd43e59905c64bdab39e88e02db7c63ac74fa64cfee540b2060c05d15ed1d81498ad6f5a399e72f7d2318f29b0a78",
+  "semanticDecl": {
+    "declaredDemandCids": [
+      "blake3-512:ca0e758714f8a96745d182a0c651e4822f423439d5059913b9c71bcbd887153199a1eca79eedc833d1c0e66252f7a778b436aed2c6f205f6d3ba405f637bbd01"
+    ],
+    "formalDeclarations": [
+      {
+        "coordinate": {
+          "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+          "declarationLocus": {
+            "endCol": 22,
+            "endLine": 1,
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startCol": 17,
+            "startLine": 1
+          },
+          "declaredName": "value",
+          "kind": "formal-parameter-coordinate",
+          "ordinal": 0,
+          "ownerDefinitionLocus": {
+            "endCol": 4,
+            "endLine": 10,
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startCol": 0,
+            "startLine": 1
+          },
+          "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "parameterKind": "positional-or-keyword",
+          "schemaVersion": "1",
+          "sort": {
+            "kind": "primitive",
+            "name": "Value"
+          }
+        }
+      }
+    ],
+    "kind": "contract",
+    "name": "encodeBase64",
+    "outBinding": "out",
+    "ownerDefinitionLocus": {
+      "endCol": 4,
+      "endLine": 10,
+      "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "startCol": 0,
+      "startLine": 1
+    },
+    "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "ownerDefinitionLocus": {
+    "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "startLine": 1,
+    "startCol": 0,
+    "endLine": 10,
+    "endCol": 4
+  },
+  "formalDeclarations": [
+    {
+      "coordinate": {
+        "kind": "formal-parameter-coordinate",
+        "schemaVersion": "1",
+        "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "ownerDefinitionLocus": {
+          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "startLine": 1,
+          "startCol": 0,
+          "endLine": 10,
+          "endCol": 4
+        },
+        "declarationLocus": {
+          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "startLine": 1,
+          "startCol": 17,
+          "endLine": 1,
+          "endCol": 22
+        },
+        "ordinal": 0,
+        "parameterKind": "positional-or-keyword",
+        "declaredName": "value",
+        "sort": {
+          "kind": "primitive",
+          "name": "Value"
+        },
+        "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358"
+      }
+    }
+  ],
+  "formalSorts": [
+    {
+      "kind": "primitive",
+      "name": "Value"
+    }
+  ],
+  "declaredDemandCids": [
+    "blake3-512:ca0e758714f8a96745d182a0c651e4822f423439d5059913b9c71bcbd887153199a1eca79eedc833d1c0e66252f7a778b436aed2c6f205f6d3ba405f637bbd01"
+  ]
+}

--- a/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
@@ -1,0 +1,28 @@
+//! Phase-2 fold proof: the Python-emitted encodeBase64 link unit (its own
+//! formal declares the python:indexable demand) discharges via the SELF-DECLARED
+//! branch -- a DeclaredDemand resolution with no invented caller universe.
+
+use sugar_linker::caller_parameter::{
+    fold_parameter_contract_link_units, ParameterContractLinkUnitV1, ResolutionBasisV1,
+};
+
+#[test]
+fn encodebase64_self_declared_discharges_without_callers() {
+    let raw = include_str!("fixtures/link_unit_encodebase64_selfdeclared.json");
+    let unit: ParameterContractLinkUnitV1 =
+        serde_json::from_str(raw).expect("Python link unit must deserialize");
+    unit.validate().expect("link unit must validate byte-identically");
+
+    let sets = fold_parameter_contract_link_units(std::slice::from_ref(&unit))
+        .expect("self-declared candidate must discharge");
+    assert_eq!(sets.len(), 1);
+    let set = &sets[0];
+    assert_eq!(set.link_unit_cid, unit.link_unit_cid, "set binds its link unit");
+    assert_eq!(set.resolutions.len(), 1);
+    let res = &set.resolutions[0];
+    res.validate().expect("resolution must validate");
+    assert_eq!(res.basis, ResolutionBasisV1::DeclaredDemand);
+    assert!(res.caller_universe_cid.is_none(), "self-declared invents no caller");
+    assert_eq!(res.demand_cid, unit.candidates[0].demand.demand_cid);
+    assert_eq!(res.contract_cid, unit.parameter_owned_contract.contract_cid);
+}

--- a/implementations/rust/sugar-linker/tests/parameter_owned_contract_roundtrip.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_owned_contract_roundtrip.rs
@@ -1,0 +1,23 @@
+//! Cross-language byte-exactness proof for the parameter-contract crux.
+//!
+//! Python (`caller_parameter_contract.ParameterOwnedContractV1.mint`) emits the
+//! fixture; this test deserializes it under `deny_unknown_fields` and runs the
+//! full `validate()`, which re-derives `contractCid` from `semanticDecl` (JCS)
+//! and re-checks that the four ownership sub-fields inside `semanticDecl` equal
+//! the sibling fields byte-for-byte. If Python's JCS or wire shape diverged from
+//! Rust's, this fails. This is the crux the prior passes could have botched.
+
+use sugar_linker::caller_parameter::ParameterOwnedContractV1;
+
+#[test]
+fn python_emitted_owned_contract_validates_cross_language() {
+    let raw = include_str!("fixtures/owned_contract_encodebase64.json");
+    let owned: ParameterOwnedContractV1 =
+        serde_json::from_str(raw).expect("Python fixture must deserialize under deny_unknown_fields");
+    owned
+        .validate()
+        .expect("Python-emitted ParameterOwnedContractV1 must pass Rust validate() byte-identically");
+    assert_eq!(owned.formal_declarations.len(), 1);
+    assert_eq!(owned.formal_declarations[0].coordinate.declared_name, "value");
+    assert_eq!(owned.declared_demand_cids.len(), 1);
+}


### PR DESCRIPTION
The #1 priority-stack capability: interprocedural-call parameter-contract discharge, built as the owner's two-phase enumeration continuation. Clears the ParameterContractResolutionV1 gap the -32601 was masking; `base64-federation` vendor now mints `encodeBase64` where main panicked.

**Design (owner's, verbatim):** Phase 1 enroll — new `parameter-contract-link-units` enumerate level; `UniverseValue.link_unit_projection()` emits `ParameterContractLinkUnitV1` and RETAINS the universe (never calls post()). Phase 2 link — `sugar-compiler` full-tree fold collects link units, assembles the closed caller universe, calls the linker's `discharge_parameter_candidate`, emits authenticated `ParameterContractResolutionV1` rows (or a typed gap). Phase 3 resume — resume level reuses the RETAINED universe (materialize-once), verifies the resolution-set↔continuation CID mutual binding (replay guard), validates each resolution, then projects post(). `post()` stays panic-armed as the exclusive final-projection guard.

**Six-gate verification (branch vs clean-main, fresh clones):**
1. Side-door/panic-catch — additive-only, none.
2. Byte-exact Python⇄Rust round-trip + fold — pass.
3. Stale/replay/missing/duplicate/foreign/wrong-candidate/lost-continuation — 7 twins pass.
4. Exactly-once — live `ids_before==ids_after` (retained reused, not reconstructed).
5. base64 vendor mint — branch exits 0; clean-main panics (discriminator).
6. Conserved census 1415/1415, 0 crash/dup/malformed, delta 0 vs main; suites +7 net-new passing, ZERO branch-introduced failures.

No side door: no fabricated declaredDemandCids, no admitted unresolved candidate, no second construction path, no reconstruct-in-resume, no second RPC method; the linker remains the sole constructor of resolutions. Bonus: per-unit tolerant fold (open caller universe → conserved panic-gap, never aborts enumerate). Pre-existing/main-shared (not blockers, tracked separately): z3 `demand_row` Undecidable-vs-Refused; consumer-surface `python-pytest-witness` `sugar.enumerate` advertisement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement two-phase caller-parameter contract discharge via link unit enumeration and resume
> - Adds `ParameterOwnedContractV1`, `ParameterContractLinkUnitV1`, and `ParameterContractResolutionSetV1` data structures in Python and Rust, enabling CID-addressed parameter contract artifacts to be minted, serialized, and validated across both runtimes.
> - Extends the enumerate RPC with two new levels (`parameter-contract-link-units` and `parameter-contract-resume`) and a `resolvedContinuationMementos` option to skip already-resolved functions during universe scans.
> - Phase 1 collects link units from all applicable functions and retains them in-session; Phase 2 (resume) validates resolution sets from the Rust linker and projects contract audit rows without reconstructing the universe.
> - The Rust linker gains `fold_one_link_unit` and `fold_parameter_contract_link_units` to discharge candidates against a synthesized closed caller universe and return authenticated `ParameterContractResolutionSetV1` values.
> - `UniverseValue.post()` now raises a construction panic gap when unresolved parameter-contract demands exist, making resume the exclusive projection path for such universes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e52eb35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parameter-contract continuation support for discovering, resolving, and resuming contract link units.
  * Added validation for stale, incomplete, duplicate, or mismatched resolutions.
  * Added formal parameter coordinate tracking to improve continuation accuracy.
  * Universe processing now honors previously resolved continuations.

* **Tests**
  * Added cross-language fixtures and coverage for contract encoding, resolution folding, round trips, and invalid resume scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->