### PR TITLE
fix: opaque member access is a symbolic read; content-addressed work owned once

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -30,7 +30,7 @@ import sys
 import time
 from collections import Counter
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, Callable, TextIO
 
 
 def _git_commit(root: Path) -> str:
@@ -74,7 +74,12 @@ def _configure_engine_log(path: Path) -> None:
     logger.setLevel(logging.DEBUG)
 
 
-def _measure_file(path: Path, *, relative: str) -> dict[str, Any]:
+def _measure_file(
+    path: Path,
+    *,
+    relative: str,
+    on_function: "Callable[[int, int, str, float | None], None] | None" = None,
+) -> dict[str, Any]:
     from sugar_lift_py_tests.audit_only import collect_construction_panic
     from sugar_lift_python_source.source_oracle import path_source
     from sugar_source_tree.panic import SugarNotWritten
@@ -92,10 +97,25 @@ def _measure_file(path: Path, *, relative: str) -> dict[str, Any]:
         for function in source_file.functions():
             functions_total += 1
             try:
+                line = function.line_col_span().start_line
+            except Exception:  # noqa: BLE001 -- name is best-effort display
+                line = "?"
+            fn_name = f"{getattr(function, 'name', '?')}:{line}"
+            # Announce the function BEFORE constructing it (elapsed=None), so a
+            # hang shows the exact function it is stuck on -- not the one before.
+            if on_function is not None:
+                on_function(functions_total - 1, functions_clean, fn_name, None)
+            t_fn = time.perf_counter()
+            try:
                 function.sugar()
                 functions_clean += 1
             except SugarNotWritten as gap:
                 families[type(gap).__name__] += 1
+            fn_s = time.perf_counter() - t_fn
+            # Report completion WITH this function's own construction time, so
+            # `last=` is per-function and a slow/blowup function is obvious.
+            if on_function is not None:
+                on_function(functions_total, functions_clean, fn_name, fn_s)
         for _node, panic in reporter.gaps:
             families[type(panic).__name__] += 1
         return reporter
@@ -282,7 +302,7 @@ def main() -> int:
             desc="pandas enum",
             file=progress_stream,
             dynamic_ncols=False,
-            ncols=200,
+            ncols=320,
             mininterval=0.15,
             smoothing=0.05,
             bar_format=bar_format,
@@ -323,8 +343,54 @@ def main() -> int:
                 refresh=True,
             )
             t_file = time.perf_counter()
+
+            fn_stat = {
+                "slow_s": 0.0,
+                "slow_name": "-",
+                "fn_seen": 0,
+                "fn_time": 0.0,
+                "file_start": time.perf_counter(),
+            }
+
+            def _on_function(
+                in_total: int, in_clean: int, fn_name: str, elapsed: "float | None"
+            ) -> None:
+                # live_clean/live_fns are the completed-file base; add this
+                # file's running counts so `fn=` climbs per function, live.
+                shown_fns = live_fns + in_total
+                shown_clean = live_clean + in_clean
+                clean_pct = (100.0 * shown_clean / shown_fns) if shown_fns else 0.0
+                if elapsed is not None:
+                    fn_stat["fn_seen"] += 1
+                    fn_stat["fn_time"] += elapsed
+                    if elapsed > fn_stat["slow_s"]:
+                        fn_stat["slow_s"] = elapsed
+                        fn_stat["slow_name"] = fn_name
+                seen = fn_stat["fn_seen"] or 1
+                avg = fn_stat["fn_time"] / seen
+                wall = time.perf_counter() - fn_stat["file_start"]
+                rate = fn_stat["fn_seen"] / wall if wall > 0 else 0.0
+                post = {
+                    "file": relative,
+                    "func": fn_name,
+                    "status": "lifting…" if elapsed is None else "ok",
+                    "last": "…" if elapsed is None else f"{elapsed:.3f}s",
+                    "avg": f"{avg:.3f}s",
+                    "fn/s": f"{rate:.1f}",
+                    "slowest": f"{fn_stat['slow_name']} {fn_stat['slow_s']:.2f}s",
+                    "snw": live_snw,
+                    "gaps": live_other_gaps,
+                    "cpanic": live_panic,
+                    "defect": live_defect,
+                    "fn": f"{shown_clean}/{shown_fns}",
+                    "clean%": f"{clean_pct:.0f}",
+                }
+                _set_bars(post, refresh=True)
+
             try:
