### PR TITLE
comprehension: one obstruction reader for all four collection forms

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_symbolic_comprehension_guarded_fold.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_symbolic_comprehension_guarded_fold.py
@@ -505,3 +505,147 @@ def test_a_name_target_construction_carries_no_destructuring_obligation():
     assert "python:unpack.destructure" not in names, names
     assert "python:unpack.project" not in names, names
     assert "python:loop.filter_guard" in names, names
+
+
+# -- a nested comprehension is just another sugar in that position -----------
+#
+# A comprehension appearing in another comprehension's element (or in a dict
+# comprehension's key or value) is NOT a shape the fold must refuse: it is one
+# more sugar the element position lifts, folded over the ENCLOSING coordinate.
+# Every collection form shares that one reader, so none of the four may refuse
+# what the others accept. The only obstruction is a walrus, which binds into
+# the enclosing scope -- a binding the scoped guarded fold does not model.
+
+
+def _exhaustion():
+    return _ctor("python:loop.exhaustion", [], symbol_kind="coordinate")
+
+
+def _inner_listcomp(iterable, coordinate_body):
+    return _ctor(
+        "py.listcomp",
+        [iterable, coordinate_body, _exhaustion()],
+        symbol_kind="coordinate",
+    )
+
+
+def test_a_comprehension_nested_in_a_dict_comprehension_value_is_constructed():
+    # The exact formula, not merely "it did not raise": the outer dictcomp
+    # folds over `xs`, and each entry pairs the outer coordinate with an INNER
+    # listcomp folded over that SAME outer coordinate.
+    post = _post_of("def f(xs, g):\n    return {x: [g(y) for y in x] for x in xs}\n")
+    kind, iterable, body = _fold(post)
+    assert kind == "py.dictcomp"
+    assert iterable == make_var("xs")
+    outer = _coordinate(body)
+    entry = body.body
+    assert entry.name == "python:dict_entry", f"entry was {entry!r}"
+    key, value = entry.args
+    assert key == outer, f"key was {key!r}"
+    assert value.name == "py.listcomp", f"value was {value!r}"
+    # The DISCRIMINATION that makes this test worth running: the inner fold
+    # ranges over the outer COORDINATE, not over the outer iterable. A lying
+    # construction that folded the inner comprehension over `xs` would satisfy
+    # "a listcomp is present" and be flatly wrong.
+    assert value.args[0] == outer, f"inner iterable was {value.args[0]!r}"
+    assert value.args[0] != make_var("xs"), f"inner iterable was {value.args[0]!r}"
+    inner = _coordinate(value.args[1])
+    assert inner != outer, "inner and outer coordinates must be distinct"
+    assert value.args[1].body == _ctor(
+        "py.call", [make_var("g"), inner]
+    ), f"inner body was {value.args[1].body!r}"
+    assert value == _inner_listcomp(outer, value.args[1]), f"value was {value!r}"
+
+
+def test_a_comprehension_nested_in_a_dict_comprehension_key_is_constructed():
+    # The key position is the value position's twin: same obligation, same
+    # coordinate, so a construction that served one and refused the other
+    # would be reading the dict's punctuation rather than its meaning.
+    post = _post_of(
+        "def f(xs, g):\n    return {tuple([g(y) for y in x]): x for x in xs}\n"
+    )
+    _kind, _iterable, body = _fold(post)
+    outer = _coordinate(body)
+    entry = body.body
+    assert entry.name == "python:dict_entry", f"entry was {entry!r}"
+    key, value = entry.args
+    assert value == outer, f"value was {value!r}"
+    nested = key.args[-1]
+    assert nested.name == "py.listcomp", f"nested was {nested!r}"
+    assert nested.args[0] == outer, f"inner iterable was {nested.args[0]!r}"
+
+
+def test_a_comprehension_nested_in_a_set_comprehension_element_is_constructed():
+    post = _post_of("def f(xs, g):\n    return {tuple([g(y) for y in x]) for x in xs}\n")
+    kind, iterable, body = _fold(post)
+    assert kind == "py.setcomp"
+    assert iterable == make_var("xs")
+    outer = _coordinate(body)
+    nested = body.body.args[-1]
+    assert nested.name == "py.listcomp", f"nested was {nested!r}"
+    assert nested.args[0] == outer, f"inner iterable was {nested.args[0]!r}"
+
+
+def test_every_collection_form_accepts_a_nested_comprehension():
+    # The unification itself under test. Four forms, one nested comprehension
+    # in the element position; a form that refused would be reading its own
+    # spelling rather than the shared obligation.
+    for source, kind in (
+        ("def f(xs, g):\n    return [[g(y) for y in x] for x in xs]\n", "py.listcomp"),
+        (
+            "def f(xs, g):\n    return ([g(y) for y in x] for x in xs)\n",
+            "py.generatorexp",
+        ),
+        (
+            "def f(xs, g):\n    return {tuple([g(y) for y in x]) for x in xs}\n",
+            "py.setcomp",
+        ),
+        ("def f(xs, g):\n    return {x: [g(y) for y in x] for x in xs}\n", "py.dictcomp"),
+    ):
+        post = _post_of(source)
+        observed, _iterable, _body = _fold(post)
+        assert observed == kind, f"{source} constructed {observed}"
+        assert "py.listcomp" in _names(post), f"{source} lost its nested fold"
+
+
+def test_a_comprehension_substituted_into_a_dict_value_is_constructed():
+    # The source text holds NO nested comprehension -- substitution puts one
+    # there by threading a local bound to a fold. The obstruction was read off
+    # the node as it stands at construction time, so this refused while its
+    # own source text looked innocent. It must construct like any other.
+    post = _post_of(
+        "def f(xs, g):\n"
+        "    ys = [g(x) for x in xs]\n"
+        "    return {k: ys for k in xs}\n"
+    )
+    kind, iterable, body = _fold(post)
+    assert kind == "py.dictcomp"
+    assert iterable == make_var("xs")
+    outer = _coordinate(body)
+    key, value = body.body.args
+    assert key == outer, f"key was {key!r}"
+    # `ys` does not depend on the outer coordinate, so the substituted fold
+    # ranges over `xs` -- the discrimination against the twin above, where the
+    # inner fold ranged over the coordinate. Same shape, different scope.
+    assert value.name == "py.listcomp", f"value was {value!r}"
+    assert value.args[0] == make_var("xs"), f"inner iterable was {value.args[0]!r}"
+    assert value.args[0] != outer, f"inner iterable was {value.args[0]!r}"
+
+
+def test_a_walrus_in_a_comprehension_element_stays_loud_in_every_form():
+    # The LYING twin's arm: opening the door to a nested comprehension must
+    # not open it to a walrus. A walrus binds into the enclosing scope, which
+    # the scoped guarded fold does not model, so every form stays loud.
+    from sugar_source_tree.panic import SugarNotWritten
+
+    for source in (
+        "def f(xs, g):\n    return [(n := g(x)) for x in xs]\n",
+        "def f(xs, g):\n    return {(n := g(x)) for x in xs}\n",
+        "def f(xs, g):\n    return ((n := g(x)) for x in xs)\n",
+        "def f(xs, g):\n    return {x: (n := g(x)) for x in xs}\n",
+    ):
+        try:
+            _post_of(source)
+        except SugarNotWritten:
+            continue
+        raise AssertionError(f"walrus constructed silently: {source}")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5803,7 +5803,18 @@ class ListComp(Expression):
         )
 
     def _contains_named_expression(self, roots: tuple) -> bool:
