### PR TITLE
fix: failed constructed-value testimony is a loud typed gap; canonicalize once per coordinate

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
@@ -1,0 +1,287 @@
+'''Canonicalization is content-addressed WORK: done once per value, never per path.
+
+``_canonical_constructed_value`` is a pure function of an immutable constructed
+value, and the constructed value graph is a DAG the recursion walks as a TREE.
+Measured on pandas ``core/indexes/base.py::_join_level``: 758,852 calls over
+1,544 distinct value objects -- 491x recomputation, and the reason a completed
+canonicalization made ``__internal_pivot_table`` take 976s.
+
+The memo is keyed by value IDENTITY (computing a content key is exactly the cost
+being removed) and each row holds a WEAK reference to the object it keyed. A hit
+is honored only when that weakref still resolves to the SAME object, so a dead
+value's recycled address (the #6212 id-reuse bug class) can never be served the
+dead object's canonical JSON.
+
+These twins pin: the work collapses, the ANSWER does not change by one byte, a
+distinct value never reads another value's row, a recycled address misses, and
+speed never comes from skipping testimony.
+'''
+
+import gc
+import os
+import tempfile
+import weakref
+from dataclasses import dataclass
+
+from sugar_source_tree import binding_state as BS
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+_SCOPE_CID = "blake3-512:" + "0" * 8
+
+
+@dataclass(frozen=True)
+class Held:
+    tag: str
+    parts: tuple
+
+
+class Unserializable:
+    pass
+
+
+def _counting_compute(only=None):
+    original = BS._compute_canonical_constructed_value
+    calls = {"n": 0}
+
+    def counting(value):
+        if only is None or isinstance(value, only):
+            calls["n"] += 1
+        return original(value)
+
+    BS._compute_canonical_constructed_value = counting
+    return calls, original
+
+
+def _function(src, name=None):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    with open(p, "w") as fh:
+        fh.write(src)
+    reporter = CollectingReporter()
+    sf = SourceFile.from_path(p, reporter=reporter)
+    for fn in sf.functions():
+        if name is None or getattr(fn, "name", None) == name:
+            return fn, reporter, sf
+    raise AssertionError("no function in fixture")
+
+
+def test_a_shared_value_canonicalizes_once_not_once_per_path():
+    # The DAG-as-tree disease in miniature: one shared leaf reached by many
+    # paths. Work must be a function of DISTINCT values, not of paths.
+    shared = Held("leaf", (1, 2, 3))
+    graph = Held("root", tuple(Held(f"branch{i}", (shared,)) for i in range(20)))
+    calls, original = _counting_compute(only=Held)
+    try:
+        BS._canonical_constructed_value(graph)
+        first = calls["n"]
+        BS._canonical_constructed_value(graph)
+        second = calls["n"]
+    finally:
+        BS._compute_canonical_constructed_value = original
+    # 1 root + 20 branches + 1 shared leaf, each computed exactly once...
+    assert first == 22, first
+    # ...and re-asking the same graph computes NOTHING new.
+    assert second == first, (first, second)
+
+
+def test_the_memo_returns_the_same_bytes_it_would_have_computed():
+    # Soundness: a wrong memo silently corrupts content addresses. Compare the
+    # warm answer against the answer computed with the memo bypassed entirely.
+    value = Held("root", (Held("a", (1,)), Held("b", ("x", b"\x00\x01")), None))
+    warm = BS._canonical_constructed_value(value)
+    warm_again = BS._canonical_constructed_value(value)
+    cold = BS._compute_canonical_constructed_value(value)
+    assert warm == cold, (warm, cold)
+    assert warm_again == cold
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    assert cid_of_json(warm) == cid_of_json(cold)
+
+
+def test_a_distinct_value_never_reads_another_values_row():
+    # Aliasing law. Two values that differ must never share an answer, however
+    # similar their shape or however adjacent their addresses.
+    one = Held("same", (1,))
+    two = Held("same", (2,))
+    assert BS._canonical_constructed_value(one) != BS._canonical_constructed_value(two)
+    assert BS._canonical_constructed_value(one)["fields"]["parts"] == [1]
+    assert BS._canonical_constructed_value(two)["fields"]["parts"] == [2]
+
+
+def test_only_categories_whose_inputs_are_named_get_a_coordinate():
+    # The key must cover every input that determines the canonical output, so a
+    # category whose inputs this module cannot enumerate gets NO row: a mutable
+    # dataclass can canonicalize two ways over its lifetime, and a ``wire()``
+    # value's inputs are inside a method call.
+    from dataclasses import dataclass as _dataclass
+
+    @_dataclass
+    class Mutable:
+        n: int
+
+    class Wired:
+        def wire(self):
+            return {"n": 1}
+
+    from sugar_source_tree.binding_state import _NO_COORDINATE as NONE_KEY
+
+    assert BS._canonicalization_coordinate(Mutable(1)) is NONE_KEY
+    assert BS._canonicalization_coordinate(Wired()) is NONE_KEY
+    assert BS._canonicalization_coordinate([1]) is NONE_KEY
+    assert BS._canonicalization_coordinate({"a": 1}) is NONE_KEY
+    assert BS._canonicalization_coordinate((1, 2)) is NONE_KEY
+    assert BS._canonicalization_coordinate(1) is NONE_KEY
+    # ...and the categories that DO have one name it: type is in the key
+    # because type is in the output, identity is only a component.
+    frozen = BS._canonicalization_coordinate(Held("t", ()))
+    assert frozen[0] == "frozen-dataclass" and frozen[1] is Held
+
+    # A mutated value therefore never reads a stale answer.
+    m = Mutable(1)
+    assert BS._canonical_constructed_value(m)["fields"]["n"] == 1
+    m.n = 2
+    assert BS._canonical_constructed_value(m)["fields"]["n"] == 2
+
+
+def test_a_node_is_keyed_by_its_authenticated_construction_shape():
+    # The strongest form: no identity in the key at all. Two distinct node
+    # VIEWS of the same content are one coordinate and share the answer.
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    with open(p, "w") as fh:
+        fh.write("x = 1\n")
+    sf = SourceFile.from_path(p, reporter=CollectingReporter())
+    root = sf.root
+    one = [n for n in root.walk() if n.kind == "Constant"][0]
+    two = [n for n in root.walk() if n.kind == "Constant"][0]
+    coordinate = BS._canonicalization_coordinate(one)
+    assert coordinate[0] == "node-shape"
+    assert coordinate == BS._canonicalization_coordinate(two)
+    assert BS._canonical_constructed_value(one) == BS._canonical_constructed_value(two)
+    assert BS._canonical_constructed_value(one)["nodeShape"] == coordinate[1]
+
+
+def test_a_recycled_address_misses_instead_of_serving_a_dead_values_answer():
+    # #6212 by construction: the row's weak reference is the live identity.
+    # Plant a row whose weakref is already dead at a LIVE value's address --
+    # exactly what address recycling produces -- and require an honest miss.
+    dead_owner = Held("dead", ())
+    dead_ref = weakref.ref(dead_owner)
+    del dead_owner
+    gc.collect()
+    assert dead_ref() is None
+
+    live = Held("live", (7,))
+    BS._CANONICAL_VALUES[BS._canonicalization_coordinate(live)] = (
+        dead_ref,
+        {"poison": True},
+    )
+    answer = BS._canonical_constructed_value(live)
+    assert answer["fields"]["parts"] == [7], answer
+    assert "poison" not in answer
+
+
+def test_a_dead_value_drops_its_row():
+    # The table is bounded by LIVE constructed values: no process-lifetime pin.
+    value = Held("transient", (1,))
+    coordinate = BS._canonicalization_coordinate(value)
+    BS._canonical_constructed_value(value)
+    assert coordinate in BS._CANONICAL_VALUES
+    del value
+    gc.collect()
+    assert coordinate not in BS._CANONICAL_VALUES
+
+
+def test_speed_never_comes_from_skipping_testimony():
+    # Both laws hold at once: the memo makes the work cheaper, never absent --
+    # a supported value still mints testimony (twice, from the memo), and an
+    # unsupported one is still the loud typed gap.
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    with open(p, "w") as fh:
+        fh.write("x = 1\n")
+    collector = CollectingReporter()
+    sf = SourceFile.from_path(p, reporter=collector)
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(_SCOPE_CID)
+    )
+    root = materialize(sf.root.unit, sf.root.ref, reporter)
+    node = [n for n in root.walk() if n.kind == "Constant"][0]
+    reporter.present_construction(node, Held("v", (1,)))
+    assert reporter.testimony_for(node) is not None
+    try:
+        reporter.present_construction(node, Unserializable())
+    except ConstructedValueTestimonyNotWritten:
+        pass
+    else:
+        # the shape memo already answered for this node -- ask a fresh coordinate
+        other = [n for n in root.walk() if n.kind == "Assign"][0]
+        try:
+            reporter.present_construction(other, Unserializable())
+        except ConstructedValueTestimonyNotWritten:
+            pass
+        else:
+            raise AssertionError("unsupported value went quiet")
+
+
+def test_real_construction_agrees_byte_for_byte_with_the_unmemoized_answer():
+    # Fingerprint every canonicalization a real function performs, with the
+    # memo live and with it bypassed, and require exact equality.
+    import hashlib
+
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    # ONE fixture file for both passes: a fresh temp path would change the
+    # source mementos and the fingerprint with them.
+    directory = tempfile.mkdtemp()
+    path = os.path.join(directory, "m.py")
+    with open(path, "w") as fh:
+        fh.write(
+            "def f(xs):\n"
+            "    total = 0\n"
+            "    for x in xs:\n"
+            "        total = total + x\n"
+            "    return total\n"
+        )
+
+    def fingerprint(bypass):
+        BS._CANONICAL_VALUES.clear()
+        original = BS._canonical_constructed_value
+        digest = hashlib.md5()
+        depth = {"d": 0}
+
+        def watched(value):
+            top = depth["d"] == 0
+            depth["d"] += 1
+            try:
+                out = (
+                    BS._compute_canonical_constructed_value(value)
+                    if bypass
+                    else original(value)
+                )
+            finally:
+                depth["d"] -= 1
+            if top:
+                digest.update(cid_of_json(out).encode())
+            return out
+
+        BS._canonical_constructed_value = watched
+        try:
+            sf = SourceFile.from_path(path, reporter=CollectingReporter())
+            fn = [f for f in sf.functions() if getattr(f, "name", None) == "f"][0]
+            fn.sugar()
+        finally:
+            BS._canonical_constructed_value = original
+        return digest.hexdigest()
+
+    memoized = fingerprint(False)
+    bypassed = fingerprint(True)
+    assert memoized == bypassed, (memoized, bypassed)
+    assert len(memoized) == 32

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
@@ -1,0 +1,199 @@
+'''A constructed value whose testimony cannot be content-addressed stays LOUD.
+
+``ConstructionTestimonyReporterV1.present_construction`` used to have two
+silent ``return`` doors: one when the node's construction-shape CID would not
+canonicalize, one when the constructed value would not. Either one left a
+falsely green construction coordinate -- the node registered, construction
+succeeded, testimony serialization failed, and the failure disappeared. (The
+measured proof it was hiding real work: teaching canonicalization to serialize
+a Node by its construction-shape CID moved pandas ``__internal_pivot_table``
+from 364s to 976s, because canonicalization that used to abort early now
+completes.)
+
+There is no third arm now:
+
+    canonicalization succeeds -> present testimony
+    canonicalization fails    -> report the gap, THEN raise the typed panic
+
+The gap is testified through the SAME roll call the census reads, and
+``Node.sugar`` raises before recording the present answer, so conservation is
+atomic: exactly one discharge per coordinate, and it is the loud absent one.
+'''
+
+import os
+import tempfile
+
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import KIND_REGISTRY
+from sugar_source_tree.panic import (
+    ConstructedValueTestimonyNotWritten,
+    SugarNotWritten,
+)
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+_SCOPE_CID = "blake3-512:" + "0" * 8
+
+
+class Unserializable:
+    """A constructed value category canonicalization has not been taught.
+
+    Not a dataclass, no ``wire()`` -- exactly the shape that made
+    ``_canonical_constructed_value`` raise ``TypeError`` in production
+    (``unserializable constructed value LineTable``).
+    """
+
+
+def _module(src):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "m.py")
+    with open(p, "w") as fh:
+        fh.write(src)
+    return p
+
+
+def _testimony_tree(src):
+    """One module materialized under a testimony reporter over a collector."""
+    path = _module(src)
+    collector = CollectingReporter()
+    sf = SourceFile.from_path(path, reporter=collector)
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(_SCOPE_CID)
+    )
+    root = materialize(sf.root.unit, sf.root.ref, reporter)
+    return root, reporter, collector
+
+
+def _first(root, kind):
+    for node in root.walk():
+        if node.kind == kind:
+            return node
+    raise AssertionError(f"no {kind} in fixture")
+
+
+def _unsupported_constructing(kind):
+    """Patch ONE node class to construct a value of an untaught category."""
+    cls = KIND_REGISTRY[kind]
+    original = cls._construct_sugar
+
+    def _construct(self):
+        return Unserializable()
+
+    cls._construct_sugar = _construct
+    return cls, original
+
+
+def test_unsupported_constructed_value_is_a_typed_loud_gap():
+    # Skip door #2: the value does not canonicalize. Never a silent return.
+    root, reporter, collector = _testimony_tree("x = 1\n")
+    node = _first(root, "Constant")
+    try:
+        reporter.present_construction(node, Unserializable())
+    except ConstructedValueTestimonyNotWritten as panic:
+        assert panic.owner == "CollectingReporter.present_construction"
+        assert "Unserializable" in panic.observed
+        assert "constructed value" in panic.observed
+        assert panic.requested == "content-addressable constructed-value testimony"
+        assert "teach canonicalization" in panic.fix
+    else:
+        raise AssertionError("failed testimony returned silently")
+    # ...and it is a SugarNotWritten, so the census counts it on the frontier
+    # rather than seeing a native crash.
+    assert issubclass(ConstructedValueTestimonyNotWritten, SugarNotWritten)
+    assert len(collector.gaps) == 1
+    assert collector.gaps[0][0] is node
+
+
+def test_supported_node_valued_construction_still_canonicalizes():
+    # Regression guard for the fix that made this loud path reachable: a
+    # constructed value legitimately CARRYING a Node canonicalizes by that
+    # node's construction-shape CID (it must not field-walk into unit ->
+    # SourceUnit -> LineTable and fail).
+    root, reporter, _ = _testimony_tree("x = 1\n")
+    node = _first(root, "Constant")
+    reporter.present_construction(node, {"held": node})
+    testimony = reporter.testimony_for(node)
+    assert testimony is not None
+    assert testimony.cid.startswith("blake3-512:")
+
+
+def test_gap_is_recorded_once_and_the_node_registers_once():
+    # Conservation, atomically: one registered coordinate, exactly one
+    # discharge, and that discharge is the loud absent one -- never a present
+    # answer beside it.
+    cls, original = _unsupported_constructing("Constant")
+    try:
+        root, reporter, collector = _testimony_tree("x = 1\n")
+        node = _first(root, "Constant")
+        try:
+            node.sugar()
+        except ConstructedValueTestimonyNotWritten:
+            pass
+        else:
+            raise AssertionError("construction stayed green")
+        coordinate = {id(n.ref) for n in collector.registered if n.kind == "Constant"}
+        assert len(coordinate) == 1, coordinate
+        assert len(collector.gaps) == 1, collector.gaps
+        assert [n for n in collector.present if n.ref is node.ref] == []
+    finally:
+        cls._construct_sugar = original
+
+
+def test_repeated_sugar_reraises_the_memoized_panic_without_new_roll_mass():
+    # The coordinate memo remembers the panic. A gap stays a gap on every
+    # call -- the SAME panic object -- and re-asking must not multiply the
+    # roll-call mass the census counts.
+    cls, original = _unsupported_constructing("Constant")
+    try:
+        root, reporter, collector = _testimony_tree("x = 1\n")
+        node = _first(root, "Constant")
+        first = second = None
+        try:
+            node.sugar()
+        except ConstructedValueTestimonyNotWritten as panic:
+            first = panic
+        gaps_after_first = len(collector.gaps)
+        try:
+            node.sugar()
+        except ConstructedValueTestimonyNotWritten as panic:
+            second = panic
+        assert first is not None and second is not None
+        assert first is second, "the memo must re-raise the SAME panic"
+        assert len(collector.gaps) == gaps_after_first == 1
+    finally:
+        cls._construct_sugar = original
+
+
+def test_no_reporter_silently_returns_from_failed_testimony_construction():
+    # Every reporter that CAN build testimony must have no silent-return door.
+    # ``NullReporter`` / ``CollectingReporter`` build none at all (nothing can
+    # fail); the testimony reporter is the only one that canonicalizes, and its
+    # two doors are checked above. This twin pins that no NEW silent door
+    # appears in its body.
+    import inspect
+
+    from sugar_source_tree import binding_state
+
+    source = inspect.getsource(
+        binding_state.ConstructionTestimonyReporterV1.present_construction
+    )
+    for handler in ("except (TypeError, ValueError)", "except Exception"):
+        if handler in source:
+            body = source.split(handler, 1)[1]
+            assert "_testimony_gap" in body.split("\n\n", 1)[0], source
+    assert source.count("return") == 1, "only the content-addressed memo returns"
+
+
+def test_no_raw_typeerror_or_valueerror_escapes():
+    root, reporter, _ = _testimony_tree("x = 1\n")
+    node = _first(root, "Constant")
+    try:
+        reporter.present_construction(node, Unserializable())
+    except (TypeError, ValueError) as raw:
+        raise AssertionError(f"raw {type(raw).__name__} escaped: {raw}")
+    except ConstructedValueTestimonyNotWritten:
+        pass

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
@@ -108,6 +108,27 @@ def test_unsupported_constructed_value_is_a_typed_loud_gap():
     assert collector.gaps[0][0] is node
 
 
