### PR TITLE
test: five opposing teeth on the vendored-corpus boundary (#6260)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_vendor_corpus_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_vendor_corpus_boundary.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Opposing teeth on the vendored-corpus boundary (#6260).
+
+T's ruling naming the category:
+
+    Vendored source fixtures are authenticated corpus data, not executable
+    pytest modules.
+
+`tests/vendor/**` is hash-pinned LIFT CORPUS. The suite reads those files as
+BYTES and parses them as AST; it never imports them. Their sha256 pins are the
+law, so they may not be edited. Because several are named `test_*.py`, pytest
+used to collect and import them — which both aborted collection when a
+third-party package was absent AND silently counted eight third-party
+assertions (numpy/pandas/requests) as Sugar passes.
+
+`tests/conftest.py` now carries `collect_ignore_glob = ["vendor/*/*.py"]`.
+
+These five teeth are deliberately OPPOSING. Tooth 1 asserts pytest does NOT
+see the corpus. Tooth 2 asserts the corpus loader DOES read every byte of it
+and verifies the pin. A change that satisfies one by breaking the other must
+turn something red here.
+
+Nothing in this module ever writes to the committed tree. Tooth 4 mutates a
+byte only in a `tmp_path` copy; tooth 5 builds its nested source only in a
+`tmp_path` structure.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import conftest as suite_conftest
+from claim_mass_corpus import ClaimMassPin
+from test_claim_mass_tripwires import PINS, _source_digest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VENDOR_DIR = TESTS_DIR / "vendor"
+PACKAGE_ROOT = TESTS_DIR.parent
+
+
+def _collect_only(target: Path, *, rootdir: Path) -> list[str]:
+    """Return the node IDs pytest collects under ``target``.
+
+    Runs a real out-of-process `pytest --collect-only`, because the thing under
+    test is pytest's own collection behaviour, not our model of it.
+    """
+    env = dict(os.environ)
+    # Collection must not depend on a resolved sugar binary or on ambient pool
+    # state; it only imports conftest.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(target),
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            "no:randomly",
+        ],
+        cwd=str(rootdir),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        # A vendored corpus module that pytest tries to IMPORT is the exact
+        # failure #6260 removed: collection aborts on the third-party import
+        # before any node ID is printed. Name that, don't report a return code.
+        vendor_errors = [
+            line.strip()
+            for line in proc.stdout.splitlines()
+            if "ERROR" in line and "vendor/" in line.replace(os.sep, "/")
+        ]
+        assert not vendor_errors, (
+            "pytest tried to IMPORT hash-pinned vendored corpus and collection "
+            f"aborted: {vendor_errors}; vendored source fixtures are "
+            "authenticated corpus data, not executable pytest modules. "
+            "replacement=widen `tests/conftest.py::collect_ignore_glob` — never "
+            "edit a vendor file to make it importable"
+        )
+        raise AssertionError(
+            "pytest --collect-only failed for reasons unrelated to the vendor "
+            f"boundary.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    node_ids = [
+        line.strip()
+        for line in proc.stdout.splitlines()
+        if "::" in line and not line.startswith(" ")
+    ]
+    assert node_ids, (
+        "collection produced no node IDs at all; a suite that collects nothing "
+        f"cannot witness this boundary.\nstdout:\n{proc.stdout}"
+    )
+    return node_ids
+
+
+def _vendor_node_ids(node_ids: list[str]) -> list[str]:
+    return [
+        node_id
+        for node_id in node_ids
+        if "vendor/" in node_id.split("::", 1)[0].replace(os.sep, "/")
+    ]
+
+
+# --------------------------------------------------------------------------
+# Tooth 1 — pytest does NOT see the corpus.
+# --------------------------------------------------------------------------
+def test_pytest_collects_no_vendor_node_ids() -> None:
+    """`pytest --collect-only` contains no `tests/vendor/**` node IDs.
+
+    Neutral: asserts the vendor slice is EMPTY, never a count of vendor files.
+    """
+    node_ids = _collect_only(TESTS_DIR, rootdir=PACKAGE_ROOT)
+    offenders = _vendor_node_ids(node_ids)
+    assert offenders == [], (
+        "pytest collected hash-pinned vendored corpus as test modules: "
+        f"{offenders}; vendored source fixtures are authenticated corpus data, "
+        "not executable pytest modules. replacement=widen "
+        "`tests/conftest.py::collect_ignore_glob` to cover them — never edit a "
+        "vendor file to make it collectable"
+    )
+
+
+# --------------------------------------------------------------------------
+# Tooth 2 — the corpus loader DOES read every vendor artifact, and verifies
+# its pin. This is the opposing tooth to #1: non-collection must not have
+# blinded the corpus tooling.
+# --------------------------------------------------------------------------
+def _pinned_files() -> set[Path]:
+    covered: set[Path] = set()
+    for pin in PINS:
+        path = VENDOR_DIR / pin.relative_path
+        assert path.exists(), (
+            f"pin {pin.name!r} names a missing corpus artifact {path}; "
+            "replacement=restore the artifact or retire the pin loudly"
+        )
+        covered.update(sorted(path.rglob("*.py")) if path.is_dir() else [path])
+    return covered
+
+
+def test_every_vendor_artifact_is_still_read_and_pinned() -> None:
+    """Every `.py` byte under `tests/vendor` is claimed by a corpus pin.
+
+    Neutral: compares two derived SETS. It never hardcodes how many vendor
+    files exist, so adding corpus is free — adding UNPINNED corpus is not.
+    """
+    on_disk = set(VENDOR_DIR.rglob("*.py"))
+    assert on_disk, (
+        f"no vendored corpus found under {VENDOR_DIR}; the boundary this module "
+        "guards would be vacuous"
+    )
+    unpinned = sorted(
+        str(path.relative_to(VENDOR_DIR)) for path in on_disk - _pinned_files()
+    )
+    assert unpinned == [], (
+        f"vendored corpus is present but read by no pin: {unpinned}. Excluding "
+        "`tests/vendor/**` from pytest collection must not make it invisible to "
+        "the corpus loader. replacement=enroll each file in a `ClaimMassPin` in "
+        "`tests/test_claim_mass_tripwires.py`"
+    )
+
+
+@pytest.mark.parametrize("pin", PINS, ids=lambda pin: pin.name)
+def test_corpus_loader_verifies_the_pinned_hash(pin: ClaimMassPin) -> None:
+    """The loader reads the real bytes and the pinned digest still matches."""
+    path = VENDOR_DIR / pin.relative_path
+    files = sorted(path.rglob("*.py")) if path.is_dir() else [path]
+    assert files, f"pin {pin.name!r} covers no files under {path}"
+    assert _source_digest(path, files) == pin.sha256, (
+        f"{pin.name} corpus drifted from its pin; replacement=re-pin the hash, "
+        "assertion count, and lifted loci in the same PR"
+    )
+
+
+# --------------------------------------------------------------------------
+# Tooth 4 — mutating a vendor byte breaks the corpus hash law even though
+# pytest ignores the file. The mutation happens ONLY in a tmp copy.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("pin", PINS, ids=lambda pin: pin.name)
+def test_a_flipped_vendor_byte_still_breaks_the_pin(
+    pin: ClaimMassPin, tmp_path: Path
+) -> None:
+    """Non-collection must not weaken the pin.
+
+    Copies the corpus, flips one byte in the copy, and shows the loader's
+    digest law rejects it. The committed tree is never touched.
+    """
+    mirror = tmp_path / "vendor"
+    shutil.copytree(VENDOR_DIR, mirror)
+    path = mirror / pin.relative_path
+    files = sorted(path.rglob("*.py")) if path.is_dir() else [path]
+
+    assert _source_digest(path, files) == pin.sha256, (
+        "the untouched tmp mirror must reproduce the pin exactly, otherwise "
+        "this tooth cannot attribute the mismatch to the flipped byte"
+    )
+
+    victim = files[0]
+    original = victim.read_bytes()
+    # A comment byte: parseable Python, different bytes. The point is the pin,
+    # not the parse.
+    victim.write_bytes(original + b"\n# corpus tamper probe\n")
+
+    assert _source_digest(path, files) != pin.sha256, (
+        f"{pin.name}: a changed vendor byte did NOT break the corpus hash law. "
+        "The pin is the only thing holding this corpus authentic now that "
+        "pytest does not collect it"
+    )
+
+
+# --------------------------------------------------------------------------
+# Teeth 3 and 5 — the glob's SHAPE. Reuses the suite's real
+# `collect_ignore_glob` value so this can never drift from the boundary it
+# describes.
+# --------------------------------------------------------------------------
+_SIBLING_OWNED_TEST = "test_claim_mass_tripwires.py"
+
+
+def test_owned_tests_adjacent_to_vendor_remain_collected() -> None:
+    """Tooth 3: the glob must not over-reach onto our own modules.
+
+    Asserts the sibling owned module that OWNS the vendor pins is still
+    collected — the exclusion removes corpus, not the tooling that reads it.
+    """
+    node_ids = _collect_only(TESTS_DIR, rootdir=PACKAGE_ROOT)
+    owned = [node_id for node_id in node_ids if _SIBLING_OWNED_TEST in node_id]
+    assert owned, (
+        f"{_SIBLING_OWNED_TEST} is no longer collected; "
+        "`collect_ignore_glob` has over-reached from vendored corpus onto our "
+        f"own tests. collected={len(node_ids)}"
+    )
+
+
+def test_a_new_nested_vendor_source_cannot_become_a_pytest_test(
+    tmp_path: Path,
+) -> None:
+    """Tooth 5: the boundary holds for corpus files that do not exist yet.
+
+    The glob's DEPTH is the thing under test. `tests/vendor` today holds both
+    `<dist>/test_x.py` (depth 2) and `<dist>/<pkg>/*.py` (depth 3, the
+    vendored `requests` package). A future nested corpus module named
+    `test_*.py` must not become collectable.
+
+    Built entirely in tmp_path, with the suite's REAL glob value.
+    """
+    glob = suite_conftest.collect_ignore_glob
+    root = tmp_path / "tests"
+    (root / "vendor" / "somepkg-1.0" / "somepkg" / "deep").mkdir(parents=True)
+    (root / "conftest.py").write_text(f"collect_ignore_glob = {glob!r}\n")
+    (root / "test_owned.py").write_text("def test_owned():\n    assert True\n")
+
+    nested = [
+        root / "vendor" / "somepkg-1.0" / "test_shallow.py",
+        root / "vendor" / "somepkg-1.0" / "somepkg" / "test_nested.py",
+        root / "vendor" / "somepkg-1.0" / "somepkg" / "deep" / "test_deeper.py",
+    ]
+    for source in nested:
+        source.write_text(
+            "import definitely_not_installed_third_party\n\n\n"
+            "def test_vendor_owned_assertion():\n    assert True\n"
+        )
+
+    node_ids = _collect_only(root, rootdir=tmp_path)
+
+    offenders = _vendor_node_ids(node_ids)
+    assert offenders == [], (
+        f"a nested vendored source became a pytest test: {offenders}. "
+        f"collect_ignore_glob={glob!r} does not cover this depth; "
+        "replacement=widen the glob (e.g. `vendor/**/*.py`) — corpus at ANY "
+        "depth is data, not our test suite"
+    )
+    assert any("test_owned.py" in node_id for node_id in node_ids), (
+        f"collect_ignore_glob={glob!r} over-reached and swallowed an owned "
+        f"sibling test. collected={node_ids}"
+    )


