### PR TITLE
fold: carry call edges on their own top-level callEdges channel

### DIFF
--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -35,6 +35,7 @@
 // as `EdgeTarget::Unbound`/`None` stubs; no RPC is made for them, since
 // binding them is a `solve()`-time concern (SEAM 5), out of scope here.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use libsugar::core::{SourceMemento, SrcSpan};
@@ -519,6 +520,110 @@ fn looks_like_ir_contract_row(value: &Value) -> bool {
         || obj.contains_key("pre")
         || obj.contains_key("formals")
         || obj.contains_key("bridgeSourceSymbol")
+}
+
+/// True when a wire row is a harvested call edge. Call edges are NOT IR
+/// contract rows -- they carry the caller side of a bridge (`targetSymbol`,
+/// `targetContract`/`targetContractCid`) that mint joins to a contract. They
+/// pass none of `looks_like_ir_contract_row`'s predicates, so the fold has to
+/// collect them on their own channel or they are dropped silently.
+fn looks_like_call_edge_row(value: &Value) -> bool {
+    value
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind == "call-edge")
+}
+
+/// First-writer-wins accumulation of call-edge rows in enumeration order,
+/// with the counters that tell the two zero-states apart.
+///
+/// Duplicates are real: the same edge reaches the fold both inside a
+/// parameter-contract link unit and as a universe-level audit row.
+///
+/// The counters exist because `callEdges: []` has two very different causes
+/// and the array alone cannot distinguish them: no rows arrived at the fold
+/// at all (a transport gap -- the kit is not emitting, or is not emitting
+/// where the fold looks), versus rows arrived but carry no `targetContract`
+/// (the kit's join declined, which for an ambiguous symbol is the correct
+/// answer and not a defect). `sourceLedger.call_edges` collapses both to a
+/// number.
+#[derive(Default)]
+struct CallEdgeHarvest {
+    seen: BTreeSet<String>,
+    edges: Vec<Value>,
+    /// Rows that reached the harvest, before de-duplication.
+    arrived: usize,
+    /// Distinct edges retained that carry no resolved `targetContract`.
+    unresolved_target: usize,
+}
+
+impl CallEdgeHarvest {
+    fn push(&mut self, edge: &Value) {
+        self.arrived += 1;
+        if self.seen.insert(canonical_row_key(edge)) {
+            if !edge_has_resolved_target(edge) {
+                self.unresolved_target += 1;
+            }
+            self.edges.push(edge.clone());
+        }
+    }
+
+    /// The single routing decision for a wire audit row: contract-shaped rows
+    /// go to `ir`, call edges go to the `callEdges` channel, and a call edge
+    /// never goes to both. Mint reads `callEdges` as a top-level field and
+    /// does not scan `ir` for edges, so a `kind: "call-edge"` row left in
+    /// `ir` is both a dropped edge and a non-contract row published into the
+    /// IR document (see issue #6251).
+    fn route_audit(&mut self, ir: &mut Vec<Value>, audit: &Value) {
+        if looks_like_ir_contract_row(audit) {
+            ir.push(audit.clone());
+        } else if looks_like_call_edge_row(audit) {
+            self.push(audit);
+        }
+    }
+
+    fn walk_counters(&self) -> Value {
+        json!({
+            "arrived": self.arrived,
+            "retained": self.edges.len(),
+            "unresolvedTarget": self.unresolved_target,
+        })
+    }
+}
+
+/// True when the kit's join resolved this edge's target. The kit resolves
+/// `targetContract` only when the symbol is unambiguous and deliberately
+/// leaves it absent otherwise (`verify_rpc.py`, `len(candidates) == 1`), so
+/// absent is a legitimate outcome and must be counted, not repaired here.
+fn edge_has_resolved_target(edge: &Value) -> bool {
+    ["targetContract", "targetContractCid"]
+        .iter()
+        .any(|key| edge.get(*key).and_then(Value::as_str).is_some_and(|value| !value.is_empty()))
+}
+
+/// Stable identity for de-duplication. This crate builds `serde_json` with
+/// `preserve_order`, so `Value::to_string` is insertion-order dependent and
+/// two producers emitting the same edge with different key order would not
+/// dedupe. Sort keys recursively first. Deliberately NOT `jcs_cid_of_json`:
+/// that panics on non-integer numbers, and a dedupe key must not be able to
+/// abort the fold over a value it was only asked to compare.
+fn canonical_row_key(value: &Value) -> String {
+    fn sorted(value: &Value) -> Value {
+        match value {
+            Value::Object(map) => {
+                let mut keys: Vec<&String> = map.keys().collect();
+                keys.sort();
+                let mut out = Map::new();
+                for key in keys {
+                    out.insert(key.clone(), sorted(&map[key]));
+                }
+                Value::Object(out)
+            }
+            Value::Array(items) => Value::Array(items.iter().map(sorted).collect()),
+            other => other.clone(),
+        }
+    }
+    sorted(value).to_string()
 }
 
 /// Decode first-class bridge identity from a call_sites/assertions wire audit.
