### PR TITLE
fix: try_fold resolves &closure args; checked-op method-call spelling folds

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7171,7 +7171,7 @@ class Attribute(Expression):
         call result is a symbolic read the witness resolves at runtime, not a
         gap. It reduces to the honest `py.getattr(recv, "attr")` EUF coordinate
         (SymbolicValue.attribute), carrying whatever the call term guarantees and
-        nothing invented. Refusing it here was the withhold, not the construct."""
+        nothing invented. Withholding it here was the gap, not the construct."""
         from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 
         return AttributeSugar(
@@ -7230,7 +7230,7 @@ class Subscript(Expression):
         call result is a symbolic read the witness resolves at runtime, not a
         gap. It reduces to the honest `py.subscript(recv, key)` EUF coordinate,
         carrying whatever the call term guarantees and nothing invented.
-        Refusing it here was the withhold, not the construct."""
+        Withholding it here was the gap, not the construct."""
         from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
 
         return SubscriptSugar(

--- a/implementations/rust/sugar-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/lib.rs
@@ -8850,7 +8850,7 @@ fn const_eval_option_closure(
         },
         other => other,
     };
-    const_eval_option_expr(body, &env)
+    const_eval_option_expr(body, &env, None)
 }
 
 /// Evaluate an expression whose VALUE is an `Option` to a concrete `Option<ConstVal>`:
@@ -8874,18 +8874,30 @@ pub(crate) fn const_eval_binary_option_closure(
         },
         other => other,
     };
