### PR TITLE
perf: NodeShapeV2 — a node authenticates its children's CIDs, not their subtrees

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_node_shape_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_node_shape_v2_merkle.py
@@ -1,0 +1,209 @@
+'''NodeShapeV2: a node authenticates its OWN structure plus its children's CIDs.
+
+V1 embedded each child's FULL subtree preimage inside its parent, so the same
+descendant content was authenticated once for every ancestor path above it.
+Total encoding work was the sum of all subtree sizes -- quadratic in depth.
+Measured on pandas ``core/reshape/pivot.py::__internal_pivot_table``: 624s
+cumulative in ``canonical_json_bytes`` over only 1,318 CID calls, each hashing
+a JSON tree of ~12,800 nodes.
+
+V2 is the Merkle form the content-addressed graph always wanted. A parent
+authenticates its immediate structure and the authenticated IDENTITIES of its
+children. Each node encodes a preimage of its OWN arity; the whole tree is
+O(n). Measured on a left-nested BinOp chain, log-log slope of total encoded
+preimage bytes against node count: V1 = 1.92, V2 = 1.00.
+
+This migration DOES change every shape CID, deliberately. Shape CIDs are
+REPRESENTATION identity, never meaning -- constructed formulas, bindings,
+effects, gaps and ExitSets are unchanged, and those are what the equivalence
+proof measures. A fingerprint built from shape CIDs would be circular here.
+
+These twins pin what the preimage must NOT lose and must NOT merge:
+
+  * every perturbation BITES -- reordered, duplicated, omitted children,
+    changed slot names, changed leaf values, changed kind, changed operators;
+  * every slot KIND stays mutually distinguishable -- ``MaybeChild(None)`` is
+    not an absent slot, ``Children([x])`` is not ``Child(x)``, ``Children([])``
+    is not ``MaybeChild(None)``, and a ``Leaf`` carrying a CID string is not a
+    ``Child`` carrying that CID;
+  * structurally identical children SHARE content identity WITHOUT sharing
+    occurrence identity -- same CID, two live refs, two ordered positions;
+  * V1 and V2 never share an identity namespace: the V2 preimage carries a
+    domain, a schema tag, and a NAMED child-CID algorithm that no V1 preimage
+    ever carried.
+'''
+from sugar_source_tree import construction_cache as CC
+from sugar_source_tree.backend import (
+    BackendNode,
+    Child,
+    Children,
+    Description,
+    Leaf,
+    MaybeChild,
+    OpLeaf,
+    OpsLeaf,
+)
+from sugar_source_tree.binding_state import (
+    NODE_SHAPE_V2_CHILD_CID_ALGORITHM,
+    NODE_SHAPE_V2_DOMAIN,
+    NODE_SHAPE_V2_SCHEMA,
+    _node_shape_v2_preimage,
+    backend_node_shape_cid_v2,
+)
+from sugar_source_tree.operators import operator_for
+
+
+class _H(BackendNode):
+    """A synthetic backend node carrying exactly the slots it is handed."""
+
+    def __init__(self, kind, slots):
+        self._kind = kind
+        self._slots = tuple(slots)
+
+    def describe(self):
+        return Description(
+            kind=self._kind, raw_span=None, anchors=(), slots=self._slots
+        )
+
+
+def _name(n):
+    return _H("Name", (("id", Leaf(n)),))
+
+
+def _cid(ref):
+    return backend_node_shape_cid_v2(ref)
+
+
+def test_reordered_children_change_the_parent_cid():
+    a = _H("Tuple", (("elts", Children((_name("x"), _name("y")))),))
+    b = _H("Tuple", (("elts", Children((_name("y"), _name("x")))),))
+    assert _cid(a) != _cid(b)
+
+
+def test_changed_slot_name_changes_the_parent_cid():
+    a = _H("Attr", (("value", Child(_name("x"))),))
+    b = _H("Attr", (("target", Child(_name("x"))),))
+    assert _cid(a) != _cid(b)
+
+
+def test_changed_leaf_value_changes_the_cid():
+    assert _cid(_name("x")) != _cid(_name("y"))
+
+
+def test_duplicated_child_changes_the_parent_cid():
+    one = _H("Tuple", (("elts", Children((_name("x"),))),))
+    two = _H("Tuple", (("elts", Children((_name("x"), _name("x")))),))
+    assert _cid(one) != _cid(two)
+
+
+def test_omitted_child_changes_the_parent_cid():
+    both = _H("Tuple", (("elts", Children((_name("x"), _name("y")))),))
+    one = _H("Tuple", (("elts", Children((_name("x"),))),))
+    assert _cid(both) != _cid(one)
+
+
+def test_changed_kind_changes_the_cid():
+    a = _H("Tuple", (("elts", Children((_name("x"),))),))
+    b = _H("List", (("elts", Children((_name("x"),))),))
+    assert _cid(a) != _cid(b)
+
+
+def test_present_but_empty_is_not_absent():
+    # MaybeChild(None) is a structural absence WITHIN a present slot. A slot
+    # the backend never emitted is a different shape, and must stay one.
+    empty = _H("Ret", (("value", MaybeChild(None)),))
+    missing = _H("Ret", ())
+    assert _cid(empty) != _cid(missing)
+
+
+def test_repeated_slot_is_not_a_single_slot():
+    repeated = _H("N", (("s", Children((_name("x"),))),))
+    single = _H("N", (("s", Child(_name("x"))),))
+    assert _cid(repeated) != _cid(single)
+
+
+def test_two_different_empties_stay_different():
+    no_children = _H("N", (("s", Children(())),))
+    no_child = _H("N", (("s", MaybeChild(None)),))
+    assert _cid(no_children) != _cid(no_child)
+
+
+def test_a_leaf_carrying_a_cid_is_not_a_child():
+    # The child slot carries a CID STRING. A leaf slot must never be readable
+    # as a child slot carrying the same string -- the wrapper key separates
+    # them, and ``childCidAlgorithm`` names what minted the child's string.
+    child_cid = _cid(_name("x"))
+    leafy = _H("N", (("s", Leaf(child_cid)),))
+    childy = _H("N", (("s", Child(_name("x"))),))
+    assert _cid(leafy) != _cid(childy)
+
+
+def test_operator_leaves_are_authenticated():
+    add = _H("BinOp", (("op", OpLeaf(operator_for("Add"))),))
+    sub = _H("BinOp", (("op", OpLeaf(operator_for("Sub"))),))
+    assert _cid(add) != _cid(sub)
+
+    lt_gt = _H("Cmp", (("ops", OpsLeaf((operator_for("Lt"), operator_for("Gt")))),))
+    gt_lt = _H("Cmp", (("ops", OpsLeaf((operator_for("Gt"), operator_for("Lt")))),))
+    assert _cid(lt_gt) != _cid(gt_lt)
+
+    ops_one = _H("Cmp", (("ops", OpsLeaf((operator_for("Lt"),))),))
+    op_one = _H("Cmp", (("ops", OpLeaf(operator_for("Lt"))),))
+    assert _cid(ops_one) != _cid(op_one)
+
+
+def test_identical_children_share_content_identity_not_occurrence_identity():
+    # BOTH arms are required. Identical structure MUST address identically --
+    # that is what content-addressing means, and it is what makes the Merkle
+    # form linear. It must NOT thereby collapse two occurrences into one: two
+    # identical `o[i]` reads at different sites stay two sites.
+    left = _H("Sub", (("v", Child(_name("o"))), ("k", Child(_name("i")))))
+    right = _H("Sub", (("v", Child(_name("o"))), ("k", Child(_name("i")))))
+    assert left is not right
+    assert _cid(left) == _cid(right)  # content identity: SHARED
+
+    parent = _H("Tuple", (("elts", Children((left, right))),))
+    backend_node_shape_cid_v2(parent)
+
+    # The ref-keyed memo holds TWO rows carrying ONE value: two live refs.
+    assert CC.shape_cid_v2_for(left) is not None
+    assert CC.shape_cid_v2_for(right) is not None
+    assert CC.shape_cid_v2_for(left) == CC.shape_cid_v2_for(right)
+
+    # And the parent carries TWO ordered positions, not a deduped one.
+    pre = _node_shape_v2_preimage(
+        parent,
+        {id(left): CC.shape_cid_v2_for(left), id(right): CC.shape_cid_v2_for(right)},
+    )
+    positions = pre["slots"][0]["value"]["children"]
+    assert len(positions) == 2
+    assert positions[0] == positions[1]
+
+    # Dropping one of the two identical occurrences is a DIFFERENT parent.
+    assert _cid(parent) != _cid(_H("Tuple", (("elts", Children((left,))),)))
+
+
+def test_v2_preimage_is_explicitly_domain_separated():
+    pre = _node_shape_v2_preimage(_name("x"), {})
+    assert pre["domain"] == NODE_SHAPE_V2_DOMAIN
+    assert pre["schema"] == NODE_SHAPE_V2_SCHEMA
+    # The child-CID ALGORITHM is named in every preimage, so a child slot's
+    # string can never be mistaken for a CID minted by some other schema.
+    assert pre["childCidAlgorithm"] == NODE_SHAPE_V2_CHILD_CID_ALGORITHM
+    # No V1 preimage ever carried these keys, so no V1 CID is reinterpretable
+    # as V2: the two live in different identity namespaces.
+    assert set(pre) == {"domain", "schema", "childCidAlgorithm", "kind", "slots"}
+
+
+def test_construction_is_bottom_up_and_never_embeds_a_subtree():
+    # A deep left-nested chain. Recursive subtree embedding cannot even ENCODE
+    # this (RecursionError, and quadratic bytes before that); bottom-up
+    # iteration encodes each node once, at its own arity.
+    node = _name("a")
+    for _ in range(2000):
+        node = _H("BinOp", (("left", Child(node)), ("op", OpLeaf(operator_for("Add")))))
+    cid = backend_node_shape_cid_v2(node)
+    assert cid.startswith("blake3-512:")
+    # Every descendant is memoized -- each encoded exactly once, ever.
+    assert CC.shape_cid_v2_for(node) == cid
+    assert CC.shape_cid_v2_for(node._slots[0][1].handle) is not None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -572,16 +572,89 @@ def node_construction_shape_cid(node: Node) -> str:
     result = cid_of_json(
         {
             "kind": "constructed-node-shape",
-            "schemaVersion": "1",
+            "schemaVersion": "2",
+            "shapeSchema": NODE_SHAPE_V2_SCHEMA,
             "source": node.fragment.seal().to_dict(),
-            "node": _backend_node_preimage(ref),
+            "nodeShape": backend_node_shape_cid_v2(ref),
         }
     )
     remember_shape_cid(ref, result)
     return result
 
 
