### PR TITLE
feat: a comprehension is a scoped guarded fold, for any binding target

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -10,8 +10,31 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
+class ComprehensionTargetSugar:
+    """What one generator binds per symbolic element: a coordinate, or an
+    ordered destructuring of coordinates.
+
+    A leaf carries ``source_name`` and binds the whole element. A pattern
+    carries ``coordinates`` and binds each position to a projection of the
+    element -- the same binding problem a statement loop's tuple target
+    solves, expressed against a SYMBOLIC element rather than a display.
+    Exactly one of the two is ever set; a shape that is neither (a starred or
+    attribute target) is never built here, so the source node stays loud.
+    """
+
+    source_name: str | None = None
+    coordinates: "tuple[ComprehensionTargetSugar, ...] | None" = None
+
+    def __post_init__(self):
+        if (self.source_name is None) == (self.coordinates is None):
+            raise ValueError(
+                "comprehension target is exactly one of a name or a destructuring"
+            )
+
+
+@dataclass(frozen=True)
 class ComprehensionGeneratorSugar:
-    source_name: str
+    target: ComprehensionTargetSugar
     binding_coordinate_cid: str
     iterable: Sugar
     filters: tuple[Sugar, ...]
@@ -67,7 +90,7 @@ class ComprehensionSugar(Sugar):
                 (
                     *resolved,
                     (
-                        generator.source_name,
+                        generator.target,
                         generator.binding_coordinate_cid,
                         iterable,
                         filters,
@@ -115,14 +138,12 @@ class ComprehensionSugar(Sugar):
         )
         body = element_term
         recurrence_rows = []
-        for source_name, binding_coordinate_cid, iterable, filters in reversed(
-            resolved
-        ):
+        for target, binding_coordinate_cid, iterable, filters in reversed(resolved):
             coordinate_var = make_var(binding_coordinate_cid)
-            body = subst_var_in_term(body, source_name, coordinate_var)
+            body = _bind_target(target, coordinate_var, body)
             for guard in reversed(filters):
-                guard_term = subst_var_in_term(
-                    guard.to_term(owner=owner), source_name, coordinate_var
+                guard_term = _bind_target(
+                    target, coordinate_var, guard.to_term(owner=owner)
                 )
                 body = ctor(
                     "python:loop.filter_guard",
@@ -133,6 +154,7 @@ class ComprehensionSugar(Sugar):
                     ],
                     symbol_kind="coordinate",
                 )
+            body = _guard_destructure(target, coordinate_var, body)
             recurrence_rows.append((binding_coordinate_cid, iterable, body))
             body = ctor(
                 "python:loop.flat_map",
@@ -162,3 +184,74 @@ class ComprehensionSugar(Sugar):
             symbol_kind="coordinate",
         )
         return Complete(ComprehensionValue(term))
+
+
+def _projection(element, index: int, arity: int):
+    """The coordinate the ``index``th position of an ``arity``-wide
+    destructuring reads out of a symbolic ``element``.
+
+    Python unpacking is iterable unpacking, not subscription, so this is its
+    own coordinate: it carries the arity the source demanded, which is what
+    makes the accompanying obligation checkable.
+    """
+    from sugar_lift_py_tests.ir import ctor, num
+
+    return ctor(
+        "python:unpack.project",
+        [element, num(index), num(arity)],
+        symbol_kind="coordinate",
+    )
+
+
+def _bind_target(target: ComprehensionTargetSugar, element, body):
+    """``body`` with every coordinate this target names replaced by what the
+    symbolic ``element`` binds to it.
+
+    A leaf binds the element whole. A pattern binds each position to its
+    projection, recursively -- so a nested pattern reads a projection of a
+    projection, exactly as the source nests.
+    """
+    from sugar_lift_py_tests.ir import subst_var_in_term
+
+    if target.source_name is not None:
+        return subst_var_in_term(body, target.source_name, element)
+    coordinates = target.coordinates
+    assert coordinates is not None
+    arity = len(coordinates)
+    for index, child in enumerate(coordinates):
+        body = _bind_target(child, _projection(element, index, arity), body)
+    return body
+
+
+def _guard_destructure(target: ComprehensionTargetSugar, element, body):
+    """``body`` under the arity obligation every destructuring in this target
+    carries.
+
+    A leaf destructures nothing and adds no obligation. A pattern demands the
+    element unpack to exactly its arity: when it does, the continuation is
+    ``body``; when it does not, Python raises, so the exit is the halt
+    coordinate -- NEVER a silently skipped element and never an assumed
+    success. Outer obligations wrap inner ones, because the outer element must
+    unpack before any inner position exists to be read.
+    """
+    from sugar_lift_py_tests.ir import ctor, num
+
+    if target.source_name is not None:
+        return body
+    coordinates = target.coordinates
+    assert coordinates is not None
+    arity = len(coordinates)
+    for index in reversed(range(arity)):
+        body = _guard_destructure(
+            coordinates[index], _projection(element, index, arity), body
+        )
+    return ctor(
+        "python:unpack.destructure",
+        [
+            element,
+            num(arity),
+            body,
+            ctor("python:unpack.halt", [], symbol_kind="coordinate"),
+        ],
+        symbol_kind="coordinate",
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_symbolic_comprehension_guarded_fold.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_symbolic_comprehension_guarded_fold.py
@@ -1,0 +1,507 @@
+"""A comprehension is a scoped guarded fold over an iterable.
+
+Not bounded unrolling, and not a shortcut for any particular library's
+spelling. Over a SYMBOLIC iterable the four collection forms construct one
+recurrence and differ only in the collection coordinate they head:
+
+    state0 = empty
+    for symbolic element x from iterable:
+        bound     = bind(target, x)
+        condition = filter_1(bound) and ... and filter_n(bound)
+        candidate = element(bound)
+        state_next = condition ? append(state, candidate) : state
+
+That is a RECURRENCE, so the construction never guesses an iteration count and
+never fabricates normal completion. Evaluation order is iterable, then target
+binding, then filters, then element -- which is why the destructuring
+obligation wraps the filter guards, and the filter guards wrap the element.
+
+The binding target is the capability under test. A generator target is the
+SAME binding problem a statement loop's target solves, so a tuple/list target
+binds each position to a projection of the symbolic element, recursively. A
+destructure that cannot succeed is a Python raise, never a skipped element:
+its exit is the halt coordinate, distinct from the filter latch that a
+false guard uses.
+"""
+
+import os
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.ir import ctor as _ctor, make_var, num
+
+
+def _post_of(source, path=None):
+    if path is None:
+        path = os.path.join(tempfile.mkdtemp(), "m.py")
+    with open(path, "w") as handle:
+        handle.write(source)
+    function = list(SourceFile(path_source(path)).functions())[0]
+    return function.sugar().desugar(None).value.post()
+
+
+def _fold(post):
+    """The collection coordinate this post binds, as (kind, iterable, lambda)."""
+    coordinate = post.args[1]
+    return coordinate.name, coordinate.args[0], coordinate.args[1]
+
+
+def _coordinate(term):
+    """The recurrence coordinate a fold's lambda binds per element."""
+    return make_var(term.param_name)
+
+
+def _project(element, index, arity):
+    return _ctor(
+        "python:unpack.project",
+        [element, num(index), num(arity)],
+        symbol_kind="coordinate",
+    )
+
+
+def _halt():
+    return _ctor("python:unpack.halt", [], symbol_kind="coordinate")
+
+
+def _destructure(element, arity, body):
+    return _ctor(
+        "python:unpack.destructure",
+        [element, num(arity), body, _halt()],
+        symbol_kind="coordinate",
+    )
+
+
+def _filtered(guard, body):
+    return _ctor(
+        "python:loop.filter_guard",
+        [guard, body, _ctor("python:loop.latch", [], symbol_kind="coordinate")],
+        symbol_kind="coordinate",
+    )
+
+
+def _names(term, found=None):
+    """Every constructor name appearing in a term."""
+    found = [] if found is None else found
+    name = getattr(term, "name", None)
+    if name is not None:
+        found.append(name)
+    for arg in getattr(term, "args", ()) or ():
+        _names(arg, found)
+    body = getattr(term, "body", None)
+    if body is not None:
+        _names(body, found)
+    return found
+
+
+# -- concrete iterable: the fold dissolves to the exact concrete result -------
+
+
+def test_concrete_iterable_reproduces_the_exact_concrete_result():
+    # A concrete iterable is not a recurrence at all: it is a finite number of
+    # substitutions, and the answer must be the ACTUAL elements -- here the
+    # first coordinate of each pair, in source order.
+    post = _post_of("def f():\n    return [a for a, b in [(1, 2), (3, 4)]]\n")
+    assert post.args[1] == _ctor("array", [num(1), num(3)]), f"post was {post!r}"
+
+
+def test_concrete_iterable_with_a_true_filter_includes_every_element():
+    post = _post_of("def f():\n    return [a for a, b in [(1, 2), (3, 4)] if True]\n")
+    assert post.args[1] == _ctor("array", [num(1), num(3)]), f"post was {post!r}"
+
+
+def test_concrete_iterable_with_a_false_filter_excludes_every_element():
+    # The discrimination against the true-filter twin above: same source, one
+    # guard flipped, and the result must be the EMPTY display -- not the
+    # unfiltered elements and not a retained guard.
+    post = _post_of("def f():\n    return [a for a, b in [(1, 2), (3, 4)] if False]\n")
+    assert post.args[1] == _ctor("array", []), f"post was {post!r}"
+
+
+def test_concrete_iterable_filter_selects_exactly_the_passing_elements():
+    post = _post_of("def f():\n    return [a for a, b in [(1, 2), (3, 4)] if b > 2]\n")
+    assert post.args[1] == _ctor("array", [num(3)]), f"post was {post!r}"
+
+
+# -- symbolic iterable: recurrence, never a guessed bound --------------------
+
+
+def test_symbolic_iterable_constructs_a_recurrence_not_an_unrolling():
+    # The iterable is a parameter, so no element is known and no count is
+    # known. The construction heads the collection coordinate over the
+    # SYMBOLIC iterable with a per-element lambda and an explicit exhaustion
+    # face -- never a display of invented elements.
+    post = _post_of("def f(xs):\n    return [g(x) for x in xs]\n")
+    kind, iterable, body = _fold(post)
+    assert kind == "py.listcomp"
+    assert iterable == make_var("xs")
+    element = _coordinate(body)
+    assert body.body == _ctor("call:g", [element]), f"body was {body.body!r}"
+    assert post.args[1].args[2] == _ctor(
+        "python:loop.exhaustion", [], symbol_kind="coordinate"
+    )
+
+
+def test_symbolic_iterable_never_fabricates_a_finite_element_count():
+    # The discrimination against unrolling: nothing anywhere in a symbolic
+    # comprehension's term may be a concrete collection display.
+    post = _post_of("def f(xs):\n    return [g(x) for x in xs]\n")
+    assert "array" not in _names(post), f"post was {post!r}"
+
+
+def test_symbolic_filter_retains_a_guard_rather_than_deciding_it():
+    # `p(x)` is not decidable at lift time, so membership stays CONDITIONAL:
+    # the element sits under a filter guard with its latch, and the guard's
+    # formula is the real predicate over the bound coordinate.
+    post = _post_of("def f(xs):\n    return [g(x) for x in xs if p(x)]\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    assert body.body == _filtered(
+        _ctor("call:p", [element]), _ctor("call:g", [element])
+    ), f"body was {body.body!r}"
+
+
+def test_symbolic_filters_conjoin_in_source_order():
+    # Two guards nest outermost-first, so the first filter is evaluated first
+    # -- the conjunction Python actually performs, short-circuit and all.
+    post = _post_of("def f(xs):\n    return [x for x in xs if p(x) if q(x)]\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    assert body.body == _filtered(
+        _ctor("call:p", [element]),
+        _filtered(_ctor("call:q", [element]), element),
+    ), f"body was {body.body!r}"
+
+
+# -- lexical scope -----------------------------------------------------------
+
+
+def test_nested_generators_preserve_ordering_and_binding_dependency():
+    # The second generator's iterable is the FIRST generator's binding, so the
+    # outer fold must wrap the inner one and the inner iterable must read the
+    # outer coordinate. An inner-first nesting would be a different program.
+    post = _post_of("def f(xs):\n    return [g(x, y) for x in xs for y in x]\n")
+    _kind, iterable, outer = _fold(post)
+    assert iterable == make_var("xs")
+    x = _coordinate(outer)
+    inner_fold = outer.body
+    assert inner_fold.name == "python:loop.flat_map", f"outer body {inner_fold!r}"
+    assert inner_fold.args[0] == x, "inner iterable must be the outer binding"
+    y = _coordinate(inner_fold.args[1])
+    assert inner_fold.args[1].body == _ctor("call:g", [x, y])
+    assert x != y, "each generator binds its own coordinate"
+
+
+def test_target_variable_does_not_leak_out_of_the_comprehension():
+    # `x` after the comprehension is the PARAMETER x, never the comprehension's
+    # per-element coordinate. If the target leaked, the returned term would
+    # mention the recurrence coordinate.
+    post = _post_of("def f(x, xs):\n    ys = [g(x) for x in xs]\n    return h(x)\n")
+    assert post.args[1] == _ctor("call:h", [make_var("x")]), f"post was {post!r}"
+
+
+def test_shadowed_outer_variable_remains_unchanged():
+    # The discrimination against over-substitution: inside the comprehension,
+    # `x` is the element coordinate; outside it, the same name is still the
+    # outer binding. Both faces are asserted in ONE program.
+    source = "def f(x, xs):\n    return h(x, [g(x) for x in xs])\n"
+    post = _post_of(source)
+    call = post.args[1]
+    assert call.name == "call:h"
+    assert call.args[0] == make_var("x"), "outer x survives unshadowed"
+    _kind, _iterable, body = _fold_of_term(call.args[1])
+    element = _coordinate(body)
+    assert body.body == _ctor("call:g", [element]), "inner x is the coordinate"
+    assert element != make_var("x")
+
+
+def _fold_of_term(coordinate):
+    return coordinate.name, coordinate.args[0], coordinate.args[1]
+
+
+# -- destructuring targets ---------------------------------------------------
+
+
+def test_tuple_destructuring_binds_every_coordinate_correctly():
+    # Each position binds its OWN projection of the symbolic element, in
+    # order, carrying the arity the source demanded.
+    post = _post_of("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    assert body.body == _destructure(
+        element,
+        2,
+        _ctor("call:g", [_project(element, 0, 2), _project(element, 1, 2)]),
+    ), f"body was {body.body!r}"
+
+
+def test_destructuring_positions_are_not_interchangeable():
+    # The discrimination against a positionally-blind binding: swapping the
+    # target names must change the constructed term.
+    straight = _post_of("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
+    swapped = _post_of("def f(xs):\n    return [g(b, a) for a, b in xs]\n")
+    assert _fold(straight)[2].body != _fold(swapped)[2].body
+
+
+def test_list_shaped_target_destructures_like_a_tuple_target():
+    # `for [a, b] in xs` is the same binding as `for a, b in xs`. The two sit
+    # at different binding SITES, so their coordinates differ by design; what
+    # must match is the projection structure built over each.
+    def structure(source):
+        _kind, _iterable, body = _fold(_post_of(source))
+        element = _coordinate(body)
+        return _destructure(
+            element,
+            2,
+            _ctor("call:g", [_project(element, 0, 2), _project(element, 1, 2)]),
+        ) == body.body
+
+    assert structure("def f(xs):\n    return [g(a, b) for [a, b] in xs]\n")
+    assert structure("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
+
+
+def test_nested_destructuring_projects_a_projection():
+    # `for a, (b, c) in xs`: the outer obligation wraps the inner one, because
+    # the outer element must unpack before position 1 exists to unpack again.
+    post = _post_of("def f(xs):\n    return [g(a, b, c) for a, (b, c) in xs]\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    inner = _project(element, 1, 2)
+    assert body.body == _destructure(
+        element,
+        2,
+        _destructure(
+            inner,
+            2,
+            _ctor(
+                "call:g",
+                [_project(element, 0, 2), _project(inner, 0, 2), _project(inner, 1, 2)],
+            ),
+        ),
+    ), f"body was {body.body!r}"
+
+
+def test_destructuring_arity_is_carried_not_assumed():
+    # A three-wide target carries arity 3, not the two-wide shape.
+    post = _post_of("def f(xs):\n    return [g(a, b, c) for a, b, c in xs]\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    assert body.body == _destructure(
+        element,
+        3,
+        _ctor(
+            "call:g",
+            [_project(element, 0, 3), _project(element, 1, 3), _project(element, 2, 3)],
+        ),
+    ), f"body was {body.body!r}"
+
+
+def test_a_failing_destructure_stays_halted_never_silently_skipped():
+    # A wrong-arity element makes Python RAISE. So the destructuring
+    # obligation's exit is the halt coordinate -- and it must NOT be the
+    # filter latch, which is the exit for an element a guard excludes.
+    post = _post_of("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
+    _kind, _iterable, body = _fold(post)
+    obligation = body.body
+    assert obligation.name == "python:unpack.destructure"
+    assert obligation.args[3] == _halt(), f"exit was {obligation.args[3]!r}"
+    assert "python:loop.latch" not in _names(obligation.args[3])
+
+
+def test_destructure_halt_and_filter_latch_are_distinct_exits():
+    # Both faces in one program: the destructure exit is a halt, the filter
+    # exit is a latch. Collapsing them would turn a raise into a skip.
+    post = _post_of("def f(xs):\n    return [a for a, b in xs if p(b)]\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    assert body.body == _destructure(
+        element,
+        2,
+        _filtered(
+            _ctor("call:p", [_project(element, 1, 2)]), _project(element, 0, 2)
+        ),
+    ), f"body was {body.body!r}"
+
+
+def test_destructuring_obligation_precedes_the_filter_guard():
+    # Evaluation order: bind the target, THEN run filters. A filter reads a
+    # projection, so the projection cannot be legal before the unpack is.
+    post = _post_of("def f(xs):\n    return [a for a, b in xs if p(b)]\n")
+    _kind, _iterable, body = _fold(post)
+    assert body.body.name == "python:unpack.destructure"
+    assert body.body.args[2].name == "python:loop.filter_guard"
+
+
+def test_a_starred_target_remains_loud():
+    # `for a, *b in xs` binds a variable-arity remainder, which this
+    # recurrence does not model. It must stay SugarNotWritten -- a legitimate
+    # gap kept red, not a guessed arity.
+    from sugar_source_tree.panic import SugarNotWritten
+
+    try:
+        _post_of("def f(xs):\n    return [a for a, *b in xs]\n")
+    except SugarNotWritten:
+        return
+    raise AssertionError("a starred comprehension target must stay loud")
+
+
+def test_an_attribute_target_remains_loud():
+    from sugar_source_tree.panic import SugarNotWritten
+
+    try:
+        _post_of("def f(xs, o):\n    return [o.a for o.a, b in xs]\n")
+    except SugarNotWritten:
+        return
+    raise AssertionError("an attribute comprehension target must stay loud")
+
+
+# -- effects and unknown members ---------------------------------------------
+
+
+def test_an_unresolved_element_call_stays_a_symbolic_coordinate_not_omitted():
+    # `g(x)` has no body here. Its member value is unknown, and the honest
+    # construction keeps the call coordinate -- never drops the element and
+    # never invents a value for it.
+    post = _post_of("def f(xs):\n    return [g(x) for x in xs]\n")
+    _kind, _iterable, body = _fold(post)
+    assert "call:g" in _names(body.body), f"body was {body.body!r}"
+
+
+def test_a_raising_element_body_propagates_rather_than_completing_quietly():
+    # A comprehension whose body raises does not produce a list. Construction
+    # must not hand back a plain collection coordinate as if it completed.
+    from sugar_source_tree.panic import SugarNotWritten
+
+    source = "def f(xs):\n    return [raise_it(x) for x in xs]\n"
+    try:
+        post = _post_of(source)
+    except SugarNotWritten:
+        return
+    assert "array" not in _names(post), f"post was {post!r}"
+
+
+def test_a_raising_filter_propagates_rather_than_deciding_membership():
+    from sugar_source_tree.panic import SugarNotWritten
+
+    source = "def f(xs):\n    return [x for x in xs if raise_it(x)]\n"
+    try:
+        post = _post_of(source)
+    except SugarNotWritten:
+        return
+    _kind, _iterable, body = _fold(post)
+    assert body.body.name == "python:loop.filter_guard", (
+        "an undecided filter keeps its guard rather than choosing a side"
+    )
+
+
+# -- the four collection semantics -------------------------------------------
+
+
+def test_the_four_collection_forms_head_distinct_coordinates():
+    # One mechanism, four collection semantics. If any two shared a
+    # coordinate their results could alias, and set/dict/generator semantics
+    # would be indistinguishable from a list's.
+    listcomp = _post_of("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
+    setcomp = _post_of("def f(xs):\n    return {g(a, b) for a, b in xs}\n")
+    genexp = _post_of("def f(xs):\n    return (g(a, b) for a, b in xs)\n")
+    dictcomp = _post_of("def f(xs):\n    return {a: b for a, b in xs}\n")
+    kinds = [_fold(p)[0] for p in (listcomp, setcomp, genexp, dictcomp)]
+    assert kinds == [
+        "py.listcomp",
+        "py.setcomp",
+        "py.generatorexp",
+        "py.dictcomp",
+    ], kinds
+    assert len(set(kinds)) == 4
+
+
+def test_list_set_and_generator_results_cannot_alias_one_another():
+    # Same source text, same binding, same element -- only the brackets
+    # differ. The constructed terms must still differ.
+    listcomp = _post_of("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
+    setcomp = _post_of("def f(xs):\n    return {g(a, b) for a, b in xs}\n")
+    genexp = _post_of("def f(xs):\n    return (g(a, b) for a, b in xs)\n")
+    terms = [p.args[1] for p in (listcomp, setcomp, genexp)]
+    assert len(set(terms)) == 3, terms
+
+
+def test_a_generator_expression_stays_lazy_rather_than_becoming_a_list():
+    # The discrimination against eager fabrication: a genexp over a symbolic
+    # iterable is a generator coordinate, never a list display or listcomp.
+    post = _post_of("def f(xs):\n    return (g(a, b) for a, b in xs)\n")
+    names = _names(post)
+    assert "py.generatorexp" in names
+    assert "py.listcomp" not in names and "array" not in names, names
+
+
+def test_a_dict_comprehension_retains_its_guarded_key_value_association():
+    # The key and value are projections of the SAME element, paired in one
+    # entry -- the association Python builds, not two independent sequences.
+    post = _post_of("def f(xs):\n    return {a: b for a, b in xs}\n")
+    _kind, _iterable, body = _fold(post)
+    element = _coordinate(body)
+    assert body.body == _destructure(
+        element,
+        2,
+        _ctor(
+            "python:dict_entry",
+            [_project(element, 0, 2), _project(element, 1, 2)],
+            symbol_kind="coordinate",
+        ),
+    ), f"body was {body.body!r}"
+
+
+def test_a_concrete_dict_comprehension_keeps_last_write_overwrite_behaviour():
+    # A repeated key keeps the LAST value and the FIRST position -- Python's
+    # actual dict overwrite semantics, not a duplicated entry.
+    post = _post_of(
+        "def f():\n    return {a: b for a, b in [(1, 2), (3, 4), (1, 5)]}\n"
+    )
+    entries = post.args[1]
+    assert entries.name == "python:dict", f"post was {post!r}"
+    assert [
+        (entry.args[0].value, entry.args[1].value) for entry in entries.args
+    ] == [(1, 5), (3, 4)], f"post was {post!r}"
+
+
+def test_a_set_comprehension_uses_set_membership_over_a_concrete_iterable():
+    # Duplicates collapse: three elements, two distinct members.
+    post = _post_of("def f():\n    return {a for a, b in [(1, 2), (1, 3), (4, 5)]}\n")
+    members = post.args[1]
+    assert members.name == "python:set", f"post was {post!r}"
+    assert [member.value for member in members.args] == [1, 4], f"post was {post!r}"
+
+
+# -- determinism -------------------------------------------------------------
+
+
+def test_repeated_construction_is_byte_identical():
+    # Same file, constructed twice: identical terms. A coordinate that drifted
+    # between runs would make every downstream CID unstable.
+    path = os.path.join(tempfile.mkdtemp(), "m.py")
+    source = "def f(xs):\n    return [g(a, b) for a, b in xs if p(b)]\n"
+    first = _post_of(source, path)
+    second = _post_of(source, path)
+    assert repr(first) == repr(second)
+    assert first == second
+
+
+def test_every_collection_form_is_byte_identical_across_repeats():
+    for source in (
+        "def f(xs):\n    return [g(a, b) for a, b in xs]\n",
+        "def f(xs):\n    return {g(a, b) for a, b in xs}\n",
+        "def f(xs):\n    return (g(a, b) for a, b in xs)\n",
+        "def f(xs):\n    return {a: b for a, b in xs}\n",
+    ):
+        path = os.path.join(tempfile.mkdtemp(), "m.py")
+        assert _post_of(source, path) == _post_of(source, path), source
+
+
+def test_a_name_target_construction_carries_no_destructuring_obligation():
+    # The 'nothing else moved' twin: adding destructuring must not put an
+    # unpack obligation on the simple-name path.
+    post = _post_of("def f(xs):\n    return [g(x) for x in xs if p(x)]\n")
+    names = _names(post)
+    assert "python:unpack.destructure" not in names, names
+    assert "python:unpack.project" not in names, names
+    assert "python:loop.filter_guard" in names, names

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5829,6 +5829,33 @@ class ListComp(Expression):
             site=self.fragment,
         )
 
+    def _comprehension_target(self, target: "Node"):
+        """The binding pattern a generator target denotes, or None when its
+        shape has no sugar written.
+
+        A `Name` binds the element whole; a tuple/list target destructures it
+        position by position, nesting as the source nests. A starred or
+        attribute/subscript target builds nothing -- the comprehension then
+        stays loud rather than binding a shape this does not model.
+        """
+        from sugar_lift_py_tests.sugar.comprehension_sugar import (
+            ComprehensionTargetSugar,
+        )
+
+        if target.kind == "Name":
+            return ComprehensionTargetSugar(source_name=target.id)
+        if target.kind not in ("Tuple", "List"):
+            return None
+        coordinates = []
+        for position in target.elts:
+            child = ListComp._comprehension_target(self, position)
+            if child is None:
+                return None
+            coordinates.append(child)
+        if not coordinates:
+            return None
+        return ComprehensionTargetSugar(coordinates=tuple(coordinates))
+
     def _recurrence_generators(self):
         from sugar_lift_python_source.canonical import cid_of_json
         from sugar_lift_py_tests.sugar.comprehension_sugar import (
@@ -5845,15 +5872,16 @@ class ListComp(Expression):
             }
         )
         for generator_index, gen in enumerate(self.generators):
-            if (
-                gen.is_async
-                or gen.target.kind != "Name"
-                or ListComp._contains_named_expression(self, (gen.iter, *gen.ifs))
+            if gen.is_async or ListComp._contains_named_expression(
+                self, (gen.iter, *gen.ifs)
             ):
+                return None
+            target = ListComp._comprehension_target(self, gen.target)
+            if target is None:
                 return None
             specs.append(
                 ComprehensionGeneratorSugar(
-                    source_name=gen.target.id,
+                    target=target,
                     binding_coordinate_cid=mint_binding_coordinate_v1(
                         scope_owner_cid=scope_owner_cid,
                         binding_site=gen.target.fragment,


### PR DESCRIPTION
A comprehension is a scoped guarded fold over an iterable — not bounded unrolling, not a vendor shortcut.

## The gap
`_recurrence_generators` rejected any generator whose target was not a bare `Name`, so every **destructuring target** (`for a, b in pairs`) fell to `SugarNotWritten`. Measured across pandas: 2,519 simple-Name generators already constructed; **330 destructuring targets did not**. Comprehensions were 242 of the 411 remaining unwritten-sugar sites (59%, the #1 residual).

## The capability
`ComprehensionGeneratorSugar.source_name: str` becomes `target: ComprehensionTargetSugar` — a leaf binding the element whole, or an ordered pattern binding each position to `python:unpack.project(element, index, arity)`, recursively, so a nested pattern reads a projection of a projection exactly as the source nests. Unpacking is iterable unpacking, not subscription, so it carries its own coordinate with the arity the source demanded.

A failed destructure exits through `python:unpack.halt`, deliberately distinct from the `python:loop.latch` a false filter uses: **a raise is not a skip**.

Evaluation order is preserved as ruled: destructure obligation wraps filter guards wrap element. All four kinds (ListComp/SetComp/DictComp/GeneratorExp) share one mechanism. Name targets take a byte-identical path (twin asserts no unpack node appears). Starred and attribute/subscript targets build nothing and stay **loud**.

## Twins — 33/33
Concrete-result; symbolic recurrence; true/false filter; retained symbolic guard; nested-generator ordering + binding dependency; shadowed outer variable (both faces); tuple destructuring; halted failed destructure; exception propagation; unknown members loud; four-collection non-aliasing; byte-identical repeats. Neutral source text throughout, asserting actual post formulas, with discrimination arms (swapped targets differ; halt != latch; genexp is not a listcomp).

## Merge gate
| gate | number |
|---|---|
| new crashes/timeouts/silent gaps | 0 (523/523 measured both trees, denominator 2782 identical) |
| new semantic test failures | 0 (33/33 new; 10/10 regression twins; adjacent modules identical both trees) |
| panic/refusal weakening | 0 (no gap silenced; starred + attribute assert-loud) |
| vendor-specific branches | 0 |
| unaffected corpus bytes changed | 0 (82-file sample: non-comprehension drift 0; census pins held) |
| R(comprehensions) | **340 -> 8 (-332)** |

## Residue classification (8)
- **4 reattributed** — panic names `Lambda.sugar` at a lambda inside them; not comprehension residue.
- **4 genuine missing capability** — a comprehension nested inside a **DictComp key/value**. Neutral twin confirms `{x: [g(y) for y in x] for x in xs}` is red while the same nesting in a ListComp is green. Next increment; stays red.

Note: `ListComp._simple_generator` is now dead code (defined, never called), left rather than widen the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support tuple/list destructuring targets in comprehension desugaring
> - `ComprehensionTargetSugar` replaces the plain `source_name` string in `ComprehensionGeneratorSugar`, representing targets as either a simple name or a recursive coordinate tuple.
> - During desugaring, `_bind_target` substitutes all bound names against appropriate `unpack.project` projections, and `_guard_destructure` inserts explicit `unpack.destructure` obligations before guard evaluation so mismatched-arity elements halt rather than silently pass.
> - `ListComp._comprehension_target` maps AST `Tuple`/`List` nodes to structured targets; unsupported shapes (starred, attribute, etc.) cause the comprehension to fall back to non-recurrence handling.
> - A new ~500-line test module covers destructuring, nesting, halting behavior, scoping, and collection-kind semantics.
> - Behavioral Change: comprehensions with tuple/list targets now emit destructure obligations; wrong-arity elements halt the fold rather than being skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d709a91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->