### PR TITLE
fix: Python showcase kits — pytest-witness serves sugar.enumerate; every Python kit testifies the sourceStamp

### DIFF
--- a/implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py
@@ -22,6 +22,7 @@ from sugar_lift_py_tests.ir import (
 )
 from sugar_lift_py_tests.canonicalizer import encode_jcs, blake3_512_of
 from sugar_lift_py_tests.filename import cid_filename
+from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
 
 import base64
 
@@ -40,6 +41,10 @@ from .witness import (
 KIT_ID = "python-pytest-witness"
 KIT_VERSION = "0.1.0"
 KIT_DECLARATION_RPC_METHOD = "sugar.plugin.kit_declaration"
+# There is no `lift` kit method. Full-tree construction is `sugar.enumerate`
+# over the SourceTree; sending method `lift` is the retired factory door
+# (sugar-cli `lift_plugin::dispatch_lift_path`).
+ENUMERATE_RPC_METHOD = "sugar.enumerate"
 RESOLVE_WITNESS_RPC_METHOD = "sugar.plugin.resolve_witness"
 COMPONENT_PLAN_RPC_METHOD = "sugar.component.plan"
 COMPONENT_PROTOCOL_VERSION = "sugar-component/1"
@@ -226,92 +231,227 @@ def component_plan_result(params: dict) -> dict:
     }
 
 
