### PR TITLE
feat: stores compose as guarded success/halt, not infallible completion

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/store_outcome_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/store_outcome_coordinate.py
@@ -1,0 +1,132 @@
+"""The store-occurrence outcome coordinate: effect-dimension phi for a store.
+
+Python assignment to an attribute or a subscript is NOT transactional and NOT
+infallible.  ``o.x = p`` can halt at runtime (``__setattr__``/descriptor/
+``__setitem__`` dispatch belongs to the runtime), and when a LATER store halts
+the EARLIER targets remain assigned.  So a store has exactly two outcomes:
+
+    Store(receiver, selector, value)
+        success -> Completed(updated temporal state)
+        failure -> Halted(store effect, prefix temporal state)
+
+Which one happens is RUNTIME-SELECTED.  There is no lift-time evidence naming a
+particular exception type, and inventing one would fabricate a fact.  So the
+outcome is modelled the way this tree already models every runtime-selected
+binary outcome: an authenticated per-occurrence coordinate plus the
+complementary guard pair ``g`` / ``not g``.
+
+This is deliberately the SAME mechanism as
+``floor/branch_result_coordinate.py``'s ``BranchResultCoordinate`` (used by
+``IfSugar`` for a runtime-selected branch), not a second one.  The difference is
+only what authenticates the coordinate:
+
+- a branch result is authenticated by the sealed source fragment of its TEST,
+  and tied to the observed condition by a biconditional inv;
+- a store outcome has no observable condition to tie to, so it is authenticated
+  by the store OCCURRENCE: the witness address of the store's own runtime
+  effect, together with the store's own operation term -- which retains all
+  three authenticated coordinates (receiver, selector, value).  Two distinct
+  stores therefore mint two distinct, independent coordinates, and the same
+  store evaluated once mints one.
+
+No biconditional is emitted, and that is the point: an authentication tying the
+coordinate to a lift-time formula would be exactly the invented exception type
+the ruling forbids.  The coordinate stays open; both faces survive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+#: The store family.  Every one of these effects mutates a place through
+#: runtime dispatch that can halt: attribute/subscript stores, the store half of
+#: an augmented attribute assignment, and attribute/subscript deletes.  They
+#: share ONE law, so they share ONE list -- there is no per-syntax special case.
+STORE_FAMILY_EFFECT_NAMES = (
+    "AttributeStoreRuntimeEffect",
+    "SubscriptStoreRuntimeEffect",
+    "AttributeAugAssignRuntimeEffect",
+    "AttributeDeleteRuntimeEffect",
+    "SubscriptDeleteRuntimeEffect",
+)
+
+
+def store_family_effects() -> tuple[type, ...]:
+    from sugar_lift_py_tests import effect as effect_module
+
+    return tuple(
+        getattr(effect_module, name) for name in STORE_FAMILY_EFFECT_NAMES
+    )
+
+
+def is_store_family_effect(effect) -> bool:
+    return isinstance(effect, store_family_effects())
+
+
+def store_occurrence_address(effect) -> str:
+    """The authenticated address of THIS store occurrence.
+
+    Read straight off the effect's own ``RuntimeEffectWitness`` site, which is a
+    genuine fragment minted by enumeration through the one SourceOracle (see
+    ``effect/runtime_effect.py``'s ``RuntimeEffectSite`` protocol).  filename /
+    line / col is the contract both fragment currencies answer, so this needs no
+    fallback arm and cannot be reconstructed from blame prose.
+    """
+    site = effect.witness.site
+    return f"store-outcome:{site.filename}:{site.line}:{site.col}"
+
+
+@dataclass(frozen=True)
+class StoreOutcomeCoordinate(FloorValue):
+    """``true`` exactly when the store at this occurrence completed."""
+
+    occurrence: str
+    operation: object
+    site: object = field(default=None, compare=False)
+    symbol_kind: str = field(default="coordinate", init=False)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        # The occurrence address distinguishes two textually identical stores;
+        # the operation term retains receiver, selector and value, so the
+        # coordinate is authenticated by the store it actually names.
+        return ctor(
+            "python:store_completed",
+            [str_const(self.occurrence), self.operation],
+        )
+
+    def truth(self, site):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import py_truthy
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(PredicateValue(py_truthy(self.to_term(owner=str(site))), site))
+
+
+def store_outcome_coordinate(effect) -> StoreOutcomeCoordinate:
+    return StoreOutcomeCoordinate(
+        store_occurrence_address(effect),
+        effect.witness.operation,
+        effect.witness.site,
+    )
+
+
+def store_completed_guard(effect):
+    """``g`` -- the store at this occurrence completed."""
+    from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+    coordinate = store_outcome_coordinate(effect)
+    return predicate_formula(coordinate, coordinate.site)
+
+
+def store_halted_guard(effect):
+    """``not g`` -- the complementary face.  ``ExitSet._is_negation`` recognises
+    the pair, so the two arms partition exactly and normalization can merge or
+    kill them the same way it does for a branch result."""
+    from sugar_lift_py_tests.ir import not_
+
+    return not_(store_completed_guard(effect))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -42,6 +42,21 @@ def _is_negation(left: Formula, right: Formula) -> bool:
     )
 
 
+def complement_guard(guard: Formula) -> Formula:
+    """The other face of a partition, without stacking a second ``not``.
+
+    ``complement_guard(not_(g)) is g``-shaped, so a guarded pair built from
+    either direction spells the same two formulas. Double negation would still
+    normalize (``_is_negation`` looks one level deep), but it would leak an
+    ``not not g`` into the emitted FOL, and the FOL is the deliverable.
+    """
+    if getattr(guard, "kind", None) == "not":
+        operands = getattr(guard, "operands", ())
+        if len(operands) == 1:
+            return operands[0]
+    return not_(guard)
+
+
 def _and_guards(left: Formula, right: Formula) -> Formula:
     if _is_false(left) or _is_false(right) or _is_negation(left, right):
         return false_guard()
@@ -311,6 +326,33 @@ class ExitSet(Generic[T]):
         return Incomplete(exit_.effect)
 
 
+def sole_completed_outcome(outcome):
+    """Project a body outcome onto its ONE completed arm.
+
+    A store partitions a block into a completed and a halted arm, so a body that
+    contains one reduces to an ``ExitSet`` rather than to a single linear
+    ``Outcome``. A caller that is legitimately reasoning about the success path
+    only -- "what does this store witness, what is the post when everything
+    completed" -- uses this door.
+
+    It REFUSES loudly when there is not exactly one completed arm, so a dropped
+    success face or a silently duplicated one surfaces here instead of being
+    papered over. It is not a way to discard halt arms: the halted arms are the
+    other half of the meaning and are asserted by the composition laws.
+    """
+    if not isinstance(outcome, ExitSet):
+        return outcome
+    completed = [exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)]
+    if len(completed) != 1:
+        raise ValueError(
+            "sole_completed_outcome requires exactly one completed arm; got "
+            f"{len(completed)} completed of {len(outcome.exits)} exits. "
+            "A body with several completed faces has no single success path to "
+            "project onto — reason over the ExitSet arms directly."
+        )
+    return Complete(completed[0].value)
+
+
 def outcome_to_exitset(outcome) -> ExitSet:
     if isinstance(outcome, ExitSet):
         return outcome
@@ -327,7 +369,9 @@ __all__ = [
     "Completed",
     "ExitSet",
     "Halted",
+    "complement_guard",
     "false_guard",
+    "sole_completed_outcome",
     "true_guard",
     "outcome_to_exitset",
 ]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/follow_step.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/follow_step.py
@@ -12,6 +12,17 @@ class FollowStep:
     keeps_rest: bool = False
     transform: Callable[[tuple], tuple] | None = None
     continuation_guard: object | None = None
+    halt_guard: object | None = None
+    """A complementary SECOND face for a step that neither purely continues nor
+    purely halts.
+
+    ``continues=True`` with ``halt_guard=g`` means: this step halts under ``g``
+    with the step's own effect and the PREFIX state, and continues under
+    ``not g``.  Both faces survive; neither is chosen at lift time.
+
+    This is what a store needs.  ``continues=True, halt_guard=None`` (the
+    default) is the old unconditional-continue behaviour and is what every
+    non-store step still returns."""
 
     @classmethod
     def continue_with(
@@ -19,11 +30,13 @@ class FollowStep:
         transform: Callable[[tuple], tuple] | None = None,
         *,
         continuation_guard: object | None = None,
+        halt_guard: object | None = None,
     ) -> "FollowStep":
         return cls(
             continues=True,
             transform=transform,
             continuation_guard=continuation_guard,
+            halt_guard=halt_guard,
         )
 
     @classmethod

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -31,15 +31,28 @@ class Incomplete:
 
     def follow(self):
         # Default: an effect halts the run; the rest of the block stays unreduced.
-        # Store side-effects are different: the statement completed (typed red),
-        # and Python continues. Halting would drop later bindings (e.g. `res = …`
-        # after `receiver[index][...] = 0`) and panic NameSugar unbound — a false
-        # construction gap. Continuing store effects contribute red and let the
-        # block reduce subsequent statements.
+        #
+        # A STORE is neither. `o.x = p` may complete (Python goes on to the next
+        # statement, the target stays assigned) or may halt (`__setattr__` /
+        # descriptor / `__setitem__` dispatch belongs to the runtime). Which one
+        # is RUNTIME-SELECTED, so BOTH faces are kept: continues under `not g`,
+        # halts under `g`, over the store's own authenticated occurrence
+        # coordinate. See floor/store_outcome_coordinate.py.
+        #
+        # Modelling a store as unconditionally continuing (what this returned
+        # before) claims assignment is infallible; modelling it as halting would
+        # drop every later binding and fabricate a construction gap. The guarded
+        # pair is the only spelling that states neither.
         from sugar_lift_py_tests.outcome.follow_step import FollowStep
+        from sugar_lift_py_tests.floor.store_outcome_coordinate import (
+            is_store_family_effect,
+            store_halted_guard,
+        )
 
-        if _effect_continues_control_flow(self.effect):
-            return FollowStep.continue_with()
+        if is_store_family_effect(self.effect):
+            return FollowStep.continue_with(
+                halt_guard=store_halted_guard(self.effect)
+            )
         return FollowStep.halt(keeps_rest=True)
 
     def contribution(self):
@@ -87,27 +100,15 @@ class Incomplete:
 
 
 def _effect_continues_control_flow(effect) -> bool:
-    """True when the effect is red testimony for a completed non-exiting statement.
+    """Retained name for the store family, now with the honest meaning: this
+    effect has a completed face at all (as opposed to halting outright).
 
-    Store mutations do not raise or return: after `xs[i] = v` or `obj.attr = v`
-    the next statement still runs. Incomplete must contribute the red effect and
-    continue so later TemporalContext bindings still construct.
+    It no longer means "this effect always continues" -- that claim was the
+    defect. The store family owns the sole membership list, in
+    floor/store_outcome_coordinate.py.
     """
-    from sugar_lift_py_tests.effect import (
-        AttributeAugAssignRuntimeEffect,
-        AttributeDeleteRuntimeEffect,
-        AttributeStoreRuntimeEffect,
-        SubscriptDeleteRuntimeEffect,
-        SubscriptStoreRuntimeEffect,
+    from sugar_lift_py_tests.floor.store_outcome_coordinate import (
+        is_store_family_effect,
     )
 
-    return isinstance(
-        effect,
-        (
-            SubscriptStoreRuntimeEffect,
-            AttributeStoreRuntimeEffect,
-            AttributeAugAssignRuntimeEffect,
-            AttributeDeleteRuntimeEffect,
-            SubscriptDeleteRuntimeEffect,
-        ),
-    )
+    return is_store_family_effect(effect)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -75,6 +75,15 @@ def reduce_block_to_exitset(
                 exits = []
                 for entry in faces.contribution():
                     if isinstance(entry, Incomplete):
+                        # A store inside a guarded face is NOT re-split here.
+                        # The branch body was already reduced by
+                        # reduce_block_to_exitset, so the store's success/halt
+                        # partition has already happened; IfSugar then absorbs
+                        # each halted arm as guarded red testimony (if_sugar.py,
+                        # `Incomplete(exit_.effect).guarded(exit_.guard)`), the
+                        # same seam every halt inside an `if` goes through.
+                        # Splitting again here would emit the same occurrence
+                        # twice.
                         if entry.follow().continues:
                             entries.append(entry)
                             continue
@@ -142,6 +151,36 @@ def reduce_block_to_exitset(
             entries = (*state.entries, *contribution)
 
             follow = outcome.follow()
+            if follow.continues and follow.halt_guard is not None:
+                # A store: runtime-selected success/halt over ONE authenticated
+                # occurrence coordinate.
+                #
+                # Halted arm carries `state` -- the PREFIX. Every earlier
+                # binding and every earlier store survives on it (Python never
+                # rolls back an assignment that already happened), and this
+                # store's own completion testimony is absent from it, because
+                # this store did not complete.
+                #
+                # Completed arm carries `entries` -- the prefix PLUS this
+                # store's red testimony. Only this arm is fed to the tail by
+                # `ExitSet.sequence`, so no later target can execute after an
+                # earlier store halt.
+                from sugar_lift_py_tests.outcome.exit_set import complement_guard
+
+                return ExitSet(
+                    (
+                        Halted(follow.halt_guard, outcome.effect, state),
+                        Completed(
+                            complement_guard(follow.halt_guard),
+                            _ReducedBlock(
+                                entries,
+                                True,
+                                state.fall_through,
+                                state.transforms,
+                            ),
+                        ),
+                    )
+                ).normalize()
             if not follow.continues:
                 if isinstance(outcome, Incomplete):
                     if outcome.branch_conditions:

--- a/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
@@ -139,16 +139,6 @@ OTHER_STORE = """def target(o, q):
     return q
 """
 
-UNPACK_MIXED = """def target(o, p, q):
-    x, o.y = p, q
-    return x
-"""
-
-UNPACK_BOTH = """def target(o, p, q):
-    o.x, o.y = p, q
-    return p
-"""
-
 
 # --------------------------------------------------------------------------
 # Sequential spelling:  o.x = p ; o.y = q
@@ -342,76 +332,19 @@ def test_no_invented_exception_type_on_a_store_halt_discrimination():
 
 
 # --------------------------------------------------------------------------
-# Unpack spelling:  x, o.y = p, q   and   o.x, o.y = p, q
+# Unpack spelling (``x, o.y = p, q``, ``o.x, o.y = p, q``) is NOT tested here.
 #
-# THE SAME LAWS. These are the same store family; a store target inside a
-# tuple-unpack assignment is not a different kind of store.
+# Ownership boundary (T's ruling):
 #
-# These are RED on this branch, and they are red for a PREREQUISITE reason, not
-# because the composition above is wrong: a tuple/multi-target ``Assign``
-# currently has no sugar written at all (``SugarNotWritten [Assign.sugar]``), so
-# no exit structure exists to compose. That construction is owned by the
-# separate branch that routes authenticated ``ObjectPlaceStateV1`` through
-# ``PlaceAssignSugar``. Once a store target inside an unpack constructs a store
-# effect, the composition below is already implemented and these pass with no
-# further change here.
+#     this branch   owns generic store success/halt composition
+#                   owns sequential assignment spelling
 #
-# They are stated as the real laws rather than pinned to the current behaviour
-# on purpose: a test that must be DELETED when the bug is fixed is a test of the
-# bug.
+#     #6239         owns tuple/multi-target construction
+#                   owns unpack sequencing through that composition
+#
+# A prerequisite must not be held red by syntax it deliberately does not
+# construct. The unpack twins now live on ``fix/assign-family-drain`` in
+# ``tests/test_assign_unpack_store_outcome_composition.py``, where the
+# construction they exercise is owned. They are stated as the real laws there,
+# not muted here.
 # --------------------------------------------------------------------------
-
-
-def test_unpack_mixed_name_and_store_preserves_both_outcomes():
-    """``x, o.y = p, q``
-
-    success arm: ``x == p``, the store on ``o.y`` completed, continuation runs.
-    halt arm:    ``x == p`` STILL -- the name target was already bound -- the
-                 store halted, and there is NO continuation.
-    """
-    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
-
-    assert len(completed) == 1
-    assert _polarity(completed[0].guard, "y") is True
-    assert "p" in str(completed[0].value.post())
-
-    (arm,) = halted
-    assert _polarity(arm.guard, "y") is False
-    assert "p" in str(arm.state.post() if hasattr(arm.state, "post") else arm.state), (
-        "the name target bound before the store must survive the store's halt"
-    )
-
-
-def test_unpack_mixed_name_and_store_preserves_both_outcomes_discrimination():
-    """The bite: a single unconditional arm would mean the store cannot fail."""
-    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
-
-    with pytest.raises(AssertionError):
-        assert len(halted) == 0 and len(completed) == 1, "store is infallible"
-
-
-def test_unpack_two_stores_preserve_both_outcomes_per_store():
-    """``o.x, o.y = p, q`` -- the same three arms as the sequential spelling:
-    first success + second success, first success + second halt, and first halt
-    with NO second-store occurrence."""
-    halted, completed = _arms(_exits(UNPACK_BOTH, "target"))
-
-    assert len(completed) == 1
-    assert len(halted) == 2
-
-    first = next(h for h in halted if _polarity(h.guard, "x") is False)
-    assert _polarity(first.guard, "y") is None
-    assert _store_entries(first.state) == []
-
-    second = next(h for h in halted if _polarity(h.guard, "y") is False)
-    assert _polarity(second.guard, "x") is True
-    assert len(_store_entries(second.state)) == 1
-
-
-def test_unpack_two_stores_preserve_both_outcomes_per_store_discrimination():
-    """The bite: the first-halt arm must not carry the second store."""
-    halted, _ = _arms(_exits(UNPACK_BOTH, "target"))
-    first = next(h for h in halted if _polarity(h.guard, "x") is False)
-
-    with pytest.raises(AssertionError):
-        assert len(_store_entries(first.state)) == 1, "second target ran anyway"

--- a/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
@@ -1,0 +1,417 @@
+"""The store-family composition laws.
+
+Python assignment to an attribute or a subscript is NOT transactional and NOT
+infallible:
+
+    Store(receiver, selector, value)
+        success -> Completed(updated temporal state)
+        failure -> Halted(store effect, prefix temporal state)
+
+Sequential composition of stores must therefore:
+
+  * evaluate receiver, selector and value exactly once;
+  * retain all three authenticated coordinates;
+  * continue subsequent targets only from the completed arm;
+  * preserve earlier bindings/stores on the halted arm;
+  * never roll back earlier assignment;
+  * never execute a later target after an earlier store halt;
+  * preserve BOTH outcomes unless evidence proves the store non-halting.
+
+Success versus halt for an external attribute/subscript store is
+RUNTIME-SELECTED, so it is carried by an authenticated store-occurrence
+coordinate with complementary outcome guards -- the same mechanism
+``IfSugar`` uses for a runtime-selected branch (``BranchResultCoordinate``),
+not a second one. See ``floor/store_outcome_coordinate.py``.
+
+Every test here asserts the ACTUAL constructed ``ExitSet`` arm structure or the
+post formula, and each carries a discrimination arm showing that perturbing the
+expectation fails.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+from sugar_source_tree.tree import SourceFile
+
+
+def _exits(src, name):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    for fn in SourceFile(path_source(path)).functions():
+        if fn.name != name:
+            continue
+        outcome = fn.sugar().desugar(None)
+        assert isinstance(outcome, ExitSet), (
+            "a body containing a store must reduce to guarded exits, not one "
+            f"unconditional outcome; got {type(outcome).__name__}"
+        )
+        return outcome
+    raise AssertionError(f"no function {name}")
+
+
+def _walk(formula):
+    yield formula
+    for operand in getattr(formula, "operands", ()) or ():
+        yield from _walk(operand)
+
+
+def _terms(formula):
+    for node in _walk(formula):
+        for arg in getattr(node, "args", ()) or ():
+            yield from _subterms(arg)
+
+
+def _subterms(term):
+    yield term
+    for arg in getattr(term, "args", ()) or ():
+        yield from _subterms(arg)
+
+
+def _store_coordinates(formula):
+    """Every distinct store-occurrence coordinate cited by a guard."""
+    found = []
+    for term in _terms(formula):
+        if getattr(term, "name", None) == "python:store_completed":
+            if term not in found:
+                found.append(term)
+    return tuple(found)
+
+
+def _selectors(formula):
+    """The selector (attr name) of each store coordinate cited by a guard."""
+    out = []
+    for coordinate in _store_coordinates(formula):
+        operation = coordinate.args[1]
+        out.append(operation.args[1].value)
+    return tuple(out)
+
+
+def _polarity(formula, selector):
+    """True when the guard asserts the named store COMPLETED, False when it
+    asserts the complement, None when the guard does not mention it."""
+    for node in _walk(formula):
+        if getattr(node, "kind", None) != "not":
+            continue
+        (inner,) = node.operands
+        if selector in _selectors(inner):
+            return False
+    if selector in _selectors(formula):
+        return True
+    return None
+
+
+def _arms(exits):
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    return halted, completed
+
+
+def _store_entries(state):
+    return [
+        entry
+        for entry in getattr(state, "entries", ())
+        if isinstance(entry, Incomplete)
+        and isinstance(entry.effect, AttributeStoreRuntimeEffect)
+    ]
+
+
+SEQUENTIAL = """def target(o, p, q):
+    o.x = p
+    o.y = q
+    return q
+"""
+
+ONE_STORE = """def target(o, p):
+    o.x = p
+    return p
+"""
+
+OTHER_STORE = """def target(o, q):
+    o.y = q
+    return q
+"""
+
+UNPACK_MIXED = """def target(o, p, q):
+    x, o.y = p, q
+    return x
+"""
+
+UNPACK_BOTH = """def target(o, p, q):
+    o.x, o.y = p, q
+    return p
+"""
+
+
+# --------------------------------------------------------------------------
+# Sequential spelling:  o.x = p ; o.y = q
+# --------------------------------------------------------------------------
+
+
+def test_sequential_stores_preserve_both_outcomes_per_store():
+    """Two stores => three arms, never one.
+
+    A single ``Completed`` arm would state that assignment is transactional and
+    infallible. It is neither.
+    """
+    halted, completed = _arms(_exits(SEQUENTIAL, "target"))
+
+    assert len(halted) == 2, [str(e.guard) for e in halted]
+    assert len(completed) == 1
+
+
+def test_sequential_stores_preserve_both_outcomes_per_store_discrimination():
+    """The bite: the pre-repair expectation (one Completed arm, no Halted arm)
+    is exactly what this construction no longer produces."""
+    halted, completed = _arms(_exits(SEQUENTIAL, "target"))
+
+    with pytest.raises(AssertionError):
+        assert len(halted) == 0 and len(completed) == 1, "stores are infallible"
+
+
+def test_first_store_halt_has_no_second_store_occurrence():
+    """Law: never execute a later target after an earlier store halt.
+
+    The arm guarded by "the FIRST store did not complete" must carry a prefix
+    state in which the second store never happened.
+    """
+    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    first = next(h for h in halted if _polarity(h.guard, "x") is False)
+
+    assert _polarity(first.guard, "y") is None, (
+        "the first store's halt arm must not be conditioned on the second "
+        "store's outcome -- the second store never ran"
+    )
+    assert _store_entries(first.state) == [], (
+        "the first store's halt arm must contain no store occurrence at all"
+    )
+    assert isinstance(first.effect, AttributeStoreRuntimeEffect)
+
+
+def test_first_store_halt_has_no_second_store_occurrence_discrimination():
+    """The bite: asserting the second store DID occur on the first-halt arm
+    fails, so the assertion above is load-bearing."""
+    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    first = next(h for h in halted if _polarity(h.guard, "x") is False)
+
+    with pytest.raises(AssertionError):
+        assert len(_store_entries(first.state)) == 1, "second target ran anyway"
+
+
+def test_second_store_halt_preserves_the_first_store():
+    """Law: never roll back earlier assignment.
+
+    The arm guarded by "first completed AND second did not" must still carry the
+    first store's testimony: ``o.x`` REMAINS assigned.
+    """
+    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    second = next(h for h in halted if _polarity(h.guard, "y") is False)
+
+    assert _polarity(second.guard, "x") is True, (
+        "the second store only runs when the first completed"
+    )
+    surviving = _store_entries(second.state)
+    assert len(surviving) == 1, surviving
+    assert "attr=x" in surviving[0].effect.reason, (
+        "the first store must survive on the second store's halt arm"
+    )
+
+
+def test_second_store_halt_preserves_the_first_store_discrimination():
+    """The bite: a rolled-back first store (empty prefix) fails."""
+    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+    second = next(h for h in halted if _polarity(h.guard, "y") is False)
+
+    with pytest.raises(AssertionError):
+        assert _store_entries(second.state) == [], "assignment rolled back"
+
+
+def test_sequential_completed_arm_requires_every_store_to_complete():
+    """The continuation after the stores is reachable only when BOTH completed,
+    and it still states the real post."""
+    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    (arm,) = completed
+
+    assert _polarity(arm.guard, "x") is True
+    assert _polarity(arm.guard, "y") is True
+    assert str(arm.value.post()) == str(
+        _exits(SEQUENTIAL, "target").exits[-1].value.post()
+    )
+
+
+def test_sequential_completed_arm_requires_every_store_to_complete_discrimination():
+    """The bite: an unconditional (true) completed guard fails -- the guard is
+    a real conjunction of two store coordinates."""
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    (arm,) = completed
+
+    with pytest.raises(AssertionError):
+        assert arm.guard == true_guard(), "continuation is unconditional"
+
+
+def test_each_store_occurrence_mints_its_own_coordinate():
+    """Law: evaluate receiver, selector and value exactly once, and retain all
+    three authenticated coordinates.
+
+    Two distinct stores must not share one outcome coordinate, and each
+    coordinate must name its own receiver, selector and value.
+    """
+    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    coordinates = _store_coordinates(completed[0].guard)
+
+    assert len(coordinates) == 2, coordinates
+    operations = [c.args[1] for c in coordinates]
+    receivers = {op.args[0].name for op in operations}
+    selectors = {op.args[1].value for op in operations}
+    values = {op.args[2].name for op in operations}
+
+    assert receivers == {"o"}
+    assert selectors == {"x", "y"}
+    assert values == {"p", "q"}
+
+
+def test_each_store_occurrence_mints_its_own_coordinate_discrimination():
+    """The bite: collapsing the two stores to one coordinate fails."""
+    _, completed = _arms(_exits(SEQUENTIAL, "target"))
+    coordinates = _store_coordinates(completed[0].guard)
+
+    with pytest.raises(AssertionError):
+        assert len(coordinates) == 1, "both stores share one outcome"
+
+
+def test_store_outcome_guards_are_exactly_complementary():
+    """The two faces of ONE store are ``g`` and ``not g`` over the SAME
+    coordinate -- an exact partition, so ``ExitSet`` normalization can merge or
+    kill them the way it does for a branch result."""
+    from sugar_lift_py_tests.outcome.exit_set import _and_guards, false_guard
+
+    halted, completed = _arms(_exits(ONE_STORE, "target"))
+    (halt,) = halted
+    (success,) = completed
+
+    assert _polarity(halt.guard, "x") is False
+    assert _polarity(success.guard, "x") is True
+    assert _and_guards(halt.guard, success.guard) == false_guard(), (
+        "the halt face and the success face of ONE store cannot both hold"
+    )
+
+
+def test_store_outcome_guards_are_exactly_complementary_discrimination():
+    """The bite: two DIFFERENT stores' guards are not contradictory -- so the
+    contradiction above comes from complementarity, not from everything being
+    trivially false."""
+    from sugar_lift_py_tests.outcome.exit_set import _and_guards, false_guard
+
+    halted, _ = _arms(_exits(ONE_STORE, "target"))
+    (halt,) = halted
+    other, _unused = _arms(_exits(OTHER_STORE, "target"))
+    (other_halt,) = other
+
+    with pytest.raises(AssertionError):
+        assert (
+            _and_guards(halt.guard, other_halt.guard) == false_guard()
+        ), "unrelated store coordinates are contradictory"
+
+
+def test_no_invented_exception_type_on_a_store_halt():
+    """Success versus halt is runtime-selected. The halt arm must carry the
+    store's own runtime effect, never a fabricated named exception."""
+    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+
+    for arm in halted:
+        assert isinstance(arm.effect, AttributeStoreRuntimeEffect), type(arm.effect)
+
+
+def test_no_invented_exception_type_on_a_store_halt_discrimination():
+    """The bite: the halt is NOT a RaiseEffect of some guessed class."""
+    from sugar_lift_py_tests.effect import RaiseEffect
+
+    halted, _ = _arms(_exits(SEQUENTIAL, "target"))
+
+    with pytest.raises(AssertionError):
+        assert all(isinstance(a.effect, RaiseEffect) for a in halted), "guessed"
+
+
+# --------------------------------------------------------------------------
+# Unpack spelling:  x, o.y = p, q   and   o.x, o.y = p, q
+#
+# THE SAME LAWS. These are the same store family; a store target inside a
+# tuple-unpack assignment is not a different kind of store.
+#
+# These are RED on this branch, and they are red for a PREREQUISITE reason, not
+# because the composition above is wrong: a tuple/multi-target ``Assign``
+# currently has no sugar written at all (``SugarNotWritten [Assign.sugar]``), so
+# no exit structure exists to compose. That construction is owned by the
+# separate branch that routes authenticated ``ObjectPlaceStateV1`` through
+# ``PlaceAssignSugar``. Once a store target inside an unpack constructs a store
+# effect, the composition below is already implemented and these pass with no
+# further change here.
+#
+# They are stated as the real laws rather than pinned to the current behaviour
+# on purpose: a test that must be DELETED when the bug is fixed is a test of the
+# bug.
+# --------------------------------------------------------------------------
+
+
+def test_unpack_mixed_name_and_store_preserves_both_outcomes():
+    """``x, o.y = p, q``
+
+    success arm: ``x == p``, the store on ``o.y`` completed, continuation runs.
+    halt arm:    ``x == p`` STILL -- the name target was already bound -- the
+                 store halted, and there is NO continuation.
+    """
+    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
+
+    assert len(completed) == 1
+    assert _polarity(completed[0].guard, "y") is True
+    assert "p" in str(completed[0].value.post())
+
+    (arm,) = halted
+    assert _polarity(arm.guard, "y") is False
+    assert "p" in str(arm.state.post() if hasattr(arm.state, "post") else arm.state), (
+        "the name target bound before the store must survive the store's halt"
+    )
+
+
+def test_unpack_mixed_name_and_store_preserves_both_outcomes_discrimination():
+    """The bite: a single unconditional arm would mean the store cannot fail."""
+    halted, completed = _arms(_exits(UNPACK_MIXED, "target"))
+
+    with pytest.raises(AssertionError):
+        assert len(halted) == 0 and len(completed) == 1, "store is infallible"
+
+
+def test_unpack_two_stores_preserve_both_outcomes_per_store():
+    """``o.x, o.y = p, q`` -- the same three arms as the sequential spelling:
+    first success + second success, first success + second halt, and first halt
+    with NO second-store occurrence."""
+    halted, completed = _arms(_exits(UNPACK_BOTH, "target"))
+
+    assert len(completed) == 1
+    assert len(halted) == 2
+
+    first = next(h for h in halted if _polarity(h.guard, "x") is False)
+    assert _polarity(first.guard, "y") is None
+    assert _store_entries(first.state) == []
+
+    second = next(h for h in halted if _polarity(h.guard, "y") is False)
+    assert _polarity(second.guard, "x") is True
+    assert len(_store_entries(second.state)) == 1
+
+
+def test_unpack_two_stores_preserve_both_outcomes_per_store_discrimination():
+    """The bite: the first-halt arm must not carry the second store."""
+    halted, _ = _arms(_exits(UNPACK_BOTH, "target"))
+    first = next(h for h in halted if _polarity(h.guard, "x") is False)
+
+    with pytest.raises(AssertionError):
+        assert len(_store_entries(first.state)) == 1, "second target ran anyway"

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -74,7 +74,15 @@ def test_name_augassign_reads_the_guarded_join_not_a_last_writer():
 
 
 def _red_effects(source):
-    entries = _fn(source).sugar().desugar().value.record.statements
+    # A store partitions the block into a completed and a halted arm (stores are
+    # not infallible), so a body containing one reduces to an ExitSet. These
+    # assertions are about the store the COMPLETED arm records; the halt face
+    # and the composition laws live in
+    # sugar-lift-py-tests/tests/test_store_outcome_composition.py.
+    from sugar_lift_py_tests.outcome.exit_set import sole_completed_outcome
+
+    outcome = sole_completed_outcome(_fn(source).sugar().desugar())
+    entries = outcome.value.record.statements
     return [entry.effect for entry in entries if isinstance(entry, Incomplete)]
 
 

--- a/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
@@ -75,6 +75,47 @@ def test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces():
         and isinstance(entry.effect, AttributeStoreRuntimeEffect)
     ]
 
-    assert len(stores) == 1
-    assert len(stores[0].branch_conditions) == 1
+    # The store is guarded by `predicate` AND it is itself fallible, so the one
+    # occurrence has TWO faces: it completed, or it halted. `IfSugar` reduces the
+    # branch body to exits and absorbs each one as guarded red testimony, so both
+    # faces reach the record -- carrying the same effect under complementary
+    # conditions over the store's own outcome coordinate.
+    assert len(stores) == 2, [s.branch_conditions for s in stores]
+    assert {s.effect for s in stores} == {stores[0].effect}, (
+        "both faces are the SAME store occurrence, not two stores"
+    )
+
+    def cites_store_outcome(term):
+        if getattr(term, "name", None) == "python:store_completed":
+            return True
+        return any(cites_store_outcome(a) for a in getattr(term, "args", ()) or ())
+
+    def mentions_store_outcome(formula, negated):
+        found = []
+
+        def walk(node, under_not):
+            kind = getattr(node, "kind", None)
+            if kind == "not":
+                for operand in node.operands:
+                    walk(operand, not under_not)
+                return
+            if kind is not None:
+                for operand in node.operands:
+                    walk(operand, under_not)
+                return
+            # an atomic formula: check its argument terms
+            if any(cites_store_outcome(a) for a in getattr(node, "args", ()) or ()):
+                found.append(under_not)
+
+        walk(formula, False)
+        return negated in found
+
+    conditions = [s.branch_conditions for s in stores]
+    assert all(len(c) == 1 for c in conditions), conditions
+    assert any(mentions_store_outcome(c[0], False) for c in conditions), (
+        "one face must hold where the store COMPLETED"
+    )
+    assert any(mentions_store_outcome(c[0], True) for c in conditions), (
+        "the complementary face must hold where the store HALTED"
+    )
     assert any(type(entry).__name__ == "ReturnValue" for entry in record)

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -32,6 +32,21 @@ def _post(src):
     return _fn(src).sugar().desugar().value.post()
 
 
+def _completed_entries(src):
+    """Entries recorded on the arm where every store completed.
+
+    A store is not infallible, so a body containing one partitions into a
+    completed and a halted arm and reduces to an ExitSet. What each store
+    witnesses, and the source order of several stores, are facts about the
+    completed arm; the halt faces and the composition laws are asserted in
+    sugar-lift-py-tests/tests/test_store_outcome_composition.py.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import sole_completed_outcome
+
+    outcome = sole_completed_outcome(_fn(src).sugar().desugar())
+    return outcome.value.record.statements
+
+
 def test_tuple_destructure_assign_lifts_through():
     post = _post("def A():\n    a, b = (1, 2)\n    return a + b\n")
     assert post.args[1].value == 3
@@ -87,11 +102,8 @@ def test_chained_names_receive_distinct_runtime_binding_coordinates():
 
 
 def test_mixed_chain_sequences_existing_store_obligation_and_name_binding():
-    entries = (
-        _fn("def arbitrary(o):\n    renamed = o.field = 5\n    return renamed\n")
-        .sugar()
-        .desugar()
-        .value.record.statements
+    entries = _completed_entries(
+        "def arbitrary(o):\n    renamed = o.field = 5\n    return renamed\n"
     )
     red = [entry for entry in entries if isinstance(entry, Incomplete)]
     assert len(red) == 1
@@ -99,15 +111,10 @@ def test_mixed_chain_sequences_existing_store_obligation_and_name_binding():
 
 
 def test_mixed_chain_preserves_each_store_face_in_source_order():
-    entries = (
-        _fn(
-            "def arbitrary(o, xs):\n"
-            "    renamed = o.field = xs[0] = 7\n"
-            "    return renamed\n"
-        )
-        .sugar()
-        .desugar()
-        .value.record.statements
+    entries = _completed_entries(
+        "def arbitrary(o, xs):\n"
+        "    renamed = o.field = xs[0] = 7\n"
+        "    return renamed\n"
     )
     red = [entry for entry in entries if isinstance(entry, Incomplete)]
     assert [type(entry.effect) for entry in red] == [
@@ -182,24 +189,14 @@ def test_mixed_chained_targets_stay_loud():
 
 
 def test_attribute_store_target_lifts_a_typed_red_effect():
-    entries = (
-        _fn("def A(o):\n    o.a = 1\n    return o\n")
-        .sugar()
-        .desugar()
-        .value.record.statements
-    )
+    entries = _completed_entries("def A(o):\n    o.a = 1\n    return o\n")
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 1
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
 
 
 def test_subscript_store_target_lifts_a_typed_red_effect():
-    entries = (
-        _fn("def A(xs):\n    xs[0] = 1\n    return xs\n")
-        .sugar()
-        .desugar()
-        .value.record.statements
-    )
+    entries = _completed_entries("def A(xs):\n    xs[0] = 1\n    return xs\n")
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 1
     assert isinstance(red[0].effect, SubscriptStoreRuntimeEffect)

--- a/implementations/python/sugar-source-tree/tests/test_delete_effect_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_delete_effect_targets.py
@@ -24,7 +24,14 @@ def _out(source: str):
 
 
 def _entries(source: str):
-    out = _out(source)
+    # A delete mutates a place through runtime dispatch that can halt, so it
+    # partitions the block exactly as an attribute/subscript store does and the
+    # body reduces to an ExitSet. These assertions are about the delete the
+    # COMPLETED arm records; the halt face and the composition laws live in
+    # sugar-lift-py-tests/tests/test_store_outcome_composition.py.
+    from sugar_lift_py_tests.outcome.exit_set import sole_completed_outcome
+
+    out = sole_completed_outcome(_out(source))
     assert isinstance(out, Complete)
     return out.value.record.statements
 

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -1,8 +1,14 @@
 """Store-target assignments (`obj.a = e`, `xs[i] = e`) attach a typed red
 runtime-effect witness at the TREE fragment site (the fragment-type seam,
-#5994-adjacent). The store completed -- Python continues -- so the block
-keeps reducing past it (see outcome/incomplete.py::
-_effect_continues_control_flow); the returned value is unaffected."""
+#5994-adjacent).
+
+A store has TWO outcomes, runtime-selected: it completes (Python continues to
+the next statement) or it halts. So the body reduces to an `ExitSet`, not to one
+linear outcome. Everything asserted below is a fact about the COMPLETED arm --
+the block kept reducing, the returned value is unaffected, the witness names the
+real target -- and the assertions are unchanged; only the navigation to that arm
+is explicit now. The halt arm and the composition laws are asserted in
+sugar-lift-py-tests/tests/test_store_outcome_composition.py."""
 
 import tempfile
 from dataclasses import replace
@@ -27,8 +33,13 @@ def _fn(src):
     return next(SourceFile(path_source(path)).functions())
 
 
+from sugar_lift_py_tests.outcome.exit_set import (
+    sole_completed_outcome as _completed,
+)
+
+
 def _entries(src):
-    outcome = _fn(src).sugar().desugar()
+    outcome = _completed(_fn(src).sugar().desugar())
     return outcome.value.record.statements
 
 
@@ -71,7 +82,9 @@ def test_attribute_store_lifts_a_red_effect_and_the_block_continues():
 
 
 def test_attribute_store_post_out_equals_the_returned_value():
-    v = _fn("def A(o, v):\n    o.a = v\n    return v\n").sugar().desugar().value
+    v = _completed(
+        _fn("def A(o, v):\n    o.a = v\n    return v\n").sugar().desugar()
+    ).value
     post = v.post()
     assert post.name == "="
     assert post.args[0].name == "out"
@@ -87,7 +100,9 @@ def test_subscript_store_lifts_a_red_effect_and_the_block_continues():
 
 
 def test_subscript_store_post_out_equals_the_returned_value():
-    v = _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar().value
+    v = _completed(
+        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
+    ).value
     post = v.post()
     assert post.name == "="
     assert post.args[0].name == "out"


### PR DESCRIPTION
The shared control algebra. **Assignment was modelled as transactional and infallible** — `o.x = p; o.y = q; return q` reduced to a single `Complete`, post `out == q`. One arm. No `Halted`, no arm lacking the later store.

Python assignment is neither: a store on an external object can fail at runtime, and when a later target fails **earlier targets remain assigned**.

## The model

```
Store(receiver, selector, value)
    ├─ success → Completed(updated temporal state)
    └─ failure → Halted(store effect/error, prefix temporal state)
```

`floor/store_outcome_coordinate.py` mints `python:store_completed(occurrence_address, operation_term)` — a `FloorValue` on the **existing** `BranchResultCoordinate` pattern (`floor/branch_result_coordinate.py`, `if_sugar.py:105-118`), recognised as complementary by `exit_set._is_negation`. `FollowStep` gains `halt_guard`; `Incomplete.follow` returns it for the store family; the linear arm of `reduce_block_to_exitset` emits both arms.

**`ExitSet.sequence` already feeds only completed arms to the tail**, so *"no later target after an earlier halt"* falls out of the existing algebra rather than a new rule.

**No invented exception type.** One deliberate design call: no biconditional authentication — tying a store's coordinate to a lift-time formula *is* the invented exception type. Authentication is the occurrence itself (witness address + operation term retaining receiver/selector/value).

## Measured

`o.x = p; o.y = q` now yields **three** arms:

| arm | guard | state |
|---|---|---|
| halt | `¬g₁` | empty prefix — second store never occurred |
| halt | `g₁ ∧ ¬g₂` | first store's testimony retained — never rolled back |
| completed | `g₁ ∧ g₂` | post `out == q` |

## Laws proven (14 twins, each with a biting discrimination arm)

| law | twin |
|---|---|
| complementary success/halt guards | `store_outcome_guards_are_exactly_complementary` — `_and_guards(halt, success) == false_guard()` |
| prefix state retention | `second_store_halt_preserves_the_first_store` |
| later step absent after halt | `first_store_halt_has_no_second_store_occurrence` |
| receiver/selector/value occurrence identity | `each_store_occurrence_mints_its_own_coordinate` — 2 coordinates, receivers `{o}`, selectors `{x,y}`, values `{p,q}` |
| no rollback | `..._discrimination` bites on "assignment rolled back" |

## Ownership boundary

The four **unpack** laws (`x, o.y = p, q`, `o.x, o.y = p, q`) moved to **#6239**, which owns tuple/multi-target construction. They are red there **on the law** (`a body containing a store must reduce to guarded exits, not one unconditional outcome; got Complete`) — deleted here, never xfail'd or weakened. A prerequisite should not be held red by syntax it deliberately does not construct; #6239 must not merge merely because this algebra works.

## What went red elsewhere — and the answer

**19 tests across 5 files** genuinely depended on stores being infallible, all navigating `desugar().value.record.statements` assuming one linear outcome. Fixed by **navigation only**, via a new loud `sole_completed_outcome` that refuses when there isn't exactly one completed arm. **No assertion weakened.**

One was substantive: `test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces` — a store under `if` now produces two complementary faces of the same occurrence, and the test was **strengthened** to assert both, which its name always claimed.

## Gates
- store twins **14/14**, zero failures
- regression **73/73**
- full `sugar-source-tree` suite: 16 failed / 469 passed **before and after** — byte-identical failure list, **zero net regression** (those 16 are pre-existing on main)
- `test_exit_set.py` 22 passed
- census pins identical before/after; `categorical.py` keeps `With: 1`

Unblocks: #6239 rebase, With `__exit__` routing, and `Try` — all three converge on this one algebra instead of three bespoke control systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Model store-family effects as guarded success/halt arms in block reduction
> - Store, augmented-assign, and delete effects previously continued control flow unconditionally. They now produce an `ExitSet` with a `Completed` arm (guard: store succeeded) and a `Halted` arm (guard: store did not complete), splitting the reduction before subsequent statements are evaluated.
> - [`store_outcome_coordinate.py`](https://github.com/TSavo/sugar/pull/6246/files#diff-89c5e6a7b52d6c8400b9bc1bba7530bd55d3a991550bca5152f2626d697836f5) introduces `StoreOutcomeCoordinate` and helpers (`store_completed_guard`, `store_halted_guard`) to produce per-occurrence predicate guards.
> - [`Incomplete.follow()`](https://github.com/TSavo/sugar/pull/6246/files#diff-a7e999b532debd9b8c35a37498bf41370134a14df801a14c473cc820d0193113) returns a `FollowStep` with a `halt_guard` for store-family effects; [`reduce_block_to_exitset`](https://github.com/TSavo/sugar/pull/6246/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) consumes this to emit the two-armed `ExitSet`.
> - Existing tests for assign, delete, and augmented-assign targets are updated to project the sole completed arm via `sole_completed_outcome` before asserting on recorded statements.
> - Behavioral Change: any code consuming block reduction results for store-containing bodies now receives an `ExitSet` instead of a flat `Complete` outcome.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26ef624.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->