-def _backend_node_preimage(ref: object) -> dict[str, Any]:
+# ---------------------------------------------------------------------------
+# NodeShapeV2 -- the Merkle shape preimage.
+#
+# V1 embedded each child's FULL subtree preimage inside its parent, so the same
+# descendant content was authenticated once for every ancestor path above it:
+# total encoding work was the sum of all subtree sizes, i.e. quadratic in depth.
+# Measured consequence: 624s cumulative in ``canonical_json_bytes`` over only
+# 1,318 CID calls on pandas ``core/reshape/pivot.py::__internal_pivot_table``.
+#
+# V2 is the content-addressed form the graph always wanted: a node authenticates
+# its own IMMEDIATE structure plus the authenticated IDENTITIES (CIDs) of its
+# children. Each node's preimage is O(its own arity); the whole tree is O(n).
+#
+# Domain separation is explicit and total:
+#   * the child-CID algorithm is NAMED in every preimage
+#     (``childCidAlgorithm``), so a child slot's string can never be mistaken
+#     for an opaque leaf or for a CID minted by some other schema;
+#   * the schema tag ``NodeShapeV2`` and the outer ``schemaVersion: "2"`` put
+#     V2 in a different identity namespace from V1 -- no V1 preimage can ever
+#     encode to a V2 preimage, so no V1 CID is ever reinterpretable as V2.
+#
+# This migration DOES change every shape CID. That is sanctioned and pinned
+# deliberately: shape CIDs are REPRESENTATION identity, never meaning. The
+# constructed meaning (formulas, bindings, effects, gaps, ExitSets, corpus
+# classification) is unchanged, and is what the equivalence proof measures --
+# a fingerprint built from shape CIDs would be circular here.
+# ---------------------------------------------------------------------------
+
+NODE_SHAPE_V2_SCHEMA = "NodeShapeV2"
+NODE_SHAPE_V2_DOMAIN = "sugar/construction/node-shape/v2"
+# The child slot carries a CID, and THIS names the algorithm that minted it:
+# the same NodeShapeV2 preimage under the repository canonical JSON CID.
+NODE_SHAPE_V2_CHILD_CID_ALGORITHM = "sugar/construction/node-shape/v2+cid_of_json"
+
+
+def _child_handles(desc: object) -> list[object]:
+    """Every child handle of ``desc``, in slot order then position order."""
+    from sugar_source_tree.backend import Child, Children, MaybeChild
+
+    handles: list[object] = []
+    for _name, slot in desc.slots:  # type: ignore[attr-defined]
+        if isinstance(slot, Child):
+            handles.append(slot.handle)
+        elif isinstance(slot, MaybeChild):
+            if slot.handle is not None:
+                handles.append(slot.handle)
+        elif isinstance(slot, Children):
+            handles.extend(slot.handles)
+    return handles
+
+
+def _node_shape_v2_preimage(ref: object, child_cid: "dict[int, str]") -> dict[str, Any]:
+    """The V2 preimage of ONE node: its kind, its local authenticated fields,
+    and its ordered slots carrying CHILD CIDS -- never child subtrees.
+
+    Every slot kind keeps its own wrapper key, so the six kinds stay mutually
+    distinguishable and none can collide with another:
+
+      Child(x)          -> {"child": cid}
+      MaybeChild(x)     -> {"maybeChild": cid}
+      MaybeChild(None)  -> {"maybeChild": None}   (present-but-empty)
+      Children([x])     -> {"children": [cid]}    (never a bare child)
+      Children([])      -> {"children": []}       (present-but-empty)
+      Leaf(v)           -> {"leaf": <canonical value>}
+      OpLeaf(op)        -> {"operator": kind}
+      OpsLeaf(ops)      -> {"operators": [kind, ...]}
+
+    An ABSENT slot emits no entry at all, and every entry carries its NAME, so
+    ``MaybeChild(None)`` (an entry whose value is ``{"maybeChild": null}``)
+    can never collide with the absence of that slot. Positions are a JSON
+    ARRAY in the backend's declared order: reordering, duplicating or omitting
+    children changes the encoding, hence the CID.
+    """
     from sugar_source_tree.backend import (
         Child,
         Children,
@@ -591,21 +664,19 @@ def _backend_node_preimage(ref: object) -> dict[str, Any]:
         OpsLeaf,
     )
 