+def test_both_outcomes_are_remembered_at_the_same_coordinate():
+    # Present and absent are symmetric at the shape coordinate: a testified
+    # shape is not recomputed, and a FAILED shape re-raises the SAME typed
+    # panic -- without adding roll-call mass, because the gap was testified
+    # once, when it happened.
+    root, reporter, collector = _testimony_tree("x = 1\n")
+    node = _first(root, "Constant")
+    first = second = None
+    try:
+        reporter.present_construction(node, Unserializable())
+    except ConstructedValueTestimonyNotWritten as panic:
+        first = panic
+    try:
+        reporter.present_construction(node, Unserializable())
+    except ConstructedValueTestimonyNotWritten as panic:
+        second = panic
+    assert first is not None and second is not None
+    assert first is second
+    assert len(collector.gaps) == 1, collector.gaps
+
+
 def test_supported_node_valued_construction_still_canonicalizes():
     # Regression guard for the fix that made this loud path reachable: a
     # constructed value legitimately CARRYING a Node canonicalizes by that

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeAlias
@@ -347,13 +348,17 @@ class ConstructionTestimonyReporterV1:
     the structural identity of the exact source/shadow node that produced it.
     """
 
-    __slots__ = ("_delegate", "_by_node_shape", "_trace_builder")
+    __slots__ = ("_delegate", "_by_node_shape", "_failed_by_node_shape", "_trace_builder")
 
     def __init__(
         self, delegate: object, trace_builder: SubstitutionTraceBuilderV1
     ) -> None:
         self._delegate = delegate
         self._by_node_shape: dict[str, ConstructedValueTestimonyV1] = {}
+        # Both outcomes are remembered at the same coordinate. A shape that
+        # could not be testified re-raises the SAME typed panic, and re-raising
+        # adds no roll-call mass: the gap was testified once, when it happened.
+        self._failed_by_node_shape: dict[str, BaseException] = {}
         self._trace_builder = trace_builder
 
     def register(self, node: Node) -> None:
@@ -373,6 +378,9 @@ class ConstructionTestimonyReporterV1:
             node_shape_cid = node_construction_shape_cid(node)
         except (TypeError, ValueError) as cause:
             self._testimony_gap(node, value, "node construction shape", cause)
+        remembered_failure = self._failed_by_node_shape.get(node_shape_cid)
+        if remembered_failure is not None:
+            raise remembered_failure
         # Same content, same testimony: a node view is presented in every
         # snapshot it survives (asof: 2,277 presentations, 187 distinct shapes
         # -- 12x). The shape CID is the content key; once it is recorded, the
@@ -383,14 +391,21 @@ class ConstructionTestimonyReporterV1:
         try:
             semantic_value_cid = cid_of_json(_constructed_preimage(value))
         except (TypeError, ValueError) as cause:
-            self._testimony_gap(node, value, "constructed value", cause)
+            self._testimony_gap(
+                node, value, "constructed value", cause, shape=node_shape_cid
+            )
         self._by_node_shape[node_shape_cid] = mint_constructed_value_testimony_v1(
             source_fragment=node.fragment,
             semantic_value_cid=semantic_value_cid,
         )
 
     def _testimony_gap(
-        self, node: Node, value: object, canonicalized: str, cause: Exception
+        self,
+        node: Node,
+        value: object,
+        canonicalized: str,
+        cause: Exception,
+        shape: str | None = None,
     ) -> NoReturn:
         """The ONE typed door for a failed constructed-value testimony.
 