### PR DESCRIPTION
## Axis

Lock the enrollment boundary established by #6260 with five opposing teeth.

T's ruling names the category: **vendored source fixtures are authenticated corpus data, not executable pytest modules.** `tests/vendor/**` is hash-pinned lift corpus — cpython `datetime.py`, itsdangerous / numpy / pandas / requests sources the suite reads as BYTES and parses as AST, never imports. Their sha256 pins are law; they may not be edited.

#6260 stopped pytest collecting them. Nothing yet stopped a later edit from undoing that — or, worse, from satisfying non-collection by *blinding the corpus loader*. Before #6260, eight third-party assertions (numpy/pandas/requests) were silently counted as Sugar passes on any box where those packages happened to be installed. That denominator is now honest; these teeth keep it honest in both directions.

## The five teeth (all in `tests/test_vendor_corpus_boundary.py`)

| # | Assertion | Bite (perturb → red → revert) |
|---|---|---|
| 1 | `pytest --collect-only` contains no `tests/vendor/**` node IDs. Real out-of-process collection; asserts the vendor slice is **empty**, never a file count. | glob → `vendor/NOPE/*.py`: `ERROR tests/vendor/itsdangerous-2.2.0/test_serializer.py`, `Interrupted: 1 error during collection` → **FAILED** `test_pytest_collects_no_vendor_node_ids` |
| 2 | **Opposing tooth.** Every `.py` under `tests/vendor` is claimed by a `ClaimMassPin`, and the loader re-reads the bytes and re-verifies each pinned sha256. | drop the first pin from `PINS`: `AssertionError: vendored corpus is present but read by no pin: [... 22 files ...]` → **FAILED** `test_every_vendor_artifact_is_still_read_and_pinned` |
| 3 | The owned sibling that OWNS the pins (`test_claim_mass_tripwires.py`) stays collected — the glob must not over-reach. | glob += `"test_claim_mass_*.py"`: `test_claim_mass_tripwires.py is no longer collected; collect_ignore_glob has over-reached ... collected=1166` → **FAILED** |
| 4 | A flipped vendor byte still breaks the corpus hash law even though pytest ignores the file. | make the tamper a no-op (`write_bytes(original)`): all 5 pins **FAILED** — `assert 'eb729075…' != 'eb729075…'` |
| 5 | A nested vendored source at depth 2 **and** depth 3+ cannot become a pytest test. Built in `tmp_path` from the suite's **real** `collect_ignore_glob` value, so the probe cannot drift from the boundary it describes. | glob → `vendor/cpython-3.11/*.py`: `ERROR .../test_shallow.py`, `.../somepkg/test_nested.py`, `.../deep/test_deeper.py` → **FAILED** |

