### PR TITLE
fix: every Python kit testifies the sourceStamp, not Git HEAD

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py
@@ -3,11 +3,22 @@
 The CLI enforces `kit_source.identity` on the `python` authoring surface so
 mint/prove can seal split-pipeline provenance. Every Python RPC that can be
 registered as that surface must include this field.
+
+Kit identity is the sourceStamp, NOT Git HEAD (#6224): the binary embeds
+`SUGAR_BUILD_STAMP` and the gate (`refuse_split_pipeline`) is
+`kit.sourceStamp == binary.sourceStamp`. #6224 migrated the
+`sugar_lift_py_tests` twin of this module and left this one on Git HEAD, which
+refused every mint that registered the `python` surface through
+`verify_rpc.run_rpc` (e.g. examples/python-bodyguard-precondition). Both
+modules must keep answering the same `kind`; `tests/source_stamp_compat_twins.sh`
+holds that line.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -24,7 +35,21 @@ def _git(root: Path, *args: str) -> str | None:
     return value or None
 
 
+def _monorepo_root() -> Path | None:
+    """Locate monorepo root from installed package paths (…/implementations/python/…)."""
+    import sugar_lift_python_source
+
+    here = Path(sugar_lift_python_source.__file__).resolve()
+    for parent in here.parents:
+        if (parent / "tools" / "sugar_source_stamp.py").is_file() and (
+            parent / "implementations" / "rust" / "Cargo.toml"
+        ).is_file():
+            return parent
+    return None
+
+
 def _content_identity(roots: list[Path]) -> str:
+    """Legacy content hash (tests / non-monorepo). Path-safe underscore form."""
     material = bytearray()
     for index, root in enumerate(roots):
         for path in sorted(
@@ -36,45 +61,105 @@ def _content_identity(roots: list[Path]) -> str:
             payload = path.read_bytes()
             material.extend(f"{index}:".encode() + relative + b"\0")
             material.extend(str(len(payload)).encode() + b"\0" + payload)
-    return blake3_512_of(bytes(material))
+    # blake3_512_of returns blake3-512:<hex>; normalize to the path-safe _ form.
+    return blake3_512_of(bytes(material)).replace(":", "_", 1)
 
 
 def source_provenance_for_roots(roots: Iterable[Path]) -> dict[str, object]:
+    """Content identity of `roots`. Git HEAD is an attestation, never identity
+    (#6224), so it only contributes the `dirty` flag."""
     resolved = [Path(root).resolve() for root in roots]
-    git_rows: list[tuple[Path, str, str]] = []
+    dirty = False
     for root in resolved:
         top = _git(root, "rev-parse", "--show-toplevel")
-        head = _git(root, "rev-parse", "HEAD")
-        if top is None or head is None:
-            return {
-                "identity": _content_identity(resolved),
-                "kind": "content",
-                "dirty": False,
-            }
-        git_rows.append((Path(top), head, root.relative_to(Path(top)).as_posix()))
-    heads = {head for _, head, _ in git_rows}
-    if len(heads) != 1:
-        return {
-            "identity": _content_identity(resolved),
-            "kind": "content",
-            "dirty": False,
-        }
-    dirty = any(
-        bool(_git(top, "status", "--porcelain", "--", relative))
-        for top, _, relative in git_rows
-    )
-    return {"identity": next(iter(heads)), "kind": "git", "dirty": dirty}
+        if top is None:
+            continue
+        try:
+            relative = root.relative_to(Path(top)).as_posix()
+        except ValueError:
+            continue
+        if bool(_git(Path(top), "status", "--porcelain", "--", relative)):
+            dirty = True
+            break
+    return {
+        "identity": _content_identity(resolved),
+        "kind": "content",
+        "dirty": dirty,
+    }
 
 
-def kit_source_provenance() -> dict[str, object]:
-    """Identity of the Python kit sources that implement this RPC process."""
+def kit_package_roots() -> list[Path]:
     import sugar_lift_python_source
 
     roots = [Path(sugar_lift_python_source.__file__).resolve().parent]
-    try:
-        import sugar_lift_py_tests
+    for module in ("sugar_lift_py_tests", "sugar_source_tree"):
+        try:
+            imported = __import__(module)
+        except ImportError:
+            continue
+        roots.append(Path(imported.__file__).resolve().parent)
+    return roots
 
-        roots.append(Path(sugar_lift_py_tests.__file__).resolve().parent)
-    except ImportError:
-        pass
-    return source_provenance_for_roots(roots)
+
+def source_stamp_for_sugar_cli(repo_root: Path | None = None) -> str | None:
+    """Same sourceStamp sugarbin / SUGAR_BUILD_STAMP use for package sugar-cli."""
+    root = repo_root or _monorepo_root()
+    if root is None:
+        return None
+    script = root / "tools" / "sugar_source_stamp.py"
+    if not script.is_file():
+        return None
+    cargo = os.environ.get("SUGAR_BINARY_CARGO") or os.environ.get("CARGO") or "cargo"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--repo-root",
+            str(root),
+            "--package",
+            "sugar-cli",
+            "--cargo",
+            cargo,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    stamp = result.stdout.strip()
+    if not stamp.startswith("blake3-512_"):
+        return None
+    return stamp
+
+
+def kit_source_provenance() -> dict[str, object]:
+    """Kit identity is the sourceStamp (not Git HEAD).
+
+    Matches the binary's embedded SUGAR_BUILD_STAMP so the split-pipeline gate
+    is kit.sourceStamp == binary.sourceStamp. Mirror of
+    `sugar_lift_py_tests.source_provenance.kit_source_provenance`: both Python
+    kits can be registered as the `python` surface, so both must answer the
+    same identity kind or one of them refuses every mint (#6224).
+    """
+    stamp = source_stamp_for_sugar_cli()
+    if stamp is not None:
+        dirty = False
+        root = _monorepo_root()
+        if root is not None:
+            dirty = any(
+                bool(_git(root, "status", "--porcelain", "--", rel))
+                for rel in (
+                    "implementations/python/sugar-lift-python-source",
+                    "implementations/python/sugar-lift-py-tests",
+                    "implementations/python/sugar-source-tree",
+                    "implementations/rust",
+                )
+            )
+        return {
+            "identity": stamp,
+            "kind": "sourceStamp",
+            "dirty": dirty,
+        }
+    # Offline / unpackaged: content identity of kit packages only.
+    return source_provenance_for_roots(kit_package_roots())

--- a/tests/source_stamp_compat_twins.sh
+++ b/tests/source_stamp_compat_twins.sh
@@ -49,4 +49,20 @@ echo "$gate" | rg -q 'SUGAR_BUILD_STAMP' || { echo "gate still not on SUGAR_BUIL
 ! rg -n 'refuse_split_pipeline\(identity, env!\("SUGAR_BUILD_GIT_HEAD"\)\)' implementations/rust/sugar-cli/src/lift_plugin.rs \
   || { echo "gate still compares to SUGAR_BUILD_GIT_HEAD" >&2; exit 1; }
 
-echo "PASS: sourceStamp twins (docs stable, rust/python protocol matter, gate uses SUGAR_BUILD_STAMP)"
+# Twin: EVERY Python kit that can be registered as the `python` surface must
+# testify the sourceStamp. #6224 migrated only the sugar-lift-py-tests module
+# and left sugar-lift-python-source answering Git HEAD, so every mint through
+# `verify_rpc.run_rpc` refused with "kit @<git sha> != binary @blake3-512_...".
+# Source-level ratchet: these modules import blake3, which the bare system
+# python3 running this script does not have.
+for provenance in implementations/python/*/src/*/source_provenance.py; do
+  rg -q 'def kit_source_provenance' "$provenance" || continue
+  rg -q '"kind": "sourceStamp"' "$provenance" \
+    || { echo "$provenance does not testify kind sourceStamp (#6224)" >&2; exit 1; }
+  ! rg -q '"kind": "git"' "$provenance" \
+    || { echo "$provenance still testifies Git HEAD as kit identity (#6224)" >&2; exit 1; }
+  rg -q 'source_stamp_for_sugar_cli' "$provenance" \
+    || { echo "$provenance does not compute the sugar-cli sourceStamp (#6224)" >&2; exit 1; }
+done
+
+echo "PASS: sourceStamp twins (docs stable, rust/python protocol matter, gate uses SUGAR_BUILD_STAMP, every python kit testifies sourceStamp)"


### PR DESCRIPTION
## What

`#6224` moved the split-pipeline gate onto `SUGAR_BUILD_STAMP` (`refuse_split_pipeline`, `implementations/rust/sugar-cli/src/lift_plugin.rs`) and migrated `sugar_lift_py_tests.source_provenance` to answer a `sourceStamp` identity. It left the twin module `sugar_lift_python_source.source_provenance` answering Git HEAD.

Both modules can be registered as the `python` authoring surface, and the surface registers through `sugar_lift_python_source.verify_rpc.run_rpc` — so mints coming in that way testified a git sha against a `blake3-512_…` binary stamp and the gate refused every one:

```
refusing to mint from a split pipeline:
kit @<git sha> != binary @blake3-512_...
```

**The gate is right and the example harness is right — the kit was testifying the wrong identity.** Neither of the two hypotheses in the original bug report.

## Change

- `kit_source_provenance()` computes the same stamp the binary embeds, via the same `tools/sugar_source_stamp.py --package sugar-cli` preimage `bin/sugarbin` hashes. Content identity remains the offline/unpackaged fallback; Git HEAD is demoted to the `dirty` flag.
- `tests/source_stamp_compat_twins.sh` gains a source-level ratchet over every `implementations/python/*/src/*/source_provenance.py` that defines `kit_source_provenance`: must testify `sourceStamp`, must not testify Git HEAD, must compute the sugar-cli stamp. A sibling left behind now fails the twin instead of refusing every mint at runtime.

No change to the gate. No change to any example's `run.sh`.

## Validation

- `tests/source_stamp_compat_twins.sh` — PASS.
- `examples/python-bodyguard-precondition/run.sh`, clean worktree — **the split-pipeline refusal is gone.**

**The example is still red, one gate later**, and that is expected rather than incomplete:

```
path=lift.enumerate: surface `python` does not advertise sugar.enumerate
and has no non-lift plugin method; sending JSON-RPC method `lift` is retired
```

The `python` source surface still advertises `{"name": "lift", "required": true}` at `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:42` and no `sugar.enumerate`. That is the separate Python sourceTree enumerate migration — out of scope here, and this PR is a strict prerequisite for it: without the stamp fix the example never reaches that gate at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Python kit source provenance to report `sourceStamp` instead of Git HEAD
> - Reimplements `kit_source_provenance` in [source_provenance.py](https://github.com/TSavo/sugar/pull/6247/files#diff-6ec4be72a5ca413055e0abda0849e3fc75ca6cdff57cf7dc129d0635455661b2) to use the sugar-cli `sourceStamp` (computed via `tools/sugar_source_stamp.py`) as the kit identity when running inside the monorepo, falling back to content-based identity when offline or unpackaged.
> - Adds `_monorepo_root` to locate the repo root from the installed package path, `kit_package_roots` to enumerate relevant Python kit package roots, and `source_stamp_for_sugar_cli` to invoke the source-stamp helper and validate its output.
> - Changes `source_provenance_for_roots` to always return `kind: 'content'` and drops the former `kind: 'git'` aggregation path.
> - Normalizes the content identity string format from `blake3-512:<hex>` to `blake3-512_<hex>`.
> - Updates [source_stamp_compat_twins.sh](https://github.com/TSavo/sugar/pull/6247/files#diff-03efd12a87f0f1d29d7b6cab01c47e194485a74d592aabf7d5cdabc664f7b7c2) to assert that every Python kit testifies `kind: 'sourceStamp'` and never `kind: 'git'`.
> - Behavioral Change: any consumer reading `kind` from kit provenance will now receive `'sourceStamp'` or `'content'` instead of `'git'`, and identity strings previously containing a colon now use an underscore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd4e293.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->