-    desc = ref.describe()
+    desc = ref.describe()  # type: ignore[attr-defined]
     slots = []
     for name, slot in desc.slots:
         if isinstance(slot, Child):
-            value = {"child": _backend_node_preimage(slot.handle)}
+            value = {"child": child_cid[id(slot.handle)]}
         elif isinstance(slot, MaybeChild):
             value = {
                 "maybeChild": (
-                    None if slot.handle is None else _backend_node_preimage(slot.handle)
+                    None if slot.handle is None else child_cid[id(slot.handle)]
                 )
             }
         elif isinstance(slot, Children):
-            value = {
-                "children": [_backend_node_preimage(handle) for handle in slot.handles]
-            }
+            value = {"children": [child_cid[id(h)] for h in slot.handles]}
         elif isinstance(slot, Leaf):
             value = {"leaf": _canonical_constructed_value(slot.value)}
         elif isinstance(slot, OpLeaf):
@@ -613,9 +684,72 @@ def _backend_node_preimage(ref: object) -> dict[str, Any]:
         elif isinstance(slot, OpsLeaf):
             value = {"operators": [operator.kind for operator in slot.ops]}
         else:
+            # NEVER a fallback to subtree embedding: an unknown slot kind is a
+            # gap in the schema, reported loudly, not inlined behind our backs.
             raise TypeError(f"unknown backend slot {type(slot).__name__}")
         slots.append({"name": name, "value": value})
