### PR TITLE
Multi-manager With nests into Python's own spelling; MultipleContextManagerItems shell deleted

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4419,6 +4419,29 @@ class With(Statement):
             raise panic
         return resolution
 
+    def _nest_items(self) -> "With":
+        """``with A, B: body`` IS ``with A: with B: body`` — Python's own law.
+
+        Multi-manager composition is NOT a second control model. It is this
+        same node, once per manager, so every routing law is inherited rather
+        than reimplemented:
+
+        - enter order is left-to-right (A is the outer node);
+        - exit order is right-to-left (B is inner, its ``__exit__`` runs first);
+        - **failure entering B still exits A**, because B's entire With — its
+          enter-halt exit included — is the *body* of A, and the per-edge
+          contract application runs over EVERY outgoing body edge.
+
+        The rewrite is idempotent on a single-item With, and recursive: a
+        three-item With nests one manager per level as its children construct.
+        """
+        if len(self.items) <= 1:
+            return self
+        from .shadow import rewrite
+
+        inner = rewrite(self, items=tuple(self.items[1:]), body=tuple(self.body))
+        return rewrite(self, items=(self.items[0],), body=(inner,))
+
     def _construct_sugar(self):
         """Build only from the pre-resolved authenticated CM contract ref.
 
@@ -4427,16 +4450,7 @@ class With(Statement):
         resource arm admits one synchronous manager and an optional simple-name
         binding to its real enter-result projection."""
         if len(self.items) != 1:
-            from .panic import MultipleContextManagerItems
-
-            panic = MultipleContextManagerItems(
-                owner="With._construct_sugar",
-                observed=f"synchronous With contains {len(self.items)} manager items",
-                requested="exactly one pre-resolved synchronous manager item",
-                fix="keep multi-item context-manager composition loud",
-            )
-            self.reporter.report_gap(self, panic)
-            raise panic
+            return self._nest_items()._construct_sugar()
         item = self.items[0]
         as_name = None
         if item.optional_vars is not None:
@@ -4653,6 +4667,12 @@ class With(Statement):
             ENTER_RESULT,
         )
 
+        if len(self.items) > 1:
+            # Nest FIRST, then substitute: an earlier manager's as-name must be
+            # in scope for a later manager's expression, exactly as it is in the
+            # nested spelling this rewrite produces.
+            return self._nest_items().substitute(scope)
+
         changed = {}
         new_items, d = self._substitute_field(self.items, scope)
         if d:
@@ -4694,7 +4714,7 @@ class With(Statement):
         del scope
         if self.unit.construction_context is not None:
             if len(self.items) != 1:
-                return None
+                return self._nest_items().substitution_binding(None)
             item = self.items[0]
             if item.optional_vars is None or item.optional_vars.kind != "Name":
                 return None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -141,7 +141,6 @@ class WithConstructionGapKind(str, Enum):
     NO_DERIVED_CONTRACT = "no-derived-contract"
     STALE_DERIVED_CONTRACT = "stale-derived-contract"
     UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS = "unsupported-context-manager-semantics"
-    MULTIPLE_CONTEXT_MANAGER_ITEMS = "multiple-context-manager-items"
     UNSUPPORTED_WITH_BINDING_TARGET = "unsupported-with-binding-target"
     ASYNC_CONTEXT_MANAGER_UNSUPPORTED = "async-context-manager-unsupported"
 
@@ -191,16 +190,6 @@ class UnsupportedContextManagerSemantics(WithConstructionGap):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             gap_kind=WithConstructionGapKind.UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS,
-            **kwargs,
-        )
-
-
-class MultipleContextManagerItems(WithConstructionGap):
-    _LABEL = "MULTIPLE CONTEXT MANAGER ITEMS"
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(
-            gap_kind=WithConstructionGapKind.MULTIPLE_CONTEXT_MANAGER_ITEMS,
             **kwargs,
         )
 

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -384,7 +384,14 @@ def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
         next(source.functions()).sugar()
 
 