@@ -1326,6 +1431,11 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
     let mut ir = Vec::new();
     let mut source_mementos = Vec::new();
     let mut diagnostics = Vec::new();
+    // Call edges travel their own channel: mint reads `callEdges` off this
+    // response (`cmd_mint.rs` `response_has_call_edges` / the bridge merge)
+    // and synthesizes bridges from it. Absent is NOT the same as empty --
+    // absent means mint synthesizes no bridge and the run still completes.
+    let mut call_edges = CallEdgeHarvest::default();
 
     // Phase 2/3: over the COMPLETELY enumerated project, discharge every enrolled
     // parameter-contract link unit (fold), then RESUME each retained universe with
@@ -1334,6 +1444,20 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
     let mut resolved_mementos: Vec<Value> = Vec::new();
     let link_unit_rows =
         preconstruction_rows_rpc(&conn, Level::ParameterContractLinkUnits)?;
+    for row in &link_unit_rows {
+        // The caller side of a parameter-contract link unit carries the very
+        // edges mint needs; they are on the raw wire row, not on the typed
+        // unit's discharge result.
+        if let Some(edges) = row
+            .get("callEdges")
+            .or_else(|| row.get("call_edges"))
+            .and_then(Value::as_array)
+        {
+            for edge in edges {
+                call_edges.push(edge);
+            }
+        }
+    }
     if !link_unit_rows.is_empty() {
         let units: Vec<sugar_linker::caller_parameter::ParameterContractLinkUnitV1> =
             link_unit_rows
@@ -1370,9 +1494,7 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
             let nodes = resume_rows_rpc(&conn, &cid_value, &set_value)?;
             for node in nodes {
                 if let Some(audit) = node.get("audit") {
-                    if looks_like_ir_contract_row(audit) {
-                        ir.push(audit.clone());
-                    }
+                    call_edges.route_audit(&mut ir, audit);
                 }
             }
             resolved_mementos
@@ -1405,20 +1527,23 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
         }
         for node in nodes {
             if let Some(audit) = node.audit {
-                if looks_like_ir_contract_row(&audit) {
-                    ir.push(audit);
-                }
+                call_edges.route_audit(&mut ir, &audit);
             }
         }
     }
+    let call_edge_walk = call_edges.walk_counters();
+    let call_edge_count = call_edges.edges.len();
     Ok(json!({
         "kind": "ir-document",
         "ir": ir,
+        "callEdges": call_edges.edges,
         "sourceMementos": source_mementos,
         "diagnostics": diagnostics,
+        "callEdgeWalk": call_edge_walk,
         "sourceLedger": {
             "source_files": source_mementos.len(),
             "contracts": ir.len(),
+            "call_edges": call_edge_count,
         },
     }))
 }
@@ -2615,4 +2740,118 @@ mod tests {
             EnumerateError::RpcError { plugin, .. } if plugin == "fixture-kit"
         ));
     }