-    return {"kind": desc.kind, "slots": slots}
+    return {
+        "domain": NODE_SHAPE_V2_DOMAIN,
+        "schema": NODE_SHAPE_V2_SCHEMA,
+        "childCidAlgorithm": NODE_SHAPE_V2_CHILD_CID_ALGORITHM,
+        "kind": desc.kind,
+        "slots": slots,
+    }
+
+
+def backend_node_shape_cid_v2(ref: object) -> str:
+    """The NodeShapeV2 CID of ``ref``, built STRICTLY BOTTOM-UP.
+
+    Explicit post-order over an iterative stack -- no recursion, no recursive
+    subtree embedding, and no Python recursion limit on deep trees. Each
+    distinct ref encodes exactly ONE preimage of its own arity, memoized in the
+    static category registry, so a shared child (substitution shares node
+    objects; the constructed graph is a DAG) is encoded once, not once per
+    incoming path.
+
+    Two structurally identical subtrees under two DISTINCT refs get the SAME
+    CID -- that is content identity, and it is the point. They remain distinct
+    OCCURRENCES: the memo is keyed by ref (two live refs, two rows, one value),
+    and the parent carries them at distinct ordered slot positions, so anything
+    keyed by occurrence still sees two.
+    """
+    from .construction_cache import (
+        remember_shape_cid_v2,
+        shape_cid_v2_for,
+    )
+
+    cached = shape_cid_v2_for(ref)
+    if cached is not None:
+        return cached
+
+    child_cid: dict[int, str] = {}
+    # ``child_cid`` is keyed by id(); pin every keyed handle for the duration so
+    # a dead handle's address can never be recycled onto another's row.
+    pinned: list[object] = []
+    # (ref, expanded?) -- expanded means its children are already resolved.
+    stack: list[tuple[object, bool]] = [(ref, False)]
+    while stack:
+        current, expanded = stack.pop()
+        if id(current) in child_cid:
+            continue
+        known = shape_cid_v2_for(current)
+        if known is not None:
+            child_cid[id(current)] = known
+            pinned.append(current)
+            continue
+        if not expanded:
+            stack.append((current, True))
+            for handle in _child_handles(current.describe()):  # type: ignore[attr-defined]
+                if id(handle) not in child_cid:
+                    stack.append((handle, False))
+            continue
+        cid = cid_of_json(_node_shape_v2_preimage(current, child_cid))
+        child_cid[id(current)] = cid
+        pinned.append(current)
+        remember_shape_cid_v2(current, cid)
+    result = child_cid[id(ref)]
+    del pinned
+    return result
 
 
 def _constructed_preimage(value: object) -> dict[str, Any]:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -33,6 +33,35 @@ def remember_shape_cid(ref: object, cid: str) -> None:
     _SHAPE_CIDS[ref] = cid
 
 