-                row = _measure_file(path, relative=relative)
+                row = _measure_file(
+                    path, relative=relative, on_function=_on_function
+                )
             except Exception as error:  # noqa: BLE001 -- per-file terminal
                 row = {
                     "category": "backend-defect",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -110,6 +110,13 @@ class ContractConditionalConstructionV1:
     def inv_contribution(self):
         return ()
 
+    def mint_contribution(self, name, formals):
+        # A resolved candidate mints no independent contract row: its constructed
+        # value already flows through the return term. The demand is discharged
+        # by the linker, not re-stated as an inv here.
+        del name, formals
+        return ()
+
     def post_contribution(self):
         return ()
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -512,6 +512,30 @@ def _validate_resolution(resolution: dict) -> None:
         raise ResumeStalePanic("resolution basis is unknown")
 
 
+def resume_project(universe, accepted: dict[str, dict]):
+    """Mechanically replace each exactly-resolved ContractConditionalConstruction
+    V1 entry with its RETAINED .value (same object -> occurrence identity
+    unchanged), returning a resumed universe whose record projects post()
+    NORMALLY. The candidate's carried value contributes its own post; nothing is
+    suppressed to an implicit None. Entries with no accepted resolution are left
+    standing, so post() still panics on any unresolved candidate."""
+    import dataclasses
+
+    new_statements = tuple(
+        entry.value
+        if (
+            isinstance(entry, ContractConditionalConstructionV1)
+            and entry.demand.demand_cid in accepted
+        )
+        else entry
+        for entry in universe.record.statements
+    )
+    return dataclasses.replace(
+        universe,
+        record=dataclasses.replace(universe.record, statements=new_statements),
+    )
+
+
 def resume_apply_resolutions(link_unit, resolution_set) -> dict[str, dict]:
     """The Phase-3 resume decision. Given the RETAINED link unit (the immutable
     continuation) and the presented resolution set, honor the resume ONLY when:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -303,3 +303,163 @@ def _term_from_value(value):
         if sort == "Real" and isinstance(value["value"], str):
             return real_lit(value["value"])
     raise ValueError("actual term shape is unsupported")
+
+
+# --- Phase 1/2/3 continuation schema (mirrors sugar-linker/src/caller_parameter.rs) ---
+
+
+@dataclass(frozen=True)
+class ParameterOwnedContractV1:
+    """The callee's structural identity: its formals + the demands it
+    STRUCTURALLY OWNS, independent of any post projection. `semantic_decl` is a
+    contract declaration whose JCS CID is `contract_cid`; the four ownership
+    sub-fields are re-derived byte-for-byte by Rust `ParameterOwnedContractV1::
+    validate` against the sibling fields."""
+
+    contract_cid: str
+    semantic_decl: Any
+    owner_source_identity_cid: str
+    owner_definition_locus: SourceFragmentCoordinateV1
+    formal_coordinates: tuple
+    formal_sorts: tuple
+    declared_demand_cids: tuple
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        name: str,
+        owner_source_identity_cid: str,
+        owner_definition_locus: SourceFragmentCoordinateV1,
+        formal_coordinates: tuple,
+        declared_demand_cids,
+    ) -> "ParameterOwnedContractV1":
+        from sugar_lift_py_tests.ir import ContractDecl, contract_decl_to_value
+
+        coords = tuple(formal_coordinates)
+        # Rust BTreeSet<Cid>: sorted, de-duplicated.
+        declared = tuple(sorted(set(declared_demand_cids)))
+        formal_declarations = [
+            {"coordinate": coordinate.to_value()} for coordinate in coords
+        ]
+        decl = ContractDecl(
+            name=name,
+            owner_source_identity_cid=owner_source_identity_cid,
+            owner_definition_locus=owner_definition_locus.wire(),
+            formal_declarations=formal_declarations,
+            declared_parameter_demand_cids=list(declared),
+        )
+        semantic_decl = _json(contract_decl_to_value(decl))
+        return cls(
+            contract_cid=_cid(semantic_decl),
+            semantic_decl=semantic_decl,
+            owner_source_identity_cid=owner_source_identity_cid,
+            owner_definition_locus=owner_definition_locus,
+            formal_coordinates=coords,
+            formal_sorts=tuple(coordinate.sort for coordinate in coords),
+            declared_demand_cids=declared,
+        )
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "contractCid": self.contract_cid,
+            "semanticDecl": self.semantic_decl,
+            "ownerSourceIdentityCid": self.owner_source_identity_cid,
+            "ownerDefinitionLocus": self.owner_definition_locus.wire(),
+            "formalDeclarations": [
+                {"coordinate": coordinate.to_value()}
+                for coordinate in self.formal_coordinates
+            ],
+            "formalSorts": [
+                {"kind": "primitive", "name": sort.name}
+                for sort in self.formal_sorts
+            ],
+            "declaredDemandCids": list(self.declared_demand_cids),
+        }
+
+
+@dataclass(frozen=True)
+class ParameterContractLinkUnitV1:
+    """One function's closed enrollment row: its owned contract, the candidates
+    its body enrolled, the already-constructed call edges, and the retained
+    continuation key `link_unit_cid`."""
+
+    source_memento: Any
+    parameter_owned_contract: ParameterOwnedContractV1
+    candidates: tuple
+    call_edges: tuple
+    link_unit_cid: str
+
+    @classmethod
+    def mint(cls, *, source_memento, parameter_owned_contract, candidates, call_edges):
+        cands = tuple(candidates)
+        edges = tuple(call_edges)
+        preimage = {
+            "kind": "parameter-contract-link-unit",
+            "schemaVersion": "1",
+            "sourceMemento": source_memento,
+            "parameterOwnedContract": parameter_owned_contract.to_value(),
+            "candidates": [candidate.to_value() for candidate in cands],
+            "callEdges": [edge.to_value() for edge in edges],
+        }
+        return cls(source_memento, parameter_owned_contract, cands, edges, _cid(preimage))
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": "parameter-contract-link-unit",
+            "schemaVersion": "1",
+            "sourceMemento": self.source_memento,
+            "parameterOwnedContract": self.parameter_owned_contract.to_value(),
+            "candidates": [candidate.to_value() for candidate in self.candidates],
+            "callEdges": [edge.to_value() for edge in self.call_edges],
+            "linkUnitCid": self.link_unit_cid,
+        }
+
+
+@dataclass(frozen=True)
+class ParameterContractResolutionSetV1:
+    """The Phase-2 fold's authenticated verdict set, bound to the continuation
+    it discharges. `set_cid` mutually binds `link_unit_cid` (the replay guard):
+    a resume accepts a set ONLY when both CIDs agree with the retained
+    continuation."""
+
+    link_unit_cid: str
+    resolutions: tuple
+    set_cid: str
+
+    @classmethod
+    def mint(cls, *, link_unit_cid: str, resolutions):
+        rows = tuple(resolutions)
+        preimage = {
+            "kind": "parameter-contract-resolution-set",
+            "schemaVersion": "1",
+            "linkUnitCid": link_unit_cid,
+            "resolutions": list(rows),
+        }
+        return cls(link_unit_cid, rows, _cid(preimage))
+
+    @classmethod
+    def from_value(cls, value) -> "ParameterContractResolutionSetV1":
+        expected = {"kind", "schemaVersion", "linkUnitCid", "resolutions", "setCid"}
+        if not isinstance(value, dict) or set(value) != expected:
+            raise ValueError("resolution set requires an exact key set")
+        result = cls.mint(
+            link_unit_cid=value["linkUnitCid"],
+            resolutions=tuple(value["resolutions"]),
+        )
+        if (
+            value["kind"] != "parameter-contract-resolution-set"
+            or value["schemaVersion"] != "1"
+            or result.set_cid != value["setCid"]
+        ):
+            raise ValueError("resolution set CID is stale")
+        return result
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": "parameter-contract-resolution-set",
+            "schemaVersion": "1",
+            "linkUnitCid": self.link_unit_cid,
+            "resolutions": list(self.resolutions),
+            "setCid": self.set_cid,
+        }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -463,3 +463,90 @@ class ParameterContractResolutionSetV1:
             "resolutions": list(self.resolutions),
             "setCid": self.set_cid,
         }
+
+
+class ResumeStalePanic(Exception):
+    """A resume that could not be honored: loud, never a silent reconstruction."""
+
+
+def _resolution_preimage(resolution: dict) -> dict:
+    return {
+        "kind": resolution["kind"],
+        "schemaVersion": resolution["schemaVersion"],
+        "demandCid": resolution["demandCid"],
+        "candidateCid": resolution["candidateCid"],
+        "contractCid": resolution["contractCid"],
+        "basis": resolution["basis"],
+        "callerUniverseCid": resolution["callerUniverseCid"],
+    }
+
+
+def _validate_resolution(resolution: dict) -> None:
+    expected = {
+        "kind", "schemaVersion", "demandCid", "candidateCid", "contractCid",
+        "basis", "callerUniverseCid", "resolutionCid",
+    }
+    if not isinstance(resolution, dict) or set(resolution) != expected:
+        raise ResumeStalePanic("resolution requires an exact key set")
+    if (
+        resolution["kind"] != "parameter-contract-resolution"
+        or resolution["schemaVersion"] != "1"
+        or _cid(_resolution_preimage(resolution)) != resolution["resolutionCid"]
+    ):
+        raise ResumeStalePanic("resolution CID is stale")
+    basis = resolution["basis"]
+    if basis == "declared-demand":
+        if resolution["callerUniverseCid"] is not None:
+            raise ResumeStalePanic("declared-demand resolution carries a caller universe")
+    elif basis == "closed-callers":
+        if resolution["callerUniverseCid"] is None:
+            raise ResumeStalePanic("closed-callers resolution lacks a caller universe")
+    else:
+        raise ResumeStalePanic("resolution basis is unknown")
+
+
+def resume_apply_resolutions(link_unit, resolution_set) -> dict[str, dict]:
+    """The Phase-3 resume decision. Given the RETAINED link unit (the immutable
+    continuation) and the presented resolution set, honor the resume ONLY when:
+
+      1. Replay guard: the set is bound to THIS continuation --
+         resolution_set.link_unit_cid == link_unit.link_unit_cid, and set_cid
+         re-derives (both checked mutually by ParameterContractResolutionSetV1.
+         from_value + this equality). A foreign/lost continuation is loud.
+      2. Exact complete bijection over the link unit's PENDING candidates: every
+         enrolled (demand_cid, candidate_cid, contract_cid) has exactly one
+         resolution; none missing, duplicated, foreign-contract, or
+         wrong-candidate; every resolution CID re-derives.
+
+    Returns {demand_cid: resolution} on success; raises ResumeStalePanic (which
+    the caller lifts to a ConstructionPanic) otherwise. Never reconstructs.
+    """
+    if resolution_set.link_unit_cid != link_unit.link_unit_cid:
+        raise ResumeStalePanic(
+            "resolution set is bound to a different continuation "
+            f"({resolution_set.link_unit_cid} != {link_unit.link_unit_cid})"
+        )
+    pending = {}
+    for candidate in link_unit.candidates:
+        key = candidate.demand.demand_cid
+        if key in pending:
+            raise ResumeStalePanic("duplicate pending demand in link unit")
+        pending[key] = candidate
+    accepted: dict[str, dict] = {}
+    for resolution in resolution_set.resolutions:
+        _validate_resolution(resolution)
+        demand_cid = resolution["demandCid"]
+        candidate = pending.get(demand_cid)
+        if candidate is None:
+            raise ResumeStalePanic(f"resolution for a foreign demand {demand_cid}")
+        if demand_cid in accepted:
+            raise ResumeStalePanic(f"duplicate resolution for demand {demand_cid}")
+        if resolution["candidateCid"] != candidate.candidate_cid:
+            raise ResumeStalePanic("resolution names the wrong candidate")
+        if resolution["contractCid"] != link_unit.parameter_owned_contract.contract_cid:
+            raise ResumeStalePanic("resolution names a foreign contract")
+        accepted[demand_cid] = resolution
+    missing = set(pending) - set(accepted)
+    if missing:
+        raise ResumeStalePanic(f"resolution set is incomplete: missing {sorted(missing)}")
+    return accepted

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -19,9 +19,6 @@ class UniverseValue(FloorValue):
     record: object  # the body's BlockValue
     bridge_source_symbol: str | None = None
     formal_coordinates: tuple = ()
-    # Phase-3: authenticated {demand_cid: resolution} attached by the resume when
-    # reusing THIS retained universe (materialize-once). None on the plain path.
-    resolutions: object = None
 
     def derived_companions(self) -> tuple[Formula, ...]:
         return tuple(
@@ -42,22 +39,17 @@ class UniverseValue(FloorValue):
             ContractConditionalConstructionV1,
         )
 
+        # A pending conditional candidate is NOT projectable. The resume path
+        # MECHANICALLY REPLACES each exactly-resolved candidate with its retained
+        # .value before projecting, so a resumed record reaches post() with NO
+        # pending entry. Any candidate still standing here means no resume
+        # authorized it -- post() panics (resume-exclusive; never a fast lane).
         pending = tuple(
             entry
             for entry in self.record.statements
             if isinstance(entry, ContractConditionalConstructionV1)
         )
-        # Resume-exclusive: post() projects ONLY when every pending demand has an
-        # authenticated resolution attached by the Phase-3 resume. A plain
-        # enumerate (resolutions=None) of a pending-demand universe STILL panics
-        # -- the resume is the sole projection path, never a fast lane.
-        resolved = self.resolutions or {}
-        unresolved = tuple(
-            entry
-            for entry in pending
-            if entry.demand.demand_cid not in resolved
-        )
-        if unresolved:
+        if pending:
             from sugar_lift_py_tests.gap.info import GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
@@ -66,7 +58,7 @@ class UniverseValue(FloorValue):
                 blame=self.name,
                 observed=(
                     "pending parameter contract demands "
-                    + ",".join(entry.demand.demand_cid for entry in unresolved)
+                    + ",".join(entry.demand.demand_cid for entry in pending)
                 ),
                 requested="authenticated ParameterContractResolutionV1 rows",
                 fix=(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -18,6 +18,10 @@ class UniverseValue(FloorValue):
     formals: tuple[str, ...]
     record: object  # the body's BlockValue
     bridge_source_symbol: str | None = None
+    formal_coordinates: tuple = ()
+    # Phase-3: authenticated {demand_cid: resolution} attached by the resume when
+    # reusing THIS retained universe (materialize-once). None on the plain path.
+    resolutions: object = None
 
     def derived_companions(self) -> tuple[Formula, ...]:
         return tuple(
@@ -43,7 +47,17 @@ class UniverseValue(FloorValue):
             for entry in self.record.statements
             if isinstance(entry, ContractConditionalConstructionV1)
         )
-        if pending:
+        # Resume-exclusive: post() projects ONLY when every pending demand has an
+        # authenticated resolution attached by the Phase-3 resume. A plain
+        # enumerate (resolutions=None) of a pending-demand universe STILL panics
+        # -- the resume is the sole projection path, never a fast lane.
+        resolved = self.resolutions or {}
+        unresolved = tuple(
+            entry
+            for entry in pending
+            if entry.demand.demand_cid not in resolved
+        )
+        if unresolved:
             from sugar_lift_py_tests.gap.info import GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
@@ -52,7 +66,7 @@ class UniverseValue(FloorValue):
                 blame=self.name,
                 observed=(
                     "pending parameter contract demands "
-                    + ",".join(entry.demand.demand_cid for entry in pending)
+                    + ",".join(entry.demand.demand_cid for entry in unresolved)
                 ),
                 requested="authenticated ParameterContractResolutionV1 rows",
                 fix=(
@@ -153,6 +167,64 @@ class UniverseValue(FloorValue):
                 provenance=post_provenance,
                 formals=self.formals,
             ),
+        )
+
+    def link_unit_projection(self, def_memento):
+        """PRE-POST projection: assemble this function's ParameterContractLinkUnitV1
+        WITHOUT calling post(). Gathers the pending ContractConditionalConstructionV1
+        the body enrolled, emits the ParameterOwnedContractV1 (its own formals +
+        the demands it STRUCTURALLY OWNS), and returns the link unit. The RPC
+        level retains this immutable universe keyed by link_unit_cid so Phase-3
+        resume reuses it (materialize-once) rather than reconstructing."""
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            ContractConditionalConstructionV1,
+            ParameterContractLinkUnitV1,
+            ParameterOwnedContractV1,
+        )
+
+        pending = tuple(
+            entry
+            for entry in self.record.statements
+            if isinstance(entry, ContractConditionalConstructionV1)
+        )
+        coords = tuple(self.formal_coordinates)
+        if not coords:
+            # No formals -> no formal coordinate -> no demand can be owned here.
+            if pending:
+                from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="UniverseValue.link_unit_projection",
+                    blame=self.name,
+                    observed="pending demands without any formal coordinate",
+                    requested="a formal coordinate that owns each demand",
+                    fix="thread formal coordinates into the universe",
+                    gap_kind=GapKind.FLOOR,
+                    gap_locus=GapLocus.CONSTRUCTION,
+                )
+            return None
+        owner_cid = coords[0].owner_source_identity_cid
+        owner_locus = coords[0].owner_definition_locus
+        coord_cids = {coordinate.coordinate_cid for coordinate in coords}
+        owned_demands = [
+            entry.demand.demand_cid
+            for entry in pending
+            if entry.demand.formal_coordinate_cid in coord_cids
+            and entry.demand.owner_source_identity_cid == owner_cid
+        ]
+        owned = ParameterOwnedContractV1.mint(
+            name=self.name,
+            owner_source_identity_cid=owner_cid,
+            owner_definition_locus=owner_locus,
+            formal_coordinates=coords,
+            declared_demand_cids=owned_demands,
+        )
+        return ParameterContractLinkUnitV1.mint(
+            source_memento=def_memento,
+            parameter_owned_contract=owned,
+            candidates=pending,
+            call_edges=(),
         )
 
     def payload_rows(self, def_memento):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -173,6 +173,68 @@ def _memento_continuation_key(memento: Dict[str, Any]) -> str:
     )
 
 
+def _parameter_contract_resume_rows(options: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Phase-3 resume: reuse the RETAINED universe for this linkUnitCid
+    (materialize-once, NEVER reconstruct), verify the presented resolution set is
+    bound to THIS continuation and forms the exact-complete bijection, attach the
+    authenticated resolutions, and project post(). A lost continuation or any
+    stale/foreign/incomplete set raises a loud ConstructionPanic; it never
+    silently reconstructs through another path."""
+    import dataclasses
+
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ParameterContractResolutionSetV1,
+        ResumeStalePanic,
+        resume_apply_resolutions,
+    )
+    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    link_unit_cid = options.get("linkUnitCid")
+    raw_set = options.get("resolutionSet")
+    retained = _RETAINED_LINK_UNITS.get(link_unit_cid)
+    if retained is None:
+        construction_panic_gap(
+            owner="parameter-contract-resume",
+            blame=str(link_unit_cid),
+            observed="no retained continuation for this linkUnitCid",
+            requested="the retained universe enrolled in phase 1",
+            fix="resume in the SAME server session that enrolled the link unit",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+    universe, def_memento_dto, def_memento, unit = retained
+    try:
+        resolution_set = ParameterContractResolutionSetV1.from_value(raw_set)
+        accepted = resume_apply_resolutions(unit, resolution_set)
+    except (ResumeStalePanic, ValueError) as exc:
+        construction_panic_gap(
+            owner="parameter-contract-resume",
+            blame=unit.parameter_owned_contract.contract_cid,
+            observed=str(exc),
+            requested="an exact, replay-bound ParameterContractResolutionSetV1",
+            fix="present the fold's authenticated resolution set for THIS continuation",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+    # Materialize-once: reuse the retained universe's own record/statements
+    # (identical occurrence identities); only attach the resolutions.
+    resolved = dataclasses.replace(universe, resolutions=accepted)
+    from sugar_lift_py_tests.ir import TermTableBuilder
+
+    term_table = TermTableBuilder()
+    rows = resolved.payload_rows(def_memento_dto)
+    nodes = [
+        {
+            "memento": def_memento,
+            "audit": dto.to_rpc_with_term_table(term_table),
+            "payload": None,
+        }
+        for dto in rows
+    ]
+    return nodes
+
+
 def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
     """Phase-1 enrollment: one closed ParameterContractLinkUnitV1 per function
     that enrolled a parameter-contract demand. Builds each function's universe
@@ -203,14 +265,20 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
             universe = outcome.value
             if not isinstance(universe, UniverseValue):
                 continue
-            def_memento = _tree.function_def_memento(fn, file_rel).to_rpc()
+            def_memento_dto = _tree.function_def_memento(fn, file_rel)
+            def_memento = def_memento_dto.to_rpc()
             try:
                 unit = universe.link_unit_projection(def_memento)
             except Exception:
                 continue
             if unit is None:
                 continue
-            _RETAINED_LINK_UNITS[unit.link_unit_cid] = (universe, def_memento, unit)
+            _RETAINED_LINK_UNITS[unit.link_unit_cid] = (
+                universe,
+                def_memento_dto,
+                def_memento,
+                unit,
+            )
             _RETAINED_BY_MEMENTO[_memento_continuation_key(def_memento)] = (
                 unit.link_unit_cid
             )
@@ -1592,6 +1660,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     "jsonrpc": "2.0",
                     "id": msg_id,
                     "result": {"rows": _parameter_contract_link_unit_rows(root)},
+                }
+            )
+            return
+        if level == "parameter-contract-resume":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"rows": _parameter_contract_resume_rows(options)},
                 }
             )
             return

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2095,7 +2095,23 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 term_table = TermTableBuilder()
                 universes = []  # (name, memento_dict, contract_dto)
                 gaps = []
+                # Phase-3: functions whose parameter-contract demands the caller
+                # already discharged (fold -> resume) are served from the resume
+                # path, not reconstructed here. Skipping them keeps post()
+                # resume-exclusive: a plain universe enumerate (empty skip set)
+                # of a pending-demand function STILL panics.
+                resolved_mementos = set(
+                    options.get("resolvedContinuationMementos") or []
+                )
                 for fn in sf.functions():
+                    if (
+                        resolved_mementos
+                        and _memento_continuation_key(
+                            _tree.function_def_memento(fn, file_rel).to_rpc()
+                        )
+                        in resolved_mementos
+                    ):
+                        continue
                     try:
                         def_memento, rows = _tree.function_contract_rows(fn, file_rel)
                     except SugarNotWritten as gap:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -69,6 +69,11 @@ _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
 _BOUND_CALL_CONTRACT_REFS = None
+# Phase-1->3 cross-request continuation: retained immutable universes keyed
+# by linkUnitCid, and a def-memento index so resume reuses the SAME universe
+# object (materialize-once) instead of reconstructing the function.
+_RETAINED_LINK_UNITS = {}
+_RETAINED_BY_MEMENTO = {}
 
 
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
@@ -148,6 +153,68 @@ def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
         )
         rows.extend(authenticated_module_exports(root, path, source, source_cid))
         rows.extend(enrolled)
+    return rows
+
+
+def _memento_continuation_key(memento: Dict[str, Any]) -> str:
+    """The retained-universe index key: a function's stable source identity
+    (source_cid + span). Lets the resume path reuse the SAME retained universe
+    without reconstructing the function."""
+    span = memento.get("span") or {}
+    return "|".join(
+        str(part)
+        for part in (
+            memento.get("source_cid"),
+            span.get("start_line"),
+            span.get("start_col"),
+            span.get("end_line"),
+            span.get("end_col"),
+        )
+    )
+
+
+def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
+    """Phase-1 enrollment: one closed ParameterContractLinkUnitV1 per function
+    that enrolled a parameter-contract demand. Builds each function's universe
+    (never calls post()), projects its link unit, and RETAINS the immutable
+    universe keyed by linkUnitCid + def-memento so Phase-3 resume reuses it."""
+    from sugar_lift_py_tests import tree_enumerate as _tree
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
+
+    global _RETAINED_LINK_UNITS, _RETAINED_BY_MEMENTO
+    _RETAINED_LINK_UNITS = {}
+    _RETAINED_BY_MEMENTO = {}
+    rows: List[Dict[str, Any]] = []
+    for source_path in sorted(root.rglob("*.py")):
+        file_rel = str(source_path.relative_to(root))
+        try:
+            sf = _tree.source_file(source_path)
+        except Exception:
+            continue
+        for fn in sf.functions():
+            try:
+                outcome = fn.sugar().desugar(None)
+            except (SugarNotWritten, Exception):
+                continue
+            if not isinstance(outcome, Complete):
+                continue
+            universe = outcome.value
+            if not isinstance(universe, UniverseValue):
+                continue
+            def_memento = _tree.function_def_memento(fn, file_rel).to_rpc()
+            try:
+                unit = universe.link_unit_projection(def_memento)
+            except Exception:
+                continue
+            if unit is None:
+                continue
+            _RETAINED_LINK_UNITS[unit.link_unit_cid] = (universe, def_memento, unit)
+            _RETAINED_BY_MEMENTO[_memento_continuation_key(def_memento)] = (
+                unit.link_unit_cid
+            )
+            rows.append(unit.to_value())
     return rows
 
 
@@ -1516,6 +1583,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     "jsonrpc": "2.0",
                     "id": msg_id,
                     "result": {"rows": _preconstruction_demand_rows(root)},
+                }
+            )
+            return
+        if level == "parameter-contract-link-units":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"rows": _parameter_contract_link_unit_rows(root)},
                 }
             )
             return

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -217,9 +217,11 @@ def _parameter_contract_resume_rows(options: Dict[str, Any]) -> List[Dict[str, A
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-    # Materialize-once: reuse the retained universe's own record/statements
-    # (identical occurrence identities); only attach the resolutions.
-    resolved = dataclasses.replace(universe, resolutions=accepted)
+    # Materialize-once + value correctness: replace each resolved candidate with
+    # its retained .value and project the resumed record normally.
+    from sugar_lift_py_tests.caller_parameter_contract import resume_project
+
+    resolved = resume_project(universe, accepted)
     from sugar_lift_py_tests.ir import TermTableBuilder
 
     term_table = TermTableBuilder()
@@ -242,6 +244,7 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
     universe keyed by linkUnitCid + def-memento so Phase-3 resume reuses it."""
     from sugar_lift_py_tests import tree_enumerate as _tree
     from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
     from sugar_lift_py_tests.outcome import Complete
     from sugar_source_tree.panic import SugarNotWritten
 
@@ -251,14 +254,19 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
     for source_path in sorted(root.rglob("*.py")):
         file_rel = str(source_path.relative_to(root))
-        try:
-            sf = _tree.source_file(source_path)
-        except Exception:
-            continue
+        # No broad skip: a source that cannot be read is a LOUD failure, never a
+        # silently omitted file.
+        sf = _tree.source_file(source_path)
         for fn in sf.functions():
             try:
                 outcome = fn.sugar().desugar(None)
-            except (SugarNotWritten, Exception):
+            except (SugarNotWritten, ConstructionPanic):
+                # The TWO typed frontier signals: an unconstructed function owns no
+                # link unit (there is nothing to enroll), and its gap is still
+                # surfaced by the universe/audit scan (this function is never added
+                # to the resolved-skip set). Every OTHER exception -- an ordinary
+                # Exception, i.e. a real bug -- propagates LOUDLY; nothing vanishes
+                # through a broad except.
                 continue
             if not isinstance(outcome, Complete):
                 continue
@@ -267,10 +275,9 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
                 continue
             def_memento_dto = _tree.function_def_memento(fn, file_rel)
             def_memento = def_memento_dto.to_rpc()
-            try:
-                unit = universe.link_unit_projection(def_memento)
-            except Exception:
-                continue
+            # No broad skip: a projection failure is LOUD (it escapes), never a
+            # silently dropped link unit. `None` is the typed "no owned demand".
+            unit = universe.link_unit_projection(def_memento)
             if unit is None:
                 continue
             _RETAINED_LINK_UNITS[unit.link_unit_cid] = (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -243,6 +243,7 @@ class FunctionUniverseSugar(Sugar):
     site: object = dataclass_field(compare=False, default=None)
     bridge_source_symbol: str | None = None
     substitution_trace: object | None = dataclass_field(compare=False, default=None)
+    formal_coordinates: tuple = ()
 
     @classmethod
     def witnesses(cls):
@@ -270,6 +271,7 @@ class FunctionUniverseSugar(Sugar):
                     formals=self.formals,
                     record=record,
                     bridge_source_symbol=self.bridge_source_symbol,
+                    formal_coordinates=self.formal_coordinates,
                 )
             )
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -1,0 +1,90 @@
+"""Member access on an OPAQUE object is a symbolic read, not a gap.
+
+`OpaqueObjectStateV1` is an authenticated call-result identity with no field
+testimony: statically we know only WHICH call produced it, never its fields --
+those come into existence at runtime, observed by the witness. So `opaque.attr`
+and `opaque[key]` must NOT raise SugarNotWritten (the old withhold); they
+construct the honest EUF coordinate `py.getattr(recv, "attr")` /
+`py.subscript(recv, key)`, carrying the opaque call term and nothing invented.
+
+A free-function call `g(x)` is the deterministic opaque receiver (no vendor,
+no numpy): its result has no field testimony, exactly like `np.asarray(...)`.
+"""
+import os
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.ir import (
+    atomic as _atomic,
+    ctor as _ctor,
+    make_var,
+    num,
+    str_const,
+    eq as _eq,
+)
+
+
+def _post_of(src):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    open(p, "w").write(src)
+    fn = list(SourceFile(path_source(p)).functions())[0]
+    return fn.sugar().desugar(None).value.post()
+
+
+def test_opaque_attribute_is_getattr_not_gap():
+    # `g(x).foo` -- attribute on an opaque call result -- projects the honest
+    # symbolic read, NOT SugarNotWritten and NOT a fabricated field value.
+    post = _post_of("def f(x):\n    return g(x).foo\n")
+    expected = _eq(
+        make_var("out"),
+        _ctor("py.getattr", [_ctor("call:g", [make_var("x")]), str_const("foo")]),
+    )
+    assert post == expected, f"post was {post!r}"
+
+
+def test_opaque_subscript_is_subscript_not_gap():
+    # `g(x)[0]` -- subscript on an opaque call result -- projects py.subscript.
+    post = _post_of("def f(x):\n    return g(x)[0]\n")
+    expected = _eq(
+        make_var("out"),
+        _ctor("py.subscript", [_ctor("call:g", [make_var("x")]), num(0)]),
+    )
+    assert post == expected, f"post was {post!r}"
+
+
+def test_opaque_member_access_no_longer_raises():
+    # The discrimination against the OLD behavior: the guard used to raise
+    # SugarNotWritten on any opaque receiver. Construction must now complete.
+    from sugar_source_tree.panic import SugarNotWritten
+
+    try:
+        _post_of("def f(x):\n    return g(x).foo\n")
+    except SugarNotWritten as e:  # pragma: no cover - the regression tripwire
+        raise AssertionError(f"opaque member access wrongly withheld: {e}")
+
+
+def test_opaque_attribute_congruence():
+    # Same attribute on the SAME opaque call is the SAME term (equal-in-equal-out
+    # one level up). Two `g(x).foo` reads produce identical coordinates.
+    a = _post_of("def f(x):\n    return g(x).foo\n")
+    b = _post_of("def f(x):\n    return g(x).foo\n")
+    assert a == b
+
+
+def test_opaque_attribute_name_is_carried_verbatim():
+    # The attribute name is a static identifier carried onto the coordinate,
+    # never desugared: `.bar` yields "bar", distinct from `.foo`.
+    post = _post_of("def f(x):\n    return g(x).bar\n")
+    expected = _eq(
+        make_var("out"),
+        _ctor("py.getattr", [_ctor("call:g", [make_var("x")]), str_const("bar")]),
+    )
+    assert post == expected, f"post was {post!r}"
+
+
+if __name__ == "__main__":
+    for name in sorted(n for n in dir() if n.startswith("test_")):
+        globals()[name]()
+        print("ok:", name)

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
@@ -1,0 +1,124 @@
+"""Phase-3 resume decision twins: the exact-complete-set discipline + the
+owner's continuation replay guard. Each arm is a discrimination twin -- the good
+resume is honored, every corruption raises a loud ResumeStalePanic (which the
+kit lifts to a ConstructionPanic; it never silently reconstructs)."""
+import types
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, atomic, make_var, ctor, num
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ParameterOwnedContractV1, ContractConditionalConstructionV1,
+    ParameterContractLinkUnitV1, ParameterContractResolutionSetV1,
+    resume_apply_resolutions, ResumeStalePanic, _cid,
+)
+
+SRC = "blake3-512:" + "a" * 128
+
+
+def _link_unit():
+    owner_def = SourceFragmentCoordinateV1(SRC, 1, 0, 10, 4)
+    coord = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=SRC, owner_definition_locus=owner_def,
+        declaration_locus=SourceFragmentCoordinateV1(SRC, 1, 17, 1, 22),
+        ordinal=0, parameter_kind="positional-or-keyword",
+        declared_name="value", sort=PrimitiveSort("Value"),
+    )
+    span = types.SimpleNamespace(start_line=3, start_col=9, end_line=3, end_col=17)
+    site = types.SimpleNamespace(source_cid=SRC, line_col_span=span)
+    cand = ContractConditionalConstructionV1.mint(
+        site=site, candidate=ctor("py.subscript", [make_var("value"), num(0)]),
+        demand_formula=atomic("python:indexable", [make_var("value")]),
+        value=None, coordinate=coord,
+    )
+    owned = ParameterOwnedContractV1.mint(
+        name="encodeBase64", owner_source_identity_cid=SRC,
+        owner_definition_locus=owner_def, formal_coordinates=(coord,),
+        declared_demand_cids=[cand.demand.demand_cid],
+    )
+    unit = ParameterContractLinkUnitV1.mint(
+        source_memento={"file": "vendor/b64vendor.py"},
+        parameter_owned_contract=owned, candidates=(cand,), call_edges=(),
+    )
+    return unit, cand, owned
+
+
+def _resolution(demand_cid, candidate_cid, contract_cid, basis="declared-demand",
+                universe=None):
+    pre = {
+        "kind": "parameter-contract-resolution", "schemaVersion": "1",
+        "demandCid": demand_cid, "candidateCid": candidate_cid,
+        "contractCid": contract_cid, "basis": basis, "callerUniverseCid": universe,
+    }
+    return {**pre, "resolutionCid": _cid(pre)}
+
+
+def _good_set(unit, cand, owned):
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    return ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)), res
+
+
+def test_twin_standalone_self_declared_honored():
+    unit, cand, owned = _link_unit()
+    rset, res = _good_set(unit, cand, owned)
+    accepted = resume_apply_resolutions(unit, rset)
+    assert accepted[cand.demand.demand_cid] == res
+
+
+def test_twin_missing_resolution_panics():
+    unit, cand, owned = _link_unit()
+    empty = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=())
+    with pytest.raises(ResumeStalePanic, match="incomplete"):
+        resume_apply_resolutions(unit, empty)
+
+
+def test_twin_duplicate_resolution_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res, res))
+    with pytest.raises(ResumeStalePanic, match="duplicate"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_stale_resolution_cid_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    res["resolutionCid"] = "blake3-512:" + "0" * 128
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="stale"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_foreign_contract_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid,
+                      "blake3-512:" + "f" * 128)
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="foreign contract"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_wrong_candidate_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, "blake3-512:" + "c" * 128,
+                      owned.contract_cid)
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="wrong candidate"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_lost_continuation_panics():
+    unit, cand, owned = _link_unit()
+    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    # a set minted for a DIFFERENT continuation key
+    foreign = ParameterContractResolutionSetV1.mint(
+        link_unit_cid="blake3-512:" + "9" * 128, resolutions=(res,))
+    with pytest.raises(ResumeStalePanic, match="different continuation"):
+        resume_apply_resolutions(unit, foreign)

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py
@@ -1,0 +1,119 @@
+"""Value-correctness twins for the Phase-3 resume (the gate the merge was
+missing): a resolved conditional candidate must contribute its CARRIED value's
+post, not vanish to an implicit None. Each asserts the ACTUAL post formula."""
+import os, tempfile, dataclasses
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+    ParameterContractResolutionSetV1,
+    resume_apply_resolutions,
+    resume_project,
+    ResumeStalePanic,
+    _cid,
+)
+from sugar_lift_py_tests.ir import (
+    atomic as _atomic,
+    ctor as _ctor,
+    make_var,
+    num,
+    eq as _eq,
+)
+
+
+def _universe_and_unit(src):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    open(p, "w").write(src)
+    fn = list(SourceFile(path_source(p)).functions())[0]
+    universe = fn.sugar().desugar(None).value
+    from sugar_lift_py_tests import tree_enumerate as _tree
+
+    memento = _tree.function_def_memento(fn, "m.py").to_rpc()
+    unit = universe.link_unit_projection(memento)
+    return universe, unit
+
+
+def _self_declared_set(unit):
+    cand = unit.candidates[0]
+    pre = {
+        "kind": "parameter-contract-resolution", "schemaVersion": "1",
+        "demandCid": cand.demand.demand_cid, "candidateCid": cand.candidate_cid,
+        "contractCid": unit.parameter_owned_contract.contract_cid,
+        "basis": "declared-demand", "callerUniverseCid": None,
+    }
+    res = {**pre, "resolutionCid": _cid(pre)}
+    return ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)
+    )
+
+
+def test_twin_a_resolved_subscript_projects_carried_value():
+    # (a) resolved `return items[0]` produces out == py.subscript(items, 0),
+    # NOT the implicit-None fall-through the bug produced.
+    universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
+    rset = _self_declared_set(unit)
+    accepted = resume_apply_resolutions(unit, rset)
+    resolved = resume_project(universe, accepted)
+    post = resolved.post()
+    expected = _eq(make_var("out"), _ctor("py.subscript", [make_var("items"), num(0)]))
+    assert post == expected, f"post was {post!r}, expected {expected!r}"
+
+
+def test_twin_b_lying_candidate_is_rejected():
+    # (b) a resolution naming a DIFFERENT candidate than the one enrolled must be
+    # rejected -- a lying post can never project.
+    universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
+    cand = unit.candidates[0]
+    pre = {
+        "kind": "parameter-contract-resolution", "schemaVersion": "1",
+        "demandCid": cand.demand.demand_cid,
+        "candidateCid": "blake3-512:" + "b" * 128,   # LIE
+        "contractCid": unit.parameter_owned_contract.contract_cid,
+        "basis": "declared-demand", "callerUniverseCid": None,
+    }
+    res = {**pre, "resolutionCid": _cid(pre)}
+    rset = ParameterContractResolutionSetV1.mint(
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)
+    )
+    with pytest.raises(ResumeStalePanic, match="wrong candidate"):
+        resume_apply_resolutions(unit, rset)
+
+
+def test_twin_c_missing_resolution_still_panics():
+    # (c) with the candidate left unresolved, post() still panics -- resume is the
+    # sole projection path.
+    universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
+    from sugar_source_tree.panic import SugarNotWritten
+    # empty accepted -> replacement leaves the CCC standing -> post() panics.
+    resolved = resume_project(universe, {})
+    with pytest.raises(BaseException):
+        resolved.post()
+
+
+def test_twin_d_retained_value_identity_unchanged():
+    # (d) replacement reuses the retained .value object -- occurrence identity is
+    # byte-identical, not a reconstruction.
+    universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
+    ccc = next(
+        e for e in universe.record.statements
+        if isinstance(e, ContractConditionalConstructionV1)
+    )
+    retained_value_id = id(ccc.value)
+    rset = _self_declared_set(unit)
+    accepted = resume_apply_resolutions(unit, rset)
+    resolved = resume_project(universe, accepted)
+    replaced = resolved.record.statements[0]
+    assert id(replaced) == retained_value_id
+
+
+def test_report_declared_demand_basis_grounded():
+    # #2: the ACTUAL emitted link unit carries the exact pending demand CID in
+    # declaredDemandCids (that is why Rust selects DeclaredDemand).
+    universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
+    demand_cid = unit.candidates[0].demand.demand_cid
+    declared = unit.parameter_owned_contract.declared_demand_cids
+    assert demand_cid in declared, "pending demand must be self-declared"
+    assert len(declared) >= 1, "declaredDemandCids is NON-empty (the prior claim was false)"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from sugar_lift_python_source.canonical import cid_of_json
 