-def handle_lift(msg_id: Any, params: dict) -> None:
+_SPLIT_CACHE: dict[tuple[str, tuple[str, ...]], tuple[List[str], List[str]]] = {}
+
+
+def _split_python_files(ws: str, source_paths: List[str]) -> tuple[List[str], List[str]]:
+    """Project-relative (code_files, test_files), both sorted.
+
+    Memoized: the fold asks `universe` once per censused file, and each of those
+    calls needs the same split to find the anchor. Without the cache a project
+    with N Python files walks the tree N+1 times.
+    """
+    key = (ws, tuple(source_paths))
+    cached = _SPLIT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    pyfiles = _iter_python_files(ws, source_paths)
+    rels = sorted(os.path.relpath(p, ws) for p in pyfiles)
+    code_rels = [r for r in rels if not os.path.basename(r).startswith("test_")]
+    test_rels = [r for r in rels if os.path.basename(r).startswith("test_")]
+    _SPLIT_CACHE[key] = (code_rels, test_rels)
+    return code_rels, test_rels
+
+
+def build_witness_ir(
+    ws: str, code_rels: List[str], test_rels: List[str]
+) -> tuple[List[dict], List[dict]]:
+    """Run the suite and return (ir_rows, memento_rows).
+
+    The suite is ONE witness package, so this runs ONCE per enumeration --
+    never per source file. The rows stay byte-identical to what mint used to
+    receive from the retired `lift` method.
+    """
+    decls: List[ContractDecl] = []
+    mementos: List[dict] = []
+    bundle_cid = None
+    if test_rels:
+        # PER-TEST run, but ONE proof member. The whole suite is a WITNESS
+        # PACKAGE: a content-addressed `.witness` bundle of per-test bodies,
+        # cid = blake3(bundle). The proof carries ONE WitnessPackageMemento
+        # (64 bytes) + ONE contract whose evidence pins the package cid -- not
+        # N mementos. The verifier asks the oracle to discharge by re-running
+        # the suite and reproducing the package cid (`discharge_bundle`).
+        bundle_bytes, bundle_cid, witnesses = build_suite_bundle(
+            ws, test_rels, code_rels
+        )
+        passed = sum(1 for w in witnesses if w.outcome == "passed")
+        try:
+            bundle_dir = os.path.join(ws, ".sugar", "witnesses")
+            os.makedirs(bundle_dir, exist_ok=True)
+            with open(
+                os.path.join(bundle_dir, cid_filename(bundle_cid, ".witness")),
+                "wb",
+            ) as f:
+                f.write(bundle_bytes)
+        except OSError:
+            pass  # the package is audit material; never fail the lift on a write error
+        proof_data = json.dumps(
+            {
+                "kind": "witness-package",
+                "packageCid": bundle_cid,
+                "testFiles": sorted(test_rels),
+                "codeFiles": sorted(code_rels),
+                "count": len(witnesses),
+                "passed": passed,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        cert = EvidenceCertificate(
+            tool="pytest",
+            version=runtime_cid(),
+            formula_hash=bundle_cid,
+            proof_data=proof_data,
+        )
+        ev = EvidenceTerm(proof_type="custom", certificate=cert)
+        decls.append(
+            ContractDecl(
+                name=f"witness-package:{bundle_cid}",
+                inv=atomic("witnessed", []),
+                evidence=ev,
+            )
+        )
+        mementos.append(
+            witness_package_memento(
+                bundle_cid, test_rels, code_rels, len(witnesses), passed
+            )
+        )
+    ir = json.loads(encode_jcs(declarations_to_value(decls))) if decls else []
+    for member in ir:
+        if member.get("kind") == "contract" and member.get("name", "").startswith(
+            "witness-package:"
+        ):
+            member["proofirProvenance"] = witness_package_proofir_provenance(
+                bundle_cid, runtime_cid()
+            )
+    return ir, mementos
+
+
+def _degenerate_file_memento(rel_path: str, source_cid: Optional[str] = None) -> dict:
+    """The file-level locator: a `source-memento` with only `file` and the
+    file's content CID populated. A whole file has no single body span or AST
+    template, so those stay absent. Same shape the python source kit seals
+    (`lift_rpc._degenerate_file_memento`)."""
+    return {
+        "kind": "source-memento",
+        "file": rel_path,
+        "function_name": "",
+        "span": None,
+        "param_names": [],
+        "source_cid": source_cid,
+        "template_cid": None,
+    }
+
+
+def _file_memento(ws: str, rel_path: str) -> dict:
+    """Seal one file's locator through the SOURCE ORACLE.
+
+    `source_cid` is minted by `path_source`, the same door the python source
+    kit uses -- never hashed here. mint requires it non-empty (it becomes the
+    `sourceCid` header on the minted source-memento), and a kit that invented
+    its own identity would address the same file differently than every other
+    kit.
+    """
+    full = os.path.join(ws, rel_path)
+    _source, _filename, cid = path_source(full)
+    return _degenerate_file_memento(rel_path, cid)
+
+
+# Levels a SOURCE kit censuses that a witness PRODUCER has nothing to say about.
+# Answering an empty census (rather than an error) keeps `prove`/report walks
+# that sweep every registered surface from failing on this kit.
+_EMPTY_CENSUS_LEVELS = frozenset(
+    {
+        "functions",
+        "call_sites",
+        "assertions",
+        "facts",
+        "implications",
+        "exports",
+        "contract-declarations",
+        "provider-contract-members",
+        "contract-demands",
+        "context-manager-edges",
+        "parameter-contract-resume",
+    }
+)
+
+
+def _send_enumerate_result(msg_id: Any, nodes: List[dict], gaps: List[dict]) -> None:
+    _send(
+        {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"nodes": nodes, "gaps": gaps},
+        }
+    )
+
+
+def handle_enumerate(msg_id: Any, params: dict) -> None:
+    """`sugar.enumerate`: the ONE construction door (the `lift` method is retired).
+
+    The Rust fold (`sugar_compiler::tree::fold_enumerate_source_tree`) walks
+    `source_files` and then asks `universe` per file, collecting each node's
+    `audit` as an IR row. A witness package is a WHOLE-SUITE artifact, not a
+    per-file one, so the suite runs exactly once: the census reports every
+    Python file (so the fold's `sourceMementos`/`sourceLedger` testify the real
+    source closure), and the package's two IR rows -- the custom-evidence
+    contract and its signed WitnessPackageMemento -- are emitted at the ANCHOR
+    file only (the first test file in sorted order). Every other file answers an
+    empty universe, which is the truth: it contributes no contract of its own.
+    """
+    level = str(params.get("level", ""))
     ws = str(params.get("workspace_root", "."))
-    sps = params.get("source_paths", ["."])
     try:
-        pyfiles = _iter_python_files(ws, sps)
-        rels = [os.path.relpath(p, ws) for p in pyfiles]
-        code_rels = [r for r in rels if not os.path.basename(r).startswith("test_")]
-        test_rels = [r for r in rels if os.path.basename(r).startswith("test_")]
-        decls: List[ContractDecl] = []
-        mementos: List[dict] = []
-        if test_rels:
-            # PER-TEST run, but ONE proof member. The whole suite is a WITNESS
-            # PACKAGE: a content-addressed `.witness` bundle of per-test bodies,
-            # cid = blake3(bundle). The proof carries ONE WitnessPackageMemento
-            # (64 bytes) + ONE contract whose evidence pins the package cid -- not
-            # N mementos. The verifier asks the oracle to discharge by re-running
-            # the suite and reproducing the package cid (`discharge_bundle`).
-            bundle_bytes, bundle_cid, witnesses = build_suite_bundle(
-                ws, test_rels, code_rels
-            )
-            passed = sum(1 for w in witnesses if w.outcome == "passed")
-            try:
-                bundle_dir = os.path.join(ws, ".sugar", "witnesses")
-                os.makedirs(bundle_dir, exist_ok=True)
-                with open(
-                    os.path.join(bundle_dir, cid_filename(bundle_cid, ".witness")),
-                    "wb",
-                ) as f:
-                    f.write(bundle_bytes)
-            except OSError:
-                pass  # the package is audit material; never fail the lift on a write error
-            proof_data = json.dumps(
-                {
-                    "kind": "witness-package",
-                    "packageCid": bundle_cid,
-                    "testFiles": sorted(test_rels),
-                    "codeFiles": sorted(code_rels),
-                    "count": len(witnesses),
-                    "passed": passed,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            cert = EvidenceCertificate(
-                tool="pytest",
-                version=runtime_cid(),
-                formula_hash=bundle_cid,
-                proof_data=proof_data,
-            )
-            ev = EvidenceTerm(proof_type="custom", certificate=cert)
-            decls.append(
-                ContractDecl(
-                    name=f"witness-package:{bundle_cid}",
-                    inv=atomic("witnessed", []),
-                    evidence=ev,
-                )
-            )
-            mementos.append(
-                witness_package_memento(
-                    bundle_cid, test_rels, code_rels, len(witnesses), passed
-                )
-            )
-        ir = json.loads(encode_jcs(declarations_to_value(decls))) if decls else []
-        for member in ir:
-            if member.get("kind") == "contract" and member.get("name", "").startswith(
-                "witness-package:"
-            ):
-                member["proofirProvenance"] = witness_package_proofir_provenance(
-                    bundle_cid, runtime_cid()
-                )
-        # The signed WitnessMementos flow as `ir` members (kind "witness-memento"):
-        # mint envelopes each into the .proof via its per-kind dispatch, so the
-        # .proof carries the signed pointer the rust verifier enumerates. (Also
-        # surfaced as `witness_mementos` for non-mint consumers.)
-        ir = ir + mementos
+        if level == "parameter-contract-link-units":
+            # A witness producer enrolls no parameter-contract link units.
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {"rows": []}})
+            return
+        if level in _EMPTY_CENSUS_LEVELS:
+            _send_enumerate_result(msg_id, [], [])
+            return
+        if level == "source_files":
+            code_rels, test_rels = _split_python_files(ws, ["."])
+            nodes = []
+            gaps = []
+            for rel in sorted(code_rels + test_rels):
+                try:
+                    memento = _file_memento(ws, rel)
+                except SourceUnavailable as unavailable:
+                    # An unreadable/undecodable file is a loud protocol gap,
+                    # never a node with a made-up identity.
+                    gaps.append(
+                        {
+                            "memento": _degenerate_file_memento(rel),
+                            "reason": str(unavailable),
+                        }
+                    )
+                    continue
+                nodes.append({"memento": memento, "audit": None, "payload": None})
+            _send_enumerate_result(msg_id, nodes, gaps)
+            return
+        if level == "universe":
+            at = params.get("at") or {}
+            file_rel = at.get("file") if isinstance(at, dict) else None
+            code_rels, test_rels = _split_python_files(ws, ["."])
+            if not test_rels or file_rel != test_rels[0]:
+                # Not the anchor: no contract of its own. (No tests at all also
+                # means no package -- an empty universe, not a gap.)
+                _send_enumerate_result(msg_id, [], [])
+                return
+            ir, mementos = build_witness_ir(ws, code_rels, test_rels)
+            anchor = _file_memento(ws, test_rels[0])
+            nodes = [{"memento": anchor, "audit": row} for row in ir + mementos]
+            _send_enumerate_result(msg_id, nodes, [])
+            return
         _send(
             {
                 "jsonrpc": "2.0",
                 "id": msg_id,
-                "result": {
-                    "kind": "ir-document",
-                    "ir": ir,
-                    "witness_mementos": mementos,
-                    "implications": [],
-                    "diagnostics": [],
-                    "warnings": [],
+                "error": {
+                    "code": -32602,
+                    "message": f"sugar.enumerate: unknown level {level!r}",
                 },
             }
         )
@@ -490,7 +630,9 @@ def main() -> None:
                                 {"name": "initialize", "required": True},
                                 {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
                                 {"name": COMPONENT_PLAN_RPC_METHOD, "required": False},
-                                {"name": "lift", "required": True},
+                                # `lift` is NOT a kit method: full-tree
+                                # construction is sugar.enumerate only.
+                                {"name": ENUMERATE_RPC_METHOD, "required": True},
                                 {"name": RESOLVE_WITNESS_RPC_METHOD, "required": False},
                                 {"name": "shutdown", "required": False},
                             ]
@@ -512,8 +654,8 @@ def main() -> None:
                     "result": component_plan_result(msg.get("params", {})),
                 }
             )