Teeth 1 and 2 are deliberately opposing: one asserts pytest does NOT see these files, the other asserts the corpus loader DOES. A change that satisfies one by breaking the other turns something red.

**No vendor byte is ever changed.** Tooth 4 copies `tests/vendor` into `tmp_path` and mutates the copy (asserting the untouched mirror reproduces the pin first, so the mismatch is attributable). Tooth 5 builds its nested corpus entirely in `tmp_path`. `git status` is clean after every bite.

## Glob correction: none needed — and a measured finding

No change to `collect_ignore_glob`. Measured: pytest's `_pytest.pathlib.fnmatch_ex` uses `fnmatch`, whose `*` **crosses path separators**, so `vendor/*/*.py` already covers arbitrary depth:

```
'vendor/*.py'              -> [True,  True ]   # a-1.0/test_x.py, a-1.0/a/deep/test_y.py
'vendor/*/*.py'            -> [True,  True ]
'vendor/**/*.py'           -> [True,  True ]
'vendor/cpython-3.11/*.py' -> [False, False]
```

That depth coverage was incidental. Tooth 5 now pins it: a *narrowed* glob (anchored to one corpus subtree) turns red. Epsilon R for a glob correction: n/a — none was required.

## Floors preserved

No test deleted, skipped, or weakened. No production change. `collect_ignore_glob` byte-identical to `origin/main`. No vendor byte touched.