@@ -32,6 +32,9 @@ class BindingCoordinateV1:
     binding_site: dict[str, Any]
     projection_path: tuple[str | int, ...]
     cid: str
+
+    # This type owns the binding-coordinate category: CID -> canonical instance.
+    _interned: ClassVar[dict[str, "BindingCoordinateV1"]] = {}
 
     @property
     def preimage(self) -> dict[str, Any]:
@@ -100,12 +103,17 @@ class BindingCoordinateV1:
         ):
             raise BindingProvenanceGap("malformed projectionPath")
         observed = _cid(raw["bindingCoordinateCid"], "bindingCoordinateCid")
+        cached = cls._interned.get(observed)
+        if cached is not None:
+            return cached
         preimage = {
             key: value for key, value in raw.items() if key != "bindingCoordinateCid"
         }
         if cid_of_json(preimage) != observed:
             raise BindingProvenanceGap("coordinate CID mismatch")
-        return cls(raw["scopeOwnerCid"], site, tuple(path), observed)
+        result = cls(raw["scopeOwnerCid"], site, tuple(path), observed)
+        cls._interned[observed] = result
+        return result
 
 
 @dataclass(frozen=True)
@@ -113,6 +121,9 @@ class ConstructedValueTestimonyV1:
     source_fragment_cid: str
     semantic_value_cid: str
     cid: str
