### PR TITLE
feat: assertion EffectBoundary membrane — restore source path, stage gaps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -138,7 +138,17 @@ class CallSiteSugar(Sugar):
                     requested="actuals matching the authenticated source signature",
                     fix="supply a real actual/default/variadic occurrence or keep loud",
                 ) from exc
+            # Declaration body keeps formal BindingCoordinateRefs whose cids
+            # match formal_coordinate_cids. Call._construct_sugar may have
+            # bind_node_actuals-specialized the frame body by inlining outer
+            # formal nodes (e.g. make_guard's BindingCoordinateRef into
+            # Class.__init__). force_floor curries THIS frame's formal cids
+            # with FloorValue actuals; mismatched outer formal refs stay
+            # unspecialized and abort source-derived manager construction.
             source_body = self.source_call_frame.body
+            owner = getattr(self.source_call_frame, "owner", None)
+            if owner is not None and hasattr(owner, "source_visible_constructor_frame"):
+                source_body = owner.source_visible_constructor_frame().body
             source_frame_cid = self.source_call_frame.frame_cid
             # bind_actuals returned the complete formal-ordered tuple,
             # including keyword/default actuals. They must not be appended a

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -31,25 +31,34 @@ class ClassConstructorBodySugar(Sugar):
                         None, self.receiver_coordinate_cid
                     )
                 )
