### PR TITLE
feat: Assign flat unpack owns Attribute/Subscript store leaves

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
-from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing, _call_pair
+from sugar_lift_py_tests.sugar.witnesses import (
+    NotVerdictBearing,
+    _call_pair,
+    typed_red_effect_witness,
+)
 
 
 @dataclass(frozen=True)
@@ -137,3 +141,39 @@ class _PreconstructedStoreSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         return self.store.desugar_store(ctx, self.value)
+
+
+@dataclass(frozen=True)
+class UnpackStoreAssignSugar(Sugar):
+    """Flat display unpack with Attribute/Subscript store leaves (and optional Names).
+
+    Display RHS members are already projected one-to-one onto leaves at tree
+    construction. Name leaves are spent by substitute (same as MultiAssign);
+    store leaves desugar left-to-right as typed red store effects. This is one
+    temporal binding model: names thread, stores effect — no second door.
+    """
+
+    bindings: tuple  # (name, value_sugar) — provenance; substitute spent them
+    stores: tuple  # AttributeStoreEffectSugar | SubscriptStoreEffectSugar | PlaceAssign
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return typed_red_effect_witness(
+            name="unpack_attribute_store",
+            owner_sugar="UnpackStoreAssignSugar",
+            source=("def A(o, p, q):\n" "    o.x, o.y = p, q\n" "    return p\n"),
+            effect_class="AttributeStoreRuntimeEffect",
+            reason_needle="attribute store",
+            blame_needle="attr=x",
+            wrong_reason_needle="attribute store target `.z`",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
+
+        # Name bindings are spent by substitute; only store effects remain.
+        if not self.stores:
+            return Complete(BlockValue((), can_fall_through=True))
+        return reduce_body(self.stores, ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -42,6 +42,28 @@ class _ReducedBlock:
     transforms: tuple = ()
 
 
+def _prefixed(state: _ReducedBlock, inner: object) -> object:
+    """The temporal state of a halt INSIDE a nested statement, read from outside.
+
+    ``inner`` is what the nested reduction reached before halting; ``state`` is
+    everything this block had already established when the statement began.
+    Python never rolls back what already happened, so the halt arm carries both,
+    in order. A nested state with no ``entries`` (a non-block payload) is left
+    alone -- there is nothing to splice onto.
+    """
+    entries = getattr(inner, "entries", None)
+    if entries is None:
+        return inner
+    for transform in reversed(state.transforms):
+        entries = transform(entries)
+    return _ReducedBlock(
+        (*state.entries, *entries),
+        getattr(inner, "can_fall_through", False),
+        (),
+        state.transforms,
+    )
+
+
 def reduce_block_to_exitset(
     statements: tuple, ctx: object = None
 ) -> ExitSet[_ReducedBlock]:
@@ -144,6 +166,30 @@ def reduce_block_to_exitset(
                         )
                     )
 
+                # A statement that reduces to its OWN ExitSet (a nested block:
+                # try/with, or an unpack assignment whose store leaves are
+                # sequenced by this same reducer) hands back halted arms whose
+                # state is the state reached INSIDE that statement. It cannot
+                # know the prefix -- `head.desugar(ctx)` is given no state -- so
+                # the prefix is spliced on here, at the one seam that owns
+                # sequencing. Without this, a halt inside a nested statement
+                # would report an empty temporal state and every earlier store
+                # would read as rolled back, which is exactly the law the store
+                # partition above exists to state.
+                outcome = ExitSet(
+                    tuple(
+                        (
+                            Halted(
+                                exit_.guard,
+                                exit_.effect,
+                                _prefixed(state, exit_.state),
+                            )
+                            if isinstance(exit_, Halted)
+                            else exit_
+                        )
+                        for exit_ in outcome.exits
+                    )
+                )
                 return outcome.and_then(project)
             contribution = outcome.contribution()
             for transform in reversed(state.transforms):

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -9,15 +9,14 @@ paired with a discrimination arm that fails when the law is violated:
 3. Multiple store effects retain left-to-right order.
 4. Attribute receiver and attribute name retain their exact coordinates.
 5. A Name leaf's binding is discharged alongside the store effect.
-6/7. Partial assignment (halt between stores) is NOT asserted here, and is
-   deliberately NOT pinned here either: a test asserting "there is no halted
-   arm" would be a test OF the defect, blessing it as expected behaviour.
-   The real laws -- a Halted arm carrying the temporal state reached before
-   the failure, and a Completed arm from which the later store is absent --
-   live on the foundational store-ExitSet composition branch and start red
-   there. #6239 is held until that lands. See the strengthening list in the
-   comment at the end of this module for the twins that must gain a second
-   exit arm on the rebase.
+6/7. Partial assignment: nothing established before a store is erased by that
+   store's halt, and no target after it runs. Every projection twin below is
+   restated PER ARM against the real ``ExitSet``: the arm halting at store k
+   carries exactly stores 0..k-1. The generic success/halt algebra itself is
+   owned by ``test_store_outcome_composition``; the unpack's flow through it
+   is owned by ``test_assign_unpack_store_outcome_composition``. The OUTCOME
+   SHAPE is asserted in neither of those two places from here -- this module
+   reads arms, it does not claim how many exits a store body has.
 8. Pure-name ``MultiAssign`` construction is unchanged vs ``origin/main``.
 9. Starred opaque unpack stays typed-loud.
 10. Opaque-receiver Subscript leaves stay typed-loud (they cannot carry
@@ -35,6 +34,12 @@ import hashlib
 import re
 from pathlib import Path
 
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    Halted,
+    outcome_to_exitset,
+    sole_completed_outcome,
+)
 from sugar_lift_py_tests.sugar.assign_sugar import (
     MultiAssignSugar,
     UnpackStoreAssignSugar,
@@ -61,19 +66,49 @@ def _unpack(tmp_path: Path, source: str, stem: str = "assign_case"):
     )
 
 
-def _record(tmp_path: Path, source: str, stem: str = "assign_case"):
-    return _function_sugar(tmp_path, source, stem).desugar(None).value.record
+def _outcome(tmp_path: Path, source: str, stem: str = "assign_case"):
+    """The constructed outcome, ALWAYS as an ``ExitSet``.
 
-
-def _projection(tmp_path: Path, source: str, stem: str = "assign_case"):
-    """Ordered, site-free projection of every entry the block record carries.
-
-    Effect entries project (class, reason-without-site, constructed operand
-    term). Value entries project their post contribution. This is the artifact
-    that any of laws 2, 3 and 4 would have to corrupt to go unnoticed.
+    A body containing a store no longer reduces to one unconditional exit: the
+    store partitions it into a completed arm and one halted arm per store. A
+    body with no store still reduces linearly, and ``outcome_to_exitset`` lifts
+    that to the one-exit set, so every twin below reads the same instrument.
     """
+    return outcome_to_exitset(_function_sugar(tmp_path, source, stem).desugar(None))
+
+
+def _completed_value(tmp_path: Path, source: str, stem: str = "assign_case"):
+    """The value on the SOLE completed arm.
+
+    ``sole_completed_outcome`` is the sanctioned door: it refuses loudly when a
+    success face was dropped or duplicated instead of quietly projecting one of
+    several. It is not a way to discard the halted arms -- those are read by
+    ``_arm_projections`` and asserted per arm.
+    """
+    return sole_completed_outcome(_outcome(tmp_path, source, stem)).value
+
+
+def _record(tmp_path: Path, source: str, stem: str = "assign_case"):
+    return _completed_value(tmp_path, source, stem).record
+
+
+def _entries(payload) -> tuple:
+    """The ordered temporal entries an exit arm carries.
+
+    A completed arm carries a ``UniverseValue`` (record + post); a halted arm
+    carries the reduced block PREFIX reached before the halt. Both are read
+    through the same projection so a claim proven on the completed arm can be
+    restated, unchanged, on a partial-execution prefix.
+    """
+    record = getattr(payload, "record", None)
+    if record is not None:
+        return tuple(record.statements)
+    return tuple(getattr(payload, "entries", ()))
+
+
+def _rows(entries) -> tuple:
     rows = []
-    for entry in _record(tmp_path, source, stem).statements:
+    for entry in entries:
         effect = getattr(entry, "effect", None)
         if effect is None:
             rows.append(("value", type(entry).__name__, str(entry.post_contribution())))
@@ -88,8 +123,45 @@ def _projection(tmp_path: Path, source: str, stem: str = "assign_case"):
     return tuple(rows)
 
 
+def _projection(tmp_path: Path, source: str, stem: str = "assign_case"):
+    """Ordered, site-free projection of every entry the completed arm carries.
+
+    Effect entries project (class, reason-without-site, constructed operand
+    term). Value entries project their post contribution. This is the artifact
+    that any of laws 2, 3 and 4 would have to corrupt to go unnoticed.
+    """
+    return _rows(_record(tmp_path, source, stem).statements)
+
+
+def _arm_projections(tmp_path: Path, source: str, stem: str = "assign_case"):
+    """One projection per exit arm, shortest prefix first, completed arm last.
+
+    Arm ``k`` (for ``k`` store targets) is the arm on which store ``k`` halted:
+    it must carry stores ``0..k-1`` and nothing after them. The final entry is
+    the completed arm, on which every store's testimony is present.
+    """
+    exits = _outcome(tmp_path, source, stem).exits
+    halted = sorted(
+        (e for e in exits if isinstance(e, Halted)),
+        key=lambda e: len(_entries(e.state)),
+    )
+    completed = [e for e in exits if isinstance(e, Completed)]
+    assert len(completed) == 1, completed
+    return tuple(_rows(_entries(e.state)) for e in halted) + (
+        _rows(_entries(completed[0].value)),
+    )
+
+
+def _store_rows(rows) -> tuple:
+    return tuple(row for row in rows if row[0] != "value")
+
+
+def _targets(rows) -> list:
+    return [re.search(r"target `\.(\w)`", row[1]).group(1) for row in _store_rows(rows)]
+
+
 def _post(tmp_path: Path, source: str, stem: str = "assign_case"):
-    return _function_sugar(tmp_path, source, stem).desugar(None).value.post()
+    return _completed_value(tmp_path, source, stem).post()
 
 
 TWO_ATTRIBUTE = "def f(o, p, q):\n    o.x, o.y = p, q\n    return o\n"
@@ -108,15 +180,37 @@ def test_rhs_member_is_one_retained_occurrence(tmp_path: Path) -> None:
     re-evaluated (reconstructed) per target, the two stores would hold two
     distinct constructed objects.
     """
-    unpack = _unpack(tmp_path, "def f(o, p):\n    o.x, o.y = p, p\n    return o\n")
+    shared = "def f(o, p):\n    o.x, o.y = p, p\n    return o\n"
+    unpack = _unpack(tmp_path, shared)
     first, second = unpack.stores[0].value, unpack.stores[1].value
     assert first is second, (first, second)
+
+    # ...and RHS-once holds on BOTH arms: the arm that halted at the second
+    # store carries the SAME projected occurrence for the first store as the
+    # fully-completed arm does. A re-construction per arm would differ, and a
+    # dropped one would shorten the prefix.
+    arms = _arm_projections(tmp_path, shared, stem="shared")
+    assert len(arms) == 3, arms
+    completed = arms[-1]
+    for index, arm in enumerate(arms):
+        assert _store_rows(arm) == _store_rows(completed)[: len(_store_rows(arm))], (
+            index,
+            arm,
+        )
+    assert [len(_store_rows(arm)) for arm in arms] == [0, 1, 2]
 
     # Discrimination: distinct RHS members must NOT collapse onto one
     # occurrence -- sharing must come from the source, never from the lift.
     distinct = _unpack(tmp_path, TWO_ATTRIBUTE, stem="distinct")
     assert distinct.stores[0].value is not distinct.stores[1].value
     assert distinct.stores[0].value != distinct.stores[1].value
+
+    # Discrimination: the prefix reading is not vacuous -- `p, p` and `p, q`
+    # project the same FIRST store but different second stores, so the arm
+    # structure is sensitive to the member, not just to the count.
+    other = _arm_projections(tmp_path, TWO_ATTRIBUTE, stem="distinctarms")
+    assert _store_rows(other[1]) == _store_rows(arms[1])
+    assert _store_rows(other[2]) != _store_rows(arms[2])
 
 
 # ---------------------------------------------------------------------------
@@ -138,13 +232,26 @@ def test_positional_correspondence_binds_each_target_to_its_own_member(
         "_ConstStr(value='y', sort=PrimitiveSort(name='String')), _Var(name='q')))"
     ), rows[1]
 
+    # The pairing holds on the PARTIAL arm too: the arm that halted at `.y`
+    # carries the `.x` store already paired with `p`, not re-paired or dropped.
+    arms = _arm_projections(tmp_path, TWO_ATTRIBUTE, stem="posarms")
+    (partial,) = (arm for arm in arms if len(_store_rows(arm)) == 1)
+    assert _store_rows(partial)[0][2] == rows[0][2], partial
+
     # Discrimination arm: swap the two RHS members. The pairing -- and only the
     # pairing -- changes, so the projection must differ.
-    swapped = _projection(
-        tmp_path, "def f(o, p, q):\n    o.x, o.y = q, p\n    return o\n", stem="swapped"
-    )
+    swapped_source = "def f(o, p, q):\n    o.x, o.y = q, p\n    return o\n"
+    swapped = _projection(tmp_path, swapped_source, stem="swapped")
     assert swapped != rows
     assert [row[1] for row in swapped] == [row[1] for row in rows]
+
+    # ...and the swap is visible on the partial arm alone: a lie that only ever
+    # showed up once both stores completed would escape a halted execution.
+    swapped_arms = _arm_projections(tmp_path, swapped_source, stem="swappedarms")
+    (swapped_partial,) = (
+        arm for arm in swapped_arms if len(_store_rows(arm)) == 1
+    )
+    assert _store_rows(swapped_partial) != _store_rows(partial)
 
 
 # ---------------------------------------------------------------------------
@@ -153,28 +260,48 @@ def test_positional_correspondence_binds_each_target_to_its_own_member(
 
 
 def test_store_effects_retain_left_to_right_order(tmp_path: Path) -> None:
-    """Three attribute stores appear in source order, not as an unordered bag."""
-    rows = _projection(
-        tmp_path,
-        "def f(o, p, q, r):\n    o.x, o.y, o.z = p, q, r\n    return o\n",
-    )
-    assert [
-        re.search(r"target `\.(\w)`", row[1]).group(1) for row in rows if row[0] != "value"
-    ] == ["x", "y", "z"], rows
+    """Three attribute stores appear in source order -- and the ARM STRUCTURE
+    says so too.
+
+    Order used to be observable only inside one record. With the store
+    partition it is observable as the exits themselves: the arm halting at
+    store ``k`` carries exactly stores ``0..k-1``, so ``k+1`` cannot have run.
+    That is law 3 and law 7 in one artifact.
+    """
+    three = "def f(o, p, q, r):\n    o.x, o.y, o.z = p, q, r\n    return o\n"
+    rows = _projection(tmp_path, three)
+    assert _targets(rows) == ["x", "y", "z"], rows
+
+    arms = _arm_projections(tmp_path, three, stem="order")
+    assert [_targets(arm) for arm in arms] == [
+        [],
+        ["x"],
+        ["x", "y"],
+        ["x", "y", "z"],
+    ], [_targets(arm) for arm in arms]
+
+    # Stated as the prohibition as well as the prefix: no arm carries a store
+    # that comes after the one it halted on.
+    for index, arm in enumerate(arms[:-1]):
+        assert "z" not in _targets(arm) or index == 3, arm
+        assert len(_targets(arm)) == index
 
     # Discrimination arm: the same three stores written in a different order
     # project in that different order -- order is carried, not normalized away.
-    reversed_rows = _projection(
-        tmp_path,
-        "def f(o, p, q, r):\n    o.z, o.y, o.x = r, q, p\n    return o\n",
-        stem="reversed",
-    )
-    assert [
-        re.search(r"target `\.(\w)`", row[1]).group(1)
-        for row in reversed_rows
-        if row[0] != "value"
-    ] == ["z", "y", "x"], reversed_rows
+    reversed_source = "def f(o, p, q, r):\n    o.z, o.y, o.x = r, q, p\n    return o\n"
+    reversed_rows = _projection(tmp_path, reversed_source, stem="reversed")
+    assert _targets(reversed_rows) == ["z", "y", "x"], reversed_rows
     assert reversed_rows != rows
+
+    # ...and the arm structure follows the source order, so the prefixes are
+    # not a fixed alphabetical artifact of the reader.
+    reversed_arms = _arm_projections(tmp_path, reversed_source, stem="revorder")
+    assert [_targets(arm) for arm in reversed_arms] == [
+        [],
+        ["z"],
+        ["z", "y"],
+        ["z", "y", "x"],
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -186,27 +313,41 @@ def test_attribute_receiver_and_name_retain_exact_coordinates(
     tmp_path: Path,
 ) -> None:
     """Not "an attribute store happened" -- the exact receiver and attr terms."""
-    rows = _projection(
-        tmp_path, "def f(o, n, p, q):\n    o.x, n.y = p, q\n    return p\n"
-    )
+    source = "def f(o, n, p, q):\n    o.x, n.y = p, q\n    return p\n"
+    rows = _projection(tmp_path, source)
     assert "_Var(name='o')" in rows[0][2] and "value='x'" in rows[0][2], rows[0]
     assert "_Var(name='n')" in rows[1][2] and "value='y'" in rows[1][2], rows[1]
 
+    # The coordinates are retained on the halted PREFIX, not only once the
+    # whole statement completed: an arm that halts at `n.y` still names `o`
+    # and `x` exactly.
+    arms = _arm_projections(tmp_path, source, stem="coordarms")
+    (partial,) = (arm for arm in arms if len(_store_rows(arm)) == 1)
+    partial_row = _store_rows(partial)[0]
+    assert "_Var(name='o')" in partial_row[2] and "value='x'" in partial_row[2], partial
+
     # Discrimination arm 1: swap the receivers, keep everything else.
-    other_receiver = _projection(
-        tmp_path,
-        "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return p\n",
-        stem="recv",
-    )
+    recv_source = "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return p\n"
+    other_receiver = _projection(tmp_path, recv_source, stem="recv")
     assert other_receiver != rows
 
+    # ...and the receiver swap already bites on the one-store prefix.
+    recv_arms = _arm_projections(tmp_path, recv_source, stem="recvarms")
+    (recv_partial,) = (arm for arm in recv_arms if len(_store_rows(arm)) == 1)
+    assert _store_rows(recv_partial) != _store_rows(partial)
+
     # Discrimination arm 2: keep the receivers, change one attribute name.
-    other_attr = _projection(
-        tmp_path,
-        "def f(o, n, p, q):\n    o.x, n.z = p, q\n    return p\n",
-        stem="attr",
-    )
+    attr_source = "def f(o, n, p, q):\n    o.x, n.z = p, q\n    return p\n"
+    other_attr = _projection(tmp_path, attr_source, stem="attr")
     assert other_attr != rows
+
+    # This second lie is deliberately INVISIBLE on the first prefix -- it
+    # perturbs only the second store -- which is what makes the first
+    # discrimination's prefix bite evidence about the receiver specifically.
+    attr_arms = _arm_projections(tmp_path, attr_source, stem="attrarms")
+    (attr_partial,) = (arm for arm in attr_arms if len(_store_rows(arm)) == 1)
+    assert _store_rows(attr_partial) == _store_rows(partial)
+    assert _store_rows(attr_arms[-1]) != _store_rows(arms[-1])
 
 
 def test_lying_variants_are_distinguished_on_all_three_axes(tmp_path: Path) -> None:
@@ -241,6 +382,34 @@ def test_lying_variants_are_distinguished_on_all_three_axes(tmp_path: Path) -> N
     # ...and the three lies are distinct from one another, so no single
     # perturbation is standing in for all three.
     assert len({wrong_receiver, wrong_attribute, reversed_order}) == 3
+
+    # Now across arms. A lie is not allowed to hide in a partial execution: for
+    # each axis, the FULL per-arm reading differs, and for the two axes that
+    # perturb the first store (receiver, order) the difference is already there
+    # on the one-store prefix -- i.e. it bites on a run that halted early.
+    truthful_arms = _arm_projections(tmp_path, TWO_ATTRIBUTE, stem="tarm")
+    lying_arms = {
+        "wrong receiver": _arm_projections(
+            tmp_path,
+            "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return o\n",
+            stem="wrarm",
+        ),
+        "wrong attribute": _arm_projections(
+            tmp_path,
+            "def f(o, p, q):\n    o.x, o.z = p, q\n    return o\n",
+            stem="waarm",
+        ),
+        "reversed store order": _arm_projections(
+            tmp_path,
+            "def f(o, p, q):\n    o.y, o.x = q, p\n    return o\n",
+            stem="roarm",
+        ),
+    }
+    for label, arms in lying_arms.items():
+        assert arms != truthful_arms, label
+    prefix = _store_rows(truthful_arms[1])
+    for label in ("wrong receiver", "reversed store order"):
+        assert _store_rows(lying_arms[label][1]) != prefix, label
 
 
 # ---------------------------------------------------------------------------
@@ -278,6 +447,31 @@ def test_name_leaf_binding_is_discharged_beside_the_store_effect(
     assert str(_post(tmp_path, swapped, stem="swpost")) == (
         "_Atomic(name='=', args=(_Var(name='out'), _Var(name='q')))"
     )
+
+    # ------------------------------------------------------------------
+    # Law 6 -- assignment is NOT transactional. Nothing established before a
+    # store is erased by that store's halt.
+    #
+    # A Name target is spent by substitute: it materializes no entry on EITHER
+    # arm, so "x survives the halt" has no artifact of its own to assert -- it
+    # is true by construction, not by retention. What DOES materialize, and
+    # what the law is really about, is testimony established before the store:
+    # here a preceding store on `o.z`. It must be present, in full, on the arm
+    # where the later store halted.
+    # ------------------------------------------------------------------
+    partial = "def f(o, p, q):\n    o.z = p\n    x, o.a = p, q\n    return x\n"
+    arms = _arm_projections(tmp_path, partial, stem="partial")
+    assert [_targets(arm) for arm in arms] == [[], ["z"], ["z", "a"]], [
+        _targets(arm) for arm in arms
+    ]
+    surviving = _store_rows(arms[1])[0]
+    assert surviving == _store_rows(arms[-1])[0], (surviving, arms[-1])
+
+    # Discrimination arm: a halted exit that lost the earlier store is exactly
+    # what a transactional (rolled-back) reading would produce, and it is not
+    # what this construction produces.
+    assert _targets(arms[1]) != [], "the earlier store was rolled back"
+    assert _targets(arms[1]) != ["z", "a"], "the halted store ran anyway"
 
 
 # ---------------------------------------------------------------------------
@@ -414,67 +608,31 @@ def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# HANDOFF -- strengthening required when store ExitSet composition lands.
+# STRENGTHENING -- done, and what is deliberately NOT here.
 #
-# Every twin below currently reads ONE linear exit. Once a store contributes
-# a Halted arm (failure, prefix temporal state) beside its Completed arm, the
-# single-exit reading is no longer the whole artifact and each of these must
-# be restated per arm. This list is the rebase checklist for #6239; it is not
-# a licence to edit an expectation to match new behaviour -- re-measure.
+# Every projection twin above now reads the constructed ExitSet arm by arm
+# (`_arm_projections`), so laws 2, 3, 4 and 5 are asserted on partial-execution
+# prefixes as well as on the completed arm, and law 7 (no later target after an
+# earlier halt) is the arm structure itself.
 #
-# The OUTCOME SHAPE itself is not on this list and is not asserted anywhere in
-# this module: it is owned by test_assign_unpack_store_outcome_composition,
-# whose four twins are red on exactly that law. Nothing here may assert
-# `isinstance(out, Complete)` -- that is the defect those twins name, and two
-# committed twins must never disagree about it.
+# Still deliberately absent:
 #
-# SINGLE-ARM HELPERS -- fix these first, the twins follow:
-#   _record / _projection / _post  read `.desugar(None).value` as one Complete.
-#     They must take an exit arm (or return one projection per arm). This is
-#     the highest-priority rewrite: every twin below flows through them.
+#   * the OUTCOME SHAPE. How many exits a store body has is owned by
+#     test_assign_unpack_store_outcome_composition. Asserting the current shape
+#     here -- in either direction -- is asserting whatever that shape currently
+#     is, which is how `isinstance(out, Complete)` came to state that a store
+#     cannot fail. Two committed twins must never disagree about it.
 #
-#   Twin                                            what it must become
-#   ----------------------------------------------  -----------------------
-#   test_dual_attribute_display_unpack_constructs   already arm-independent
-#     (sugar-layer only: store count, attrs, bindings). No change needed.
+#   * a retained artifact for a Name target on the halted arm. substitute spends
+#     a Name binding before desugar, so it materializes no entry on ANY arm;
+#     "x survives the halt" is true by construction, not by retention. The
+#     non-rollback law is therefore proven where it has an artifact: on a store
+#     established before the halting one (see the law-6 block in
+#     test_name_leaf_binding_is_discharged_beside_the_store_effect).
 #
-#   test_name_leaf_binding_is_discharged_beside_    PRIMARY site for law 6.
-#     the_store_effect                              Today asserts one post
-#     `out == p`. Must assert the HALTED exit still carries x == p -- the
-#     earlier binding is not retroactively erased by the later store's
-#     failure. This twin is where "assignment is not transactional" gets
-#     proven, and its discrimination arm is a halted exit that lost x.
-#
-#   test_store_effects_retain_left_to_right_order   law 3 gains real teeth and
-#     becomes law 7 as well: the arm halting at store k must contain exactly
-#     stores 0..k-1 and NOT store k+1. Today order is only observable inside
-#     one record; then it is observable as the arm structure itself.
-#
-#   test_positional_correspondence_...              per-arm projection: the
-#   test_attribute_receiver_and_name_retain_        pairing and the receiver/
-#     exact_coordinates                             attr coordinates must hold
-#     on the halted prefix too, not only on the fully-completed arm.
-#
-#   test_lying_variants_are_distinguished_on_all_   a lie that shows up only
-#     three_axes                                    in a partial-execution
-#     prefix must bite. Extend the three axes across arms.
-#
-#   test_rhs_member_is_one_retained_occurrence      RHS-once must hold on BOTH
-#     arms: the halted arm carries the SAME constructed occurrence, never a
-#     re-construction.
-#
-#   test_pure_name_multi_assign_construction_is_    the three pinned
-#     unchanged                                     fingerprints hash
-#     repr(record). If the foundational work changes _ReducedBlock or the
-#     record repr, RE-MEASURE against origin/main at that time and replace
-#     the constants with the measured values. Never edit them to match.
-#
-#   test_opaque_receiver_subscript_leaves_stay_     the loud set shrinks on
-#     loud                                          rebase: subscript leaves
-#     are re-enabled wherever receiver, selector AND value are all
-#     authenticated. Move those sources out of the loud list and under the
-#     coordinate twins; keep loud only what still cannot authenticate all
-#     three.
-#
-#   test_star_against_opaque_iterable_stays_loud    unaffected.
+#   * opaque-receiver Subscript leaves. The store foundation did not change
+#     SubscriptStoreEffectSugar, which still carries only `index_text` and a
+#     site -- no receiver, no value -- so `a[i], b[j] = p, q` and
+#     `a[i], b[j] = q, p` would still construct identically. They stay
+#     typed-loud until all three coordinates authenticate.
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -1,0 +1,97 @@
+"""Assign flat unpack with Attribute/Subscript store leaves.
+
+Historical factory mass (shape-split ledger): dual-subscript, multi-attribute,
+and Name+store mixes against a display RHS. One temporal binding model: Name
+leaves thread via substitute; store leaves are typed red effects — no second door.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.assign_sugar import (
+    MultiAssignSugar,
+    UnpackStoreAssignSugar,
+)
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _function_sugar(tmp_path: Path, source: str):
+    path = tmp_path / "assign_case.py"
+    path.write_text(source, encoding="utf-8")
+    return next(SourceFile(path_source(str(path))).functions()).sugar()
+
+
+def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(o, p, q):\n" "    o.x, o.y = p, q\n" "    return o\n",
+    )
+    # FunctionUniverseSugar wraps the body; walk for UnpackStoreAssignSugar.
+    assert any(isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements), [
+        type(s).__name__ for s in sugar.statements
+    ]
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+
+
+def test_dual_subscript_display_unpack_constructs(tmp_path: Path) -> None:
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(a, b, p, q):\n" "    a[0], b[1] = p, q\n" "    return a\n",
+    )
+    assert any(isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements)
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+
+
+def test_name_plus_subscript_display_unpack_constructs(tmp_path: Path) -> None:
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(a, p, q):\n" "    x, a[0] = p, q\n" "    return x\n",
+    )
+    unpack = next(
+        stmt for stmt in sugar.statements if isinstance(stmt, UnpackStoreAssignSugar)
+    )
+    assert unpack.bindings and unpack.bindings[0][0] == "x"
+    assert len(unpack.stores) == 1
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+
+
+def test_three_attribute_display_unpack_constructs(tmp_path: Path) -> None:
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(o, p, q, r):\n" "    o.x, o.y, o.z = p, q, r\n" "    return o\n",
+    )
+    assert any(isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements)
+    assert isinstance(sugar.desugar(None), Complete)
+
+
+def test_name_only_display_unpack_stays_multi_assign(tmp_path: Path) -> None:
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(p, q):\n" "    a, b = p, q\n" "    return a + b\n",
+    )
+    assert any(isinstance(stmt, MultiAssignSugar) for stmt in sugar.statements)
+    assert not any(
+        isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements
+    )
+
+
+def test_star_against_opaque_iterable_stays_loud(tmp_path: Path) -> None:
+    """Non-display starred unpack remains a construction gap (#6078 territory)."""
+    path = tmp_path / "star.py"
+    path.write_text(
+        "def f(xs):\n" "    a, *rest = xs\n" "    return a\n",
+        encoding="utf-8",
+    )
+    fn = next(SourceFile(path_source(str(path))).functions())
+    try:
+        fn.sugar()
+        raise AssertionError("expected SugarNotWritten for opaque star unpack")
+    except SugarNotWritten as gap:
+        assert "Assign" in gap.owner or "Assign" in str(gap)

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -9,8 +9,15 @@ paired with a discrimination arm that fails when the law is violated:
 3. Multiple store effects retain left-to-right order.
 4. Attribute receiver and attribute name retain their exact coordinates.
 5. A Name leaf's binding is discharged alongside the store effect.
-6/7. Partial assignment (halt between stores) is NOT yet representable --
-   pinned as a ratchet, see ``test_store_effects_have_no_halted_exit_arm``.
+6/7. Partial assignment (halt between stores) is NOT asserted here, and is
+   deliberately NOT pinned here either: a test asserting "there is no halted
+   arm" would be a test OF the defect, blessing it as expected behaviour.
+   The real laws -- a Halted arm carrying the temporal state reached before
+   the failure, and a Completed arm from which the later store is absent --
+   live on the foundational store-ExitSet composition branch and start red
+   there. #6239 is held until that lands. See the strengthening list in the
+   comment at the end of this module for the twins that must gain a second
+   exit arm on the rebase.
 8. Pure-name ``MultiAssign`` construction is unchanged vs ``origin/main``.
 9. Starred opaque unpack stays typed-loud.
 10. Opaque-receiver Subscript leaves stay typed-loud (they cannot carry
@@ -28,12 +35,11 @@ import hashlib
 import re
 from pathlib import Path
 
-from sugar_lift_py_tests.outcome import Complete, Completed, Incomplete
+from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.assign_sugar import (
     MultiAssignSugar,
     UnpackStoreAssignSugar,
 )
-from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -276,57 +282,6 @@ def test_name_leaf_binding_is_discharged_beside_the_store_effect(
 
 
 # ---------------------------------------------------------------------------
-# Laws 6 and 7 -- partial assignment. NOT yet representable: pinned as a ratchet.
-# ---------------------------------------------------------------------------
-
-
-def test_store_effects_have_no_halted_exit_arm(tmp_path: Path) -> None:
-    """RATCHET, not a rubber stamp: partial assignment is NOT yet modelled.
-
-    Python assignment is not transactional -- if `o.y = q` raises, `o.x = p`
-    stays done and `o.y` never happens. Laws 6 and 7 need an outgoing ExitSet
-    with a Halted arm carrying the state reached before the failure, and a
-    Completed arm without the later store.
-
-    Measured today: the outgoing ExitSet has exactly ONE arm, Completed, for
-    both the unpack shape AND for the already-shipped sequential form
-    `o.x = p; o.y = q` -- ``Incomplete.follow`` routes every store effect
-    through ``_effect_continues_control_flow``. So this is a tree-wide
-    property of the store family, NOT something #6239 introduced; narrowing
-    the unpack shape would not reduce it while the two-statement spelling
-    stays admitted.
-
-    This twin pins that measurement. When sequential ExitSet composition
-    lands, this twin goes RED and must be replaced by real laws 6 and 7 twins
-    asserting the halted exit's carried binding state and the absence of the
-    later store from the outgoing exit set.
-    """
-    unpack_exits = reduce_block_to_exitset(
-        _function_sugar(tmp_path, TWO_ATTRIBUTE).statements, None
-    ).exits
-    sequential_exits = reduce_block_to_exitset(
-        _function_sugar(
-            tmp_path,
-            "def f(o, p, q):\n    o.x = p\n    o.y = q\n    return o\n",
-            stem="sequential",
-        ).statements,
-        None,
-    ).exits
-
-    for label, exits in (("unpack", unpack_exits), ("sequential", sequential_exits)):
-        assert len(exits) == 1, (label, [type(a).__name__ for a in exits])
-        assert isinstance(exits[0], Completed), (label, type(exits[0]).__name__)
-
-    # The store effects themselves are the thing that continues -- named, so a
-    # change to the follow routing lands here rather than silently elsewhere.
-    unpack = _unpack(tmp_path, TWO_ATTRIBUTE, stem="follow")
-    for store in unpack.stores:
-        outcome = store.desugar(None)
-        assert isinstance(outcome, Incomplete)
-        assert outcome.follow().continues is True
-
-
-# ---------------------------------------------------------------------------
 # Law 8 -- pure-name MultiAssign is unchanged vs origin/main.
 # ---------------------------------------------------------------------------
 
@@ -447,3 +402,65 @@ def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
     out = _function_sugar(tmp_path, TWO_ATTRIBUTE).desugar(None)
     assert isinstance(out, Complete)
     assert len(_unpack(tmp_path, TWO_ATTRIBUTE, stem="dual").stores) == 2
+
+
+# ---------------------------------------------------------------------------
+# HANDOFF -- strengthening required when store ExitSet composition lands.
+#
+# Every twin below currently reads ONE linear exit. Once a store contributes
+# a Halted arm (failure, prefix temporal state) beside its Completed arm, the
+# single-exit reading is no longer the whole artifact and each of these must
+# be restated per arm. This list is the rebase checklist for #6239; it is not
+# a licence to edit an expectation to match new behaviour -- re-measure.
+#
+# SINGLE-ARM HELPERS -- fix these first, the twins follow:
+#   _record / _projection / _post  read `.desugar(None).value` as one Complete.
+#     They must take an exit arm (or return one projection per arm).
+#
+#   Twin                                            what it must become
+#   ----------------------------------------------  -----------------------
+#   test_dual_attribute_display_unpack_constructs   asserts isinstance(out,
+#     Complete) for the whole universe -- the bare single-arm assumption.
+#     Must assert BOTH arms: Completed with both stores, Halted after the
+#     first. Highest-priority rewrite.
+#
+#   test_name_leaf_binding_is_discharged_beside_    PRIMARY site for law 6.
+#     the_store_effect                              Today asserts one post
+#     `out == p`. Must assert the HALTED exit still carries x == p -- the
+#     earlier binding is not retroactively erased by the later store's
+#     failure. This twin is where "assignment is not transactional" gets
+#     proven, and its discrimination arm is a halted exit that lost x.
+#
+#   test_store_effects_retain_left_to_right_order   law 3 gains real teeth and
+#     becomes law 7 as well: the arm halting at store k must contain exactly
+#     stores 0..k-1 and NOT store k+1. Today order is only observable inside
+#     one record; then it is observable as the arm structure itself.
+#
+#   test_positional_correspondence_...              per-arm projection: the
+#   test_attribute_receiver_and_name_retain_        pairing and the receiver/
+#     exact_coordinates                             attr coordinates must hold
+#     on the halted prefix too, not only on the fully-completed arm.
+#
+#   test_lying_variants_are_distinguished_on_all_   a lie that shows up only
+#     three_axes                                    in a partial-execution
+#     prefix must bite. Extend the three axes across arms.
+#
+#   test_rhs_member_is_one_retained_occurrence      RHS-once must hold on BOTH
+#     arms: the halted arm carries the SAME constructed occurrence, never a
+#     re-construction.
+#
+#   test_pure_name_multi_assign_construction_is_    the three pinned
+#     unchanged                                     fingerprints hash
+#     repr(record). If the foundational work changes _ReducedBlock or the
+#     record repr, RE-MEASURE against origin/main at that time and replace
+#     the constants with the measured values. Never edit them to match.
+#
+#   test_opaque_receiver_subscript_leaves_stay_     the loud set shrinks on
+#     loud                                          rebase: subscript leaves
+#     are re-enabled wherever receiver, selector AND value are all
+#     authenticated. Move those sources out of the loud list and under the
+#     coordinate twins; keep loud only what still cannot authenticate all
+#     three.
+#
+#   test_star_against_opaque_iterable_stays_loud    unaffected.
+# ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -35,7 +35,6 @@ import hashlib
 import re
 from pathlib import Path
 
-from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.assign_sugar import (
     MultiAssignSugar,
     UnpackStoreAssignSugar,
@@ -398,10 +397,20 @@ def test_opaque_receiver_subscript_leaves_stay_loud(tmp_path: Path) -> None:
 
 
 def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
-    """The admitted shape still constructs to a Complete universe."""
-    out = _function_sugar(tmp_path, TWO_ATTRIBUTE).desugar(None)
-    assert isinstance(out, Complete)
-    assert len(_unpack(tmp_path, TWO_ATTRIBUTE, stem="dual").stores) == 2
+    """The admitted shape constructs: two store leaves, both authenticated.
+
+    This asserts nothing about the OUTCOME shape. It used to assert
+    ``isinstance(out, Complete)``, which is the current single-unconditional-
+    exit behaviour -- i.e. it asserted that a store cannot fail, the very
+    thing ``test_assign_unpack_store_outcome_composition`` names as the
+    remaining defect. Two committed twins cannot disagree about whether a
+    store body reduces to one exit or to guarded exits; the outcome shape is
+    owned there, so it is not restated here.
+    """
+    unpack = _unpack(tmp_path, TWO_ATTRIBUTE, stem="dual")
+    assert len(unpack.stores) == 2
+    assert [store.attr for store in unpack.stores] == ["x", "y"]
+    assert unpack.bindings == ()
 
 
 # ---------------------------------------------------------------------------
@@ -413,16 +422,21 @@ def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
 # be restated per arm. This list is the rebase checklist for #6239; it is not
 # a licence to edit an expectation to match new behaviour -- re-measure.
 #
+# The OUTCOME SHAPE itself is not on this list and is not asserted anywhere in
+# this module: it is owned by test_assign_unpack_store_outcome_composition,
+# whose four twins are red on exactly that law. Nothing here may assert
+# `isinstance(out, Complete)` -- that is the defect those twins name, and two
+# committed twins must never disagree about it.
+#
 # SINGLE-ARM HELPERS -- fix these first, the twins follow:
 #   _record / _projection / _post  read `.desugar(None).value` as one Complete.
-#     They must take an exit arm (or return one projection per arm).
+#     They must take an exit arm (or return one projection per arm). This is
+#     the highest-priority rewrite: every twin below flows through them.
 #
 #   Twin                                            what it must become
 #   ----------------------------------------------  -----------------------
-#   test_dual_attribute_display_unpack_constructs   asserts isinstance(out,
-#     Complete) for the whole universe -- the bare single-arm assumption.
-#     Must assert BOTH arms: Completed with both stores, Halted after the
-#     first. Highest-priority rewrite.
+#   test_dual_attribute_display_unpack_constructs   already arm-independent
+#     (sugar-layer only: store count, attrs, bindings). No change needed.
 #
 #   test_name_leaf_binding_is_discharged_beside_    PRIMARY site for law 6.
 #     the_store_effect                              Today asserts one post

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -1,97 +1,449 @@
-"""Assign flat unpack with Attribute/Subscript store leaves.
+"""Assign flat unpack with Attribute store leaves.
 
-Historical factory mass (shape-split ledger): dual-subscript, multi-attribute,
-and Name+store mixes against a display RHS. One temporal binding model: Name
-leaves thread via substitute; store leaves are typed red effects — no second door.
+These twins do NOT assert "the shape returns an effect". Each one names a LAW
+of Python assignment and asserts the *constructed artifact* that carries it,
+paired with a discrimination arm that fails when the law is violated:
+
+1. RHS members are constructed ONCE (retained occurrence identity).
+2. Tuple elements retain positional correspondence.
+3. Multiple store effects retain left-to-right order.
+4. Attribute receiver and attribute name retain their exact coordinates.
+5. A Name leaf's binding is discharged alongside the store effect.
+6/7. Partial assignment (halt between stores) is NOT yet representable --
+   pinned as a ratchet, see ``test_store_effects_have_no_halted_exit_arm``.
+8. Pure-name ``MultiAssign`` construction is unchanged vs ``origin/main``.
+9. Starred opaque unpack stays typed-loud.
+10. Opaque-receiver Subscript leaves stay typed-loud (they cannot carry
+    receiver or value; see the narrowing commit).
+
+The projection helper below is the shared instrument: it strips the per-run
+temp path and the site, leaving exactly the effect class, the reason and the
+constructed operand term. Two sources that differ in receiver, in attribute,
+in value pairing or in store order MUST project differently.
 """
 
 from __future__ import annotations
 
+import hashlib
+import re
 from pathlib import Path
 
-from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome import Complete, Completed, Incomplete
 from sugar_lift_py_tests.sugar.assign_sugar import (
     MultiAssignSugar,
     UnpackStoreAssignSugar,
 )
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
-def _function_sugar(tmp_path: Path, source: str):
-    path = tmp_path / "assign_case.py"
+def _function(tmp_path: Path, source: str, stem: str = "assign_case"):
+    path = tmp_path / f"{stem}.py"
     path.write_text(source, encoding="utf-8")
-    return next(SourceFile(path_source(str(path))).functions()).sugar()
+    return next(SourceFile(path_source(str(path))).functions())
 
 
-def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
-    sugar = _function_sugar(
-        tmp_path,
-        "def f(o, p, q):\n" "    o.x, o.y = p, q\n" "    return o\n",
-    )
-    # FunctionUniverseSugar wraps the body; walk for UnpackStoreAssignSugar.
-    assert any(isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements), [
-        type(s).__name__ for s in sugar.statements
-    ]
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete)
+def _function_sugar(tmp_path: Path, source: str, stem: str = "assign_case"):
+    return _function(tmp_path, source, stem).sugar()
 
 
-def test_dual_subscript_display_unpack_constructs(tmp_path: Path) -> None:
-    sugar = _function_sugar(
-        tmp_path,
-        "def f(a, b, p, q):\n" "    a[0], b[1] = p, q\n" "    return a\n",
-    )
-    assert any(isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements)
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete)
-
-
-def test_name_plus_subscript_display_unpack_constructs(tmp_path: Path) -> None:
-    sugar = _function_sugar(
-        tmp_path,
-        "def f(a, p, q):\n" "    x, a[0] = p, q\n" "    return x\n",
-    )
-    unpack = next(
+def _unpack(tmp_path: Path, source: str, stem: str = "assign_case"):
+    sugar = _function_sugar(tmp_path, source, stem)
+    return next(
         stmt for stmt in sugar.statements if isinstance(stmt, UnpackStoreAssignSugar)
     )
-    assert unpack.bindings and unpack.bindings[0][0] == "x"
-    assert len(unpack.stores) == 1
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete)
 
 
-def test_three_attribute_display_unpack_constructs(tmp_path: Path) -> None:
-    sugar = _function_sugar(
-        tmp_path,
-        "def f(o, p, q, r):\n" "    o.x, o.y, o.z = p, q, r\n" "    return o\n",
+def _record(tmp_path: Path, source: str, stem: str = "assign_case"):
+    return _function_sugar(tmp_path, source, stem).desugar(None).value.record
+
+
+def _projection(tmp_path: Path, source: str, stem: str = "assign_case"):
+    """Ordered, site-free projection of every entry the block record carries.
+
+    Effect entries project (class, reason-without-site, constructed operand
+    term). Value entries project their post contribution. This is the artifact
+    that any of laws 2, 3 and 4 would have to corrupt to go unnoticed.
+    """
+    rows = []
+    for entry in _record(tmp_path, source, stem).statements:
+        effect = getattr(entry, "effect", None)
+        if effect is None:
+            rows.append(("value", type(entry).__name__, str(entry.post_contribution())))
+            continue
+        rows.append(
+            (
+                type(effect).__name__,
+                re.sub(r" site=.*$", "", effect.reason),
+                str(getattr(effect.runtime_operand, "term", None)),
+            )
+        )
+    return tuple(rows)
+
+
+def _post(tmp_path: Path, source: str, stem: str = "assign_case"):
+    return _function_sugar(tmp_path, source, stem).desugar(None).value.post()
+
+
+TWO_ATTRIBUTE = "def f(o, p, q):\n    o.x, o.y = p, q\n    return o\n"
+
+
+# ---------------------------------------------------------------------------
+# Law 1 -- the RHS is constructed once.
+# ---------------------------------------------------------------------------
+
+
+def test_rhs_member_is_one_retained_occurrence(tmp_path: Path) -> None:
+    """`o.x, o.y = p, p` must retain ONE constructed occurrence of `p`.
+
+    Proven at the layer that owns it: construction identity of the retained
+    occurrence. No counter, no instrumented call tally -- if the RHS were
+    re-evaluated (reconstructed) per target, the two stores would hold two
+    distinct constructed objects.
+    """
+    unpack = _unpack(tmp_path, "def f(o, p):\n    o.x, o.y = p, p\n    return o\n")
+    first, second = unpack.stores[0].value, unpack.stores[1].value
+    assert first is second, (first, second)
+
+    # Discrimination: distinct RHS members must NOT collapse onto one
+    # occurrence -- sharing must come from the source, never from the lift.
+    distinct = _unpack(tmp_path, TWO_ATTRIBUTE, stem="distinct")
+    assert distinct.stores[0].value is not distinct.stores[1].value
+    assert distinct.stores[0].value != distinct.stores[1].value
+
+
+# ---------------------------------------------------------------------------
+# Law 2 -- positional correspondence.
+# ---------------------------------------------------------------------------
+
+
+def test_positional_correspondence_binds_each_target_to_its_own_member(
+    tmp_path: Path,
+) -> None:
+    """`o.x, o.y = p, q` stores p into `.x` and q into `.y` -- a swap must bite."""
+    rows = _projection(tmp_path, TWO_ATTRIBUTE)
+    assert rows[0][2] == (
+        "_Ctor(name='python:attribute_store', args=(_Var(name='o'), "
+        "_ConstStr(value='x', sort=PrimitiveSort(name='String')), _Var(name='p')))"
+    ), rows[0]
+    assert rows[1][2] == (
+        "_Ctor(name='python:attribute_store', args=(_Var(name='o'), "
+        "_ConstStr(value='y', sort=PrimitiveSort(name='String')), _Var(name='q')))"
+    ), rows[1]
+
+    # Discrimination arm: swap the two RHS members. The pairing -- and only the
+    # pairing -- changes, so the projection must differ.
+    swapped = _projection(
+        tmp_path, "def f(o, p, q):\n    o.x, o.y = q, p\n    return o\n", stem="swapped"
     )
-    assert any(isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements)
-    assert isinstance(sugar.desugar(None), Complete)
+    assert swapped != rows
+    assert [row[1] for row in swapped] == [row[1] for row in rows]
 
 
-def test_name_only_display_unpack_stays_multi_assign(tmp_path: Path) -> None:
-    sugar = _function_sugar(
+# ---------------------------------------------------------------------------
+# Law 3 -- left-to-right store order.
+# ---------------------------------------------------------------------------
+
+
+def test_store_effects_retain_left_to_right_order(tmp_path: Path) -> None:
+    """Three attribute stores appear in source order, not as an unordered bag."""
+    rows = _projection(
         tmp_path,
-        "def f(p, q):\n" "    a, b = p, q\n" "    return a + b\n",
+        "def f(o, p, q, r):\n    o.x, o.y, o.z = p, q, r\n    return o\n",
+    )
+    assert [
+        re.search(r"target `\.(\w)`", row[1]).group(1) for row in rows if row[0] != "value"
+    ] == ["x", "y", "z"], rows
+
+    # Discrimination arm: the same three stores written in a different order
+    # project in that different order -- order is carried, not normalized away.
+    reversed_rows = _projection(
+        tmp_path,
+        "def f(o, p, q, r):\n    o.z, o.y, o.x = r, q, p\n    return o\n",
+        stem="reversed",
+    )
+    assert [
+        re.search(r"target `\.(\w)`", row[1]).group(1)
+        for row in reversed_rows
+        if row[0] != "value"
+    ] == ["z", "y", "x"], reversed_rows
+    assert reversed_rows != rows
+
+
+# ---------------------------------------------------------------------------
+# Law 4 -- exact receiver coordinates.
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_receiver_and_name_retain_exact_coordinates(
+    tmp_path: Path,
+) -> None:
+    """Not "an attribute store happened" -- the exact receiver and attr terms."""
+    rows = _projection(
+        tmp_path, "def f(o, n, p, q):\n    o.x, n.y = p, q\n    return p\n"
+    )
+    assert "_Var(name='o')" in rows[0][2] and "value='x'" in rows[0][2], rows[0]
+    assert "_Var(name='n')" in rows[1][2] and "value='y'" in rows[1][2], rows[1]
+
+    # Discrimination arm 1: swap the receivers, keep everything else.
+    other_receiver = _projection(
+        tmp_path,
+        "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return p\n",
+        stem="recv",
+    )
+    assert other_receiver != rows
+
+    # Discrimination arm 2: keep the receivers, change one attribute name.
+    other_attr = _projection(
+        tmp_path,
+        "def f(o, n, p, q):\n    o.x, n.z = p, q\n    return p\n",
+        stem="attr",
+    )
+    assert other_attr != rows
+
+
+def test_lying_variants_are_distinguished_on_all_three_axes(tmp_path: Path) -> None:
+    """The lying twin must bite on receiver, on attribute AND on store order.
+
+    The class-level ``witnesses()`` pair varies only the attribute (`.z`).
+    These are the other two discriminations, asserted on the constructed
+    artifact: each perturbation alone changes the projection.
+    """
+    truthful = _projection(tmp_path, TWO_ATTRIBUTE)
+    wrong_receiver = _projection(
+        tmp_path,
+        "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return o\n",
+        stem="wr",
+    )
+    wrong_attribute = _projection(
+        tmp_path,
+        "def f(o, p, q):\n    o.x, o.z = p, q\n    return o\n",
+        stem="wa",
+    )
+    reversed_order = _projection(
+        tmp_path,
+        "def f(o, p, q):\n    o.y, o.x = q, p\n    return o\n",
+        stem="ro",
+    )
+    for label, lying in (
+        ("wrong receiver", wrong_receiver),
+        ("wrong attribute", wrong_attribute),
+        ("reversed store order", reversed_order),
+    ):
+        assert lying != truthful, label
+    # ...and the three lies are distinct from one another, so no single
+    # perturbation is standing in for all three.
+    assert len({wrong_receiver, wrong_attribute, reversed_order}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Law 5 -- a Name leaf's binding is discharged alongside the store.
+# ---------------------------------------------------------------------------
+
+
+def test_name_leaf_binding_is_discharged_beside_the_store_effect(
+    tmp_path: Path,
+) -> None:
+    """`x, o.a = p, q` binds x to p AND emits the `.a` store carrying q.
+
+    The Name leaf has no ordered record entry: substitute spends it before
+    desugar, threading `p` into every later reference. So "x = p occurs before
+    the store" is carried as: the store is the first record entry, and the
+    continuation's post already reads `p`.
+    """
+    source = "def f(o, p, q):\n    x, o.a = p, q\n    return x\n"
+    unpack = _unpack(tmp_path, source)
+    assert [name for name, _ in unpack.bindings] == ["x"]
+    assert len(unpack.stores) == 1
+
+    rows = _projection(tmp_path, source, stem="mix")
+    assert rows[0][0] == "AttributeStoreRuntimeEffect"
+    assert "_Var(name='o')" in rows[0][2] and "_Var(name='q')" in rows[0][2], rows[0]
+    assert str(_post(tmp_path, source, stem="post")) == (
+        "_Atomic(name='=', args=(_Var(name='out'), _Var(name='p')))"
+    )
+
+    # Discrimination arm: swap the members. x must now carry q, and the store
+    # must now carry p -- both halves flip together.
+    swapped = "def f(o, p, q):\n    x, o.a = q, p\n    return x\n"
+    swapped_rows = _projection(tmp_path, swapped, stem="mixswap")
+    assert "_Var(name='p')" in swapped_rows[0][2], swapped_rows[0]
+    assert str(_post(tmp_path, swapped, stem="swpost")) == (
+        "_Atomic(name='=', args=(_Var(name='out'), _Var(name='q')))"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Laws 6 and 7 -- partial assignment. NOT yet representable: pinned as a ratchet.
+# ---------------------------------------------------------------------------
+
+
+def test_store_effects_have_no_halted_exit_arm(tmp_path: Path) -> None:
+    """RATCHET, not a rubber stamp: partial assignment is NOT yet modelled.
+
+    Python assignment is not transactional -- if `o.y = q` raises, `o.x = p`
+    stays done and `o.y` never happens. Laws 6 and 7 need an outgoing ExitSet
+    with a Halted arm carrying the state reached before the failure, and a
+    Completed arm without the later store.
+
+    Measured today: the outgoing ExitSet has exactly ONE arm, Completed, for
+    both the unpack shape AND for the already-shipped sequential form
+    `o.x = p; o.y = q` -- ``Incomplete.follow`` routes every store effect
+    through ``_effect_continues_control_flow``. So this is a tree-wide
+    property of the store family, NOT something #6239 introduced; narrowing
+    the unpack shape would not reduce it while the two-statement spelling
+    stays admitted.
+
+    This twin pins that measurement. When sequential ExitSet composition
+    lands, this twin goes RED and must be replaced by real laws 6 and 7 twins
+    asserting the halted exit's carried binding state and the absence of the
+    later store from the outgoing exit set.
+    """
+    unpack_exits = reduce_block_to_exitset(
+        _function_sugar(tmp_path, TWO_ATTRIBUTE).statements, None
+    ).exits
+    sequential_exits = reduce_block_to_exitset(
+        _function_sugar(
+            tmp_path,
+            "def f(o, p, q):\n    o.x = p\n    o.y = q\n    return o\n",
+            stem="sequential",
+        ).statements,
+        None,
+    ).exits
+
+    for label, exits in (("unpack", unpack_exits), ("sequential", sequential_exits)):
+        assert len(exits) == 1, (label, [type(a).__name__ for a in exits])
+        assert isinstance(exits[0], Completed), (label, type(exits[0]).__name__)
+
+    # The store effects themselves are the thing that continues -- named, so a
+    # change to the follow routing lands here rather than silently elsewhere.
+    unpack = _unpack(tmp_path, TWO_ATTRIBUTE, stem="follow")
+    for store in unpack.stores:
+        outcome = store.desugar(None)
+        assert isinstance(outcome, Incomplete)
+        assert outcome.follow().continues is True
+
+
+# ---------------------------------------------------------------------------
+# Law 8 -- pure-name MultiAssign is unchanged vs origin/main.
+# ---------------------------------------------------------------------------
+
+# Fingerprints of the constructed graph, measured on origin/main (which lacks
+# UnpackStoreAssignSugar entirely) and on this branch. Identical on both.
+MAIN_FINGERPRINTS = {
+    "def f(p, q):\n    a, b = p, q\n    return a + b\n": (
+        "a759418749e787d443760eb87874d8be"
+    ),
+    "def f(p, q, r):\n    a, b, c = p, q, r\n    return a + b + c\n": (
+        "c1a84ba04f846dfdb3b908f9ef245627"
+    ),
+    "def f(p):\n    x = y = p\n    return x + y\n": (
+        "cdae1b2a2b67be6ecf2476b3cbc1e1d5"
+    ),
+}
+
+
+def _fingerprint(tmp_path: Path, source: str, stem: str) -> str:
+    sugar = _function_sugar(tmp_path, source, stem)
+    text = "\n".join(
+        [
+            *(type(stmt).__name__ for stmt in sugar.statements),
+            repr(sugar.desugar(None).value.record),
+        ]
+    )
+    text = re.sub(r"/.*?/%s\.py" % re.escape(stem), "CASE", text)
+    text = re.sub(r"blake3-512:[0-9a-f]+", "CID", text)
+    text = re.sub(r"<SourceFragment[^>]*>", "FRAGMENT", text)
+    return hashlib.blake2b(text.encode(), digest_size=16).hexdigest()
+
+
+def test_pure_name_multi_assign_construction_is_unchanged(tmp_path: Path) -> None:
+    """Not "it is a MultiAssignSugar" -- the constructed graph is byte-identical.
+
+    Pinned against fingerprints measured by running this same projection with
+    PYTHONPATH pointed at an ``origin/main`` checkout. Any drift in the
+    pure-name path -- the path this branch must not touch -- flips this red.
+    """
+    for index, (source, expected) in enumerate(MAIN_FINGERPRINTS.items()):
+        stem = f"pure{index}"
+        assert _fingerprint(tmp_path, source, stem) == expected, source
+
+    sugar = _function_sugar(
+        tmp_path, "def f(p, q):\n    a, b = p, q\n    return a + b\n", stem="purekind"
     )
     assert any(isinstance(stmt, MultiAssignSugar) for stmt in sugar.statements)
     assert not any(
         isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements
     )
 
-
-def test_star_against_opaque_iterable_stays_loud(tmp_path: Path) -> None:
-    """Non-display starred unpack remains a construction gap (#6078 territory)."""
-    path = tmp_path / "star.py"
-    path.write_text(
-        "def f(xs):\n" "    a, *rest = xs\n" "    return a\n",
-        encoding="utf-8",
+    # Discrimination arm: the fingerprint is sensitive -- a different pure-name
+    # assign does not collide with the pinned one.
+    assert (
+        _fingerprint(tmp_path, "def f(p, q):\n    a, b = q, p\n    return a + b\n", "d")
+        not in MAIN_FINGERPRINTS.values()
     )
-    fn = next(SourceFile(path_source(str(path))).functions())
+
+
+# ---------------------------------------------------------------------------
+# Laws 9 and 10 -- what stays typed-loud.
+# ---------------------------------------------------------------------------
+
+
+def _assert_loud(tmp_path: Path, source: str, stem: str) -> None:
+    fn = _function(tmp_path, source, stem)
     try:
         fn.sugar()
-        raise AssertionError("expected SugarNotWritten for opaque star unpack")
     except SugarNotWritten as gap:
-        assert "Assign" in gap.owner or "Assign" in str(gap)
+        assert "Assign" in gap.owner or "Assign" in str(gap), gap
+        return
+    raise AssertionError(f"expected SugarNotWritten [Assign.sugar] for: {source!r}")
+
+
+def test_star_against_opaque_iterable_stays_loud(tmp_path: Path) -> None:
+    """Starred opaque unpack is not a replacement binding door (#6078)."""
+    _assert_loud(tmp_path, "def f(xs):\n    a, *rest = xs\n    return a\n", "star")
+
+    # Discrimination arm: a starred unpack against a CONCRETE display is a
+    # different shape and must still construct -- "loud" is about the opaque
+    # iterable, not about the star.
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(p, q, r):\n    a, *rest = p, q, r\n    return a\n",
+        stem="stardisplay",
+    )
+    assert any(isinstance(stmt, MultiAssignSugar) for stmt in sugar.statements)
+
+
+def test_opaque_receiver_subscript_leaves_stay_loud(tmp_path: Path) -> None:
+    """A store that cannot carry its receiver or its value is not admitted.
+
+    ``SubscriptStoreEffectSugar`` holds only ``index_text`` and a site, so
+    ``a[i], b[j] = p, q`` and ``a[i], b[j] = q, p`` construct identically --
+    positional correspondence, the whole claim of an unpack, would be
+    unprovable. Those shapes stay typed-loud.
+    """
+    _assert_loud(
+        tmp_path,
+        "def f(a, b, i, j, p, q):\n    a[i], b[j] = p, q\n    return p\n",
+        "sub2",
+    )
+    _assert_loud(
+        tmp_path, "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n", "namesub"
+    )
+
+    # Discrimination arm: the Attribute sibling -- which DOES carry receiver
+    # and value -- is still admitted, so this is a coordinate-retention rule,
+    # not a blanket refusal of store leaves.
+    unpack = _unpack(
+        tmp_path, "def f(o, p, q):\n    x, o.a = p, q\n    return x\n", stem="nameattr"
+    )
+    assert len(unpack.stores) == 1
+
+
+def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
+    """The admitted shape still constructs to a Complete universe."""
+    out = _function_sugar(tmp_path, TWO_ATTRIBUTE).desugar(None)
+    assert isinstance(out, Complete)
+    assert len(_unpack(tmp_path, TWO_ATTRIBUTE, stem="dual").stores) == 2

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
@@ -22,6 +22,27 @@ store branch supplies the exit algebra. Red here is the law failing, not a
 missing construction -- the unpack currently reduces to ONE unconditional
 ``Complete``, i.e. it states that an attribute/subscript store is infallible.
 
+GATE CONDITIONS FOR WHOEVER TURNS THESE GREEN -- all four are red at the SAME
+line today (``_exits`` raises before any body runs), so none of the per-twin
+structure below has ever executed. Green is not enough; check each:
+
+  1. Both ``_discrimination`` twins currently die inside ``_exits`` and never
+     reach their ``pytest.raises`` block, so right now they are duplicates of
+     the two law twins, not independent evidence. When ``_exits`` returns an
+     ``ExitSet``, confirm each one actually ENTERS its ``pytest.raises`` body
+     and that the body's assertion genuinely fails. A
+     ``pytest.raises(AssertionError)`` wrapper is the classic shape that goes
+     green while asking nothing.
+
+  2. ``test_unpack_two_stores_..._discrimination`` only requires
+     ``_store_entries(first.state) != 1``, which 0 AND 2 both satisfy. The law
+     twin's ``== []`` carries the real claim. Do not count that discrimination
+     as independent evidence for the empty-prefix law.
+
+  3. The law twins have never run past their first assertion either. Re-measure
+     every line, do not assume the arm counts and polarities are right merely
+     because the file stops failing.
+
 # TODO(post-store-merge): the helper block below (``_exits``, ``_walk``,
 # ``_terms``, ``_subterms``, ``_store_coordinates``, ``_selectors``,
 # ``_polarity``, ``_arms``, ``_store_entries``) is copied verbatim from
@@ -29,7 +50,9 @@ missing construction -- the unpack currently reduces to ONE unconditional
 # this file was written because ``feat/store-exitset-composition`` was not yet
 # on main. Once the store foundation merges, DELETE this block and import the
 # helpers from ``test_store_outcome_composition`` instead -- one definition,
-# one owner.
+# one owner. While doing that, switch ``_exits`` off
+# ``NamedTemporaryFile(delete=False, dir="/tmp")``: it leaks a .py per call and
+# bypasses pytest's ``tmp_path``, which every other twin in this package uses.
 """
 
 from __future__ import annotations

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
@@ -17,142 +17,40 @@ through that composition: a store leaf inside an unpack is not a different kind
 of store, so ``x, o.y = p, q`` and ``o.x, o.y = p, q`` must produce exactly the
 same arm structure as the sequential spelling.
 
-These are RED until BOTH halves land: this branch constructs the unpack, the
-store branch supplies the exit algebra. Red here is the law failing, not a
-missing construction -- the unpack currently reduces to ONE unconditional
-``Complete``, i.e. it states that an attribute/subscript store is infallible.
+ONE CONTROL MODEL: the helpers below are IMPORTED from the sequential twins'
+module, not copied. If the two spellings were reading the artifact through two
+instruments, "the same laws" would be an assertion about the instruments rather
+than about the construction. ``UnpackStoreAssignSugar.desugar`` likewise owns no
+sequencing of its own -- it hands its store leaves to ``reduce_body``, i.e. to
+``reduce_block_to_exitset``, the same reducer the sequential spelling reaches
+directly. The success/halt partition is minted in exactly one place
+(``FollowStep.halt_guard`` handling in ``function_universe_sugar``).
 
-GATE CONDITIONS FOR WHOEVER TURNS THESE GREEN -- all four are red at the SAME
-line today (``_exits`` raises before any body runs), so none of the per-twin
-structure below has ever executed. Green is not enough; check each:
+GATE CONDITIONS recorded before these went green -- DISCHARGED, kept here so the
+discharge is auditable rather than assumed:
 
-  1. Both ``_discrimination`` twins currently die inside ``_exits`` and never
-     reach their ``pytest.raises`` block, so right now they are duplicates of
-     the two law twins, not independent evidence. When ``_exits`` returns an
-     ``ExitSet``, confirm each one actually ENTERS its ``pytest.raises`` body
-     and that the body's assertion genuinely fails. A
-     ``pytest.raises(AssertionError)`` wrapper is the classic shape that goes
-     green while asking nothing.
-
-  2. ``test_unpack_two_stores_..._discrimination`` only requires
-     ``_store_entries(first.state) != 1``, which 0 AND 2 both satisfy. The law
-     twin's ``== []`` carries the real claim. Do not count that discrimination
-     as independent evidence for the empty-prefix law.
-
-  3. The law twins have never run past their first assertion either. Re-measure
-     every line, do not assume the arm counts and polarities are right merely
-     because the file stops failing.
-
-# TODO(post-store-merge): the helper block below (``_exits``, ``_walk``,
-# ``_terms``, ``_subterms``, ``_store_coordinates``, ``_selectors``,
-# ``_polarity``, ``_arms``, ``_store_entries``) is copied verbatim from
-# ``tests/test_store_outcome_composition.py``. It could not be imported when
-# this file was written because ``feat/store-exitset-composition`` was not yet
-# on main. Once the store foundation merges, DELETE this block and import the
-# helpers from ``test_store_outcome_composition`` instead -- one definition,
-# one owner. While doing that, switch ``_exits`` off
-# ``NamedTemporaryFile(delete=False, dir="/tmp")``: it leaks a .py per call and
-# bypasses pytest's ``tmp_path``, which every other twin in this package uses.
+  1. Both ``_discrimination`` twins used to die inside ``_exits`` and never
+     reach their ``pytest.raises`` block, so they were duplicates of the two law
+     twins rather than independent evidence. They now enter those bodies; each
+     was re-checked to fail for its own reason (a ``pytest.raises(AssertionError)``
+     wrapper is the classic shape that goes green while asking nothing).
+  2. ``test_unpack_two_stores_..._discrimination`` only required
+     ``_store_entries(first.state) != 1``, which 0 AND 2 both satisfy. It now
+     pins the EXACT arm cardinality from both sides.
+  3. The law twins had never run past their first assertion. Every line was
+     re-measured against the constructed artifact, and each twin was perturbed
+     (prefix splice removed; unpack projected onto its sole completed arm; store
+     order reversed) to confirm it fails for the right reason.
 """
 
 from __future__ import annotations
 
-import tempfile
-
 import pytest
 
-from sugar_lift_python_source.source_oracle import path_source
-from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
-from sugar_lift_py_tests.outcome import Incomplete
-from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
-from sugar_source_tree.tree import SourceFile
-
-# --------------------------------------------------------------------------
-# TODO(post-store-merge): dedupe -- import from test_store_outcome_composition.
-# --------------------------------------------------------------------------
-
-
-def _exits(src, name):
-    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
-        path = f.name
-    for fn in SourceFile(path_source(path)).functions():
-        if fn.name != name:
-            continue
-        outcome = fn.sugar().desugar(None)
-        assert isinstance(outcome, ExitSet), (
-            "a body containing a store must reduce to guarded exits, not one "
-            f"unconditional outcome; got {type(outcome).__name__}"
-        )
-        return outcome
-    raise AssertionError(f"no function {name}")
-
-
-def _walk(formula):
-    yield formula
-    for operand in getattr(formula, "operands", ()) or ():
-        yield from _walk(operand)
-
-
-def _terms(formula):
-    for node in _walk(formula):
-        for arg in getattr(node, "args", ()) or ():
-            yield from _subterms(arg)
-
-
-def _subterms(term):
-    yield term
-    for arg in getattr(term, "args", ()) or ():
-        yield from _subterms(arg)
-
-
-def _store_coordinates(formula):
-    """Every distinct store-occurrence coordinate cited by a guard."""
-    found = []
-    for term in _terms(formula):
-        if getattr(term, "name", None) == "python:store_completed":
-            if term not in found:
-                found.append(term)
-    return tuple(found)
-
-
-def _selectors(formula):
-    """The selector (attr name) of each store coordinate cited by a guard."""
-    out = []
-    for coordinate in _store_coordinates(formula):
-        operation = coordinate.args[1]
-        out.append(operation.args[1].value)
-    return tuple(out)
-
-
-def _polarity(formula, selector):
-    """True when the guard asserts the named store COMPLETED, False when it
-    asserts the complement, None when the guard does not mention it."""
-    for node in _walk(formula):
-        if getattr(node, "kind", None) != "not":
-            continue
-        (inner,) = node.operands
-        if selector in _selectors(inner):
-            return False
-    if selector in _selectors(formula):
-        return True
-    return None
-
-
-def _arms(exits):
-    halted = [e for e in exits.exits if isinstance(e, Halted)]
-    completed = [e for e in exits.exits if isinstance(e, Completed)]
-    return halted, completed
-
-
-def _store_entries(state):
-    return [
-        entry
-        for entry in getattr(state, "entries", ())
-        if isinstance(entry, Incomplete)
-        and isinstance(entry.effect, AttributeStoreRuntimeEffect)
-    ]
-
+# ONE definition, one owner. These were duplicated verbatim while the store
+# ExitSet foundation was still on a branch; it is on main now, so the copy is
+# deleted rather than left to diverge silently.
+from test_store_outcome_composition import _arms, _exits, _polarity, _store_entries
 
 UNPACK_MIXED = """def target(o, p, q):
     x, o.y = p, q
@@ -174,18 +72,19 @@ UNPACK_BOTH = """def target(o, p, q):
 #
 # They are stated as the real laws rather than pinned to the current behaviour
 # on purpose: a test that must be DELETED when the bug is fixed is a test of the
-# bug.
+# bug, and a test that must be EDITED when the fix lands was asserting the
+# defect.
 # --------------------------------------------------------------------------
 
 
-def test_unpack_mixed_name_and_store_preserves_both_outcomes():
+def test_unpack_mixed_name_and_store_preserves_both_outcomes(tmp_path) -> None:
     """``x, o.y = p, q``
 
     success arm: ``x == p``, the store on ``o.y`` completed, continuation runs.
     halt arm:    ``x == p`` STILL -- the name target was already bound -- the
                  store halted, and there is NO continuation.
     """
-    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
+    halted, completed = _arms(_exits(tmp_path, UNPACK_MIXED, "target"))
 
     assert len(completed) == 1
     assert _polarity(completed[0].guard, "y") is True
@@ -193,24 +92,60 @@ def test_unpack_mixed_name_and_store_preserves_both_outcomes():
 
     (arm,) = halted
     assert _polarity(arm.guard, "y") is False
-    assert "p" in str(arm.state.post() if hasattr(arm.state, "post") else arm.state), (
-        "the name target bound before the store must survive the store's halt"
+
+    # "x == p still" on the halt arm.
+    #
+    # A Name target is spent by substitute -- it is inlined into every later
+    # reference and materializes no entry on either arm -- so it cannot be
+    # asserted as a retained entry on the halted state; there is nothing there
+    # to lose and nothing there to read. The claim with an artifact behind it
+    # is the one about anything ESTABLISHED before the store, and the honest
+    # spelling of it is a preceding store: it must survive.
+    prior = "def target(o, p, q):\n    o.z = p\n    x, o.y = p, q\n    return x\n"
+    prior_halted, prior_completed = _arms(_exits(tmp_path, prior, "target"))
+    survivor = next(h for h in prior_halted if _polarity(h.guard, "y") is False)
+    assert _polarity(survivor.guard, "z") is True
+    assert len(_store_entries(survivor.state)) == 1, (
+        "the store completed before the halting one must survive the halt -- "
+        "Python rolls back nothing"
     )
+    assert "attr=z" in _store_entries(survivor.state)[0].effect.reason
+    assert len(prior_completed) == 1
 
 
-def test_unpack_mixed_name_and_store_preserves_both_outcomes_discrimination():
-    """The bite: a single unconditional arm would mean the store cannot fail."""
-    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
+def test_unpack_mixed_name_and_store_preserves_both_outcomes_discrimination(
+    tmp_path,
+) -> None:
+    """The bite: a single unconditional arm would mean the store cannot fail.
+
+    Stated as the EXACT pre-repair cardinality (0 halted, 1 completed) so that
+    the arm count is pinned from both sides -- ``!= 1`` would be satisfied by a
+    zero-arm reading as well as by the real two-arm one.
+    """
+    halted, completed = _arms(_exits(tmp_path, UNPACK_MIXED, "target"))
 
     with pytest.raises(AssertionError):
         assert len(halted) == 0 and len(completed) == 1, "store is infallible"
 
+    # ...and the guard on the halt arm really is this store's complement, not
+    # some unrelated coordinate that happens to be negated.
+    with pytest.raises(AssertionError):
+        assert _polarity(halted[0].guard, "y") is True, "halt arm asserts completion"
 
-def test_unpack_two_stores_preserve_both_outcomes_per_store():
+    # ...and the non-rollback reading bites: a halted arm with an empty prefix
+    # after an earlier store is the transactional lie.
+    prior = "def target(o, p, q):\n    o.z = p\n    x, o.y = p, q\n    return x\n"
+    prior_halted, _ = _arms(_exits(tmp_path, prior, "target"))
+    survivor = next(h for h in prior_halted if _polarity(h.guard, "y") is False)
+    with pytest.raises(AssertionError):
+        assert _store_entries(survivor.state) == [], "assignment rolled back"
+
+
+def test_unpack_two_stores_preserve_both_outcomes_per_store(tmp_path) -> None:
     """``o.x, o.y = p, q`` -- the same three arms as the sequential spelling:
     first success + second success, first success + second halt, and first halt
     with NO second-store occurrence."""
-    halted, completed = _arms(_exits(UNPACK_BOTH, "target"))
+    halted, completed = _arms(_exits(tmp_path, UNPACK_BOTH, "target"))
 
     assert len(completed) == 1
     assert len(halted) == 2
@@ -224,10 +159,67 @@ def test_unpack_two_stores_preserve_both_outcomes_per_store():
     assert len(_store_entries(second.state)) == 1
 
 
-def test_unpack_two_stores_preserve_both_outcomes_per_store_discrimination():
-    """The bite: the first-halt arm must not carry the second store."""
-    halted, _ = _arms(_exits(UNPACK_BOTH, "target"))
+def test_unpack_two_stores_preserve_both_outcomes_per_store_discrimination(
+    tmp_path,
+) -> None:
+    """The bite: the first-halt arm must not carry the second store, and the
+    three-arm structure is pinned to EXACTLY three.
+
+    ``len(halted) != 1`` would be satisfied by zero halted arms too -- i.e. by
+    the very defect these twins exist to forbid -- so the cardinality is stated
+    exactly.
+    """
+    halted, completed = _arms(_exits(tmp_path, UNPACK_BOTH, "target"))
     first = next(h for h in halted if _polarity(h.guard, "x") is False)
 
     with pytest.raises(AssertionError):
         assert len(_store_entries(first.state)) == 1, "second target ran anyway"
+
+    with pytest.raises(AssertionError):
+        assert (len(halted), len(completed)) == (0, 1), "stores are infallible"
+
+    with pytest.raises(AssertionError):
+        assert (len(halted), len(completed)) == (1, 1), "one store swallowed the other"
+
+    # ...and the first-halt arm is not conditioned on the second store at all.
+    with pytest.raises(AssertionError):
+        assert _polarity(first.guard, "y") is not None, "second store was consulted"
+
+
+def test_unpack_and_sequential_spellings_produce_the_same_arm_structure(
+    tmp_path,
+) -> None:
+    """T's merge criterion, stated as a twin.
+
+    ``o.x = p; o.y = q`` and ``o.x, o.y = p, q`` are two spellings of the same
+    two stores. Read through the SAME instrument they must present the same
+    partition: three arms, the same guard polarities per store, the same prefix
+    contents per halted arm. Anything else means the unpack grew a second
+    sequencing door.
+    """
+    sequential = "def target(o, p, q):\n    o.x = p\n    o.y = q\n    return p\n"
+
+    def shape(src):
+        halted, completed = _arms(_exits(tmp_path, src, "target"))
+        return (
+            len(completed),
+            sorted(
+                (
+                    _polarity(h.guard, "x"),
+                    _polarity(h.guard, "y"),
+                    len(_store_entries(h.state)),
+                )
+                for h in halted
+            ),
+            sorted(
+                (_polarity(c.guard, "x"), _polarity(c.guard, "y")) for c in completed
+            ),
+        )
+
+    assert shape(UNPACK_BOTH) == shape(sequential)
+
+    # Discrimination: the instrument is not blind -- a spelling with only ONE
+    # store presents a different shape through the same reader.
+    assert shape(UNPACK_BOTH) != shape(
+        "def target(o, p, q):\n    o.x = p\n    return p\n"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
@@ -1,0 +1,210 @@
+"""Unpack store-outcome composition laws -- owned by the Assign-family branch.
+
+Ownership boundary (T's ruling):
+
+    store ExitSet branch   owns generic store success/halt composition
+                           owns sequential assignment spelling
+
+    this branch (#6239)    owns tuple/multi-target construction
+                           owns unpack sequencing through that composition
+
+The generic algebra -- ``python:store_completed(occurrence, operation)``,
+``FollowStep.halt_guard``, ``Halted(g, effect, prefix_state)`` paired with
+``Completed(not g, state_with_testimony)`` -- is the store branch's work and is
+proven there by the SEQUENTIAL twins. What is proven HERE is that the
+tuple/multi-target ``Assign`` construction this branch owns actually flows
+through that composition: a store leaf inside an unpack is not a different kind
+of store, so ``x, o.y = p, q`` and ``o.x, o.y = p, q`` must produce exactly the
+same arm structure as the sequential spelling.
+
+These are RED until BOTH halves land: this branch constructs the unpack, the
+store branch supplies the exit algebra. Red here is the law failing, not a
+missing construction -- the unpack currently reduces to ONE unconditional
+``Complete``, i.e. it states that an attribute/subscript store is infallible.
+
+# TODO(post-store-merge): the helper block below (``_exits``, ``_walk``,
+# ``_terms``, ``_subterms``, ``_store_coordinates``, ``_selectors``,
+# ``_polarity``, ``_arms``, ``_store_entries``) is copied verbatim from
+# ``tests/test_store_outcome_composition.py``. It could not be imported when
+# this file was written because ``feat/store-exitset-composition`` was not yet
+# on main. Once the store foundation merges, DELETE this block and import the
+# helpers from ``test_store_outcome_composition`` instead -- one definition,
+# one owner.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+from sugar_source_tree.tree import SourceFile
+
+# --------------------------------------------------------------------------
+# TODO(post-store-merge): dedupe -- import from test_store_outcome_composition.
+# --------------------------------------------------------------------------
+
+
+def _exits(src, name):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    for fn in SourceFile(path_source(path)).functions():
+        if fn.name != name:
+            continue
+        outcome = fn.sugar().desugar(None)
+        assert isinstance(outcome, ExitSet), (
+            "a body containing a store must reduce to guarded exits, not one "
+            f"unconditional outcome; got {type(outcome).__name__}"
+        )
+        return outcome
+    raise AssertionError(f"no function {name}")
+
+
+def _walk(formula):
+    yield formula
+    for operand in getattr(formula, "operands", ()) or ():
+        yield from _walk(operand)
+
+
+def _terms(formula):
+    for node in _walk(formula):
+        for arg in getattr(node, "args", ()) or ():
+            yield from _subterms(arg)
+
+
+def _subterms(term):
+    yield term
+    for arg in getattr(term, "args", ()) or ():
+        yield from _subterms(arg)
+
+
+def _store_coordinates(formula):
+    """Every distinct store-occurrence coordinate cited by a guard."""
+    found = []
+    for term in _terms(formula):
+        if getattr(term, "name", None) == "python:store_completed":
+            if term not in found:
+                found.append(term)
+    return tuple(found)
+
+
+def _selectors(formula):
+    """The selector (attr name) of each store coordinate cited by a guard."""
+    out = []
+    for coordinate in _store_coordinates(formula):
+        operation = coordinate.args[1]
+        out.append(operation.args[1].value)
+    return tuple(out)
+
+
+def _polarity(formula, selector):
+    """True when the guard asserts the named store COMPLETED, False when it
+    asserts the complement, None when the guard does not mention it."""
+    for node in _walk(formula):
+        if getattr(node, "kind", None) != "not":
+            continue
+        (inner,) = node.operands
+        if selector in _selectors(inner):
+            return False
+    if selector in _selectors(formula):
+        return True
+    return None
+
+
+def _arms(exits):
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    return halted, completed
+
+
+def _store_entries(state):
+    return [
+        entry
+        for entry in getattr(state, "entries", ())
+        if isinstance(entry, Incomplete)
+        and isinstance(entry.effect, AttributeStoreRuntimeEffect)
+    ]
+
+
+UNPACK_MIXED = """def target(o, p, q):
+    x, o.y = p, q
+    return x
+"""
+
+UNPACK_BOTH = """def target(o, p, q):
+    o.x, o.y = p, q
+    return p
+"""
+
+
+# --------------------------------------------------------------------------
+# Unpack spelling:  x, o.y = p, q   and   o.x, o.y = p, q
+#
+# THE SAME LAWS as the sequential spelling. These are the same store family; a
+# store target inside a tuple-unpack assignment is not a different kind of
+# store.
+#
+# They are stated as the real laws rather than pinned to the current behaviour
+# on purpose: a test that must be DELETED when the bug is fixed is a test of the
+# bug.
+# --------------------------------------------------------------------------
+
+
+def test_unpack_mixed_name_and_store_preserves_both_outcomes():
+    """``x, o.y = p, q``
+
+    success arm: ``x == p``, the store on ``o.y`` completed, continuation runs.
+    halt arm:    ``x == p`` STILL -- the name target was already bound -- the
+                 store halted, and there is NO continuation.
+    """
+    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
+
+    assert len(completed) == 1
+    assert _polarity(completed[0].guard, "y") is True
+    assert "p" in str(completed[0].value.post())
+
+    (arm,) = halted
+    assert _polarity(arm.guard, "y") is False
+    assert "p" in str(arm.state.post() if hasattr(arm.state, "post") else arm.state), (
+        "the name target bound before the store must survive the store's halt"
+    )
+
+
+def test_unpack_mixed_name_and_store_preserves_both_outcomes_discrimination():
+    """The bite: a single unconditional arm would mean the store cannot fail."""
+    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
+
+    with pytest.raises(AssertionError):
+        assert len(halted) == 0 and len(completed) == 1, "store is infallible"
+
+
+def test_unpack_two_stores_preserve_both_outcomes_per_store():
+    """``o.x, o.y = p, q`` -- the same three arms as the sequential spelling:
+    first success + second success, first success + second halt, and first halt
+    with NO second-store occurrence."""
+    halted, completed = _arms(_exits(UNPACK_BOTH, "target"))
+
+    assert len(completed) == 1
+    assert len(halted) == 2
+
+    first = next(h for h in halted if _polarity(h.guard, "x") is False)
+    assert _polarity(first.guard, "y") is None
+    assert _store_entries(first.state) == []
+
+    second = next(h for h in halted if _polarity(h.guard, "y") is False)
+    assert _polarity(second.guard, "x") is True
+    assert len(_store_entries(second.state)) == 1
+
+
+def test_unpack_two_stores_preserve_both_outcomes_per_store_discrimination():
+    """The bite: the first-halt arm must not carry the second store."""
+    halted, _ = _arms(_exits(UNPACK_BOTH, "target"))
+    first = next(h for h in halted if _polarity(h.guard, "x") is False)
+
+    with pytest.raises(AssertionError):
+        assert len(_store_entries(first.state)) == 1, "second target ran anyway"

--- a/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
@@ -30,7 +30,8 @@ expectation fails.
 
 from __future__ import annotations
 
-import tempfile
+import hashlib
+from pathlib import Path
 
 import pytest
 
@@ -41,11 +42,18 @@ from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
 from sugar_source_tree.tree import SourceFile
 
 
-def _exits(src, name):
-    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
-        path = f.name
-    for fn in SourceFile(path_source(path)).functions():
+def _exits(tmp_path: Path, src, name):
+    """The constructed ExitSet for ``name`` in ``src``.
+
+    ``tmp_path`` is pytest's per-test directory: the case file is written where
+    the fixture will remove it. An earlier spelling used
+    ``NamedTemporaryFile(delete=False, dir="/tmp")``, which leaked one ``.py``
+    per call.
+    """
+    stem = hashlib.blake2b(f"{name}\0{src}".encode(), digest_size=8).hexdigest()
+    path = tmp_path / f"case_{stem}.py"
+    path.write_text(src, encoding="utf-8")
+    for fn in SourceFile(path_source(str(path))).functions():
         if fn.name != name:
             continue
         outcome = fn.sugar().desugar(None)
@@ -145,34 +153,34 @@ OTHER_STORE = """def target(o, q):
 # --------------------------------------------------------------------------
 
 
-def test_sequential_stores_preserve_both_outcomes_per_store():
+def test_sequential_stores_preserve_both_outcomes_per_store(tmp_path: Path) -> None:
     """Two stores => three arms, never one.
 
     A single ``Completed`` arm would state that assignment is transactional and
     infallible. It is neither.
     """
-    halted, completed = _arms(_exits(SEQUENTIAL, "target"))
+    halted, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
 
     assert len(halted) == 2, [str(e.guard) for e in halted]
     assert len(completed) == 1
 
 
-def test_sequential_stores_preserve_both_outcomes_per_store_discrimination():
+def test_sequential_stores_preserve_both_outcomes_per_store_discrimination(tmp_path: Path) -> None:
     """The bite: the pre-repair expectation (one Completed arm, no Halted arm)
     is exactly what this construction no longer produces."""
-    halted, completed = _arms(_exits(SEQUENTIAL, "target"))
+    halted, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
 
     with pytest.raises(AssertionError):
         assert len(halted) == 0 and len(completed) == 1, "stores are infallible"
 
 
-def test_first_store_halt_has_no_second_store_occurrence():
+def test_first_store_halt_has_no_second_store_occurrence(tmp_path: Path) -> None:
     """Law: never execute a later target after an earlier store halt.
 
     The arm guarded by "the FIRST store did not complete" must carry a prefix
     state in which the second store never happened.
     """
-    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     first = next(h for h in halted if _polarity(h.guard, "x") is False)
 
     assert _polarity(first.guard, "y") is None, (
@@ -185,23 +193,23 @@ def test_first_store_halt_has_no_second_store_occurrence():
     assert isinstance(first.effect, AttributeStoreRuntimeEffect)
 
 
-def test_first_store_halt_has_no_second_store_occurrence_discrimination():
+def test_first_store_halt_has_no_second_store_occurrence_discrimination(tmp_path: Path) -> None:
     """The bite: asserting the second store DID occur on the first-halt arm
     fails, so the assertion above is load-bearing."""
-    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     first = next(h for h in halted if _polarity(h.guard, "x") is False)
 
     with pytest.raises(AssertionError):
         assert len(_store_entries(first.state)) == 1, "second target ran anyway"
 
 
-def test_second_store_halt_preserves_the_first_store():
+def test_second_store_halt_preserves_the_first_store(tmp_path: Path) -> None:
     """Law: never roll back earlier assignment.
 
     The arm guarded by "first completed AND second did not" must still carry the
     first store's testimony: ``o.x`` REMAINS assigned.
     """
-    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     second = next(h for h in halted if _polarity(h.guard, "y") is False)
 
     assert _polarity(second.guard, "x") is True, (
@@ -214,48 +222,48 @@ def test_second_store_halt_preserves_the_first_store():
     )
 
 
-def test_second_store_halt_preserves_the_first_store_discrimination():
+def test_second_store_halt_preserves_the_first_store_discrimination(tmp_path: Path) -> None:
     """The bite: a rolled-back first store (empty prefix) fails."""
-    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     second = next(h for h in halted if _polarity(h.guard, "y") is False)
 
     with pytest.raises(AssertionError):
         assert _store_entries(second.state) == [], "assignment rolled back"
 
 
-def test_sequential_completed_arm_requires_every_store_to_complete():
+def test_sequential_completed_arm_requires_every_store_to_complete(tmp_path: Path) -> None:
     """The continuation after the stores is reachable only when BOTH completed,
     and it still states the real post."""
-    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    _, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     (arm,) = completed
 
     assert _polarity(arm.guard, "x") is True
     assert _polarity(arm.guard, "y") is True
     assert str(arm.value.post()) == str(
-        _exits(SEQUENTIAL, "target").exits[-1].value.post()
+        _exits(tmp_path, SEQUENTIAL, "target").exits[-1].value.post()
     )
 
 
-def test_sequential_completed_arm_requires_every_store_to_complete_discrimination():
+def test_sequential_completed_arm_requires_every_store_to_complete_discrimination(tmp_path: Path) -> None:
     """The bite: an unconditional (true) completed guard fails -- the guard is
     a real conjunction of two store coordinates."""
     from sugar_lift_py_tests.outcome.exit_set import true_guard
 
-    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    _, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     (arm,) = completed
 
     with pytest.raises(AssertionError):
         assert arm.guard == true_guard(), "continuation is unconditional"
 
 
-def test_each_store_occurrence_mints_its_own_coordinate():
+def test_each_store_occurrence_mints_its_own_coordinate(tmp_path: Path) -> None:
     """Law: evaluate receiver, selector and value exactly once, and retain all
     three authenticated coordinates.
 
     Two distinct stores must not share one outcome coordinate, and each
     coordinate must name its own receiver, selector and value.
     """
-    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    _, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     coordinates = _store_coordinates(completed[0].guard)
 
     assert len(coordinates) == 2, coordinates
@@ -269,22 +277,22 @@ def test_each_store_occurrence_mints_its_own_coordinate():
     assert values == {"p", "q"}
 
 
-def test_each_store_occurrence_mints_its_own_coordinate_discrimination():
+def test_each_store_occurrence_mints_its_own_coordinate_discrimination(tmp_path: Path) -> None:
     """The bite: collapsing the two stores to one coordinate fails."""
-    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    _, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     coordinates = _store_coordinates(completed[0].guard)
 
     with pytest.raises(AssertionError):
         assert len(coordinates) == 1, "both stores share one outcome"
 
 
-def test_store_outcome_guards_are_exactly_complementary():
+def test_store_outcome_guards_are_exactly_complementary(tmp_path: Path) -> None:
     """The two faces of ONE store are ``g`` and ``not g`` over the SAME
     coordinate -- an exact partition, so ``ExitSet`` normalization can merge or
     kill them the way it does for a branch result."""
     from sugar_lift_py_tests.outcome.exit_set import _and_guards, false_guard
 
-    halted, completed = _arms(_exits(ONE_STORE, "target"))
+    halted, completed = _arms(_exits(tmp_path, ONE_STORE, "target"))
     (halt,) = halted
     (success,) = completed
 
@@ -295,15 +303,15 @@ def test_store_outcome_guards_are_exactly_complementary():
     )
 
 
-def test_store_outcome_guards_are_exactly_complementary_discrimination():
+def test_store_outcome_guards_are_exactly_complementary_discrimination(tmp_path: Path) -> None:
     """The bite: two DIFFERENT stores' guards are not contradictory -- so the
     contradiction above comes from complementarity, not from everything being
     trivially false."""
     from sugar_lift_py_tests.outcome.exit_set import _and_guards, false_guard
 
-    halted, _ = _arms(_exits(ONE_STORE, "target"))
+    halted, _ = _arms(_exits(tmp_path, ONE_STORE, "target"))
     (halt,) = halted
-    other, _unused = _arms(_exits(OTHER_STORE, "target"))
+    other, _unused = _arms(_exits(tmp_path, OTHER_STORE, "target"))
     (other_halt,) = other
 
     with pytest.raises(AssertionError):
@@ -312,20 +320,20 @@ def test_store_outcome_guards_are_exactly_complementary_discrimination():
         ), "unrelated store coordinates are contradictory"
 
 
-def test_no_invented_exception_type_on_a_store_halt():
+def test_no_invented_exception_type_on_a_store_halt(tmp_path: Path) -> None:
     """Success versus halt is runtime-selected. The halt arm must carry the
     store's own runtime effect, never a fabricated named exception."""
-    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
 
     for arm in halted:
         assert isinstance(arm.effect, AttributeStoreRuntimeEffect), type(arm.effect)
 
 
-def test_no_invented_exception_type_on_a_store_halt_discrimination():
+def test_no_invented_exception_type_on_a_store_halt_discrimination(tmp_path: Path) -> None:
     """The bite: the halt is NOT a RaiseEffect of some guessed class."""
     from sugar_lift_py_tests.effect import RaiseEffect
 
-    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
 
     with pytest.raises(AssertionError):
         assert all(isinstance(a.effect, RaiseEffect) for a in halted), "guessed"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2722,29 +2722,9 @@ class Assign(Statement):
         ):
             return None
 
-        starred = [
-            index
-            for index, element in enumerate(target.elts)
-            if isinstance(element, Starred)
-        ]
-        if len(starred) > 1:
+        pairs = self._display_unpack_pairs(target, value)
+        if pairs is None:
             return None
-        pairs = []
-        if not starred:
-            if len(target.elts) != len(value.elts):
-                return None
-            pairs = list(zip(target.elts, value.elts))
-        else:
-            star_index = starred[0]
-            suffix = len(target.elts) - star_index - 1
-            if len(value.elts) < len(target.elts) - 1:
-                return None
-            pairs.extend(zip(target.elts[:star_index], value.elts[:star_index]))
-            rest_end = len(value.elts) - suffix if suffix else len(value.elts)
-            rest = self._make_unpack_rest_list(value.elts[star_index:rest_end])
-            pairs.append((target.elts[star_index].value, rest))
-            if suffix:
-                pairs.extend(zip(target.elts[-suffix:], value.elts[-suffix:]))
 
         bindings = {}
         for child_target, child_value in pairs:
@@ -2752,6 +2732,75 @@ class Assign(Statement):
             if child is None:
                 return None
             bindings.update(child)
+        return bindings
+
+    def _display_unpack_pairs(self, target, value):
+        """Zip one Tuple/List target against a matching display RHS.
+
+        Supports at most one starred element. Returns ``None`` when arity or
+        structure cannot be authenticated from a concrete display.
+        """
+        if not isinstance(target, (Tuple_, List)) or not isinstance(
+            value, (Tuple_, List)
+        ):
+            return None
+        starred = [
+            index
+            for index, element in enumerate(target.elts)
+            if isinstance(element, Starred)
+        ]
+        if len(starred) > 1:
+            return None
+        if not starred:
+            if len(target.elts) != len(value.elts):
+                return None
+            return list(zip(target.elts, value.elts))
+        star_index = starred[0]
+        suffix = len(target.elts) - star_index - 1
+        if len(value.elts) < len(target.elts) - 1:
+            return None
+        pairs = list(zip(target.elts[:star_index], value.elts[:star_index]))
+        rest_end = len(value.elts) - suffix if suffix else len(value.elts)
+        rest = self._make_unpack_rest_list(value.elts[star_index:rest_end])
+        pairs.append((target.elts[star_index].value, rest))
+        if suffix:
+            pairs.extend(zip(target.elts[-suffix:], value.elts[-suffix:]))
+        return pairs
+
+    def _flat_store_unpack_pairs(self):
+        """Flat Name|Attribute|Subscript leaves against a display RHS.
+
+        Nested unpack patterns stay on the name-only destructure path (or
+        loud). This is the mass residual: ``o.x, o.y = p, q`` and
+        ``a[i], b[j] = p, q`` and mixed ``x, a[i] = p, q``.
+        """
+        if len(self.targets) != 1:
+            return None
+        target = self.targets[0]
+        if not isinstance(target, (Tuple_, List)):
+            return None
+        if not isinstance(self.value, (Tuple_, List)):
+            return None
+        pairs = self._display_unpack_pairs(target, self.value)
+        if pairs is None:
+            return None
+        for leaf, _value in pairs:
+            if not isinstance(leaf, (Name, Attribute, Subscript)):
+                return None
+        # Only useful when at least one leaf is a store (Attribute/Subscript);
+        # pure-Name flat unpack is MultiAssignSugar via _destructured_binding.
+        if not any(isinstance(leaf, (Attribute, Subscript)) for leaf, _ in pairs):
+            return None
+        return pairs
+
+    def _name_bindings_from_store_unpack(self, pairs):
+        """Lexical Name leaves only — stores are not temporal bindings."""
+        bindings = {}
+        for leaf, value in pairs:
+            if isinstance(leaf, Name):
+                bindings[leaf.id] = value
+            elif isinstance(leaf, Starred) and isinstance(leaf.value, Name):
+                bindings[leaf.value.id] = value
         return bindings
 
     def _make_unpack_rest_list(self, elements):
@@ -2844,7 +2893,18 @@ class Assign(Statement):
                     and entry.state.object_identity_cid
                     == target.value.object_identity_cid
                 }
-            return self._destructured_binding()
+            # Name-only nested/flat display unpack.
+            name_only = self._destructured_binding()
+            if name_only is not None:
+                return name_only
+            # Mixed Name + Attribute/Subscript leaves against a display: bind
+            # only the Name leaves; stores are construction effects, not
+            # temporal bindings.
+            store_pairs = self._flat_store_unpack_pairs()
+            if store_pairs is not None:
+                names = self._name_bindings_from_store_unpack(store_pairs)
+                return names if names else None
+            return None
         if all(isinstance(t, (Name, Attribute, Subscript)) for t in self.targets):
             # Store targets do not bind lexical names, but they also do not
             # erase the Name targets in the same left-to-right assignment.
@@ -3048,29 +3108,103 @@ class Assign(Statement):
 
         if len(self.targets) == 1 and isinstance(self.targets[0], (Tuple_, List)):
             bindings = self._destructured_binding()
-            if bindings is None:
-                target = self.targets[0]
-                if (
-                    not isinstance(self.value, (Tuple_, List))
-                    and target.elts
-                    and all(isinstance(item, Name) for item in target.elts)
-                ):
-                    from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
-                        DynamicUnpackAssignSugar,
-                    )
+            if bindings is not None:
+                from sugar_lift_py_tests.sugar.assign_sugar import MultiAssignSugar
 
-                    return DynamicUnpackAssignSugar(
-                        tuple(item.id for item in target.elts),
-                        self.value.sugar(),
-                        self.fragment,
-                    )
-                return super()._construct_sugar()
-            from sugar_lift_py_tests.sugar.assign_sugar import MultiAssignSugar
+                return MultiAssignSugar(
+                    bindings=tuple(
+                        (name, val.sugar()) for name, val in bindings.items()
+                    ),
+                    site=self.fragment,
+                )
+            # Flat Name|Attribute|Subscript leaves against a display RHS —
+            # historical factory mass (dual-subscript / multi-attribute unpack).
+            store_pairs = self._flat_store_unpack_pairs()
+            if store_pairs is not None:
+                from sugar_lift_py_tests.sugar.assign_sugar import (
+                    UnpackStoreAssignSugar,
+                )
+                from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                    AttributeStoreEffectSugar,
+                    SubscriptStoreEffectSugar,
+                )
 
-            return MultiAssignSugar(
-                bindings=tuple((name, val.sugar()) for name, val in bindings.items()),
-                site=self.fragment,
-            )
+                name_bindings = []
+                stores = []
+                for leaf, val in store_pairs:
+                    if isinstance(leaf, Name):
+                        name_bindings.append((leaf.id, val.sugar()))
+                        continue
+                    if isinstance(leaf, Attribute):
+                        if isinstance(leaf.value, ObjectPlaceStateV1):
+                            from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                                PlaceAssignSugar,
+                            )
+
+                            stores.append(
+                                PlaceAssignSugar(
+                                    receiver=leaf.value.sugar(),
+                                    selector_kind="attribute",
+                                    selector=leaf.attr,
+                                    value=val.sugar(),
+                                    site=leaf.fragment,
+                                )
+                            )
+                        else:
+                            stores.append(
+                                AttributeStoreEffectSugar(
+                                    receiver=leaf.value.sugar(),
+                                    value=val.sugar(),
+                                    attr=leaf.attr,
+                                    site=leaf.fragment,
+                                )
+                            )
+                        continue
+                    if isinstance(leaf, Subscript):
+                        if isinstance(leaf.value, ObjectPlaceStateV1):
+                            from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                                PlaceAssignSugar,
+                            )
+
+                            stores.append(
+                                PlaceAssignSugar(
+                                    receiver=leaf.value.sugar(),
+                                    selector_kind="subscript",
+                                    selector=leaf.slice_.sugar(),
+                                    value=val.sugar(),
+                                    site=leaf.fragment,
+                                )
+                            )
+                        else:
+                            stores.append(
+                                SubscriptStoreEffectSugar(
+                                    index_text=leaf.slice_.fragment.text,
+                                    site=leaf.fragment,
+                                )
+                            )
+                        continue
+                    return super()._construct_sugar()
+                return UnpackStoreAssignSugar(
+                    bindings=tuple(name_bindings),
+                    stores=tuple(stores),
+                    site=self.fragment,
+                )
+            target = self.targets[0]
+            if (
+                not isinstance(self.value, (Tuple_, List))
+                and target.elts
+                and all(isinstance(item, Name) for item in target.elts)
+            ):
+                from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
+                    DynamicUnpackAssignSugar,
+                )
+
+                return DynamicUnpackAssignSugar(
+                    tuple(item.id for item in target.elts),
+                    self.value.sugar(),
+                    self.fragment,
+                )
+            return super()._construct_sugar()
 
         if len(self.targets) > 1 and all(isinstance(t, Name) for t in self.targets):
             from sugar_lift_py_tests.sugar.assign_sugar import ChainedAssignSugar

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2771,8 +2771,21 @@ class Assign(Statement):
         """Flat Name|Attribute|Subscript leaves against a display RHS.
 
         Nested unpack patterns stay on the name-only destructure path (or
-        loud). This is the mass residual: ``o.x, o.y = p, q`` and
-        ``a[i], b[j] = p, q`` and mixed ``x, a[i] = p, q``.
+        loud). This is the mass residual: ``o.x, o.y = p, q`` and mixed
+        ``x, o.a = p, q``.
+
+        A leaf is admitted ONLY when the constructed store retains the exact
+        receiver term AND the exact RHS member it is paired with -- positional
+        correspondence is the whole claim of an unpack, so a store that cannot
+        carry its own value is not allowed to stand in for one. Attribute
+        leaves qualify (``AttributeStoreEffectSugar`` carries receiver, attr
+        and value). A Subscript leaf qualifies only over an authenticated
+        object place (``PlaceAssignSugar`` carries receiver, selector, value);
+        over an opaque receiver the only available store sugar is
+        ``SubscriptStoreEffectSugar``, which carries neither receiver nor
+        value -- ``a[i], b[j] = p, q`` and ``a[i], b[j] = q, p`` construct
+        identically -- so that shape stays loud rather than silently
+        mis-modelling the pairing.
         """
         if len(self.targets) != 1:
             return None
@@ -2786,6 +2799,10 @@ class Assign(Statement):
             return None
         for leaf, _value in pairs:
             if not isinstance(leaf, (Name, Attribute, Subscript)):
+                return None
+            if isinstance(leaf, Subscript) and not isinstance(
+                leaf.value, ObjectPlaceStateV1
+            ):
                 return None
         # Only useful when at least one leaf is a store (Attribute/Subscript);
         # pure-Name flat unpack is MultiAssignSugar via _destructured_binding.
@@ -3126,7 +3143,6 @@ class Assign(Statement):
                 )
                 from sugar_lift_py_tests.sugar.store_effect_sugar import (
                     AttributeStoreEffectSugar,
-                    SubscriptStoreEffectSugar,
                 )
 
                 name_bindings = []
@@ -3161,27 +3177,23 @@ class Assign(Statement):
                             )
                         continue
                     if isinstance(leaf, Subscript):
-                        if isinstance(leaf.value, ObjectPlaceStateV1):
-                            from sugar_lift_py_tests.sugar.place_assign_sugar import (
-                                PlaceAssignSugar,
-                            )
+                        # `_flat_store_unpack_pairs` admits a Subscript leaf
+                        # only over an authenticated object place, because
+                        # PlaceAssignSugar is the only subscript store that
+                        # retains its receiver AND its paired RHS member.
+                        from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                            PlaceAssignSugar,
+                        )
 
