### PR TITLE
fix: CI floors — panic-catch membrane + ExitSet force_floor typed gap

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -27,8 +27,10 @@ from pathlib import Path
 
 
 def census(root: Path) -> int:
+    from sugar_lift_py_tests.audit_only.collect_construction_gaps import (
+        collect_construction_panic,
+    )
     from sugar_lift_py_tests.desugar_axis import DesugarAxis
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
     from sugar_source_tree.tree import SourceFile
@@ -44,16 +46,21 @@ def census(root: Path) -> int:
     for i, f in enumerate(files):
         ft = time.time()
         rel = str(f.relative_to(root))
-        try:
+
+        def _measure_file(
+            _f=f,
+            _rel=rel,
+        ):
+            nonlocal total_fns, clean_fns, clean_files
             reporter = CollectingReporter()
-            sf = SourceFile.from_path(str(f), reporter=reporter)
+            sf = SourceFile.from_path(str(_f), reporter=reporter)
             for fn in sf.functions():
                 total_fns += 1
                 try:
                     span = fn.line_col_span()
-                    where = f"{rel}:{span.start_line}:{span.start_col}"
+                    where = f"{_rel}:{span.start_line}:{span.start_col}"
                 except Exception:  # noqa: BLE001
-                    where = f"{rel}:?"
+                    where = f"{_rel}:?"
                 try:
                     sugar = fn.sugar()  # ONE construction; nested gaps self-report
                     clean_fns += 1
@@ -70,27 +77,36 @@ def census(root: Path) -> int:
                     families[node.kind] += 1
             if not reporter.gaps:
                 clean_files += 1
-            print(
-                f"[{i + 1}/{len(files)}] {time.time() - ft:5.1f}s "
-                f"gaps={len(reporter.gaps):5d} "
-                f"desugar={sum(desugar.families.values()):5d} {rel}",
-                flush=True,
-            )
-        except ConstructionPanic as panic:
-            # A BaseException: `except Exception` below cannot see it, and an
-            # uncaught one aborts the whole run. Named arm, red row, keep going.
-            crashes[f"ConstructionPanic:{panic.info.owner}"] += 1
-            print(
-                f"[{i + 1}/{len(files)}]  CONSTRUCTION PANIC "
-                f"{panic.info.owner} {rel}",
-                flush=True,
-            )
+            return len(reporter.gaps)
+
+        # Sole ConstructionPanic membrane: audit_only.collect_construction_panic.
+        # No local ``except ConstructionPanic`` soft continue (panic-catch law).
+        try:
+            _, panic_row = collect_construction_panic(rel, _measure_file)
         except Exception as e:  # a crash is a DEFECT row, never silence
             crashes[type(e).__name__] += 1
             print(
                 f"[{i + 1}/{len(files)}]  CRASH {type(e).__name__} {rel}",
                 flush=True,
             )
