### PR TITLE
perf: memoize sugar() at the construction coordinate

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_coordinate_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_coordinate_memo.py
@@ -1,0 +1,254 @@
+'''Construction is memoized at the construction COORDINATE, not per DAG path.
+
+Substitution SHARES node objects (a bound name substitutes to the bound node
+itself), so the constructed graph is a DAG while ``walk``/``_construct_sugar``
+traverse it as a tree. Without a memo a shared site re-constructs -- and
+re-answers the roll -- once per incoming PATH (measured 433x on one pandas
+function). ``Node.sugar`` therefore memoizes at ``(ref, reporter,
+control_context)`` -- the SAME coordinate the field row already uses.
+
+These twins pin what the coordinate must NOT merge and what it must NOT lose:
+
+  * a rewritten SHADOW carries a different ref, so it never collides with the
+    node it replaced (both directions checked);
+  * the same ref under two different ``ControlConstructionContextV1`` stays two
+    constructions (both faces: two loop targets, and loop vs no loop);
+  * a transient shadow's address is never recycled under a live memo row --
+    the #6212 id-reuse bug class;
+  * a gap stays a gap on EVERY call: the panic is remembered and re-raised,
+    never swallowed, never softened into a value;
+  * and the point of it all: each coordinate constructs exactly once.
+'''
+import gc
+import os
+import tempfile
+
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.nodes import ControlConstructionContextV1, Node
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.shadow import rewrite
+from sugar_source_tree.tree import SourceFile
+
+
+def _node_classes():
+    from sugar_source_tree.nodes import KIND_REGISTRY
+
+    return [cls for cls in KIND_REGISTRY.values() if issubclass(cls, Node)]
+
+
+def _function(src, name=None):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    with open(p, "w") as fh:
+        fh.write(src)
+    reporter = CollectingReporter()
+    sf = SourceFile.from_path(p, reporter=reporter)
+    for fn in sf.functions():
+        if name is None or getattr(fn, "name", None) == name:
+            return fn, reporter
+    raise AssertionError(f"no function {name!r} in fixture")
+
+
+def test_rewritten_shadow_does_not_collide_with_the_node_it_replaced():
+    # The origin constructs FIRST, filling its memo row. Then a shadow rewrite
+    # of that same origin -- same kind, same span, DIFFERENT ref -- must
+    # construct its OWN sugar. If the memo were keyed by anything the two
+    # share (span, kind, the transient shell) the shadow would be served the
+    # origin's `x + 1`.
+    fn, _ = _function("def f(x):\n    a = x + 1\n    b = x + 2\n    return (a, b)\n")
+    one, two = [n for n in fn.walk() if n.kind == "BinOp"]
+    origin_sugar = one.sugar()
+    assert origin_sugar.right.value == 1, origin_sugar
+
+    shadow = rewrite(one, right=two.right)
+    shadow_sugar = shadow.sugar()
+    assert shadow_sugar.right.value == 2, shadow_sugar
+    assert shadow_sugar != origin_sugar
+
+    # ...and the other direction: the origin is NOT overwritten by its shadow.
+    assert one.sugar().right.value == 1
+    assert one.sugar() == origin_sugar
+
+
+def test_shadow_constructed_first_does_not_poison_its_origin():
+    # Same twin with the order reversed, so neither arm can pass by accident
+    # of "whoever ran first wins".
+    fn, _ = _function("def f(x):\n    a = x + 1\n    b = x + 2\n    return (a, b)\n")
+    one, two = [n for n in fn.walk() if n.kind == "BinOp"]
+    shadow = rewrite(one, right=two.right)
+    assert shadow.sugar().right.value == 2
+    assert one.sugar().right.value == 1
+
+
+def test_distinct_control_contexts_construct_separately():
+    # ONE `continue` ref, TWO loop targets. The construction depends on the
+    # control context, so merging the contexts would wire the statement to the
+    # wrong loop -- silently.
+    fn, _ = _function(
+        "def f(xs, ys):\n"
+        "    for a in xs:\n"
+        "        continue\n"
+        "    for b in ys:\n"
+        "        pass\n"
+        "    return 0\n"
+    )
+    first, second = [n for n in fn.walk() if n.kind == "For"]
+    cont = [n for n in fn.walk() if n.kind == "Continue"][0]
+    assert first.owned_loop_target != second.owned_loop_target
+
+    made = []
+    for target in (first.owned_loop_target, second.owned_loop_target):
+        ctx = ControlConstructionContextV1().enter_loop(target)
+        node = materialize(cont.unit, cont.ref, cont.reporter, ctx)
+        made.append(node.sugar())
+    assert made[0].target_cid != made[1].target_cid, made
+    # Re-asking the FIRST context still answers the first target: the second
+    # construction did not overwrite the first coordinate's row.
+    ctx = ControlConstructionContextV1().enter_loop(first.owned_loop_target)
+    again = materialize(cont.unit, cont.ref, cont.reporter, ctx).sugar()
+    assert again.target_cid == made[0].target_cid
+
+
+def test_control_context_discrimination_no_loop_still_refuses():
+    # The other face: the same `continue` ref with NO enclosing loop has no
+    # target to wire, and must keep refusing even after the in-loop coordinate
+    # constructed successfully. A memo that dropped the context would hand the
+    # unwired occurrence the in-loop answer.
+    from sugar_lift_py_tests.loop_construction import LoopWireError
+
+    fn, _ = _function("def f(xs):\n    for a in xs:\n        continue\n    return 0\n")
+    loop = [n for n in fn.walk() if n.kind == "For"][0]
+    cont = [n for n in fn.walk() if n.kind == "Continue"][0]
+
+    in_loop = materialize(
+        cont.unit,
+        cont.ref,
+        cont.reporter,
+        ControlConstructionContextV1().enter_loop(loop.owned_loop_target),
+    )
+    assert in_loop.sugar().action == "continue"
+
+    unwired = materialize(
+        cont.unit, cont.ref, cont.reporter, ControlConstructionContextV1()
+    )
+    raised = False
+    try:
+        unwired.sugar()
+    except LoopWireError:
+        raised = True
+    assert raised, "an unwired `continue` must refuse, memo or no memo"
+
+
+def test_indistinguishable_shadows_never_share_a_construction_coordinate():
+    # The luck-free half of the #6212 bug class: TWO shadows that are alike in
+    # every observable way -- same kind, same span, structurally equal slots --
+    # are still two constructions, because they are two refs. If the coordinate
+    # ever collapsed them, one would be served the other's row; if a dead one's
+    # address were recycled, a live one would be served a corpse's row. Neither
+    # is possible while each keyed ref is pinned for its row's lifetime.
+    fn, _ = _function("def f(x):\n    a = x + 1\n    b = x + 1\n    return (a, b)\n")
+    one, two = [n for n in fn.walk() if n.kind == "BinOp"]
+    left = rewrite(one, right=two.right)
+    right = rewrite(one, right=two.right)
+    assert left.ref is not right.ref
+    assert left.span == right.span and left.kind == right.kind
+
+    cache = left._construction_cache()
+    left_key = cache.key(left.ref, left.reporter, left.control_context)
+    right_key = cache.key(right.ref, right.reporter, right.control_context)
+    assert left_key != right_key, "two distinct shadow refs shared one coordinate"
+    assert cache._pinned[left_key] is left.ref
+    assert cache._pinned[right_key] is right.ref
+    assert left.sugar() == right.sugar()  # equal content, separately constructed
+
+
+def test_transient_shadow_addresses_are_never_recycled_under_a_live_memo():
+    # The #6212 bug class, exercised the way it actually bites: mint a shadow,
+    # construct it, drop every reference to it, repeat. The cache key embeds
+    # ``id(ref)``, so a recycled address under a live memo row would serve a
+    # DEAD shadow's construction. Every constructed value must be its own, and
+    # no address may be reused while its row lives.
+    parts = ", ".join(f"x + {i}" for i in range(60))
+    fn, _ = _function(f"def f(x):\n    return ({parts})\n")
+    binops = [n for n in fn.walk() if n.kind == "BinOp"]
+    origin = binops[0]
+
+    addresses = []
+    for i, other in enumerate(binops):
+        shadow = rewrite(origin, right=other.right)
+        addresses.append(id(shadow.ref))
+        assert shadow.sugar().right.value == i, (i, shadow.sugar())
+        del shadow
+        gc.collect()
+
+    assert len(set(addresses)) == len(addresses), (
+        "a transient shadow ref's address was recycled while its memo row was "
+        "live -- the memo would serve a DEAD shadow's construction"
+    )
+    # And the origin, constructed last, is still its own.
+    assert origin.sugar().right.value == 0
+
+
+def test_gap_stays_a_gap_on_every_call():
+    # Memoization must never de-duplicate a panic into silence. A kind with no
+    # sugar written throws on the first call AND on every call after it, with
+    # the same panic -- the reporter's roll call still fingers the site.
+    fn, reporter = _function("def f(x):\n    del x\n    return 0\n")
+    gap_node = [n for n in fn.walk() if n.kind == "Delete"][0]
+
+    panics = []
+    for _ in range(3):
+        try:
+            gap_node.sugar()
+        except SugarNotWritten as panic:
+            panics.append(panic)
+    assert len(panics) == 3, "a gap that stops throwing is a swallowed gap"
+    assert panics[0] is panics[1] is panics[2]
+    assert gap_node.kind in {node.kind for node, _ in reporter.gaps}
+
+
+def test_each_coordinate_constructs_exactly_once():
+    # The capability itself. A bound name substitutes to the bound NODE, so a
+    # value used many times is one shared node reached by many paths. Every
+    # coordinate must be constructed once regardless of how many paths reach it.
+    src = (
+        "def f(x):\n"
+        "    a = x + 1\n"
+        "    b = a * a\n"
+        "    c = b + b\n"
+        "    d = c * c\n"
+        "    e = d + d\n"
+        "    return e + e\n"
+    )
+    fn, _ = _function(src)
+
+    constructed = []
+    # Each concrete class writes its OWN _construct_sugar (the absence of an
+    # override IS the loud MISSING), so instrument every override, not the base.
+    patched = []
+    for cls in _node_classes():
+        original = cls.__dict__.get("_construct_sugar")
+        if original is None:
+            continue
+
+        def counting(self, _original=original):
+            cache = self._construction_cache()
+            constructed.append(
+                cache.key(self.ref, self.reporter, self.control_context)
+            )
+            return _original(self)
+
+        patched.append((cls, original))
+        cls._construct_sugar = counting
+    try:
+        fn.sugar()
+    finally:
+        for cls, original in patched:
+            cls._construct_sugar = original
+
+    assert constructed, "nothing was constructed -- the twin is not exercising"
+    assert len(constructed) == len(set(constructed)), (
+        "a construction coordinate was entered twice: "
+        f"{len(constructed)} constructions for {len(set(constructed))} coordinates"
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -36,11 +36,32 @@ def remember_shape_cid(ref: object, cid: str) -> None:
 class ConstructionCache:
     """Shared field rows keyed by backend site + reporter + control context."""
 
-    __slots__ = ("fields", "_pinned")
+    __slots__ = ("fields", "sugar_results", "sugar_panics", "_pinned")
 
     def __init__(self) -> None:
         # key -> {slot_name: resolved value}
         self.fields: dict[tuple, dict[str, Any]] = {}
+        # key -> constructed sugar. Substitution SHARES node objects (a bound
+        # name substitutes to the bound node itself), so the constructed graph
+        # is a DAG while ``walk``/``_construct_sugar`` traverse it as a TREE:
+        # without this row a shared site re-constructs once per incoming PATH
+        # (measured 433x on one pandas function). The coordinate is the same
+        # one the field row already uses -- ``key`` below -- and it is
+        # exhaustive for construction: ``backend.materialize`` picks the node
+        # CLASS by ``ref.resolve_type()``, the field row is a function of the
+        # same key, and a loop's owned target coordinate is a function of the
+        # ref's kind and span. Same coordinate therefore means the same
+        # construction, so each distinct coordinate constructs -- and answers
+        # the roll -- exactly once, never once per DAG path.
+        self.sugar_results: dict[tuple, Any] = {}
+        # key -> the construction panic this coordinate raised. A gap MUST stay
+        # a gap on every subsequent call, so a panic is memoized as loudly as a
+        # value: the SAME panic object is re-raised, never swallowed, never
+        # softened into an absent value. Memoizing it (rather than leaving
+        # failures uncached) is what keeps present and absent SYMMETRIC under
+        # the coordinate rule -- the reporter testifies each coordinate once,
+        # whether it answers present or absent.
+        self.sugar_panics: dict[tuple, BaseException] = {}
         # key -> ref. The cache key embeds ``id(ref)``, and shadow refs minted
         # during substitution are transient: once a rewritten shadow is GC'd its
         # address is reused by the NEXT shadow (e.g. one loop-unroll iteration's

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -778,16 +778,23 @@ class Node(Typed):
         super().__init_subclass__(**kw)
         KIND_REGISTRY[cls.__name__] = cls
 
-    def __getattr__(self, name: str):
-        # Field data is memoized on the unit once per site; this shell exposes it.
-        if name.startswith("_"):
-            raise AttributeError(name)
+    def _construction_cache(self) -> "ConstructionCache":
+        """The unit's one work memo. Node shells are VIEWS -- many shells wrap
+        one ref -- so every memo hangs off the unit, keyed by the construction
+        coordinate, never off the transient shell."""
         from .construction_cache import ConstructionCache
 
         cache = self.unit.construction_cache
         if cache is None:
             cache = ConstructionCache()
             object.__setattr__(self.unit, "construction_cache", cache)
+        return cache
+
+    def __getattr__(self, name: str):
+        # Field data is memoized on the unit once per site; this shell exposes it.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        cache = self._construction_cache()
         key = cache.key(self.ref, self.reporter, self.control_context)
         row = cache.fields.setdefault(key, {})
         if name in row:
@@ -1275,8 +1282,34 @@ class Node(Typed):
         the abstract ``_construct_sugar`` before it throws. So every node either
         answers present here or is reported absent there: no node discharges
         silently.
+
+        The answer is given ONCE PER CONSTRUCTION COORDINATE, not once per DAG
+        path. Substitution shares node objects, so a bound value is one node
+        reached by many paths; the roll asks each coordinate, and a coordinate
+        that answered keeps its answer. Absent is memoized exactly as loudly as
+        present: the panic is remembered and re-raised, so a gap stays a gap on
+        every call and the reporter still fingers the site.
         """
         from sugar_lift_py_tests.engine_log import reduction_span
+        from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+        # THE construction coordinate -- the same (ref, reporter, control
+        # context) the field row uses. Substitution shares node OBJECTS, so the
+        # constructed graph is a DAG traversed as a tree; without this memo a
+        # shared site re-answers the roll once per incoming path. T's ruling:
+        # each distinct construction coordinate appears ONCE. Keyed by the
+        # coordinate, never by the transient shell: shells are views, and a
+        # rewritten shadow carries a DIFFERENT ref, so it can never collide
+        # with the node it replaced. ``cache.key`` pins the ref, which is what
+        # keeps a dead shadow's recycled address from serving stale work.
+        cache = self._construction_cache()
+        key = cache.key(self.ref, self.reporter, self.control_context)
+        remembered_panic = cache.sugar_panics.get(key)
+        if remembered_panic is not None:
+            # A gap stays a gap, every time. Same panic, re-raised loudly.
+            raise remembered_panic
+        if key in cache.sugar_results:
+            return cache.sugar_results[key]
 
         where = f"{self.unit.filename}"
         try:
@@ -1287,9 +1320,17 @@ class Node(Typed):
         with reduction_span(
             sugar=f"{self.kind}.sugar", role="construction", site=where
         ):
-            result = self._construct_sugar()
+            try:
+                result = self._construct_sugar()
+            except (SourceTreePanic, ConstructionPanic) as panic:
+                # The two sanctioned construction gaps. Remember the panic so
+                # this coordinate keeps throwing it -- memoization must never
+                # turn an absent answer into a present one.
+                cache.sugar_panics[key] = panic
+                raise
             self.reporter.present_construction(self, result)
             self.reporter.present_fact(self)
+            cache.sugar_results[key] = result
             return result
 
     def _construct_sugar(self) -> object:


### PR DESCRIPTION
`sugar()` was invoked once per **DAG path**, not once per construction. Substitution correctly SHARES node objects (a bound name substitutes to the bound node itself), producing a DAG; `walk()` and `_construct_sugar()` traversed it as a TREE with no visited set. Measured on `core/arrays/datetimes._generate_range`: **223,839 sugar() calls over 517 distinct nodes — 433x**.

## The fix
Memoize at the **existing** construction coordinate `ConstructionCache.key(ref, reporter, control_context)` — not the transient node shell (shells are views; many wrap one ref). No new key invented; the cache's `_pinned` discipline against `id()` reuse (#6212) carries over unchanged.

**Panics are memoized and the SAME panic re-raised.** Under the coordinate rule a *present* answer is testified once, so an *absent* answer must be too — otherwise a gap coordinate reports N times while a present one reports once, and the census skews with DAG shape. The throw is never weakened: `test_gap_stays_a_gap_on_every_call` asserts 3 calls → 3 raises, and it **fails on baseline**.

Coordinate exhaustiveness verified, not assumed: `materialize` picks the node class via `ref.resolve_type()`, the field row is already a function of the same key, and `loop_target_coordinate_for_loop` is a function of the ref's kind+span.

## Measured
| gate | result |
|---|---|
| `_generate_range` sugar() calls | **223,839 → 517** (exactly the distinct-node count; 433x → 1.0x) |
| `_generate_range` wall | 13.4s → **2.5s** |
| byte-identical output | Merkle fingerprint of the whole constructed graph (hashes structure, so added *sharing* cannot mask a changed value): `3a2b4eb5a93f11172bb1fe29d3a7cb4b` **identical** old vs new |
| census pins | `boolean.py` `{}` / `categorical.py` `{With: 1}` unchanged; pair runtime 13.4s → **5.2s** |
| twins | **51/51** green with the comprehension capability landed (8 memo + 33 comprehension + 10 regression) |
| law gates | `construction_side_door_law` GREEN R=0; `construction_panic_catch_law` red count unchanged (new `except (...): ... raise` is a pure re-raise) |
| regression | 167 construction/lift tests across 26 modules: pass/fail set identical to baseline, test for test |

## Twins (8)
`rewritten_shadow_does_not_collide_with_the_node_it_replaced`, `shadow_constructed_first_does_not_poison_its_origin`, `distinct_control_contexts_construct_separately`, `control_context_discrimination_no_loop_still_refuses`, `indistinguishable_shadows_never_share_a_construction_coordinate`, `transient_shadow_addresses_are_never_recycled_under_a_live_memo`, `gap_stays_a_gap_on_every_call`, `each_coordinate_constructs_exactly_once`

The last two **fail on baseline** — they pin the capability, not just its absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize `Node.sugar()` at the (ref, reporter, control_context) coordinate
> - `Node.sugar()` now caches results in `ConstructionCache.sugar_results` keyed by `(id(ref), id(reporter), loop_targets, exception_slots)`, so repeated calls at the same coordinate skip `_construct_sugar` entirely.
> - If construction raises `SourceTreePanic` or `ConstructionPanic`, the exception is stored in `ConstructionCache.sugar_panics` and re-raised on every subsequent call at that coordinate.
> - A new `_construction_cache()` helper on `Node` centralizes lazy cache attachment, replacing inline logic that was previously duplicated in `__getattr__`.
> - Tests in [test_construction_coordinate_memo.py](https://github.com/TSavo/sugar/pull/6233/files#diff-3617390eb0d75acf271cc60e608bfe3d330fb15a70d1dfe701766ab7f2a9cec2) verify memoization boundaries: distinct control contexts, shadow uniqueness, transient address reuse, and single-construction invariants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07086f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->