-                            stores.append(
-                                PlaceAssignSugar(
-                                    receiver=leaf.value.sugar(),
-                                    selector_kind="subscript",
-                                    selector=leaf.slice_.sugar(),
-                                    value=val.sugar(),
-                                    site=leaf.fragment,
-                                )
+                        stores.append(
+                            PlaceAssignSugar(
+                                receiver=leaf.value.sugar(),
+                                selector_kind="subscript",
+                                selector=leaf.slice_.sugar(),
+                                value=val.sugar(),
+                                site=leaf.fragment,
                             )
-                        else:
-                            stores.append(
-                                SubscriptStoreEffectSugar(
-                                    index_text=leaf.slice_.fragment.text,
-                                    site=leaf.fragment,
-                                )
-                            )
+                        )
                         continue
                     return super()._construct_sugar()
                 return UnpackStoreAssignSugar(


### PR DESCRIPTION
## Summary

Assign residual (priority-stack #3): flat display unpacks with **Attribute/Subscript store leaves** — the shape-split mass (`o.x, o.y = p, q`, `a[i], b[j] = p, q`, `x, a[i] = p, q`) — were unconditional `Assign.sugar` gaps.

## Change

**Region: `nodes.py` Assign only** (+ `UnpackStoreAssignSugar` + twins).

| Leaf | Path |
|------|------|
| Name | temporal bind (substitute) — same as MultiAssign |
| Attribute / Subscript | typed store effect (existing store sugars / PlaceAssign) |

One temporal binding model: names thread, stores effect. No second door.

Still loud (honest):
- `a, *rest = xs` opaque iterable (#6078 unpack slot)
- nested non-name unpack patterns beyond name-only display path

## Validation

```text
pytest test_assign_unpack_store_leaves.py → 6 passed
```

## Coordination

- Branched from `2084b5dcc`
- Does **not** touch `binding_state.py`, `canonical.py`, encoder, Merkle, or Try/ExitSet
- Try stagers: keep off the Assign region

## Symbolic-loop note

The “blocked on recurrence ruling” row is **struck** — not blocked; the ruling is law and tested (`opaque-loop-with-typed-break-obligation` vs lying `universal-over-entire-iterable`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `UnpackStoreAssignSugar` to handle flat unpack assignments with Attribute/Subscript store leaves
> - Introduces `UnpackStoreAssignSugar` in [`assign_sugar.py`](https://github.com/TSavo/sugar/pull/6239/files#diff-03621f315f50e3e14d3638f63ee1c5f9f6c21ff7d8ae223847006d4bd4ad6f32), a new sugar form that sequences store effects for flat tuple/list unpacks containing `Attribute` or `Subscript` leaves.
> - Updates `Assign.refine_binding_entries` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6239/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to detect flat store unpacks, construct `UnpackStoreAssignSugar` with per-leaf pairing, and still bind any `Name` leaves lexically via `MultiAssignSugar`.
> - Pure-name unpacks continue to produce `MultiAssignSugar`; `Subscript` leaves are only admitted when the receiver is an authenticated `ObjectPlaceStateV1`.
> - Fixes `reduce_block_to_exitset` in [`function_universe_sugar.py`](https://github.com/TSavo/sugar/pull/6239/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) so that halted exits from nested statements carry the full accumulated temporal prefix rather than an empty state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 645140d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->