## Epsilon R

- **Predicted Epsilon R: 0.** +5 instruments (14 node IDs, all parametrized over the real pins), 0 production change.
- Local, package as rootdir: `14 passed in 8.89s`.
- Whole-package collection unchanged: `--collect-only -q` yields **0** `tests/vendor/**` node IDs on this branch, same as `origin/main`.
- These teeth are independent of the `sugar-lift-py-tests` failed-node-ID baseline (provisional pending the module-level cache order-dependence repair) — none of them read a pass count.

## Survey (reported, not fixed here)

**Other corpus dirs with the same trap:** none armed. `tests/vendor` is the only directory containing third-party `test_*.py` under a Python test root. The ~50 other `vendor/` dirs (`examples/**`, `implementations/java/sugar-lift-java-tests/tests/fixtures/**`) hold Java/example sources that pytest never walks. No other `collect_ignore` in the repo.

**Remaining hand-written parallel test-dependency lists.** T: *"workflows must not maintain parallel hand-written test dependency lists."* `pyproject.toml[test]` is the authority (`pytest>=7, black, pyright, itsdangerous, numpy, pandas, …`). These install `sugar-lift-py-tests` **without** `[test]` and hand-list `pytest` instead:

- `.github/workflows/bare-exception-zero-tolerance.yml:27`
- `.github/workflows/factory-zero-tolerance.yml:45` (also hand-lists `tqdm`)
- `.github/workflows/native-crash-zero-tolerance.yml:25`
- `.github/workflows/timeout-zero-tolerance.yml:26`

And these use `[test]` correctly but still hand-list runtime deps alongside it:

- `.github/workflows/ci.yml:129,178` — `blake3 pynacl cbor2 pytest`
- `.github/workflows/restored-suite-scoreboard.yml:62-63` — `pandas`
- `.github/workflows/numpy-wall.yml:44`, `pandas-wall.yml:44` — `numpy` / `pandas` (deliberate wall inputs, but already in `[test]`)

Left out of scope: four of these are the zero-tolerance floors, and swapping their install line is a CI change with its own Epsilon R, not a test-instrument change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add five tests enforcing the vendored-corpus boundary in the test suite
> - Adds [test_vendor_corpus_boundary.py](https://github.com/TSavo/sugar/pull/6267/files#diff-d28b4a3bad4e8dd1f1e9d01f4c44274eecbf9959ac46477400a3626e141460ea) with five tests that assert pytest never collects files under `tests/vendor/`, all vendored `.py` files are covered by a pin, pinned hashes match on-disk content, byte mutations break the digest, and `collect_ignore_glob` does not overreach onto owned tests.
> - Uses an out-of-process `pytest --collect-only` helper to get real collection results, avoiding false positives from in-process collection.
> - Parametrized hash and mutation tests run per-pin, so adding a new vendored artifact without a pin entry causes an immediate test failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 073b9db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->