### PR TITLE
feat: desugar-layer census axis (#6243)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -20,6 +20,13 @@ presentation duplication — e.g. mid-band With CM residual ≈213 sites, not
 ~2×). Demand/resolution ``BackendDefect``s are a separate hygiene axis
 (``R_backend_defects``), never merged into construction R.
 
+Behind the desugar door the membrane (sugar_lift_py_tests.desugar_axis) keeps
+three quantities apart: ``R_desugar`` (typed refusals + typed red effects, keyed
+by authenticated effect occurrence), ``desugarConstructionPanics``
+(construction-law None arms — ``ConstructionPanic`` is a ``BaseException``,
+caught BY NAME) and ``desugarDefects`` (ordinary exceptions and named audit /
+instrument gaps). The last two are red and are never semantic R.
+
 No subprocess. No process pool. Construction context is required: bare
 ``fn.sugar()`` with ``construction_context is None`` paints every With as
 ``RuntimeSelectedContextManager`` regardless of resolvability (instrument
@@ -87,55 +94,6 @@ def _configure_engine_log(path: Path) -> None:
     logger.setLevel(logging.DEBUG)
 
 
-def _desugar_owner_key(gap: Exception | BaseException) -> str:
-    """Stable family key for a desugar-layer refusal."""
-    owner = getattr(gap, "owner", None)
-    if isinstance(owner, str) and owner:
-        return owner
-    return type(gap).__name__
-
-
-def _typed_red_owners(outcome: object) -> list[str]:
-    """Effect class names surfaced at desugar (Incomplete / Halted exits)."""
-    from sugar_lift_py_tests.floor.block_value import BlockValue
-    from sugar_lift_py_tests.floor.universe_value import UniverseValue
-    from sugar_lift_py_tests.outcome import (
-        Complete,
-        Completed,
-        ExitSet,
-        Halted,
-        Incomplete,
-    )
-
-    owners: list[str] = []
-
-    def visit(obj: object, depth: int = 0) -> None:
-        if depth > 24 or obj is None:
-            return
-        if isinstance(obj, Incomplete):
-            owners.append(type(obj.effect).__name__)
-            return
-        if isinstance(obj, Complete):
-            visit(obj.value, depth + 1)
-            return
-        if isinstance(obj, ExitSet):
-            for exit_ in getattr(obj, "exits", ()):
-                if isinstance(exit_, Halted):
-                    owners.append(type(exit_.effect).__name__)
-                elif isinstance(exit_, Completed):
-                    visit(exit_.value, depth + 1)
-            return
-        if isinstance(obj, UniverseValue):
-            visit(obj.record, depth + 1)
-            return
-        if isinstance(obj, BlockValue):
-            for entry in getattr(obj, "statements", ()):
-                visit(entry, depth + 1)
-
-    visit(outcome)
-    return owners
-
-
 def _occurrence_key(
     kind: str,
     relative: str,
@@ -181,58 +139,21 @@ def _backend_defect_key(exc: object) -> str:
     ):
         return "BackendDefect:call-demand-missing-from-resolution"
     if "BackendDefect" in name or "backend defect" in lowered:
-        return f"BackendDefect:{name}" if name != "BackendDefect" else "BackendDefect"
+        # Always keyed `BackendDefect:<what>` — a bare "BackendDefect" would
+        # collide with the axis label itself and made this key unreadable as a
+        # row (its own twin asserted the prefix and was red).
+        return f"BackendDefect:{name}" if name != "BackendDefect" else (
+            "BackendDefect:unclassified"
+        )
     return f"BackendDefect:{name}"
 
 
-def _measure_desugar_axis(
-    sugar: object,
-    *,
-    relative: str,
-    line: object,
-    desugar_families: Counter[str],
-    desugar_seen: set[tuple[str, str, object, object]],
-) -> None:
-    """Tally desugar-layer SNW and typed red; one occurrence once.
-
-    Occurrence key is (owner, file, line, col). Prefer sugar.site / gap
-    fragment coordinates over the function line so two refusals in one
-    function do not collapse, and catch+reporter never double.
-    """
-    from sugar_source_tree.panic import SugarNotWritten
-
-    def site_from_sugar() -> tuple[object, object]:
-        site = getattr(sugar, "site", None)
-        if site is None:
-            return line, -1
-        return getattr(site, "line", line), getattr(site, "col", -1)
-
-    def tally(owner: str, *, node: object | None = None, ln=None, col=-1) -> None:
-        if ln is None:
-            ln, col = site_from_sugar()
-        key = _occurrence_key(owner, relative, node=node, line=ln, col=col)
-        if key in desugar_seen:
-            return
-        desugar_seen.add(key)
-        desugar_families[owner] += 1
-
-    try:
-        outcome = sugar.desugar(None)  # type: ignore[attr-defined]
-    except SugarNotWritten as gap:
-        # Prefer blame fragment on the gap when present.
-        blame = getattr(gap, "info", None)
-        blame_str = getattr(blame, "blame", None) if blame is not None else None
-        ln, col = site_from_sugar()
-        tally(_desugar_owner_key(gap), ln=ln, col=col)
-        del blame_str
-        return
-    except Exception as exc:  # noqa: BLE001 -- desugar crash is a defect row
-        ln, col = site_from_sugar()
-        tally(f"desugar-crash:{type(exc).__name__}", ln=ln, col=col)
-        return
-    for owner in _typed_red_owners(outcome):
-        ln, col = site_from_sugar()
-        tally(owner, ln=ln, col=col)
+# The desugar membrane lives in ONE place — sugar_lift_py_tests.desugar_axis —
+# so this script and `python -m sugar_lift_py_tests.census` cannot drift into
+# two different definitions of R_desugar. It also owns the three separations:
+# ConstructionPanic (BaseException, caught BY NAME) and ordinary defects are
+# kept out of semantic R, and rows are keyed by the authenticated effect
+# occurrence rather than the enclosing function's line.
 
 
 def _measure_file(
@@ -244,6 +165,7 @@ def _measure_file(
     on_function: "Callable[[int, int, str, float | None], None] | None" = None,
 ) -> dict[str, Any]:
     from sugar_lift_py_tests.audit_only import collect_construction_panic
+    from sugar_lift_py_tests.desugar_axis import DesugarAxis
     from sugar_lift_py_tests.lift_rpc import (
         open_source_file_for_construction,
         tree_construction_context_for_workspace,
@@ -254,10 +176,9 @@ def _measure_file(
     functions_total = 0
     functions_clean = 0
     families: Counter[str] = Counter()
-    desugar_families: Counter[str] = Counter()
     construction_seen: set[tuple[str, str, object, object]] = set()
-    desugar_seen: set[tuple[str, str, object, object]] = set()
     backend_defects: Counter[str] = Counter()
+    desugar_axis = DesugarAxis()
     root = workspace_root if workspace_root is not None else path.parent
 
     def tally_construction(kind: str, node: object | None = None, line: object = "?") -> None:
@@ -290,9 +211,12 @@ def _measure_file(
         for function in source_file.functions():
             functions_total += 1
             try:
-                line = function.line_col_span().start_line
+                span = function.line_col_span()
+                line: object = span.start_line
+                where = f"{relative}:{span.start_line}:{span.start_col}"
             except Exception:  # noqa: BLE001 -- name is best-effort display
                 line = "?"
+                where = f"{relative}:?"
             fn_name = f"{getattr(function, 'name', '?')}:{line}"
             # Announce the function BEFORE constructing it (elapsed=None), so a
             # hang shows the exact function it is stuck on -- not the one before.
@@ -308,13 +232,7 @@ def _measure_file(
                 # what turned 196 With gaps into a false 392.
                 sugar = None
             if sugar is not None:
-                _measure_desugar_axis(
-                    sugar,
-                    relative=relative,
-                    line=line,
-                    desugar_families=desugar_families,
-                    desugar_seen=desugar_seen,
-                )
+                desugar_axis.measure(sugar, where=where)
             fn_s = time.perf_counter() - t_fn
             # Report completion WITH this function's own construction time, so
             # `last=` is per-function and a slow/blowup function is obvious.
@@ -343,20 +261,18 @@ def _measure_file(
             "functionsTotal": functions_total,
             "functionsClean": functions_clean,
             "families": dict(families),
-            "desugarFamilies": dict(desugar_families),
-            "R_desugar": sum(desugar_families.values()),
             "backendDefects": dict(backend_defects),
             "R_backend_defects": sum(backend_defects.values()),
+            **desugar_axis.row(),
         }
     return {
         "category": "completed",
         "functionsTotal": functions_total,
         "functionsClean": functions_clean,
         "families": dict(families),
-        "desugarFamilies": dict(desugar_families),
-        "R_desugar": sum(desugar_families.values()),
         "backendDefects": dict(backend_defects),
         "R_backend_defects": sum(backend_defects.values()),
+        **desugar_axis.row(),
     }
 
 
@@ -457,6 +373,10 @@ def main() -> int:
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
     backend_defects: Counter[str] = Counter()
+    # Three disjoint desugar-layer quantities; the two below are NEVER folded
+    # into R_desugar and both make the run red.
+    desugar_construction_panics: list[dict[str, Any]] = []
+    desugar_defects: list[dict[str, Any]] = []
     files_completed = 0
     functions_total = 0
     functions_clean = 0
@@ -485,10 +405,14 @@ def main() -> int:
             cat = str(raw.get("category") or "")
             live_fns += int(raw.get("functionsTotal") or 0)
             live_clean += int(raw.get("functionsClean") or 0)
-            families = raw.get("families") or {}
-            live_snw += int(families.get("SugarNotWritten") or 0)
+            # NOT `families`: that name is main's accumulating Counter, and
+            # rebinding it to this plain dict made the later
+            # `families["ConstructionPanic"] += 1` a KeyError crash — the whole
+            # run lost, at the exact moment a panic row appeared.
+            row_families = raw.get("families") or {}
+            live_snw += int(row_families.get("SugarNotWritten") or 0)
             live_other_gaps += sum(
-                int(v) for k, v in families.items() if k != "SugarNotWritten"
+                int(v) for k, v in row_families.items() if k != "SugarNotWritten"
             )
             if cat == "construction-panic":
                 live_panic += 1
@@ -692,6 +616,8 @@ def main() -> int:
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
         backend_defects.update(row.get("backendDefects") or {})
+        desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
+        desugar_defects.extend(row.get("desugarDefects") or [])
         if category == "completed":
             files_completed += 1
         elif category == "construction-panic":
@@ -764,6 +690,13 @@ def main() -> int:
         "backendDefects": dict(
             sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
         ),
+        # Neither of these is semantic R. A construction-law None arm during
+        # desugar is a construction gap; an ordinary exception is an
+        # implementation defect. Both are red, separately.
+        "desugarConstructionPanics": desugar_construction_panics,
+        "R_desugar_construction_panics": len(desugar_construction_panics),
+        "desugarDefects": desugar_defects,
+        "R_desugar_defects": len(desugar_defects),
         "elapsedSeconds": time.time() - started,
         "python": sys.version,
         "floorSummary": floor_summary(
@@ -774,6 +707,8 @@ def main() -> int:
                 "R_control_effect": r_construction + len(defects),
                 "R_desugar": r_desugar,
                 "R_backend_defects": r_backend,
+                "desugarConstructionPanics": len(desugar_construction_panics),
+                "desugarDefects": len(desugar_defects),
                 "constructionPanics": len(construction_panics),
                 "backendDefectsOrProcessTerminals": len(defects),
             },
@@ -791,7 +726,13 @@ def main() -> int:
         flush=True,
     )
     return (
-        1 if defects or construction_panics or files_completed != len(file_names) else 0
+        1
+        if defects
+        or construction_panics
+        or desugar_construction_panics
+        or desugar_defects
+        or files_completed != len(file_names)
+        else 0
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -14,6 +14,12 @@ Construction R answers "is the tree total?". Desugar R answers "is meaning
 reducible?". Yield/YieldFrom construct then refuse at desugar — correct; they
 must stay on the board under axis 2 (see #6243).
 
+Occurrence identity: one gap = (kind, file, line, col). Construction families
+are tallied only from ``reporter.gaps`` (catch+reporter type double-count is
+presentation duplication — e.g. mid-band With CM residual ≈213 sites, not
+~2×). Demand/resolution ``BackendDefect``s are a separate hygiene axis
+(``R_backend_defects``), never merged into construction R.
+
 No subprocess. No process pool. Construction context is required: bare
 ``fn.sugar()`` with ``construction_context is None`` paints every With as
 ``RuntimeSelectedContextManager`` regardless of resolvability (instrument
@@ -130,19 +136,81 @@ def _typed_red_owners(outcome: object) -> list[str]:
     return owners
 
 
+def _occurrence_key(
+    kind: str,
+    relative: str,
+    *,
+    node: object | None = None,
+    line: object = "?",
+    col: object = -1,
+) -> tuple[str, str, object, object]:
+    """One gap/effect occurrence = (kind, file, line, col). Never double-tally."""
+    if node is not None:
+        try:
+            lc = node.line_col_span()  # type: ignore[attr-defined]
+            return (kind, relative, lc.start_line, lc.start_col)
+        except Exception:  # noqa: BLE001 -- fall back to hints
+            pass
+    return (kind, relative, line, col)
+
+
+def _backend_defect_key(exc: object) -> str:
+    """Classify demand/resolution table hygiene — never construction mass.
+
+    The mid-band With probe surfaces two distinct BackendDefects that are
+    table bijection failures, not residual construction mass:
+
+    1. enrolled context-manager demand missing from resolution table
+    2. enrolled call demand missing from resolution table
+
+    Preserve them as separate keys so the board can track each to zero
+    without conflating either with ContextManagerResolutionConstructionGap.
+    """
+    text = str(exc)
+    name = type(exc).__name__ if not isinstance(exc, str) else "BackendDefect"
+    observed = getattr(exc, "observed", None)
+    if isinstance(observed, str) and observed:
+        text = f"{text} {observed}"
+    lowered = text.lower()
+    if "context-manager demand missing" in lowered or (
+        "context-manager" in lowered and "missing from resolution" in lowered
+    ):
+        return "BackendDefect:cm-demand-missing-from-resolution"
+    if "call demand missing" in lowered or (
+        "call demand" in lowered and "missing from resolution" in lowered
+    ):
+        return "BackendDefect:call-demand-missing-from-resolution"
+    if "BackendDefect" in name or "backend defect" in lowered:
+        return f"BackendDefect:{name}" if name != "BackendDefect" else "BackendDefect"
+    return f"BackendDefect:{name}"
+
+
 def _measure_desugar_axis(
     sugar: object,
     *,
     relative: str,
     line: object,
     desugar_families: Counter[str],
-    desugar_seen: set[tuple[str, str, object]],
+    desugar_seen: set[tuple[str, str, object, object]],
 ) -> None:
-    """Tally desugar-layer SNW and typed red; dedup by (owner, file, line)."""
+    """Tally desugar-layer SNW and typed red; one occurrence once.
+
+    Occurrence key is (owner, file, line, col). Prefer sugar.site / gap
+    fragment coordinates over the function line so two refusals in one
+    function do not collapse, and catch+reporter never double.
+    """
     from sugar_source_tree.panic import SugarNotWritten
 
-    def tally(owner: str) -> None:
-        key = (owner, relative, line)
+    def site_from_sugar() -> tuple[object, object]:
+        site = getattr(sugar, "site", None)
+        if site is None:
+            return line, -1
+        return getattr(site, "line", line), getattr(site, "col", -1)
+
+    def tally(owner: str, *, node: object | None = None, ln=None, col=-1) -> None:
+        if ln is None:
+            ln, col = site_from_sugar()
+        key = _occurrence_key(owner, relative, node=node, line=ln, col=col)
         if key in desugar_seen:
             return
         desugar_seen.add(key)
@@ -151,13 +219,20 @@ def _measure_desugar_axis(
     try:
         outcome = sugar.desugar(None)  # type: ignore[attr-defined]
     except SugarNotWritten as gap:
-        tally(_desugar_owner_key(gap))
+        # Prefer blame fragment on the gap when present.
+        blame = getattr(gap, "info", None)
+        blame_str = getattr(blame, "blame", None) if blame is not None else None
+        ln, col = site_from_sugar()
+        tally(_desugar_owner_key(gap), ln=ln, col=col)
+        del blame_str
         return
     except Exception as exc:  # noqa: BLE001 -- desugar crash is a defect row
-        tally(f"desugar-crash:{type(exc).__name__}")
+        ln, col = site_from_sugar()
+        tally(f"desugar-crash:{type(exc).__name__}", ln=ln, col=col)
         return
     for owner in _typed_red_owners(outcome):
-        tally(owner)
+        ln, col = site_from_sugar()
+        tally(owner, ln=ln, col=col)
 
 
 def _measure_file(
@@ -180,8 +255,17 @@ def _measure_file(
     functions_clean = 0
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
-    desugar_seen: set[tuple[str, str, object]] = set()
+    construction_seen: set[tuple[str, str, object, object]] = set()
+    desugar_seen: set[tuple[str, str, object, object]] = set()
+    backend_defects: Counter[str] = Counter()
     root = workspace_root if workspace_root is not None else path.parent
+
+    def tally_construction(kind: str, node: object | None = None, line: object = "?") -> None:
+        key = _occurrence_key(kind, relative, node=node, line=line)
+        if key in construction_seen:
+            return
+        construction_seen.add(key)
+        families[kind] += 1
 
     def construct():
         nonlocal functions_total, functions_clean
@@ -200,9 +284,8 @@ def _measure_file(
                 populate_derived=True,
             )
         except SugarNotWritten as gap:
-            # Derivation can hit a real missing sugar (e.g. ClassDef) before any
-            # function body is walked — count it as a typed family, not a crash.
-            families[type(gap).__name__] += 1
+            # Derivation can hit a real missing sugar before any function walk.
+            tally_construction(type(gap).__name__, line=0)
             return reporter
         for function in source_file.functions():
             functions_total += 1
@@ -219,8 +302,10 @@ def _measure_file(
             try:
                 sugar = function.sugar()
                 functions_clean += 1
-            except SugarNotWritten as gap:
-                families[type(gap).__name__] += 1
+            except SugarNotWritten:
+                # Do NOT tally type here — report_gap already recorded the
+                # occurrence on the reporter. Catch+reporter double-tally is
+                # what turned 196 With gaps into a false 392.
                 sugar = None
             if sugar is not None:
                 _measure_desugar_axis(
@@ -235,8 +320,14 @@ def _measure_file(
             # `last=` is per-function and a slow/blowup function is obvious.
             if on_function is not None:
                 on_function(functions_total, functions_clean, fn_name, fn_s)
-        for _node, panic in reporter.gaps:
-            families[type(panic).__name__] += 1
+        # Sole construction-gap source: reporter occurrences, site-deduped.
+        # BackendDefect is table hygiene — own counter, never construction R.
+        for node, panic in reporter.gaps:
+            kind = type(panic).__name__
+            if kind == "BackendDefect" or "BackendDefect" in kind:
+                backend_defects[_backend_defect_key(panic)] += 1
+                continue
+            tally_construction(kind, node=node)
         return reporter
 
     _reporter, panic_row = collect_construction_panic(relative, construct)
@@ -254,6 +345,8 @@ def _measure_file(
             "families": dict(families),
             "desugarFamilies": dict(desugar_families),
             "R_desugar": sum(desugar_families.values()),
+            "backendDefects": dict(backend_defects),
+            "R_backend_defects": sum(backend_defects.values()),
         }
     return {
         "category": "completed",
@@ -262,6 +355,8 @@ def _measure_file(
         "families": dict(families),
         "desugarFamilies": dict(desugar_families),
         "R_desugar": sum(desugar_families.values()),
+        "backendDefects": dict(backend_defects),
+        "R_backend_defects": sum(backend_defects.values()),
     }
 
 
@@ -361,6 +456,7 @@ def main() -> int:
     floor_rows: list[dict[str, Any]] = []
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
+    backend_defects: Counter[str] = Counter()
     files_completed = 0
     functions_total = 0
     functions_clean = 0
@@ -595,13 +691,17 @@ def main() -> int:
         functions_clean += int(row.get("functionsClean") or 0)
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
+        backend_defects.update(row.get("backendDefects") or {})
         if category == "completed":
             files_completed += 1
         elif category == "construction-panic":
             panic = row.get("panic")
             if isinstance(panic, dict):
                 construction_panics.append(panic)
-            families["ConstructionPanic"] += 1
+            # Occurrence-keyed already if present in families; avoid a bare +1
+            # that has no site identity.
+            if "ConstructionPanic" not in (row.get("families") or {}):
+                families["ConstructionPanic"] += 1
         else:
             defect = row.get("defect")
             defects.append(
@@ -609,11 +709,25 @@ def main() -> int:
                 if isinstance(defect, dict)
                 else {"file": file, "type": category, "message": category}
             )
+            # Demand/resolution table hygiene — own counter, not mass residual.
+            # Keep CM-demand vs call-demand bijection failures separate.
+            if isinstance(defect, dict):
+                msg = f"{defect.get('type', '')}: {defect.get('message', '')}"
+            else:
+                msg = str(category)
+            if "BackendDefect" in msg or "backend defect" in msg.lower() or (
+                isinstance(defect, dict)
+                and "BackendDefect" in str(defect.get("type", ""))
+            ):
+                backend_defects[_backend_defect_key(msg)] += 1
+            elif category == "backend-defect":
+                backend_defects[_backend_defect_key(msg)] += 1
 
     from pandas_floor_summary import floor_summary
 
     r_construction = sum(families.values())
     r_desugar = sum(desugar_families.values())
+    r_backend = sum(backend_defects.values())
     result: dict[str, Any] = {
         "kind": "control-effect-construction-recensus",
         "commit": args.commit or _git_commit(args.repo),
@@ -633,7 +747,8 @@ def main() -> int:
         "R_construction_panics": len(construction_panics),
         "functionsTotal": functions_total,
         "functionsConstructClean": functions_clean,
-        # Axis 1 — construction totality (tree owned). Never merge with R_desugar.
+        # Axis 1 — construction totality (tree owned). Occurrence-deduped.
+        # Never merge with R_desugar. Never double-count catch+reporter.
         "R": r_construction,
         "R_construction": r_construction,
         "families": dict(
@@ -644,6 +759,11 @@ def main() -> int:
         "desugarFamilies": dict(
             sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
         ),
+        # Table hygiene — not residual mass (probe: 2 BackendDefect files).
+        "R_backend_defects": r_backend,
+        "backendDefects": dict(
+            sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
+        ),
         "elapsedSeconds": time.time() - started,
         "python": sys.version,
         "floorSummary": floor_summary(
@@ -653,6 +773,7 @@ def main() -> int:
             totals={
                 "R_control_effect": r_construction + len(defects),
                 "R_desugar": r_desugar,
+                "R_backend_defects": r_backend,
                 "constructionPanics": len(construction_panics),
                 "backendDefectsOrProcessTerminals": len(defects),
             },

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""Pandas control/effect construction recensus.
+"""Pandas control/effect construction + desugar-layer recensus.
 
-One process. Enumeration only:
+One process. Two named axes (never merged into one R):
 
     SourceTree(corpus).paths()
       → provisional_contract_refs_from_demands(corpus)  (once)
       → open_source_file_for_construction (context + source-derived CM refs)
       → functions()
-      → fn.sugar()
+      → fn.sugar()                    # axis 1: construction families
+      → sugar.desugar(None)           # axis 2: desugar refusals + typed red
+
+Construction R answers "is the tree total?". Desugar R answers "is meaning
+reducible?". Yield/YieldFrom construct then refuse at desugar — correct; they
+must stay on the board under axis 2 (see #6243).
 
 No subprocess. No process pool. Construction context is required: bare
 ``fn.sugar()`` with ``construction_context is None`` paints every With as
@@ -76,6 +81,85 @@ def _configure_engine_log(path: Path) -> None:
     logger.setLevel(logging.DEBUG)
 
 
+def _desugar_owner_key(gap: Exception | BaseException) -> str:
+    """Stable family key for a desugar-layer refusal."""
+    owner = getattr(gap, "owner", None)
+    if isinstance(owner, str) and owner:
+        return owner
+    return type(gap).__name__
+
+
+def _typed_red_owners(outcome: object) -> list[str]:
+    """Effect class names surfaced at desugar (Incomplete / Halted exits)."""
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.outcome import (
+        Complete,
+        Completed,
+        ExitSet,
+        Halted,
+        Incomplete,
+    )
+
+    owners: list[str] = []
+
+    def visit(obj: object, depth: int = 0) -> None:
+        if depth > 24 or obj is None:
+            return
+        if isinstance(obj, Incomplete):
+            owners.append(type(obj.effect).__name__)
+            return
+        if isinstance(obj, Complete):
+            visit(obj.value, depth + 1)
+            return
+        if isinstance(obj, ExitSet):
+            for exit_ in getattr(obj, "exits", ()):
+                if isinstance(exit_, Halted):
+                    owners.append(type(exit_.effect).__name__)
+                elif isinstance(exit_, Completed):
+                    visit(exit_.value, depth + 1)
+            return
+        if isinstance(obj, UniverseValue):
+            visit(obj.record, depth + 1)
+            return
+        if isinstance(obj, BlockValue):
+            for entry in getattr(obj, "statements", ()):
+                visit(entry, depth + 1)
+
+    visit(outcome)
+    return owners
+
+
+def _measure_desugar_axis(
+    sugar: object,
+    *,
+    relative: str,
+    line: object,
+    desugar_families: Counter[str],
+    desugar_seen: set[tuple[str, str, object]],
+) -> None:
+    """Tally desugar-layer SNW and typed red; dedup by (owner, file, line)."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    def tally(owner: str) -> None:
+        key = (owner, relative, line)
+        if key in desugar_seen:
+            return
+        desugar_seen.add(key)
+        desugar_families[owner] += 1
+
+    try:
+        outcome = sugar.desugar(None)  # type: ignore[attr-defined]
+    except SugarNotWritten as gap:
+        tally(_desugar_owner_key(gap))
+        return
+    except Exception as exc:  # noqa: BLE001 -- desugar crash is a defect row
+        tally(f"desugar-crash:{type(exc).__name__}")
+        return
+    for owner in _typed_red_owners(outcome):
+        tally(owner)
+
+
 def _measure_file(
     path: Path,
     *,
@@ -95,6 +179,8 @@ def _measure_file(
     functions_total = 0
     functions_clean = 0
     families: Counter[str] = Counter()
+    desugar_families: Counter[str] = Counter()
+    desugar_seen: set[tuple[str, str, object]] = set()
     root = workspace_root if workspace_root is not None else path.parent
 
     def construct():
@@ -131,10 +217,19 @@ def _measure_file(
                 on_function(functions_total - 1, functions_clean, fn_name, None)
             t_fn = time.perf_counter()
             try:
-                function.sugar()
+                sugar = function.sugar()
                 functions_clean += 1
             except SugarNotWritten as gap:
                 families[type(gap).__name__] += 1
+                sugar = None
+            if sugar is not None:
+                _measure_desugar_axis(
+                    sugar,
+                    relative=relative,
+                    line=line,
+                    desugar_families=desugar_families,
+                    desugar_seen=desugar_seen,
+                )
             fn_s = time.perf_counter() - t_fn
             # Report completion WITH this function's own construction time, so
             # `last=` is per-function and a slow/blowup function is obvious.
@@ -157,12 +252,16 @@ def _measure_file(
             "functionsTotal": functions_total,
             "functionsClean": functions_clean,
             "families": dict(families),
+            "desugarFamilies": dict(desugar_families),
+            "R_desugar": sum(desugar_families.values()),
         }
     return {
         "category": "completed",
         "functionsTotal": functions_total,
         "functionsClean": functions_clean,
         "families": dict(families),
+        "desugarFamilies": dict(desugar_families),
+        "R_desugar": sum(desugar_families.values()),
     }
 
 
@@ -261,6 +360,7 @@ def main() -> int:
     construction_panics: list[dict[str, Any]] = []
     floor_rows: list[dict[str, Any]] = []
     families: Counter[str] = Counter()
+    desugar_families: Counter[str] = Counter()
     files_completed = 0
     functions_total = 0
     functions_clean = 0
@@ -494,6 +594,7 @@ def main() -> int:
         functions_total += int(row.get("functionsTotal") or 0)
         functions_clean += int(row.get("functionsClean") or 0)
         families.update(row.get("families") or {})
+        desugar_families.update(row.get("desugarFamilies") or {})
         if category == "completed":
             files_completed += 1
         elif category == "construction-panic":
@@ -511,11 +612,13 @@ def main() -> int:
 
     from pandas_floor_summary import floor_summary
 
+    r_construction = sum(families.values())
+    r_desugar = sum(desugar_families.values())
     result: dict[str, Any] = {
         "kind": "control-effect-construction-recensus",
         "commit": args.commit or _git_commit(args.repo),
         "corpus": str(args.corpus),
-        "door": "enum:path_source→SourceFile→functions→sugar",
+        "door": "enum:path_source→SourceFile→functions→sugar→desugar",
         "isolation": "in-process",
         "paths": {
             "engineLog": str(engine_path.resolve()),
@@ -530,9 +633,16 @@ def main() -> int:
         "R_construction_panics": len(construction_panics),
         "functionsTotal": functions_total,
         "functionsConstructClean": functions_clean,
-        "R": sum(families.values()),
+        # Axis 1 — construction totality (tree owned). Never merge with R_desugar.
+        "R": r_construction,
+        "R_construction": r_construction,
         "families": dict(
             sorted(families.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        # Axis 2 — desugar refusals + typed red (#6243). Separate quantity.
+        "R_desugar": r_desugar,
+        "desugarFamilies": dict(
+            sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
         ),
         "elapsedSeconds": time.time() - started,
         "python": sys.version,
@@ -541,7 +651,8 @@ def main() -> int:
             files=file_names,
             rows=floor_rows,
             totals={
-                "R_control_effect": sum(families.values()) + len(defects),
+                "R_control_effect": r_construction + len(defects),
+                "R_desugar": r_desugar,
                 "constructionPanics": len(construction_panics),
                 "backendDefectsOrProcessTerminals": len(defects),
             },

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -2,14 +2,19 @@
 
     python -m sugar_lift_py_tests.census <package-root> [--engine-log PATH]
 
-Two named quantities (never merged into one R):
+Two named axes (never merged into one R):
 
 1. **Construction** — ``fn.sugar()`` gaps, deduped by (node.kind, line, col).
-2. **Desugar** — ``sugar.desugar(None)`` refusals (owner-keyed) and typed red
-   effects at desugar, deduped by (owner, file, line).
+2. **Desugar** — ``sugar.desugar(None)`` refusals and typed red effects,
+   deduped by (owner, authenticated effect-occurrence coordinate).
 
 Yield/YieldFrom construct then refuse at desugar: construction-total, still
 on the board under R_desugar.
+
+Behind the desugar door, ``ConstructionPanic`` (a ``BaseException``) and
+ordinary exceptions are counted SEPARATELY from semantic R and make the run
+red — see :mod:`sugar_lift_py_tests.desugar_axis`, which owns the membrane for
+this module and for ``scripts/control_effect_recensus.py`` alike.
 """
 
 from __future__ import annotations
@@ -21,62 +26,16 @@ from collections import Counter
 from pathlib import Path
 
 
-def _desugar_owner_key(gap: BaseException) -> str:
-    owner = getattr(gap, "owner", None)
-    if isinstance(owner, str) and owner:
-        return owner
-    return type(gap).__name__
-
-
-def _typed_red_owners(outcome: object) -> list[str]:
-    from sugar_lift_py_tests.floor.block_value import BlockValue
-    from sugar_lift_py_tests.floor.universe_value import UniverseValue
-    from sugar_lift_py_tests.outcome import (
-        Complete,
-        Completed,
-        ExitSet,
-        Halted,
-        Incomplete,
-    )
-
-    owners: list[str] = []
-
-    def visit(obj: object, depth: int = 0) -> None:
-        if depth > 24 or obj is None:
-            return
-        if isinstance(obj, Incomplete):
-            owners.append(type(obj.effect).__name__)
-            return
-        if isinstance(obj, Complete):
-            visit(obj.value, depth + 1)
-            return
-        if isinstance(obj, ExitSet):
-            for exit_ in getattr(obj, "exits", ()):
-                if isinstance(exit_, Halted):
-                    owners.append(type(exit_.effect).__name__)
-                elif isinstance(exit_, Completed):
-                    visit(exit_.value, depth + 1)
-            return
-        if isinstance(obj, UniverseValue):
-            visit(obj.record, depth + 1)
-            return
-        if isinstance(obj, BlockValue):
-            for entry in getattr(obj, "statements", ()):
-                visit(entry, depth + 1)
-
-    visit(outcome)
-    return owners
-
-
 def census(root: Path) -> int:
+    from sugar_lift_py_tests.desugar_axis import DesugarAxis
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
     from sugar_source_tree.tree import SourceFile
 
     files = sorted(root.rglob("*.py"))
     families: Counter = Counter()
-    desugar_families: Counter = Counter()
-    desugar_seen: set[tuple[str, str, object]] = set()
+    desugar = DesugarAxis()
     crashes: Counter = Counter()
     clean_files = 0
     total_fns = 0
@@ -91,32 +50,17 @@ def census(root: Path) -> int:
             for fn in sf.functions():
                 total_fns += 1
                 try:
-                    line = fn.line_col_span().start_line
+                    span = fn.line_col_span()
+                    where = f"{rel}:{span.start_line}:{span.start_col}"
                 except Exception:  # noqa: BLE001
-                    line = "?"
+                    where = f"{rel}:?"
                 try:
                     sugar = fn.sugar()  # ONE construction; nested gaps self-report
                     clean_fns += 1
                 except SugarNotWritten:
                     sugar = None
                 if sugar is not None:
-
-                    def tally(owner: str, line_key: object = line) -> None:
-                        key = (owner, rel, line_key)
-                        if key in desugar_seen:
-                            return
-                        desugar_seen.add(key)
-                        desugar_families[owner] += 1
-
-                    try:
-                        outcome = sugar.desugar(None)
-                    except SugarNotWritten as gap:
-                        tally(_desugar_owner_key(gap))
-                    except Exception as exc:  # noqa: BLE001
-                        tally(f"desugar-crash:{type(exc).__name__}")
-                    else:
-                        for owner in _typed_red_owners(outcome):
-                            tally(owner)
+                    desugar.measure(sugar, where=where)
             seen = set()
             for node, _p in reporter.gaps:
                 lc = node.line_col_span()
@@ -129,7 +73,16 @@ def census(root: Path) -> int:
             print(
                 f"[{i + 1}/{len(files)}] {time.time() - ft:5.1f}s "
                 f"gaps={len(reporter.gaps):5d} "
-                f"desugar={sum(desugar_families.values()):5d} {rel}",
+                f"desugar={sum(desugar.families.values()):5d} {rel}",
+                flush=True,
+            )
+        except ConstructionPanic as panic:
+            # A BaseException: `except Exception` below cannot see it, and an
+            # uncaught one aborts the whole run. Named arm, red row, keep going.
+            crashes[f"ConstructionPanic:{panic.info.owner}"] += 1
+            print(
+                f"[{i + 1}/{len(files)}]  CONSTRUCTION PANIC "
+                f"{panic.info.owner} {rel}",
                 flush=True,
             )
         except Exception as e:  # a crash is a DEFECT row, never silence
@@ -149,9 +102,19 @@ def census(root: Path) -> int:
     print(f"R_construction = {sum(families.values())}")
     for kind, n in families.most_common(40):
         print(f"{n:8d}  {kind}")
-    print("--- desugar-layer families (top 40, deduped by owner+file+line) ---")
-    print(f"R_desugar = {sum(desugar_families.values())}")
-    for kind, n in desugar_families.most_common(40):
+    print("--- desugar families (top 40, deduped by owner+effect occurrence) ---")
+    print(f"R_desugar = {sum(desugar.families.values())}")
+    for kind, n in desugar.families.most_common(40):
+        print(f"{n:8d}  {kind}")
+    print("--- desugar construction panics (construction law, NOT R_desugar) ---")
+    print(f"desugarConstructionPanics = {len(desugar.construction_panics)}")
+    for panic in desugar.construction_panics[:40]:
+        print(f"          {panic['owner']}  @{panic['where']}")
+    print("--- desugar defects (implementation/audit, NOT R_desugar) ---")
+    print(f"desugarDefects = {len(desugar.defects)}")
+    for kind, n in Counter(
+        f"{row['kind']}:{row['detail']}" for row in desugar.defects
+    ).most_common(40):
         print(f"{n:8d}  {kind}")
     print("--- crashes (defects, not gaps) ---")
     for k, n in crashes.most_common():
@@ -160,7 +123,11 @@ def census(root: Path) -> int:
     # the row is testimony, but a successful process status would let callers
     # bank a partial denominator as a complete census.  Keep ordinary
     # SugarNotWritten gaps measurable while making every defect row red.
-    return 1 if crashes else 0
+    # Desugar-layer panics and defects are red for the same reason: a
+    # construction-law gap or an instrument defect must never let a caller bank
+    # a partial denominator as a complete census. R_desugar itself is a
+    # measured frontier, not a failure — it does not colour the exit.
+    return 1 if crashes or desugar.red else 0
 
 
 def main() -> int:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -1,13 +1,15 @@
-"""The corpus census: construct every function once, rank the frontier.
+"""The corpus census: construction axis + desugar-layer axis (#6243).
 
     python -m sugar_lift_py_tests.census <package-root> [--engine-log PATH]
 
-One construction per function; the reporter witnesses every gap DURING that
-construction (linear -- never a per-node re-ask). Per-file progress on stdout;
-the ranked gap-family table at the end. The engine log (configure_live_log) is
-the bisection instrument: every function construction enters a reduction_span,
-so the heartbeat names the exact function a slow lift is inside -- macro
-progress tells you THAT it is slow, the span log tells you WHERE to cut next.
+Two named quantities (never merged into one R):
+
+1. **Construction** — ``fn.sugar()`` gaps, deduped by (node.kind, line, col).
+2. **Desugar** — ``sugar.desugar(None)`` refusals (owner-keyed) and typed red
+   effects at desugar, deduped by (owner, file, line).
+
+Yield/YieldFrom construct then refuse at desugar: construction-total, still
+on the board under R_desugar.
 """
 
 from __future__ import annotations
@@ -19,6 +21,53 @@ from collections import Counter
 from pathlib import Path
 
 
+def _desugar_owner_key(gap: BaseException) -> str:
+    owner = getattr(gap, "owner", None)
+    if isinstance(owner, str) and owner:
+        return owner
+    return type(gap).__name__
+
+
+def _typed_red_owners(outcome: object) -> list[str]:
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.outcome import (
+        Complete,
+        Completed,
+        ExitSet,
+        Halted,
+        Incomplete,
+    )
+
+    owners: list[str] = []
+
+    def visit(obj: object, depth: int = 0) -> None:
+        if depth > 24 or obj is None:
+            return
+        if isinstance(obj, Incomplete):
+            owners.append(type(obj.effect).__name__)
+            return
+        if isinstance(obj, Complete):
+            visit(obj.value, depth + 1)
+            return
+        if isinstance(obj, ExitSet):
+            for exit_ in getattr(obj, "exits", ()):
+                if isinstance(exit_, Halted):
+                    owners.append(type(exit_.effect).__name__)
+                elif isinstance(exit_, Completed):
+                    visit(exit_.value, depth + 1)
+            return
+        if isinstance(obj, UniverseValue):
+            visit(obj.record, depth + 1)
+            return
+        if isinstance(obj, BlockValue):
+            for entry in getattr(obj, "statements", ()):
+                visit(entry, depth + 1)
+
+    visit(outcome)
+    return owners
+
+
 def census(root: Path) -> int:
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
@@ -26,6 +75,8 @@ def census(root: Path) -> int:
 
     files = sorted(root.rglob("*.py"))
     families: Counter = Counter()
+    desugar_families: Counter = Counter()
+    desugar_seen: set[tuple[str, str, object]] = set()
     crashes: Counter = Counter()
     clean_files = 0
     total_fns = 0
@@ -33,17 +84,39 @@ def census(root: Path) -> int:
     t0 = time.time()
     for i, f in enumerate(files):
         ft = time.time()
-        rel = f.relative_to(root)
+        rel = str(f.relative_to(root))
         try:
             reporter = CollectingReporter()
             sf = SourceFile.from_path(str(f), reporter=reporter)
             for fn in sf.functions():
                 total_fns += 1
                 try:
-                    fn.sugar()  # ONE construction; nested gaps self-report
+                    line = fn.line_col_span().start_line
+                except Exception:  # noqa: BLE001
+                    line = "?"
+                try:
+                    sugar = fn.sugar()  # ONE construction; nested gaps self-report
                     clean_fns += 1
                 except SugarNotWritten:
-                    pass
+                    sugar = None
+                if sugar is not None:
+
+                    def tally(owner: str, line_key: object = line) -> None:
+                        key = (owner, rel, line_key)
+                        if key in desugar_seen:
+                            return
+                        desugar_seen.add(key)
+                        desugar_families[owner] += 1
+
+                    try:
+                        outcome = sugar.desugar(None)
+                    except SugarNotWritten as gap:
+                        tally(_desugar_owner_key(gap))
+                    except Exception as exc:  # noqa: BLE001
+                        tally(f"desugar-crash:{type(exc).__name__}")
+                    else:
+                        for owner in _typed_red_owners(outcome):
+                            tally(owner)
             seen = set()
             for node, _p in reporter.gaps:
                 lc = node.line_col_span()
@@ -55,7 +128,8 @@ def census(root: Path) -> int:
                 clean_files += 1
             print(
                 f"[{i + 1}/{len(files)}] {time.time() - ft:5.1f}s "
-                f"gaps={len(reporter.gaps):5d} {rel}",
+                f"gaps={len(reporter.gaps):5d} "
+                f"desugar={sum(desugar_families.values()):5d} {rel}",
                 flush=True,
             )
         except Exception as e:  # a crash is a DEFECT row, never silence
@@ -71,8 +145,13 @@ def census(root: Path) -> int:
         f"{time.time() - t0:.0f}s ===",
         flush=True,
     )
-    print("--- gap families (top 40, deduped by source site) ---")
+    print("--- construction gap families (top 40, deduped by source site) ---")
+    print(f"R_construction = {sum(families.values())}")
     for kind, n in families.most_common(40):
+        print(f"{n:8d}  {kind}")
+    print("--- desugar-layer families (top 40, deduped by owner+file+line) ---")
+    print(f"R_desugar = {sum(desugar_families.values())}")
+    for kind, n in desugar_families.most_common(40):
         print(f"{n:8d}  {kind}")
     print("--- crashes (defects, not gaps) ---")
     for k, n in crashes.most_common():

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -1,0 +1,328 @@
+"""The desugar-layer census axis: four disjoint quantities, one membrane.
+
+The census measures two axes that are NEVER summed into one R:
+
+    R_construction   tree construction totality      (door: ``fn.sugar()``)
+    R_desugar        typed semantic refusals/effects (door: ``sugar.desugar(None)``)
+
+Behind the desugar door three different things can happen, and folding any of
+them into ``R_desugar`` produces a number whose denominator is a lie:
+
+``R_desugar``                 typed refusals (``SugarNotWritten``) and typed red
+                              effects (``Incomplete`` / ``Halted``).
+``desugarConstructionPanics`` a construction-law None arm fired *during*
+                              desugar. ``ConstructionPanic`` is a
+                              ``BaseException``: neither ``except
+                              SugarNotWritten`` nor ``except Exception`` sees
+                              it, so without an explicit arm here it escapes
+                              the per-function loop and can abort a whole
+                              census run with no row at all. Caught BY NAME —
+                              never ``except BaseException``.
+``desugarDefects``            ordinary exceptions (implementation bugs), plus
+                              named audit defects raised by the instrument
+                              itself (unsupported outcome envelope, outcome
+                              cycle, effect with no occurrence coordinate).
+
+Both new collections make the final instrument exit RED. Neither is ever added
+to ``R_desugar``.
+
+Row identity is the *effect occurrence*, not the enclosing function line. A
+function holding three distinct stores is three rows; the same occurrence
+reached twice through a shared outcome DAG is one row. An effect that carries
+no authenticated occurrence coordinate does not get a fabricated key: it is
+reported as an instrument gap in ``desugarDefects``.
+
+The outcome graph is walked with an explicit worklist and a visited set. There
+is NO depth cap: a depth cap makes a deep-but-valid body look cleaner than it
+is, which is exactly the silent skip this axis exists to eliminate.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections import Counter
+from enum import Enum
+from typing import Any
+
+
+# --------------------------------------------------------------------------
+# occurrence coordinates
+# --------------------------------------------------------------------------
+
+
+def effect_owner(effect: object) -> str:
+    """The family key of a typed red effect: its named type."""
+    return type(effect).__name__
+
+
+def effect_occurrence(effect: object) -> str | None:
+    """The authenticated occurrence coordinate of one typed effect.
+
+    Each arm reads a field the effect ITSELF carries about where it occurred:
+
+    * ``RuntimeEffect``      -- ``witness.site`` (the one SourceFragment
+                                currency: filename/line/col).
+    * ``RaiseEffect`` /
+      ``GroupedRaiseEffect`` -- ``occurrence_id`` (the raise site, distinct
+                                from the exception type name).
+    * ``LoopControlEffect``  -- ``occurrence_cid`` (a CID, not a name).
+    * ``CoverageGapEffect``  -- ``boundary``.
+    * ``ExpectationNotMetEffect`` / ``WarningEffect`` -- their own ``site`` /
+      ``blame``.
+
+    ``None`` means the effect states no occurrence. The caller reports that as
+    an instrument gap; it must NOT fall back to the enclosing function's line,
+    which would silently collapse distinct effects into one row.
+    """
+    witness = getattr(effect, "witness", None)
+    fragment = _fragment_coordinate(getattr(witness, "site", None))
+    if fragment is not None:
+        return f"site:{fragment}"
+
+    occurrence = getattr(effect, "occurrence_id", None)
+    if isinstance(occurrence, str) and occurrence:
+        return f"occurrence:{occurrence}"
+
+    occurrence_cid = getattr(effect, "occurrence_cid", None)
+    if isinstance(occurrence_cid, str) and occurrence_cid:
+        return f"occurrence-cid:{occurrence_cid}"
+
+    site = _fragment_coordinate(getattr(effect, "site", None))
+    if site is not None:
+        return f"site:{site}"
+
+    boundary = getattr(effect, "boundary", None)
+    if isinstance(boundary, str) and boundary:
+        return f"boundary:{boundary}"
+
+    blame = getattr(effect, "blame", None)
+    if isinstance(blame, str) and blame:
+        # A locus the effect carries about ITSELF (file:line:col prose minted
+        # from the owning fragment). Tagged so a row never claims fragment
+        # authority it does not have.
+        return f"blame:{blame}"
+
+    return None
+
+
+def _fragment_coordinate(site: object) -> str | None:
+    """``filename:line:col`` from anything answering the fragment contract."""
+    filename = getattr(site, "filename", None)
+    line = getattr(site, "line", None)
+    col = getattr(site, "col", None)
+    if isinstance(filename, str) and isinstance(line, int) and isinstance(col, int):
+        return f"{filename}:{line}:{col}"
+    return None
+
+
+# --------------------------------------------------------------------------
+# outcome traversal
+# --------------------------------------------------------------------------
+
+
+# The walk's domain is the outcome/value graph the desugar door returns: the
+# lift's own outcome envelopes and floor values, plus plain containers.
+#
+# It is NOT the whole object world. Measured on a 20-file slice, an unrestricted
+# dataclass walk left the outcome graph entirely through provenance fields and
+# reached tree infrastructure — SourceUnit, _Handle, ShadowNode, LineTable,
+# SymbolTable, CollectingReporter, ConstructionCache (and SourceUnit's genuine
+# parent/child cycle). Those are foreign currencies: an outcome cannot live
+# inside them, and walking them would drown real audit defects in noise.
+#
+# Two subdomains inside the lift are leaves by nature: ``ir`` (the proof-term /
+# formula language — terms hold no outcomes) and ``effect`` (an effect is
+# RECORDED at its Incomplete/Halted position; its interior is testimony, and
+# descending would recount a construction-total RaiseValue's effect as red).
+_SCALAR_TERMINALS = (str, bytes, bytearray, int, float, complex, bool, type, Enum)
+_WALK_DOMAIN = "sugar_lift_py_tests."
+_LEAF_SUBDOMAINS = ("sugar_lift_py_tests.ir", "sugar_lift_py_tests.effect")
+
+
+def _is_walkable_domain(obj: object) -> bool:
+    module = type(obj).__module__ or ""
+    return module.startswith(_WALK_DOMAIN) and not module.startswith(_LEAF_SUBDOMAINS)
+
+
+def _is_terminal(obj: object) -> bool:
+    if obj is None or isinstance(obj, _SCALAR_TERMINALS):
+        return True
+    if isinstance(obj, (tuple, list, set, frozenset, dict)):
+        return False
+    return not _is_walkable_domain(obj)
+
+
+def _children(obj: object) -> list[object] | None:
+    """Structural children, or ``None`` when the shape is not walkable."""
+    if isinstance(obj, (tuple, list, set, frozenset)):
+        return list(obj)
+    if isinstance(obj, dict):
+        return [*obj.keys(), *obj.values()]
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return [getattr(obj, f.name) for f in dataclasses.fields(obj)]
+    return None
+
+
+class OutcomeWalk:
+    """One traversal of an outcome DAG: typed red effects + audit defects.
+
+    Worklist + visited identity set, so a shared sub-outcome reached twice is
+    walked once and a cycle terminates. No depth cap. Every shape the walk
+    cannot descend and cannot justify as a leaf is recorded as a named audit
+    defect.
+    """
+
+    def __init__(self) -> None:
+        self.effects: list[object] = []
+        self.defects: list[str] = []
+
+    def walk(self, outcome: object) -> "OutcomeWalk":
+        # The two effect-bearing outcome positions. Every other envelope
+        # (Complete, Completed, ExitSet, and every floor value) is walked
+        # structurally as a dataclass, so a new envelope class cannot silently
+        # hide an effect from the census.
+        from sugar_lift_py_tests.outcome import Halted, Incomplete
+
+        visited: set[int] = set()
+        on_path: set[int] = set()
+        # (object, entering) — the exit marker pops the DFS path so a genuine
+        # back edge is distinguishable from lawful DAG sharing.
+        work: list[tuple[object, bool]] = [(outcome, True)]
+        while work:
+            obj, entering = work.pop()
+            if not entering:
+                on_path.discard(id(obj))
+                continue
+            if id(obj) in on_path:
+                self.defects.append(f"outcome-cycle:{type(obj).__name__}")
+                continue
+            if id(obj) in visited:
+                continue
+            visited.add(id(obj))
+
+            if isinstance(obj, (Incomplete, Halted)):
+                self.effects.append(obj.effect)
+                continue
+            if _is_terminal(obj):
+                continue
+            children = _children(obj)
+            if children is None:
+                self.defects.append(
+                    f"unsupported-outcome-envelope:{type(obj).__name__}"
+                )
+                continue
+            on_path.add(id(obj))
+            work.append((obj, False))
+            work.extend((child, True) for child in reversed(children))
+        return self
+
+
+# --------------------------------------------------------------------------
+# the audit membrane
+# --------------------------------------------------------------------------
+
+
+class DesugarAxis:
+    """Accumulates the four disjoint desugar-layer quantities for a file/run."""
+
+    def __init__(self) -> None:
+        self.families: Counter[str] = Counter()
+        self.construction_panics: list[dict[str, Any]] = []
+        self.defects: list[dict[str, Any]] = []
+        # Row identity: (owner, authenticated effect-occurrence coordinate).
+        self._seen: set[tuple[str, str]] = set()
+
+    # -- rows ---------------------------------------------------------------
+
+    def _tally(self, owner: str, occurrence: str) -> None:
+        key = (owner, occurrence)
+        if key in self._seen:
+            return
+        self._seen.add(key)
+        self.families[owner] += 1
+
+    def _defect(self, kind: str, where: str, detail: str) -> None:
+        self.defects.append({"kind": kind, "where": where, "detail": detail})
+
+    # -- the one door -------------------------------------------------------
+
+    def measure(self, sugar: object, *, where: str) -> None:
+        """Reduce one constructed function and classify the outcome.
+
+        ``where`` is the construction coordinate of the function whose sugar
+        this is (``file:line:col``) — it identifies the desugar CALL, which is
+        the true grain of a refusal (one refusal per reduction), and appears in
+        defect rows. It is never used as an effect-occurrence key.
+        """
+        from sugar_lift_py_tests.gap.panic import ConstructionPanic
+        from sugar_source_tree.panic import SugarNotWritten
+
+        try:
+            outcome = sugar.desugar(None)  # type: ignore[attr-defined]
+        except SugarNotWritten as gap:
+            # A refusal aborts the whole reduction: exactly one per desugar
+            # call, so the call coordinate IS the occurrence. (Instrument gap:
+            # SourceTreePanic carries owner/observed/requested/fix and no
+            # fragment, so a refusal cannot say WHERE inside the function.)
+            owner = _refusal_owner(gap)
+            self._tally(owner, f"desugar-call:{where}")
+            return
+        except ConstructionPanic as panic:
+            # BaseException by design. Caught BY NAME so it neither escapes the
+            # census nor lands in semantic R. Red, separately counted.
+            self.construction_panics.append(
+                {
+                    "where": where,
+                    "owner": getattr(panic.info, "owner", None),
+                    "message": panic.info.message,
+                }
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 -- an ordinary defect, not R
+            self._defect("desugar-exception", where, f"{type(exc).__name__}: {exc}")
+            return
+
+        walk = OutcomeWalk().walk(outcome)
+        for defect in walk.defects:
+            self._defect("audit-defect", where, defect)
+        for effect in walk.effects:
+            occurrence = effect_occurrence(effect)
+            if occurrence is None:
+                # No authenticated coordinate: report the instrument gap rather
+                # than fabricating a key from the enclosing function.
+                self._defect(
+                    "instrument-gap",
+                    where,
+                    f"no-occurrence-coordinate:{effect_owner(effect)}",
+                )
+                continue
+            self._tally(effect_owner(effect), occurrence)
+
+    # -- reporting ----------------------------------------------------------
+
+    def merge(self, other: "DesugarAxis") -> None:
+        self.families.update(other.families)
+        self.construction_panics.extend(other.construction_panics)
+        self.defects.extend(other.defects)
+        self._seen |= other._seen
+
+    def row(self) -> dict[str, Any]:
+        return {
+            "desugarFamilies": dict(self.families),
+            "R_desugar": sum(self.families.values()),
+            "desugarConstructionPanics": list(self.construction_panics),
+            "desugarDefects": list(self.defects),
+        }
+
+    @property
+    def red(self) -> bool:
+        """Panics and defects make the instrument exit red. R_desugar does not:
+        a typed refusal is a measured frontier row, not a broken instrument."""
+        return bool(self.construction_panics or self.defects)
+
+
+def _refusal_owner(gap: BaseException) -> str:
+    owner = getattr(gap, "owner", None)
+    if isinstance(owner, str) and owner:
+        return owner
+    return type(gap).__name__

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -1,0 +1,267 @@
+"""The desugar axis (#6243/#6244): four disjoint quantities, exact cardinality.
+
+Every twin here asserts an EXACT count. ``>= 1`` passes with extra incorrect
+rows and with a misclassified owner — which is exactly how a second axis starts
+reporting a useful-looking number whose denominator is not honest.
+
+The four quantities the door produces, and which twin separates them:
+
+    R_desugar                  typed refusals + typed red effects   (1, 2, 3, 5, 8)
+    R_construction             tree construction totality           (4)
+    desugarConstructionPanics  construction law during desugar      (6)
+    desugarDefects             ordinary + audit/instrument defects  (7, 9)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from sugar_lift_py_tests.gap.info import ConstructionGap
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str):
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeSugar:
+    """A constructed sugar whose desugar outcome (or panic) is dictated."""
+
+    def __init__(self, *, outcome=None, raises=None) -> None:
+        self._outcome = outcome
+        self._raises = raises
+
+    def desugar(self, ctx=None):
+        del ctx
+        if self._raises is not None:
+            raise self._raises
+        return self._outcome
+
+
+def _raise_effect(occurrence: str):
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    return RaiseEffect(exception_name="ValueError", occurrence=occurrence)
+
+
+def _incomplete(occurrence: str):
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    return Incomplete(_raise_effect(occurrence))
+
+
+def _axis():
+    from sugar_lift_py_tests.desugar_axis import DesugarAxis
+
+    return DesugarAxis()
+
+
+# -- 1. one YieldFrom refusal -> EXACTLY one desugar row ---------------------
+
+
+def test_twin_1_yield_from_refusal_is_exactly_one_desugar_row(tmp_path: Path) -> None:
+    module = _load("control_effect_recensus")
+    path = tmp_path / "gen.py"
+    path.write_text("def f(xs):\n    yield from xs\n", encoding="utf-8")
+    row = module._measure_file(path, relative="gen.py", workspace_root=tmp_path)
+    assert row["category"] == "completed"
+    assert row["functionsClean"] == 1
+    assert row["R_desugar"] == 1
+    assert row["desugarFamilies"] == {"YieldFromSugar.desugar": 1}
+
+
+# -- 2. two same-class effects on DIFFERENT sites -> two rows ----------------
+
+
+def test_twin_2_two_effect_sites_are_two_rows() -> None:
+    axis = _axis()
+    outcome = (_incomplete("gen.py:2:4"), _incomplete("gen.py:7:4"))
+    axis.measure(_FakeSugar(outcome=outcome), where="gen.py:1:0")
+    row = axis.row()
+    # The defect this bites: keying by the enclosing function's DEFINITION line
+    # collapses both raises into one row, because both live in one function.
+    assert row["R_desugar"] == 2
+    assert row["desugarFamilies"] == {"RaiseEffect": 2}
+
+
+# -- 3. the SAME occurrence reached twice -> one row -------------------------
+
+
+def test_twin_3_same_occurrence_twice_is_one_row() -> None:
+    axis = _axis()
+    shared = _incomplete("gen.py:2:4")
+    # Once as a shared object (lawful DAG re-entry), once as an equal-coordinate
+    # twin reached down another edge.
+    outcome = (shared, shared, _incomplete("gen.py:2:4"))
+    axis.measure(_FakeSugar(outcome=outcome), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar"] == 1
+    assert row["desugarFamilies"] == {"RaiseEffect": 1}
+
+
+# -- 4. a construction gap changes ONLY R_construction ----------------------
+
+
+def test_twin_4_construction_gap_moves_only_the_construction_axis(
+    tmp_path: Path,
+) -> None:
+    module = _load("control_effect_recensus")
+    path = tmp_path / "coro.py"
+    path.write_text("async def h(x):\n    return x\n", encoding="utf-8")
+    row = module._measure_file(path, relative="coro.py", workspace_root=tmp_path)
+    assert row["functionsClean"] == 0
+    # ONE gap occurrence, tallied once (catch + reporter is not two rows).
+    assert row["families"] == {"SugarNotWritten": 1}
+    assert row["R_desugar"] == 0
+    assert row["desugarFamilies"] == {}
+    assert row["desugarConstructionPanics"] == []
+    assert row["desugarDefects"] == []
+
+
+# -- 5. a typed desugar refusal changes ONLY R_desugar ----------------------
+
+
+def test_twin_5_typed_refusal_moves_only_the_desugar_axis(tmp_path: Path) -> None:
+    module = _load("control_effect_recensus")
+    path = tmp_path / "gen.py"
+    path.write_text("def f(xs):\n    yield from xs\n", encoding="utf-8")
+    row = module._measure_file(path, relative="gen.py", workspace_root=tmp_path)
+    assert row["families"] == {}
+    assert row["R_desugar"] == 1
+    assert row["desugarConstructionPanics"] == []
+    assert row["desugarDefects"] == []
+
+
+# -- 6. ConstructionPanic -> ONLY desugarConstructionPanics, and RED --------
+
+
+def test_twin_6_construction_panic_is_its_own_collection_and_red() -> None:
+    axis = _axis()
+    panic = ConstructionPanic(
+        ConstructionGap(
+            owner="MissingConstructor",
+            blame="gen.py:2:4",
+            observed="OpaqueValue",
+            requested="constructed value",
+            fix="implement the constructor",
+        )
+    )
+    # A BaseException: neither `except SugarNotWritten` nor `except Exception`
+    # sees it. Unhandled it escapes the per-function loop and can abort a whole
+    # census run with no row at all.
+    axis.measure(_FakeSugar(raises=panic), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar"] == 0
+    assert row["desugarFamilies"] == {}
+    assert row["desugarDefects"] == []
+    assert len(row["desugarConstructionPanics"]) == 1
+    assert row["desugarConstructionPanics"][0]["owner"] == "MissingConstructor"
+    assert axis.red is True
+    # ...and measurement CONTINUES: the next function is still measured.
+    axis.measure(_FakeSugar(outcome=_incomplete("gen.py:9:4")), where="gen.py:8:0")
+    assert axis.row()["R_desugar"] == 1
+
+
+# -- 7. an ordinary Exception -> ONLY desugarDefects, and RED ---------------
+
+
+def test_twin_7_ordinary_exception_is_a_defect_not_semantic_r() -> None:
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=KeyError("boom")), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar"] == 0
+    assert row["desugarFamilies"] == {}
+    assert row["desugarConstructionPanics"] == []
+    assert len(row["desugarDefects"]) == 1
+    assert row["desugarDefects"][0]["kind"] == "desugar-exception"
+    assert row["desugarDefects"][0]["detail"].startswith("KeyError")
+    assert axis.red is True
+
+
+# -- 8. depth GREATER than 24 is still fully measured -----------------------
+
+
+def test_twin_8_no_semantic_depth_cap() -> None:
+    from sugar_lift_py_tests.outcome import Complete
+
+    axis = _axis()
+    outcome: object = _incomplete("deep.py:40:8")
+    for _ in range(40):  # far past the deleted `if depth > 24: return`
+        outcome = Complete(outcome)  # type: ignore[arg-type]
+    axis.measure(_FakeSugar(outcome=outcome), where="deep.py:1:0")
+    row = axis.row()
+    assert row["R_desugar"] == 1
+    assert row["desugarFamilies"] == {"RaiseEffect": 1}
+    assert row["desugarDefects"] == []
+
+
+# -- 9. cyclic / unsupported outcome traversal -> a LOUD audit defect -------
+
+
+def test_twin_9_cycle_is_a_named_audit_defect() -> None:
+    axis = _axis()
+    cycle: list = [_incomplete("gen.py:2:4")]
+    cycle.append(cycle)
+    axis.measure(_FakeSugar(outcome=cycle), where="gen.py:1:0")
+    row = axis.row()
+    # The reachable effect is still measured; the cycle is NAMED, never an
+    # empty return.
+    assert row["R_desugar"] == 1
+    assert len(row["desugarDefects"]) == 1
+    assert row["desugarDefects"][0]["kind"] == "audit-defect"
+    assert row["desugarDefects"][0]["detail"] == "outcome-cycle:list"
+    assert axis.red is True
+
+
+def test_twin_9_unsupported_outcome_envelope_is_a_named_audit_defect() -> None:
+    unsupported = type("UnwalkableEnvelope", (), {})
+    # In the lift's own domain, so the walk is obliged to descend it — and it
+    # is neither a dataclass nor a container.
+    unsupported.__module__ = "sugar_lift_py_tests.fake_envelope"
+    axis = _axis()
+    axis.measure(_FakeSugar(outcome=unsupported()), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar"] == 0
+    assert len(row["desugarDefects"]) == 1
+    assert (
+        row["desugarDefects"][0]["detail"]
+        == "unsupported-outcome-envelope:UnwalkableEnvelope"
+    )
+    assert axis.red is True
+
+
+# -- the instrument gap: an effect that states no occurrence -----------------
+
+
+def test_effect_without_occurrence_is_an_instrument_gap_not_a_fabricated_key() -> None:
+    """No authenticated coordinate => NO row and a named instrument gap.
+
+    The forbidden alternative is substituting the enclosing function's line,
+    which silently collapses distinct effects and inflates nothing visibly.
+    """
+    from sugar_lift_py_tests.effect.source_oracle_effect import SourceOracleEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    axis = _axis()
+    effect = SourceOracleEffect(reason="source absent")
+    axis.measure(
+        _FakeSugar(outcome=(Incomplete(effect), Incomplete(effect))),
+        where="gen.py:1:0",
+    )
+    row = axis.row()
+    assert row["R_desugar"] == 0
+    assert row["desugarFamilies"] == {}
+    assert len(row["desugarDefects"]) == 2
+    assert {d["kind"] for d in row["desugarDefects"]} == {"instrument-gap"}
+    assert {d["detail"] for d in row["desugarDefects"]} == {
+        "no-occurrence-coordinate:SourceOracleEffect"
+    }
+    assert axis.red is True

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -125,3 +125,47 @@ def test_desugar_axis_separate_from_construction_r(tmp_path: Path) -> None:
     assert "desugarFamilies" in row
     assert "R_desugar" in row
     assert isinstance(row["R_desugar"], int)
+
+
+def test_construction_gap_occurrence_counted_once(tmp_path: Path) -> None:
+    """Catch+reporter must not double-tally (392 vs 196 class of defect).
+
+    A With that report_gap then raises is ONE occurrence. Family type total
+    equals distinct with-node gaps, not 2×.
+    """
+    module = _load("control_effect_recensus")
+    path = tmp_path / "with_param.py"
+    path.write_text(
+        "def use(manager):\n" "    with manager:\n" "        pass\n",
+        encoding="utf-8",
+    )
+    row = module._measure_file(
+        path, relative="with_param.py", workspace_root=tmp_path
+    )
+    assert row["category"] == "completed"
+    families = row.get("families") or {}
+    # One With site → one CM gap occurrence (not catch+reporter = 2).
+    cm = families.get("ContextManagerResolutionConstructionGap", 0)
+    rs = families.get("RuntimeSelectedContextManager", 0)
+    assert rs == 0
+    assert cm == 1, families
+    # No presentation-duplicate keys.
+    assert not any(k.startswith("owner:") for k in families)
+    assert not any(k.startswith("with-node:") for k in families)
+
+
+def test_backend_defect_keys_split_cm_and_call_demand() -> None:
+    """Demand/resolution BackendDefects are hygiene axes, not construction R."""
+    module = _load("control_effect_recensus")
+    cm = module._backend_defect_key(
+        "BackendDefect: enrolled context-manager demand missing from resolution table"
+    )
+    call = module._backend_defect_key(
+        "BackendDefect: enrolled call demand missing from resolution table"
+    )
+    other = module._backend_defect_key("BackendDefect: something else")
+    assert cm == "BackendDefect:cm-demand-missing-from-resolution"
+    assert call == "BackendDefect:call-demand-missing-from-resolution"
+    assert cm != call
+    assert other.startswith("BackendDefect:")
+    assert other not in {cm, call}

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -93,40 +93,6 @@ def test_with_census_injects_construction_context(tmp_path: Path) -> None:
     assert row["families"].get("RuntimeSelectedContextManager", 0) == 0
 
 
-def test_desugar_axis_counts_yield_from_refusal(tmp_path: Path) -> None:
-    """#6243: construction-total YieldFrom stays on the board under R_desugar."""
-    module = _load("control_effect_recensus")
-    path = tmp_path / "gen.py"
-    path.write_text(
-        "def f(xs):\n" "    yield from xs\n",
-        encoding="utf-8",
-    )
-    row = module._measure_file(path, relative="gen.py", workspace_root=tmp_path)
-    assert row["category"] == "completed"
-    assert row["functionsClean"] == 1
-    # Construction total — no construction family for YieldFrom.
-    assert row["families"].get("SugarNotWritten", 0) == 0 or (
-        "YieldFrom" not in str(row.get("families"))
-    )
-    # Desugar axis owns the refusal.
-    assert row["R_desugar"] >= 1
-    desugar = row.get("desugarFamilies") or {}
-    assert any(
-        "YieldFrom" in key or "yield from" in key.lower() for key in desugar
-    ), desugar
-
-
-def test_desugar_axis_separate_from_construction_r(tmp_path: Path) -> None:
-    """Axes must not be summed into one R on the per-file row."""
-    module = _load("control_effect_recensus")
-    path = tmp_path / "plain.py"
-    path.write_text("def a(z):\n    return z\n", encoding="utf-8")
-    row = module._measure_file(path, relative="plain.py", workspace_root=tmp_path)
-    assert "desugarFamilies" in row
-    assert "R_desugar" in row
-    assert isinstance(row["R_desugar"], int)
-
-
 def test_construction_gap_occurrence_counted_once(tmp_path: Path) -> None:
     """Catch+reporter must not double-tally (392 vs 196 class of defect).
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -91,3 +91,37 @@ def test_with_census_injects_construction_context(tmp_path: Path) -> None:
     # open is not source-derived under provisional gaps — honest residual is a
     # typed CM gap, never unconditional RuntimeSelected from missing context.
     assert row["families"].get("RuntimeSelectedContextManager", 0) == 0
+
+
+def test_desugar_axis_counts_yield_from_refusal(tmp_path: Path) -> None:
+    """#6243: construction-total YieldFrom stays on the board under R_desugar."""
+    module = _load("control_effect_recensus")
+    path = tmp_path / "gen.py"
+    path.write_text(
+        "def f(xs):\n" "    yield from xs\n",
+        encoding="utf-8",
+    )
+    row = module._measure_file(path, relative="gen.py", workspace_root=tmp_path)
+    assert row["category"] == "completed"
+    assert row["functionsClean"] == 1
+    # Construction total — no construction family for YieldFrom.
+    assert row["families"].get("SugarNotWritten", 0) == 0 or (
+        "YieldFrom" not in str(row.get("families"))
+    )
+    # Desugar axis owns the refusal.
+    assert row["R_desugar"] >= 1
+    desugar = row.get("desugarFamilies") or {}
+    assert any(
+        "YieldFrom" in key or "yield from" in key.lower() for key in desugar
+    ), desugar
+
+
+def test_desugar_axis_separate_from_construction_r(tmp_path: Path) -> None:
+    """Axes must not be summed into one R on the per-file row."""
+    module = _load("control_effect_recensus")
+    path = tmp_path / "plain.py"
+    path.write_text("def a(z):\n    return z\n", encoding="utf-8")
+    row = module._measure_file(path, relative="plain.py", workspace_root=tmp_path)
+    assert "desugarFamilies" in row
+    assert "R_desugar" in row
+    assert isinstance(row["R_desugar"], int)


### PR DESCRIPTION
## Summary

Implements #6243: a **second named census axis** for desugar-layer refusals and typed red effects, so construction-total sites (Yield, YieldFrom, …) do not vanish from the board.

| Axis | Door | Answers |
|------|------|---------|
| `R` / `families` | `fn.sugar()` + `reporter.gaps` | Is the tree total? (occurrence-deduped) |
| `R_desugar` / `desugarFamilies` | `sugar.desugar(None)` | Is meaning reducible? |
| `R_backend_defects` / `backendDefects` | demand/resolution table hygiene | CM vs call bijection failures (not mass) |

Never one number. Construction and desugar use occurrence keys `(kind, file, line, col)`. Construction tallies **only** `reporter.gaps` — catch+reporter type double-count was presentation duplication (mid-band With: ~443 naive vs ~213 site-deduped CM gaps; plan against the site residual, not 2×).

## Sequencing note

- Land this instrument before trusting desugar counts for board claims.
- Source-derived CM **contract resolution** can proceed in parallel (contracts, not exit routing).
- Resource-With **ExitSet routing** waits for store ExitSet foundation — one exit model only.
- Assertion managers (`pytest.raises`) remain a separate membrane.

## Files

- `scripts/control_effect_recensus.py`
- `sugar_lift_py_tests/census.py`
- twins in `test_recensus_panic_collection.py`

## Validation

```text
smoke: occurrence-once cm==1; backend keys split cm vs call; clean file clean
```

Closes #6243.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add desugar-layer census axis to measure and report typed red effects separately from construction families
> - Introduces [`DesugarAxis`](https://github.com/TSavo/sugar/pull/6244/files#diff-881c3a69977ae00d55b817c4db3cf34ef4f1997c99e3ea9611429dc14c1e9ecf) to measure desugar-layer outcomes: refusals, typed red effects (deduped by authenticated occurrence coordinate), `ConstructionPanic`, and ordinary exceptions.
> - Updates [`census.py`](https://github.com/TSavo/sugar/pull/6244/files#diff-33e0e08a2acade24345dc0b94e0f322c8825c67008eeb014b004a5d09f3f2669) and [`control_effect_recensus.py`](https://github.com/TSavo/sugar/pull/6244/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to integrate desugar measurement, report `R_desugar`/`R_construction`/`R_backend_defects` separately, and exit non-zero when desugar panics or defects are present.
> - Backend defects are bucketed under stable keys (with separate buckets for context-manager and call-demand missing cases) and excluded from construction R.
> - Construction family counting is now occurrence-deduped via `_occurrence_key` to prevent double-counting the same site.
> - Risk: the exit status of `control_effect_recensus.py` now goes non-zero on desugar construction panics or desugar defects, which are newly detected failure conditions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08068d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate reporting for construction gaps and desugaring outcomes.
  * Added tracking for desugaring refusals, construction panics, backend defects, and implementation defects.
  * Reports now include per-file and overall totals for each measurement category.
  * Process failures now reflect desugaring panics and defects in addition to construction issues.

* **Bug Fixes**
  * Prevented duplicate counting of construction gaps and repeated desugaring occurrences.
  * Improved handling and reporting of cycles, unsupported outcomes, and missing effect locations.

* **Tests**
  * Added comprehensive coverage for outcome classification, deduplication, deep traversal, and defect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->