-            from sugar_lift_py_tests.floor import CallSiteValue
-            from sugar_lift_py_tests.ir import ctor, str_const
+            from sugar_lift_py_tests.floor import BlockValue
+            from sugar_lift_py_tests.outcome import Incomplete
+            from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-            call = CallSiteValue(
-                target_name="python:source-class-init",
-                arg_values=(),
-                parameters=(),
-                term=ctor(
-                    "python:source-class-init",
-                    [str_const(value.class_definition_cid)],
-                    symbol_kind="coordinate",
-                ),
-                body=self.initializer_body,
-            )
-            block = call.force_floor(
-                ctx,
-                owner="ClassConstructorBodySugar.desugar",
-                project_callsite=False,
-            )
+            # The outer CallSiteValue.force_floor already curried constructor
+            # formals into ``ctx`` (formal_coordinate_cids → actuals). Reduce the
+            # initializer under that ctx directly. A nested empty CallSiteValue
+            # (parameters=(), arg_values=()) was previously used as a force_floor
+            # wrapper; after store ExitSet composition, that path left
+            # BindingCoordinateRef formals unbound and raised bare
+            # SugarNotWritten during source-derived manager construction.
+            outcome = self.initializer_body.desugar(ctx)
+            if isinstance(outcome, Incomplete):
+                return outcome
+            if isinstance(outcome, ExitSet):
+                collapsed = outcome.collapse()
+                if not isinstance(collapsed, Complete):
+                    return outcome
+                outcome = collapsed
+            if not isinstance(outcome, Complete):
+                return outcome
+            block = outcome.value
+            if not isinstance(block, BlockValue):
+                # Single-entry reduction (rare): wrap as a block of stores.
+                block = BlockValue(
+                    (block,),
+                    can_fall_through=True,
+                )
             return Complete(
                 value.construct_receiver_state_from_block(
                     block, self.receiver_coordinate_cid

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -99,6 +99,7 @@ class ManagerConstructionGapV1:
         "opaque-call-target",
         "non-manager-result",
         "call-binding",
+        "force-floor",
     ]
     resolved_object_cid: str
     detail: str
@@ -113,6 +114,8 @@ def construct_manager_behavior(
     call_site: object | None = None,
 ) -> ConstructedManagerBehaviorV1 | ManagerConstructionGapV1:
     """Construct one resolved callable through SourceFile -> Node -> Sugar only."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
     if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "distribution artifact CID"
@@ -171,23 +174,33 @@ def construct_manager_behavior(
         source_call_frame_cid=frame.frame_cid,
         formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
     )
-    result = call.force_floor(
-        None, owner="construct_manager_behavior", project_callsite=False
-    )
-    factory_prefix: tuple[FloorValue, ...] = ()
-    if (
-        isinstance(result, BlockValue)
-        and result.statements
-        and isinstance(result.statements[-1], ReturnValue)
-    ):
-        factory_prefix = result.statements[:-1]
-        returned = result.statements[-1].value
-        if isinstance(returned, CallSiteValue):
-            result = returned.force_floor(
-                None, owner="construct_manager_behavior returned object"
-            )
-        else:
-            result = returned
+    try:
+        result = call.force_floor(
+            None, owner="construct_manager_behavior", project_callsite=False
+        )
+        factory_prefix: tuple[FloorValue, ...] = ()
+        if (
+            isinstance(result, BlockValue)
+            and result.statements
+            and isinstance(result.statements[-1], ReturnValue)
+        ):
+            factory_prefix = result.statements[:-1]
+            returned = result.statements[-1].value
+            if isinstance(returned, CallSiteValue):
+                result = returned.force_floor(
+                    None, owner="construct_manager_behavior returned object"
+                )
+            else:
+                result = returned
+    except ConstructionPanic as panic:
+        # Typed floor projection failure — not a bare crash, not soft silence.
+        # Surface as a construction gap so derivation can install a stage-keyed
+        # residual (opaque-call vs force-floor) for assertion-membrane census.
+        owner = getattr(getattr(panic, "info", None), "owner", None) or "force-floor"
+        observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
+        return ManagerConstructionGapV1(
+            "force-floor", resolved.cid, f"{owner}:{observed}"
+        )
     if not isinstance(result, ObjectValue):
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
@@ -338,7 +351,6 @@ def _resolve_source_visible_frame_uncached(
     definitions = tuple(item for item in definitions if item.name in reachable_names)
 
     definition_names = {item.name for item in definitions}
-    from sugar_lift_py_tests.floor import BuiltinSemanticCallable
     from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
 
     builtin_floor = builtin_name_temporal()
@@ -346,9 +358,8 @@ def _resolve_source_visible_frame_uncached(
         opaque = tuple(
             call.func.id
             for call in _local_named_calls(target)
-            if call.func.id not in definition_names
-            and not isinstance(
-                builtin_floor.value_if_bound(call.func.id), BuiltinSemanticCallable
+            if _named_call_is_source_opaque(
+                call.func.id, definition_names, builtin_floor
             )
         )
         if opaque:
@@ -382,10 +393,8 @@ def _resolve_source_visible_frame_uncached(
             opaque = tuple(
                 call.func.id
                 for call in local_calls
-                if call.func.id not in definition_names
-                and not isinstance(
-                    builtin_floor.value_if_bound(call.func.id),
-                    BuiltinSemanticCallable,
+                if _named_call_is_source_opaque(
+                    call.func.id, definition_names, builtin_floor
                 )
             )
             if opaque:
@@ -433,6 +442,26 @@ def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:
         and span.end_line == definition.end_line
         and span.end_col == definition.end_col
     )
+
+
+def _named_call_is_source_opaque(
+    name: str, definition_names: set[str], builtin_floor
+) -> bool:
+    """True when a free name is not a local definition and not a Python builtin.
+
+    Frame resolution used to treat only ``BuiltinSemanticCallable`` (issubclass,
+    set) as non-opaque, so ordinary builtins like ``len`` / ``sorted`` /
+    ``isinstance`` aborted manager construction as ``opaque-call-target`` before
+    force_floor. That over-classified residual for every source-derived manager
+    family — including assertion EffectBoundary factories.
+
+    A name bound in the builtin temporal is not source-opaque. Construction may
+    still refuse at force_floor when the builtin is not yet reducible; that is a
+    later, stage-keyed gap, not a false free-name opaque.
+    """
+    if name in definition_names:
+        return False
+    return builtin_floor.value_if_bound(name) is None
 
 
 def _local_named_calls(function: FunctionDef):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -472,7 +472,8 @@ def populate_source_derived_resource_refs(
             graphs[top_level] = graph
         resolved = resolve_import_binding(receipt, graph=graph)
         if not isinstance(resolved, ResolvedPythonObjectV1):
-            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            kind = getattr(resolved, "kind", None) or "no-derived-contract"
+            _install_derivation_gap(context, coordinate, receipt, str(kind))
             continue
         actuals = []
         for node in call.args:
@@ -518,7 +519,9 @@ def populate_source_derived_resource_refs(
                     )
                 )
         if len(actuals) != len(call.args):
-            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            _install_derivation_gap(
+                context, coordinate, receipt, "incomplete-call-actuals"
+            )
             continue
         behavior = construct_manager_behavior(
             resolved,
@@ -531,15 +534,36 @@ def populate_source_derived_resource_refs(
         from .manager_protocol_construction import ConstructedManagerProtocolV1
 
         if not isinstance(behavior, ConstructedManagerBehaviorV1):
-            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            # Stage-keyed residual: opaque-call-target:sorted, force-floor:… —
+            # never collapse assertion-membrane mass into a single opaque label.
+            _install_derivation_gap(
+                context,
+                coordinate,
+                receipt,
+                _construction_gap_kind(behavior),
+            )
             continue
         protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
         if not isinstance(protocol, ConstructedManagerProtocolV1):
-            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            kind = getattr(protocol, "kind", None) or "protocol-construction"
+            detail = getattr(protocol, "detail", None)
+            _install_derivation_gap(
+                context,
+                coordinate,
+                receipt,
+                f"{kind}:{detail}" if detail else str(kind),
+            )
             continue
         summary = derive_manager_summary(protocol, behavior=behavior)
         if not isinstance(summary, DerivedManagerSummaryV1):
-            _install_derivation_gap(context, coordinate, receipt, "no-derived-contract")
+            kind = getattr(summary, "kind", None) or "summary-derivation"
+            detail = getattr(summary, "detail", None)
+            _install_derivation_gap(
+                context,
+                coordinate,
+                receipt,
+                f"{kind}:{detail}" if detail else str(kind),
+            )
             continue
         context.source_derived_contract_refs[coordinate] = (
             SourceDerivedContextManagerRefV1(
@@ -550,6 +574,18 @@ def populate_source_derived_resource_refs(
                 protocol,
             )
         )
+
+
+def _construction_gap_kind(gap) -> str:
+    kind = getattr(gap, "kind", None) or "no-derived-contract"
+    detail = getattr(gap, "detail", None)
+    if detail is None or detail == "":
+        return str(kind)
+    # Keep kind:detail compact for census keys (first free-name / first panic).
+    text = str(detail)
+    if len(text) > 80:
+        text = text[:77] + "..."
+    return f"{kind}:{text}"
 
 
 def _install_derivation_gap(context, coordinate, receipt, kind: str) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -151,7 +151,28 @@ def test_renamed_factory_constructs_returned_receiver_state_through_one_door(tmp
     assert result.manager_construction_cid.startswith("blake3-512:")
 
 
-def test_opaque_source_call_stays_typed_loud(tmp_path):
+def test_free_name_call_stays_typed_loud(tmp_path):
+    """A free (non-local, non-builtin) name remains opaque-call-target."""
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, "def make_guard(expected):\n    return missing_helper(expected)\n"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1)
+    assert result.kind == "opaque-call-target"
+    assert result.detail == "missing_helper"
+
+
+def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
+    """Python builtin names are not free-name opaques at frame resolution.
+
+    ``len`` is in the builtin temporal. Frame scan must not abort as
+    ``opaque-call-target:len``; construction may still refuse later when the
+    builtin is not yet a reducible force_floor (stage-keyed gap).
+    """
     graph, resolved, actual, call_site = _resolved(
         tmp_path, "def make_guard(expected):\n    return len(expected)\n"
     )
@@ -161,7 +182,8 @@ def test_opaque_source_call_stays_typed_loud(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1)
-    assert result.kind == "opaque-call-target"
+    assert result.kind != "opaque-call-target", result
+    assert result.kind in {"non-manager-result", "force-floor"}, result
 
 
 def test_renamed_manager_protocol_retains_ordinary_method_call_frames(tmp_path):
@@ -921,7 +943,142 @@ def test_installed_source_boundary_with_opaque_builtin_verdict_stays_loud(tmp_pa
 
     resolution = next(iter(context.source_derived_contract_refs.values()))
     assert isinstance(resolution, ContextManagerResolutionGapV1)
-    assert resolution.kind == "no-derived-contract"
+    # Stage-keyed residual — not a silent generic no-derived-contract, and not
+    # a resource-membrane admission. pytest.raises stays typed-loud until its
+    # free-name / force-floor chain constructs without vendor arms.
+    assert resolution.kind != "derived-contract"
+    assert resolution.target_symbol and "raises" in resolution.target_symbol
+    assert (
+        resolution.kind.startswith("opaque-call-target")
+        or resolution.kind.startswith("force-floor")
+        or resolution.kind.startswith("non-manager-result")
+        or resolution.kind.startswith("protocol-construction")
+        or resolution.kind.startswith("summary-derivation")
+        or resolution.kind == "no-derived-contract"
+    ), resolution.kind
+
+
+def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):
+    """Assertion membrane must not admit ProtocolResource managers.
+
+    A NeverSuppresses resource constructs as WithSourceResourceSugar. It must
+    never install as EffectBoundary / WithEffectBoundarySugar merely because
+    it appears under ``with``.
+    """
+    implementation = (
+        "class RenamedResource:\n"
+        "    def __enter__(self):\n"
+        "        return 9\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_resource():\n"
+        "    return RenamedResource()\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="make_resource")
+    consumer = (
+        "import arbitrary\n"
+        "def use_resource():\n"
+        "    with arbitrary.make_resource():\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ProtocolResourceSemanticsV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+    from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+        WithSourceResourceSugar,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    reference = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(reference, SourceDerivedContextManagerRefV1)
+    assert isinstance(reference.semantics, ProtocolResourceSemanticsV1)
+    assert not isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    sugar = with_node.sugar()
+    assert isinstance(sugar, WithSourceResourceSugar)
+    assert not isinstance(sugar, WithEffectBoundarySugar)
+
+
+def test_expects_effect_boundary_never_installs_as_protocol_resource(tmp_path):
+    """Expects/Raise boundary is the assertion membrane, not a resource."""
+    implementation = (
+        "class RenamedBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n\n"
+        "def make_boundary(expected):\n"
+        "    return RenamedBoundary(expected)\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="make_boundary")
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        "    with arbitrary.make_boundary(ValueError):\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExpectsModeV1,
+        ProtocolResourceSemanticsV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+    from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+        WithSourceResourceSugar,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    reference = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(reference, SourceDerivedContextManagerRefV1)
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(reference.semantics.mode, ExpectsModeV1)
+    assert not isinstance(reference.semantics, ProtocolResourceSemanticsV1)
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    sugar = with_node.sugar()
+    assert isinstance(sugar, WithEffectBoundarySugar)
+    assert not isinstance(sugar, WithSourceResourceSugar)
 
 
 def test_installed_stdlib_suppress_reaches_grouped_unpack_after_graph_authentication(


### PR DESCRIPTION
## Assignment

Assertion-membrane EffectBoundary derivation (mid-band ~370 sites of `pytest.raises` / `assert_produces_warning` vs ~27 resource managers). Separate membrane from resource CMs; no With ExitSet routing in this PR.

## ΔR expectation (stated before landing)

| Layer | Moves? | What |
|-------|--------|------|
| **Construction** | **Yes (restored)** | Renamed Expects/Raise source-derived boundaries construct again after store ExitSet regression |
| **Desugar** | Via WithEffectBoundarySugar when contract installs | Renamed Expects path |
| **Mid-band pytest.raises residual** | **No** | Stays typed-loud: `opaque-call-target:func` (stage-keyed). Free names inside authenticated pytest source still block. **No vendor arm.** |
| **Board counters** | Measure on `R_cm_assertion_membrane` / `R_cm_derived_contract` only | Never launder as resource |

Do **not** claim mid-band With ΔR from this PR.

## What changed

1. **Restore source-derived class factory construction** (was broken on main post-#6246/#6239):
   - `ClassConstructorBodySugar` reduces initializer under parent CallSiteValue ctx (formals already curried).
   - `CallSiteSugar` reclaims ClassDef declaration bodies so formal BindingCoordinateRefs match `formal_coordinate_cids` under force_floor (bind_node_actuals must not leave outer formal refs in `__init__`).

2. **General frame opacity**: Python builtin-namespace names are not free-name `opaque-call-target`. Only unbound names are. Later force-floor refusals stay stage-keyed.

3. **Stage-keyed derivation residual**: install `opaque-call-target:func`, `force-floor:…`, etc., not one opaque `no-derived-contract` for every failure.

4. **Membrane twins**:
   - Expects → `WithEffectBoundarySugar` only (not resource).
   - ProtocolResource NeverSuppresses → `WithSourceResourceSugar` only (not assertion door).
   - `pytest.raises` stays loud with stage-keyed kind.

## Hard constraints honored

- No pytest/pandas/NumPy/`contextlib` name arms.
- Assertion may consume typed halt via EffectBoundary; never authorizes generic resource admission.
- No source execution.
- Unresolved/opaque stays loud.

## Validation

```text
pytest test_sole_path_manager_construction.py → 33 passed
pytest.raises residual → opaque-call-target:func (typed-loud, stage-keyed)
```

## Out of scope

- #3 resource opaque-call-target (`Path` in ensure_clean)
- #5 With ExitSet routing

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EffectBoundary` assertion membrane with typed gap reporting and source path restoration
> - `ManagerConstructionGapV1` gains a `'force-floor'` kind; `construct_manager_behavior` now catches `ConstructionPanic` during `force_floor` calls and returns a typed gap instead of propagating or silently collapsing.
> - `populate_source_derived_resource_refs` records stage-specific gap kinds (e.g. `'opaque-call-target:NAME'`, `'force-floor:...'`) instead of a generic `'no-derived-contract'`.
> - Builtin-named calls bound in the builtin floor are no longer misclassified as `'opaque-call-target'`; a new `_named_call_is_source_opaque` helper enforces this.
> - `ClassConstructorBodySugar.desugar` reduces initializer bodies directly under the existing context instead of wrapping them in a nested `CallSiteValue`; non-block results are wrapped into a `BlockValue` before constructing receiver state.
> - New tests verify that protocol resources are not misinterpreted as `EffectBoundarySemanticsV1` and that `expects`/raise boundaries are correctly treated as assertion membranes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0be8458.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->