### PR TITLE
feat: CallSiteValue.guarded rides under a branch

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -176,6 +176,18 @@ class CallSiteValue(FloorValue):
         del owner
         return self.term
 
+    def guarded(self, formula):
+        """A callsite coordinate rides under a guard unchanged.
+
+        Like ImportAliasValue / FunctionCallable: the authenticated call term is
+        the value. It is not a return or inv that becomes an implication; the
+        branch guard already owns control. Absence of this arm was
+        ``write more Floor: implement CallSiteValue.guarded`` (to_dict /
+        base_parser residual).
+        """
+        del formula
+        return self
+
     def truth(self, site):
         # A callsite EMITS py.truthy over its term, carrying itself as an operand.
         # Ground (lift-time-decidable) coordinates must construct, never mint

--- a/implementations/python/sugar-lift-py-tests/tests/test_callsite_value_guarded.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callsite_value_guarded.py
@@ -1,0 +1,44 @@
+"""CallSiteValue.guarded — ride under a branch without floor panic.
+
+Known residual: owner=guarded blame=CallSiteValue requested=ride under a guard
+(to_dict.py / base_parser.py). Mirrors ImportAliasValue / FunctionCallable:
+the authenticated call coordinate is the value; the guard owns control.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.function_callable import FunctionCallable
+from sugar_lift_py_tests.ir import ctor, make_var, num, py_eq
+from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+
+def _callsite() -> CallSiteValue:
+    return CallSiteValue(
+        "vendor.op",
+        (),
+        (),
+        ctor("call:vendor.op", []),
+        None,
+    )
+
+
+def test_callsite_guarded_returns_self() -> None:
+    site = _callsite()
+    assert site.guarded(true_guard()) is site
+
+
+def test_callsite_guarded_matches_callable_identity_pattern() -> None:
+    """Same arm shape as FunctionCallable: formula discarded, value unchanged."""
+    site = _callsite()
+    formula = true_guard()
+    assert site.guarded(formula) is site
+    # FunctionCallable.guarded is the established identity pattern for
+    # non-inv/return floor coordinates under a branch.
+    assert FunctionCallable.guarded is not None
+
+
+def test_callsite_guarded_accepts_symbolic_formula() -> None:
+    site = _callsite()
+    formula = py_eq(make_var("z"), num(1))
+    assert site.guarded(formula) is site


### PR DESCRIPTION
## Summary

Named residual: `owner=guarded blame=CallSiteValue requested=ride under a guard` (known sites: to_dict / base_parser). Default `FloorValue.guarded` panics with `write more Floor: implement CallSiteValue.guarded`.

## Change

`CallSiteValue.guarded` returns `self` — same identity pattern as `FunctionCallable` / `ImportAliasValue`. A call coordinate is not a return/inv that becomes an implication; the branch guard already owns control.

## Validation

```text
pytest test_callsite_value_guarded.py → 3 passed
```

## Scope

- File: `floor/call_site_value.py` only (+ twin)
- Does not touch `binding_state.py` or `nodes.py`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CallSiteValue.guarded` method that returns self unchanged
> Implements `guarded(formula)` on `CallSiteValue` in [call_site_value.py](https://github.com/TSavo/sugar/pull/6236/files#diff-8c40ae10c3e0722cf284a5e0bb43d2d29524ce10b6eb590893ccfcab4785689a), matching the identity pattern already used by `ImportAliasValue` and `FunctionCallable`. The method discards the formula and returns the same instance, reflecting that a callsite coordinate rides under a guard unchanged. Tests in [test_callsite_value_guarded.py](https://github.com/TSavo/sugar/pull/6236/files#diff-b5b7bd37cfcace336aa8e764ab944fc754b3b2e71db1d6503e81c0751985bc60) cover true guards and symbolic formula inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e9bf71.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->