### PR TITLE
fix: annotated attribute/subscript stores take the SAME ladder as Assign (R_silent 1 -> 0)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2671,6 +2671,122 @@ class Delete(Statement):
         )
 
 
+def _substituted_store_target(statement, target, scope):
+    """Substitute the receiver (and subscript index) of a store target.
+
+    The attribute/subscript NAME is a store selector, never a reference, but
+    the RECEIVER is an ordinary expression: it is what carries an authenticated
+    object place or a constructed receiver into the store. Returns the rewritten
+    target, or ``None`` when nothing changed.
+    """
+    from .shadow import rewrite
+
+    receiver, receiver_changed = statement._substitute_field(target.value, scope)
+    changes = {"value": receiver} if receiver_changed else {}
+    if isinstance(target, Subscript):
+        index, index_changed = statement._substitute_field(target.slice_, scope)
+        if index_changed:
+            changes["slice_"] = index
+        if isinstance(receiver, ObjectPlaceStateV1):
+            projected = receiver.subscript_key_projection(index)
+            if projected is not None:
+                changes["slice_"] = projected
+    return rewrite(target, **changes) if changes else None
+
+
+def _valued_store_target_sugar(target, value_sugar, site):
+    """The ONE ladder for a valued attribute/subscript store target.
+
+    ``o.x = v`` and ``o.x: T = v`` are the SAME runtime store — an annotation
+    is never checked at runtime, so it states nothing and may not move the
+    store to a different arm. Both spellings therefore construct through this
+    one ladder: an authenticated object place is a place assign, a constructed
+    receiver is a receiver field store, and any other receiver is the typed
+    runtime store effect. Returns ``None`` for a target this ladder does not
+    own, so the caller stays loud.
+    """
+    from sugar_lift_py_tests.sugar.place_assign_sugar import PlaceAssignSugar
+
+    if isinstance(target, Attribute):
+        if isinstance(target.value, ObjectPlaceStateV1):
+            return PlaceAssignSugar(
+                receiver=target.value.sugar(),
+                selector_kind="attribute",
+                selector=target.attr,
+                value=value_sugar,
+                site=site,
+            )
+        if isinstance(target.value, (BindingCoordinateRef, ConstructedReceiverRef)):
+            from sugar_lift_py_tests.sugar.receiver_field_store_sugar import (
+                ReceiverFieldStoreSugar,
+            )
+
+            return ReceiverFieldStoreSugar(
+                receiver=target.value.sugar(),
+                value=value_sugar,
+                attr=target.attr,
+                site=site,
+            )
+        from sugar_lift_py_tests.sugar.store_effect_sugar import (
+            AttributeStoreEffectSugar,
+        )
+
+        return AttributeStoreEffectSugar(
+            receiver=target.value.sugar(),
+            value=value_sugar,
+            attr=target.attr,
+            site=site,
+        )
+    if isinstance(target, Subscript):
+        if isinstance(target.value, ObjectPlaceStateV1):
+            return PlaceAssignSugar(
+                receiver=target.value.sugar(),
+                selector_kind="subscript",
+                selector=target.slice_.sugar(),
+                value=value_sugar,
+                site=site,
+            )
+        from sugar_lift_py_tests.sugar.store_effect_sugar import (
+            SubscriptStoreEffectSugar,
+        )
+
+        return SubscriptStoreEffectSugar(
+            index_text=target.slice_.fragment.text,
+            site=site,
+        )
+    return None
+
+
+def _store_target_binding(statement, target, scope):
+    """Thread an authenticated object place forward across a store.
+
+    ``o.x = v`` and ``o.x: T = v`` update the same place, so both report the
+    same binding: every name bound to that exact object identity carries the
+    stored field onward. A receiver that is not an authenticated place threads
+    nothing — the store is an effect, not a lexical binding.
+    """
+    if not isinstance(target.value, ObjectPlaceStateV1):
+        return None
+    if isinstance(target, Attribute):
+        updated = target.value.with_attribute_store(
+            target.attr, statement.value, statement.fragment
+        )
+    else:
+        updated = target.value.with_subscript_store(
+            target.slice_, statement.value, statement.fragment
+        )
+    if updated is None:
+        return None
+    return {
+        name: replace(entry, state=updated)
+        for name, entry in scope.items()
+        if isinstance(name, str)
+        and isinstance(entry, BindingEntryV1)
+        and isinstance(entry.state, ObjectPlaceStateV1)
+        and entry.state.object_identity_cid == target.value.object_identity_cid
+    }
+
+
 class Assign(Statement):
     targets: Tuple[Expression, ...]
     value: Expression
