### PR TITLE
Stop collecting the hash-pinned lift corpus as sugar-lift-py-tests' own tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,13 @@ jobs:
 
       - name: Install lift package deps
         if: matrix.python
-        run: python -m pip install --quiet blake3 pynacl cbor2 pytest
+        # Declared test extras, not a hand-maintained list: the package's
+        # `[project.optional-dependencies].test` is the single source of truth
+        # for what its suite needs to COLLECT.
+        run: |
+          python -m pip install --quiet blake3 pynacl cbor2 pytest
+          python -m pip install --quiet \
+            -e implementations/python/sugar-lift-py-tests[test]
 
       - name: Install source-audit system deps
         if: matrix.z3
@@ -172,7 +178,7 @@ jobs:
           python -m pip install --quiet \
             blake3 pynacl cbor2 pytest \
             -e implementations/python/sugar-build-witness \
-            -e implementations/python/sugar-lift-py-tests \
+            -e implementations/python/sugar-lift-py-tests[test] \
             -e implementations/python/sugar-lift-python-source \
             -e implementations/python/sugar-lift-py-pytest-witness
 

--- a/implementations/python/sugar-lift-py-tests/pyproject.toml
+++ b/implementations/python/sugar-lift-py-tests/pyproject.toml
@@ -18,7 +18,20 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7", "black==26.5.1", "pyright==1.1.411", "itsdangerous==2.2.0"]
+# `numpy` is imported at MODULE scope by tests/test_vendor_special_case_law.py
+# and tests/test_numpy_pandas_panic_audit.py; `pandas` is imported inside tests
+# in the same file. Both are required by this package's ordinary suite, so they
+# are declared here rather than hand-listed at each call site — an undeclared
+# module-scope import aborts collection for the WHOLE package.
+# `itsdangerous` stays declared for the claim-mass tripwire corpus tooling.
+test = [
+    "pytest>=7",
+    "black==26.5.1",
+    "pyright==1.1.411",
+    "itsdangerous==2.2.0",
+    "numpy",
+    "pandas",
+]
 
 [project.scripts]
 sugar-lift-python = "sugar_lift_py_tests.lift_rpc:main"

--- a/implementations/python/sugar-lift-py-tests/tests/conftest.py
+++ b/implementations/python/sugar-lift-py-tests/tests/conftest.py
@@ -20,6 +20,24 @@ from sugar_lift_py_tests.sugar_binary import (  # noqa: E402
 )
 from claim_mass_corpus import DATETIME_SHA256  # noqa: E402
 
+# `tests/vendor/**` is hash-pinned LIFT CORPUS, not this package's test suite.
+# Those files are third-party sources (cpython datetime.py, itsdangerous /
+# numpy / pandas / requests test modules) that the suite reads as BYTES and
+# parses as AST — see `claim_mass_corpus.ClaimMassPin` and the sha256 pins in
+# `tests/claim_mass_tripwires`/`cpython_311_datetime_path`. They are never
+# imported by us, and their sha256 pins mean we may not edit them to add an
+# `importorskip` guard.
+#
+# Because they are named `test_*.py`, pytest was collecting them as OUR tests
+# and IMPORTING them. `tests/vendor/itsdangerous-2.2.0/test_serializer.py`
+# imports `itsdangerous` at module scope, so collection of the ENTIRE package
+# aborted with `ModuleNotFoundError: itsdangerous` whenever that third-party
+# package was absent — hiding ~1165 real tests behind one corpus file. The
+# same trap is armed for numpy/pandas/requests.
+#
+# Corpus is data. Data does not get collected as tests.
+collect_ignore_glob = ["vendor/*/*.py"]
+
 _SUGAR_PROJECT_SUBCOMMANDS = frozenset({"mint", "prove", "lift", "verify"})
 
 


### PR DESCRIPTION
Stop collecting the hash-pinned lift corpus as sugar-lift-py-tests' own tests

`implementations/python/sugar-lift-py-tests` could not be swept as a package
at all. Collection aborted:

    ERROR collecting tests/vendor/itsdangerous-2.2.0/test_serializer.py
    tests/vendor/itsdangerous-2.2.0/test_serializer.py:14: in <module>
        from itsdangerous.exc import BadPayload
    E   ModuleNotFoundError: No module named 'itsdangerous'
    !!!!! Interrupted: 1 error during collection !!!!!
    1165 tests collected, 1 error in 16.07s

Every "regression N green" claim for this package therefore came from targeted
file invocations that dodged the abort. The package holds most of the law twins
and had never been run whole.

Classification, with evidence: the offending file is not a test of ours. It is
third-party LIFT CORPUS. `tests/vendor/**` is read as bytes and parsed as AST by
`tests/claim_mass_corpus.py` (`ClaimMassPin`, `VENDOR = .../vendor`) and by the
`cpython_311_datetime_path` fixture, and each entry is sha256-pinned. It is never
imported by us, and the pins forbid editing those files to add an `importorskip`
guard. It was only being imported because pytest saw `test_*.py` and collected it.

The same trap was armed for the numpy / pandas / requests corpora - those merely
happened to import on boxes that had those packages installed, and their vendored
assertions were silently counted as sugar passes.

Fix (declared configuration, honored by CI and a fresh clone alike):

* `tests/conftest.py`: `collect_ignore_glob = ["vendor/*/*.py"]`. Corpus is data;
  data is not collected as tests. No test of ours is deleted or skipped.
* `pyproject.toml` test extras: declare `numpy` and `pandas`. Both are imported by
  our own suite (`tests/test_vendor_special_case_law.py` and
  `tests/test_numpy_pandas_panic_audit.py` import `numpy` at MODULE scope) and were
  undeclared - the identical collection-abort defect, one `pip install -e .[test]`
  away from firing.
* `.github/workflows/ci.yml`: both python install steps now install
  `-e implementations/python/sugar-lift-py-tests[test]` instead of a hand-kept
  list, so the package's declared extras are the single source of truth.

Focused evidence:

    $ python3 -m pytest tests -q -p no:cacheprovider --collect-only
    1157 tests collected in 3.33s        # 0 errors (was: 1165 + Interrupted)

    $ python3 -m pytest -q tests/test_claim_mass_tripwires.py
    5 passed in 268.99s

1165 -> 1157 is the removal of 8 vendored numpy/pandas assertions that were never
ours; the itsdangerous corpus file never contributed a collected item at all.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop pytest from collecting vendor corpus files in `sugar-lift-py-tests`
> - Adds `collect_ignore_glob = ["vendor/*/*.py"]` in [conftest.py](https://github.com/TSavo/sugar/pull/6260/files#diff-5ae28455ee4b64000d9ffa15563748869aff229e068e9b13fe2c770dc4a871cf) to prevent pytest from treating hash-pinned lift corpus files under `tests/vendor/` as part of this package's own test suite.
> - Adds `numpy` and `pandas` to the `[test]` optional dependencies in [pyproject.toml](https://github.com/TSavo/sugar/pull/6260/files#diff-261ec8796a9b416fbd4a4be1c4d29020ef3e684186d192280285d81a390a3a94) so the corpus tests have their runtime requirements available.
> - Updates [ci.yml](https://github.com/TSavo/sugar/pull/6260/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to install `sugar-lift-py-tests[test]` (with extras) in both relevant CI steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe926a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->