### PR TITLE
Own every source-resolution memo with a bounded session

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -19,6 +19,7 @@ from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
 from .canonical import blake3_512_of, cid_of_json
+from .resolution_session import SourceResolutionSession, session_or_new
 from .source_oracle import SourceUnavailable, dependency_artifact_file
 
 
@@ -762,8 +763,13 @@ def resolve_import_binding(
     authenticated_use: Any,
     *,
     graph: DependencyArtifactGraph,
+    session: "SourceResolutionSession | None" = None,
 ) -> PythonObjectResolutionV1:
-    """Resolve a final-checked #6090 import use through one artifact graph."""
+    """Resolve a final-checked #6090 import use through one artifact graph.
+
+    ``session`` owns every resolution memo consulted on the way.  ``None``
+    opens one bounded to this single call; it is never process state.
+    """
     from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
 
     if not isinstance(authenticated_use, AuthenticatedImportUseV1):
@@ -828,6 +834,7 @@ def resolve_import_binding(
         exported_name,
         (),
         frozenset(),
+        session=session_or_new(session),
     )
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -14,19 +14,8 @@ from dataclasses import replace
 from typing import Any, Literal
 
 from .canonical import blake3_512_of
+from .resolution_session import SourceResolutionSession, session_or_new
 from .source_tables import parsed_tree
-
-# Top-level export resolution (empty warrants + empty seen) is pure in
-# (distribution_artifact_cid, module_name, exported_name).  Pandas call-frame
-# preconstruction repeats the same symbol many times per file; re-running the
-# full-module static export walk per receipt was the residual wall after
-# lexical revalidation amortization (see docs/audits/pandas-recensus-latency-bisect.md).
-_EXPORT_RESOLUTION_CACHE: dict[tuple[str, str, str], Any] = {}
-
-
-def clear_export_resolution_cache() -> None:
-    """Drop amortized export resolutions (tests / hermetic process reuse)."""
-    _EXPORT_RESOLUTION_CACHE.clear()
 
 
 def _bind() -> None:
@@ -65,9 +54,23 @@ def resolve_export(
     exported_name: str,
     warrants: tuple[ReexportWarrantV1, ...],
     seen: frozenset[tuple[str, str]],
+    *,
+    session: SourceResolutionSession | None = None,
 ) -> PythonObjectResolutionV1:
+    """Resolve one static export.
+
+    Structural export resolution is pure in (distribution_artifact_cid,
+    module_name, exported_name), and repeating the full-module static export
+    walk per receipt was the residual megamodule wall (see
+    docs/audits/pandas-recensus-latency-bisect.md).  So it is memoized -- but
+    the memo is owned by the caller's ``session``, never by module state: the
+    resolution names live ``ReexportWarrantV1``/definition objects whose
+    validity is bounded by the construction that asked for them.  ``None``
+    opens a session bounded to this single call.
+    """
     _bind()