+# The NodeShapeV2 (Merkle) shape CID of a ref, WITHOUT the node's source
+# fragment: it is a pure function of the ref's own kind, local fields, and its
+# children's V2 CIDs. This is the registry bottom-up construction reads and
+# fills, so each ref encodes ONE preimage of its own arity, once, ever --
+# the difference between O(sum of subtree sizes) and O(n).
+#
+# SEPARATE from ``_SHAPE_CIDS`` on purpose. That one holds the node-level
+# construction-shape CID, which additionally binds the node's fragment
+# coordinate; the two live in different identity namespaces and must never be
+# read for each other.
+#
+# Content identity WITHOUT occurrence identity: two structurally identical
+# subtrees under two distinct refs get two ROWS carrying the SAME value. They
+# share content identity (that is what content-addressing means) and stay
+# distinct occurrences (two live refs, and distinct ordered slot positions in
+# their parents).
+_SHAPE_CIDS_V2: "weakref.WeakKeyDictionary[object, str]" = weakref.WeakKeyDictionary()
+
+
+def shape_cid_v2_for(ref: object) -> str | None:
+    """The memoized NodeShapeV2 CID for ``ref``, or None if unseen."""
+    return _SHAPE_CIDS_V2.get(ref)
+
+
+def remember_shape_cid_v2(ref: object, cid: str) -> None:
+    """Record ``ref``'s NodeShapeV2 CID in the static category registry."""
+    _SHAPE_CIDS_V2[ref] = cid
+
+
 class ConstructionCache:
     """Shared field rows keyed by backend site + reporter + control context."""
 


