### PR TITLE
fix: permanent Python floor reds (panic-catch + ground BoolOp)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -241,10 +241,17 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
     """Phase-1 enrollment: one closed ParameterContractLinkUnitV1 per function
     that enrolled a parameter-contract demand. Builds each function's universe
     (never calls post()), projects its link unit, and RETAINS the immutable
-    universe keyed by linkUnitCid + def-memento so Phase-3 resume reuses it."""
+    universe keyed by linkUnitCid + def-memento so Phase-3 resume reuses it.
+
+    Soft-skip is only ``SugarNotWritten`` (typed tree frontier), matching
+    universe enumerate. ``ConstructionPanic`` is *not* caught here — the sole
+    production soft membranes are audit enumeration and
+    ``_production_lift_child``; panics propagate to the process-terminal
+    JSON-RPC error + SystemExit handler. Incomplete / non-Universe outcomes
+    simply enroll no link unit (no owned demand).
+    """
     from sugar_lift_py_tests import tree_enumerate as _tree
     from sugar_lift_py_tests.floor.universe_value import UniverseValue
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
     from sugar_lift_py_tests.outcome import Complete
     from sugar_source_tree.panic import SugarNotWritten
 
@@ -260,13 +267,10 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
         for fn in sf.functions():
             try:
                 outcome = fn.sugar().desugar(None)
-            except (SugarNotWritten, ConstructionPanic):
-                # The TWO typed frontier signals: an unconstructed function owns no
-                # link unit (there is nothing to enroll), and its gap is still
-                # surfaced by the universe/audit scan (this function is never added
-                # to the resolved-skip set). Every OTHER exception -- an ordinary
-                # Exception, i.e. a real bug -- propagates LOUDLY; nothing vanishes
-                # through a broad except.
+            except SugarNotWritten:
+                # Typed tree frontier: no link unit to enroll. Gap remains
+                # visible on the universe/audit scan; never catch
+                # ConstructionPanic to soft-continue.
                 continue
             if not isinstance(outcome, Complete):
                 continue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -39,9 +39,11 @@ class BoolOpSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from functools import reduce
+
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.ir import and_, or_
         from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.outcome.exit_set import _and_guards, _or_guards
         from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
         formulas = []
@@ -57,5 +59,9 @@ class BoolOpSugar(Sugar):
             # NotImplementedError on a constructible ground boolean.
             formulas.append(predicate_formula(out.value, self.site))
 
-        combine = and_ if self.op_kind == "And" else or_
-        return Complete(PredicateValue(combine(formulas), self.site))
+        # Fold with the shared guard algebra so ground identities absorb:
+        #   false ∧ φ → false,  true ∧ φ → φ,  true ∨ φ → true,  false ∨ φ → φ.
+        # Raw and_/or_ would leave and_([false, true]) as a connective and hide
+        # that None and True is false in boolean context.
+        combine = _and_guards if self.op_kind == "And" else _or_guards
+        return Complete(PredicateValue(reduce(combine, formulas), self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -42,6 +42,7 @@ class BoolOpSugar(Sugar):
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.ir import and_, or_
         from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
         formulas = []
         for operand in self.values:
@@ -50,16 +51,11 @@ class BoolOpSugar(Sugar):
                 # An operand that is itself an effect propagates -- the boolean is
                 # not decidable once a conjunct halts.
                 return out
-            truth = out.value.truth(self.site)
-            formula = getattr(getattr(truth, "value", None), "formula", None)
-            if formula is None:
-                # A ground-bool operand (no formula) is not lifted yet -- LOUD,
-                # never drop a conjunct silently.
-                raise NotImplementedError(
-                    "boolean operand that folds to a ground boolean is not lifted "
-                    f"yet (got {type(getattr(out, 'value', out)).__name__})"
-                )
-            formulas.append(formula)
+            # Same truth→formula projection as if/if-exp: symbolic formulas stand
+            # as themselves; ground True/False (including None.truth → False)
+            # fold through true_guard/false_guard. Never raise bare
+            # NotImplementedError on a constructible ground boolean.
+            formulas.append(predicate_formula(out.value, self.site))
 
         combine = and_ if self.op_kind == "And" else or_
         return Complete(PredicateValue(combine(formulas), self.site))

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py
@@ -1,0 +1,60 @@
+"""BoolOpSugar ground operands fold via the shared predicate_formula path.
+
+Permanent floor: a ground boolean (None → False, True, False) must not raise a
+bare NotImplementedError — that was R_bare_exceptions=1 on import_binding.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+@dataclass(frozen=True)
+class _Site:
+    filename: str = "test_bool_op_ground_operand.py"
+    line: int = 1
+    col: int = 0
+    source: str = "None and True"
+
+
+def test_none_and_true_folds_to_predicate() -> None:
+    site = _Site()
+    sugar = BoolOpSugar(
+        op_kind="And",
+        values=(NoneLiteralSugar(site=site), TrueBoolLiteralSugar(site=site)),
+        site=site,
+    )
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, PredicateValue)
+
+
+def test_true_and_false_folds_to_predicate() -> None:
+    site = _Site()
+    sugar = BoolOpSugar(
+        op_kind="And",
+        values=(TrueBoolLiteralSugar(site=site), FalseBoolLiteralSugar(site=site)),
+        site=site,
+    )
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, PredicateValue)
+
+
+def test_none_or_true_folds_to_predicate() -> None:
+    site = _Site()
+    sugar = BoolOpSugar(
+        op_kind="Or",
+        values=(NoneLiteralSugar(site=site), TrueBoolLiteralSugar(site=site)),
+        site=site,
+    )
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, PredicateValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py
@@ -1,7 +1,8 @@
-"""BoolOpSugar ground operands fold via the shared predicate_formula path.
+"""BoolOpSugar ground and mixed operands — exact formula twins.
 
 Permanent floor: a ground boolean (None → False, True, False) must not raise a
