### PR TITLE
fix: guarded-loop-recurrence instrument measures our tree, not vendored code

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
@@ -26,11 +26,31 @@ def _finding(path: Path, root: Path, line: int, code: str, replacement: str):
     return GuardedLoopRecurrenceFinding(rendered, line, code, replacement)
 
 
+_VENDORED_DIRS = frozenset(
+    {".venv", "venv", "site-packages", "node_modules", ".git", ".tox", "build", "dist"}
+)
+
+
+def _is_vendored(path: Path) -> bool:
+    """True for third-party code that is not this tree's to measure.
+
+    The instrument audits OUR construction sources. A virtualenv vendored under
+    the repo carries other projects' files -- and some share our filenames (a
+    `_pytest/nodes.py` is not our `nodes.py`) -- so scanning them reports a
+    finding no one here can discharge. Measuring foreign code is an instrument
+    defect, not a residual: it must be excluded, never suppressed by loosening
+    a rule.
+    """
+    return any(part in _VENDORED_DIRS for part in path.parts)
+
+
 def scan_guarded_loop_recurrence(
     root: Path,
 ) -> tuple[GuardedLoopRecurrenceFinding, ...]:
     findings: list[GuardedLoopRecurrenceFinding] = []
-    python_files = sorted(root.rglob("*.py"))
+    python_files = sorted(
+        path for path in root.rglob("*.py") if not _is_vendored(path)
+    )
     for path in python_files:
         text = path.read_text()
         tree = ast.parse(text, filename=str(path))


### PR DESCRIPTION
`test_current_tree_measurement_is_stable_zero` went red with `R_guarded_loop_recurrence = 1`.

The finding was `missing-source-loop-recurrence-projection` in `provekit-lift-py-tests/.venv/lib/python3.14/site-packages/_pytest/nodes.py` — **pytest's file, not ours**, matched because it shares a filename with our `nodes.py`.

`scan_guarded_loop_recurrence` walked `root.rglob("*.py")` with no exclusions, so a virtualenv vendored under the repo put third-party sources on our roll call. That is an **instrument defect, not a residual**: it reports a finding no owner here can discharge, and it would keep the floor red forever.

Fix excludes vendored trees by path part (`.venv`, `venv`, `site-packages`, `node_modules`, `.git`, `.tox`, `build`, `dist`). The remedy is exclusion, **never loosening the detector** — weakening the rule so the foreign file passes would lower the bar for our own tree too.

Measured: `R_guarded_loop_recurrence` **1 → 0**, findings `()`. `test_guarded_loop_recurrence_idd.py` **6/6** pass (`tmp_path` fixtures unaffected).

Context: the other 28 loop tests were already green, including `test_symbolic_break_runtime_twin_rejects_whole_iterable_claim`, which encodes the recurrence ruling as a twin — truthful `opaque-loop-with-typed-break-obligation`, lying `universal-over-entire-iterable`, disposition `typed-loud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude vendored directories from `scan_guarded_loop_recurrence` file scanning
> The scanner was previously picking up `.py` files inside vendored and build directories (e.g. `.venv`, `site-packages`, `node_modules`, `build`), causing it to measure third-party code instead of the project's own source tree. A new `_is_vendored` helper checks each path component against a `_VENDORED_DIRS` frozenset, and the file enumeration in `scan_guarded_loop_recurrence` now filters out any matching paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f1ae42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->