-        """True when a walrus would bind outside the comprehension coordinate."""
+        """True when a walrus would bind outside the comprehension coordinate.
+
+        This -- not `_contains_forbidden_shape` -- is the obstruction every
+        comprehension kind consults when constructing its sugar. A walrus in
+        the element (or a dict's key/value) binds into the ENCLOSING scope,
+        a binding the scoped guarded fold does not model, so the node stays
+        loud. A nested comprehension is no obstruction at all: it is simply
+        another sugar in that position, constructed by its own
+        `_construct_sugar` when the element is lifted. All four kinds share
+        this one reader; `_contains_forbidden_shape` remains the separate,
+        stricter question asked only when DISSOLVING to a display.
+        """
         return any(node.kind == "NamedExpr" for root in roots for node in root.walk())
 
     def _calls_shadowed_range(self, iterable, scope) -> bool:
@@ -6029,7 +6040,7 @@ class SetComp(Expression):
 
     def _construct_sugar(self):
         generators = ListComp._recurrence_generators(self)
-        if generators is None or ListComp._contains_forbidden_shape(self, (self.elt,)):
+        if generators is None or ListComp._contains_named_expression(self, (self.elt,)):
             return super()._construct_sugar()
         from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
 
@@ -6137,7 +6148,7 @@ class DictComp(Expression):
 
     def _construct_sugar(self):
         generators = ListComp._recurrence_generators(self)