-        elif method == "lift":
-            handle_lift(mid, msg.get("params", {}))
+        elif method == ENUMERATE_RPC_METHOD:
+            handle_enumerate(mid, msg.get("params", {}))
         elif method == RESOLVE_WITNESS_RPC_METHOD:
             handle_resolve_witness(mid, msg.get("params", {}))
         elif method == "shutdown":

--- a/implementations/python/sugar-lift-py-pytest-witness/tests/test_witness.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/tests/test_witness.py
@@ -505,15 +505,39 @@ def test_discharge_command_refuses_mutated(tmp_path):
 # python-literal-base64).
 
 
-def test_lsp_lift_stamps_witness_package_contract_with_proofir_provenance(tmp_path):
-    from sugar_pytest_witness.lift_lsp import handle_lift
+def _enumerate_call(proj, params):
+    from sugar_pytest_witness.lift_lsp import handle_enumerate
 
-    proj = _project(tmp_path, GOOD)
     captured = io.StringIO()
     with contextlib.redirect_stdout(captured):
-        handle_lift(1, {"workspace_root": proj})
-    resp = json.loads(captured.getvalue().strip().splitlines()[-1])
-    ir = resp["result"]["ir"]
+        handle_enumerate(1, dict(params, workspace_root=proj))
+    return json.loads(captured.getvalue().strip().splitlines()[-1])
+
+
+def _enumerate_universe_ir(proj):
+    """Drive the kit's ONE construction door and return the anchor's IR rows.
+
+    Mirrors `fold_enumerate_source_tree`: census `source_files`, then ask
+    `universe` at each file and collect every node's `audit` as an IR row.
+    """
+    census = _enumerate_call(proj, {"level": "source_files"})
+    assert "error" not in census, census
+    files = [node["memento"]["file"] for node in census["result"]["nodes"]]
+    assert files, f"source census enumerated no files: {census}"
+    rows = []
+    for file_rel in files:
+        reply = _enumerate_call(proj, {"level": "universe", "at": {"file": file_rel}})
+        assert "error" not in reply, reply
+        assert not reply["result"]["gaps"], reply
+        rows.extend(
+            node["audit"] for node in reply["result"]["nodes"] if node.get("audit")
+        )
+    return rows
+
+
+def test_lsp_lift_stamps_witness_package_contract_with_proofir_provenance(tmp_path):
+    proj = _project(tmp_path, GOOD)
+    ir = _enumerate_universe_ir(proj)
     contracts = [
         m
         for m in ir
@@ -529,3 +553,86 @@ def test_lsp_lift_stamps_witness_package_contract_with_proofir_provenance(tmp_pa
     )
     warrants = contract["proofirProvenance"]["warrants"]
     assert warrants and warrants[0]["kind"] == "Derived", contract["proofirProvenance"]
+
+
+# --- The retired `lift` door: construction is sugar.enumerate only -----------
+# sugar-cli `lift_plugin::dispatch_lift_path` refuses a surface that neither
+# advertises `sugar.enumerate` nor sets a non-`lift` manifest method: "sending
+# JSON-RPC method `lift` is retired". The kit declaration is what that gate
+# reads, so the advertisement is load-bearing, not documentation.
+
+
+def test_kit_declaration_advertises_enumerate_and_never_lift():
+    reply = _rpc("sugar.plugin.kit_declaration", {})
+    methods = reply["result"]["rpc"]["methods"]
+    names = [m["name"] for m in methods]
+    assert "sugar.enumerate" in names, (
+        "kit must advertise sugar.enumerate or dispatch_lift_path refuses the "
+        f"surface as a retired-lift kit: {names}"
+    )
+    assert "lift" not in names, (
+        f"`lift` is not a kit method; advertising it re-opens the retired door: {names}"
+    )
+    required = {m["name"] for m in methods if m.get("required")}
+    assert "sugar.enumerate" in required, methods
+
+
+def test_enumerate_emits_the_signed_witness_package_memento_as_an_ir_row(tmp_path):
+    """The memento is the proof's ONLY pointer to the witness body.
+
+    It rides the same `audit` channel as the contract it pins, so
+    `sugar_compiler::tree::looks_like_ir_contract_row` must let `witness-memento`
+    through -- otherwise mint's `witness-memento` dispatch never sees it and the
+    custom-evidence contract can never be discharged.
+    """
+    proj = _project(tmp_path, GOOD)
+    rows = _enumerate_universe_ir(proj)
+    mementos = [r for r in rows if r.get("kind") == "witness-memento"]
+    assert len(mementos) == 1, f"expected exactly one package memento: {rows}"
+    memento = mementos[0]
+    assert memento["witness_kind"] == "pytest-witness-package", memento
+    for field in ("witness_cid", "signer", "signature", "test_files", "code_files"):
+        assert memento.get(field), f"memento missing {field}: {memento}"
+    contracts = [
+        r
+        for r in rows
+        if r.get("kind") == "contract"
+        and r.get("name", "").startswith("witness-package:")
+    ]
+    assert len(contracts) == 1, rows
+    # The memento pins exactly the package the contract's evidence names.
+    assert contracts[0]["name"] == f"witness-package:{memento['witness_cid']}"
+
+
+def test_enumerate_runs_the_suite_once_at_the_anchor_file_only(tmp_path):
+    """A witness package is a whole-suite artifact, so exactly one file in the
+    census may answer a non-empty universe -- otherwise the suite runs N times
+    and the proof carries N duplicate packages."""
+    proj = _project(tmp_path, GOOD)
+    census = _enumerate_call(proj, {"level": "source_files"})
+    files = [node["memento"]["file"] for node in census["result"]["nodes"]]
+    non_empty = [
+        f
+        for f in files
+        if _enumerate_call(proj, {"level": "universe", "at": {"file": f}})["result"][
+            "nodes"
+        ]
+    ]
+    assert len(non_empty) == 1, (
+        f"exactly one anchor file may carry the package; got {non_empty}"
+    )
+    tests = sorted(f for f in files if f.split("/")[-1].startswith("test_"))
+    assert non_empty == [tests[0]], (
+        f"anchor must be the first test file in sorted order: {non_empty} vs {tests}"
+    )
+
+
+def test_enumerate_link_units_and_unrelated_levels_are_empty_not_errors(tmp_path):
+    proj = _project(tmp_path, GOOD)
+    link_units = _enumerate_call(proj, {"level": "parameter-contract-link-units"})
+    assert link_units["result"] == {"rows": []}, link_units
+    for level in ("functions", "call_sites", "assertions", "facts", "exports"):
+        reply = _enumerate_call(proj, {"level": level})
+        assert reply["result"] == {"nodes": [], "gaps": []}, (level, reply)
+    unknown = _enumerate_call(proj, {"level": "no-such-level"})
+    assert "error" in unknown, unknown

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py
@@ -3,11 +3,22 @@
 The CLI enforces `kit_source.identity` on the `python` authoring surface so
 mint/prove can seal split-pipeline provenance. Every Python RPC that can be
 registered as that surface must include this field.
+
+Kit identity is the sourceStamp, NOT Git HEAD (#6224): the binary embeds
+`SUGAR_BUILD_STAMP` and the gate (`refuse_split_pipeline`) is
+`kit.sourceStamp == binary.sourceStamp`. #6224 migrated the
+`sugar_lift_py_tests` twin of this module and left this one on Git HEAD, which
+refused every mint that registered the `python` surface through
+`verify_rpc.run_rpc` (e.g. examples/python-bodyguard-precondition). Both
+modules must keep answering the same `kind`; `tests/source_stamp_compat_twins.sh`
+holds that line.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -24,7 +35,21 @@ def _git(root: Path, *args: str) -> str | None:
     return value or None
 
 
+def _monorepo_root() -> Path | None:
+    """Locate monorepo root from installed package paths (…/implementations/python/…)."""
+    import sugar_lift_python_source
+
+    here = Path(sugar_lift_python_source.__file__).resolve()
+    for parent in here.parents:
+        if (parent / "tools" / "sugar_source_stamp.py").is_file() and (
+            parent / "implementations" / "rust" / "Cargo.toml"
+        ).is_file():
+            return parent
+    return None
+
+
 def _content_identity(roots: list[Path]) -> str:
+    """Legacy content hash (tests / non-monorepo). Path-safe underscore form."""
     material = bytearray()
     for index, root in enumerate(roots):
         for path in sorted(
@@ -36,45 +61,105 @@ def _content_identity(roots: list[Path]) -> str:
             payload = path.read_bytes()
             material.extend(f"{index}:".encode() + relative + b"\0")
             material.extend(str(len(payload)).encode() + b"\0" + payload)
-    return blake3_512_of(bytes(material))
+    # blake3_512_of returns blake3-512:<hex>; normalize to the path-safe _ form.
+    return blake3_512_of(bytes(material)).replace(":", "_", 1)
 
 
 def source_provenance_for_roots(roots: Iterable[Path]) -> dict[str, object]:
+    """Content identity of `roots`. Git HEAD is an attestation, never identity
+    (#6224), so it only contributes the `dirty` flag."""
     resolved = [Path(root).resolve() for root in roots]
-    git_rows: list[tuple[Path, str, str]] = []
+    dirty = False
     for root in resolved:
         top = _git(root, "rev-parse", "--show-toplevel")
-        head = _git(root, "rev-parse", "HEAD")
-        if top is None or head is None:
-            return {
-                "identity": _content_identity(resolved),
-                "kind": "content",
-                "dirty": False,
-            }
-        git_rows.append((Path(top), head, root.relative_to(Path(top)).as_posix()))
-    heads = {head for _, head, _ in git_rows}
-    if len(heads) != 1:
-        return {
-            "identity": _content_identity(resolved),
-            "kind": "content",
-            "dirty": False,
-        }
-    dirty = any(
-        bool(_git(top, "status", "--porcelain", "--", relative))
-        for top, _, relative in git_rows
-    )
-    return {"identity": next(iter(heads)), "kind": "git", "dirty": dirty}
+        if top is None:
+            continue
+        try:
+            relative = root.relative_to(Path(top)).as_posix()
+        except ValueError:
+            continue
+        if bool(_git(Path(top), "status", "--porcelain", "--", relative)):
+            dirty = True
+            break
+    return {
+        "identity": _content_identity(resolved),
+        "kind": "content",
+        "dirty": dirty,
+    }
 
 
-def kit_source_provenance() -> dict[str, object]:
-    """Identity of the Python kit sources that implement this RPC process."""
+def kit_package_roots() -> list[Path]:
     import sugar_lift_python_source
 
     roots = [Path(sugar_lift_python_source.__file__).resolve().parent]
-    try:
-        import sugar_lift_py_tests
+    for module in ("sugar_lift_py_tests", "sugar_source_tree"):
+        try:
+            imported = __import__(module)
+        except ImportError:
+            continue
+        roots.append(Path(imported.__file__).resolve().parent)
+    return roots
 
-        roots.append(Path(sugar_lift_py_tests.__file__).resolve().parent)
-    except ImportError:
-        pass
-    return source_provenance_for_roots(roots)
+
+def source_stamp_for_sugar_cli(repo_root: Path | None = None) -> str | None:
+    """Same sourceStamp sugarbin / SUGAR_BUILD_STAMP use for package sugar-cli."""
+    root = repo_root or _monorepo_root()
+    if root is None:
+        return None
+    script = root / "tools" / "sugar_source_stamp.py"
+    if not script.is_file():
+        return None
+    cargo = os.environ.get("SUGAR_BINARY_CARGO") or os.environ.get("CARGO") or "cargo"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--repo-root",
+            str(root),
+            "--package",
+            "sugar-cli",
+            "--cargo",
+            cargo,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    stamp = result.stdout.strip()
+    if not stamp.startswith("blake3-512_"):
+        return None
+    return stamp
+
+
+def kit_source_provenance() -> dict[str, object]:
+    """Kit identity is the sourceStamp (not Git HEAD).
+
+    Matches the binary's embedded SUGAR_BUILD_STAMP so the split-pipeline gate
+    is kit.sourceStamp == binary.sourceStamp. Mirror of
+    `sugar_lift_py_tests.source_provenance.kit_source_provenance`: both Python
+    kits can be registered as the `python` surface, so both must answer the
+    same identity kind or one of them refuses every mint (#6224).
+    """
+    stamp = source_stamp_for_sugar_cli()
+    if stamp is not None:
+        dirty = False
+        root = _monorepo_root()
+        if root is not None:
+            dirty = any(
+                bool(_git(root, "status", "--porcelain", "--", rel))
+                for rel in (
+                    "implementations/python/sugar-lift-python-source",
+                    "implementations/python/sugar-lift-py-tests",
+                    "implementations/python/sugar-source-tree",
+                    "implementations/rust",
+                )
+            )
+        return {
+            "identity": stamp,
+            "kind": "sourceStamp",
+            "dirty": dirty,
+        }
+    # Offline / unpackaged: content identity of kit packages only.
+    return source_provenance_for_roots(kit_package_roots())

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -512,6 +512,16 @@ fn looks_like_ir_contract_row(value: &Value) -> bool {
     if kind == "contract" || kind == "function-contract" {
         return true;
     }
+    // A WITNESS kit (pytest-witness, cargo-test-witness) folds its signed
+    // WitnessMemento through the same audit channel as the contract that
+    // memento pins -- there is no second wire for it. Mint dispatches
+    // `witness-memento` rows straight out of `response["ir"]`
+    // (`cmd_mint::mint_witness_memento`), so dropping the row here would
+    // strip the proof's ONLY pointer to the witness body and leave the
+    // custom-evidence contract permanently undischargeable.
+    if kind == "witness-memento" {
+        return true;
+    }
     // IR rows always carry at least one body slot or formals even if kind is
     // missing under a future kit dialect.
     obj.contains_key("inv")
@@ -2200,6 +2210,33 @@ impl Assertion {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A witness kit has no second wire for its signed memento: it rides the
+    /// same `audit` channel as the contract it pins, and mint dispatches
+    /// `witness-memento` straight out of `response["ir"]`. If the fold's row
+    /// filter drops it, the proof loses its only pointer to the witness body
+    /// and the custom-evidence contract can never discharge.
+    #[test]
+    fn ir_row_filter_admits_witness_mementos() {
+        assert!(looks_like_ir_contract_row(&json!({
+            "kind": "witness-memento",
+            "witness_cid": "blake3-512:abc",
+            "witness_kind": "pytest-witness-package",
+            "signer": "ed25519:k",
+            "signature": "ed25519:s",
+        })));
+    }
+
+    #[test]
+    fn ir_row_filter_still_admits_contracts_and_rejects_non_rows() {
+        assert!(looks_like_ir_contract_row(&json!({"kind": "contract"})));
+        assert!(looks_like_ir_contract_row(&json!({"kind": "function-contract"})));
+        assert!(looks_like_ir_contract_row(&json!({"inv": {}})));
+        // Not an IR row: no recognized kind and no body slot.
+        assert!(!looks_like_ir_contract_row(&json!({"kind": "source-memento"})));
+        assert!(!looks_like_ir_contract_row(&json!({"kind": "term-ref"})));
+        assert!(!looks_like_ir_contract_row(&json!("not an object")));
+    }
 
     fn recovered_owner(file: &str, function: &str, line: usize) -> SourceMemento {
         SourceMemento {

--- a/tests/source_stamp_compat_twins.sh
+++ b/tests/source_stamp_compat_twins.sh
@@ -49,4 +49,20 @@ echo "$gate" | rg -q 'SUGAR_BUILD_STAMP' || { echo "gate still not on SUGAR_BUIL
 ! rg -n 'refuse_split_pipeline\(identity, env!\("SUGAR_BUILD_GIT_HEAD"\)\)' implementations/rust/sugar-cli/src/lift_plugin.rs \
   || { echo "gate still compares to SUGAR_BUILD_GIT_HEAD" >&2; exit 1; }
 
-echo "PASS: sourceStamp twins (docs stable, rust/python protocol matter, gate uses SUGAR_BUILD_STAMP)"
+# Twin: EVERY Python kit that can be registered as the `python` surface must
+# testify the sourceStamp. #6224 migrated only the sugar-lift-py-tests module
+# and left sugar-lift-python-source answering Git HEAD, so every mint through
+# `verify_rpc.run_rpc` refused with "kit @<git sha> != binary @blake3-512_...".
+# Source-level ratchet: these modules import blake3, which the bare system
+# python3 running this script does not have.
+for provenance in implementations/python/*/src/*/source_provenance.py; do
+  rg -q 'def kit_source_provenance' "$provenance" || continue
+  rg -q '"kind": "sourceStamp"' "$provenance" \
+    || { echo "$provenance does not testify kind sourceStamp (#6224)" >&2; exit 1; }
+  ! rg -q '"kind": "git"' "$provenance" \
+    || { echo "$provenance still testifies Git HEAD as kit identity (#6224)" >&2; exit 1; }
+  rg -q 'source_stamp_for_sugar_cli' "$provenance" \
+    || { echo "$provenance does not compute the sugar-cli sourceStamp (#6224)" >&2; exit 1; }
+done
+
+echo "PASS: sourceStamp twins (docs stable, rust/python protocol matter, gate uses SUGAR_BUILD_STAMP, every python kit testifies sourceStamp)"


### PR DESCRIPTION
Two independent Python-side showcase failures on `main` (`e62bebe`).

## 1. `python-pytest-witness` still used the retired `lift` method

`dispatch_lift_path` refuses a surface that neither advertises `sugar.enumerate` nor sets a non-`lift` manifest method. The kit advertised `{"name": "lift", "required": true}` and served a `lift` handler, so every project registering `python-pytest-witness` refused at mint.

It now advertises and serves `sugar.enumerate`:

- **`source_files`** censuses every project Python file, sealing each locator through the **source oracle** (`path_source`, the same door the python source kit uses). mint requires a non-empty `source_cid` — it becomes the `sourceCid` header on the minted source-memento — and a kit that hashed files itself would address the same file differently than every other kit. Unreadable files become loud protocol gaps, never nodes with invented identity.
- **`universe`** emits the package's two IR rows (custom-evidence contract + signed `WitnessPackageMemento`) at the **anchor** file only — the first test file in sorted order. A witness package is a whole-suite artifact, so the suite runs exactly once regardless of census size; every other file answers an empty universe, which is the truth: it contributes no contract of its own.
- **`parameter-contract-link-units`** answers no rows, and the census levels a source kit owns answer empty rather than erroring, so `prove` walks that sweep every registered surface don't fail on a witness producer.

Emitted rows stay byte-identical to what mint received from the retired method, so the `.proof` shape doesn't move.

One Rust change makes this possible: **`tree::looks_like_ir_contract_row` now admits `witness-memento`.** A witness kit folds its signed memento through the same `audit` channel as the contract that memento pins — there is no second wire — and mint dispatches `witness-memento` straight out of `response["ir"]` (`cmd_mint::mint_witness_memento`). Dropping the row would strip the proof's only pointer to the witness body and leave the custom-evidence contract permanently undischargeable.

## 2. Only one of two Python provenance modules was migrated by #6224

#6224 moved the split-pipeline gate onto the sourceStamp but migrated only `sugar_lift_py_tests.source_provenance`. The sibling in `sugar-lift-python-source` still answered `{"identity": <git HEAD>, "kind": "git"}`. Both back the `python` surface, so mint through `verify_rpc.run_rpc` compared a Git sha to a stamped binary and refused:

```
refusing to mint from a split pipeline: kit @<git sha> != binary @blake3-512_...
```

The gate keys identity correctly; the kit was mis-testifying. Both modules now return identical `identity`/`kind`, matching what `tools/sugar_source_stamp.py` prints for the same tree.

## Validation

- **32** pytest-witness kit tests pass.
- **End-to-end**, minimal project registering only `python-pytest-witness`: `sugar mint` produces a `.proof`; `sugar verify` reports `witnessDimension.total=2` both verified, `outcomeClass: Verified`, and `consistency:witness-package:... -> discharged` ("witness package verified by rust via package; all 1 outcomes passed"). The same project refused at mint before this change.
- **Two new `tree.rs` unit tests** pin the IR-row filter; confirmed the `witness-memento` one fails when the admission is removed.
- `tests/source_stamp_compat_twins.sh` gains a twin failing any `implementations/python/*/src/*/source_provenance.py` that doesn't testify `sourceStamp`; confirmed it fails against the pre-fix module.
- **Part 2 proven end-to-end**: `examples/python-bodyguard-precondition/run.sh` no longer produces the split-pipeline refusal. `enforce_python_kit_source` (`lift_plugin.rs:400`) runs *before* the enumerate dispatch (`:405`), so the run reaches and passes the gate.

## Known-failing, pre-existing, not from this change

All A/B-confirmed by reverting `tree.rs` to `e62bebe`:

- `sugar-compiler/tests/native_export_producer.rs:35` fails to compile (`E0283` on `"native".into()`), so `cargo test -p sugar-compiler` cannot complete on `main`.
- `tree::tests::recovered_audit_leaf_golden_fold_attaches_demanded_body` fails on `e62bebe` too.
- 10 integration targets baselined at `e62bebe` show identical pass/fail counts with and without this change (`memento_self_locating` varies run to run and looks flaky).

## Explicitly NOT fixed here — separate blockers

Neither showcase `run.sh` goes green, each blocked by something outside this change:

1. **`examples/sklearn-showcase`** dies before the witness kit is reached, on a ConstructionPanic in the `python` kit: `illegal free var(s): np` / `owner=proofir.scope.ScopedFormula`. Migrating the witness kit cannot fix this.
2. **`examples/python-bodyguard-precondition`** now clears the gate and stops at a *different* retired-`lift` refusal: surface `python` served by `sugar_lift_python_source.verify_rpc` is itself unmigrated. That is the separate Python sourceTree enumerate migration.

Also unmigrated, same state, not touched: `sugar-lift-rust-cargo-test-witness` (`src/bin/witness_rpc.rs:216`) and `sugar-build-witness` (`src/sugar_build_witness/lift_lsp.py`) both advertise `lift` and set no manifest method.

Note: `tools/sugarbin-build.mk` hardcodes `CARGO_INCREMENTAL=1` for the debug profile, which sccache refuses ("incremental compilation is prohibited"). Debug showcases need `CARGO_BUILD_RUSTC_WRAPPER=""` on machines with a global sccache wrapper. Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sugar.enumerate` support for pytest-witness discovery and suite witness generation.
  * Added source mementos for Python files, including unreadable-file handling.
  * Added source provenance based on build stamps, with content-based fallback.

* **Bug Fixes**
  * Preserved witness memento rows during IR enumeration.
  * Ensured witness provenance and contract relationships are reported correctly.

* **Tests**
  * Added coverage for enumeration levels, anchor-file behavior, provenance, and source-stamp compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `lift` RPC with `sugar.enumerate` in Python pytest-witness kit and align source provenance to `sourceStamp`
> - The pytest-witness LSP server no longer handles `lift` calls; it now advertises and serves `sugar.enumerate`, returning per-file source mementos and witness IR only at the designated anchor file under the `universe` level.
> - [`source_provenance.py`](https://github.com/TSavo/sugar/pull/6249/files#diff-6ec4be72a5ca413055e0abda0849e3fc75ca6cdff57cf7dc129d0635455661b2) is rewritten to prefer a monorepo `sourceStamp` for the kit's self-reported identity (`kind: 'sourceStamp'`), falling back to content-hash when offline or unpackaged.
> - [`tree.rs`](https://github.com/TSavo/sugar/pull/6249/files#diff-1e76daa010a218df51ed5a9f321167e9101bfbc1ef2983cc15a1da0d4fe553eb) extends `looks_like_ir_contract_row` to admit `witness-memento` rows so they propagate to mint alongside contracts.
> - A compat test in [`source_stamp_compat_twins.sh`](https://github.com/TSavo/sugar/pull/6249/files#diff-03efd12a87f0f1d29d7b6cab01c47e194485a74d592aabf7d5cdabc664f7b7c2) asserts every Python kit reports `kind: 'sourceStamp'` and never `kind: 'git'`.
> - Risk: the content-identity separator changes from `:` to `_` (e.g. `blake3-512_<hex>`), which breaks any downstream string comparisons expecting the colon format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1454a75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


## Unit-level proof: unavailable, and why

I attempted to validate this migration against the Rust `enumerate_*` / `mint_fold_parity` / `feed_from_tree` targets. It is not possible: those nine tests fail on `-32601 method 'lift' not found` on both main and this branch, because they call the retired `lift` door through `whole_project_lift_payload()` against a kit (`sugar_lift_py_tests.lift_rpc`) that correctly no longer serves it (`lift_rpc.py:922-923`). Stale test callers, not an unmigrated kit, and unrelated to this PR. Detail in the comment below.

Part 1 therefore rests on the minimal-project end-to-end mint/verify, not on unit tests.