### PR DESCRIPTION
`_backend_node_preimage` recursively inlined the entire subtree, so every node's shape CID hashed its whole subtree — total work was the sum of all subtree sizes, **quadratic in depth**. A parent should authenticate its immediate structure and the authenticated **identities** of its children.

## Schema
```
{ "domain": "sugar/construction/node-shape/v2",
  "schema": "NodeShapeV2",
  "childCidAlgorithm": "sugar/construction/node-shape/v2+cid_of_json",
  "kind": <desc.kind>,
  "slots": [ {"name": n, "value": <slot>}, ... ] }
```
`node_construction_shape_cid` binds the source coordinate on top (`schemaVersion "2"`, key `node`→`nodeShape`). The child-CID **algorithm is named inside every preimage**, so a child slot's string cannot be read as a leaf or as a CID from another schema. `domain`/`schema`/`childCidAlgorithm` are keys **no V1 preimage carried** — V1 and V2 cannot collide and no V1 CID is reinterpretable as V2. Reader and writer are the same single function; nothing else referenced `_backend_node_preimage`, so the flip is atomic.

Slot distinguishability, all twin-tested: `{"child":cid}` / `{"maybeChild":cid|null}` / `{"children":[cid…]}` / `{"leaf":…}` / `{"operator":…}` / `{"operators":[…]}`. Absent slot emits no entry; every entry carries its name.

Bottom-up: iterative post-order, **no recursion limit**, and **no fallback to subtree embedding for any slot kind** — an unknown slot kind raises. New static memo `_SHAPE_CIDS_V2`, namespace-separate from `_SHAPE_CIDS`.

## Linearity — the structural acceptance test
| sweep | V1 | V2 |
|---|---|---|
| depth (nested chain, 18→258 nodes) | slope **1.92** bytes / 1.91 visits | **1.00** / **1.00** |
| breadth (flat body, 125→15,365) | 1.00 | 1.00 |

At 514 and 1026 nodes **V1 cannot encode at all** (RecursionError); V2 continues at slope 1.00. Ratio at n=258: 17.4×, growing. The breadth sweep is reported as a non-result — depth is flat there, which is exactly why `pivot_table` specifically hurt.