-bare NotImplementedError — that was R_bare_exceptions=1 on import_binding.py.
+bare NotImplementedError. Formulas must be the FOL truth values (or the
+symbolic atom with ground identities absorbed), not merely "some PredicateValue".
 """
 
 from __future__ import annotations
@@ -9,9 +10,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+from sugar_lift_py_tests.ir import make_var, num, py_eq
 from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 
@@ -23,38 +29,110 @@ class _Site:
     col: int = 0
     source: str = "None and True"
 
+    def compare_left(self):
+        # EqualityOpSugar refinement path; ground/symbolic fold tests do not
+        # need a real coordinate.
+        class _Left:
+            def dotted_expr_name(self):
+                return None
 
-def test_none_and_true_folds_to_predicate() -> None:
+        return _Left()
+
+
+def _bool_op(kind: str, *operands: object) -> PredicateValue:
     site = _Site()
-    sugar = BoolOpSugar(
-        op_kind="And",
-        values=(NoneLiteralSugar(site=site), TrueBoolLiteralSugar(site=site)),
+    sugar = BoolOpSugar(op_kind=kind, values=operands, site=site)
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete), out
+    assert isinstance(out.value, PredicateValue), type(out.value)
+    return out.value
+
+
+def _z_eq_1() -> EqualityOpSugar:
+    site = _Site()
+    return EqualityOpSugar(
+        left=NameSugar(name="z", site=site),
+        right=IntLiteralSugar(value=1, site=site),
         site=site,
     )
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete)
-    assert isinstance(out.value, PredicateValue)
 
 
-def test_true_and_false_folds_to_predicate() -> None:
+def _symbolic_z_eq_1():
+    return py_eq(make_var("z"), num(1))
+
+
+def test_none_and_true_is_false() -> None:
     site = _Site()
-    sugar = BoolOpSugar(
-        op_kind="And",
-        values=(TrueBoolLiteralSugar(site=site), FalseBoolLiteralSugar(site=site)),
-        site=site,
+    value = _bool_op(
+        "And",
+        NoneLiteralSugar(site=site),
+        TrueBoolLiteralSugar(site=site),
     )
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete)
-    assert isinstance(out.value, PredicateValue)
+    assert value.formula == false_guard()
 
 
-def test_none_or_true_folds_to_predicate() -> None:
+def test_true_and_false_is_false() -> None:
     site = _Site()
-    sugar = BoolOpSugar(
-        op_kind="Or",
-        values=(NoneLiteralSugar(site=site), TrueBoolLiteralSugar(site=site)),
-        site=site,
+    value = _bool_op(
+        "And",
+        TrueBoolLiteralSugar(site=site),
+        FalseBoolLiteralSugar(site=site),
     )
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete)
-    assert isinstance(out.value, PredicateValue)
+    assert value.formula == false_guard()
+
+
+def test_none_or_true_is_true() -> None:
+    site = _Site()
+    value = _bool_op(
+        "Or",
+        NoneLiteralSugar(site=site),
+        TrueBoolLiteralSugar(site=site),
+    )
+    assert value.formula == true_guard()
+
+
+def test_symbolic_and_true_absorbs_to_symbolic() -> None:
+    """(z == 1) and True → py.eq(z, 1); True is identity of ∧."""
+    site = _Site()
+    value = _bool_op("And", _z_eq_1(), TrueBoolLiteralSugar(site=site))
+    assert value.formula == _symbolic_z_eq_1()
+
+
+def test_true_and_symbolic_absorbs_to_symbolic() -> None:
+    """True and (z == 1) → py.eq(z, 1); order must not matter for absorption."""
+    site = _Site()
+    value = _bool_op("And", TrueBoolLiteralSugar(site=site), _z_eq_1())
+    assert value.formula == _symbolic_z_eq_1()
+
+
+def test_symbolic_or_false_absorbs_to_symbolic() -> None:
+    """(z == 1) or False → py.eq(z, 1); False is identity of ∨."""
+    site = _Site()
+    value = _bool_op("Or", _z_eq_1(), FalseBoolLiteralSugar(site=site))
+    assert value.formula == _symbolic_z_eq_1()
+
+
+def test_false_and_symbolic_is_false() -> None:
+    """False and (z == 1) → false; proves ∧ selects false, not the symbolic."""
+    site = _Site()
+    value = _bool_op("And", FalseBoolLiteralSugar(site=site), _z_eq_1())
+    assert value.formula == false_guard()
+
+
+def test_true_or_symbolic_is_true() -> None:
+    """True or (z == 1) → true; proves ∨ selects true, not the symbolic."""
+    site = _Site()
+    value = _bool_op("Or", TrueBoolLiteralSugar(site=site), _z_eq_1())
+    assert value.formula == true_guard()
+
+
+def test_symbolic_and_false_is_false() -> None:
+    site = _Site()
+    value = _bool_op("And", _z_eq_1(), FalseBoolLiteralSugar(site=site))
+    assert value.formula == false_guard()
+
+
+def test_symbolic_or_true_is_true() -> None:
+    site = _Site()
+    value = _bool_op("Or", _z_eq_1(), TrueBoolLiteralSugar(site=site))
+    assert value.formula == true_guard()


### PR DESCRIPTION
## Summary

Tip `factory-zero-tolerance` is red on main. Measured R on `4a2d0184d`:

| Axis | R | Locus |
|------|---|-------|
| `R_construction_panic_catches_outside_audit` | **1** | `lift_rpc._parameter_contract_link_unit_rows` soft-continued on `ConstructionPanic` |
| `R_bare_exceptions` | **1** | `import_binding.py` → `BoolOpSugar` raised bare `NotImplementedError` for ground `NoneValue` operand |
| `R_factory_walk_unclassified` | incomplete | `auditor_errors=1` (388/389 files; same surface) |

## Changes

1. **Panic-catch law** — stop catching `ConstructionPanic` in parameter-contract link-unit enrollment. Soft-skip only `SugarNotWritten` (matches universe enumerate). `ConstructionPanic` propagates to the process-terminal JSON-RPC handler.
2. **BoolOpSugar** — ground boolean operands fold through shared `predicate_formula` (same path as if/if-exp: `None.truth` → False, True/False guards). Never bare `NotImplementedError` for constructible ground truth.
3. **Twin** — `test_bool_op_ground_operand.py` locks the ground fold.

## Predicted Epsilon R

- `R_construction_panic_catches_outside_audit`: 1 → **0**
- `R_bare_exceptions`: 1 → **0**
- Floors preserved: ownership, side doors, vendor, silent, finite-cap, etc.

Note: locally, post-fix `import_binding.py` can still hit the 30s supervised enum timeout (deeper construction after the bare abort is removed). That is a separate `R_timeouts` signal if CI reports it — fix forward, do not reintroduce bare exceptions.

## Validation

```text
construction_panic_catch_law GREEN (R=0)
factory_ownership_law GREEN
construction_side_door_law GREEN
pytest test_bool_op_ground_operand + test_construction_panic_catch_law → 10 passed
```

## Next (top mass, after floors)

Historical board (`95e58d0ff`) + open issues — dispatch order by mass once permanent floors are green:

1. **#5254 / shape-split** driver (python.factory by exact missing shape)
2. **sklearn residual #5274** (~195 factory files historical)
3. **ClassDef family #5263/#5264**
4. **TemporalContext #5167**
5. **Unclassified walk #5252** (separate axis; do not fold into factory panic mass)

This PR only restores permanent-floor zeros; does not claim corpus walls.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BoolOpSugar.desugar` to handle ground boolean operands and propagate `ConstructionPanic`
> - [`BoolOpSugar.desugar`](https://github.com/TSavo/sugar/pull/6231/files#diff-73c2a5ae1e04df48a3942a0cb20fba48229df0773e79787ec3b8a7f11aae8199) now handles ground (`None`/`True`/`False`) and mixed boolean operands using `predicate_formula` and `functools.reduce`, applying FOL absorption rules (e.g. `false ∧ φ → false`, `true ∨ φ → true`) instead of raising `NotImplementedError`.
> - [`_parameter_contract_link_unit_rows`](https://github.com/TSavo/sugar/pull/6231/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now only soft-skips `SugarNotWritten`; `ConstructionPanic` propagates out of Phase-1 enrollment instead of being silently swallowed.
> - Adds a new test suite in [`test_bool_op_ground_operand.py`](https://github.com/TSavo/sugar/pull/6231/files#diff-49398ea02061e5069f73fbfbc3e81b2c2e256ff72dd60ff4947ea530f129dee8) covering ground-only and mixed operand cases.
> - Behavioral Change: `ConstructionPanic` during per-function desugar now surfaces as a hard failure rather than a silent skip.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f13f5f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->