@@ -416,6 +431,8 @@ class ConstructionTestimonyReporterV1:
                 "(_canonical_constructed_value) or keep the coordinate loud"
             ),
         )
+        if shape is not None:
+            self._failed_by_node_shape[shape] = panic
         self.report_gap(node, panic)
         raise panic
 
@@ -609,7 +626,117 @@ def _constructed_preimage(value: object) -> dict[str, Any]:
     }
 
 
+# Canonicalization is content-addressed WORK over a shared value DAG that the
+# recursion below walks as a TREE. Measured on pandas
+# ``core/indexes/base.py::_join_level``: 758,852 calls over 1,544 distinct value
+# objects -- 491x recomputation, and the cost the silent testimony skip used to
+# hide by aborting canonicalization early. Same ruling as the static
+# ``_SHAPE_CIDS`` registry: the work is content-addressed, so it is done once at
+# its coordinate and read thereafter. Never skip testimony to buy speed.
+#
+# THE KEY IS THE COORDINATE, NOT THE ADDRESS. The key must cover every input
+# that determines the canonical output, so a row is written only for value
+# categories whose canonicalization this module can NAME the inputs of:
+#
+#   Node             -> keyed by the AUTHENTICATED construction-shape CID, with
+#                       no identity component at all. The Node arm's output is
+#                       exactly ``{"nodeShape": node_construction_shape_cid(v)}``,
+#                       a pure function of that CID: two different node views of
+#                       the same content are the same coordinate and must share
+#                       the answer.
+#   frozen dataclass -> keyed by (type, live object). The output is the type's
+#                       module/qualname plus the canonicalization of each field,
+#                       and ``frozen=True`` is what makes the field tuple a
+#                       function of the object. Type is IN the key because it is
+#                       IN the output; identity is a component, never the whole.
+#   Enum             -> keyed by (type, member). The output is the enum type's
+#                       module/qualname plus its canonicalized ``.value``; the
+#                       member is the coordinate and members are singletons.
+#
+# Everything else is deliberately NOT memoized, because its canonical output is
+# NOT a function of the value object alone (or is too cheap to be worth a row):
+#
+#   list / dict / set / non-frozen dataclass -- MUTABLE. The same object can
+#       canonicalize two ways over its lifetime, so identity is not a
+#       coordinate. (These are also the arms that cannot be weakref'd.)
+#   objects canonicalized via ``.wire()`` -- ``wire()`` is a method call that
+#       may read state beyond the value; this module cannot enumerate its
+#       inputs, so it does not claim a coordinate for it.
+#   tuple -- immutable, but its answer is exactly its elements' answers, which
+#       ARE memoized individually; a row would buy the walk of one tuple.
+#   None / bool / int / float / str / bytes -- the answer is a constant-time
+#       spelling of the value; a row costs more than it saves.
+#   SourceFragment / SourceMemento -- delegated to ``seal()`` / ``to_dict()``,
+#       which own their own authentication; not this module's coordinate.
+#
+# The id-reuse hazard (#6212) is closed by construction wherever identity IS a
+# key component: the row holds a WEAK reference to the object it keyed and a hit
+# is honored only when that weakref still resolves to the SAME object, so a
+# recycled address misses instead of reading a dead value's JSON. The weakref
+# callback drops the row, bounding the table by LIVE values rather than pinning
+# every constructed value for the life of a corpus census.
+_CANONICAL_VALUES: dict[Any, tuple[Any, Any]] = {}
+
+_NO_COORDINATE = object()
+
+
+def _canonicalization_coordinate(value: object) -> Any:
+    """This value's canonical-testimony coordinate, or ``_NO_COORDINATE``."""
+    from sugar_source_tree.nodes import Node
+
+    if isinstance(value, Node):
+        return ("node-shape", node_construction_shape_cid(value))
+    if isinstance(value, Enum):
+        return ("enum", type(value), value)
+    if (
+        is_dataclass(value)
+        and not isinstance(value, type)
+        and getattr(value, "__dataclass_params__", None) is not None
+        and value.__dataclass_params__.frozen
+    ):
+        return ("frozen-dataclass", type(value), id(value))
+    return _NO_COORDINATE
+
+
 def _canonical_constructed_value(value: object) -> Any:
