### PR TITLE
fix: sequence concat accepts symbolic comprehension folds

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/runtime_effect.py
@@ -129,6 +129,7 @@ def is_lift_time_decidable(term: Term) -> bool:
         _ConstReal,
         _ConstStr,
         _Ctor,
+        _Lambda,
         _Var,
     )
 
@@ -145,6 +146,16 @@ def is_lift_time_decidable(term: Term) -> bool:
         if isinstance(current, _Var):
             decisions[identity] = False
             continue
+        # Symbolic fold / comprehension element maps are open bodies: the
+        # param binds over iteration; the body is not a ground constant even
+        # when every free name is known. py.listcomp carries _Lambda children —
+        # treating them as unknown TypeError made sequence_concat reject a
+        # correctly-constructed symbolic fold as a RuntimeEffect operand.
+        if isinstance(current, _Lambda):
+            decisions[identity] = False
+            if id(current.body) not in decisions:
+                work.append((current.body, False))
+            continue
         if not isinstance(current, _Ctor):
             raise TypeError(
                 f"unknown RuntimeEffect operand term: {type(current).__name__}"
@@ -158,6 +169,16 @@ def is_lift_time_decidable(term: Term) -> bool:
         # executing the guarded operation. The exception class coordinate may
         # be ground, but the occurrence testimony is runtime-by-nature.
         if current.name == "py.except":
+            decisions[identity] = False
+            continue
+        # Comprehension / generator folds are iteration products; members are
+        # not decidable at lift time even when the iterable coordinate is a var.
+        if current.name in (
+            "py.listcomp",
+            "py.setcomp",
+            "py.dictcomp",
+            "py.genexp",
+        ):
             decisions[identity] = False
             continue
         if not finishing:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
@@ -76,38 +76,25 @@ class ComprehensionValue(FloorValue):
         )
 
     def add(self, other, site):
-        from sugar_lift_py_tests.effect import (
-            SequenceConcatenationRuntimeEffect,
-            is_lift_time_decidable,
-            runtime_effect_evidence,
-        )
         from sugar_lift_py_tests.floor.list_value import ListValue
         from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome import Complete
 
         if type(other) in (ComprehensionValue, ListValue):
+            # Symbolic folds are constructed coordinates. Sequence concat of two
+            # such coordinates is another coordinate (py.sequence_concat as `+`
+            # ctor), not a RuntimeEffect that re-asks for a "genuine runtime
+            # operand" while already holding the fold term.
             other_term = other.to_term(owner=str(site))