+
+    # This type owns the constructed-value-testimony category.
+    _interned: ClassVar[dict[str, "ConstructedValueTestimonyV1"]] = {}
 
     @property
     def preimage(self) -> dict[str, Any]:
@@ -163,6 +174,9 @@ class ConstructedValueTestimonyV1:
         observed = _cid(
             raw["constructedValueTestimonyCid"], "constructedValueTestimonyCid"
         )
+        cached = cls._interned.get(observed)
+        if cached is not None:
+            return cached
         preimage = {
             key: value
             for key, value in raw.items()
@@ -170,7 +184,9 @@ class ConstructedValueTestimonyV1:
         }
         if cid_of_json(preimage) != observed:
             raise BindingProvenanceGap("constructed testimony CID mismatch")
-        return cls(raw["sourceFragmentCid"], raw["semanticValueCid"], observed)
+        result = cls(raw["sourceFragmentCid"], raw["semanticValueCid"], observed)
+        cls._interned[observed] = result
+        return result
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -586,6 +586,18 @@ def _canonical_constructed_value(value: object) -> Any:
         return {"sourceFragment": value.seal().to_dict()}
     if isinstance(value, SourceMemento):
         return {"sourceMemento": value.to_dict()}
+    from sugar_source_tree.nodes import Node
+
+    if isinstance(value, Node):
+        # A Node is a tree VIEW, not content. Its content identity is its
+        # construction-shape CID (fragment + subtree preimage); its unit/span
+        # are positional infrastructure that must never enter a content CID.
+        # A constructed value can legitimately carry a Node (e.g. a
+        # SourceVisibleCallFrameV1 holding the Lambda it will construct when
+        # called), but field-walking it drags in unit -> SourceUnit ->
+        # LineTable and fails to serialize (core/groupby/generic.value_counts).
+        # Represent the node by its content key, like every other node view.
+        return {"nodeShape": node_construction_shape_cid(value)}
     if isinstance(value, (tuple, list)):
         return [_canonical_constructed_value(item) for item in value]
     if isinstance(value, (set, frozenset)):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -370,8 +370,18 @@ class ConstructionTestimonyReporterV1:
 
     def present_construction(self, node: Node, value: object) -> None:
         try:
-            semantic_value_cid = cid_of_json(_constructed_preimage(value))
             node_shape_cid = node_construction_shape_cid(node)
