### PR TITLE
chore: black sweep — 26 files, formatting only (CI / core (Python format) red -> green)

### DIFF
--- a/implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py
@@ -234,7 +234,9 @@ def component_plan_result(params: dict) -> dict:
 _SPLIT_CACHE: dict[tuple[str, tuple[str, ...]], tuple[List[str], List[str]]] = {}
 
 
-def _split_python_files(ws: str, source_paths: List[str]) -> tuple[List[str], List[str]]:
+def _split_python_files(
+    ws: str, source_paths: List[str]
+) -> tuple[List[str], List[str]]:
     """Project-relative (code_files, test_files), both sorted.
 
     Memoized: the fold asks `universe` once per censused file, and each of those

--- a/implementations/python/sugar-lift-py-pytest-witness/tests/test_witness.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/tests/test_witness.py
@@ -570,9 +570,9 @@ def test_kit_declaration_advertises_enumerate_and_never_lift():
         "kit must advertise sugar.enumerate or dispatch_lift_path refuses the "
         f"surface as a retired-lift kit: {names}"
     )
-    assert "lift" not in names, (
-        f"`lift` is not a kit method; advertising it re-opens the retired door: {names}"
-    )
+    assert (
+        "lift" not in names
+    ), f"`lift` is not a kit method; advertising it re-opens the retired door: {names}"
     required = {m["name"] for m in methods if m.get("required")}
     assert "sugar.enumerate" in required, methods
 
@@ -618,13 +618,13 @@ def test_enumerate_runs_the_suite_once_at_the_anchor_file_only(tmp_path):
             "nodes"
         ]
     ]
-    assert len(non_empty) == 1, (
-        f"exactly one anchor file may carry the package; got {non_empty}"
-    )
+    assert (
+        len(non_empty) == 1
+    ), f"exactly one anchor file may carry the package; got {non_empty}"
     tests = sorted(f for f in files if f.split("/")[-1].startswith("test_"))
-    assert non_empty == [tests[0]], (
-        f"anchor must be the first test file in sorted order: {non_empty} vs {tests}"
-    )
+    assert non_empty == [
+        tests[0]
+    ], f"anchor must be the first test file in sorted order: {non_empty} vs {tests}"
 
 
 def test_enumerate_link_units_and_unrelated_levels_are_empty_not_errors(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -203,8 +203,10 @@ def _backend_defect_key(exc: object) -> str:
         # Always keyed `BackendDefect:<what>` — a bare "BackendDefect" would
         # collide with the axis label itself and made this key unreadable as a
         # row (its own twin asserted the prefix and was red).
-        return f"BackendDefect:{name}" if name != "BackendDefect" else (
-            "BackendDefect:unclassified"
+        return (
+            f"BackendDefect:{name}"
+            if name != "BackendDefect"
+            else ("BackendDefect:unclassified")
         )
     return f"BackendDefect:{name}"
 
@@ -243,7 +245,9 @@ def _measure_file(
     desugar_axis = DesugarAxis()
     root = workspace_root if workspace_root is not None else path.parent
 
-    def tally_construction(kind: str, node: object | None = None, line: object = "?") -> None:
+    def tally_construction(
+        kind: str, node: object | None = None, line: object = "?"
+    ) -> None:
         key = _occurrence_key(kind, relative, node=node, line=line)
         if key in construction_seen:
             return
@@ -718,9 +722,13 @@ def main() -> int:
                 msg = f"{defect.get('type', '')}: {defect.get('message', '')}"
             else:
                 msg = str(category)
-            if "BackendDefect" in msg or "backend defect" in msg.lower() or (
-                isinstance(defect, dict)
-                and "BackendDefect" in str(defect.get("type", ""))
+            if (
+                "BackendDefect" in msg
+                or "backend defect" in msg.lower()
+                or (
+                    isinstance(defect, dict)
+                    and "BackendDefect" in str(defect.get("type", ""))
+                )
             ):
                 backend_defects[_backend_defect_key(msg)] += 1
             elif category == "backend-defect":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -378,8 +378,7 @@ class ParameterOwnedContractV1:
                 for coordinate in self.formal_coordinates
             ],
             "formalSorts": [
-                {"kind": "primitive", "name": sort.name}
-                for sort in self.formal_sorts
+                {"kind": "primitive", "name": sort.name} for sort in self.formal_sorts
             ],
             "declaredDemandCids": list(self.declared_demand_cids),
         }
@@ -409,7 +408,9 @@ class ParameterContractLinkUnitV1:
             "candidates": [candidate.to_value() for candidate in cands],
             "callEdges": [edge.to_value() for edge in edges],
         }
-        return cls(source_memento, parameter_owned_contract, cands, edges, _cid(preimage))
+        return cls(
+            source_memento, parameter_owned_contract, cands, edges, _cid(preimage)
+        )
 
     def to_value(self) -> dict[str, Any]:
         return {
@@ -490,8 +491,14 @@ def _resolution_preimage(resolution: dict) -> dict:
 
 def _validate_resolution(resolution: dict) -> None:
     expected = {
-        "kind", "schemaVersion", "demandCid", "candidateCid", "contractCid",
-        "basis", "callerUniverseCid", "resolutionCid",
+        "kind",
+        "schemaVersion",
+        "demandCid",
+        "candidateCid",
+        "contractCid",
+        "basis",
+        "callerUniverseCid",
+        "resolutionCid",
     }
     if not isinstance(resolution, dict) or set(resolution) != expected:
         raise ResumeStalePanic("resolution requires an exact key set")
@@ -504,7 +511,9 @@ def _validate_resolution(resolution: dict) -> None:
     basis = resolution["basis"]
     if basis == "declared-demand":
         if resolution["callerUniverseCid"] is not None:
-            raise ResumeStalePanic("declared-demand resolution carries a caller universe")
+            raise ResumeStalePanic(
+                "declared-demand resolution carries a caller universe"
+            )
     elif basis == "closed-callers":
         if resolution["callerUniverseCid"] is None:
             raise ResumeStalePanic("closed-callers resolution lacks a caller universe")
@@ -522,12 +531,14 @@ def resume_project(universe, accepted: dict[str, dict]):
     import dataclasses
 
     new_statements = tuple(
-        entry.value
-        if (
-            isinstance(entry, ContractConditionalConstructionV1)
-            and entry.demand.demand_cid in accepted
+        (
+            entry.value
+            if (
+                isinstance(entry, ContractConditionalConstructionV1)
+                and entry.demand.demand_cid in accepted
+            )
+            else entry
         )
-        else entry
         for entry in universe.record.statements
     )
     return dataclasses.replace(
@@ -579,5 +590,7 @@ def resume_apply_resolutions(link_unit, resolution_set) -> dict[str, dict]:
         accepted[demand_cid] = resolution
     missing = set(pending) - set(accepted)
     if missing:
-        raise ResumeStalePanic(f"resolution set is incomplete: missing {sorted(missing)}")
+        raise ResumeStalePanic(
+            f"resolution set is incomplete: missing {sorted(missing)}"
+        )
     return accepted

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -44,7 +44,6 @@ from collections import Counter
 from enum import Enum
 from typing import Any
 
-
 # --------------------------------------------------------------------------
 # occurrence coordinates
 # --------------------------------------------------------------------------
@@ -275,9 +274,11 @@ class DesugarAxis:
             self.construction_panics.append(
                 {
                     "where": where,
-                    "owner": (panic_row.info or {}).get("owner")
-                    if isinstance(panic_row.info, dict)
-                    else getattr(getattr(panic_row, "info", None), "owner", None),
+                    "owner": (
+                        (panic_row.info or {}).get("owner")
+                        if isinstance(panic_row.info, dict)
+                        else getattr(getattr(panic_row, "info", None), "owner", None)
+                    ),
                     "message": panic_row.message,
                 }
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/store_outcome_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/store_outcome_coordinate.py
@@ -56,9 +56,7 @@ STORE_FAMILY_EFFECT_NAMES = (
 def store_family_effects() -> tuple[type, ...]:
     from sugar_lift_py_tests import effect as effect_module
 
-    return tuple(
-        getattr(effect_module, name) for name in STORE_FAMILY_EFFECT_NAMES
-    )
+    return tuple(getattr(effect_module, name) for name in STORE_FAMILY_EFFECT_NAMES)
 
 
 def is_store_family_effect(effect) -> bool:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
@@ -48,9 +48,7 @@ def scan_guarded_loop_recurrence(
     root: Path,
 ) -> tuple[GuardedLoopRecurrenceFinding, ...]:
     findings: list[GuardedLoopRecurrenceFinding] = []
-    python_files = sorted(
-        path for path in root.rglob("*.py") if not _is_vendored(path)
-    )
+    python_files = sorted(path for path in root.rglob("*.py") if not _is_vendored(path))
     for path in python_files:
         text = path.read_text()
         tree = ast.parse(text, filename=str(path))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -50,9 +50,7 @@ class Incomplete:
         )
 
         if is_store_family_effect(self.effect):
-            return FollowStep.continue_with(
-                halt_guard=store_halted_guard(self.effect)
-            )
+            return FollowStep.continue_with(halt_guard=store_halted_guard(self.effect))
         return FollowStep.halt(keeps_rest=True)
 
     def contribution(self):

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -248,9 +248,7 @@ def test_positional_correspondence_binds_each_target_to_its_own_member(
     # ...and the swap is visible on the partial arm alone: a lie that only ever
     # showed up once both stores completed would escape a halted execution.
     swapped_arms = _arm_projections(tmp_path, swapped_source, stem="swappedarms")
-    (swapped_partial,) = (
-        arm for arm in swapped_arms if len(_store_rows(arm)) == 1
-    )
+    (swapped_partial,) = (arm for arm in swapped_arms if len(_store_rows(arm)) == 1)
     assert _store_rows(swapped_partial) != _store_rows(partial)
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_canonical_string_encoder_differential.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_canonical_string_encoder_differential.py
@@ -122,8 +122,7 @@ def test_combining_forms_are_not_normalized():
 
 
 def test_zero_width_and_bidi_controls_are_verbatim():
-    for value in ["​‌‍﻿", "‪‫‬‭‮",
-                  "⁦⁧⁨⁩", "؜"]:
+    for value in ["​‌‍﻿", "‪‫‬‭‮", "⁦⁧⁨⁩", "؜"]:
         assert C.encode_jcs(C.vstr(value)) == f'"{value}"'
         _assert_identical(value)
 
@@ -216,7 +215,9 @@ def test_differential_fuzz_whole_documents_and_cids():
             checked += 1
         else:
             raised += 1
-    assert checked > 0 and raised > 0, "fuzz must cover both encodable and lone-surrogate documents"
+    assert (
+        checked > 0 and raised > 0
+    ), "fuzz must cover both encodable and lone-surrogate documents"
 
 
 def test_realistic_preimage_documents_keep_their_cids():
@@ -235,7 +236,9 @@ def test_realistic_preimage_documents_keep_their_cids():
             "coordinate": ["blake3-512:" + "ab" * 64, "reporter/0", "control:none"],
             "testimony": {"present": True, "note": 'quote " and backslash \\ and \n'},
         },
-        {"docstring": "Return the sum.\n\n    Parameters\n    ----------\n    x : int\n"},
+        {
+            "docstring": "Return the sum.\n\n    Parameters\n    ----------\n    x : int\n"
+        },
         {"names": ["≤", "≠", "∀", "日本語", "😀"], "empty": "", "nested": [[], [[]]]},
     ]
     for doc in docs:

--- a/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
@@ -1,4 +1,4 @@
-'''Canonicalization is content-addressed WORK: done once per value, never per path.
+"""Canonicalization is content-addressed WORK: done once per value, never per path.
 
 ``_canonical_constructed_value`` is a pure function of an immutable constructed
 value, and the constructed value graph is a DAG the recursion walks as a TREE.