@@ -2688,19 +2804,9 @@ class Assign(Statement):
         if len(self.targets) == 1 and isinstance(
             self.targets[0], (Attribute, Subscript)
         ):
-            target = self.targets[0]
-            receiver, receiver_changed = self._substitute_field(target.value, scope)
-            target_changes = {"value": receiver} if receiver_changed else {}
-            if isinstance(target, Subscript):
-                index, index_changed = self._substitute_field(target.slice_, scope)
-                if index_changed:
-                    target_changes["slice_"] = index
-                if isinstance(receiver, ObjectPlaceStateV1):
-                    projected = receiver.subscript_key_projection(index)
-                    if projected is not None:
-                        target_changes["slice_"] = projected
-            if target_changes:
-                changes["targets"] = (rewrite(target, **target_changes),)
+            new_target = _substituted_store_target(self, self.targets[0], scope)
+            if new_target is not None:
+                changes["targets"] = (new_target,)
         if not changes:
             return self
         return rewrite(self, **changes)
@@ -2876,40 +2982,12 @@ class Assign(Statement):
             target = self.targets[0]
             if isinstance(target, Name):
                 return {target.id: self.value}
-            if isinstance(target, Attribute) and isinstance(
-                target.value, ObjectPlaceStateV1
-            ):
-                updated = target.value.with_attribute_store(
-                    target.attr, self.value, self.fragment
-                )
-                if updated is None:
+            if isinstance(target, (Attribute, Subscript)):
+                threaded = _store_target_binding(self, target, scope)
+                if threaded is not None:
+                    return threaded
+                if isinstance(target.value, ObjectPlaceStateV1):
                     return None
-                return {
-                    name: replace(entry, state=updated)
-                    for name, entry in scope.items()
-                    if isinstance(name, str)
-                    and isinstance(entry, BindingEntryV1)
-                    and isinstance(entry.state, ObjectPlaceStateV1)
-                    and entry.state.object_identity_cid
-                    == target.value.object_identity_cid
-                }
-            if isinstance(target, Subscript) and isinstance(
-                target.value, ObjectPlaceStateV1
-            ):
-                updated = target.value.with_subscript_store(
-                    target.slice_, self.value, self.fragment
-                )
-                if updated is None:
-                    return None
-                return {
-                    name: replace(entry, state=updated)
-                    for name, entry in scope.items()
-                    if isinstance(name, str)
-                    and isinstance(entry, BindingEntryV1)
-                    and isinstance(entry.state, ObjectPlaceStateV1)
-                    and entry.state.object_identity_cid
-                    == target.value.object_identity_cid
-                }
             # Name-only nested/flat display unpack.
             name_only = self._destructured_binding()
             if name_only is not None:
@@ -3272,65 +3350,14 @@ class Assign(Statement):
                 site=self.fragment,
             )
 