-def test_multiple_items_and_non_name_binding_stay_typed_loud(tmp_path):
+def test_multiple_items_nest_and_non_name_binding_stays_typed_loud(tmp_path):
+    """Multi-item With is no longer a gap: it nests into single-item Withs.
+
+    ``MultipleContextManagerItems`` was the shell that watched this; it is
+    deleted, because the illegal shape (a multi-manager With reaching the
+    resource router) is now unconstructable — construction rewrites it into
+    Python's own nested spelling first. Non-Name binding targets stay loud.
+    """
     from sugar_lift_python_source.source_oracle import path_source
 
     multiple = tmp_path / "multiple.py"
@@ -404,9 +411,22 @@ def test_multiple_items_and_non_name_binding_stay_typed_loud(tmp_path):
         ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
     )
     source = SourceFile(path_source(str(multiple)), construction_context=context)
-    with pytest.raises(SugarNotWritten) as caught:
-        next(source.functions()).sugar()
-    assert type(caught.value).__name__ == "MultipleContextManagerItems"
+    nested = next(source.functions()).sugar()
+    chain = []
+
+    def _walk(node):
+        if isinstance(node, WithResourceSugar):
+            chain.append(node)
+            for child in node.body:
+                _walk(child)
+            return
+        for field in ("body", "statements", "entries"):
+            for child in getattr(node, field, ()) or ():
+                _walk(child)
+
+    _walk(nested)
+    assert len(chain) == 2
+    assert chain[1] in chain[0].body
 
     target = tmp_path / "target.py"
     target.write_text(

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -1,0 +1,400 @@
+"""Multi-manager resource ``with``: Python's own nesting, one control model.
+
+    with A() as a, B() as b:
+        body
+
+IS
+
+    with A() as a:
+        with B() as b:
+            body
+
+so multi-manager routing is not a second sequencing mechanism. Construction
+rewrites the multi-item ``With`` into single-item ``With`` nodes and the SAME
+``WithResourceSugar`` / ``ExitSet.and_exit`` algebra carries every law:
+
+- enter order is left-to-right (A is the outer node, entered first);
+- exit order is right-to-left (B is inner, so its ``__exit__`` runs first);
+- **failure entering B still exits A**, because B's whole With — including its
+  enter-halt exit — is the *body* of A, and ``and_exit`` runs A's ``__exit__``
+  over EVERY outgoing body edge, never only the completed one;
+- a manager whose disposition is not authenticated stays typed-loud: routing
+  admits nothing.
+
+Every law twin here is paired 1:1 with a discrimination arm that perturbs the
+expectation and asserts the perturbation fails.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppresses,
+    NeverSuppressesDispositionV1,
+    ProtocolResourceSemanticsV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ImportSignatureV2,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SourceTreePanic
+from sugar_source_tree.tree import SourceFile
+
+
+# ---------------------------------------------------------------- tree fixture
+
+
+def _cid(char: str) -> str:
+    return "blake3-512:" + char * 128
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _resolved(use_site) -> ContextManagerContractRefV1:
+    """A total Value / NeverSuppresses authenticated protocol-resource member."""
+    return ContextManagerContractRefV1(
+        resolution_cid=_cid("r"),
+        demand_cid=_cid("d"),
+        use_site=use_site,
+        use_site_cid=_hash_json(use_site.wire()),
+        authenticated_import_use_cid=_cid("u"),
+        import_binding_cid=_cid("i"),
+        construction_context_generation_cid=_cid("g"),
+        contract_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        provenance_cid=_cid("v"),
+        distribution_artifact_cid=_cid("a"),
+        dependency_artifact_graph_cid=_cid("b"),
+        module_source_cid=_cid("s"),
+        resolved_definition_cid=_cid("f"),
+        manager_construction_cid=_cid("n"),
+        enter_testimony_cid=_cid("1"),
+        exit_testimony_cid=_cid("2"),
+        import_signature=ImportSignatureV2(()),
+        semantics=ProtocolResourceSemanticsV1(
+            enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+            exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+        ),
+    )
+
+
+def _function_sugar(tmp_path, src: str, *, resolve_items=None, name="f"):
+    """Construct ``name``'s sugar with every With manager authenticated.
+
+    ``resolve_items`` selects which manager item indices (per With node, in
+    source order) get an authenticated row; the rest are left unresolved so the
+    typed-loud face can be exercised.
+    """
+    path = tmp_path / "case.py"
+    path.write_text(src, encoding="utf-8")
+    identity = path_source(str(path))
+    probe = SourceFile(identity)
+    rows = {}
+    for node in probe.nodes():
+        if node.kind != "With":
+            continue
+        for index, item in enumerate(node.items):
+            if resolve_items is not None and index not in resolve_items:
+                continue
+            coordinate = _coordinate(item.context_expr)
+            rows[coordinate] = _resolved(coordinate)
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+    )
+    source = SourceFile(identity, construction_context=context)
+    for fn in source.functions():
+        if fn.name == name:
+            return fn.sugar()
+    raise AssertionError(f"no function {name}")
+
+
+def _with_chain(sugar):
+    """The chain of nested WithResourceSugars reachable from a function sugar."""
+    chain = []
+
+    def walk(node):
+        if isinstance(node, WithResourceSugar):
+            chain.append(node)
+            for child in node.body:
+                walk(child)
+            return
+        for field in ("body", "statements", "entries"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return chain
+
+
+TWO_MANAGERS = "def f(m, n):\n    with m, n:\n        pass\n    return m\n"
+NESTED_SPELLING = (
+    "def f(m, n):\n    with m:\n        with n:\n            pass\n    return m\n"
+)
+
+
+# ------------------------------------------------------- law / discrimination
+
+
+def test_two_managers_nest_into_single_item_with_nodes(tmp_path):
+    """LAW: `with m, n:` constructs A-outer / B-inner, one manager each."""
+    chain = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    assert len(chain) == 2, f"expected two nested resource withs, got {len(chain)}"
+    outer, inner = chain
+    assert inner in outer.body
+    assert outer.manager_slot_id != inner.manager_slot_id
+
+
+def test_discrimination_two_managers_do_not_collapse_to_one(tmp_path):
+    """BITE: a single flattened With would satisfy a naive `>=1` assertion."""
+    chain = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    with pytest.raises(AssertionError):
+        assert len(chain) == 1, "two managers must not collapse into one With"
+
+
+def test_enter_order_is_left_to_right(tmp_path):
+    """LAW: the FIRST source manager is the OUTER node — entered first."""
+    sugar = _function_sugar(tmp_path, TWO_MANAGERS)
+    outer, inner = _with_chain(sugar)
+    path = tmp_path / "case.py"
+    node = next(n for n in SourceFile(path_source(str(path))).nodes() if n.kind == "With")
+    first_slot = node.items[0]._manager_slot_id()
+    second_slot = node.items[1]._manager_slot_id()
+    assert outer.manager_slot_id == first_slot
+    assert inner.manager_slot_id == second_slot
+
+
+def test_discrimination_enter_order_is_not_right_to_left(tmp_path):
+    """BITE: swapping the expectation fails — order is real, not incidental."""
+    sugar = _function_sugar(tmp_path, TWO_MANAGERS)
+    outer, inner = _with_chain(sugar)
+    path = tmp_path / "case.py"
+    node = next(n for n in SourceFile(path_source(str(path))).nodes() if n.kind == "With")
+    with pytest.raises(AssertionError):
+        assert outer.manager_slot_id == node.items[1]._manager_slot_id()
+
+
+def test_exit_order_is_right_to_left(tmp_path):
+    """LAW: B is inner, so B.__exit__ is applied before A.__exit__.
+
+    Nesting IS the exit order: the inner With's ExitSet (already past B's exit)
+    is what A's ``and_exit`` consumes.
+    """
+    outer, inner = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    assert inner in outer.body
+    assert outer not in inner.body
+
+
+def test_discrimination_exit_order_is_not_left_to_right(tmp_path):
+    """BITE: the reversed containment must not hold."""
+    outer, inner = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    with pytest.raises(AssertionError):
+        assert outer in inner.body
+
+
+def test_multi_item_spelling_equals_nested_spelling(tmp_path):
+    """LAW: `with m, n:` and the nested spelling build the SAME arm structure.
+
+    Same instrument, both sides: identical WithResourceSugar chain shape, same
+    dispositions, same body — proof that no parallel sequencing model was added.
+    """
+    flat = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    nested = _with_chain(_function_sugar(tmp_path, NESTED_SPELLING))
+    assert len(flat) == len(nested) == 2
+    assert [type(s).__name__ for s in flat] == [type(s).__name__ for s in nested]
+    assert [s.disposition for s in flat] == [s.disposition for s in nested]
+    assert [len(s.body) for s in flat] == [len(s.body) for s in nested]
+
+
+def test_discrimination_equivalence_is_not_vacuous(tmp_path):
+    """BITE: the equivalence would fail against a genuinely different shape."""
+    flat = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    one = _with_chain(
+        _function_sugar(tmp_path, "def f(m, n):\n    with m:\n        pass\n    return m\n")
+    )
+    with pytest.raises(AssertionError):
+        assert len(flat) == len(one)
+
+
+def test_second_manager_without_authentication_stays_typed_loud(tmp_path):
+    """LAW: routing is not admission — an unauthenticated B is still loud.
+
+    Nesting gives the second manager its own construction door, and that door
+    still demands an authenticated disposition. The exact panic class depends
+    on *how* the authority is missing (an absent table row is a
+    ``BackendDefect``; a published resolution gap is a
+    ``ContextManagerResolutionConstructionGap``); both are typed panics under
+    ``SourceTreePanic`` and neither yields a constructed sugar.
+    """
+    with pytest.raises(SourceTreePanic):
+        _function_sugar(tmp_path, TWO_MANAGERS, resolve_items={0})
+
+
+def test_discrimination_authenticated_pair_is_not_loud(tmp_path):
+    """BITE: the loudness above is caused by the MISSING row, not by nesting."""
+    chain = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
+    assert len(chain) == 2
+
+
+# --------------------------------------- routing law at the sugar/ExitSet layer
+
+
+class _FixedSugar(Sugar):
+    def __init__(self, outcome, *, probe=None):
+        self._outcome = outcome
+        self._probe = probe
+
+    def desugar(self, ctx=None):
+        del ctx
+        if self._probe is not None:
+            self._probe.append(1)
+        return self._outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _FloorValue:
+    def __init__(self, label: str):
+        self.label = label
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import str_const
+
+        return str_const(self.label)
+
+
+def _resource(*, enter=None, body=None, slot="M", exit_probe=None):
+    exit_sugar = _FixedSugar(Complete(_FloorValue("exited")), probe=exit_probe)
+    return WithResourceSugar(
+        manager=_FixedSugar(Complete(_FloorValue(f"mgr{slot}"))),
+        manager_slot_id=slot,
+        enter=enter or _FixedSugar(Complete(_FloorValue("entered"))),
+        exit=exit_sugar,
+        exit_face_id=f"{slot}#exit_face",
+        body=body if body is not None else (),
+        disposition=NeverSuppresses(),
+        site=None,
+    )
+
+
+def _nested_pair(inner_enter, *, outer_exit_probe, inner_exit_probe):
+    inner = _resource(enter=inner_enter, slot="B", exit_probe=inner_exit_probe)
+    return _resource(body=(inner,), slot="A", exit_probe=outer_exit_probe)
+
+
+def test_failure_entering_second_manager_still_exits_first():
+    """LAW: B's ``__enter__`` halting still runs A's ``__exit__``.
+
+    B's own exit must NOT run (B was never entered); A's exit MUST, because the
+    enter-halt is an outgoing edge of A's body and ``and_exit`` fans over every
+    outgoing edge, not only the completed one.
+    """
+    outer_exit, inner_exit = [], []
+    halt = RaiseEffect(exception_name="OSError", occurrence="b.py:1:0")
+    sugar = _nested_pair(
+        _FixedSugar(Incomplete(halt)),
+        outer_exit_probe=outer_exit,
+        inner_exit_probe=inner_exit,
+    )
+    out = sugar.desugar()
+    assert inner_exit == [], "B was never entered; B.__exit__ must not run"
+    assert outer_exit == [1], "A was entered; A.__exit__ must run on B's enter halt"
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert any(r.effect == halt for r in reds), "the enter halt must be preserved"
+
+
+def test_discrimination_first_exit_is_not_skipped_on_the_halted_edge():
+    """BITE: approximating ``__exit__`` as completion-only would leave A's exit
+    unran. Assert the wrong expectation and show it fails."""
+    outer_exit, inner_exit = [], []
+    sugar = _nested_pair(
+        _FixedSugar(Incomplete(RaiseEffect(exception_name="OSError"))),
+        outer_exit_probe=outer_exit,
+        inner_exit_probe=inner_exit,
+    )
+    sugar.desugar()
+    with pytest.raises(AssertionError):
+        assert outer_exit == [], "normal-path-only exit would leave this empty"
+
+
+def test_body_completion_still_runs_both_exits():
+    """LAW: the completed edge runs both exits too (inner then outer)."""
+    outer_exit, inner_exit = [], []
+    sugar = _nested_pair(
+        _FixedSugar(Complete(_FloorValue("entered"))),
+        outer_exit_probe=outer_exit,
+        inner_exit_probe=inner_exit,
+    )
+    sugar.desugar()
+    assert inner_exit == [1]
+    assert outer_exit == [1]
+
+
+def test_discrimination_completion_path_does_not_skip_the_inner_exit():
+    outer_exit, inner_exit = [], []
+    sugar = _nested_pair(
+        _FixedSugar(Complete(_FloorValue("entered"))),
+        outer_exit_probe=outer_exit,
+        inner_exit_probe=inner_exit,
+    )
+    sugar.desugar()
+    with pytest.raises(AssertionError):
+        assert inner_exit == []
+
+
+def test_body_halt_inside_nested_managers_runs_both_exits():
+    """LAW: a halting BODY still exits B then A; the halt is preserved under
+    NeverSuppresses."""
+    outer_exit, inner_exit = [], []
+    halt = RaiseEffect(exception_name="ValueError", occurrence="body.py:2:4")
+    inner = _resource(
+        body=(_FixedSugar(Incomplete(halt)),), slot="B", exit_probe=inner_exit
+    )
+    sugar = _resource(body=(inner,), slot="A", exit_probe=outer_exit)
+    out = sugar.desugar()
+    assert inner_exit == [1]
+    assert outer_exit == [1]
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert any(r.effect == halt for r in reds)
+
+
+def test_discrimination_body_halt_is_not_suppressed_by_never_suppresses():
+    outer_exit, inner_exit = [], []
+    halt = RaiseEffect(exception_name="ValueError", occurrence="body.py:2:4")
+    inner = _resource(
+        body=(_FixedSugar(Incomplete(halt)),), slot="B", exit_probe=inner_exit
+    )
+    out = _resource(body=(inner,), slot="A", exit_probe=outer_exit).desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    with pytest.raises(AssertionError):
+        assert reds == [], "NeverSuppresses must not consume the body halt"
+
+
+assert BlockValue is not None  # imported for the block-shape contract above


### PR DESCRIPTION
## Mechanism

`with A() as a, B() as b: body` **is** `with A() as a: with B() as b: body`. `With._nest_items()` rewrites a multi-item `With` into single-item `With` nodes (shadow rewrite, one manager per level, recursive for 3+). Applied at the top of `substitute` (so an earlier manager's as-name is in scope for a later manager's expression), `_construct_sugar`, and `substitution_binding`.

## Proof it is not a second control model

Nothing was added to the routing layer. `WithResourceSugar`, `ExitSet.and_exit`, `reduce_block_to_exitset`, `sequence` — all untouched. The nesting rewrite is 8 lines in `nodes.py` and every multi-manager law falls out of the *existing* single-manager algebra:

- **enter left-to-right** — A is the outer node.
- **exit right-to-left** — B is inner, so B's `__exit__` is applied to the body ExitSet before A's.
- **failure entering B still exits A** — B's entire With, *including its enter-halt exit*, is the body of A; `and_exit` fans A's exit over EVERY outgoing body edge. No normal-path approximation anywhere.
- **contract is a parameter, not a hardcoded `__exit__`** — the router is `body -> ExitSet -> and_exit(exit_es, disposition=<typed>)`. `exit_es` is a prebuilt ExitSet and `disposition` a typed contract; the per-edge dispatch is indifferent to which contract is applied. **The integration twin (`same body ExitSet -> resource With applies __exit__ / assertion membrane applies EffectBoundary`) hooks in here**, at `ExitSet.and_exit` vs the EffectBoundary application in `with_effect_boundary_sugar.py`, once the assertion slice lands.
- **zero assertion handling** — no `pytest.raises` arm, no matcher branch, no vendor names anywhere in this diff.
- **equivalence twin** — `with m, n:` and the nested spelling are asserted to build the identical `WithResourceSugar` chain shape, dispositions and body arity, through the same instrument.

## Twins (16: 8 laws, 8 discrimination arms that bite)

`implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py`

| Law | Bite |
| --- | --- |
| two managers nest into single-item With nodes | flattening to one With fails |
| enter order is left-to-right | swapping outer/inner slot ids fails |
| exit order is right-to-left (inner contained in outer) | reversed containment fails |
| multi-item spelling == nested spelling arm structure | fails against a genuinely one-manager shape |
| unauthenticated second manager stays typed-loud | the authenticated pair is *not* loud — loudness is caused by the missing row, not by nesting |
| **failure entering B still exits A** (A's exit probe fires, B's does not, halt preserved) | asserting A's exit did *not* run fails — a completion-only approximation would pass it |
| body completion runs both exits | asserting the inner exit was skipped fails |
| body halt runs both exits, halt preserved under NeverSuppresses | asserting the halt was suppressed fails |

## Epsilon R

- **Axis**: `with_construction_gaps` (multi-manager `With` sites refused at construction), and specifically the `MULTIPLE_CONTEXT_MANAGER_ITEMS` gap kind.
- **Predicted ΔR**: that gap kind goes to **unrepresentable** — its `R` axis is deleted, not lowered. The observed corpus `R` drop on the *resource* family is expected to be **small in absolute terms**: the mid-band `With` residual is ~95% assertion membrane and only tens of protocol-resource sites, and multi-manager is a fraction of those. **That small number is a success, and it is stated up front so it is not read as a shortfall.**
- **Shape of the win**: this is a **construction** win (the tree normalizes to Python's own nesting before the router sees it). It is **not** a control-model win — the control model is unchanged, deliberately — and it is not a desugar-layer win. Do not let the deleted panic class read as an algebra change.
- **Floors preserved**: no panic weakened (`RuntimeSelectedContextManager`, `ContextManagerResolutionConstructionGap`, `UnsupportedContextManagerSemantics`, `UnsupportedWithBindingTarget`, `AsyncContextManagerUnsupported` all intact and still fire); no normal-path fabrication; `__exit__` still runs on every outgoing edge; no test deleted to go green; async With still loud.

## Shell deleted

`panic.MultipleContextManagerItems` and `WithConstructionGapKind.MULTIPLE_CONTEXT_MANAGER_ITEMS`. It watched a shape that is now unconstructable: a multi-manager `With` cannot reach the resource router. Rung climbed: auditor/panic → construction-time impossibility.

## Validation

```
pytest sugar-source-tree/tests/test_with_multiple_managers.py          -> 16 passed
pytest sugar-source-tree/tests/test_with_authenticated_contract_ref.py -> 12 passed
```
Red-first confirmed: the new file failed with `MultipleContextManagerItems` before the change.

Broader sweeps (`test_exit_set.py`, `test_with_resource_sugar.py`, `test_store_outcome_composition.py`, full `make test-python`) are launched as background telemetry after merge, not as a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Nest multi-manager `with` statements into chained single-item `With` nodes
> - Adds `With._nest_items()` in [nodes.py](https://github.com/TSavo/sugar/pull/6256/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to recursively rewrite multi-item `with` nodes into nested single-item `With` nodes, matching Python's own semantics.
> - Updates `_construct_sugar`, `substitute`, and `substitution_binding` to call `_nest_items()` instead of raising or returning `None` for multi-item cases.
> - Removes the `MultipleContextManagerItems` panic class and its `WithConstructionGapKind` enum member from [panic.py](https://github.com/TSavo/sugar/pull/6256/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb).
> - Adds a new test module [test_with_multiple_managers.py](https://github.com/TSavo/sugar/pull/6256/files#diff-5051383de8f0cf7e9105cc7fadfc72de913d7a33359a6978f643c346233753ed) covering nesting shape, enter/exit ordering, equivalence with explicitly nested spelling, and exit routing laws.
> - Behavioral Change: multi-item `with` statements no longer raise a panic; they are silently transformed into a nested chain of `WithResourceSugar` nodes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f3620b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->