-    const_eval_option_expr(body, &env)
+    // The accumulator ascription (`acc: i32`) is the only kind witness the
+    // method-call spelling of checked ops has; the UFCS spelling carries the
+    // kind in its path instead.
+    const_eval_option_expr(body, &env, closure_param_int_kind(&closure.inputs[0]))
+}
+
+fn closure_param_int_kind(pat: &Pat) -> Option<PrimitiveIntKind> {
+    let Pat::Type(typed) = pat else { return None };
+    let syn::Type::Path(ty) = &*typed.ty else {
+        return None;
+    };
+    primitive_int_kind(&ty.path.get_ident()?.to_string())
 }
 
 fn const_eval_option_expr(
     expr: &Expr,
     env: &BTreeMap<String, ConstVal>,
+    acc_kind: Option<PrimitiveIntKind>,
 ) -> Option<Option<ConstVal>> {
     match expr {
-        Expr::Paren(p) => const_eval_option_expr(&p.expr, env),
-        Expr::Group(g) => const_eval_option_expr(&g.expr, env),
+        Expr::Paren(p) => const_eval_option_expr(&p.expr, env, acc_kind),
+        Expr::Group(g) => const_eval_option_expr(&g.expr, env, acc_kind),
         Expr::Block(b) => match b.block.stmts.as_slice() {
-            [Stmt::Expr(e, None)] => const_eval_option_expr(e, env),
+            [Stmt::Expr(e, None)] => const_eval_option_expr(e, env, acc_kind),
             _ => None,
         },
         // `None` constructor.
@@ -8908,15 +8920,98 @@ fn const_eval_option_expr(
             // shape pre-filter needed.
             let cond = const_eval(&if_expr.cond, env)?.as_bool()?;
             let then_opt = match if_expr.then_branch.stmts.as_slice() {
-                [Stmt::Expr(e, None)] => const_eval_option_expr(e, env)?,
+                [Stmt::Expr(e, None)] => const_eval_option_expr(e, env, acc_kind)?,
                 _ => return None,
             };
             let else_branch = if_expr.else_branch.as_ref()?;
-            let else_opt = const_eval_option_expr(&else_branch.1, env)?;
+            let else_opt = const_eval_option_expr(&else_branch.1, env, acc_kind)?;
             Some(if cond { then_opt } else { else_opt })
         }
+        // `<recv>.checked_*(<rhs>)`, possibly chained through `?`.
+        Expr::MethodCall(_) => const_eval_checked_method_chain(expr, env, acc_kind),
         _ => None,
     }
+}
+
+/// `<recv>.checked_{add,sub,mul,div}(<rhs>)` — the method-call spelling of the UFCS
+/// checked ops handled by `const_eval_checked_int_call`. The receiver may itself be a
+/// checked call followed by `?`, which short-circuits `None` through the closure body
+/// (`acc.checked_mul(2)?.checked_add(x)`). The int kind is witnessed by the receiver
+/// value's `PrimitiveInt` kind, or by the accumulator's type ascription for a plain
+/// `Int` receiver; with no witness there is no single overflow bound to check, so BAIL.
+/// Signed results surface as plain `Int`, exactly as the UFCS spelling does, so either
+/// spelling folds to the same term.
+fn const_eval_checked_method_chain(
+    expr: &Expr,
+    env: &BTreeMap<String, ConstVal>,
+    acc_kind: Option<PrimitiveIntKind>,
+) -> Option<Option<ConstVal>> {
+    let Expr::MethodCall(call) = expr else {
+        return None;
+    };
+    if call.turbofish.is_some() || call.args.len() != 1 {
+        return None;
+    }
+    let op = match call.method.to_string().as_str() {
+        "checked_add" => "add",
+        "checked_sub" => "sub",
+        "checked_mul" => "mul",
+        "checked_div" => "div",
+        _ => return None,
+    };
+    let receiver = match &*call.receiver {
+        Expr::Try(inner) => match const_eval_checked_method_chain(&inner.expr, env, acc_kind)? {
+            None => return Some(None),
+            Some(value) => value,
+        },
+        other => const_eval(other, env)?,
+    };
+    let kind = match &receiver {
+        ConstVal::PrimitiveInt { kind, .. } => *kind,
+        ConstVal::UInt128(_) => primitive_int_kind("u128")?,
+        ConstVal::Int(_) => acc_kind?,
+        _ => return None,
+    };
+    let rhs = const_eval(call.args.first()?, env)?;
+    if kind.signed {
+        let lhs = signed_value_for_kind(&receiver, kind)?;
+        let rhs = signed_value_for_kind(&rhs, kind)?;
+        let value = match op {
+            "add" => lhs.checked_add(rhs),
+            "sub" => lhs.checked_sub(rhs),
+            "mul" => lhs.checked_mul(rhs),
+            "div" if rhs != 0 => lhs.checked_div(rhs),
+            _ => None,
+        };
+        return Some(
+            value
+                .filter(|value| signed_fits_kind(*value, kind))
+                .map(ConstVal::Int),
+        );
+    }
+    let lhs = unsigned_value_for_kind(&receiver, kind)?;
+    let rhs = unsigned_value_for_kind(&rhs, kind)?;
+    let value = match op {
+        "add" => lhs.checked_add(rhs),
+        "sub" => lhs.checked_sub(rhs),
+        "mul" => lhs.checked_mul(rhs),
+        "div" if rhs != 0 => Some(lhs / rhs),
+        _ => None,
+    };
+    Some(
+        value
+            .filter(|value| *value <= primitive_int_max_raw(kind))
+            .map(|raw| {
+                if kind.name == "u128" {
+                    ConstVal::UInt128(raw)
+                } else {
+                    ConstVal::PrimitiveInt {
+                        raw: mask_raw(raw, kind.bits),
+                        kind,
+                    }
+                }
+            }),
+    )
 }
 
 fn const_eval_checked_int_call(

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/iter_terminal.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/iter_terminal.rs
@@ -1831,11 +1831,8 @@ fn resolve_try_fold_closure<'a>(
     }
     match strip_refs_groups(expr) {
         Expr::Closure(closure) => Some(closure.clone()),
-        Expr::Reference(reference) => {
-            resolve_try_fold_closure(&reference.expr, let_inits, scope, depth + 1)
-        }
-        Expr::Path(_) => {
-            let name = simple_path_name(expr)?;
+        stripped @ Expr::Path(_) => {
+            let name = simple_path_name(stripped)?;
             let init = let_inits
                 .get(&name)
                 .copied()


### PR DESCRIPTION
## Problem
The `coretests invariants` CI job on main panics at `iter_terminal.rs:1872`: `a.iter().try_fold(0, &fold)` (Rust 1.96 coretests `slice.rs::test_iter_folds`) never reaches a lawful floor. Separately, the `refusal vocabulary` job is red.

## Root causes and fixes
1. **`&closure` argument never resolved** — `resolve_try_fold_closure` matched on `strip_refs_groups(expr)` but called `simple_path_name` on the original unstripped `&fold`, which always returns `None` for a reference. Now the Path arm uses the stripped expr; the `Expr::Reference` arm was dead (strip already removes refs) and is deleted.
2. **Method-call spelling of checked ops didn't fold** — `const_eval_option_expr` only knew UFCS `i32::checked_add(..)`. Added `const_eval_checked_method_chain` for `acc.checked_mul(2)?.checked_add(x)`: `?` short-circuits `None`, int kind is witnessed by the accumulator's type ascription (or the receiver's `PrimitiveInt` kind), and signed results surface as plain `Int` so both spellings fold to identical terms. No witness → BAIL (safe under-claim).
3. **Refusal vocabulary** — two docstrings from #6230 (`nodes.py:7174/:7233`) added unclassified `refus*` sites after the #6225 census re-ratchet. Reworded (internal docstrings, not wire-visible); census passes.

## Validation
- `cargo test -p sugar-lift-rust-tests`: 928 passed, 1 failed — the failure (`term_dispatch::predicate_visitor_folds_nested_deref_bitand_comparison_floor`) reproduces on clean main e62bebe, i.e. pre-existing and unrelated.
- `python3 tools/check-lift-refusal-vocabulary.py`: PASS.
- `make coretests-invariants`: advances past the try_fold panic; now stops at the **next** latent gap — `MonoidFold gap: terminal=sum, element_type=Result::<i32,_>, missing=CarrierEmbedding` — being fixed separately. This PR is a strict advance of the frontier, not the full green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `try_fold` closure arg resolution and add checked arithmetic method-call folding
> - `resolve_try_fold_closure` in [iter_terminal.rs](https://github.com/TSavo/sugar/pull/6252/files#diff-06db931d2d4634bc7dafc005327aa7800e369818b9d6fa633d9adb676cd0bd64) now strips refs/groups before matching, removing the dedicated `Expr::Reference` arm so reference closure args resolve correctly.
> - `const_eval_checked_method_chain` is introduced to const-evaluate method-call forms of `checked_add/sub/mul/div` (including `?`-chained receivers), matching the existing UFCS evaluation semantics.
> - `const_eval_option_expr` gains an `acc_kind` parameter threaded through all recursive calls, and dispatches `Expr::MethodCall` to the new chain evaluator.
> - `const_eval_binary_option_closure` now extracts the accumulator's integer kind from its type ascription and forwards it, enabling checked method-call bodies that previously bailed to const-fold.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0bcdc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->