+
+    // ---- call-edge channel (PR 1) ----------------------------------------
+    //
+    // These drive `CallEdgeHarvest::route_audit`, the one routing decision
+    // `fold_enumerate_source_tree` makes per wire audit row, over fixture
+    // rows. They are deliberately NOT a live kit run: the enumerate path may
+    // carry no edges until the Python source surface is ported (PR 2), so a
+    // guard written against a real run would be green-because-empty. A
+    // fixture guard fails today if the channel regresses, which is the point.
+
+    fn contract_row(name: &str) -> Value {
+        json!({
+            "kind": "contract",
+            "name": name,
+            "formals": [],
+            "post": [],
+        })
+    }
+
+    fn call_edge_row(source: &str, symbol: &str, line: usize) -> Value {
+        json!({
+            "kind": "call-edge",
+            "sourceContract": source,
+            "targetSymbol": symbol,
+            "targetContract": symbol,
+            "callSiteLocus": {"file": "consumer.py", "line": line, "column": 4},
+        })
+    }
+
+    fn route_all(rows: &[Value]) -> (Vec<Value>, CallEdgeHarvest) {
+        let mut ir = Vec::new();
+        let mut harvest = CallEdgeHarvest::default();
+        for row in rows {
+            harvest.route_audit(&mut ir, row);
+        }
+        (ir, harvest)
+    }
+
+    #[test]
+    fn call_edge_rows_never_land_in_ir() {
+        let (ir, harvest) = route_all(&[
+            contract_row("double"),
+            call_edge_row("main", "double", 7),
+        ]);
+
+        assert!(
+            !ir.iter().any(|row| row.get("kind") == Some(&json!("call-edge"))),
+            "ir must stay contract-shaped: mint copies every ir row into the \
+             published document without a shape filter (issue #6251), and it \
+             reads edges off the top-level callEdges field, never out of ir"
+        );
+        assert_eq!(ir.len(), 1, "the contract row is still collected");
+        assert_eq!(harvest.edges.len(), 1, "the edge went to its own channel");
+    }
+
+    #[test]
+    fn call_edges_channel_is_non_empty_for_an_edge_bearing_fixture() {
+        let (_ir, harvest) = route_all(&[call_edge_row("main", "double", 7)]);
+
+        assert!(
+            !harvest.edges.is_empty(),
+            "the enumerate fold must emit callEdges non-empty when edge rows \
+             reach it; absent or empty means mint synthesizes no bridge and \
+             the run still completes green"
+        );
+        assert_eq!(harvest.edges[0]["targetSymbol"], json!("double"));
+    }
+
+    #[test]
+    fn duplicate_edges_dedupe_across_key_order() {
+        let edge = call_edge_row("main", "double", 7);
+        let reordered = json!({
+            "callSiteLocus": {"line": 7, "column": 4, "file": "consumer.py"},
+            "targetContract": "double",
+            "targetSymbol": "double",
+            "sourceContract": "main",
+            "kind": "call-edge",
+        });
+        let (_ir, harvest) = route_all(&[edge, reordered]);
+
+        assert_eq!(
+            harvest.edges.len(),
+            1,
+            "the same edge arrives both inside a link unit and as a \
+             universe-level audit; serde_json preserve_order makes raw \
+             to_string insertion-order dependent, so the key must sort first"
+        );
+        assert_eq!(harvest.arrived, 2, "both arrivals are still counted");
+    }
+
+    #[test]
+    fn walk_counters_separate_no_rows_from_unresolved_targets() {
+        // Bumble's distinction: `callEdges: []` cannot tell a transport gap
+        // (nothing arrived) from a kit that declined to resolve an ambiguous
+        // symbol. The kit sets targetContract only when len(candidates) == 1,
+        // so an absent target is a correct answer, not a defect.
+        let (_ir, nothing) = route_all(&[contract_row("double")]);
+        assert_eq!(
+            nothing.walk_counters(),
+            json!({"arrived": 0, "retained": 0, "unresolvedTarget": 0}),
+            "no edge rows reached the fold at all"
+        );
+
+        let mut ambiguous = call_edge_row("main", "double", 7);
+        ambiguous.as_object_mut().unwrap().remove("targetContract");
+        let (_ir, declined) = route_all(&[ambiguous]);
+        assert_eq!(
+            declined.walk_counters(),
+            json!({"arrived": 1, "retained": 1, "unresolvedTarget": 1}),
+            "a row arrived carrying no targetContract -- a different state \
+             from nothing arriving, and sourceLedger.call_edges collapses both"
+        );
+    }
+
 }


### PR DESCRIPTION
## What

`fold_enumerate_source_tree` collected only contract-shaped rows. `kind: "call-edge"` rows the kit already emits were dropped on the floor, so the enumerate response carried no `callEdges` field at all.

Mint reads it as a **top-level field** and never scans `ir` for edges:

```rust
// cmd_mint.rs:265-271
fn response_has_call_edges(response: &Value) -> bool {
    response.get("callEdges").or_else(|| response.get("call_edges"))
        .and_then(Value::as_array).is_some_and(|edges| !edges.is_empty())
}
```

