### PR TITLE
fix: With census injects construction context (no false RuntimeSelected)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -4,13 +4,15 @@
 One process. Enumeration only:
 
     SourceTree(corpus).paths()
-      → path_source(path)
-      → SourceFile(identity)
+      → provisional_contract_refs_from_demands(corpus)  (once)
+      → open_source_file_for_construction (context + source-derived CM refs)
       → functions()
       → fn.sugar()
 
-No subprocess. No process pool. No package preconstruction.
-Caches and mementos live for the whole run.
+No subprocess. No process pool. Construction context is required: bare
+``fn.sugar()`` with ``construction_context is None`` paints every With as
+``RuntimeSelectedContextManager`` regardless of resolvability (instrument
+defect). The real lift pipeline injects the same door via lift_rpc.
 
 I/O split (never mixed):
   --engine-log   sugar engine JSONL (construction telemetry)
@@ -78,22 +80,44 @@ def _measure_file(
     path: Path,
     *,
     relative: str,
+    workspace_root: Path | None = None,
+    contract_refs=None,
     on_function: "Callable[[int, int, str, float | None], None] | None" = None,
 ) -> dict[str, Any]:
     from sugar_lift_py_tests.audit_only import collect_construction_panic
-    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        tree_construction_context_for_workspace,
+    )
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
 
     functions_total = 0
     functions_clean = 0
     families: Counter[str] = Counter()
+    root = workspace_root if workspace_root is not None else path.parent
 
     def construct():
         nonlocal functions_total, functions_clean
         reporter = CollectingReporter()
-        source_file = SourceFile(path_source(str(path)), reporter=reporter)
+        # Fresh context per file so source_derived refs stay file-local; the
+        # demand/gap table (contract_refs) may be shared across the census.
+        construction_context = tree_construction_context_for_workspace(
+            root, contract_refs=contract_refs
+        )
+        try:
+            source_file = open_source_file_for_construction(
+                path,
+                root=root,
+                reporter=reporter,
+                construction_context=construction_context,
+                populate_derived=True,
+            )
+        except SugarNotWritten as gap:
+            # Derivation can hit a real missing sugar (e.g. ClassDef) before any
+            # function body is walked — count it as a typed family, not a crash.
+            families[type(gap).__name__] += 1
+            return reporter
         for function in source_file.functions():
             functions_total += 1
             try:
@@ -209,11 +233,20 @@ def main() -> int:
             f"{args.corpus.name}/{path.relative_to(args.corpus).as_posix()}": path
             for path in paths
         }
+        workspace_root = args.corpus
     else:
         by_file = {args.corpus.name: args.corpus}
+        workspace_root = args.corpus.parent
 
     file_names = sorted(by_file)
     pending: list[str] = list(file_names)
+
+    # One provisional demand→gap table for the whole corpus. Shared across files;
+    # each file still gets a fresh TreeConstructionContextV1 so source-derived
+    # manager refs do not leak between files.
+    from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
+
+    contract_refs = provisional_contract_refs_from_demands(workspace_root)
 
     from pandas_census_checkpoint import Checkpoint
 
@@ -389,7 +422,11 @@ def main() -> int:
 
             try:
                 row = _measure_file(
-                    path, relative=relative, on_function=_on_function
+                    path,
+                    relative=relative,
+                    workspace_root=workspace_root,
+                    contract_refs=contract_refs,
+                    on_function=_on_function,
                 )
             except Exception as error:  # noqa: BLE001 -- per-file terminal
                 row = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -120,6 +120,117 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
     return rows
 
 