@@ -15,7 +15,7 @@ dead object's canonical JSON.
 These twins pin: the work collapses, the ANSWER does not change by one byte, a
 distinct value never reads another value's row, a recycled address misses, and
 speed never comes from skipping testimony.
-'''
+"""
 
 import gc
 import os

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_coordinate_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_coordinate_memo.py
@@ -1,4 +1,4 @@
-'''Construction is memoized at the construction COORDINATE, not per DAG path.
+"""Construction is memoized at the construction COORDINATE, not per DAG path.
 
 Substitution SHARES node objects (a bound name substitutes to the bound node
 itself), so the constructed graph is a DAG while ``walk``/``_construct_sugar``
@@ -18,7 +18,8 @@ These twins pin what the coordinate must NOT merge and what it must NOT lose:
   * a gap stays a gap on EVERY call: the panic is remembered and re-raised,
     never swallowed, never softened into a value;
   * and the point of it all: each coordinate constructs exactly once.
-'''
+"""
+
 import gc
 import os
 import tempfile
@@ -234,9 +235,7 @@ def test_each_coordinate_constructs_exactly_once():
 
         def counting(self, _original=original):
             cache = self._construction_cache()
-            constructed.append(
-                cache.key(self.ref, self.reporter, self.control_context)
-            )
+            constructed.append(cache.key(self.ref, self.reporter, self.control_context))
             return _original(self)
 
         patched.append((cls, original))

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
@@ -1,4 +1,4 @@
-'''A constructed value whose testimony cannot be content-addressed stays LOUD.
+"""A constructed value whose testimony cannot be content-addressed stays LOUD.
 
 ``ConstructionTestimonyReporterV1.present_construction`` used to have two
 silent ``return`` doors: one when the node's construction-shape CID would not
@@ -18,7 +18,7 @@ There is no third arm now:
 The gap is testified through the SAME roll call the census reads, and
 ``Node.sugar`` raises before recording the present answer, so conservation is
 atomic: exactly one discharge per coordinate, and it is the loud absent one.
-'''
+"""
 
 import os
 import tempfile

--- a/implementations/python/sugar-lift-py-tests/tests/test_node_shape_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_node_shape_v2_merkle.py
@@ -1,4 +1,4 @@
-'''NodeShapeV2: a node authenticates its OWN structure plus its children's CIDs.
+"""NodeShapeV2: a node authenticates its OWN structure plus its children's CIDs.
 
 V1 embedded each child's FULL subtree preimage inside its parent, so the same
 descendant content was authenticated once for every ancestor path above it.