+    """The value's canonical JSON: computed once per coordinate, read after."""
+    coordinate = _canonicalization_coordinate(value)
+    if coordinate is _NO_COORDINATE:
+        return _compute_canonical_constructed_value(value)
+
+    remembered = _CANONICAL_VALUES.get(coordinate)
+    if remembered is not None:
+        keyed, canonical = remembered
+        # An identity-bearing key is honored only while the object it named is
+        # alive and the SAME object; a content coordinate carries no identity to
+        # check (``keyed`` is None) and is honored unconditionally.
+        if keyed is None or keyed() is value:
+            return canonical
+
+    canonical = _compute_canonical_constructed_value(value)
+    _memoize_canonical(coordinate, value, canonical)
+    return canonical
+
+
+def _memoize_canonical(coordinate: Any, value: object, canonical: Any) -> None:
+    if coordinate[0] == "node-shape":
+        # Pure content coordinate: no address, nothing to outlive.
+        _CANONICAL_VALUES[coordinate] = (None, canonical)
+        return
+    try:
+
+        def _forget(_dead: Any, coordinate: Any = coordinate) -> None:
+            _CANONICAL_VALUES.pop(coordinate, None)
+
+        reference = weakref.ref(value, _forget)
+    except TypeError:
+        # Cannot hold the live identity its key names -> no row, rather than a
+        # row a recycled address could read.
+        return
+    _CANONICAL_VALUES[coordinate] = (reference, canonical)
+
+
+def _compute_canonical_constructed_value(value: object) -> Any:
     from sugar_source_tree.fragment import SourceFragment, SourceMemento
 
     if value is None or isinstance(value, (bool, int, str)):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeAlias
 
 from sugar_lift_python_source.canonical import cid_of_json
 