## CID-independent equivalence — zero differences
413 functions / 426 rows. Fingerprint = terminal classification + constructed-graph digest + exit/ExitSet vocabulary + effect vocabulary + every gap site `(kind,line,col)` + census families, with **all 167,693 CID occurrences masked** by positional placeholder before hashing (sharing *pattern* preserved, never a value). **DIFFS: 0.**

Distinct CID identities in rendered graphs: **V1 11,322 = V2 11,322** — the migration neither merged nor split a single occurrence at corpus scale. Census pins hold: `boolean.py {}`, `categorical.py {'With': 1}`.

## Lying twins — 14, all bite
reordered children · changed slot name · changed leaf value · duplicated child · omitted child · changed kind · changed operator · OpsLeaf order · `MaybeChild(None)` vs absent · `Children([x])` vs `Child(x)` · `Children([])` vs `MaybeChild(None)` · `OpLeaf` vs `OpsLeaf` · a `Leaf` carrying a CID string vs a `Child` carrying it.

**Content identity without occurrence identity**, both arms: two structurally identical distinct subtrees get the **same** CID; the memo holds **two live rows carrying one value**; the parent carries **two ordered positions** with equal CIDs; dropping one of the two **changes the parent CID**.

## Timings — and the honest limit
| function | V1 | V2 | |
|---|---|---|---|
| `pivot.py::__internal_pivot_table` | 1467.3s | **551.9s** | 2.66× |
| `generic.py::value_counts` | 185.3s | 200.5s | **0.92× — 8% slower** |
| `numeric.py::to_numeric` | 63.3s | 57.7s | 1.10× |
| `generic.py::_where` | 45.5s | 29.7s | 1.53× |

Terminal classification and gap families identical in all four. The `value_counts` regression is real: shallow/wide function where V1's quadratic never bit, and V2 pays one hash per node instead of one big hash per root.

**552s is not yet bounded enough for the census loop, and this cut is not why.** Post-V2 profiling localizes the remainder: `cid_of_json` still **2736s cumulative over only 1,482 calls** (~39,100 JSON nodes/call), from `present_construction` → `_constructed_preimage`. There is a **second preimage of the same defect class one layer up** — the constructed semantic-value DAG still walked as a tree. That is a separate ruling and a separate cut.

Gates: new twins **14 passed**; regression **73 passed**; encoder differential + conformance **27 passed**; combined re-run **101 passed**; `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced NodeShapeV2 content identifiers for backend node construction.
  * Node shape identities now capture node kinds, ordered child slots, slot presence, leaf values, and operator data.
  * Added explicit schema and domain separation for NodeShapeV2 identifiers.
  * Preserved shared content identity while maintaining distinct ordered child occurrences.

* **Bug Fixes**
  * Prevented structural differences—such as reordered, duplicated, omitted, or empty children—from producing identical node identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NodeShapeV2 Merkle CID computation that authenticates child CIDs instead of subtrees
> - Introduces `backend_node_shape_cid_v2` in [`binding_state.py`](https://github.com/TSavo/sugar/pull/6253/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40), which builds a bottom-up Merkle CID for each node by hashing only the node's immediate structure and its children's CIDs rather than embedding full subtrees.
> - Adds `_node_shape_v2_preimage` to produce a domain- and schema-tagged JSON structure per node, with per-slot entries typed as `child`, `maybeChild`, `children`, `leaf`, `operator`, or `operators`.
> - Updates `node_construction_shape_cid` to schema version 2, replacing the old subtree-embedded preimage with the new Merkle-form CID under key `nodeShape`.
> - Adds memoization support in [`construction_cache.py`](https://github.com/TSavo/sugar/pull/6253/files#diff-fec1dbfe7718a35848f37642330b8df50429df86eae284a72524c6bf8352972f) via `shape_cid_v2_for` and `remember_shape_cid_v2`.
> - Risk: CID values produced by `node_construction_shape_cid` will differ from v1 and are not backward compatible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4be71e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->