+            continue
+        if panic_row is not None:
+            owner = (
+                (panic_row.info or {}).get("owner")
+                if isinstance(panic_row.info, dict)
+                else "ConstructionPanic"
+            )
+            crashes[f"ConstructionPanic:{owner}"] += 1
+            print(
+                f"[{i + 1}/{len(files)}]  CONSTRUCTION PANIC " f"{owner} {rel}",
+                flush=True,
+            )
+            continue
+        print(
+            f"[{i + 1}/{len(files)}] {time.time() - ft:5.1f}s "
+            f"desugar={sum(desugar.families.values()):5d} {rel}",
+            flush=True,
+        )
 
     print(
         f"\n=== census: {len(files)} files ({clean_files} clean), "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -254,31 +254,40 @@ class DesugarAxis:
         the true grain of a refusal (one refusal per reduction), and appears in
         defect rows. It is never used as an effect-occurrence key.
         """
-        from sugar_lift_py_tests.gap.panic import ConstructionPanic
+        from sugar_lift_py_tests.audit_only.collect_construction_gaps import (
+            collect_construction_panic,
+        )
         from sugar_source_tree.panic import SugarNotWritten
 
-        try:
-            outcome = sugar.desugar(None)  # type: ignore[attr-defined]
-        except SugarNotWritten as gap:
-            # A refusal aborts the whole reduction: exactly one per desugar
-            # call, so the call coordinate IS the occurrence. (Instrument gap:
-            # SourceTreePanic carries owner/observed/requested/fix and no
-            # fragment, so a refusal cannot say WHERE inside the function.)
-            owner = _refusal_owner(gap)
-            self._tally(owner, f"desugar-call:{where}")
-            return
-        except ConstructionPanic as panic:
-            # BaseException by design. Caught BY NAME so it neither escapes the
-            # census nor lands in semantic R. Red, separately counted.
+        # ConstructionPanic is a BaseException. Hold it only through the sole
+        # sanctioned audit membrane (collect_construction_panic) — never with a
+        # local ``except ConstructionPanic`` soft continue (panic-catch law).
+        def _desugar():
+            try:
+                return sugar.desugar(None)  # type: ignore[attr-defined]
+            except SugarNotWritten as gap:
+                return ("refusal", gap)
+            except Exception as exc:  # noqa: BLE001 -- ordinary defect, not R
+                return ("defect", exc)
+
+        outcome, panic_row = collect_construction_panic(where, _desugar)
+        if panic_row is not None:
             self.construction_panics.append(
                 {
                     "where": where,
-                    "owner": getattr(panic.info, "owner", None),
-                    "message": panic.info.message,
+                    "owner": (panic_row.info or {}).get("owner")
+                    if isinstance(panic_row.info, dict)
+                    else getattr(getattr(panic_row, "info", None), "owner", None),
+                    "message": panic_row.message,
                 }
             )
             return
-        except Exception as exc:  # noqa: BLE001 -- an ordinary defect, not R
+        if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == "refusal":
+            owner = _refusal_owner(outcome[1])
+            self._tally(owner, f"desugar-call:{where}")
+            return
+        if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == "defect":
+            exc = outcome[1]
             self._defect("desugar-exception", where, f"{type(exc).__name__}: {exc}")
             return
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py
@@ -8,8 +8,39 @@ from .outcome import Outcome
 
 
 def complete_value(outcome: Outcome, *, owner: str) -> FloorValue:
+    """Project a single completed floor value, or refuse loudly.
+
+    After store ExitSet composition (#6246), a body may reduce to multi-arm
+    ``ExitSet`` rather than ``Complete``. Reading ``.value`` on that is a bare
+    ``AttributeError`` — permanent-floor red. Refuse as a typed construction
+    gap so kit-domain multi-arm outcomes stay on the typed-gap axis, never bare.
+    """
     if isinstance(outcome, Incomplete):
         raise RuntimeError(
             f"{owner} cannot read completed value from incomplete effect: {outcome.reason}"
         )
-    return outcome.value
+    if isinstance(outcome, Complete):
+        return outcome.value
+    from .exit_set import ExitSet
+
+    if isinstance(outcome, ExitSet):
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic
+
+        construction_panic(
+            ConstructionGap(
+                owner=owner,
+                blame=owner,
+                observed=f"ExitSet with {len(outcome.exits)} arms",
+                requested="one Complete floor value",
+                fix=(
+                    "multi-arm store/control outcomes cannot force_floor to a single "
+                    "value; leave the projection absent or reduce under ExitSet routing"
+                ),
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.PROJECTION,
+            )
+        )
+    raise RuntimeError(
+        f"{owner} cannot read completed value from {type(outcome).__name__}"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
@@ -303,6 +303,49 @@ def test_store_outcome_guards_are_exactly_complementary(tmp_path: Path) -> None:
     )
 
 
+def test_store_pairing_enforcement_one_occurrence_complementary_total(
+    tmp_path: Path,
+) -> None:
+    """Pairing law for one store occurrence (post-#6246 foundation).
+
+    Success and halt arms of ONE attribute store must:
+      1. cite the same store-occurrence coordinate;
+      2. carry complementary guards (``g`` and ``not g``);
+      3. cover the runtime outcome without overlap (conjunction is false)
+         and without omission (exactly two faces for one store in a
+         single-store body: one Halted + one Completed).
+
+    This is the invariant With and Try will reuse. Keep it named and loud.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import _and_guards, false_guard
+
+    exits = _exits(tmp_path, ONE_STORE, "target")
+    halted, completed = _arms(exits)
+    assert len(halted) == 1 and len(completed) == 1, (
+        "one store body must emit exactly one halt face and one success face, "
+        f"got halted={len(halted)} completed={len(completed)}"
+    )
+    (halt,) = halted
+    (success,) = completed
+
+    # 1 + 2: same occurrence, complementary polarities
+    halt_coords = _store_coordinates(halt.guard)
+    success_coords = _store_coordinates(success.guard)
+    assert len(halt_coords) == 1 and len(success_coords) == 1
+    assert halt_coords[0] == success_coords[0], (
+        "halt and success must share one store-occurrence coordinate"
+    )
+    assert _polarity(halt.guard, "x") is False
+    assert _polarity(success.guard, "x") is True
+
+    # 3: no overlap
+    assert _and_guards(halt.guard, success.guard) == false_guard()
+
+    # 3: no omission — every ExitSet face of this body is one of those two arms
+    assert len(exits.exits) == 2
+    assert {type(e).__name__ for e in exits.exits} == {"Halted", "Completed"}
+
+
 def test_store_outcome_guards_are_exactly_complementary_discrimination(tmp_path: Path) -> None:
     """The bite: two DIFFERENT stores' guards are not contradictory -- so the
     contradiction above comes from complementarity, not from everything being


### PR DESCRIPTION
## Triage (before fix)

Four red CI jobs on main after store ExitSet (#6246) + desugar axis (#6244):

| Job | Root cause |
|-----|------------|
| **Bare exception zero tolerance** | (1) panic-catch R=2 blocks first; (2) `ExitSet.value` AttributeError on `import_binding.py` |
| **Timeout zero tolerance** | Same panic-catch R=2 (shared self-check step — not a timeout regression) |
| **Python sole-construction floors** | Same panic-catch R=2 first; then bare ExitSet residual |
| **CI umbrella** | Downstream of the above |

**Discrimination caution:** bare-exception and timeout were **not** reporting that their bad twins stopped being caught. Both failed on `construction_panic_catch_law` before their own floors ran.

Panic-catch loci (from #6244 desugar axis):
- `census.py:79` — soft `except ConstructionPanic` continue
- `desugar_axis.py:270` — same

## Fix

1. **Panic-catch law:** route census + desugar_axis through sole sanctioned membrane `audit_only.collect_construction_panic`. No local soft continue.
2. **Bare ExitSet residual:** `complete_value` refuses multi-arm `ExitSet` as `ConstructionPanic` (floor projection gap) instead of bare `AttributeError`. Production lift → `typed-gap`.
3. **Store pairing-enforcement twin:** one occurrence, complementary guards, exact two-face cover for a single-store body (foundation for With/Try ExitSet reuse).

## Validation

```text
construction_panic_catch_law → GREEN R=0
production_lift(import_binding.py) → typed-gap (not bare AttributeError)
pytest test_store_pairing_enforcement… → pass
```

## Not in this PR

- opaque-call-target reduction (With resolution next arm)
- EffectBoundary from `_pytest.raises` (assertion membrane)
- With routing over ExitSet (unblocked; coordinate after this is green)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI floors by routing `ConstructionPanic` through an audit membrane and adding typed gap for `ExitSet` floor projection
> - `complete_value` now raises a `ConstructionPanic` with a typed `ConstructionGap` (FLOOR/PROJECTION) when called on a multi-arm `ExitSet` outcome, replacing a silent `AttributeError`.
> - `DesugarAxis.measure` and `census.census` replace local `except ConstructionPanic` blocks with `collect_construction_panic`, recording panics in structured audit rows instead of letting them escape or swallow silently.
> - Non-panic exceptions in `census.census` are now caught generically and reported as `CRASH {ExceptionType}` lines; the per-file progress line no longer includes a `gaps=` field.
> - A new test in [test_store_outcome_composition.py](https://github.com/TSavo/sugar/pull/6254/files#diff-3db92ac0d73a2872c454af2182326102610cb610226666f6f46fcd9d55c34501) asserts pairing invariants for single-store occurrences (complementary guards, no overlap, exactly one Halted and one Completed arm).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0382c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->