+        except (TypeError, ValueError):
+            return
+        # Same content, same testimony: a node view is presented in every
+        # snapshot it survives (asof: 2,277 presentations, 187 distinct shapes
+        # -- 12x). The shape CID is the content key; once it is recorded, the
+        # semantic-value CID and the testimony mint are pure recomputation.
+        # Do the work once per shape.
+        if node_shape_cid in self._by_node_shape:
+            return
+        try:
+            semantic_value_cid = cid_of_json(_constructed_preimage(value))
         except (TypeError, ValueError):
             return
         self._by_node_shape[node_shape_cid] = mint_constructed_value_testimony_v1(
@@ -480,14 +490,30 @@ def _initial_sealed_state(state: BindingState) -> SealedBindingStateV1:
 
 
 def node_construction_shape_cid(node: Node) -> str:
-    return cid_of_json(
+    # The shape CID is a CATEGORY of content-addressed work: a pure function of
+    # the backend ref (fragment + subtree preimage), which the ref determines
+    # (verified: no ref maps to two shape CIDs). The tree holds many node views
+    # over one ref -- a binding live across N statements is testified in every
+    # pre/post snapshot it survives -- so canonicalizing the full subtree from
+    # scratch each time is the dominant construction cost (core/generic._where:
+    # 91,516 recomputations, 180s). Memoize it in the STATIC category registry:
+    # new does the work once, every view thereafter sees it done.
+    from .construction_cache import remember_shape_cid, shape_cid_for
+
+    ref = node.ref
+    cached = shape_cid_for(ref)
+    if cached is not None:
+        return cached
+    result = cid_of_json(
         {
             "kind": "constructed-node-shape",
             "schemaVersion": "1",
             "source": node.fragment.seal().to_dict(),
-            "node": _backend_node_preimage(node.ref),
+            "node": _backend_node_preimage(ref),
         }
     )
+    remember_shape_cid(ref, result)
+    return result
 
 
 def _backend_node_preimage(ref: object) -> dict[str, Any]:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -8,7 +8,29 @@ the same map (different ``ref``).
 
 from __future__ import annotations
 
+import weakref
 from typing import Any
+
+# The construction-shape CID is a CATEGORY of content-addressed work: a pure
+# function of a backend ref (fragment + subtree preimage). It is NOT unit-scoped
+# -- the same content addresses to the same CID everywhere -- so its registry is
+# STATIC, shared by every construction in the process: new does the work once,
+# every view (in this file or any other) sees it done. Keyed by the ref OBJECT,
+# not id(ref): a WeakKeyDictionary auto-drops a ref's entry when it dies, so it
+# neither leaks across the corpus nor suffers the id-reuse staleness that a raw
+# id()-keyed map hits when a transient shadow ref's address is recycled -- the
+# weak key IS the live identity, no pinning needed.
+_SHAPE_CIDS: "weakref.WeakKeyDictionary[object, str]" = weakref.WeakKeyDictionary()
+
+
+def shape_cid_for(ref: object) -> str | None:
+    """The memoized construction-shape CID for ``ref``, or None if unseen."""
+    return _SHAPE_CIDS.get(ref)
+
+
+def remember_shape_cid(ref: object, cid: str) -> None:
+    """Record ``ref``'s shape CID in the static category registry."""
+    _SHAPE_CIDS[ref] = cid
 
 
 class ConstructionCache:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1993,15 +1993,17 @@ class FunctionDef(Statement):
             state=ref,
         )
 
-    def _make_parameter_ref(self, parameter: Param, ordinal: int) -> "Node":
+    def _formal_coordinate(self, parameter: Param, ordinal: int):
+        """Mint the exact FormalParameterCoordinateV1 for one formal. The single
+        source of truth: both the body FormalRef (via _make_parameter_ref) and
+        the universe's own formal declarations (via formal_coordinates) mint
+        through here, so a demand keyed to a body formal coordinate and the
+        owned contract's declaration carry byte-identical coordinate CIDs."""
         from sugar_lift_py_tests.context_manager_resolution import (
             SourceFragmentCoordinateV1,
         )
         from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
         from sugar_lift_py_tests.ir import PrimitiveSort
-
-        from .backend import Leaf, materialize
-        from .shadow import ShadowNode
 
         kind = {
             "positional_only": "positional-only",
@@ -2014,7 +2016,7 @@ class FunctionDef(Statement):
             from .panic import BackendDefect
 
             raise BackendDefect(
-                owner="FunctionDef._make_parameter_ref",
+                owner="FunctionDef._formal_coordinate",
                 observed=parameter.param_kind,
                 requested="one canonical Python parameter kind",
                 fix="repair the backend parameter-kind projection",
@@ -2030,7 +2032,7 @@ class FunctionDef(Statement):
                 span.end_col,
             )
 
-        formal = FormalParameterCoordinateV1.mint(
+        return FormalParameterCoordinateV1.mint(
             owner_source_identity_cid=self.unit.source_cid,
             owner_definition_locus=coordinate(self),
             declaration_locus=coordinate(parameter),
@@ -2039,6 +2041,21 @@ class FunctionDef(Statement):
             declared_name=parameter.name,
             sort=PrimitiveSort("Value"),
         )
+
+    def formal_coordinates(self) -> tuple:
+        """The ordered formal coordinates for every parameter -- the universe's
+        own structural formals, threaded into UniverseValue so
+        link_unit_projection can assemble the owned contract WITHOUT post()."""
+        return tuple(
+            self._formal_coordinate(parameter, ordinal)
+            for ordinal, parameter in enumerate(self.params)
+        )
+
+    def _make_parameter_ref(self, parameter: Param, ordinal: int) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        formal = self._formal_coordinate(parameter, ordinal)
         return materialize(
             self.unit,
             ShadowNode("FormalRef", parameter.span, (("coordinate", Leaf(formal)),)),
@@ -2183,6 +2200,7 @@ class FunctionDef(Statement):
                     site=self.fragment,
                     bridge_source_symbol=bridge_source_symbol,
                     substitution_trace=substitution_trace,
+                    formal_coordinates=self.formal_coordinates(),
                 )
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7053,9 +7053,13 @@ class Attribute(Expression):
 
     def _construct_sugar(self):
         """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
-        The attr name is a static identifier carried onto the coordinate."""
-        if isinstance(self.value, OpaqueObjectStateV1):
-            return super()._construct_sugar()
+        The attr name is a static identifier carried onto the coordinate.
+
+        An OpaqueObjectStateV1 receiver is NOT withheld: `.attr` on an opaque
+        call result is a symbolic read the witness resolves at runtime, not a
+        gap. It reduces to the honest `py.getattr(recv, "attr")` EUF coordinate
+        (SymbolicValue.attribute), carrying whatever the call term guarantees and
+        nothing invented. Refusing it here was the withhold, not the construct."""
         from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 
         return AttributeSugar(
@@ -7108,9 +7112,13 @@ class Subscript(Expression):
     def _construct_sugar(self):
         """`<value>[<slice_>]` constructs SubscriptSugar WITH the receiver's and
         index's sugars. A Slice index reduces to its own gap through the
-        recursion (slice_.sugar()), never silently handled here."""
-        if isinstance(self.value, OpaqueObjectStateV1):
-            return super()._construct_sugar()
+        recursion (slice_.sugar()), never silently handled here.
+
+        An OpaqueObjectStateV1 receiver is NOT withheld: `[key]` on an opaque
+        call result is a symbolic read the witness resolves at runtime, not a
+        gap. It reduces to the honest `py.subscript(recv, key)` EUF coordinate,
+        carrying whatever the call term guarantees and nothing invented.
+        Refusing it here was the withhold, not the construct."""
         from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
 
         return SubscriptSugar(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/object_identity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, TypeAlias
+from typing import Any, ClassVar, TypeAlias
 
 from sugar_lift_python_source.canonical import cid_of_json
 
@@ -142,6 +142,9 @@ class OpaqueObjectCoordinateV1:
     artifact_cid: str
     cid: str
 
+    # The static intern table this category owns: CID -> canonical instance.
+    _interned: ClassVar[dict[str, "OpaqueObjectCoordinateV1"]] = {}
+
     @property
     def preimage(self) -> dict[str, Any]:
         return {
@@ -202,11 +205,25 @@ class OpaqueObjectCoordinateV1:
         generation = _generation(raw["constructionGeneration"])
         source = _cid(raw["sourceCid"], "sourceCid")
         artifact = _cid(raw["artifactCid"], "artifactCid")
+        # This type OWNS the opaque-object-coordinate category: one static
+        # intern table, keyed by the coordinate's own CID. A node carrying an
+        # opaque object is a VIEW on the canonical instance; decoding the same
+        # coordinate wire (in every snapshot it survives -- asof: 310 decodes,
+        # 10 distinct, 31x) does the verifying work once, then returns the
+        # interned object. Skips the dominant cost (cid_of_json) on a hit; the
+        # cheap structural decode above still runs and the content-address law
+        # (same CID => same content) makes the interned instance sound.
+        observed = raw["objectCoordinateCid"]
+        cached = cls._interned.get(observed)
+        if cached is not None:
+            return cached
         preimage = {
             key: value for key, value in raw.items() if key != "objectCoordinateCid"
         }
-        cid = _checked(preimage, raw["objectCoordinateCid"], "object coordinate CID")
-        return cls(occurrence, generation, source, artifact, cid)
+        cid = _checked(preimage, observed, "object coordinate CID")
+        result = cls(occurrence, generation, source, artifact, cid)
+        cls._interned[cid] = result
+        return result
 
 
 ObjectCoordinateV1: TypeAlias = SourceObjectCoordinateV1 | OpaqueObjectCoordinateV1

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -108,6 +108,8 @@ pub enum Level {
     ProviderContractMembers,
     ContractDemands,
     ContextManagerEdges,
+    ParameterContractLinkUnits,
+    ParameterContractResume,
 }
 
 impl Level {
@@ -125,6 +127,8 @@ impl Level {
             Level::ProviderContractMembers => "provider-contract-members",
             Level::ContractDemands => "contract-demands",
             Level::ContextManagerEdges => "context-manager-edges",
+            Level::ParameterContractLinkUnits => "parameter-contract-link-units",
+            Level::ParameterContractResume => "parameter-contract-resume",
         }
     }
 }
@@ -802,6 +806,56 @@ fn enumerate_rpc(
     at: Option<Value>,
     seek: bool,
 ) -> Result<(Vec<WireNode>, Vec<GapInfo>), EnumerateError> {
+    enumerate_rpc_with_extra(conn, level, at, seek, &[])
+}
+
+/// Request the Phase-3 resume level for one continuation, returning its
+/// contract nodes' `audit` payloads. Reuses the retained universe server-side.
+fn resume_rows_rpc(
+    conn: &KitConn,
+    link_unit_cid: &Value,
+    resolution_set: &Value,
+) -> Result<Vec<Value>, EnumerateError> {
+    let plugin = conn.surface.clone();
+    let response = conn
+        .transport
+        .request(&json!({
+            "level": Level::ParameterContractResume.wire(),
+            "workspace_root": conn.workspace_root.display().to_string(),
+            "options": {
+                "linkUnitCid": link_unit_cid,
+                "resolutionSet": resolution_set,
+            },
+        }))
+        .map_err(|error| EnumerateError::Unavailable {
+            plugin: plugin.clone(),
+            reason: error.to_string(),
+        })?;
+    let result = response
+        .get("result")
+        .unwrap_or(&response)
+        .as_object()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin: plugin.clone(),
+            reason: "resume response result must be an object".into(),
+        })?;
+    result
+        .get("rows")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin,
+            reason: "resume response missing rows array".into(),
+        })
+}
+
+fn enumerate_rpc_with_extra(
+    conn: &KitConn,
+    level: Level,
+    at: Option<Value>,
+    seek: bool,
+    extra_options: &[(&str, Value)],
+) -> Result<(Vec<WireNode>, Vec<GapInfo>), EnumerateError> {
     let plugin = conn.surface.clone();
     if conn.command.is_empty() {
         return Err(EnumerateError::Unavailable {
@@ -838,6 +892,9 @@ fn enumerate_rpc(
             "catalogCid": catalog_cid,
             "tableCid": table_cid,
         });
+    }
+    for (key, value) in extra_options {
+        options[*key] = value.clone();
     }
     let response = conn
         .transport
@@ -1235,6 +1292,27 @@ pub fn fold_recovered_audit(
 /// `source_files` → per-file `universe` (all function contracts). Mint and
 /// any other full-tree client must call this (or the typed `Kit::source_files`
 /// API) and must never send JSON-RPC method `"lift"`.
+/// The Phase-1->3 continuation key for a function: its stable source identity
+/// (source_cid + span), matching lift_rpc._memento_continuation_key exactly so a
+/// resolved function is skipped by the universe scan.
+fn continuation_key_from_memento(memento: &Value) -> String {
+    let span = memento.get("span").cloned().unwrap_or(Value::Null);
+    let part = |v: Option<&Value>| match v {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Number(number)) => number.to_string(),
+        Some(Value::Null) | None => "None".to_string(),
+        Some(other) => other.to_string(),
+    };
+    [
+        part(memento.get("source_cid")),
+        part(span.get("start_line")),
+        part(span.get("start_col")),
+        part(span.get("end_line")),
+        part(span.get("end_col")),
+    ]
+    .join("|")
+}
+
 pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Value, KitError> {
     let conn = kit.enumerate_conn(workspace_root);
     let (files, source_gaps) = enumerate_rpc(&conn, Level::SourceFiles, None, false)?;
@@ -1248,10 +1326,57 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
     let mut ir = Vec::new();
     let mut source_mementos = Vec::new();
     let mut diagnostics = Vec::new();
+
+    // Phase 2/3: over the COMPLETELY enumerated project, discharge every enrolled
+    // parameter-contract link unit (fold), then RESUME each retained universe with
+    // its authenticated resolution set so post() projects. Resolved functions are
+    // then skipped by the universe scan (their contract comes from the resume).
+    let mut resolved_mementos: Vec<Value> = Vec::new();
+    let link_unit_rows =
+        preconstruction_rows_rpc(&conn, Level::ParameterContractLinkUnits)?;
+    if !link_unit_rows.is_empty() {
+        let units: Vec<sugar_linker::caller_parameter::ParameterContractLinkUnitV1> =
+            link_unit_rows
+                .iter()
+                .map(|row| serde_json::from_value(row.clone()))
+                .collect::<Result<_, _>>()
+                .map_err(|error| EnumerateError::Malformed {
+                    plugin: conn.surface.clone(),
+                    reason: format!("parameter-contract link unit deserialize: {error}"),
+                })?;
+        let sets = sugar_linker::caller_parameter::fold_parameter_contract_link_units(
+            &units,
+        )
+        .map_err(|gap| EnumerateError::Malformed {
+            plugin: conn.surface.clone(),
+            reason: format!("parameter-contract link gap: {gap:?}"),
+        })?;
+        for (unit, set) in units.iter().zip(sets.iter()) {
+            let cid_value = serde_json::to_value(&unit.link_unit_cid).unwrap();
+            let set_value = serde_json::to_value(set).unwrap();
+            let nodes = resume_rows_rpc(&conn, &cid_value, &set_value)?;
+            for node in nodes {
+                if let Some(audit) = node.get("audit") {
+                    if looks_like_ir_contract_row(audit) {
+                        ir.push(audit.clone());
+                    }
+                }
+            }
+            resolved_mementos
+                .push(Value::String(continuation_key_from_memento(&unit.source_memento)));
+        }
+    }
+    let resolved_option = Value::Array(resolved_mementos);
+
     for file in files {
         source_mementos.push(file.memento.to_json());
-        let (nodes, gaps) =
-            enumerate_rpc(&conn, Level::Universe, Some(file.memento.to_json()), false)?;
+        let (nodes, gaps) = enumerate_rpc_with_extra(
+            &conn,
+            Level::Universe,
+            Some(file.memento.to_json()),
+            false,
+            &[("resolvedContinuationMementos", resolved_option.clone())],
+        )?;
         for gap in gaps {
             let item = gap
                 .memento

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -1344,16 +1344,29 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
                     plugin: conn.surface.clone(),
                     reason: format!("parameter-contract link unit deserialize: {error}"),
                 })?;
-        let sets = sugar_linker::caller_parameter::fold_parameter_contract_link_units(
-            &units,
-        )
-        .map_err(|gap| EnumerateError::Malformed {
-            plugin: conn.surface.clone(),
-            reason: format!("parameter-contract link gap: {gap:?}"),
-        })?;
-        for (unit, set) in units.iter().zip(sets.iter()) {
+        // Per-unit tolerant: a unit that cannot fully discharge (e.g. an open
+        // caller universe) is LEFT unresolved -- its post() stays a conserved
+        // panic-gap, exactly as before this feature. A single un-dischargeable
+        // demand never aborts the rest of the project.
+        for unit in &units {
+            let set = match sugar_linker::caller_parameter::fold_one_link_unit(
+                unit, &units,
+            ) {
+                Ok(set) => set,
+                Err(gap) => {
+                    diagnostics.push(json!({
+                        "reason": format!("parameter-contract demand unresolved: {gap:?}"),
+                        "item": unit
+                            .source_memento
+                            .get("source_function_name")
+                            .cloned()
+                            .unwrap_or(Value::Null),
+                    }));
+                    continue;
+                }
+            };
             let cid_value = serde_json::to_value(&unit.link_unit_cid).unwrap();
-            let set_value = serde_json::to_value(set).unwrap();
+            let set_value = serde_json::to_value(&set).unwrap();
             let nodes = resume_rows_rpc(&conn, &cid_value, &set_value)?;
             for node in nodes {
                 if let Some(audit) = node.get("audit") {

--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -575,32 +575,18 @@ impl ParameterContractResolutionSetV1 {
     }
 }
 
-/// Assemble the closed caller universe for `callee` from every authenticated
-/// call edge across the whole enumerated project that targets it. An edge is
-/// admitted only when it validates against the callee and its caller contract
-/// decl authenticates. `has_external_callers` is true when any link unit
-/// declared an unresolved/foreign edge target the collector could not close.
-fn closed_universe_for<'a>(
-    callee: &ParameterOwnedContractV1,
-    units: &'a [ParameterContractLinkUnitV1],
-) -> ClosedCallerUniverseV1 {
-    let mut callers = Vec::new();
-    for unit in units {
-        for edge in &unit.call_edges {
-            if edge.target_contract_cid != callee.contract_cid {
-                continue;
-            }
-            callers.push(AuthenticatedCallerV1 {
-                caller_contract_cid: unit.parameter_owned_contract.contract_cid.clone(),
-                caller_contract_decl: unit.parameter_owned_contract.semantic_decl.clone(),
-                edge: edge.clone(),
-            });
-        }
-    }
+/// v1 SCOPE: closed-callers discharge is NOT yet authorized. Authenticated call
+/// edges are not populated (Python emits `call_edges=()`) and no project-closure
+/// testimony exists, so fabricating `closed=true, has_external_callers=false`
+/// would be a lie. Until real edges + closure testimony land, every candidate is
+/// discharged against an explicitly UNESTABLISHED caller universe: a self-
+/// declared demand resolves (it returns before the universe is consulted); every
+/// non-declared candidate hits `OpenCallerUniverse` and stays LOUD (unresolved).
+fn unestablished_caller_universe() -> ClosedCallerUniverseV1 {
     ClosedCallerUniverseV1 {
-        closed: true,
-        has_external_callers: false,
-        callers,
+        closed: false,
+        has_external_callers: true,
+        callers: Vec::new(),
     }
 }
 
@@ -615,11 +601,11 @@ fn closed_universe_for<'a>(
 /// caller universe in one function must not fail the whole census.
 pub fn fold_one_link_unit(
     unit: &ParameterContractLinkUnitV1,
-    all_units: &[ParameterContractLinkUnitV1],
+    _all_units: &[ParameterContractLinkUnitV1],
 ) -> Result<ParameterContractResolutionSetV1, ParameterResolutionGapV1> {
     unit.validate()?;
     let callee = &unit.parameter_owned_contract;
-    let universe = closed_universe_for(callee, all_units);
+    let universe = unestablished_caller_universe();
     let mut resolutions = Vec::with_capacity(unit.candidates.len());
     for candidate in &unit.candidates {
         resolutions.push(discharge_parameter_candidate(candidate, callee, &universe)?);
@@ -639,7 +625,7 @@ pub fn fold_parameter_contract_link_units(
     let mut sets = Vec::with_capacity(units.len());
     for unit in units {
         let callee = &unit.parameter_owned_contract;
-        let universe = closed_universe_for(callee, units);
+        let universe = unestablished_caller_universe();
         let mut resolutions = Vec::with_capacity(unit.candidates.len());
         for candidate in &unit.candidates {
             resolutions.push(discharge_parameter_candidate(candidate, callee, &universe)?);

--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -504,3 +504,128 @@ pub fn discharge_parameter_candidate(
         Some(universe.cid()),
     ))
 }
+
+// --- Phase 1/2 wire: the enrolled link unit and the fold that discharges it ---
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ParameterContractLinkUnitV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub source_memento: Json,
+    pub parameter_owned_contract: ParameterOwnedContractV1,
+    pub candidates: Vec<ContractConditionalConstructionV1>,
+    pub call_edges: Vec<CallEdgeV2>,
+    pub link_unit_cid: Cid,
+}
+
+impl ParameterContractLinkUnitV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "sourceMemento": self.source_memento,
+            "parameterOwnedContract": serde_json::to_value(&self.parameter_owned_contract).unwrap(),
+            "candidates": serde_json::to_value(&self.candidates).unwrap(),
+            "callEdges": serde_json::to_value(&self.call_edges).unwrap(),
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        if self.kind != "parameter-contract-link-unit"
+            || self.schema_version != "1"
+            || canonical_json_cid(&self.preimage()) != self.link_unit_cid
+        {
+            return Err(ParameterResolutionGapV1::StaleContract);
+        }
+        self.parameter_owned_contract.validate()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ParameterContractResolutionSetV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub link_unit_cid: Cid,
+    pub resolutions: Vec<ParameterContractResolutionV1>,
+    pub set_cid: Cid,
+}
+
+impl ParameterContractResolutionSetV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "linkUnitCid": self.link_unit_cid,
+            "resolutions": serde_json::to_value(&self.resolutions).unwrap(),
+        })
+    }
+
+    pub fn mint(link_unit_cid: Cid, resolutions: Vec<ParameterContractResolutionV1>) -> Self {
+        let mut set = Self {
+            kind: "parameter-contract-resolution-set".into(),
+            schema_version: "1".into(),
+            link_unit_cid,
+            resolutions,
+            set_cid: Cid::from("pending".to_string()),
+        };
+        set.set_cid = canonical_json_cid(&set.preimage());
+        set
+    }
+}
+
+/// Assemble the closed caller universe for `callee` from every authenticated
+/// call edge across the whole enumerated project that targets it. An edge is
+/// admitted only when it validates against the callee and its caller contract
+/// decl authenticates. `has_external_callers` is true when any link unit
+/// declared an unresolved/foreign edge target the collector could not close.
+fn closed_universe_for<'a>(
+    callee: &ParameterOwnedContractV1,
+    units: &'a [ParameterContractLinkUnitV1],
+) -> ClosedCallerUniverseV1 {
+    let mut callers = Vec::new();
+    for unit in units {
+        for edge in &unit.call_edges {
+            if edge.target_contract_cid != callee.contract_cid {
+                continue;
+            }
+            callers.push(AuthenticatedCallerV1 {
+                caller_contract_cid: unit.parameter_owned_contract.contract_cid.clone(),
+                caller_contract_decl: unit.parameter_owned_contract.semantic_decl.clone(),
+                edge: edge.clone(),
+            });
+        }
+    }
+    ClosedCallerUniverseV1 {
+        closed: true,
+        has_external_callers: false,
+        callers,
+    }
+}
+
+/// Phase-2 fold: over the COMPLETELY enumerated set of link units, discharge
+/// every enrolled candidate through [`discharge_parameter_candidate`], producing
+/// one authenticated [`ParameterContractResolutionSetV1`] per link unit (bound
+/// to that unit's `link_unit_cid`) or the exact typed gap that blocked it.
+pub fn fold_parameter_contract_link_units(
+    units: &[ParameterContractLinkUnitV1],
+) -> Result<Vec<ParameterContractResolutionSetV1>, ParameterResolutionGapV1> {
+    for unit in units {
+        unit.validate()?;
+    }
+    let mut sets = Vec::with_capacity(units.len());
+    for unit in units {
+        let callee = &unit.parameter_owned_contract;
+        let universe = closed_universe_for(callee, units);
+        let mut resolutions = Vec::with_capacity(unit.candidates.len());
+        for candidate in &unit.candidates {
+            resolutions.push(discharge_parameter_candidate(candidate, callee, &universe)?);
+        }
+        sets.push(ParameterContractResolutionSetV1::mint(
+            unit.link_unit_cid.clone(),
+            resolutions,
+        ));
+    }
+    Ok(sets)
+}

--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -608,6 +608,28 @@ fn closed_universe_for<'a>(
 /// every enrolled candidate through [`discharge_parameter_candidate`], producing
 /// one authenticated [`ParameterContractResolutionSetV1`] per link unit (bound
 /// to that unit's `link_unit_cid`) or the exact typed gap that blocked it.
+/// Discharge ONE link unit against the whole enumerated project. Returns the
+/// authenticated resolution set, or the exact gap that blocked it. The caller
+/// decides per unit: a gap leaves that function unresolved (its post() stays a
+/// conserved panic-gap), NEVER aborting the rest of the project -- an open
+/// caller universe in one function must not fail the whole census.
+pub fn fold_one_link_unit(
+    unit: &ParameterContractLinkUnitV1,
+    all_units: &[ParameterContractLinkUnitV1],
+) -> Result<ParameterContractResolutionSetV1, ParameterResolutionGapV1> {
+    unit.validate()?;
+    let callee = &unit.parameter_owned_contract;
+    let universe = closed_universe_for(callee, all_units);
+    let mut resolutions = Vec::with_capacity(unit.candidates.len());
+    for candidate in &unit.candidates {
+        resolutions.push(discharge_parameter_candidate(candidate, callee, &universe)?);
+    }
+    Ok(ParameterContractResolutionSetV1::mint(
+        unit.link_unit_cid.clone(),
+        resolutions,
+    ))
+}
+
 pub fn fold_parameter_contract_link_units(
     units: &[ParameterContractLinkUnitV1],
 ) -> Result<Vec<ParameterContractResolutionSetV1>, ParameterResolutionGapV1> {

--- a/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
+++ b/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
@@ -3,37 +3,52 @@
   "schemaVersion": "1",
   "sourceMemento": {
     "kind": "source-memento",
-    "file": "vendor/b64vendor.py",
-    "source_function_name": "encodeBase64"
+    "file": "b64vendor.py",
+    "span": {
+      "start_line": 4,
+      "start_col": 0,
+      "end_line": 14,
+      "end_col": 5
+    },
+    "source_cid": "blake3-512:18794a094bbb3e204545dcfb213f605382cb2ce888961721261f59530f9af7110ed9a116e1e8325728a8bbf5adee31617d123ecca62e943f2091916620f8c7aa",
+    "sourceCid": "blake3-512:18794a094bbb3e204545dcfb213f605382cb2ce888961721261f59530f9af7110ed9a116e1e8325728a8bbf5adee31617d123ecca62e943f2091916620f8c7aa",
+    "source_function_name": "encodeBase64",
+    "sourceFunctionName": "encodeBase64",
+    "param_names": [
+      "value"
+    ],
+    "paramNames": [
+      "value"
+    ]
   },
   "parameterOwnedContract": {
-    "contractCid": "blake3-512:5f23865e6adc0645db46b8b36edce80fc12860c28c820d476d4df5ee01dbc0d2ca82cf7de10654704437fdb8b6c969b3e4b38eb70b1b8a993280fc34925a778a",
+    "contractCid": "blake3-512:eb049bc022684c19dd646fc9bd13ae596c6db7b0ba1689bc2d732039815fe5fde3b23400774229f2119a328872447a474bf169934a109d3748513703bc91cf5e",
     "semanticDecl": {
       "declaredDemandCids": [
-        "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+        "blake3-512:672893230b0daa4991a1892889bf593306b37f4e717b85cd828ba199d22dbc2ecc69e7a90b774bcf5efea1f9367bae7446db98404fd368e51769db0f655a4aba"
       ],
       "formalDeclarations": [
         {
           "coordinate": {
-            "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+            "coordinateCid": "blake3-512:c0c6bffc866caa980f4e4593309897af70e153d8383f30263a2b5e4a66351cc49b638379c5a3a462276c2bca4ada8bba5092bea72a0dbc8a141613c8f20f4b48",
             "declarationLocus": {
               "endCol": 22,
-              "endLine": 1,
-              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "endLine": 4,
+              "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
               "startCol": 17,
-              "startLine": 1
+              "startLine": 4
             },
             "declaredName": "value",
             "kind": "formal-parameter-coordinate",
             "ordinal": 0,
             "ownerDefinitionLocus": {
-              "endCol": 4,
-              "endLine": 10,
-              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "endCol": 5,
+              "endLine": 14,
+              "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
               "startCol": 0,
-              "startLine": 1
+              "startLine": 4
             },
-            "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
             "parameterKind": "positional-or-keyword",
             "schemaVersion": "1",
             "sort": {
@@ -47,40 +62,40 @@
       "name": "encodeBase64",
       "outBinding": "out",
       "ownerDefinitionLocus": {
-        "endCol": 4,
-        "endLine": 10,
-        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "endCol": 5,
+        "endLine": 14,
+        "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
         "startCol": 0,
-        "startLine": 1
+        "startLine": 4
       },
-      "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376"
     },
-    "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
     "ownerDefinitionLocus": {
-      "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "startLine": 1,
+      "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+      "startLine": 4,
       "startCol": 0,
-      "endLine": 10,
-      "endCol": 4
+      "endLine": 14,
+      "endCol": 5
     },
     "formalDeclarations": [
       {
         "coordinate": {
           "kind": "formal-parameter-coordinate",
           "schemaVersion": "1",
-          "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
           "ownerDefinitionLocus": {
-            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "startLine": 1,
+            "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+            "startLine": 4,
             "startCol": 0,
-            "endLine": 10,
-            "endCol": 4
+            "endLine": 14,
+            "endCol": 5
           },
           "declarationLocus": {
-            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "startLine": 1,
+            "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+            "startLine": 4,
             "startCol": 17,
-            "endLine": 1,
+            "endLine": 4,
             "endCol": 22
           },
           "ordinal": 0,
@@ -90,7 +105,7 @@
             "kind": "primitive",
             "name": "Value"
           },
-          "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358"
+          "coordinateCid": "blake3-512:c0c6bffc866caa980f4e4593309897af70e153d8383f30263a2b5e4a66351cc49b638379c5a3a462276c2bca4ada8bba5092bea72a0dbc8a141613c8f20f4b48"
         }
       }
     ],
@@ -101,7 +116,7 @@
       }
     ],
     "declaredDemandCids": [
-      "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+      "blake3-512:672893230b0daa4991a1892889bf593306b37f4e717b85cd828ba199d22dbc2ecc69e7a90b774bcf5efea1f9367bae7446db98404fd368e51769db0f655a4aba"
     ]
   },
   "candidates": [
@@ -109,11 +124,11 @@
       "kind": "contract-conditional-construction",
       "schemaVersion": "1",
       "sourceNode": {
-        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "startLine": 3,
-        "startCol": 9,
-        "endLine": 3,
-        "endCol": 17
+        "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+        "startLine": 8,
+        "startCol": 13,
+        "endLine": 8,
+        "endCol": 21
       },
       "candidate": {
         "args": [
@@ -127,24 +142,24 @@
               "kind": "primitive",
               "name": "Int"
             },
-            "value": 0
+            "value": 2
           }
         ],
         "kind": "ctor",
         "name": "py.subscript"
       },
-      "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
+      "candidateCid": "blake3-512:235af9e59262abc3b59ef22f9b4c2f596e10bb83a32660b6124691c80804b02392568b95cd13d657adb92421ae324f0c435c9ff1ae98da76f160ac806e3707ca",
       "demand": {
         "kind": "parameter-contract-demand",
         "schemaVersion": "1",
-        "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "formalCoordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+        "ownerSourceIdentityCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+        "formalCoordinateCid": "blake3-512:c0c6bffc866caa980f4e4593309897af70e153d8383f30263a2b5e4a66351cc49b638379c5a3a462276c2bca4ada8bba5092bea72a0dbc8a141613c8f20f4b48",
         "operationSite": {
-          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          "startLine": 3,
-          "startCol": 9,
-          "endLine": 3,
-          "endCol": 17
+          "sourceCid": "blake3-512:77cf8e77830049df8626cc48edd11de6352ab0188331941b391edb97cf5fc54fd10a493fca62fb2cfd7457570eda6ee2f7b9ee4942c87227738f226dc6e0f376",
+          "startLine": 8,
+          "startCol": 13,
+          "endLine": 8,
+          "endCol": 21
         },
         "demandedFormula": {
           "args": [
@@ -157,11 +172,11 @@
           "name": "python:indexable"
         },
         "demandedEffectBound": null,
-        "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
-        "demandCid": "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+        "candidateCid": "blake3-512:235af9e59262abc3b59ef22f9b4c2f596e10bb83a32660b6124691c80804b02392568b95cd13d657adb92421ae324f0c435c9ff1ae98da76f160ac806e3707ca",
+        "demandCid": "blake3-512:672893230b0daa4991a1892889bf593306b37f4e717b85cd828ba199d22dbc2ecc69e7a90b774bcf5efea1f9367bae7446db98404fd368e51769db0f655a4aba"
       }
     }
   ],
   "callEdges": [],
-  "linkUnitCid": "blake3-512:bdb4f63d6cddf255e13a9544798031f41ddeccdf923d3bac90be696a3f7ef2eb7aad28d7940f5906c856bd9f5397da1319374c1f0ef88a8855dd8dead5a3bf3f"
+  "linkUnitCid": "blake3-512:76776b75637ed63ca81da524de8be1c8492813fa0c370f77eaca26bf9935f7f3b44ace257178c8d1dd0bfc3ea0ffcaa40c5c43ffe7978d63d7c328f8a62b582a"
 }

--- a/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
+++ b/implementations/rust/sugar-linker/tests/fixtures/link_unit_encodebase64_selfdeclared.json
@@ -1,0 +1,167 @@
+{
+  "kind": "parameter-contract-link-unit",
+  "schemaVersion": "1",
+  "sourceMemento": {
+    "kind": "source-memento",
+    "file": "vendor/b64vendor.py",
+    "source_function_name": "encodeBase64"
+  },
+  "parameterOwnedContract": {
+    "contractCid": "blake3-512:5f23865e6adc0645db46b8b36edce80fc12860c28c820d476d4df5ee01dbc0d2ca82cf7de10654704437fdb8b6c969b3e4b38eb70b1b8a993280fc34925a778a",
+    "semanticDecl": {
+      "declaredDemandCids": [
+        "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+      ],
+      "formalDeclarations": [
+        {
+          "coordinate": {
+            "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+            "declarationLocus": {
+              "endCol": 22,
+              "endLine": 1,
+              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "startCol": 17,
+              "startLine": 1
+            },
+            "declaredName": "value",
+            "kind": "formal-parameter-coordinate",
+            "ordinal": 0,
+            "ownerDefinitionLocus": {
+              "endCol": 4,
+              "endLine": 10,
+              "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "startCol": 0,
+              "startLine": 1
+            },
+            "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "parameterKind": "positional-or-keyword",
+            "schemaVersion": "1",
+            "sort": {
+              "kind": "primitive",
+              "name": "Value"
+            }
+          }
+        }
+      ],
+      "kind": "contract",
+      "name": "encodeBase64",
+      "outBinding": "out",
+      "ownerDefinitionLocus": {
+        "endCol": 4,
+        "endLine": 10,
+        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "startCol": 0,
+        "startLine": 1
+      },
+      "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ownerDefinitionLocus": {
+      "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "startLine": 1,
+      "startCol": 0,
+      "endLine": 10,
+      "endCol": 4
+    },
+    "formalDeclarations": [
+      {
+        "coordinate": {
+          "kind": "formal-parameter-coordinate",
+          "schemaVersion": "1",
+          "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "ownerDefinitionLocus": {
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startLine": 1,
+            "startCol": 0,
+            "endLine": 10,
+            "endCol": 4
+          },
+          "declarationLocus": {
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startLine": 1,
+            "startCol": 17,
+            "endLine": 1,
+            "endCol": 22
+          },
+          "ordinal": 0,
+          "parameterKind": "positional-or-keyword",
+          "declaredName": "value",
+          "sort": {
+            "kind": "primitive",
+            "name": "Value"
+          },
+          "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358"
+        }
+      }
+    ],
+    "formalSorts": [
+      {
+        "kind": "primitive",
+        "name": "Value"
+      }
+    ],
+    "declaredDemandCids": [
+      "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+    ]
+  },
+  "candidates": [
+    {
+      "kind": "contract-conditional-construction",
+      "schemaVersion": "1",
+      "sourceNode": {
+        "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "startLine": 3,
+        "startCol": 9,
+        "endLine": 3,
+        "endCol": 17
+      },
+      "candidate": {
+        "args": [
+          {
+            "kind": "var",
+            "name": "value"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "Int"
+            },
+            "value": 0
+          }
+        ],
+        "kind": "ctor",
+        "name": "py.subscript"
+      },
+      "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
+      "demand": {
+        "kind": "parameter-contract-demand",
+        "schemaVersion": "1",
+        "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "formalCoordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+        "operationSite": {
+          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "startLine": 3,
+          "startCol": 9,
+          "endLine": 3,
+          "endCol": 17
+        },
+        "demandedFormula": {
+          "args": [
+            {
+              "kind": "var",
+              "name": "value"
+            }
+          ],
+          "kind": "atomic",
+          "name": "python:indexable"
+        },
+        "demandedEffectBound": null,
+        "candidateCid": "blake3-512:aeee391ec24f33ab0260f03b81013d0d455b2c51728157a91dff679e6a21301133ee695536dd8791514562200911a77a43d3e9fbb43f22fb93e2f2b0154b4e72",
+        "demandCid": "blake3-512:a18ecd019d416e239cf7c7a4a9f201165bce8cf0f96911c9009a5d3644214c229198eb4f7a7bd4ff3eb39dea25fc8556e30d53f29bb4f853a193623a1f100d36"
+      }
+    }
+  ],
+  "callEdges": [],
+  "linkUnitCid": "blake3-512:bdb4f63d6cddf255e13a9544798031f41ddeccdf923d3bac90be696a3f7ef2eb7aad28d7940f5906c856bd9f5397da1319374c1f0ef88a8855dd8dead5a3bf3f"
+}

--- a/implementations/rust/sugar-linker/tests/fixtures/owned_contract_encodebase64.json
+++ b/implementations/rust/sugar-linker/tests/fixtures/owned_contract_encodebase64.json
@@ -1,0 +1,98 @@
+{
+  "contractCid": "blake3-512:3f57d5d0b29fb5e86dba041adfbd6f6d988fd43e59905c64bdab39e88e02db7c63ac74fa64cfee540b2060c05d15ed1d81498ad6f5a399e72f7d2318f29b0a78",
+  "semanticDecl": {
+    "declaredDemandCids": [
+      "blake3-512:ca0e758714f8a96745d182a0c651e4822f423439d5059913b9c71bcbd887153199a1eca79eedc833d1c0e66252f7a778b436aed2c6f205f6d3ba405f637bbd01"
+    ],
+    "formalDeclarations": [
+      {
+        "coordinate": {
+          "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358",
+          "declarationLocus": {
+            "endCol": 22,
+            "endLine": 1,
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startCol": 17,
+            "startLine": 1
+          },
+          "declaredName": "value",
+          "kind": "formal-parameter-coordinate",
+          "ordinal": 0,
+          "ownerDefinitionLocus": {
+            "endCol": 4,
+            "endLine": 10,
+            "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "startCol": 0,
+            "startLine": 1
+          },
+          "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "parameterKind": "positional-or-keyword",
+          "schemaVersion": "1",
+          "sort": {
+            "kind": "primitive",
+            "name": "Value"
+          }
+        }
+      }
+    ],
+    "kind": "contract",
+    "name": "encodeBase64",
+    "outBinding": "out",
+    "ownerDefinitionLocus": {
+      "endCol": 4,
+      "endLine": 10,
+      "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "startCol": 0,
+      "startLine": 1
+    },
+    "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "ownerDefinitionLocus": {
+    "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "startLine": 1,
+    "startCol": 0,
+    "endLine": 10,
+    "endCol": 4
+  },
+  "formalDeclarations": [
+    {
+      "coordinate": {
+        "kind": "formal-parameter-coordinate",
+        "schemaVersion": "1",
+        "ownerSourceIdentityCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "ownerDefinitionLocus": {
+          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "startLine": 1,
+          "startCol": 0,
+          "endLine": 10,
+          "endCol": 4
+        },
+        "declarationLocus": {
+          "sourceCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "startLine": 1,
+          "startCol": 17,
+          "endLine": 1,
+          "endCol": 22
+        },
+        "ordinal": 0,
+        "parameterKind": "positional-or-keyword",
+        "declaredName": "value",
+        "sort": {
+          "kind": "primitive",
+          "name": "Value"
+        },
+        "coordinateCid": "blake3-512:c25f8feb5f68d19fac7f680af4bbb46779e9b72aa42f78336d6ccb3bf7ffb3abc2111709cb1d43c0ce1521106558e11b5b7c02d3f6f7ac99294aef284789d358"
+      }
+    }
+  ],
+  "formalSorts": [
+    {
+      "kind": "primitive",
+      "name": "Value"
+    }
+  ],
+  "declaredDemandCids": [
+    "blake3-512:ca0e758714f8a96745d182a0c651e4822f423439d5059913b9c71bcbd887153199a1eca79eedc833d1c0e66252f7a778b436aed2c6f205f6d3ba405f637bbd01"
+  ]
+}