-            if is_lift_time_decidable(self.term) and is_lift_time_decidable(other_term):
-                return Complete(
-                    ComprehensionValue(
-                        ctor(
-                            "+",
-                            [
-                                self.term,
-                                other_term,
-                            ],
-                        )
+            return Complete(
+                ComprehensionValue(
+                    ctor(
+                        "+",
+                        [
+                            self.term,
+                            other_term,
+                        ],
                     )
-                )
-            return Incomplete(
-                SequenceConcatenationRuntimeEffect(
-                    "sequence concatenation depends on runtime comprehension "
-                    f"members; owner=ComprehensionValue.add site={site}",
-                    **runtime_effect_evidence(
-                        "py.sequence_concat",
-                        self if not is_lift_time_decidable(self.term) else other,
-                        site,
-                    ),
                 )
             )
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -68,32 +68,24 @@ class ListValue(FloorValue):
         from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
 
         if type(other) is ComprehensionValue:
-            from sugar_lift_py_tests.effect import (
-                SequenceConcatenationRuntimeEffect,
-                is_lift_time_decidable,
-                runtime_effect_evidence,
-            )
+            # A constructed comprehension is already a sequence coordinate
+            # (symbolic fold). Concatenate as another coordinate — never mint
+            # RuntimeEffect over ComprehensionValue (that path required a
+            # genuine runtime operand and rejected/faulted on py.listcomp
+            # bodies carrying _Lambda before effect/runtime_effect admitted them).
             from sugar_lift_py_tests.ir import ctor
-            from sugar_lift_py_tests.outcome import Complete, Incomplete
+            from sugar_lift_py_tests.outcome import Complete
 
             self_term = self.to_term(owner=str(site))
-            if is_lift_time_decidable(self_term) and is_lift_time_decidable(other.term):
-                return Complete(
-                    ComprehensionValue(
-                        ctor(
-                            "+",
-                            [
-                                self_term,
-                                other.term,
-                            ],
-                        )
+            return Complete(
+                ComprehensionValue(
+                    ctor(
+                        "+",
+                        [
+                            self_term,
+                            other.term,
+                        ],
                     )
-                )
-            return Incomplete(
-                SequenceConcatenationRuntimeEffect(
-                    "list concatenation depends on runtime comprehension members; "
-                    f"owner=ListValue.add site={site}",
-                    **runtime_effect_evidence("py.sequence_concat", other, site),
                 )
             )
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_concat_symbolic_fold.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_concat_symbolic_fold.py
@@ -1,0 +1,67 @@
+"""py.sequence_concat accepts a constructed symbolic fold (comprehension).
+
+Residual: RuntimeEffect over ComprehensionValue failed because
+is_lift_time_decidable did not know _Lambda inside py.listcomp, and concat
+minted RuntimeEffect instead of a symbolic + coordinate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.effect.runtime_effect import is_lift_time_decidable
+from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+from sugar_lift_py_tests.floor.list_value import ListValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.universe_value import UniverseValue
+from sugar_lift_py_tests.ir import PrimitiveSort, _Lambda, ctor, make_var, num
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def test_lambda_body_is_not_lift_time_decidable() -> None:
+    body = make_var("p")
+    lam = _Lambda("p", PrimitiveSort("Value"), body)
+    term = ctor(
+        "py.listcomp",
+        [make_var("xs"), lam, ctor("python:loop.exhaustion", [])],
+    )
+    assert is_lift_time_decidable(term) is False
+    assert is_lift_time_decidable(lam) is False
+
+
+def test_list_plus_comprehension_constructs_symbolic_concat() -> None:
+    left = ListValue((TermValue(1),))
+    right = ComprehensionValue(
+        ctor(
+            "py.listcomp",
+            [
+                make_var("xs"),
+                _Lambda("p", PrimitiveSort("Value"), make_var("p")),
+                ctor("python:loop.exhaustion", []),
+            ],
+        )
+    )
+
+    class _Site:
+        filename = "test_sequence_concat_symbolic_fold.py"
+        line = 1
+        col = 0
+
+    out = left.add(right, site=_Site())
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, ComprehensionValue)
+    assert out.value.term.name == "+"  # type: ignore[attr-defined]
+
+
+def test_source_list_plus_comprehension_returns_universe(tmp_path: Path) -> None:
+    path = tmp_path / "t.py"
+    path.write_text(
+        "def f(xs):\n" "    return [1] + [x for x in xs]\n",
+        encoding="utf-8",
+    )
+    fn = next(SourceFile(path_source(str(path))).functions())
+    out = fn.sugar().desugar(None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)


### PR DESCRIPTION
## Summary

Named residual: `py.sequence_concat` with a symbolic fold operand —
`RuntimeEffect` / `is_lift_time_decidable` faulted on `_Lambda` inside
`py.listcomp` (`TypeError: unknown RuntimeEffect operand term: _Lambda`).
The comprehension already constructs; concat could not accept it.

## Changes

| File | Change |
|------|--------|
| `effect/runtime_effect.py` | `_Lambda` → not decidable; `py.listcomp`/`setcomp`/`dictcomp`/`genexp` → always runtime products |
| `floor/list_value.py` | `ListValue + ComprehensionValue` → symbolic `+` coordinate (Complete) |
| `floor/comprehension_value.py` | same for comprehension peers |
| twin | `test_sequence_concat_symbolic_fold.py` |

## Validation

```text
pytest test_sequence_concat_symbolic_fold.py → 3 passed
```

Does not touch `binding_state.py` or `nodes.py` Assign.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sequence concat to accept symbolic comprehension folds
> - `ComprehensionValue.add` and `ListValue.add` now always return a `Complete` result with a symbolic `ctor('+', ...)` term when adding comprehension or list values, removing the prior `Incomplete`/`SequenceConcatenationRuntimeEffect` path.
> - `is_lift_time_decidable` is extended to classify `_Lambda` terms and comprehension/generator ctors (`py.listcomp`, `py.setcomp`, `py.dictcomp`, `py.genexp`) as not lift-time decidable (returns `False`) instead of raising `TypeError` or treating them as ordinary ctors.
> - New tests in [`test_sequence_concat_symbolic_fold.py`](https://github.com/TSavo/sugar/pull/6237/files#diff-c90249c8344adeff95e5fe06d5d5eb9a581d853d7f9e7a3ad49160b88ab1523c) cover decidability, value addition, and an end-to-end source case.
> - Behavioral Change: code paths that previously returned `Incomplete` for comprehension/list addition now always return `Complete`; `is_lift_time_decidable` no longer raises for `_Lambda`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be3a48c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->