@@ -31,7 +31,8 @@ These twins pin what the preimage must NOT lose and must NOT merge:
   * V1 and V2 never share an identity namespace: the V2 preimage carries a
     domain, a schema tag, and a NAMED child-CID algorithm that no V1 preimage
     ever carried.
-'''
+"""
+
 from sugar_source_tree import construction_cache as CC
 from sugar_source_tree.backend import (
     BackendNode,

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -10,6 +10,7 @@ construct the honest EUF coordinate `py.getattr(recv, "attr")` /
 A free-function call `g(x)` is the deterministic opaque receiver (no vendor,
 no numpy): its result has no field testimony, exactly like `np.asarray(...)`.
 """
+
 import os
 import tempfile
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
@@ -2,6 +2,7 @@
 owner's continuation replay guard. Each arm is a discrimination twin -- the good
 resume is honored, every corruption raises a loud ResumeStalePanic (which the
 kit lifts to a ConstructionPanic; it never silently reconstructs)."""
+
 import types
 import pytest
 
@@ -9,9 +10,13 @@ from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordin
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import PrimitiveSort, atomic, make_var, ctor, num
 from sugar_lift_py_tests.caller_parameter_contract import (
-    ParameterOwnedContractV1, ContractConditionalConstructionV1,
-    ParameterContractLinkUnitV1, ParameterContractResolutionSetV1,
-    resume_apply_resolutions, ResumeStalePanic, _cid,
+    ParameterOwnedContractV1,
+    ContractConditionalConstructionV1,
+    ParameterContractLinkUnitV1,
+    ParameterContractResolutionSetV1,
+    resume_apply_resolutions,
+    ResumeStalePanic,
+    _cid,
 )
 
 SRC = "blake3-512:" + "a" * 128
@@ -20,44 +25,62 @@ SRC = "blake3-512:" + "a" * 128
 def _link_unit():
     owner_def = SourceFragmentCoordinateV1(SRC, 1, 0, 10, 4)
     coord = FormalParameterCoordinateV1.mint(
-        owner_source_identity_cid=SRC, owner_definition_locus=owner_def,
+        owner_source_identity_cid=SRC,
+        owner_definition_locus=owner_def,
         declaration_locus=SourceFragmentCoordinateV1(SRC, 1, 17, 1, 22),
-        ordinal=0, parameter_kind="positional-or-keyword",
-        declared_name="value", sort=PrimitiveSort("Value"),
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="value",
+        sort=PrimitiveSort("Value"),
     )
     span = types.SimpleNamespace(start_line=3, start_col=9, end_line=3, end_col=17)
     site = types.SimpleNamespace(source_cid=SRC, line_col_span=span)
     cand = ContractConditionalConstructionV1.mint(
-        site=site, candidate=ctor("py.subscript", [make_var("value"), num(0)]),
+        site=site,
+        candidate=ctor("py.subscript", [make_var("value"), num(0)]),
         demand_formula=atomic("python:indexable", [make_var("value")]),
-        value=None, coordinate=coord,
+        value=None,
+        coordinate=coord,
     )
     owned = ParameterOwnedContractV1.mint(
-        name="encodeBase64", owner_source_identity_cid=SRC,
-        owner_definition_locus=owner_def, formal_coordinates=(coord,),
+        name="encodeBase64",
+        owner_source_identity_cid=SRC,
+        owner_definition_locus=owner_def,
+        formal_coordinates=(coord,),
         declared_demand_cids=[cand.demand.demand_cid],
     )
     unit = ParameterContractLinkUnitV1.mint(
         source_memento={"file": "vendor/b64vendor.py"},
-        parameter_owned_contract=owned, candidates=(cand,), call_edges=(),
+        parameter_owned_contract=owned,
+        candidates=(cand,),
+        call_edges=(),
     )
     return unit, cand, owned
 
 
-def _resolution(demand_cid, candidate_cid, contract_cid, basis="declared-demand",
-                universe=None):
+def _resolution(
+    demand_cid, candidate_cid, contract_cid, basis="declared-demand", universe=None
+):
     pre = {
-        "kind": "parameter-contract-resolution", "schemaVersion": "1",
-        "demandCid": demand_cid, "candidateCid": candidate_cid,
-        "contractCid": contract_cid, "basis": basis, "callerUniverseCid": universe,
+        "kind": "parameter-contract-resolution",
+        "schemaVersion": "1",
+        "demandCid": demand_cid,
+        "candidateCid": candidate_cid,
+        "contractCid": contract_cid,
+        "basis": basis,
+        "callerUniverseCid": universe,
     }
     return {**pre, "resolutionCid": _cid(pre)}
 
 
 def _good_set(unit, cand, owned):
     res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
-    return ParameterContractResolutionSetV1.mint(
-        link_unit_cid=unit.link_unit_cid, resolutions=(res,)), res
+    return (
+        ParameterContractResolutionSetV1.mint(
+            link_unit_cid=unit.link_unit_cid, resolutions=(res,)
+        ),
+        res,
+    )
 
 
 def test_twin_standalone_self_declared_honored():
@@ -70,7 +93,8 @@ def test_twin_standalone_self_declared_honored():
 def test_twin_missing_resolution_panics():
     unit, cand, owned = _link_unit()
     empty = ParameterContractResolutionSetV1.mint(
-        link_unit_cid=unit.link_unit_cid, resolutions=())
+        link_unit_cid=unit.link_unit_cid, resolutions=()
+    )
     with pytest.raises(ResumeStalePanic, match="incomplete"):
         resume_apply_resolutions(unit, empty)
 
@@ -79,7 +103,8 @@ def test_twin_duplicate_resolution_panics():
     unit, cand, owned = _link_unit()
     res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
     rset = ParameterContractResolutionSetV1.mint(
-        link_unit_cid=unit.link_unit_cid, resolutions=(res, res))
+        link_unit_cid=unit.link_unit_cid, resolutions=(res, res)
+    )
     with pytest.raises(ResumeStalePanic, match="duplicate"):
         resume_apply_resolutions(unit, rset)
 
@@ -89,27 +114,32 @@ def test_twin_stale_resolution_cid_panics():
     res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
     res["resolutionCid"] = "blake3-512:" + "0" * 128
     rset = ParameterContractResolutionSetV1.mint(
-        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)
+    )
     with pytest.raises(ResumeStalePanic, match="stale"):
         resume_apply_resolutions(unit, rset)
 
 
 def test_twin_foreign_contract_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.demand.demand_cid, cand.candidate_cid,
-                      "blake3-512:" + "f" * 128)
+    res = _resolution(
+        cand.demand.demand_cid, cand.candidate_cid, "blake3-512:" + "f" * 128
+    )
     rset = ParameterContractResolutionSetV1.mint(
-        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)
+    )
     with pytest.raises(ResumeStalePanic, match="foreign contract"):
         resume_apply_resolutions(unit, rset)
 
 
 def test_twin_wrong_candidate_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.demand.demand_cid, "blake3-512:" + "c" * 128,
-                      owned.contract_cid)
+    res = _resolution(
+        cand.demand.demand_cid, "blake3-512:" + "c" * 128, owned.contract_cid
+    )
     rset = ParameterContractResolutionSetV1.mint(
-        link_unit_cid=unit.link_unit_cid, resolutions=(res,))
+        link_unit_cid=unit.link_unit_cid, resolutions=(res,)
+    )
     with pytest.raises(ResumeStalePanic, match="wrong candidate"):
         resume_apply_resolutions(unit, rset)
 
@@ -119,6 +149,7 @@ def test_twin_lost_continuation_panics():
     res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
     # a set minted for a DIFFERENT continuation key
     foreign = ParameterContractResolutionSetV1.mint(
-        link_unit_cid="blake3-512:" + "9" * 128, resolutions=(res,))
+        link_unit_cid="blake3-512:" + "9" * 128, resolutions=(res,)
+    )
     with pytest.raises(ResumeStalePanic, match="different continuation"):
         resume_apply_resolutions(unit, foreign)

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py
@@ -1,6 +1,7 @@
 """Value-correctness twins for the Phase-3 resume (the gate the merge was
 missing): a resolved conditional candidate must contribute its CARRIED value's
 post, not vanish to an implicit None. Each asserts the ACTUAL post formula."""
+
 import os, tempfile, dataclasses
 import pytest
 
@@ -39,10 +40,13 @@ def _universe_and_unit(src):
 def _self_declared_set(unit):
     cand = unit.candidates[0]
     pre = {
-        "kind": "parameter-contract-resolution", "schemaVersion": "1",
-        "demandCid": cand.demand.demand_cid, "candidateCid": cand.candidate_cid,
+        "kind": "parameter-contract-resolution",
+        "schemaVersion": "1",
+        "demandCid": cand.demand.demand_cid,
+        "candidateCid": cand.candidate_cid,
         "contractCid": unit.parameter_owned_contract.contract_cid,
-        "basis": "declared-demand", "callerUniverseCid": None,
+        "basis": "declared-demand",
+        "callerUniverseCid": None,
     }
     res = {**pre, "resolutionCid": _cid(pre)}
     return ParameterContractResolutionSetV1.mint(
@@ -68,11 +72,13 @@ def test_twin_b_lying_candidate_is_rejected():
     universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
     cand = unit.candidates[0]
     pre = {
-        "kind": "parameter-contract-resolution", "schemaVersion": "1",
+        "kind": "parameter-contract-resolution",
+        "schemaVersion": "1",
         "demandCid": cand.demand.demand_cid,
-        "candidateCid": "blake3-512:" + "b" * 128,   # LIE
+        "candidateCid": "blake3-512:" + "b" * 128,  # LIE
         "contractCid": unit.parameter_owned_contract.contract_cid,
-        "basis": "declared-demand", "callerUniverseCid": None,
+        "basis": "declared-demand",
+        "callerUniverseCid": None,
     }
     res = {**pre, "resolutionCid": _cid(pre)}
     rset = ParameterContractResolutionSetV1.mint(
@@ -87,6 +93,7 @@ def test_twin_c_missing_resolution_still_panics():
     # sole projection path.
     universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
     from sugar_source_tree.panic import SugarNotWritten
+
     # empty accepted -> replacement leaves the CCC standing -> post() panics.
     resolved = resume_project(universe, {})
     with pytest.raises(BaseException):
@@ -98,7 +105,8 @@ def test_twin_d_retained_value_identity_unchanged():
     # byte-identical, not a reconstruction.
     universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
     ccc = next(
-        e for e in universe.record.statements
+        e
+        for e in universe.record.statements
         if isinstance(e, ContractConditionalConstructionV1)
     )
     retained_value_id = id(ccc.value)
@@ -116,4 +124,6 @@ def test_report_declared_demand_basis_grounded():
     demand_cid = unit.candidates[0].demand.demand_cid
     declared = unit.parameter_owned_contract.declared_demand_cids
     assert demand_cid in declared, "pending demand must be self-declared"
-    assert len(declared) >= 1, "declaredDemandCids is NON-empty (the prior claim was false)"
+    assert (
+        len(declared) >= 1
+    ), "declaredDemandCids is NON-empty (the prior claim was false)"

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -105,9 +105,7 @@ def test_construction_gap_occurrence_counted_once(tmp_path: Path) -> None:
         "def use(manager):\n" "    with manager:\n" "        pass\n",
         encoding="utf-8",
     )
-    row = module._measure_file(
-        path, relative="with_param.py", workspace_root=tmp_path
-    )
+    row = module._measure_file(path, relative="with_param.py", workspace_root=tmp_path)
     assert row["category"] == "completed"
     families = row.get("families") or {}
     # One With site → one CM gap occurrence (not catch+reporter = 2).
@@ -140,9 +138,7 @@ def test_backend_defect_keys_split_cm_and_call_demand() -> None:
 def test_cm_membrane_bucket_keeps_assertion_separate_from_resource() -> None:
     """With ΔR must never merge assertion membrane with protocol resource."""
     module = _load("control_effect_recensus")
-    assert (
-        module._cm_membrane_bucket("python:pytest.raises") == "assertion-membrane"
-    )
+    assert module._cm_membrane_bucket("python:pytest.raises") == "assertion-membrane"
     assert (
         module._cm_membrane_bucket("python:pandas._testing.assert_produces_warning")
         == "assertion-membrane"

--- a/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
@@ -165,7 +165,9 @@ def test_sequential_stores_preserve_both_outcomes_per_store(tmp_path: Path) -> N
     assert len(completed) == 1
 
 
-def test_sequential_stores_preserve_both_outcomes_per_store_discrimination(tmp_path: Path) -> None:
+def test_sequential_stores_preserve_both_outcomes_per_store_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: the pre-repair expectation (one Completed arm, no Halted arm)
     is exactly what this construction no longer produces."""
     halted, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
@@ -187,13 +189,15 @@ def test_first_store_halt_has_no_second_store_occurrence(tmp_path: Path) -> None
         "the first store's halt arm must not be conditioned on the second "
         "store's outcome -- the second store never ran"
     )
-    assert _store_entries(first.state) == [], (
-        "the first store's halt arm must contain no store occurrence at all"
-    )
+    assert (
+        _store_entries(first.state) == []
+    ), "the first store's halt arm must contain no store occurrence at all"
     assert isinstance(first.effect, AttributeStoreRuntimeEffect)
 
 
-def test_first_store_halt_has_no_second_store_occurrence_discrimination(tmp_path: Path) -> None:
+def test_first_store_halt_has_no_second_store_occurrence_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: asserting the second store DID occur on the first-halt arm
     fails, so the assertion above is load-bearing."""
     halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
@@ -212,17 +216,19 @@ def test_second_store_halt_preserves_the_first_store(tmp_path: Path) -> None:
     halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     second = next(h for h in halted if _polarity(h.guard, "y") is False)
 
-    assert _polarity(second.guard, "x") is True, (
-        "the second store only runs when the first completed"
-    )
+    assert (
+        _polarity(second.guard, "x") is True
+    ), "the second store only runs when the first completed"
     surviving = _store_entries(second.state)
     assert len(surviving) == 1, surviving
-    assert "attr=x" in surviving[0].effect.reason, (
-        "the first store must survive on the second store's halt arm"
-    )
+    assert (
+        "attr=x" in surviving[0].effect.reason
+    ), "the first store must survive on the second store's halt arm"
 
 
-def test_second_store_halt_preserves_the_first_store_discrimination(tmp_path: Path) -> None:
+def test_second_store_halt_preserves_the_first_store_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: a rolled-back first store (empty prefix) fails."""
     halted, _ = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     second = next(h for h in halted if _polarity(h.guard, "y") is False)
@@ -231,7 +237,9 @@ def test_second_store_halt_preserves_the_first_store_discrimination(tmp_path: Pa
         assert _store_entries(second.state) == [], "assignment rolled back"
 
 
-def test_sequential_completed_arm_requires_every_store_to_complete(tmp_path: Path) -> None:
+def test_sequential_completed_arm_requires_every_store_to_complete(
+    tmp_path: Path,
+) -> None:
     """The continuation after the stores is reachable only when BOTH completed,
     and it still states the real post."""
     _, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
@@ -244,7 +252,9 @@ def test_sequential_completed_arm_requires_every_store_to_complete(tmp_path: Pat
     )
 
 
-def test_sequential_completed_arm_requires_every_store_to_complete_discrimination(tmp_path: Path) -> None:
+def test_sequential_completed_arm_requires_every_store_to_complete_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: an unconditional (true) completed guard fails -- the guard is
     a real conjunction of two store coordinates."""
     from sugar_lift_py_tests.outcome.exit_set import true_guard
@@ -277,7 +287,9 @@ def test_each_store_occurrence_mints_its_own_coordinate(tmp_path: Path) -> None:
     assert values == {"p", "q"}
 
 
-def test_each_store_occurrence_mints_its_own_coordinate_discrimination(tmp_path: Path) -> None:
+def test_each_store_occurrence_mints_its_own_coordinate_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: collapsing the two stores to one coordinate fails."""
     _, completed = _arms(_exits(tmp_path, SEQUENTIAL, "target"))
     coordinates = _store_coordinates(completed[0].guard)
@@ -298,9 +310,9 @@ def test_store_outcome_guards_are_exactly_complementary(tmp_path: Path) -> None:
 
     assert _polarity(halt.guard, "x") is False
     assert _polarity(success.guard, "x") is True
-    assert _and_guards(halt.guard, success.guard) == false_guard(), (
-        "the halt face and the success face of ONE store cannot both hold"
-    )
+    assert (
+        _and_guards(halt.guard, success.guard) == false_guard()
+    ), "the halt face and the success face of ONE store cannot both hold"
 
 
 def test_store_pairing_enforcement_one_occurrence_complementary_total(
@@ -332,9 +344,9 @@ def test_store_pairing_enforcement_one_occurrence_complementary_total(
     halt_coords = _store_coordinates(halt.guard)
     success_coords = _store_coordinates(success.guard)
     assert len(halt_coords) == 1 and len(success_coords) == 1
-    assert halt_coords[0] == success_coords[0], (
-        "halt and success must share one store-occurrence coordinate"
-    )
+    assert (
+        halt_coords[0] == success_coords[0]
+    ), "halt and success must share one store-occurrence coordinate"
     assert _polarity(halt.guard, "x") is False
     assert _polarity(success.guard, "x") is True
 
@@ -346,7 +358,9 @@ def test_store_pairing_enforcement_one_occurrence_complementary_total(
     assert {type(e).__name__ for e in exits.exits} == {"Halted", "Completed"}
 
 
-def test_store_outcome_guards_are_exactly_complementary_discrimination(tmp_path: Path) -> None:
+def test_store_outcome_guards_are_exactly_complementary_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: two DIFFERENT stores' guards are not contradictory -- so the
     contradiction above comes from complementarity, not from everything being
     trivially false."""
@@ -372,7 +386,9 @@ def test_no_invented_exception_type_on_a_store_halt(tmp_path: Path) -> None:
         assert isinstance(arm.effect, AttributeStoreRuntimeEffect), type(arm.effect)
 
 
-def test_no_invented_exception_type_on_a_store_halt_discrimination(tmp_path: Path) -> None:
+def test_no_invented_exception_type_on_a_store_halt_discrimination(
+    tmp_path: Path,
+) -> None:
     """The bite: the halt is NOT a RaiseEffect of some guessed class."""
     from sugar_lift_py_tests.effect import RaiseEffect
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_symbolic_comprehension_guarded_fold.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_symbolic_comprehension_guarded_fold.py
@@ -250,11 +250,14 @@ def test_list_shaped_target_destructures_like_a_tuple_target():
     def structure(source):
         _kind, _iterable, body = _fold(_post_of(source))
         element = _coordinate(body)
-        return _destructure(
-            element,
-            2,
-            _ctor("call:g", [_project(element, 0, 2), _project(element, 1, 2)]),
-        ) == body.body
+        return (
+            _destructure(
+                element,
+                2,
+                _ctor("call:g", [_project(element, 0, 2), _project(element, 1, 2)]),
+            )
+            == body.body
+        )
 
     assert structure("def f(xs):\n    return [g(a, b) for [a, b] in xs]\n")
     assert structure("def f(xs):\n    return [g(a, b) for a, b in xs]\n")
@@ -317,9 +320,7 @@ def test_destructure_halt_and_filter_latch_are_distinct_exits():
     assert body.body == _destructure(
         element,
         2,
-        _filtered(
-            _ctor("call:p", [_project(element, 1, 2)]), _project(element, 0, 2)
-        ),
+        _filtered(_ctor("call:p", [_project(element, 1, 2)]), _project(element, 0, 2)),
     ), f"body was {body.body!r}"
 
 
@@ -389,9 +390,9 @@ def test_a_raising_filter_propagates_rather_than_deciding_membership():
     except SugarNotWritten:
         return
     _kind, _iterable, body = _fold(post)
-    assert body.body.name == "python:loop.filter_guard", (
-        "an undecided filter keeps its guard rather than choosing a side"
-    )
+    assert (
+        body.body.name == "python:loop.filter_guard"
+    ), "an undecided filter keeps its guard rather than choosing a side"
 
 
 # -- the four collection semantics -------------------------------------------
@@ -459,9 +460,10 @@ def test_a_concrete_dict_comprehension_keeps_last_write_overwrite_behaviour():
     )
     entries = post.args[1]
     assert entries.name == "python:dict", f"post was {post!r}"
-    assert [
-        (entry.args[0].value, entry.args[1].value) for entry in entries.args
-    ] == [(1, 5), (3, 4)], f"post was {post!r}"
+    assert [(entry.args[0].value, entry.args[1].value) for entry in entries.args] == [
+        (1, 5),
+        (3, 4),
+    ], f"post was {post!r}"
 
 
 def test_a_set_comprehension_uses_set_membership_over_a_concrete_iterable():
@@ -576,7 +578,9 @@ def test_a_comprehension_nested_in_a_dict_comprehension_key_is_constructed():
 
 
 def test_a_comprehension_nested_in_a_set_comprehension_element_is_constructed():
-    post = _post_of("def f(xs, g):\n    return {tuple([g(y) for y in x]) for x in xs}\n")
+    post = _post_of(
+        "def f(xs, g):\n    return {tuple([g(y) for y in x]) for x in xs}\n"
+    )
     kind, iterable, body = _fold(post)
     assert kind == "py.setcomp"
     assert iterable == make_var("xs")
@@ -600,7 +604,10 @@ def test_every_collection_form_accepts_a_nested_comprehension():
             "def f(xs, g):\n    return {tuple([g(y) for y in x]) for x in xs}\n",
             "py.setcomp",
         ),
-        ("def f(xs, g):\n    return {x: [g(y) for y in x] for x in xs}\n", "py.dictcomp"),
+        (
+            "def f(xs, g):\n    return {x: [g(y) for y in x] for x in xs}\n",
+            "py.dictcomp",
+        ),
     ):
         post = _post_of(source)
         observed, _iterable, _body = _fold(post)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/canonical.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/canonical.py
@@ -123,7 +123,8 @@ _ESCAPE_TABLE: dict[int, str] = {
     0x22: '\\"',
     0x5C: "\\\\",
     **{
-        codepoint: "\\u00" + "0123456789abcdef"[codepoint >> 4]
+        codepoint: "\\u00"
+        + "0123456789abcdef"[codepoint >> 4]
         + "0123456789abcdef"[codepoint & 0xF]
         for codepoint in range(0x20)
     },

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -406,9 +406,7 @@ def _resolve_source_visible_frame_uncached(
             name = call.func.id
             if name in external_frames:
                 continue
-            if not _named_call_is_source_opaque(
-                name, definition_names, builtin_floor
-            ):
+            if not _named_call_is_source_opaque(name, definition_names, builtin_floor):
                 continue
             if name in external_opaque:
                 opaque.append(name)

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -106,9 +106,12 @@ def _construct(root: Path, *, factory_source: str, support_source: str):
         literal.fragment, _term_content_cid(value.to_term(owner="test"))
     )
     actual = ConstructedCallActualV1(literal, value, testimony)
-    return construct_manager_behavior(
-        resolved, graph=graph, actuals=(actual,), call_site=call.fragment
-    ), value
+    return (
+        construct_manager_behavior(
+            resolved, graph=graph, actuals=(actual,), call_site=call.fragment
+        ),
+        value,
+    )
 
 
 _CROSS_MODULE_CLASS_FACTORY = (
@@ -119,9 +122,7 @@ _CROSS_MODULE_CLASS_FACTORY = (
 )
 
 _CROSS_MODULE_CLASS_SUPPORT = (
-    "class ScopedSlot:\n"
-    "    def __init__(self, label):\n"
-    "        self.label = 7\n"
+    "class ScopedSlot:\n" "    def __init__(self, label):\n" "        self.label = 7\n"
 )
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -348,7 +348,12 @@ class ConstructionTestimonyReporterV1:
     the structural identity of the exact source/shadow node that produced it.
     """
 
-    __slots__ = ("_delegate", "_by_node_shape", "_failed_by_node_shape", "_trace_builder")
+    __slots__ = (
+        "_delegate",
+        "_by_node_shape",
+        "_failed_by_node_shape",
+        "_trace_builder",
+    )
 
     def __init__(
         self, delegate: object, trace_builder: SubstitutionTraceBuilderV1

--- a/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
@@ -81,9 +81,9 @@ def test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces():
     # faces reach the record -- carrying the same effect under complementary
     # conditions over the store's own outcome coordinate.
     assert len(stores) == 2, [s.branch_conditions for s in stores]
-    assert {s.effect for s in stores} == {stores[0].effect}, (
-        "both faces are the SAME store occurrence, not two stores"
-    )
+    assert {s.effect for s in stores} == {
+        stores[0].effect
+    }, "both faces are the SAME store occurrence, not two stores"
 
     def cites_store_outcome(term):
         if getattr(term, "name", None) == "python:store_completed":
@@ -112,10 +112,10 @@ def test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces():
 
     conditions = [s.branch_conditions for s in stores]
     assert all(len(c) == 1 for c in conditions), conditions
-    assert any(mentions_store_outcome(c[0], False) for c in conditions), (
-        "one face must hold where the store COMPLETED"
-    )
-    assert any(mentions_store_outcome(c[0], True) for c in conditions), (
-        "the complementary face must hold where the store HALTED"
-    )
+    assert any(
+        mentions_store_outcome(c[0], False) for c in conditions
+    ), "one face must hold where the store COMPLETED"
+    assert any(
+        mentions_store_outcome(c[0], True) for c in conditions
+    ), "the complementary face must hold where the store HALTED"
     assert any(type(entry).__name__ == "ReturnValue" for entry in record)

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -56,7 +56,6 @@ from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SourceTreePanic
 from sugar_source_tree.tree import SourceFile
 
-
 # ---------------------------------------------------------------- tree fixture
 
 
@@ -181,7 +180,9 @@ def test_enter_order_is_left_to_right(tmp_path):
     sugar = _function_sugar(tmp_path, TWO_MANAGERS)
     outer, inner = _with_chain(sugar)
     path = tmp_path / "case.py"
-    node = next(n for n in SourceFile(path_source(str(path))).nodes() if n.kind == "With")
+    node = next(
+        n for n in SourceFile(path_source(str(path))).nodes() if n.kind == "With"
+    )
     first_slot = node.items[0]._manager_slot_id()
     second_slot = node.items[1]._manager_slot_id()
     assert outer.manager_slot_id == first_slot
@@ -193,7 +194,9 @@ def test_discrimination_enter_order_is_not_right_to_left(tmp_path):
     sugar = _function_sugar(tmp_path, TWO_MANAGERS)
     outer, inner = _with_chain(sugar)
     path = tmp_path / "case.py"
-    node = next(n for n in SourceFile(path_source(str(path))).nodes() if n.kind == "With")
+    node = next(
+        n for n in SourceFile(path_source(str(path))).nodes() if n.kind == "With"
+    )
     with pytest.raises(AssertionError):
         assert outer.manager_slot_id == node.items[1]._manager_slot_id()
 
@@ -234,7 +237,9 @@ def test_discrimination_equivalence_is_not_vacuous(tmp_path):
     """BITE: the equivalence would fail against a genuinely different shape."""
     flat = _with_chain(_function_sugar(tmp_path, TWO_MANAGERS))
     one = _with_chain(
-        _function_sugar(tmp_path, "def f(m, n):\n    with m:\n        pass\n    return m\n")
+        _function_sugar(
+            tmp_path, "def f(m, n):\n    with m:\n        pass\n    return m\n"
+        )
     )
     with pytest.raises(AssertionError):
         assert len(flat) == len(one)


### PR DESCRIPTION
## The red

`CI / core (Python format)` on `main`:

```
Oh no! 💥 💔 💥
23 files would be reformatted, 795 files would be left unchanged.
make: *** [Makefile:346: test-python-format] Error 1
```

At current HEAD (`a356e506e`) the drift had grown to **26 files**. It is formatting only, accumulated across many owners' merges — no line of meaning changes.

## The fix

`black implementations/python` at `black==26.5.1`, the pin declared in `sugar-lift-py-tests[test]` and the exact version the Makefile target installs.

## Epsilon R

- **R axis lowered:** `CI / core (Python format)` — 26 files reformatted → **0**.
- **Predicted Epsilon R: 0.** Measured: `black --check implementations/python` → `820 files would be left unchanged`.

## Floors preserved

No detector weakened, no test deleted or skipped, no semantics touched — every hunk is whitespace and line-wrapping under the repo's own pinned formatter.

## Not fixed here (other owners)

The `CI` workflow is red on further, unrelated jobs at HEAD: `showcases (0-3/4)`, `core (coretests invariants)`, `core (refusal vocabulary)`, and `acid test (make ci)`. Those are separate axes and are not touched by this sweep.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply black formatting across 26 Python files to fix CI format check
> This is a formatting-only sweep using black, with no intentional logic changes across the affected files. One functional fix is included: [canonical.py](https://github.com/TSavo/sugar/pull/6263/files#diff-3ed681453f3ebf802f3639e478e0cee1a4521ba9440c07a9be956d9a7bd035bc) corrects a bug in `_ESCAPE_TABLE` where control character Unicode escapes (U+0000–U+001F) were producing malformed hex output due to a duplicated nibble expression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee1fd00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->