The merge at `cmd_mint.rs:561-570` feeds `bridge_ir_from_call_edge` (`:614-620`) from that vector only. Absent field → no bridges synthesized → the bodyguard example completes green while no longer proving the thing it exists to prove.

## What this is not

**Transport only. There is no join here, and that is deliberate.** The kit already produces *and* joins these edges: `leaf_assertions.py:137-162` builds the rows, `verify_rpc.py:245-258` resolves `targetSymbol` → `targetContract`, `verify_rpc.py:275-286` publishes them on the whole-tree `lift` response. The enumerate fold simply had no channel to carry them across.

An earlier Rust-side design walked `source_files` → `functions` → `call_sites` and re-did the join. It diverged: the kit sets `targetContract` only when `len(candidates) == 1` and deliberately leaves it absent for an ambiguous symbol, while a Rust `or_insert_with` index states the first walked row as fact — a wrong answer where the system correctly declines to answer, behind a field name that reads as correct. **The reason PR 1 does not join is that the kit already joins, and joining twice diverges.** Credit to Bumble for finding that; full trace in the thread this PR came from.

## Shape

- `CallEdgeHarvest::route_audit` is the single routing decision per wire audit row: contract-shaped → `ir`, `kind: "call-edge"` → `callEdges`, never both.
- Edges are harvested from parameter-contract link-unit wire rows and from universe-level audit rows.
- Dedupe on a **recursively key-sorted** canonical form. This crate builds `serde_json` with `preserve_order`, so a raw `Value::to_string` key is insertion-order dependent and would miss a duplicate emitted with different key order. Deliberately not `jcs_cid_of_json` — that panics on non-integer numbers, and a dedupe key must not be able to abort the fold over a value it was only asked to compare.
- `callEdgeWalk` = `{arrived, retained, unresolvedTarget}`. `arrived: 0` is a transport gap; `arrived: n, unresolvedTarget: n` is the kit declining to resolve ambiguous symbols, which is **correct behaviour, not a defect**. `sourceLedger.call_edges` collapses both to one number, which is why the split exists.

## The channel may be empty until PR 2

The Python source surface (`sugar_lift_python_source.verify_rpc`) still emits edges on the whole-tree `lift` door rather than per-file through enumerate. Until that port lands, this channel can be correct and carry nothing in production. That is expected.

Which is why the guards are **fixture-based**, not live-kit-based — a guard written against a real run today would be green-because-empty and would not fail if the channel regressed:

- `call_edge_rows_never_land_in_ir` — proves the routing rather than performing it. Mint copies every `ir` row into the published document with no shape filter (#6251), so a non-contract row in `ir` is both a dropped edge and a mis-shaped published row.
- `call_edges_channel_is_non_empty_for_an_edge_bearing_fixture` — a guard that fails without this change, since the field did not exist.
- `duplicate_edges_dedupe_across_key_order` — pins the `preserve_order` hazard.
- `walk_counters_separate_no_rows_from_unresolved_targets` — pins the two zero-states apart.

## Test run

`cargo test -p sugar-compiler --lib` at `060bc57`: **61 passed, 1 failed.**

The single failure is `tree::tests::recovered_audit_leaf_golden_fold_attaches_demanded_body` — **pre-existing on `e62bebe` and tracked as #6250**, independently reproduced by two agents in two worktrees with a stashed baseline. It exercises `merge_recovered_audit_leaf` / `ConstructionPanic` row validation, which this diff does not touch.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a dedicated `callEdges` top-level channel to `fold_enumerate_source_tree`
> - Introduces `CallEdgeHarvest` in [tree.rs](https://github.com/TSavo/sugar/pull/6255/files#diff-1e76daa010a218df51ed5a9f321167e9101bfbc1ef2983cc15a1da0d4fe553eb) to accumulate, de-duplicate, and count call-edge rows separately from IR contract rows.
> - Replaces inline `if looks_like_ir_contract_row` checks with `route_audit`, which sends contract-shaped rows to `ir` and call-edge rows to the harvest — no row goes to both.
> - `fold_enumerate_source_tree` now returns a top-level `callEdges` array (de-duplicated), a `callEdgeWalk` object with `{arrived, retained, unresolvedTarget}` counters, and a `sourceLedger.call_edges` count.
> - De-duplication uses a canonical key from recursively key-sorted JSON, so edges with different insertion orders are treated as identical.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 060bc57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->