@@ -371,8 +371,8 @@ class ConstructionTestimonyReporterV1:
     def present_construction(self, node: Node, value: object) -> None:
         try:
             node_shape_cid = node_construction_shape_cid(node)
-        except (TypeError, ValueError):
-            return
+        except (TypeError, ValueError) as cause:
+            self._testimony_gap(node, value, "node construction shape", cause)
         # Same content, same testimony: a node view is presented in every
         # snapshot it survives (asof: 2,277 presentations, 187 distinct shapes
         # -- 12x). The shape CID is the content key; once it is recorded, the
@@ -382,18 +382,51 @@ class ConstructionTestimonyReporterV1:
             return
         try:
             semantic_value_cid = cid_of_json(_constructed_preimage(value))
-        except (TypeError, ValueError):
-            return
+        except (TypeError, ValueError) as cause:
+            self._testimony_gap(node, value, "constructed value", cause)
         self._by_node_shape[node_shape_cid] = mint_constructed_value_testimony_v1(
             source_fragment=node.fragment,
             semantic_value_cid=semantic_value_cid,
         )
 
+    def _testimony_gap(
+        self, node: Node, value: object, canonicalized: str, cause: Exception
+    ) -> NoReturn:
+        """The ONE typed door for a failed constructed-value testimony.
+
+        Conservation is atomic: the gap is testified through the SAME roll call
+        the census reads (``report_gap``, delegated to the collecting reporter)
+        BEFORE the panic is raised, and ``Node.sugar`` raises before it records
+        the present answer. So the coordinate carries exactly one discharge --
+        the loud absent one -- never a present testimony it does not have and
+        never no discharge at all.
+        """
+        from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
+
+        panic = ConstructedValueTestimonyNotWritten(
+            owner="CollectingReporter.present_construction",
+            observed=(
+                f"{canonicalized} of {type(value).__name__} at "
+                f"{_testimony_blame(node)} does not canonicalize: "
+                f"{type(cause).__name__}: {cause}"
+            ),
+            requested="content-addressable constructed-value testimony",
+            fix=(
+                "teach canonicalization the general value category "
+                "(_canonical_constructed_value) or keep the coordinate loud"
+            ),
+        )
+        self.report_gap(node, panic)
+        raise panic
+
     def testimony_for(self, node: Node) -> ConstructedValueTestimonyV1 | None:
