### PR TITLE
fix: decorated defs are static exports; partition With membranes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -112,6 +112,67 @@ def _occurrence_key(
     return (kind, relative, line, col)
 
 
+def _cm_membrane_bucket(target_symbol: object) -> str:
+    """Partition With residual by authenticated target symbol — measurement only.
+
+    Assertion membranes and protocol-resource candidates must never share one
+    ΔR number. This classifier labels residual rows; it is not a construction
+    door and must not grant semantics from spelling.
+    """
+    if not isinstance(target_symbol, str) or not target_symbol:
+        return "unclassified"
+    symbol = target_symbol.removeprefix("python:")
+    leaf = symbol.rsplit(".", 1)[-1]
+    # Community assertion managers (separate membrane from resource CMs).
+    if leaf in {
+        "raises",
+        "assert_produces_warning",
+        "asserts_raises",
+        "assertRaises",
+        "assertRaisesRegex",
+        "external_error_raised",
+        "raises_chained_assignment_error",
+    }:
+        return "assertion-membrane"
+    if leaf in {
+        "ensure_clean",
+        "option_context",
+        "catch_warnings",
+        "nullcontext",
+        "closing",
+        "ExitStack",
+        "chdir",
+        "decompress_file",
+        "set_timezone",
+        "use_numexpr",
+        "with_csv_dialect",
+    }:
+        return "protocol-resource-candidate"
+    if leaf == "open" or symbol in {"builtins.open", "io.open"}:
+        return "io-resource-candidate"
+    return "other-manager"
+
+
+def _tally_cm_membrane(context) -> Counter[str]:
+    """Count derived-table rows by membrane from authenticated target symbols."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        SourceDerivedContextManagerRefV1,
+    )
+
+    buckets: Counter[str] = Counter()
+    refs = getattr(context, "source_derived_contract_refs", None) or {}
+    for resolution in refs.values():
+        if isinstance(resolution, SourceDerivedContextManagerRefV1):
+            buckets["derived-contract"] += 1
+            continue
+        if isinstance(resolution, ContextManagerResolutionGapV1):
+            buckets[_cm_membrane_bucket(resolution.target_symbol)] += 1
+            continue
+        buckets["unclassified"] += 1
+    return buckets
+
+
 def _backend_defect_key(exc: object) -> str:
     """Classify demand/resolution table hygiene — never construction mass.
 
@@ -178,6 +239,7 @@ def _measure_file(
     families: Counter[str] = Counter()
     construction_seen: set[tuple[str, str, object, object]] = set()
     backend_defects: Counter[str] = Counter()
+    cm_membranes: Counter[str] = Counter()
     desugar_axis = DesugarAxis()
     root = workspace_root if workspace_root is not None else path.parent
 
@@ -208,6 +270,9 @@ def _measure_file(
             # Derivation can hit a real missing sugar before any function walk.
             tally_construction(type(gap).__name__, line=0)
             return reporter
+        # Membrane partition from the derived table (manager-expression sites,
+        # not functions-blocked). Assertion mass must not launder as resource.
+        cm_membranes.update(_tally_cm_membrane(construction_context))
         for function in source_file.functions():
             functions_total += 1
             try:
@@ -249,6 +314,14 @@ def _measure_file(
         return reporter
 
     _reporter, panic_row = collect_construction_panic(relative, construct)
+    membrane_row = {
+        "cmMembranes": dict(cm_membranes),
+        "R_cm_assertion_membrane": int(cm_membranes.get("assertion-membrane", 0)),
+        "R_cm_protocol_resource_candidate": int(
+            cm_membranes.get("protocol-resource-candidate", 0)
+        ),
+        "R_cm_derived_contract": int(cm_membranes.get("derived-contract", 0)),
+    }
     if panic_row is not None:
         return {
             "category": "construction-panic",
@@ -263,6 +336,7 @@ def _measure_file(
             "families": dict(families),
             "backendDefects": dict(backend_defects),
             "R_backend_defects": sum(backend_defects.values()),
+            **membrane_row,
             **desugar_axis.row(),
         }
     return {
@@ -272,6 +346,7 @@ def _measure_file(
         "families": dict(families),
         "backendDefects": dict(backend_defects),
         "R_backend_defects": sum(backend_defects.values()),
+        **membrane_row,
         **desugar_axis.row(),
     }
 
@@ -373,6 +448,7 @@ def main() -> int:
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
     backend_defects: Counter[str] = Counter()
+    cm_membranes: Counter[str] = Counter()
     # Three disjoint desugar-layer quantities; the two below are NEVER folded
     # into R_desugar and both make the run red.
     desugar_construction_panics: list[dict[str, Any]] = []
@@ -616,6 +692,7 @@ def main() -> int:
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
         backend_defects.update(row.get("backendDefects") or {})
+        cm_membranes.update(row.get("cmMembranes") or {})
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
         desugar_defects.extend(row.get("desugarDefects") or [])
         if category == "completed":
@@ -690,6 +767,16 @@ def main() -> int:
         "backendDefects": dict(
             sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
         ),
+        # With residual partition (manager-expression sites, derived table).
+        # Assertion membrane ≠ protocol resource; never one With ΔR number.
+        "cmMembranes": dict(
+            sorted(cm_membranes.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "R_cm_assertion_membrane": int(cm_membranes.get("assertion-membrane", 0)),
+        "R_cm_protocol_resource_candidate": int(
+            cm_membranes.get("protocol-resource-candidate", 0)
+        ),
+        "R_cm_derived_contract": int(cm_membranes.get("derived-contract", 0)),
         # Neither of these is semantic R. A construction-law None arm during
         # desugar is a construction gap; an ordinary exception is an
         # implementation defect. Both are red, separately.
@@ -707,6 +794,12 @@ def main() -> int:
                 "R_control_effect": r_construction + len(defects),
                 "R_desugar": r_desugar,
                 "R_backend_defects": r_backend,
+                "R_cm_assertion_membrane": int(
+                    cm_membranes.get("assertion-membrane", 0)
+                ),
+                "R_cm_protocol_resource_candidate": int(
+                    cm_membranes.get("protocol-resource-candidate", 0)
+                ),
                 "desugarConstructionPanics": len(desugar_construction_panics),
                 "desugarDefects": len(desugar_defects),
                 "constructionPanics": len(construction_panics),

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -135,3 +135,26 @@ def test_backend_defect_keys_split_cm_and_call_demand() -> None:
     assert cm != call
     assert other.startswith("BackendDefect:")
     assert other not in {cm, call}
+
+
+def test_cm_membrane_bucket_keeps_assertion_separate_from_resource() -> None:
+    """With ΔR must never merge assertion membrane with protocol resource."""
+    module = _load("control_effect_recensus")
+    assert (
+        module._cm_membrane_bucket("python:pytest.raises") == "assertion-membrane"
+    )
+    assert (
+        module._cm_membrane_bucket("python:pandas._testing.assert_produces_warning")
+        == "assertion-membrane"
+    )
+    assert (
+        module._cm_membrane_bucket("python:pandas._testing.ensure_clean")
+        == "protocol-resource-candidate"
+    )
+    assert (
+        module._cm_membrane_bucket("python:pandas.option_context")
+        == "protocol-resource-candidate"
+    )
+    assert module._cm_membrane_bucket("python:pytest.raises") != (
+        module._cm_membrane_bucket("python:pandas._testing.ensure_clean")
+    )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -359,11 +359,13 @@ def _export_statement(statement: ast.stmt, name: str, state):
     if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
         if statement.name != name:
             return state
-        return (
-            ("definition", statement)
-            if not statement.decorator_list
-            else ("dynamic", statement)
-        )
+        # Decorators are part of the definition site, not export opacity.
+        # ``@contextmanager def f`` still statically binds ``f`` at this
+        # statement; construction authenticates decorator application and
+        # may stay loud if a decorator is opaque. Treating any decorator
+        # list as ``dynamic-export`` erased real families (e.g. re-exported
+        # ``@contextmanager`` resources) without a general capability gap.
+        return ("definition", statement)
     if isinstance(statement, ast.ImportFrom):
         for alias in statement.names:
             if (alias.asname or alias.name) == name:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -139,6 +139,95 @@ def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
     assert result.distribution_artifact_cid == graph.distribution_artifact_cid
 
 
+def test_decorated_definition_resolves_without_decorator_name_authority(
+    tmp_path: Path,
+) -> None:
+    """``@decorator def name`` is still a static export of ``name``.
+
+    Mid-band residual diagnosis: re-export of ``@contextmanager`` resources
+    stopped at dynamic-export solely because any decorator_list was treated
+    as opaque. Export resolution must not require recognizing the decorator
+    spelling; construction may still refuse opaque decorator application.
+    """
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source=(
+            "def wrap(fn):\n"
+            "    return fn\n\n"
+            "@wrap\n"
+            "def build(value):\n"
+            "    return value\n"
+        ),
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.kind == "function"
+    assert result.definition.name == "build"
+    assert result.module_name == "example_pkg.implementation"
+    assert result.reexport_warrants
+    assert "example_pkg" not in sys.modules
+
+
+def test_contextmanager_decorated_reexport_resolves_as_definition(
+    tmp_path: Path,
+) -> None:
+    """Re-exported ``@contextmanager`` factory resolves to its definition.
+
+    εR board note: this unblocks *export* for ensure_clean-class sites.
+    Full contract ΔR still requires constructing the body/disposition; body
+    opaques remain separate residual. Do not claim tens-of-sites With ΔR
+    from export alone.
+    """
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import make_resource\n",
+        implementation_source=(
+            "from contextlib import contextmanager\n\n"
+            "@contextmanager\n"
+            "def make_resource():\n"
+            "    yield 9\n"
+        ),
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    demand = _demand(
+        tmp_path,
+        "import example_pkg\nwith example_pkg.make_resource():\n    pass\n",
+    )
+    result = resolve_import_binding(demand, graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "make_resource"
+    assert result.definition.kind == "function"
+    assert result.module_name == "example_pkg.implementation"
+
+
+def test_real_pandas_ensure_clean_export_resolves_without_name_authority() -> None:
+    """Live residual sample: export no longer stops at decorator dynamic-export."""
+    graph = DependencyArtifactGraph.authenticate(
+        importlib.metadata.distribution("pandas")
+    )
+    # Demand shape matches authenticated import use of the re-export chain.
+    import tempfile
+    from pathlib import Path as P
+
+    root = P(tempfile.mkdtemp())
+    demand = _demand(
+        root,
+        "from pandas._testing import ensure_clean\nensure_clean()\n",
+    )
+    result = resolve_import_binding(demand, graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
+    assert result.definition.name == "ensure_clean"
+    assert result.definition.kind == "function"
+    assert "contexts" in result.module_name
+    # No vendor arm: resolution is content/source, not the spelling ensure_clean
+    # special-cased in Sugar.
+
+
 def test_real_pytest_reexport_resolves_without_manager_name_recognition(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Mid-band With residual partition forced a plan correction (~95% assertion membrane vs ~tens of protocol-resource candidates). This PR lands the next general capability slice and honest measurement labels.

### Export: decorated definition ≠ dynamic-export

`@contextmanager def ensure_clean` failed at `resolve_import_binding` with `dynamic-export` solely because **any** `decorator_list` was classified dynamic. The re-export chain to `pandas._testing.contexts` already succeeded.

A decorated `FunctionDef`/`ClassDef` still statically binds its name at that statement. Construction authenticates decorator application and may stay loud on opaque bodies (`Path`, etc.).

**εR / ΔR expectation (set before landing):**
- This is an **export capability** success.
- Live `ensure_clean` now resolves to a definition coordinate.
- Construct still stops at `opaque-call-target: Path` — **do not claim mid-band With residual ΔR** (not tens of construction sites yet).
- The ~370 assertion-membrane sites need EffectBoundary-from-authenticated-source (separate cut).

### Census: partition membranes

Derived-table rows report:
- `R_cm_assertion_membrane` (`raises`, `assert_produces_warning`, …)
- `R_cm_protocol_resource_candidate` (`ensure_clean`, `option_context`, …)
- `R_cm_derived_contract`

Grain check: mid-band **400 = manager-expression sites** (with-items), not functions-blocked / gap-rows (`items > fn_blocked` on sampled files).

### Holds

- Resource-With **ExitSet routing** until store ExitSet.
- **With ΔR claim** until post-Merkle reprobe (4/15 mid-band files were 20s timeouts; tail unquantified).
- `pytest.raises` as resource CM → **never**.

## Validation

```text
pytest test_dependency_artifact_graph.py → 25 passed
smoke: membrane buckets; occurrence-once; ensure_clean export resolves
```

## Governing test

| Change | Completes | Honesty | Easier to finish |
|--------|-----------|---------|------------------|
| Decorated export | general export path | restores erased definitions | unblocks construct work on real coords |
| Membrane partition | — | prevents assertion/resource laundering | steers next cut correctly |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix decorated definitions to export as static and partition `With` context managers by membrane
> - Changes [`_export_statement`](https://github.com/TSavo/sugar/pull/6248/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) to classify decorated `def`/`class` nodes as `'definition'` instead of `'dynamic'`, so they resolve without requiring decorator name authority.
> - Adds membrane partitioning to the recensus script, classifying context manager references into buckets (`assertion-membrane`, `protocol-resource-candidate`, `derived-contract`, etc.) and surfacing per-file and aggregate rollups in the output JSON.
> - Behavioral Change: decorated definitions that previously resolved as `'dynamic'` exports now resolve as `'definition'`, which may affect downstream construction authentication logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a811d56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->