-        if generators is None or ListComp._contains_forbidden_shape(
+        if generators is None or ListComp._contains_named_expression(
             self, (self.key, self.value)
         ):
             return super()._construct_sugar()


### PR DESCRIPTION
Closes the comprehension ledger. **Comprehension-owner R: 6 → 0.**

## The true mechanism (not what I guessed)
Not a nested-comprehension guard on a key/value path — an **asymmetry between the four `_construct_sugar` methods**. `ListComp` and `GeneratorExp` consulted `_contains_named_expression` (walrus only); `SetComp` and `DictComp` consulted `_contains_forbidden_shape` (walrus **or any nested comprehension**). The same source constructed inside a list was refused inside a dict.

The fix unifies all four on the one reader. A nested comprehension is no obstruction at all — it is simply another sugar in that position, constructed by its own `_construct_sugar` when the element is lifted. A walrus still stays loud in every form: it binds into the ENCLOSING scope, which the scoped guarded fold does not model. `_contains_forbidden_shape` is untouched — it remains the separate, stricter question asked only when a comprehension **dissolves to a display**.

Second half of the mechanism, and why neutral reductions of the "simple" three came back green: the obstruction is read off the node **as it stands at construction time**, i.e. after substitution. A dictcomp whose source text holds no nested comprehension still refused once a local bound to a fold was threaded into its value. Measured neutrally: `ys = [g(x) for x in xs]; return {k: ys for k in xs}` — RED on baseline, GREEN after.

## Per-site classification — all six, exact panic text, real files
| site | after | classification |
|---|---|---|
| `groupby/ops.py:666` | GREEN | closed |
| `tests/io/test_stata.py:2599` | GREEN | closed |
| `methods/to_dict.py:271` | RED | **another owner** — `ConstructionPanic owner=guarded blame=CallSiteValue requested=ride under a guard fix=implement CallSiteValue.guarded` |
| `io/parsers/base_parser.py:756` | RED | **another owner** — identical `CallSiteValue.guarded` |
| `tests/interchange/test_impl.py:148` | RED | **another owner** — `RuntimeSelectedContextManager [With.sugar]` |
| `tests/window/test_expanding.py:87` | RED | **another owner** — `RuntimeEffect: py.sequence_concat operand=ComprehensionValue` — the comprehension constructs correctly; the concat cannot take a symbolic fold as an operand |

Comprehension machinery absorbs none of these. Nothing was implemented for the four reattributed sites.

## Measured
- 6 named files: comprehension sites 77, **RED 3 → 0**
- function-level at the 6 named sites: `SugarNotWritten [DictComp.sugar]` **6 → 0**
- **Drift** (all node kinds over `core/groupby`, `core/methods`, `io/parsers`, `tests/interchange`, `tests/window`, both arms in one process, identical node population asserted): only three counters moved — `DictComp/SugarNotWritten 3→0`, `FunctionDef/SugarNotWritten 20→15`, `FunctionDef/RuntimeSelectedContextManager 135→136` (a function stopped refusing under DictComp and now surfaces its pre-existing With owner). ~50 other families byte-identical. **No other family drifts.**

## Twins — 6 new, 39 comprehension total, 57 overall green
`nested_in_a_dict_comprehension_value_is_constructed` (full term equality; discrimination: inner fold must range over the outer **coordinate**, not `xs`), `..._key_is_constructed`, `..._set_comprehension_element...`, `every_collection_form_accepts_a_nested_comprehension` (the unification itself), `substituted_into_a_dict_value_is_constructed` (discriminates the other way), `a_walrus_in_a_comprehension_element_stays_loud_in_every_form` (the lying arm — all four kinds must still raise).

**Teeth verified**: on baseline 5 of the 6 FAIL with the exact `SugarNotWritten [DictComp.sugar]`/`[SetComp.sugar]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow nested comprehensions in set and dict comprehension sugar construction
> - In [`nodes.py`](https://github.com/TSavo/sugar/pull/6234/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), `SetComp._construct_sugar` and `DictComp._construct_sugar` now gate on `_contains_named_expression` instead of `_contains_forbidden_shape`, so only walrus expressions block sugar construction — nested comprehensions in element/key/value positions are now accepted.
> - New tests in [`test_symbolic_comprehension_guarded_fold.py`](https://github.com/TSavo/sugar/pull/6234/files#diff-eff0316a55861d3d6064d389e5741ff34e6c2d51bca495440a1407567b67fbe0) cover nested comprehensions in all four collection forms (list, set, dict, generator) and confirm walrus expressions still raise `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3b264a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested comprehensions in list, set, generator, and dictionary comprehensions.
  * Ensured nested expressions use the correct outer comprehension context.
  * Walrus operators inside comprehensions are now rejected explicitly instead of being modeled incorrectly.

* **Tests**
  * Added coverage for nested comprehension keys, values, and elements across all supported collection forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->