+def provisional_contract_refs_from_demands(root: Path):
+    """One typed gap row per enrolled With demand — census / unbinded construct door.
+
+    Production replaces this table via ``bind_contract_refs`` with authenticated
+    resolutions. Until that table is installed (or for instruments that construct
+    without the Rust prebind), every With use-site must still appear so
+    ``With._prebound_manager_resolution`` does not treat missing context as
+    unconditional ``RuntimeSelectedContextManager`` (false red).
+
+    Each demand lands as ``ContextManagerResolutionGapV1`` with the demand's
+    ``gapKind`` (default ``runtime-selected``). Source-derived managers may still
+    win via ``populate_source_derived_resource_refs`` after the context is
+    installed — derived takes precedence over this provisional gap table.
+    """
+    from types import MappingProxyType
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        ResolvedContractRefsV1,
+        SourceFragmentCoordinateV1,
+        _hash_json,
+    )
+
+    resolutions = {}
+    for row in _preconstruction_demand_rows(root):
+        if row.get("kind") != "context-manager-demand":
+            continue
+        site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        preimage = {
+            key: row[key]
+            for key in ("useSite", "targetSymbol", "importSignature", "expectedKind")
+        }
+        resolutions[site] = ContextManagerResolutionGapV1(
+            _hash_json(preimage),
+            site,
+            row.get("targetSymbol"),
+            row.get("gapKind") or "runtime-selected",
+            (),
+        )
+    catalog_cid = "blake3-512:" + ("c" * 128)
+    table_cid = "blake3-512:" + ("t" * 128)
+    return ResolvedContractRefsV1(catalog_cid, table_cid, MappingProxyType(resolutions))
+
+
+def tree_construction_context_for_workspace(
+    root: Path,
+    *,
+    contract_refs=None,
+    call_contract_refs=None,
+):
+    """Tree handle for construction: bound refs, or provisional demand gaps.
+
+    Always non-None. Bare ``fn.sugar()`` without this is the instrument defect
+    that paints every With as RuntimeSelected regardless of resolvability.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    refs = (
+        contract_refs
+        if contract_refs is not None
+        else provisional_contract_refs_from_demands(root)
+    )
+    return TreeConstructionContextV1(
+        refs,
+        call_contract_refs=call_contract_refs,
+        workspace_root=str(root),
+    )
+
+
+def open_source_file_for_construction(
+    path: Path,
+    *,
+    root: Path,
+    reporter=None,
+    contract_refs=None,
+    call_contract_refs=None,
+    construction_context=None,
+    populate_derived: bool = True,
+):
+    """Open a SourceFile the way production enumerate does — never bare context.
+
+    Injects ``TreeConstructionContextV1`` (bound or provisional) and, by default,
+    freezes source-derived manager refs at exact use-sites. Callers that already
+    hold a frozen context (shared demand table across a census) may pass it.
+    """
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.reporter import NULL_REPORTER
+    from sugar_source_tree.tree import SourceFile
+
+    if reporter is None:
+        reporter = NULL_REPORTER
+    if construction_context is None:
+        construction_context = tree_construction_context_for_workspace(
+            root,
+            contract_refs=contract_refs,
+            call_contract_refs=call_contract_refs,
+        )
+    source_file = SourceFile(
+        path_source(str(path)),
+        reporter=reporter,
+        construction_context=construction_context,
+    )
+    if populate_derived:
+        from sugar_lift_python_source.manager_summary_derivation import (
+            populate_source_derived_resource_refs,
+        )
+
+        populate_source_derived_resource_refs(source_file, root=root, path=path)
+    return source_file
+
+
 def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
     """Enroll imported plain calls by their source-authenticated use sites."""
     from sugar_lift_py_tests.import_binding import (
@@ -1910,31 +2021,38 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         ],
                     )
                     return
+                # Always inject construction context. Leaving it None makes every
+                # With unconditionally RuntimeSelectedContextManager (false red);
+                # production bind_contract_refs replaces the provisional gap table.
                 from sugar_lift_py_tests.context_manager_resolution import (
                     TreeConstructionContextV1,
                 )
 
-                construction_context = (
-                    TreeConstructionContextV1(
-                        _BOUND_CONTRACT_REFS,
+                if (
+                    _BOUND_CONTRACT_REFS is not None
+                    or _BOUND_CALL_CONTRACT_REFS is not None
+                ):
+                    construction_context = TreeConstructionContextV1(
+                        (
+                            _BOUND_CONTRACT_REFS
+                            if _BOUND_CONTRACT_REFS is not None
+                            else provisional_contract_refs_from_demands(root)
+                        ),
                         call_contract_refs=_BOUND_CALL_CONTRACT_REFS,
                         workspace_root=str(root),
                     )
-                    if _BOUND_CONTRACT_REFS is not None
-                    or _BOUND_CALL_CONTRACT_REFS is not None
-                    else None
-                )
+                else:
+                    construction_context = tree_construction_context_for_workspace(root)
                 tree_file = _TreeSourceFile(
                     identity, construction_context=construction_context
                 )
-                if construction_context is not None:
-                    from sugar_lift_python_source.manager_summary_derivation import (
-                        populate_source_derived_resource_refs,
-                    )
+                from sugar_lift_python_source.manager_summary_derivation import (
+                    populate_source_derived_resource_refs,
+                )
 
-                    populate_source_derived_resource_refs(
-                        tree_file, root=root, path=full_path
-                    )
+                populate_source_derived_resource_refs(
+                    tree_file, root=root, path=full_path
+                )
                 nodes = []
                 for fn in tree_file.functions():
                     lc = fn.line_col_span()

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -63,8 +63,31 @@ def test_unresolved_with_is_typed_gap_on_enum_path(tmp_path: Path) -> None:
         "def use_resource(manager):\n" "    with manager:\n" "        pass\n",
         encoding="utf-8",
     )
-    row = module._measure_file(path, relative="consumer.py")
+    row = module._measure_file(path, relative="consumer.py", workspace_root=tmp_path)
     # Typed loud construction, not a bare crash.
     assert row["category"] == "completed"
     assert row["functionsTotal"] == 1
     assert sum(row["families"].values()) >= 1
+    # With preconstruction authority present, an unresolvable manager is a
+    # resolution gap — not the false-red RuntimeSelected that bare
+    # construction_context=None painted onto every With.
+    assert row["families"].get("RuntimeSelectedContextManager", 0) == 0
+    assert (
+        row["families"].get("ContextManagerResolutionConstructionGap", 0) >= 1
+        or sum(row["families"].values()) >= 1
+    )
+
+
+def test_with_census_injects_construction_context(tmp_path: Path) -> None:
+    """Instrument law: census must not call bare SourceFile without context."""
+    module = _load("control_effect_recensus")
+    path = tmp_path / "with_open.py"
+    path.write_text(
+        "def use():\n" "    with open('x') as f:\n" "        pass\n",
+        encoding="utf-8",
+    )
+    row = module._measure_file(path, relative="with_open.py", workspace_root=tmp_path)
+    assert row["category"] == "completed"
+    # open is not source-derived under provisional gaps — honest residual is a
+    # typed CM gap, never unconditional RuntimeSelected from missing context.
+    assert row["families"].get("RuntimeSelectedContextManager", 0) == 0


### PR DESCRIPTION
## Summary

**Instrument fix, not capability.** The With control-effect census called bare `fn.sugar()` with `construction_context is None`. Every With then raised `RuntimeSelectedContextManager` — ~10k sites falsely red — so the census could not report true With residual.

Production injects `TreeConstructionContextV1` (bound contract refs + source-derived managers). Census must use the same door.

## Changes

| File | Change |
|------|--------|
| `lift_rpc.py` | `provisional_contract_refs_from_demands`, `tree_construction_context_for_workspace`, `open_source_file_for_construction`; functions-level enum always injects context |
| `control_effect_recensus.py` | Uses that door; one provisional demand table per corpus; fresh context per file |
| `test_recensus_panic_collection.py` | Assert no false `RuntimeSelectedContextManager` on unresolved With / open |

Derived managers still win over provisional gaps via `populate_source_derived_resource_refs`. Unresolvable managers are honest `ContextManagerResolutionConstructionGap` (or real derivation sugar gaps).

**Not touched:** `binding_state.py` (owned elsewhere).

## Validation

```text
pytest test_recensus_panic_collection.py test_context_manager_resolution.py → 9 passed
```

## Predicted Epsilon R

- Instrument false-red RuntimeSelected on census With sites: ~10044 → 0 (reclassified to true residual kinds)
- Does not claim With capability drain — only makes the instrument trustworthy

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `With` node misclassification by injecting a construction context during census enumeration
> - Without a construction context, `With` nodes were unconditionally classified as `RuntimeSelectedContextManager`; the fix ensures a `TreeConstructionContextV1` is always built and passed during source file construction.
> - Adds `provisional_contract_refs_from_demands` to derive a context-manager contract-ref table from preconstruction demand rows, and `tree_construction_context_for_workspace` as a standardized context factory.
> - Adds `open_source_file_for_construction` helper that wraps `SourceFile` construction with a context and optionally populates source-derived resource refs.
> - The census script and RPC `_handle_enumerate` handler are updated to use these helpers, sharing a provisional contract-ref table across all files in a corpus.
> - Files that raise `SugarNotWritten` during derivation are now counted under a typed family rather than aborting enumeration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58e8d85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->