-    # Only the entry form used by resolve_import_binding is safe to cache:
+    session = session_or_new(session)
+    # Only the entry form used by resolve_import_binding is memoizable:
     # non-empty warrants/seen encode path context that must not be shared.
     cacheable = not warrants and not seen
     cache_key = (
@@ -76,7 +79,7 @@ def resolve_export(
         exported_name,
     )
     if cacheable:
-        hit = _EXPORT_RESOLUTION_CACHE.get(cache_key)
+        hit = session.export_hit(cache_key)
         if hit is not None:
             return _restamp_export_result(hit, binding_cid)
 
@@ -87,9 +90,10 @@ def resolve_export(
         exported_name,
         warrants,
         seen,
+        session=session,
     )
     if cacheable:
-        _EXPORT_RESOLUTION_CACHE[cache_key] = result
+        session.remember_export(cache_key, result)
     return result
 
 
@@ -100,6 +104,8 @@ def _resolve_export_uncached(
     exported_name: str,
     warrants: tuple[ReexportWarrantV1, ...],
     seen: frozenset[tuple[str, str]],
+    *,
+    session: SourceResolutionSession,
 ) -> PythonObjectResolutionV1:
     key = (module_name, exported_name)
     if key in seen:
@@ -156,6 +162,7 @@ def _resolve_export_uncached(
             alias.name,
             (*warrants, warrant),
             seen | {key},
+            session=session,
         )
     if binding is not None and binding[0] == "alias":
         return resolve_export(
@@ -165,6 +172,7 @@ def _resolve_export_uncached(
             binding[1].id,
             warrants,
             seen | {key},
+            session=session,
         )
     if binding is not None and binding[0] == "unsupported":
         return _gap(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -24,6 +24,7 @@ from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
 from .canonical import cid_of_json
 from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
+from .resolution_session import SourceResolutionSession, session_or_new
 
 
 @dataclass(frozen=True)
@@ -112,10 +113,12 @@ def construct_manager_behavior(
     actuals: tuple[ConstructedCallActualV1, ...],
     keyword_actuals: tuple[tuple[str, ConstructedCallActualV1], ...] = (),
     call_site: object | None = None,
+    session: SourceResolutionSession | None = None,
 ) -> ConstructedManagerBehaviorV1 | ManagerConstructionGapV1:
     """Construct one resolved callable through SourceFile -> Node -> Sugar only."""
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
+    session = session_or_new(session)
     if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "distribution artifact CID"
@@ -126,7 +129,9 @@ def construct_manager_behavior(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
 
-    frame_result = resolve_source_visible_frame(resolved, graph=graph)
+    frame_result = resolve_source_visible_frame(
+        resolved, graph=graph, session=session
+    )
     if isinstance(frame_result, ManagerConstructionGapV1):
         return frame_result
     frame, _target = frame_result
@@ -254,41 +259,32 @@ def construct_manager_behavior(
     )
 
 
-# Source-visible frames are pure in (artifact, definition coordinate).  The same
-# authenticated definition is projected once per repeated call-site receipt in
-# pandas megamodules; re-materializing SourceFile + class base sugar each time
-# was residual wall after export/revalidation amortization.
-_SOURCE_VISIBLE_FRAME_CACHE: dict[
-    tuple[str, str, str, str, int, int, int, int],
-    tuple[object, Node] | ManagerConstructionGapV1,
-] = {}
-# Keep SourceFile alive for cached (frame, target) node identity.
-_SOURCE_VISIBLE_FRAME_HOLD: dict[
-    tuple[str, str, str, str, int, int, int, int], object
-] = {}
-# In-progress definition coordinates.  A cross-module call graph that re-enters
-# a definition already being projected is a cycle: it stays typed-loud exactly
-# like the local recursive case, and never loops.
-_SOURCE_VISIBLE_FRAME_ACTIVE: set[tuple[str, str, str, str, int, int, int, int]] = set()
-
-
-def clear_source_visible_frame_cache() -> None:
-    """Drop amortized source-visible frames (tests / hermetic process reuse)."""
-    _SOURCE_VISIBLE_FRAME_CACHE.clear()
-    _SOURCE_VISIBLE_FRAME_HOLD.clear()
-    _SOURCE_VISIBLE_FRAME_ACTIVE.clear()
-
-
 def resolve_source_visible_frame(
     resolved: ResolvedPythonObjectV1,
     *,
     graph: DependencyArtifactGraph,
+    session: SourceResolutionSession | None = None,
 ) -> tuple[object, Node] | ManagerConstructionGapV1:
     """Resolve one authenticated definition into the ordinary source frame.
 
     This is orchestration over typed Nodes.  Function/Class bodies still
     construct only through their existing ``source_visible_*_frame`` arms.
+
+    The projection is memoized on ``session``: the same authenticated
+    definition is projected once per repeated call-site receipt in pandas
+    megamodules, and re-materializing SourceFile + class base sugar each time
+    was the residual wall after export/revalidation amortization.
+
+    The memo may NOT be process-global even though its key is a content
+    address.  ``_resolve_source_visible_frame_uncached`` mints a fresh
+    ``TreeConstructionContextV1`` and WRITES into its mutable
+    ``source_class_bases`` / ``source_call_frames`` tables; the returned
+    ``frame``/``target`` Nodes are bound to that context.  Serving them to a
+    later construction hands it another session's live context, so a warm
+    answer from one project would silently become another project's answer.
+    ``session`` is the boundary that makes that unrepresentable.
     """
+    session = session_or_new(session)
     if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "distribution artifact CID"
@@ -309,31 +305,31 @@ def resolve_source_visible_frame(
         definition.end_line,
         definition.end_col,
     )
-    hit = _SOURCE_VISIBLE_FRAME_CACHE.get(cache_key)
+    hit = session.frame_hit(cache_key)
     if hit is not None:
         return hit
-    if cache_key in _SOURCE_VISIBLE_FRAME_ACTIVE:
-        # Re-entered while its own frame is still being projected.  Not cached:
-        # the cycle is a property of the traversal, not of this definition.
+    if cache_key in session.frame_active:
+        # Re-entered while its own frame is still being projected.  Not
+        # memoized: the cycle is a property of this traversal, not of this
+        # definition.
         return ManagerConstructionGapV1(
             "opaque-call-target", resolved.cid, "recursive source call graph"
         )
 
-    _SOURCE_VISIBLE_FRAME_ACTIVE.add(cache_key)
+    session.frame_active.add(cache_key)
     try:
         result = _resolve_source_visible_frame_uncached(
-            resolved, graph=graph, module=module
+            resolved, graph=graph, module=module, session=session
         )
     finally:
-        _SOURCE_VISIBLE_FRAME_ACTIVE.discard(cache_key)
+        session.frame_active.discard(cache_key)
     if isinstance(result, tuple) and len(result) == 3:
         frame, target, source_file = result
         # Hold the SourceFile that owns target/frame node identity.
-        _SOURCE_VISIBLE_FRAME_HOLD[cache_key] = source_file
-        _SOURCE_VISIBLE_FRAME_CACHE[cache_key] = (frame, target)
+        session.remember_frame(cache_key, (frame, target), hold=source_file)
         return frame, target
     assert not isinstance(result, tuple)
-    _SOURCE_VISIBLE_FRAME_CACHE[cache_key] = result
+    session.remember_frame(cache_key, result)
     return result
 
 
@@ -342,6 +338,7 @@ def _resolve_source_visible_frame_uncached(
     *,
     graph: DependencyArtifactGraph,
     module,
+    session: SourceResolutionSession,
 ) -> tuple[object, Node, object] | ManagerConstructionGapV1:
     context = TreeConstructionContextV1.for_source_call_construction()
     source_file = SourceFile(
@@ -411,7 +408,9 @@ def _resolve_source_visible_frame_uncached(
             if name in external_opaque:
                 opaque.append(name)
                 continue
-            frame = _resolve_external_call_frame(name, resolved=resolved, graph=graph)
+            frame = _resolve_external_call_frame(
+                name, resolved=resolved, graph=graph, session=session
+            )
             if frame is None:
                 external_opaque.add(name)
                 opaque.append(name)
@@ -487,6 +486,7 @@ def _resolve_external_call_frame(
     *,
     resolved: ResolvedPythonObjectV1,
     graph: DependencyArtifactGraph,
+    session: SourceResolutionSession,
 ) -> object | None:
     """Project one non-local call target through the authenticated export door.
 
@@ -514,10 +514,11 @@ def _resolve_external_call_frame(
         name,
         (),
         frozenset(),
+        session=session,
     )
     if not isinstance(callee, _Resolved):
         return None
-    projected = resolve_source_visible_frame(callee, graph=graph)
+    projected = resolve_source_visible_frame(callee, graph=graph, session=session)
     if isinstance(projected, ManagerConstructionGapV1):
         return None
     frame, _target = projected

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -384,8 +384,13 @@ def populate_source_derived_resource_refs(
     path,
     distribution_index=None,
     artifact_graph_cache: dict | None = None,
+    session=None,
 ) -> None:
-    """Preconstruct imported resource managers and freeze exact use-site rows."""
+    """Preconstruct imported resource managers and freeze exact use-site rows.
+
+    ``session`` owns every resolution memo for this population; the default
+    opens one bounded to this source file.
+    """
     from pathlib import Path
 
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -407,7 +412,9 @@ def populate_source_derived_resource_refs(
         construct_manager_behavior,
     )
     from .manager_protocol_construction import construct_manager_protocol
+    from .resolution_session import session_or_new
 
+    session = session_or_new(session)
     context = source_file.root.unit.construction_context
     if context is None:
         return
@@ -470,7 +477,7 @@ def populate_source_derived_resource_refs(
                 )
                 continue
             graphs[top_level] = graph
-        resolved = resolve_import_binding(receipt, graph=graph)
+        resolved = resolve_import_binding(receipt, graph=graph, session=session)
         if not isinstance(resolved, ResolvedPythonObjectV1):
             kind = getattr(resolved, "kind", None) or "no-derived-contract"
             _install_derivation_gap(context, coordinate, receipt, str(kind))
@@ -529,6 +536,7 @@ def populate_source_derived_resource_refs(
             actuals=tuple(actuals),
             keyword_actuals=tuple(keyword_actuals),
             call_site=call.fragment,
+            session=session,
         )
         from .manager_construction import ConstructedManagerBehaviorV1
         from .manager_protocol_construction import ConstructedManagerProtocolV1

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -1,0 +1,97 @@
+"""The bounded owner of every source-resolution memo.
+
+Authority model
+---------------
+A memo may only be served inside the session that produced it.
+
+Two kinds of registry are legitimate in this tree, and they are not
+interchangeable:
+
+* A **content-addressed** registry (``construction_cache._SHAPE_CIDS``, the
+  ``_interned`` ClassVar tables) is legitimately process-global, because the CID
+  *is* the complete key: the same content addresses to the same value
+  everywhere, forever, under every authority.
+
+* A **projection** memo is not. ``resolve_export`` and
+  ``resolve_source_visible_frame`` are keyed by a content address, but their
+  *values* are not content: they are objects bound to one live
+  ``TreeConstructionContextV1`` -- a mutable per-session table of
+  ``source_call_frames`` / ``source_call_resolutions`` / ``source_class_bases``
+  that ``_resolve_source_visible_frame_uncached`` writes into as it projects.
+  Serving such a value to a later construction hands that construction a node
+  whose context belongs to somebody else's session. That is a leak of authority,
+  not a cache hit, and it is how one project warms another project's answer
+  inside a long-lived ``lift_rpc`` daemon.
+
+So the memo is owned by a session object, created by whoever owns the
+construction, and discarded with it. It is deliberately NOT a module-level dict
+with an ever-more-elaborate key: an elaborate global key is how this class of
+bug returns, because every newly authenticated input is one more thing someone
+forgets to add to the key. A session cannot be forgotten -- it either exists for
+this construction or the memo does not answer.
+
+``enabled=False`` disables memoization entirely. That switch must change
+performance ONLY: never a formula, never a gap, never a verdict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class SourceResolutionSession:
+    """One bounded construction / source-oracle session and its memo tables."""
+
+    __slots__ = (
+        "enabled",
+        "export_resolutions",
+        "frame_results",
+        "frame_holds",
+        "frame_active",
+    )
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self.enabled = enabled
+        # (distribution_artifact_cid, module_name, exported_name) -> resolution
+        self.export_resolutions: dict[tuple[str, str, str], Any] = {}
+        # definition coordinate -> (frame, target) | ManagerConstructionGapV1
+        self.frame_results: dict[tuple, Any] = {}
+        # Keep the SourceFile that owns cached (frame, target) node identity
+        # alive for exactly as long as this session serves that memo.
+        self.frame_holds: dict[tuple, Any] = {}
+        # In-progress definition coordinates.  A cross-module call graph that
+        # re-enters a definition already being projected is a cycle: it stays
+        # typed-loud exactly like the local recursive case, and never loops.
+        # Re-entrancy is a property of THIS traversal, so it is session state.
+        self.frame_active: set[tuple] = set()
+
+    # -- export resolution memo ------------------------------------------
+
+    def export_hit(self, key: tuple[str, str, str]) -> Any | None:
+        return self.export_resolutions.get(key) if self.enabled else None
+
+    def remember_export(self, key: tuple[str, str, str], result: Any) -> None:
+        if self.enabled:
+            self.export_resolutions[key] = result
+
+    # -- source-visible frame memo ---------------------------------------
+
+    def frame_hit(self, key: tuple) -> Any | None:
+        return self.frame_results.get(key) if self.enabled else None
+
+    def remember_frame(self, key: tuple, result: Any, hold: Any = None) -> None:
+        if not self.enabled:
+            return
+        if hold is not None:
+            self.frame_holds[key] = hold
+        self.frame_results[key] = result
+
+
+def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionSession:
+    """Resolve the caller's session, or open one bounded to this single call.
+
+    ``None`` never means "share the process": it means "this call is its own
+    session". The memo then dies with the call, which is slower and always
+    correct.
+    """
+    return SourceResolutionSession() if session is None else session

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -37,10 +37,19 @@ def populate_source_visible_call_frames(
     path: Path,
     distribution_index=None,
     artifact_graph_cache: dict | None = None,
+    session=None,
 ) -> None:
-    """Populate exact-use source frames and one closed classification row."""
+    """Populate exact-use source frames and one closed classification row.
+
+    ``session`` owns every resolution memo for this population.  The default
+    opens one bounded to this source file, so no frame projected for one file
+    (or one project) can ever answer for another.
+    """
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
+    from .resolution_session import session_or_new
+
+    session = session_or_new(session)
     context = source_file.unit.construction_context
     if context is None:
         return
@@ -79,7 +88,7 @@ def populate_source_visible_call_frames(
                 )
                 continue
             graphs[top_level] = graph
-        resolved = resolve_import_binding(receipt, graph=graph)
+        resolved = resolve_import_binding(receipt, graph=graph, session=session)
         if isinstance(resolved, PythonObjectResolutionGapV1):
             context.source_call_resolutions[coordinate] = (
                 SourceCallPreconstructionGapV1(
@@ -97,7 +106,9 @@ def populate_source_visible_call_frames(
         from sugar_source_tree.panic import SugarNotWritten
 
         try:
-            frame_result = resolve_source_visible_frame(resolved, graph=graph)
+            frame_result = resolve_source_visible_frame(
+                resolved, graph=graph, session=session
+            )
         except SugarNotWritten as exc:
             context.source_call_resolutions[coordinate] = (
                 SourceCallPreconstructionGapV1("source-body-gap", coordinate, str(exc))

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -580,6 +580,7 @@ def test_resolve_export_amortizes_repeated_static_scans(tmp_path: Path) -> None:
     """
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
     from sugar_lift_python_source import dependency_export_adapter as de
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
 
     distribution = _install_distribution(
         tmp_path,
@@ -587,7 +588,9 @@ def test_resolve_export_amortizes_repeated_static_scans(tmp_path: Path) -> None:
         implementation_source="def build(value):\n    return value\n",
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
-    de.clear_export_resolution_cache()
+    # One session, as a real population has: amortization is a property of the
+    # session, not of the process.
+    session = SourceResolutionSession()
 
     n_sites = 8
     lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
@@ -609,10 +612,12 @@ def test_resolve_export_amortizes_repeated_static_scans(tmp_path: Path) -> None:
 
     de._export_block = counting_export_block
     try:
-        results = [resolve_import_binding(receipt, graph=graph) for receipt in receipts]
+        results = [
+            resolve_import_binding(receipt, graph=graph, session=session)
+            for receipt in receipts
+        ]
     finally:
         de._export_block = original_block
-        de.clear_export_resolution_cache()
 
     assert all(isinstance(item, ResolvedPythonObjectV1) for item in results)
     # First receipt: package reexport walk + implementation definition (2).
@@ -640,6 +645,7 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
     from sugar_lift_python_source.manager_construction import (
         resolve_source_visible_frame,
     )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
     from sugar_source_tree.tree import SourceFile
 
     distribution = _install_distribution(
@@ -648,7 +654,7 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
         implementation_source="def build(value):\n    return value\n",
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
-    mc.clear_source_visible_frame_cache()
+    session = SourceResolutionSession()
 
     n_sites = 6
     lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
@@ -672,10 +678,12 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
 
     mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]
     try:
-        frames = [resolve_source_visible_frame(item, graph=graph) for item in resolved]
+        frames = [
+            resolve_source_visible_frame(item, graph=graph, session=session)
+            for item in resolved
+        ]
     finally:
         mc.SourceFile = original_sf  # type: ignore[misc, assignment]
-        mc.clear_source_visible_frame_cache()
 
     assert all(isinstance(item, tuple) for item in frames)
     assert materializations["count"] <= 1, (

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -39,19 +39,17 @@ from sugar_lift_python_source.manager_construction import (
     ConstructedManagerBehaviorV1,
     ManagerConstructionGapV1,
     _resolve_external_call_frame,
-    clear_source_visible_frame_cache,
     construct_manager_behavior,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.nodes import Call, Constant
 from sugar_source_tree.tree import SourceFile
 
-
-@pytest.fixture(autouse=True)
-def _hermetic_frames():
-    clear_source_visible_frame_cache()
-    yield
-    clear_source_visible_frame_cache()
+# No hermetic-frames fixture: there is no process state left to clear.  Every
+# resolution memo is owned by a SourceResolutionSession bounded to its own
+# construction, so each test is isolated by construction rather than by a
+# fixture that scrubs globals after the fact.
 
 
 def _distribution(
@@ -334,7 +332,9 @@ def test_external_call_frame_demand_maps_exactly_onto_availability(
         support_source=_CROSS_MODULE_CLASS_SUPPORT,
     )
 
-    frame = _resolve_external_call_frame(name, resolved=resolved, graph=graph)
+    frame = _resolve_external_call_frame(
+        name, resolved=resolved, graph=graph, session=SourceResolutionSession()
+    )
 
     assert (frame is not None) is available
     if available:
@@ -351,7 +351,12 @@ def test_external_call_frame_is_the_callee_defining_source_not_the_caller(tmp_pa
         support_source=_CROSS_MODULE_CLASS_SUPPORT,
     )
 
-    frame = _resolve_external_call_frame("ScopedSlot", resolved=resolved, graph=graph)
+    frame = _resolve_external_call_frame(
+        "ScopedSlot",
+        resolved=resolved,
+        graph=graph,
+        session=SourceResolutionSession(),
+    )
 
     assert frame is not None
     assert frame.source_identity_cid == graph.modules["arbitrary.support"].source_cid

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -1,0 +1,486 @@
+"""Authority twins for the source-resolution memo.
+
+A memo that can change an answer is not a memo. These eight twins pin that
+``SourceResolutionSession`` bounds every resolution memo, and each carries a
+discrimination arm that bites: it perturbs the input and shows the answer
+actually moves, so the positive assertion cannot pass vacuously.
+
+The last twin is the load-bearing law: disabling the memo entirely must change
+performance ONLY -- never a formula, never a gap, never a verdict.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+import sys
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source import manager_construction as mc
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import (
+    resolve_source_visible_frame,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+_PACKAGE = "from example_pkg.implementation import build\n"
+_IMPL_A = "def build(value):\n    return value\n"
+_IMPL_B = "def build(value):\n    return value + 1\n"
+
+
+def _install(root: Path, *, implementation_source: str):
+    """Install one authenticated distribution seat under ``root``."""
+    root.mkdir(parents=True, exist_ok=True)
+    package = root / "example_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(_PACKAGE, encoding="utf-8")
+    (package / "implementation.py").write_text(implementation_source, encoding="utf-8")
+    metadata = root / "example_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: example-dist\nVersion: 1.0\n", encoding="utf-8"
+    )
+    (metadata / "top_level.txt").write_text("example_pkg\n", encoding="utf-8")
+    recorded = (
+        "example_pkg/__init__.py",
+        "example_pkg/implementation.py",
+        "example_dist-1.0.dist-info/METADATA",
+        "example_dist-1.0.dist-info/top_level.txt",
+        "example_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    sys.modules.pop("example_pkg", None)
+    sys.modules.pop("example_pkg.implementation", None)
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _receipt(root: Path):
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    source = "import example_pkg\nexample_pkg.build(1)\n"
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, source, blake3_512_of(source.encode("utf-8")), module_identities={}
+    )
+    assert len(receipts) == 1
+    return receipts[0]
+
+
+def _project(tmp_path: Path, name: str, implementation_source: str):
+    """One independent project: its own seat, graph, and consumer receipt."""
+    root = tmp_path / name
+    distribution = _install(root, implementation_source=implementation_source)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    return graph, _receipt(root)
+
+
+def _resolve(project, session):
+    graph, receipt = project
+    resolved = resolve_import_binding(receipt, graph=graph, session=session)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    return resolved
+
+
+def _verdict(project, session):
+    """The full observable answer: resolution identity + projected frame."""
+    graph, _ = project
+    resolved = _resolve(project, session)
+    projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
+    assert isinstance(projected, tuple), projected
+    frame, target = projected
+    return {
+        "resolved_cid": resolved.cid,
+        "module_name": resolved.module_name,
+        "source_cid": resolved.source_cid,
+        "fragment_cid": resolved.definition.fragment_cid,
+        "frame_cid": frame.frame_cid,
+        "target_name": target.name,
+    }
+
+
+class _MaterializeCounter:
+    """Count SourceFile materializations inside ``resolve_source_visible_frame``."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __enter__(self):
+        from sugar_source_tree.tree import SourceFile
+
+        self._original = SourceFile
+        counter = self
+
+        class CountingSourceFile(SourceFile):
+            def __init__(self, *args, **kwargs):
+                counter.count += 1
+                super().__init__(*args, **kwargs)
+
+        mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]
+        return self
+
+    def __exit__(self, *exc):
+        mc.SourceFile = self._original  # type: ignore[misc, assignment]
+        return False
+
+
+# ---------------------------------------------------------------- twin 1
+
+
+def test_cold_result_equals_warm_result(tmp_path: Path) -> None:
+    """A warm memo answers exactly what a cold resolution answers."""
+    project = _project(tmp_path, "p", _IMPL_A)
+
+    cold = _verdict(project, SourceResolutionSession())
+    session = SourceResolutionSession()
+    _verdict(project, session)  # warm it
+    warm = _verdict(project, session)
+
+    assert cold == warm
+
+    # Discrimination: the memo is genuinely consulted, so equality above is not
+    # vacuous -- a warm session re-answers without re-materializing.
+    assert session.export_resolutions and session.frame_results
+    with _MaterializeCounter() as counter:
+        _verdict(project, session)
+    assert counter.count == 0, "warm session still re-materialized: memo is dead"
+    with _MaterializeCounter() as cold_counter:
+        _verdict(project, SourceResolutionSession())
+    assert cold_counter.count >= 1, "cold session did no work: twin cannot bite"
+
+
+# ---------------------------------------------------------------- twin 2
+
+
+def test_a_then_b_equals_b_then_a(tmp_path: Path) -> None:
+    """Resolution order inside one session cannot change either answer."""
+    a = _project(tmp_path, "a", _IMPL_A)
+    b = _project(tmp_path, "b", _IMPL_B)
+
+    forward = SourceResolutionSession()
+    a_first = _verdict(a, forward)
+    b_second = _verdict(b, forward)
+
+    backward = SourceResolutionSession()
+    b_first = _verdict(b, backward)
+    a_second = _verdict(a, backward)
+
+    assert a_first == a_second
+    assert b_first == b_second
+
+    # Discrimination: A and B really do answer differently, so an order that
+    # leaked one into the other would have been caught above.
+    assert a_first["fragment_cid"] != b_first["fragment_cid"]
+
+
+# ---------------------------------------------------------------- twin 3
+
+
+def test_isolated_result_equals_result_after_other_work(tmp_path: Path) -> None:
+    """A project's answer is the same alone as it is after a full population."""
+    target = _project(tmp_path, "target", _IMPL_A)
+    noise = _project(tmp_path, "noise", _IMPL_B)
+
+    isolated = _verdict(target, SourceResolutionSession())
+
+    crowded_session = SourceResolutionSession()
+    _verdict(noise, crowded_session)
+    crowded = _verdict(target, crowded_session)
+
+    assert isolated == crowded
+
+    # Discrimination: the noise really ran and really populated the session, so
+    # "crowded" is not secretly the isolated path.
+    assert len(crowded_session.frame_results) >= 2
+
+
+# ---------------------------------------------------------------- twin 4
+
+
+def test_changed_source_content_invalidates_the_answer(tmp_path: Path) -> None:
+    """Different source content must never be served the earlier answer."""
+    session = SourceResolutionSession()
+    before = _verdict(_project(tmp_path, "v1", _IMPL_A), session)
+    after = _verdict(_project(tmp_path, "v2", _IMPL_B), session)
+
+    # Discrimination arm and assertion are the same edge: the memo did not
+    # answer for content it never saw.
+    assert before["source_cid"] != after["source_cid"], "sourceStamp did not move"
+    assert before["fragment_cid"] != after["fragment_cid"]
+    assert before["frame_cid"] != after["frame_cid"]
+
+    # ...and the unchanged half still agrees, so the difference is content, not
+    # session churn.
+    assert before["module_name"] == after["module_name"]
+    assert before["target_name"] == after["target_name"]
+
+
+# ---------------------------------------------------------------- twin 5
+
+
+def test_equal_paths_under_different_authorities_do_not_alias(tmp_path: Path) -> None:
+    """Same module path + same exported name, different authority, no alias."""
+    session = SourceResolutionSession()
+    left_graph, _ = left = _project(tmp_path, "left", _IMPL_A)
+    right_graph, _ = right = _project(tmp_path, "right", _IMPL_B)
+
+    left_answer = _verdict(left, session)
+    right_answer = _verdict(right, session)
+
+    # Everything a path-or-name key would see is identical...
+    assert left_answer["module_name"] == right_answer["module_name"]
+    assert left_answer["target_name"] == right_answer["target_name"]
+    # ...and the authority is the only thing separating them.
+    assert left_graph.distribution_artifact_cid != right_graph.distribution_artifact_cid
+    assert left_answer["fragment_cid"] != right_answer["fragment_cid"]
+
+    # Discrimination: drop the authority from the key and the two collapse to
+    # one entry -- which is exactly the aliasing this twin forbids.
+    keys = list(session.export_resolutions)
+    assert len({key[0] for key in keys}) == 2, keys
+    assert len({key[1:] for key in keys}) == 1, keys
+
+
+# ---------------------------------------------------------------- twin 6
+
+
+def test_distinct_sessions_do_not_share_a_control_context(tmp_path: Path) -> None:
+    """No construction ever reads another construction's live context.
+
+    The projected ``target`` Node is bound to a ``TreeConstructionContextV1``
+    that the projection WRITES into (``source_class_bases``,
+    ``source_call_frames``). Two sessions must therefore never be handed the
+    same node object.
+    """
+    graph, receipt = project = _project(tmp_path, "p", _IMPL_A)
+
+    def project_target(session):
+        resolved = _resolve(project, session)
+        _frame, target = resolve_source_visible_frame(
+            resolved, graph=graph, session=session
+        )
+        return target
+
+    first = project_target(SourceResolutionSession())
+    second = project_target(SourceResolutionSession())
+
+    assert first is not second
+    assert first.unit.construction_context is not second.unit.construction_context
+
+    # Discrimination: inside ONE session the node IS shared -- that is the
+    # amortization this repair preserves, and it proves the check above is
+    # detecting session identity rather than always-fresh construction.
+    shared = SourceResolutionSession()
+    assert project_target(shared) is project_target(shared)
+
+
+# ---------------------------------------------------------------- twin 7
+
+
+def test_one_project_cannot_warm_another_projects_result(tmp_path: Path) -> None:
+    """A warm session for project A does no work on behalf of project B."""
+    a = _project(tmp_path, "a", _IMPL_A)
+    b = _project(tmp_path, "b", _IMPL_A)  # byte-identical module source
+
+    session_a = SourceResolutionSession()
+    _verdict(a, session_a)
+
+    session_b = SourceResolutionSession()
+    with _MaterializeCounter() as counter:
+        _verdict(b, session_b)
+    assert counter.count >= 1, "project B was served project A's materialization"
+
+    # The memo KEYS may coincide -- byte-identical content addresses to the same
+    # CID, and that is what content addressing means.  What must never coincide
+    # is the VALUE: a projected node carries a live construction context, and
+    # project B must own its own.
+    (a_frame, a_target), = session_a.frame_results.values()
+    (b_frame, b_target), = session_b.frame_results.values()
+    assert a_target is not b_target
+    assert a_frame is not b_frame
+    assert a_target.unit.construction_context is not b_target.unit.construction_context
+
+    # Discrimination: the two projects are as alias-prone as they can be -- same
+    # module name, same exported name, same source bytes, same artifact CID --
+    # and still nothing crosses.
+    assert a[0].distribution_artifact_cid == b[0].distribution_artifact_cid
+    assert set(session_a.frame_results) == set(session_b.frame_results)
+
+
+# ---------------------------------------------------------------- twin 8
+
+
+def test_memo_disablement_changes_performance_only(tmp_path: Path) -> None:
+    """The load-bearing law: a memo that changes an answer is not a memo."""
+    project = _project(tmp_path, "p", _IMPL_A)
+
+    enabled = SourceResolutionSession(enabled=True)
+    disabled = SourceResolutionSession(enabled=False)
+
+    with _MaterializeCounter() as enabled_counter:
+        first_enabled = _verdict(project, enabled)
+        second_enabled = _verdict(project, enabled)
+
+    with _MaterializeCounter() as disabled_counter:
+        first_disabled = _verdict(project, disabled)
+        second_disabled = _verdict(project, disabled)
+
+    # Formulas, gaps and verdicts are identical under both settings.
+    assert first_enabled == second_enabled == first_disabled == second_disabled
+
+    # Discrimination: disablement is real -- it costs work, and only work.
+    assert not disabled.export_resolutions and not disabled.frame_results
+    assert disabled_counter.count > enabled_counter.count, (
+        f"disabled did {disabled_counter.count} materializations vs enabled "
+        f"{enabled_counter.count}; the switch is not doing anything"
+    )
+
+
+# --------------------------------------------------- gaps are memoized too
+
+
+def test_disablement_preserves_gap_verdicts(tmp_path: Path) -> None:
+    """A gap answers identically warm, cold, and with the memo switched off."""
+    root = tmp_path / "gap"
+    _install(root, implementation_source="def build(value):\n    return other(value)\n")
+    distribution = importlib.metadata.Distribution.at(
+        root / "example_dist-1.0.dist-info"
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    receipt = _receipt(root)
+
+    def answer(session):
+        resolved = resolve_import_binding(receipt, graph=graph, session=session)
+        assert isinstance(resolved, ResolvedPythonObjectV1)
+        return resolve_source_visible_frame(resolved, graph=graph, session=session)
+
+    warm_session = SourceResolutionSession()
+    first_warm = answer(warm_session)
+    second_warm = answer(warm_session)
+    cold = answer(SourceResolutionSession())
+    off = answer(SourceResolutionSession(enabled=False))
+
+    assert isinstance(first_warm, mc.ManagerConstructionGapV1), first_warm
+    assert first_warm == second_warm == cold == off
+
+
+# ------------------------------------------------- both sides of the door
+#
+# The twins above are only worth their runtime if they fail when the memo is
+# put back into a shape this repair forbids.  These two tests run the other
+# side of that discriminator in-process, so the bite is executable rather than
+# asserted in a commit message.
+
+
+@pytest.fixture
+def leaky_process_memo(monkeypatch):
+    """Restore the defect: every session shares ONE set of process-wide tables."""
+    exports: dict = {}
+    frames: dict = {}
+    holds: dict = {}
+    active: set = set()
+
+    def leaky_init(self, *, enabled: bool = True) -> None:
+        self.enabled = enabled
+        self.export_resolutions = exports
+        self.frame_results = frames
+        self.frame_holds = holds
+        self.frame_active = active
+
+    monkeypatch.setattr(SourceResolutionSession, "__init__", leaky_init)
+
+
+@pytest.fixture
+def authority_blind_key(monkeypatch):
+    """Restore the other defect: a key that forgot an authenticated input."""
+
+    def strip(key):
+        return key[1:]  # drop distribution_artifact_cid
+
+    monkeypatch.setattr(
+        SourceResolutionSession,
+        "export_hit",
+        lambda self, key: self.export_resolutions.get(strip(key))
+        if self.enabled
+        else None,
+    )
+    monkeypatch.setattr(
+        SourceResolutionSession,
+        "remember_export",
+        lambda self, key, result: self.export_resolutions.__setitem__(
+            strip(key), result
+        )
+        if self.enabled
+        else None,
+    )
+    monkeypatch.setattr(
+        SourceResolutionSession,
+        "frame_hit",
+        lambda self, key: self.frame_results.get(strip(key)) if self.enabled else None,
+    )
+    monkeypatch.setattr(
+        SourceResolutionSession,
+        "remember_frame",
+        lambda self, key, result, hold=None: self.frame_results.__setitem__(
+            strip(key), result
+        )
+        if self.enabled
+        else None,
+    )
+
+
+def test_process_wide_memo_leaks_one_project_into_another(
+    tmp_path: Path, leaky_process_memo
+) -> None:
+    """DISCRIMINATION for twins 1/6/7/8: shared tables serve a foreign context."""
+    a = _project(tmp_path, "a", _IMPL_A)
+    b = _project(tmp_path, "b", _IMPL_A)
+
+    _verdict(a, SourceResolutionSession())
+    with _MaterializeCounter() as counter:
+        _verdict(b, SourceResolutionSession())
+
+    assert counter.count == 0, (
+        "the leaky shape was expected to serve project B from project A's "
+        "materialization; if this no longer reproduces, the twins guarding it "
+        "have stopped biting and must be re-derived"
+    )
+
+
+def test_authority_blind_key_aliases_two_distributions(
+    tmp_path: Path, authority_blind_key
+) -> None:
+    """DISCRIMINATION for twins 2/3/4/5: dropping the authority aliases them."""
+    session = SourceResolutionSession()
+    left_project = _project(tmp_path, "left", _IMPL_A)
+    right_project = _project(tmp_path, "right", _IMPL_B)
+
+    left = _resolve(left_project, session)
+    right = _resolve(right_project, session)
+
+    assert left.definition.fragment_cid == right.definition.fragment_cid, (
+        "a key missing distribution_artifact_cid was expected to serve the "
+        "left distribution's definition for the right one; if it no longer "
+        "does, the twins guarding the key have stopped biting"
+    )
+    # The forged answer still carries the WRONG artifact authority, which the
+    # downstream projection floor then refuses rather than constructing.  A
+    # wrong memo does not get to be quiet: it becomes a gap.
+    assert right.distribution_artifact_cid != (
+        right_project[0].distribution_artifact_cid
+    )
+    projected = resolve_source_visible_frame(
+        right, graph=right_project[0], session=session
+    )
+    assert isinstance(projected, mc.ManagerConstructionGapV1)
+    assert projected.kind == "artifact-mismatch"


### PR DESCRIPTION
Own every source-resolution memo with a bounded session

## The defect

`_SOURCE_VISIBLE_FRAME_CACHE` and `_EXPORT_RESOLUTION_CACHE` were module-level
dicts. Both keys are content addresses, so the *key* was not the bug. The *value*
was.

`_resolve_source_visible_frame_uncached` mints a fresh
`TreeConstructionContextV1` and **writes into** its mutable
`source_class_bases` / `source_call_frames` tables while it projects. The
`(frame, target)` it returns are Nodes bound to that live context. Caching them
in module state means the next construction -- next test, next file, next
project in a long-lived `lift_rpc` daemon -- is handed somebody else's context.

Measured on unmodified `origin/main` (f7fe8b9), two independent projects, each
with its own temp root, its own `authenticate` call, its own construction:

```
project A: artifact_cid=blake3-512:bf73926a6674b context_id=4472776960 target_id=4473325280
project B: artifact_cid=blake3-512:bf73926a6674b context_id=4472776960 target_id=4473325280

SAME target node object served to both projects: True
SAME construction context served to both projects: True
```

After this change:

```
SAME target node object served to both projects: False
SAME construction context served to both projects: False
```

## The shape

`SourceResolutionSession` (`resolution_session.py`) owns both memos plus the
re-entrancy set. It is threaded as `session=` through `resolve_export`,
`resolve_import_binding`, `resolve_source_visible_frame`,
`_resolve_external_call_frame`, `construct_manager_behavior`,
`populate_source_visible_call_frames` and
`populate_source_derived_resource_refs`. `None` opens a session bounded to that
single call -- it never means "share the process".

Session, not a bigger global key, on purpose: an elaborate global key is how
this class of bug returns, because every newly authenticated input is one more
thing someone forgets to add. Precedent read first: `ConstructionCache`
(per-unit, `_pinned` against `id()` reuse) for the session shape;
`_SHAPE_CIDS` / `_interned` for the registries that are legitimately global
because the CID *is* the complete key.

The autouse fixture in `test_external_call_target_construction.py` that scrubbed
globals is deleted. There is no process state left to scrub.

## Twins

`tests/test_resolution_session_authority.py`, 11 tests, all green. Each of T's
eight, plus a gap-verdict twin and two executable discrimination tests that run
the *other* side of the door in-process:

| twin | bites under |
| --- | --- |
| cold == warm | value-sharing perturbation |
| A->B == B->A | authority-blind key |
| isolated == full-package | authority-blind key |
| changed content/sourceStamp invalidates | authority-blind key |
| equal paths, different authorities do not alias | authority-blind key |
| distinct control contexts do not alias | value-sharing perturbation |
| one project cannot warm another's | value-sharing perturbation |
| disablement is performance-only | value-sharing perturbation |

The two perturbations partition the eight cleanly, which is itself the finding:
four twins guard the key (already correct), four guard the value (the actual
defect). `test_process_wide_memo_leaks_one_project_into_another` and
`test_authority_blind_key_aliases_two_distributions` assert the perturbed shape
*fails*, so the bite is executable rather than claimed.

`enabled=False` is asserted to change materialization count and nothing else --
no formula, no gap, no verdict.

## Epsilon R

- **Axis lowered**: source-resolution memo authority. R(module-level caches
  leaking across source/test scopes in `sugar-lift-python-source`) 2 -> 0.
- **Predicted Epsilon R**: 0 verdicts. This is a measurement-integrity repair:
  it restores `sugar-lift-python-source` counts to authoritative, so corpus
  Delta R may again be claimed from this package.
- **Floors preserved**: no panic weakened, no fallback added, no test deleted or
  skipped. The amortization instruments
  (`test_resolve_export_amortizes_repeated_static_scans`,
  `test_resolve_source_visible_frame_amortizes_repeated_materialize`) still
  demand O(1) recompute -- now per session, which is where amortization belongs.

## Reported, not fixed: a third offender, worse than these two

`_AUTHENTICATE_GRAPH_CACHE` (`dependency_artifact.py:31`) is keyed by the
**dist-info path alone** -- no content, no stat. Measured:

```
on-disk source now: 'def build(value):\n    return value + 1\n'
graph 1 source:     'def build(value):\n    return value\n'
graph 2 source:     'def build(value):\n    return value\n'
STALE: second authenticate returned the first graph: True
```

Authenticating a *changed* installation returns the stale graph, and the
artifact CID it reports does not match the bytes on disk. It fails twin 4
outright. Note the neighbouring disk cache deliberately stats `RECORD` while
this in-memory one checks nothing.

Not fixed here: unlike this repair, correcting it can legitimately change
verdicts (a corpus run currently reading stale graphs would start reading fresh
ones), and that must not ride along inside a change claiming zero verdict
change. Needs its own shot with its own before/after.

Same-shape caches worth a look, not touched: `_REVALIDATION_SNAPSHOTS`
(`sugar-lift-py-tests/import_binding.py:680`, keyed by resolved path + content
+ identity hash -- content is in the key, but it carries its own
`clear_lexical_revalidation_snapshots` diagnostic), and `_SPLIT_CACHE`
(`sugar_pytest_witness/lift_lsp.py:234`).

## Cost to know about

The default session is now per source file, where the module globals were
per process. In the `lift_rpc` daemon that removes cross-file amortization of a
shared dependency's projection. `populate_*` already takes `artifact_graph_cache`
for exactly this "caller owns the run-scoped table" purpose; threading one
`SourceResolutionSession` per lift request alongside it restores
project-scoped amortization without process-scoped leakage. Deliberately left to
the caller so widening the memo's scope is an explicit, auditable act rather
than an accident.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace process-global resolution caches with bounded `SourceResolutionSession` objects
> - Introduces [`SourceResolutionSession`](https://github.com/TSavo/sugar/pull/6266/files#diff-54257d48026540505071d0613a7c672ce198dc916935415abb69c38a81451ce5), a new class that owns memoization state for export resolutions and source-visible frame projections, including in-session cycle detection.
> - Removes process-global caches (`_EXPORT_RESOLUTION_CACHE`, `_SOURCE_VISIBLE_FRAME_CACHE`, etc.) and their `clear_*` functions from [`dependency_export_adapter.py`](https://github.com/TSavo/sugar/pull/6266/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) and [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6266/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1).
> - All public resolution entry points (`resolve_import_binding`, `resolve_export`, `resolve_source_visible_frame`, `construct_manager_behavior`, etc.) now accept an optional `session` parameter; when omitted, a fresh per-call session is created via `session_or_new`.
> - Behavioral Change: `clear_export_resolution_cache` and `clear_source_visible_frame_cache` are removed; callers that relied on them to isolate test state or reset process-wide memo must now manage sessions explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab58d3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->