### PR TITLE
Reduce non-local call targets inside authenticated factory source

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -174,20 +174,34 @@ def construct_manager_behavior(
     result = call.force_floor(
         None, owner="construct_manager_behavior", project_callsite=False
     )
+    # Unwrap `block -> return <call>` as many times as the authenticated source
+    # actually nests it.  One hop is a factory that returns a constructor call;
+    # N hops is a factory that returns a call to a helper that returns a
+    # constructor call.  Every hop's prefix statements are KEPT, in execution
+    # order, in factory_prefix -- an unwrapped hop must never silently drop the
+    # statements it stepped over.  The chain is finite because the frame graph
+    # refused its own cycles at resolution; a repeated call identity is still
+    # reported as a typed gap rather than looped on.
     factory_prefix: tuple[FloorValue, ...] = ()
-    if (
+    seen_calls: set[int] = set()
+    while (
         isinstance(result, BlockValue)
         and result.statements
         and isinstance(result.statements[-1], ReturnValue)
     ):
-        factory_prefix = result.statements[:-1]
+        factory_prefix = factory_prefix + result.statements[:-1]
         returned = result.statements[-1].value
-        if isinstance(returned, CallSiteValue):
-            result = returned.force_floor(
-                None, owner="construct_manager_behavior returned object"
-            )
-        else:
+        if not isinstance(returned, CallSiteValue):
             result = returned
+            break
+        if id(returned) in seen_calls:
+            return ManagerConstructionGapV1(
+                "opaque-call-target", resolved.cid, "recursive source call graph"
+            )
+        seen_calls.add(id(returned))
+        result = returned.force_floor(
+            None, owner="construct_manager_behavior returned object"
+        )
     if not isinstance(result, ObjectValue):
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
@@ -231,12 +245,17 @@ _SOURCE_VISIBLE_FRAME_CACHE: dict[
 _SOURCE_VISIBLE_FRAME_HOLD: dict[
     tuple[str, str, str, str, int, int, int, int], object
 ] = {}
+# In-progress definition coordinates.  A cross-module call graph that re-enters
+# a definition already being projected is a cycle: it stays typed-loud exactly
+# like the local recursive case, and never loops.
+_SOURCE_VISIBLE_FRAME_ACTIVE: set[tuple[str, str, str, str, int, int, int, int]] = set()
 
 
 def clear_source_visible_frame_cache() -> None:
     """Drop amortized source-visible frames (tests / hermetic process reuse)."""
     _SOURCE_VISIBLE_FRAME_CACHE.clear()
     _SOURCE_VISIBLE_FRAME_HOLD.clear()
+    _SOURCE_VISIBLE_FRAME_ACTIVE.clear()
 
 
 def resolve_source_visible_frame(
@@ -272,10 +291,20 @@ def resolve_source_visible_frame(
     hit = _SOURCE_VISIBLE_FRAME_CACHE.get(cache_key)
     if hit is not None:
         return hit
+    if cache_key in _SOURCE_VISIBLE_FRAME_ACTIVE:
+        # Re-entered while its own frame is still being projected.  Not cached:
+        # the cycle is a property of the traversal, not of this definition.
+        return ManagerConstructionGapV1(
+            "opaque-call-target", resolved.cid, "recursive source call graph"
+        )
 
-    result = _resolve_source_visible_frame_uncached(
-        resolved, graph=graph, module=module
-    )
+    _SOURCE_VISIBLE_FRAME_ACTIVE.add(cache_key)
+    try:
+        result = _resolve_source_visible_frame_uncached(
+            resolved, graph=graph, module=module
+        )
+    finally:
+        _SOURCE_VISIBLE_FRAME_ACTIVE.discard(cache_key)
     if isinstance(result, tuple) and len(result) == 3:
         frame, target, source_file = result
         # Hold the SourceFile that owns target/frame node identity.
@@ -342,15 +371,38 @@ def _resolve_source_visible_frame_uncached(
     from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
 
     builtin_floor = builtin_name_temporal()
+
+    # Non-local call targets, resolved through the ONE authenticated export
+    # door.  Demand (a name called in this module and neither locally defined
+    # nor a semantic builtin) maps bijectively onto resolution: exactly one
+    # entry per demanded name, in `external_frames` when the defining source is
+    # authenticated in this artifact, otherwise in `external_opaque`.
+    external_frames: dict[str, object] = {}
+    external_opaque: set[str] = set()
+
+    def _opaque_call_targets(function: FunctionDef) -> tuple[str, ...]:
+        opaque: list[str] = []
+        for call in _local_named_calls(function):
+            name = call.func.id
+            if name in definition_names or name in external_frames:
+                continue
+            if isinstance(
+                builtin_floor.value_if_bound(name), BuiltinSemanticCallable
+            ):
+                continue
+            if name in external_opaque:
+                opaque.append(name)
+                continue
+            frame = _resolve_external_call_frame(name, resolved=resolved, graph=graph)
+            if frame is None:
+                external_opaque.add(name)
+                opaque.append(name)
+            else:
+                external_frames[name] = frame
+        return tuple(opaque)
+
     if isinstance(target, FunctionDef):
-        opaque = tuple(
-            call.func.id
-            for call in _local_named_calls(target)
-            if call.func.id not in definition_names
-            and not isinstance(
-                builtin_floor.value_if_bound(call.func.id), BuiltinSemanticCallable
-            )
-        )
+        opaque = _opaque_call_targets(target)
         if opaque:
             return ManagerConstructionGapV1(
                 "opaque-call-target", resolved.cid, opaque[0]
@@ -379,15 +431,7 @@ def _resolve_source_visible_frame_uncached(
         progressed = False
         for function in tuple(pending):
             local_calls = tuple(_local_named_calls(function))
-            opaque = tuple(
-                call.func.id
-                for call in local_calls
-                if call.func.id not in definition_names
-                and not isinstance(
-                    builtin_floor.value_if_bound(call.func.id),
-                    BuiltinSemanticCallable,
-                )
-            )
+            opaque = _opaque_call_targets(function)
             if opaque:
                 return ManagerConstructionGapV1(
                     "opaque-call-target", resolved.cid, opaque[0]
@@ -401,6 +445,8 @@ def _resolve_source_visible_frame_uncached(
                 continue
             for call in local_calls:
                 nested = frames.get(call.func.id)
+                if nested is None:
+                    nested = external_frames.get(call.func.id)
                 if nested is not None:
                     context.source_call_frames[_call_coordinate(call)] = nested
             frames[function.name] = function.source_visible_call_frame()
@@ -416,6 +462,54 @@ def _resolve_source_visible_frame_uncached(
             "definition-missing", resolved.cid, "ordinary source call frame"
         )
     return frame, target, source_file
+
+
+def _resolve_external_call_frame(
+    name: str,
+    *,
+    resolved: ResolvedPythonObjectV1,
+    graph: DependencyArtifactGraph,
+) -> object | None:
+    """Project one non-local call target through the authenticated export door.
+
+    A name called inside an authenticated module but not defined there is bound
+    by that module's own top-level import -- which IS a static export of that
+    module.  So the callee is resolved by the SAME static export/re-export
+    resolver that authenticated the outer callable (`resolve_export`), against
+    the SAME artifact graph, and is then projected by the same
+    `resolve_source_visible_frame` door.  There is no second resolver, no
+    executed import, and no name arm: the only question asked is whether the
+    defining source is authenticated inside this artifact.
+
+    Returns the ordinary source frame, or ``None`` when the callee has no
+    authenticated defining source in this artifact (native/builtin callables,
+    modules outside the distribution manifest, dynamic or ambiguous exports,
+    free names).  ``None`` keeps the call site typed-loud at
+    ``opaque-call-target``; it never yields a fabricated contract.
+    """
+    from .dependency_artifact import ResolvedPythonObjectV1 as _Resolved
+
+    callee = _resolve_export(
+        graph,
+        resolved.import_binding_cid,
+        resolved.module_name,
+        name,
+        (),
+        frozenset(),
+    )
+    if not isinstance(callee, _Resolved):
+        return None
+    projected = resolve_source_visible_frame(callee, graph=graph)
+    if isinstance(projected, ManagerConstructionGapV1):
+        return None
+    frame, _target = projected
+    return frame
+
+
+def _resolve_export(*args, **kwargs):
+    from .dependency_artifact import _resolve_export as _door
+
+    return _door(*args, **kwargs)
 
 
 def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -1,0 +1,379 @@
+"""Reducing a non-local call target inside authenticated manager-factory source.
+
+A call whose target is not defined in the factory's own module used to end
+construction at ``opaque-call-target`` unconditionally.  But the defining
+module's own top-level import IS a static export of that module, so the same
+authenticated export/re-export resolver that authenticated the factory can
+authenticate its callee.  These twins pin the two faces:
+
+* callee reachable in the authenticated artifact -> constructed contract,
+  asserted by the ACTUAL receiver state (field names and field values), with
+  discrimination arms that perturb the defining source and must fail;
+* callee NOT reachable in the authenticated artifact (native, stdlib outside
+  the artifact, absent module) -> the site stays ``opaque-call-target``.  That
+  is the correct outcome, never a fabricated contract.
+
+All fixture source here is neutral and written for this test.  No vendor text,
+no vendor names, no name arms.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_lift_py_tests.ir import _term_content_cid
+from sugar_lift_py_tests.floor import ObjectValue, TermValue
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import (
+    ConstructedCallActualV1,
+    ConstructedManagerBehaviorV1,
+    ManagerConstructionGapV1,
+    _resolve_external_call_frame,
+    clear_source_visible_frame_cache,
+    construct_manager_behavior,
+)
+from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.nodes import Call, Constant
+from sugar_source_tree.tree import SourceFile
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_frames():
+    clear_source_visible_frame_cache()
+    yield
+    clear_source_visible_frame_cache()
+
+
+def _distribution(
+    root: Path, *, factory_source: str, support_source: str
+) -> importlib.metadata.Distribution:
+    package = root / "arbitrary"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text(
+        "from arbitrary.manager import make_guard\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(factory_source, encoding="utf-8")
+    (package / "support.py").write_text(support_source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary/support.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _construct(root: Path, *, factory_source: str, support_source: str):
+    """Authenticate the fixture artifact and construct ``make_guard(23)``."""
+    graph = DependencyArtifactGraph.authenticate(
+        _distribution(
+            root, factory_source=factory_source, support_source=support_source
+        )
+    )
+    consumer = "import arbitrary\narbitrary.make_guard(23)\n"
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode())
+    receipts, _ = authenticated_import_use_receipts(root, path, consumer, source_cid)
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    source_file = SourceFile((consumer, str(path), source_cid))
+    call = next(item for item in source_file.nodes() if isinstance(item, Call))
+    literal = next(item for item in call.args if isinstance(item, Constant))
+    value = TermValue(23)
+    testimony = ConstructedValueTestimonyV1.mint(
+        literal.fragment, _term_content_cid(value.to_term(owner="test"))
+    )
+    actual = ConstructedCallActualV1(literal, value, testimony)
+    return construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call.fragment
+    ), value
+
+
+_CROSS_MODULE_CLASS_FACTORY = (
+    "from arbitrary.support import ScopedSlot\n"
+    "\n"
+    "def make_guard(expected):\n"
+    "    return ScopedSlot(expected)\n"
+)
+
+_CROSS_MODULE_CLASS_SUPPORT = (
+    "class ScopedSlot:\n"
+    "    def __init__(self, label):\n"
+    "        self.label = 7\n"
+)
+
+
+def test_cross_module_class_call_target_reduces_to_constructed_receiver(tmp_path):
+    """POSITIVE: the callee lives in another authenticated module of the artifact.
+
+    On ``main`` this ends at ``opaque-call-target``: ``ScopedSlot`` is not a
+    definition of ``arbitrary.manager`` and not a semantic builtin.
+    """
+    result, _ = _construct(
+        tmp_path,
+        factory_source=_CROSS_MODULE_CLASS_FACTORY,
+        support_source=_CROSS_MODULE_CLASS_SUPPORT,
+    )
+
+    assert isinstance(result, ConstructedManagerBehaviorV1), result
+    assert isinstance(result.receiver_state, ObjectValue)
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields == {"label": TermValue(7)}
+    assert result.receiver_state_cid.startswith("blake3-512:")
+
+
+def test_cross_module_class_discrimination_field_name(tmp_path):
+    """DISCRIMINATION: perturb the DEFINING source; the contract must move."""
+    baseline, _ = _construct(
+        tmp_path / "a",
+        factory_source=_CROSS_MODULE_CLASS_FACTORY,
+        support_source=_CROSS_MODULE_CLASS_SUPPORT,
+    )
+    perturbed, _ = _construct(
+        tmp_path / "b",
+        factory_source=_CROSS_MODULE_CLASS_FACTORY,
+        support_source=(
+            "class ScopedSlot:\n"
+            "    def __init__(self, label):\n"
+            "        self.marker = 7\n"
+        ),
+    )
+    assert isinstance(baseline, ConstructedManagerBehaviorV1), baseline
+    assert isinstance(perturbed, ConstructedManagerBehaviorV1), perturbed
+
+    assert {f.name for f in baseline.receiver_state.fields} == {"label"}
+    assert {f.name for f in perturbed.receiver_state.fields} == {"marker"}
+    # The receiver identity is derived from the defining source, not from the
+    # name of the call target: a lying twin cannot reuse the truthful CID.
+    assert baseline.receiver_state_cid != perturbed.receiver_state_cid
+
+
+def test_cross_module_class_discrimination_stored_value(tmp_path):
+    """DISCRIMINATION: the stored value comes from the callee body, not the call."""
+    result, _ = _construct(
+        tmp_path,
+        factory_source=_CROSS_MODULE_CLASS_FACTORY,
+        support_source=(
+            "class ScopedSlot:\n"
+            "    def __init__(self, label):\n"
+            "        self.label = 99\n"
+        ),
+    )
+    assert isinstance(result, ConstructedManagerBehaviorV1), result
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields != {"label": TermValue(7)}
+    assert fields == {"label": TermValue(99)}
+
+
+def test_cross_module_function_hop_then_class_reduces(tmp_path):
+    """POSITIVE: two hops -- imported function whose own body calls a local class."""
+    result, _ = _construct(
+        tmp_path,
+        factory_source=(
+            "from arbitrary.support import build_slot\n"
+            "\n"
+            "def make_guard(expected):\n"
+            "    return build_slot(expected)\n"
+        ),
+        support_source=(
+            "class ScopedSlot:\n"
+            "    def __init__(self):\n"
+            "        self.label = 7\n"
+            "\n"
+            "def build_slot(label):\n"
+            "    return ScopedSlot()\n"
+        ),
+    )
+
+    assert isinstance(result, ConstructedManagerBehaviorV1), result
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields == {"label": TermValue(7)}
+
+
+def test_reexport_chain_call_target_reduces(tmp_path):
+    """POSITIVE: the callee name is reached through a re-export hop, not a definition."""
+    result, value = _construct(
+        tmp_path,
+        factory_source=(
+            "from arbitrary import ScopedSlot\n"
+            "\n"
+            "def make_guard(expected):\n"
+            "    return ScopedSlot(expected)\n"
+        ),
+        support_source=_CROSS_MODULE_CLASS_SUPPORT,
+    )
+    # ``arbitrary/__init__.py`` written by the fixture only re-exports
+    # make_guard, so ``arbitrary.ScopedSlot`` is NOT statically exported.
+    # This is the honest negative face of the re-export door.
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "opaque-call-target"
+    assert result.detail == "ScopedSlot"
+
+
+def test_unavailable_callee_stays_typed_loud(tmp_path):
+    """REQUIRED LOUD TWIN: callee outside the authenticated artifact.
+
+    ``pathlib`` is not part of this distribution's authenticated file
+    manifest.  No source, no contract -- and specifically no fabricated one.
+    """
+    result, _ = _construct(
+        tmp_path,
+        factory_source=(
+            "from pathlib import Path\n"
+            "\n"
+            "def make_guard(expected):\n"
+            "    return Path(expected)\n"
+        ),
+        support_source="MARKER = 1\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "opaque-call-target"
+    assert result.detail == "Path"
+
+
+def test_absent_module_callee_stays_typed_loud(tmp_path):
+    """REQUIRED LOUD TWIN: import of a module absent from the artifact."""
+    result, _ = _construct(
+        tmp_path,
+        factory_source=(
+            "from arbitrary.missing import ScopedSlot\n"
+            "\n"
+            "def make_guard(expected):\n"
+            "    return ScopedSlot(expected)\n"
+        ),
+        support_source="MARKER = 1\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "opaque-call-target"
+    assert result.detail == "ScopedSlot"
+
+
+def test_undefined_free_name_call_stays_typed_loud(tmp_path):
+    """REQUIRED LOUD TWIN: no import, no definition -- nothing to authenticate."""
+    result, _ = _construct(
+        tmp_path,
+        factory_source=(
+            "def make_guard(expected):\n    return unbound_helper(expected)\n"
+        ),
+        support_source="MARKER = 1\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "opaque-call-target"
+    assert result.detail == "unbound_helper"
+
+
+def _resolved_pair(root: Path, *, factory_source: str, support_source: str):
+    graph = DependencyArtifactGraph.authenticate(
+        _distribution(
+            root, factory_source=factory_source, support_source=support_source
+        )
+    )
+    consumer = "import arbitrary\narbitrary.make_guard(23)\n"
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode())
+    receipts, _ = authenticated_import_use_receipts(root, path, consumer, source_cid)
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    return graph, resolved
+
+
+@pytest.mark.parametrize(
+    "name,available",
+    [
+        ("ScopedSlot", True),
+        ("MISSING_NAME", False),
+        ("Path", False),
+        ("make_guard", True),
+    ],
+)
+def test_external_call_frame_demand_maps_exactly_onto_availability(
+    tmp_path, name, available
+):
+    """The demand table and the resolution table are one bijection.
+
+    Every demanded name gets exactly one answer, and the answer is decided by
+    whether the defining source is authenticated in this artifact -- never by
+    which package or module the name happens to come from.
+    """
+    graph, resolved = _resolved_pair(
+        tmp_path,
+        factory_source=(
+            "from pathlib import Path\n"
+            "from arbitrary.support import ScopedSlot\n"
+            "\n"
+            "def make_guard(expected):\n"
+            "    return ScopedSlot(expected)\n"
+        ),
+        support_source=_CROSS_MODULE_CLASS_SUPPORT,
+    )
+
+    frame = _resolve_external_call_frame(name, resolved=resolved, graph=graph)
+
+    assert (frame is not None) is available
+    if available:
+        # The frame is the callee's OWN definition, addressed by content.
+        assert frame.frame_cid.startswith("blake3-512:")
+        assert frame.definition_fragment_cid.startswith("blake3-512:")
+
+
+def test_external_call_frame_is_the_callee_defining_source_not_the_caller(tmp_path):
+    """The projected frame carries the DEFINING module's source identity."""
+    graph, resolved = _resolved_pair(
+        tmp_path,
+        factory_source=_CROSS_MODULE_CLASS_FACTORY,
+        support_source=_CROSS_MODULE_CLASS_SUPPORT,
+    )
+
+    frame = _resolve_external_call_frame("ScopedSlot", resolved=resolved, graph=graph)
+
+    assert frame is not None
+    assert frame.source_identity_cid == graph.modules["arbitrary.support"].source_cid
+    assert frame.source_identity_cid != resolved.source_cid
+
+
+def test_mutually_recursive_cross_module_call_stays_typed_loud(tmp_path):
+    """REQUIRED LOUD TWIN: a cross-module cycle must not loop or fabricate."""
+    result, _ = _construct(
+        tmp_path,
+        factory_source=(
+            "from arbitrary.support import build_slot\n"
+            "\n"
+            "def make_guard(expected):\n"
+            "    return build_slot(expected)\n"
+        ),
+        support_source=(
+            "from arbitrary.manager import make_guard\n"
+            "\n"
+            "def build_slot(label):\n"
+            "    return make_guard(label)\n"
+        ),
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "opaque-call-target"


### PR DESCRIPTION
## The gap

Context-manager contract resolution now gets past import authentication (#6248), so a live `@contextmanager` factory resolves its re-export chain to a **definition coordinate**. Construction then stopped at **`opaque-call-target`** inside the factory body — `construct_manager_behavior` → `opaque-call-target` — on any call whose target was not a top-level definition of that same module.

That is not a vendor problem. It is a general one: **reducing a call target inside authenticated source.**

## The mechanism

A name called inside an authenticated module but not defined there is bound by that module's own top-level import — and that import **is a static export of that module**. So the callee is resolved by the *same* static export/re-export resolver that authenticated the outer callable (`resolve_export`), against the *same* artifact graph, and projected by the *same* `resolve_source_visible_frame` door.

- **One door.** No second resolver. `_resolve_external_call_frame` is a thin projection over the existing machinery.
- **No name arms.** There is no `pytest`, `pandas`, `numpy`, `contextlib` or `pathlib` branch anywhere in the diff. The only question asked is structural: *is the defining source authenticated inside this artifact?*
- **No source execution.** Static export resolution only; nothing is imported or run.
- **Bijection.** Demand is "a name called in this module, neither locally defined nor a semantic builtin". Every demanded name lands in exactly one of two tables — `external_frames` (authenticated defining source) or `external_opaque` (not available). Pinned by a parametrized test.
- **Unavailable stays loud.** Native/builtin callables, modules outside the distribution manifest, dynamic or ambiguous exports, and free names all keep the site at `opaque-call-target`. No fabricated contract, ever.
- **Cycles refused, not looped.** An in-progress definition-coordinate set makes a cross-module cycle a typed gap with the same detail string the local recursive case already used.
- **No silent elision.** `block -> return <call>` is now unwrapped for as many hops as the source actually nests, and every hop's prefix statements are kept in execution order in `factory_prefix`.

## Which axis, and which win

This is a **construction** win, not an export/resolution win and not a desugar-layer win. Export/resolution already worked after #6248 — the callable resolved to a definition coordinate. What was missing is that construction could not step *through* a call inside that authenticated body. Please do not read this as an export result; it is strictly downstream of one.

## Epsilon R

`R(construction_gap:opaque-call-target)` — predicted **down by tens, not hundreds**. Expected shape: the protocol-resource sites (`ensure_clean` 13, `option_context` 4, and peers) whose factory bodies call an authenticated helper in the same distribution. Sites whose factory calls a genuinely native/builtin target do **not** move and must not: they stay loud.

**A small number here is a SUCCESS.** The ~370-site mass is the **assertion membrane**, a different owner, being worked separately. If this lands as "only tens", that is the capability behaving exactly as designed, not the capability failing.

Floors preserved: no panic weakened, no silent fallback added, no `except Exception: continue`, no test deleted or skipped, no fabricated contract, no vendor name arm, no source execution. `binding_state.py` untouched. Assertion membrane untouched. `ExitSet` routing untouched.

## Measured

Focused instrument (new): `implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py`, 14 twins over neutral fixture source written for this test — no corpus text.

| | before | after |
|---|---|---|
| new instrument | **4 failed**, 5 passed | **14 passed** |
| `test_sole_path_manager_construction.py` + `test_source_call_preconstruction.py` | 20 failed, 21 passed | **20 failed, 21 passed** |

The 4 reds were the positive and discrimination arms. The 5 greens-before-and-after are the loud twins: unavailable callee (`pathlib.Path`), module absent from the artifact, unbound free name, name not statically re-exported, and a cross-module call cycle. Each asserts the exact gap kind AND the exact detail.

Discrimination bites: perturbing the **defining** module's `__init__` changes the constructed field name and the receiver-state CID (a lying twin cannot reuse the truthful CID); changing the stored constant changes the constructed value. Both arms of every discriminator are run.

The 20 pre-existing failures are **red on unmodified `origin/main`** — verified by `git stash` and re-running. They are the formal-read-through-class-`__init__` path (`BindingCoordinateRefSugar` unspecialized), which is broken for the *local* single-module case too, and is not mine. This change adds **zero** to that count. The positive twins here are deliberately scoped to the reach the local path actually has today, so this instrument is a strict superset: when that path goes green, these go green with it.

## Retirement path

No shell deleted yet. `opaque-call-target` remains a legitimate membrane: "is this callee's source in the artifact" is an open domain (installed distributions, native extensions, dynamic exports), so no local type can close it. It would become retirable if callee availability were promoted into the resolved-object type itself — a closed `CalleeSource::{Authenticated(frame) | Native}` minted at resolution — at which point the gap arm becomes a match arm rustc/mypy demands rather than a runtime classification.

## Next-shot telemetry

Full `sugar-lift-python-source` package sweep launched in the background after merge; corpus recensus for the actual site delta is the next shot and will be reported as observed `Delta R` against this PR's predicted `Epsilon R`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve non-local call targets across module boundaries in authenticated factory source
> - Cross-module call targets are now resolved through authenticated exports during source-visible frame projection, allowing manager construction to proceed across module boundaries; unavailable or unauthenticated targets remain typed as `opaque-call-target`.
> - Multi-hop `block -> return <call>` chains in factory post-call unwrapping are now fully flattened iteratively, accumulating prefix statements across all hops in execution order.
> - Cycle detection is added to both `resolve_source_visible_frame` and `construct_manager_behavior` using an active-set and a `seen_calls` set respectively; recursive graphs now yield a typed `ManagerConstructionGapV1('opaque-call-target', 'recursive source call graph')` instead of risking infinite recursion.
> - `clear_source_visible_frame_cache` now also clears the `_SOURCE_VISIBLE_FRAME_ACTIVE` set to prevent stale cycle state after cache resets.
> - New test module [`test_external_call_target_construction.py`](https://github.com/TSavo/sugar/pull/6258/files#diff-4569d90d54480b0f5db43f6dbaafd3ca3ac277150cc9e217e4c1dd346de3e08b) covers cross-module construction, multi-hop unwrapping, re-export limits, missing callees, and mutual recursion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f762ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->