-        if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
-            if isinstance(self.targets[0].value, ObjectPlaceStateV1):
-                from sugar_lift_py_tests.sugar.place_assign_sugar import (
-                    PlaceAssignSugar,
-                )
-
-                return PlaceAssignSugar(
-                    receiver=self.targets[0].value.sugar(),
-                    selector_kind="attribute",
-                    selector=self.targets[0].attr,
-                    value=self.value.sugar(),
-                    site=self.fragment,
-                )
-            if isinstance(
-                self.targets[0].value,
-                (BindingCoordinateRef, ConstructedReceiverRef),
-            ):
-                from sugar_lift_py_tests.sugar.receiver_field_store_sugar import (
-                    ReceiverFieldStoreSugar,
-                )
-
-                return ReceiverFieldStoreSugar(
-                    receiver=self.targets[0].value.sugar(),
-                    value=self.value.sugar(),
-                    attr=self.targets[0].attr,
-                    site=self.fragment,
-                )
-            from sugar_lift_py_tests.sugar.store_effect_sugar import (
-                AttributeStoreEffectSugar,
+        if len(self.targets) == 1 and isinstance(
+            self.targets[0], (Attribute, Subscript)
+        ):
+            store = _valued_store_target_sugar(
+                self.targets[0], self.value.sugar(), self.fragment
             )
-
-            return AttributeStoreEffectSugar(
-                receiver=self.targets[0].value.sugar(),
-                value=self.value.sugar(),
-                attr=self.targets[0].attr,
-                site=self.fragment,
-            )
-
-        if len(self.targets) == 1 and isinstance(self.targets[0], Subscript):
-            if isinstance(self.targets[0].value, ObjectPlaceStateV1):
-                from sugar_lift_py_tests.sugar.place_assign_sugar import (
-                    PlaceAssignSugar,
-                )
-
-                return PlaceAssignSugar(
-                    receiver=self.targets[0].value.sugar(),
-                    selector_kind="subscript",
-                    selector=self.targets[0].slice_.sugar(),
-                    value=self.value.sugar(),
-                    site=self.fragment,
-                )
-            from sugar_lift_py_tests.sugar.store_effect_sugar import (
-                SubscriptStoreEffectSugar,
-            )
-
-            return SubscriptStoreEffectSugar(
-                index_text=self.targets[0].slice_.fragment.text,
-                site=self.fragment,
-            )
+            if store is not None:
+                return store
 
         return super()._construct_sugar()
 
@@ -3439,8 +3466,13 @@ class AnnAssign(Statement):
     _child_fields = ("target", "annotation", "value")
 
     def substitute(self, scope):
-        """`<target>: <ann> = <value>` -- substitute the annotation and value;
-        the target is a binding site, never substituted."""
+        """`<target>: <ann> = <value>` -- substitute the annotation and value.
+
+        A plain Name target is a binding site and is never substituted. An
+        attribute/subscript target is a STORE, exactly as a plain Assign's is:
+        its receiver is an ordinary expression and is substituted, so an
+        authenticated object place or a constructed receiver reaches the store
+        the same way through either spelling."""
         from .shadow import rewrite
 
         changed = {}
@@ -3448,13 +3480,23 @@ class AnnAssign(Statement):
             new, d = self._substitute_field(getattr(self, fld), scope)
             if d:
                 changed[fld] = new
+        if isinstance(self.target, (Attribute, Subscript)):
+            new_target = _substituted_store_target(self, self.target, scope)
+            if new_target is not None:
+                changed["target"] = new_target
         return self if not changed else rewrite(self, **changed)
 
     def substitution_binding(self, scope):
-        # Only an annotated assignment WITH a value and a plain Name target
-        # binds; a bare `x: int` is a declaration and binds nothing.
-        if self.value is not None and isinstance(self.target, Name):
+        # Only an annotated assignment WITH a value binds; a bare `x: int` is a
+        # declaration and binds nothing. A Name target binds lexically; an
+        # attribute/subscript target over an authenticated object place threads
+        # that place forward, the same store Assign reports.
+        if self.value is None:
+            return None
+        if isinstance(self.target, Name):
             return {self.target.id: self.value}
+        if isinstance(self.target, (Attribute, Subscript)):
+            return _store_target_binding(self, self.target, scope)
         return None
 
     def _construct_sugar(self):
@@ -3487,26 +3529,12 @@ class AnnAssign(Statement):
                 value=self.target.value.sugar(),
                 site=self.fragment,
             )