+        # A miss is an honest None (this node was never presented); a
+        # canonicalization FAILURE is not, and never returns quietly.
         try:
-            return self._by_node_shape.get(node_construction_shape_cid(node))
-        except (TypeError, ValueError):
-            return None
+            node_shape_cid = node_construction_shape_cid(node)
+        except (TypeError, ValueError) as cause:
+            self._testimony_gap(node, node, "node construction shape", cause)
+        return self._by_node_shape.get(node_shape_cid)
 
     def seal_snapshot(
         self, snapshot: tuple[tuple[str, BindingEntryV1], ...]
@@ -402,6 +435,21 @@ class ConstructionTestimonyReporterV1:
 
     def projected_snapshots_for(self, statement: Node):
         return self._trace_builder.projected_snapshots_for(statement, self)
+
+
+def _testimony_blame(node: object) -> str:
+    """The node's site, by the same projection ``Node.sugar`` uses."""
+    from sugar_source_tree.panic import SourceTreePanic
+
+    unit = getattr(node, "unit", None)
+    where = getattr(unit, "filename", None)
+    if not isinstance(where, str):
+        return str(type(node).__name__)
+    try:
+        lc = node.line_col_span()
+    except SourceTreePanic:
+        return where
+    return f"{where}:{lc.start_line}:{lc.start_col}"
 
 
 def _seal_trace_record(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1322,13 +1322,19 @@ class Node(Typed):
         ):
             try:
                 result = self._construct_sugar()
+                # Testimony projection is INSIDE the discharge, not after it.
+                # A constructed value whose testimony cannot be content-
+                # addressed raises ConstructedValueTestimonyNotWritten here, so
+                # the coordinate records the ABSENT answer (memoized panic, gap
+                # already testified through the reporter) instead of a present
+                # answer whose testimony silently failed to exist.
+                self.reporter.present_construction(self, result)
             except (SourceTreePanic, ConstructionPanic) as panic:
                 # The two sanctioned construction gaps. Remember the panic so
                 # this coordinate keeps throwing it -- memoization must never
                 # turn an absent answer into a present one.
                 cache.sugar_panics[key] = panic
                 raise
-            self.reporter.present_construction(self, result)
             self.reporter.present_fact(self)
             cache.sugar_results[key] = result
             return result

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -107,6 +107,28 @@ class RuntimeSelectedContextManager(SugarNotWritten):
     _LABEL = "RUNTIME-SELECTED CONTEXT MANAGER"
 
 
+class ConstructedValueTestimonyNotWritten(SugarNotWritten):
+    """A construction succeeded but its constructed-value testimony could not
+    be content-addressed.
+
+    The coordinate registered, the node constructed, and the testimony
+    serialization failed. Before, both failure doors in
+    ``ConstructionTestimonyReporterV1.present_construction`` returned silently:
+    the node kept its PRESENT discharge and the failure disappeared -- a falsely
+    green construction coordinate. There is no such third arm now. Either the
+    constructed value canonicalizes (present testimony) or this typed gap is
+    reported through the same roll call and raised.
+
+    A *named* subclass of ``SugarNotWritten`` (like
+    ``RuntimeSelectedContextManager``) so the census counts testimony gaps
+    separately from shapes with no ``.sugar()`` override. The fix is always to
+    teach canonicalization the general value CATEGORY -- never a per-type
+    allowlist, never a silent return.
+    """
+
+    _LABEL = "CONSTRUCTED VALUE TESTIMONY NOT WRITTEN"
+
+
 class WithConstructionGapKind(str, Enum):
     RUNTIME_SELECTED = "runtime-selected"
     UNRESOLVED_SYMBOL = "unresolved-symbol"


### PR DESCRIPTION
Two deliberately separate commits: **honesty first, then speed.**

## A — `d799a4c1c` loud typed testimony failure (verified ALONE, before B existed)

`ConstructionTestimonyReporterV1.present_construction` held two silent `return`s (and `testimony_for` the same swallow):

```python
except (TypeError, ValueError):
    return          # node registered, construction succeeded,
                    # testimony serialization failed, failure disappeared
```

That is a falsely green construction coordinate. Both now mint **`ConstructedValueTestimonyNotWritten`**, a named subclass of `SugarNotWritten` in `sugar_source_tree/panic.py` — chosen because the census ledger *is* `reporter.report_gap(node, SugarNotWritten)` and the corpus loop catches `SourceTreePanic`, so a named subclass lets testimony gaps be counted separately (precedent: `RuntimeSelectedContextManager`). `ConstructionPanic`/`ConstructionGap` was rejected: a `BaseException` outside the tree's roll-call ledger.

**Atomic conservation**: `Node.sugar()` now calls `present_construction` *inside* the construction `try`. Either the value is testified (`present_fact` + result cached) or the gap is reported through the same reporter and the panic is memoized at `ConstructionCache.key(...)` — `present_fact` never runs. One discharge per coordinate, and it is the loud absent one.

**Newly-red from A: 0** on a 20-file breadth probe (`pandas/core/arrays/*.py`), gap sets byte-identical to baseline. The swallows were hiding *work*, not failures on that sample. The legitimate shape memo stays.

## B — `3681b3c08` canonicalize once per authenticated coordinate

Key is **not** `id(value)`. Only categories whose inputs this module can name get a row:
- **Node** → the construction-shape CID, with **no identity component at all**
- **frozen dataclass** → `(type, live object)` — type is in the key because it is in the output; `frozen=True` is what makes the field tuple a function of the object
- **Enum** → `(type, member)`

Explicitly **no row** for list/dict/set/non-frozen dataclass (mutable — identity is not a coordinate), `.wire()` values (inputs inside a method call), tuples (their elements are already memoized), primitives, and `SourceFragment`/`SourceMemento` (they delegate to `seal()`/`to_dict()`, which own their authentication). Where identity is a component the row holds a weakref, and a hit is honored only if it still resolves to the *same* object — #6212's id-reuse hazard closed by construction, not pinning. Failures are memoized too and re-raise the *same* panic with no new roll-call mass.

## Verification
```
constructed graph fingerprint: byte-identical (abfd4cd1b613d8777b570bcd9781ab70 before and after)
present/gap coordinate set:    identical (20-file probe, base == A == A+B)
unsupported values:            typed loud (ConstructedValueTestimonyNotWritten)
silent registered nodes:       0
raw canonicalization errors:   0
_join_level redundancy:        758,852 calls -> 41,260 (33x less canonicalization work)
twins:                         73/73 (16 new + 57 regression) on rebased main
```

## Honest limitation — the memo does NOT fix the wall clock
`value_counts` 174→141s, `_where` 45.8→38.1s, `to_numeric` ~flat. **~15%.** Canonicalization *recomputation* was never the dominant cost. cProfile names the real one: `canonical.py::_encode_string` — **535.8s tottime over 22,463,477 calls**, driving 735M `list.append` and 615M `ord`; `canonical_json_bytes` is 624s cumulative over just **1,318 calls**, i.e. each CID hashes a JSON tree of ~12,800 nodes.

Two independent causes, neither addressed here: (1) the canonical JSON encoder escapes strings character-by-character in pure Python — mechanical, no CID change; (2) `_backend_node_preimage` **inlines whole subtrees**, so encoding is quadratic in depth — a Merkle reference to each child's already-computed shape CID would make it linear, but changes every shape CID and is a content-addressing migration, not an optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise typed `ConstructedValueTestimonyNotWritten` panic on canonicalization failure and memoize results per coordinate
> - Canonicalization failures in `ConstructionTestimonyReporterV1.present_construction` and `testimony_for` now raise a typed `ConstructedValueTestimonyNotWritten` panic and report a gap instead of silently returning `None`.
> - Failures are memoized per node-shape CID so repeated calls re-raise the same panic instance without growing the gap count.
> - Introduces a coordinate system in `_canonicalization_coordinate` to classify values for memoization: Nodes by shape CID, Enums by identity, and frozen dataclasses by `(type, id)`; other categories bypass memoization.
> - Cache entries for identity-bearing coordinates use weak references and are evicted on garbage collection to prevent stale hits from recycled addresses.
> - `Node.sugar` now calls `present_construction` inside the try block so testimony failures are captured as construction panics and prevent `present_fact` from recording a false success.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3681b3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->