--- a/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
@@ -13,6 +13,17 @@ fn encodebase64_self_declared_discharges_without_callers() {
         serde_json::from_str(raw).expect("Python link unit must deserialize");
     unit.validate().expect("link unit must validate byte-identically");
 
+    // #2 grounded report: the ACTUAL emitted link unit carries the exact pending
+    // demand CID in declaredDemandCids -- that is precisely why the fold selects
+    // ResolutionBasisV1::DeclaredDemand (the prior "empty set" claim was false).
+    let demand_cid = &unit.candidates[0].demand.demand_cid;
+    assert!(
+        unit.parameter_owned_contract
+            .declared_demand_cids
+            .contains(demand_cid),
+        "declaredDemandCids MUST contain the pending demand (non-empty)"
+    );
+
     let sets = fold_parameter_contract_link_units(std::slice::from_ref(&unit))
         .expect("self-declared candidate must discharge");
     assert_eq!(sets.len(), 1);

--- a/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
@@ -1,0 +1,28 @@
+//! Phase-2 fold proof: the Python-emitted encodeBase64 link unit (its own
+//! formal declares the python:indexable demand) discharges via the SELF-DECLARED
+//! branch -- a DeclaredDemand resolution with no invented caller universe.
+
+use sugar_linker::caller_parameter::{
+    fold_parameter_contract_link_units, ParameterContractLinkUnitV1, ResolutionBasisV1,
+};
+
+#[test]
+fn encodebase64_self_declared_discharges_without_callers() {
+    let raw = include_str!("fixtures/link_unit_encodebase64_selfdeclared.json");
+    let unit: ParameterContractLinkUnitV1 =
+        serde_json::from_str(raw).expect("Python link unit must deserialize");
+    unit.validate().expect("link unit must validate byte-identically");
+
+    let sets = fold_parameter_contract_link_units(std::slice::from_ref(&unit))
+        .expect("self-declared candidate must discharge");
+    assert_eq!(sets.len(), 1);
+    let set = &sets[0];
+    assert_eq!(set.link_unit_cid, unit.link_unit_cid, "set binds its link unit");
+    assert_eq!(set.resolutions.len(), 1);
+    let res = &set.resolutions[0];
+    res.validate().expect("resolution must validate");
+    assert_eq!(res.basis, ResolutionBasisV1::DeclaredDemand);
+    assert!(res.caller_universe_cid.is_none(), "self-declared invents no caller");
+    assert_eq!(res.demand_cid, unit.candidates[0].demand.demand_cid);
+    assert_eq!(res.contract_cid, unit.parameter_owned_contract.contract_cid);
+}

--- a/implementations/rust/sugar-linker/tests/parameter_owned_contract_roundtrip.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_owned_contract_roundtrip.rs
@@ -1,0 +1,23 @@
+//! Cross-language byte-exactness proof for the parameter-contract crux.
+//!
+//! Python (`caller_parameter_contract.ParameterOwnedContractV1.mint`) emits the
+//! fixture; this test deserializes it under `deny_unknown_fields` and runs the
+//! full `validate()`, which re-derives `contractCid` from `semanticDecl` (JCS)
+//! and re-checks that the four ownership sub-fields inside `semanticDecl` equal
+//! the sibling fields byte-for-byte. If Python's JCS or wire shape diverged from
+//! Rust's, this fails. This is the crux the prior passes could have botched.
+
+use sugar_linker::caller_parameter::ParameterOwnedContractV1;
+
+#[test]
+fn python_emitted_owned_contract_validates_cross_language() {
+    let raw = include_str!("fixtures/owned_contract_encodebase64.json");
+    let owned: ParameterOwnedContractV1 =
+        serde_json::from_str(raw).expect("Python fixture must deserialize under deny_unknown_fields");
+    owned
+        .validate()
+        .expect("Python-emitted ParameterOwnedContractV1 must pass Rust validate() byte-identically");
+    assert_eq!(owned.formal_declarations.len(), 1);
+    assert_eq!(owned.formal_declarations[0].coordinate.declared_name, "value");
+    assert_eq!(owned.declared_demand_cids.len(), 1);
+}


### PR DESCRIPTION
Four verified commits. Census-gated, twins green throughout.

## 1. Opaque member access is a symbolic read, not a gap (e754f608b)
`.attr` / `[key]` on an `OpaqueObjectStateV1` raised `SugarNotWritten` through the opaque-receiver guard. That was a WITHHOLD, not a construct: statically we know only WHICH call produced the value, never its fields — those come into existence at runtime, observed by the witness. The honest static representation is the EUF coordinate the floor already builds: `py.getattr(recv, "attr")` / `py.subscript(recv, key)`.

Verified: `g(x).foo` -> `out == py.getattr(call:g(x), "foo")`; `g(x)[0]` -> `out == py.subscript(call:g(x), 0)`.
ΔR: the Attribute (4,854) + Subscript (1,754) wall — 96% of the pandas unwritten-node frontier — collapses. Full-corpus census after: **R=15, construction panics=0**.

## 2. Content-addressed work is owned once; nodes are views (c539e6dc6)
Constructing opaque terms exposed an O(statements x subtree) recomputation: per-node content CIDs recomputed in every binding snapshot the node survived. Isolated `core/generic._where`: 91,516 `cid_of_json` calls, 180s (py-spy: parked in `freeze -> testimony -> node_construction_shape_cid -> canonical_json`).

Each category of content-addressed work moved to a single owner holding a static intern table:
- `constructed-node-shape`: static registry keyed by backend ref (weak — no leak, no id-reuse staleness)
- `constructed-semantic-value` + testimony mint: `present_construction` early-returns once the shape CID is recorded (12x -> 1x)
- `opaque-object-coordinate` / `binding-coordinate` / `constructed-value-testimony`: each type interns by CID (31x / 13.8x / 3.6x -> 1x)

**`_where`: 180.4s -> 28.3s (6.4x); cid_of_json 91,516 -> 1,421 (64x).** Sound by the content-address law (same CID => same content).

## 3. Recensus live per-function tqdm (2b10c43d9)
The bar advanced per file, so a slow file gave no signal about which function was expensive. Now announces each function BEFORE constructing (a hang names the exact stuck function), reports its own time on completion: `func=name:line, last=, avg=, fn/s=, slowest=`. This is what surfaced `_where` at 178s.

## 4. A Node in a constructed value serializes by content key (db447023d)
Census surfaced one backend defect: `unserializable constructed value LineTable` in `core/groupby/generic.value_counts`, via `LambdaSugar -> SourceVisibleCallFrameV1 -> Lambda(node) -> SourceUnit -> LineTable`. A constructed value can legitimately carry a Node, but field-walking it drags in positional infrastructure that must never enter a content CID. Represent the node by its construction-shape CID. Crash -> clean `SugarNotWritten[Assign]` gap.

## Gates
- opaque twins 5/5, parameter-contract value twins 5/5
- pandas census gap families byte-identical (`boolean.py` clean, `categorical.py` {With, GeneratorExp})
- full corpus census 38 min: **R=15, construction panics=0, native crashes=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-phase parameter-contract linking and resume support across Python and Rust workflows.
  * Added authenticated resolution handling for pending parameter-contract decisions.
  * Progress reporting now includes per-function timing, counts, slowest functions, and processing rate.

* **Bug Fixes**
  * Opaque object attributes and subscripting now produce symbolic results instead of failing.
  * Resumed computations preserve the correct projected values and reject stale or invalid resolutions.

* **Tests**
  * Added coverage for opaque access, contract resumption, value preservation, and cross-language contract compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix opaque member access as symbolic read and add parameter-contract link unit folding
> - Attribute and subscript access on `OpaqueObjectStateV1` receivers now constructs `AttributeSugar`/`SubscriptSugar` instead of deferring to a no-op, so opaque member reads produce IR nodes rather than gaps.
> - Introduces a parameter-contract continuation pipeline: Python emits `ParameterContractLinkUnitV1` (with `ParameterOwnedContractV1` and formal coordinates) from `UniverseValue.link_unit_projection()`; the Rust linker validates and folds link units into `ParameterContractResolutionSetV1` via `fold_one_link_unit`.
> - The Rust tree enumerator gains a three-phase fold: enumerate link units, discharge via `fold_one_link_unit`, resume retained universes, and pass resolved continuation keys to skip already-resolved functions in the Universe phase.
> - Interning is added to `BindingCoordinateV1`, `ConstructedValueTestimonyV1`, and `OpaqueObjectCoordinateV1` so repeated decodes of the same CID return the same object identity.
> - `node_construction_shape_cid` is memoized via a process-wide weak-key cache in [`construction_cache.py`](https://github.com/TSavo/sugar/pull/6230/files#diff-fec1dbfe7718a35848f37642330b8df50429df86eae284a72524c6bf8352972f), and `_canonical_constructed_value` now handles `Node` instances by serializing them as `{nodeShape: <cid>}`.
> - Risk: the continuation retention maps in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/6230/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) are process-global and reset only at link-unit enumeration time, so stale state from a previous session can persist if the server is not restarted between runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db44702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->