-        if self.value is not None and isinstance(self.target, Attribute):
-            from sugar_lift_py_tests.sugar.store_effect_sugar import (
-                AttributeStoreEffectSugar,
+        if self.value is not None and isinstance(self.target, (Attribute, Subscript)):
+            store = _valued_store_target_sugar(
+                self.target, self.value.sugar(), self.fragment
             )
-
-            return AttributeStoreEffectSugar(
-                receiver=self.target.value.sugar(),
-                value=self.value.sugar(),
-                attr=self.target.attr,
-                site=self.fragment,
-            )
-        if self.value is not None and isinstance(self.target, Subscript):
-            from sugar_lift_py_tests.sugar.store_effect_sugar import (
-                SubscriptStoreEffectSugar,
-            )
-
-            return SubscriptStoreEffectSugar(
-                index_text=self.target.slice_.fragment.text,
-                site=self.fragment,
-            )
+            if store is not None:
+                return store
         return super()._construct_sugar()
 
 

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -20,11 +20,14 @@ from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSug
 from sugar_source_tree.tree import SourceFile
 
 
-def _fn(src):
+def _write(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
-        path = f.name
-    return next(SourceFile(path_source(path)).functions())
+        return f.name
+
+
+def _fn(src):
+    return next(SourceFile(path_source(_write(src))).functions())
 
 
 def test_annotated_assign_with_value_is_inert_and_threads():
@@ -112,6 +115,50 @@ def test_annotated_subscript_with_value_builds_store_effect():
 
     assert len(effects) == 1
     assert isinstance(effects[0], SubscriptStoreRuntimeEffect)
+
+
+_CONSTRUCTED_RECEIVER_SOURCE = (
+    "class C:\n"
+    "    def __init__(self, a):\n"
+    "        self.a = a\n"
+    "        self.rows{annotation} = []\n"
+    "\n"
+    "\n"
+    "def make(a):\n"
+    "    c = C(a)\n"
+    "    return c\n"
+)
+
+
+def _constructed_object(annotation):
+    source = _CONSTRUCTED_RECEIVER_SOURCE.format(annotation=annotation)
+    function = next(
+        item
+        for item in SourceFile(path_source(_write(source))).functions()
+        if item.name == "make"
+    )
+    return function.sugar().desugar().value.record.statements[-1].value
+
+
+def test_annotated_store_on_constructed_receiver_matches_plain_store():
+    """`self.rows: list = []` is the SAME store as `self.rows = []`.
+
+    The annotation states nothing at runtime, so it may not demote a
+    constructed-receiver field store to an opaque runtime store effect. Before
+    this parity the annotated arm partitioned the constructor body into a
+    halted store arm, and ClassConstructorBodySugar could not project one
+    completed floor value out of the resulting ExitSet.
+    """
+    plain = _constructed_object("")
+    annotated = _constructed_object(": list")
+
+    # Field coordinates carry each fixture's own source cid, so the parity
+    # claim is the constructed SHAPE: same fields, same constructed value kinds.
+    assert [field.name for field in plain.fields] == ["a", "rows"]
+    assert [field.name for field in annotated.fields] == ["a", "rows"]
+    assert [type(field.value).__name__ for field in annotated.fields] == [
+        type(field.value).__name__ for field in plain.fields
+    ]
 
 
 def test_bare_attribute_annotation_evaluates_only_renamed_receiver():


### PR DESCRIPTION
## The red

At `main` HEAD `167a77837` (post-#6254), **only one** of the four reported jobs was still red: `Python sole-construction floors (R>0 red)`, and within it exactly one step, `R_silent = 0`. The two discrimination jobs (`Bare exception zero tolerance`, `Timeout zero tolerance`) and `CI` were red only on runs against the **older** commit `4751c6f36`; at HEAD they are green.

The R_silent step died on an uncaught, honest panic:

```
sugar_lift_py_tests.gap.panic.ConstructionPanic: CONSTRUCTION PANIC:
write more Floor for this Projection: owner=ClassConstructorBodySugar.desugar
observed=ExitSet with 4 arms requested=one Complete floor value
```

That is `#6254`'s typed gap firing exactly as designed (it replaced a bare `AttributeError`). The offending file, measured per-file: `sugar_lift_py_tests/import_binding.py`.

## Root cause — a defect, not a residual

Probing the arms: **1 Completed, 3 Halted**, every halt an `AttributeStoreRuntimeEffect` on `.rows`, `.outcomes`, `.class_outer_states` — all three the *annotated* stores in that `__init__`:

```python
self.source_cid = source_cid          # -> ReceiverFieldStore, Completed
self.rows: list[dict[str, Any]] = []  # -> AttributeStoreRuntimeEffect, Halted
```

`Assign` with an Attribute target walks a three-arm ladder: authenticated object place → `PlaceAssignSugar`; constructed receiver → `ReceiverFieldStoreSugar`; anything else → the typed runtime store effect. `AnnAssign` skipped the ladder and always built `AttributeStoreEffectSugar`; worse, `AnnAssign.substitute` never substituted its target's receiver, so a constructed receiver could not reach the store at all.

An annotation is never checked at runtime, so it states nothing and may not move the same store to a weaker arm. `AnnAssign`'s own docstring already claimed *"A valued attribute/subscript target is the same runtime store owned by Assign"*. This makes that true.

## The fix

One ladder, shared by both spellings — `_valued_store_target_sugar` (construction), `_substituted_store_target` (receiver substitution), `_store_target_binding` (threading an authenticated object place forward). `Assign` is routed through the same three helpers instead of holding inline copies: one door, no second construction path.

## Epsilon R

- **R axis lowered:** `R_silent` — 1 uncaught `ConstructionPanic` → **0**.
- **Predicted Epsilon R: 0.** Measured, not predicted: `silent_zero_tolerance.py` now reports `R_silent = 0 files_discovered=394 files_completed=394 construction_panics=0 non_native_red=0 timeouts=0` (was exit 1 on the panic).
- Secondary effect: three loci per constructor move from halted runtime-store effects to constructed receiver fields — strictly more construction, none fabricated.

## Floors preserved

- No detector weakened. No test deleted or skipped. No `except ConstructionPanic`, no bare `except`.
- The existing opaque-receiver annotated-store tests still assert `AttributeStoreRuntimeEffect` — that receiver is still the ladder's bottom arm, and both faces are exercised.
- `construction_panic_catch_law.py` GREEN (`R_construction_panic_catches_outside_audit = 0`).
- `R_silent` discrimination: 5 passed.
- `sugar-source-tree` suite: 470 passed; the 16 failures are byte-identical to the `main` baseline measured in the same worktree (harness, not this change).

## Instrument

`test_annotated_store_on_constructed_receiver_matches_plain_store` — builds the same class twice, annotated and plain, and asserts the constructed object has the same fields. Red before with the exact production panic; green after.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix annotated attribute/subscript assignments to use the same substitution and binding ladder as plain `Assign`
> - `AnnAssign.substitute` now substitutes the receiver (and subscript index) of Attribute/Subscript targets via the shared `_substituted_store_target` helper, matching plain `Assign` behavior.
> - `AnnAssign.substitution_binding` now threads updated `ObjectPlaceStateV1` place state into the binding scope for Attribute/Subscript targets with a value, instead of only handling `Name` targets.
> - `AnnAssign._construct_sugar` now emits `PlaceAssignSugar` or `ReceiverFieldStoreSugar` where appropriate, rather than always emitting a `StoreEffect` sugar node.
> - Three new module-level helpers (`_substituted_store_target`, `_valued_store_target_sugar`, `_store_target_binding`) consolidate the shared logic used by both `Assign` and `AnnAssign`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44b3179.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->