### PR TITLE
perf: ConstructedValueV2 — a value authenticates its children's CIDs, not their subtrees

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -394,6 +394,37 @@ class LoopConstructionV1:
     def wire_graph(self) -> dict[str, Any]:
         return deepcopy(self._graph)
 
+    # ------------------------------------------------------------------
+    # The authenticated native identity of this constructed value.
+    #
+    # ``_graph`` is an ALREADY-SEALED wire document: its root is a Merkle root
+    # whose every field is either a scalar or the CID of a record in the store,
+    # and ``loop_construction_cid`` is ``hash(root minus its own CID field)`` --
+    # exactly what ``_validate_seal`` checks on decode. So this pair
+    # (``preimage``, ``cid``) is self-authenticating and covers the COMPLETE
+    # semantic content: ``target``, ``pre_state``, ``operation`` and
+    # ``completed_faces`` are the decoded forms of the very CIDs the root binds.
+    #
+    # Declaring it is what lets ConstructedValueV2 reference this value by its
+    # VALIDATED native CID instead of walking the raw wire document. Without
+    # the declaration, ``_graph`` is a bare ``dict`` holding bare ``list``s --
+    # mutable containers with no content coordinate, which ConstructedValueV2
+    # correctly refuses to snapshot and reports as a typed gap.
+    # ------------------------------------------------------------------
+    @property
+    def preimage(self) -> dict[str, Any]:
+        """The preimage ``loop_construction_cid`` is the hash of."""
+        return {
+            key: value
+            for key, value in self._graph["root"].items()
+            if key != "loopConstructionCid"
+        }
+
+    @property
+    def cid(self) -> str:
+        """This construction's authenticated native CID."""
+        return self.loop_construction_cid
+
 
 def _decode_record(raw: Any) -> LoopRecordV1:
     if not isinstance(raw, dict):

--- a/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
@@ -1,18 +1,19 @@
 """Canonicalization is content-addressed WORK: done once per value, never per path.
 
-``_canonical_constructed_value`` is a pure function of an immutable constructed
-value, and the constructed value graph is a DAG the recursion walks as a TREE.
-Measured on pandas ``core/indexes/base.py::_join_level``: 758,852 calls over
-1,544 distinct value objects -- 491x recomputation, and the reason a completed
-canonicalization made ``__internal_pivot_table`` take 976s.
+The ConstructedValueV2 CID of a value is a pure function of its immutable
+semantic content, and the constructed value graph is a DAG that a naive encoder
+walks as a TREE. Measured on pandas ``core/indexes/base.py::_join_level``:
+758,852 canonicalizations over 1,544 distinct value objects -- 491x
+recomputation, and the reason a completed canonicalization made
+``__internal_pivot_table`` take 976s.
 
 The memo is keyed by value IDENTITY (computing a content key is exactly the cost
 being removed) and each row holds a WEAK reference to the object it keyed. A hit
 is honored only when that weakref still resolves to the SAME object, so a dead
 value's recycled address (the #6212 id-reuse bug class) can never be served the
-dead object's canonical JSON.
+dead object's CID.
 
-These twins pin: the work collapses, the ANSWER does not change by one byte, a
+These twins pin: the work collapses, the ANSWER does not change by one bit, a
 distinct value never reads another value's row, a recycled address misses, and
 speed never comes from skipping testimony.
 """
@@ -24,9 +25,11 @@ import weakref
 from dataclasses import dataclass
 
 from sugar_source_tree import binding_state as BS
+from sugar_source_tree import construction_cache as CC
 from sugar_source_tree.binding_state import (
     ConstructionTestimonyReporterV1,
     SubstitutionTraceBuilderV1,
+    constructed_value_cid_v2,
 )
 from sugar_source_tree.backend import materialize
 from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
@@ -46,63 +49,54 @@ class Unserializable:
     pass
 
 
-def _counting_compute(only=None):
-    original = BS._compute_canonical_constructed_value
+def _counting_preimages():
+    """Count the preimages actually HASHED, which is the work being removed."""
+    original = BS.cid_of_json
     calls = {"n": 0}
 
     def counting(value):
-        if only is None or isinstance(value, only):
+        if isinstance(value, dict) and value.get("schema") == (
+            BS.CONSTRUCTED_VALUE_V2_SCHEMA
+        ):
             calls["n"] += 1
         return original(value)
 
-    BS._compute_canonical_constructed_value = counting
+    BS.cid_of_json = counting
     return calls, original
-
-
-def _function(src, name=None):
-    d = tempfile.mkdtemp()
-    p = os.path.join(d, "m.py")
-    with open(p, "w") as fh:
-        fh.write(src)
-    reporter = CollectingReporter()
-    sf = SourceFile.from_path(p, reporter=reporter)
-    for fn in sf.functions():
-        if name is None or getattr(fn, "name", None) == name:
-            return fn, reporter, sf
-    raise AssertionError("no function in fixture")
 
 
 def test_a_shared_value_canonicalizes_once_not_once_per_path():
     # The DAG-as-tree disease in miniature: one shared leaf reached by many
     # paths. Work must be a function of DISTINCT values, not of paths.
+    CC._CONSTRUCTED_VALUE_CIDS_V2.clear()
     shared = Held("leaf", (1, 2, 3))
     graph = Held("root", tuple(Held(f"branch{i}", (shared,)) for i in range(20)))
-    calls, original = _counting_compute(only=Held)
+    calls, original = _counting_preimages()
     try:
-        BS._canonical_constructed_value(graph)
+        constructed_value_cid_v2(graph)
         first = calls["n"]
-        BS._canonical_constructed_value(graph)
+        constructed_value_cid_v2(graph)
         second = calls["n"]
     finally:
-        BS._compute_canonical_constructed_value = original
-    # 1 root + 20 branches + 1 shared leaf, each computed exactly once...
-    assert first == 22, first
-    # ...and re-asking the same graph computes NOTHING new.
+        BS.cid_of_json = original
+    # 1 root + 1 root's tuple + 20 branches + 20 branch tuples + 1 shared leaf
+    # + 1 shared leaf's tuple, each hashed exactly once -- and the shared leaf
+    # ONCE, not once per incoming path.
+    assert first == 44, first
+    # ...and re-asking the same graph hashes NOTHING new.
     assert second == first, (first, second)
 
 
-def test_the_memo_returns_the_same_bytes_it_would_have_computed():
+def test_the_memo_returns_the_same_cid_it_would_have_computed():
     # Soundness: a wrong memo silently corrupts content addresses. Compare the
-    # warm answer against the answer computed with the memo bypassed entirely.
+    # warm answer against the answer computed with the memo emptied entirely.
     value = Held("root", (Held("a", (1,)), Held("b", ("x", b"\x00\x01")), None))
-    warm = BS._canonical_constructed_value(value)
-    warm_again = BS._canonical_constructed_value(value)
-    cold = BS._compute_canonical_constructed_value(value)
+    warm = constructed_value_cid_v2(value)
+    warm_again = constructed_value_cid_v2(value)
+    CC._CONSTRUCTED_VALUE_CIDS_V2.clear()
+    cold = constructed_value_cid_v2(value)
     assert warm == cold, (warm, cold)
     assert warm_again == cold
-    from sugar_lift_python_source.canonical import cid_of_json
-
-    assert cid_of_json(warm) == cid_of_json(cold)
 
 
 def test_a_distinct_value_never_reads_another_values_row():
@@ -110,16 +104,19 @@ def test_a_distinct_value_never_reads_another_values_row():
     # similar their shape or however adjacent their addresses.
     one = Held("same", (1,))
     two = Held("same", (2,))
-    assert BS._canonical_constructed_value(one) != BS._canonical_constructed_value(two)
-    assert BS._canonical_constructed_value(one)["fields"]["parts"] == [1]
-    assert BS._canonical_constructed_value(two)["fields"]["parts"] == [2]
+    assert constructed_value_cid_v2(one) != constructed_value_cid_v2(two)
+    # ...and two values that are EQUAL share content identity, which is the
+    # point of content addressing, while remaining distinct occurrences.
+    three = Held("same", (1,))
+    assert one is not three
+    assert constructed_value_cid_v2(one) == constructed_value_cid_v2(three)
 
 
 def test_only_categories_whose_inputs_are_named_get_a_coordinate():
-    # The key must cover every input that determines the canonical output, so a
-    # category whose inputs this module cannot enumerate gets NO row: a mutable
-    # dataclass can canonicalize two ways over its lifetime, and a ``wire()``
-    # value's inputs are inside a method call.
+    # The key must cover every input that determines the CID, so a category
+    # whose inputs this module cannot enumerate gets NO row: a mutable
+    # dataclass can canonicalize two ways over its lifetime, and a mapping is
+    # mutable in exactly the same way.
     from dataclasses import dataclass as _dataclass
 
     @_dataclass
@@ -130,29 +127,29 @@ def test_only_categories_whose_inputs_are_named_get_a_coordinate():
         def wire(self):
             return {"n": 1}
 
-    from sugar_source_tree.binding_state import _NO_COORDINATE as NONE_KEY
+    assert CC._constructed_value_coordinate(Mutable(1)) is None
+    assert CC._constructed_value_coordinate(Wired()) is None
+    assert CC._constructed_value_coordinate([1]) is None
+    assert CC._constructed_value_coordinate({"a": 1}) is None
+    assert CC._constructed_value_coordinate((1, 2)) is None
+    assert CC._constructed_value_coordinate(1) is None
+    # ...and the category that DOES have one names it: type is in the key
+    # because the semantic type tag is in the output, identity is a component.
+    frozen = CC._constructed_value_coordinate(Held("t", ()))
+    assert frozen[0] == "constructed-value-v2" and frozen[1] is Held
 
-    assert BS._canonicalization_coordinate(Mutable(1)) is NONE_KEY
-    assert BS._canonicalization_coordinate(Wired()) is NONE_KEY
-    assert BS._canonicalization_coordinate([1]) is NONE_KEY
-    assert BS._canonicalization_coordinate({"a": 1}) is NONE_KEY
-    assert BS._canonicalization_coordinate((1, 2)) is NONE_KEY
-    assert BS._canonicalization_coordinate(1) is NONE_KEY
-    # ...and the categories that DO have one name it: type is in the key
-    # because type is in the output, identity is only a component.
-    frozen = BS._canonicalization_coordinate(Held("t", ()))
-    assert frozen[0] == "frozen-dataclass" and frozen[1] is Held
+    # A MUTABLE value has no content coordinate at all, so V2 refuses it as a
+    # typed gap rather than memoizing a moment as if it were a value.
+    import pytest
 
-    # A mutated value therefore never reads a stale answer.
-    m = Mutable(1)
-    assert BS._canonical_constructed_value(m)["fields"]["n"] == 1
-    m.n = 2
-    assert BS._canonical_constructed_value(m)["fields"]["n"] == 2
+    with pytest.raises(BS.ConstructedValueCategoryGap):
+        constructed_value_cid_v2(Held("holds", (Mutable(1),)))
 
 
-def test_a_node_is_keyed_by_its_authenticated_construction_shape():
-    # The strongest form: no identity in the key at all. Two distinct node
-    # VIEWS of the same content are one coordinate and share the answer.
+def test_a_node_is_referenced_by_its_authenticated_construction_shape():
+    # The strongest form: no identity in the encoding at all. A Node is a tree
+    # VIEW, so it inlines as its authenticated NodeShapeV2 CID and two distinct
+    # views of the same content encode identically.
     d = tempfile.mkdtemp()
     p = os.path.join(d, "m.py")
     with open(p, "w") as fh:
@@ -161,11 +158,11 @@ def test_a_node_is_keyed_by_its_authenticated_construction_shape():
     root = sf.root
     one = [n for n in root.walk() if n.kind == "Constant"][0]
     two = [n for n in root.walk() if n.kind == "Constant"][0]
-    coordinate = BS._canonicalization_coordinate(one)
-    assert coordinate[0] == "node-shape"
-    assert coordinate == BS._canonicalization_coordinate(two)
-    assert BS._canonical_constructed_value(one) == BS._canonical_constructed_value(two)
-    assert BS._canonical_constructed_value(one)["nodeShape"] == coordinate[1]
+    shape = BS.node_construction_shape_cid(one)
+    assert BS._cv2_leaf(one) == {"nodeShapeCid": shape}
+    assert BS._cv2_leaf(one) == BS._cv2_leaf(two)
+    # The node's positional occurrence (unit, span) is NOT in the content key.
+    assert shape == BS.node_construction_shape_cid(two)
 
 
 def test_a_recycled_address_misses_instead_of_serving_a_dead_values_answer():
@@ -179,24 +176,24 @@ def test_a_recycled_address_misses_instead_of_serving_a_dead_values_answer():
     assert dead_ref() is None
 
     live = Held("live", (7,))
-    BS._CANONICAL_VALUES[BS._canonicalization_coordinate(live)] = (
+    honest = constructed_value_cid_v2(live)
+    CC._CONSTRUCTED_VALUE_CIDS_V2[CC._constructed_value_coordinate(live)] = (
         dead_ref,
-        {"poison": True},
+        "blake3-512:poison",
     )
-    answer = BS._canonical_constructed_value(live)
-    assert answer["fields"]["parts"] == [7], answer
-    assert "poison" not in answer
+    assert CC.constructed_value_cid_v2_for(live) is None
+    assert constructed_value_cid_v2(live) == honest
 
 
 def test_a_dead_value_drops_its_row():
     # The table is bounded by LIVE constructed values: no process-lifetime pin.
     value = Held("transient", (1,))
-    coordinate = BS._canonicalization_coordinate(value)
-    BS._canonical_constructed_value(value)
-    assert coordinate in BS._CANONICAL_VALUES
+    coordinate = CC._constructed_value_coordinate(value)
+    constructed_value_cid_v2(value)
+    assert coordinate in CC._CONSTRUCTED_VALUE_CIDS_V2
     del value
     gc.collect()
-    assert coordinate not in BS._CANONICAL_VALUES
+    assert coordinate not in CC._CONSTRUCTED_VALUE_CIDS_V2
 
 
 def test_speed_never_comes_from_skipping_testimony():
@@ -231,15 +228,12 @@ def test_speed_never_comes_from_skipping_testimony():
             raise AssertionError("unsupported value went quiet")
 
 
-def test_real_construction_agrees_byte_for_byte_with_the_unmemoized_answer():
-    # Fingerprint every canonicalization a real function performs, with the
-    # memo live and with it bypassed, and require exact equality.
-    import hashlib
-
-    from sugar_lift_python_source.canonical import cid_of_json
-
-    # ONE fixture file for both passes: a fresh temp path would change the
-    # source mementos and the fingerprint with them.
+def test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer():
+    # For EVERY semantic value a real function presents, mint its CID with the
+    # memo warm and again with the memo emptied, and require them equal. Done
+    # in ONE pass so no other warm cache (node shape, sugar() coordinate) can
+    # make the two answers incomparable: a wrong memo is caught at the exact
+    # value it corrupted, not averaged into a digest.
     directory = tempfile.mkdtemp()
     path = os.path.join(directory, "m.py")
     with open(path, "w") as fh:
@@ -251,37 +245,26 @@ def test_real_construction_agrees_byte_for_byte_with_the_unmemoized_answer():
             "    return total\n"
         )
 
-    def fingerprint(bypass):
-        BS._CANONICAL_VALUES.clear()
-        original = BS._canonical_constructed_value
-        digest = hashlib.md5()
-        depth = {"d": 0}
+    original = BS._constructed_preimage
+    compared = []
 
-        def watched(value):
-            top = depth["d"] == 0
-            depth["d"] += 1
-            try:
-                out = (
-                    BS._compute_canonical_constructed_value(value)
-                    if bypass
-                    else original(value)
-                )
-            finally:
-                depth["d"] -= 1
-            if top:
-                digest.update(cid_of_json(out).encode())
-            return out
+    def watched(value):
+        out = original(value)
+        warm = BS.cid_of_json(out)
+        CC._CONSTRUCTED_VALUE_CIDS_V2.clear()
+        cold = BS.cid_of_json(original(value))
+        assert warm == cold, (type(value).__name__, warm, cold)
+        compared.append(warm)
+        return out
 
-        BS._canonical_constructed_value = watched
-        try:
-            sf = SourceFile.from_path(path, reporter=CollectingReporter())
-            fn = [f for f in sf.functions() if getattr(f, "name", None) == "f"][0]
-            fn.sugar()
-        finally:
-            BS._canonical_constructed_value = original
-        return digest.hexdigest()
-
-    memoized = fingerprint(False)
-    bypassed = fingerprint(True)
-    assert memoized == bypassed, (memoized, bypassed)
-    assert len(memoized) == 32
+    BS._constructed_preimage = watched
+    try:
+        sf = SourceFile.from_path(path, reporter=CollectingReporter())
+        fn = [f for f in sf.functions() if getattr(f, "name", None) == "f"][0]
+        fn.sugar()
+    finally:
+        BS._constructed_preimage = original
+    # A real function presents several distinct values (8 measured here); a
+    # silent zero comparisons would make this test prove nothing at all.
+    assert len(compared) >= 8, len(compared)
+    assert len(set(compared)) > 1, compared

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
@@ -1,0 +1,525 @@
+"""ConstructedValueV2: a value authenticates its children's CIDs, not their content.
+
+NodeShapeV2 (#6253) fixed the NODE layer. The CONSTRUCTED SEMANTIC VALUE layer
+one level up still recursively INLINED every child value's canonical form, so
+the shared constructed DAG was walked as a TREE and the same descendant content
+was encoded once for every ancestor path above it. Measured after #6253:
+``cid_of_json`` 2,736s cumulative over only 1,482 calls out of
+``present_construction`` -- ~39,100 JSON nodes per call -- on pandas
+``core/reshape/pivot.py::__internal_pivot_table``.
+
+V2 is T's child identity law made mechanical: a child constructed semantic value
+is referenced by a DOMAIN-SEPARATED CID of that child's immutable semantic
+content, and its OCCURRENCE identity remains separate and is never inferred from
+the content CID. Two identities, always explicit:
+
+    semantic content CID     answers "what value?"
+    construction occurrence  answers "which construction/site produced it?"
+
+These twins pin what the form must NOT lose and must NOT merge:
+
+  * every perturbation BITES -- reordered tuple children, renamed dataclass
+    fields, changed mapping pairing, omitted and duplicated children, changed
+    leaf values, changed semantic type;
+  * every category stays mutually distinguishable -- a leaf carrying a
+    CID-shaped string is not a child carrying that CID, an ``IntEnum`` member is
+    not the bare integer, an empty tuple is not an empty mapping;
+  * equal content SHARES the semantic CID and NEVER shares occurrence -- same
+    CID, distinct objects, distinct ``at`` coordinates, distinct rows;
+  * a shared DAG child is hashed ONCE per content coordinate;
+  * classification is CLOSED -- mutable containers, mutable dataclasses, cycles
+    and unnameable categories are typed testimony gaps, never reflection and
+    never an opportunistic snapshot;
+  * V1 and V2 never share an identity namespace.
+"""
+
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_source_tree import binding_state as BS
+from sugar_source_tree import construction_cache as CC
+from sugar_source_tree.binding_state import (
+    CONSTRUCTED_VALUE_V2_CHILD_CID_ALGORITHM,
+    CONSTRUCTED_VALUE_V2_DOMAIN,
+    CONSTRUCTED_VALUE_V2_SCHEMA,
+    ConstructedValueCategoryGap,
+    _constructed_preimage,
+    constructed_value_cid_v2,
+    constructed_value_slot_v2,
+)
+
+
+@dataclass(frozen=True)
+class Pair:
+    left: object
+    right: object
+
+
+@dataclass(frozen=True)
+class Renamed:
+    left: object
+    other: object
+
+
+@dataclass(frozen=True)
+class Chain:
+    tail: object
+
+
+@dataclass(frozen=True)
+class Holder:
+    items: object
+
+
+@dataclass
+class Mutable:
+    field: object
+
+
+class Colour(Enum):
+    RED = 1
+    BLUE = 1  # noqa: PIE796 -- deliberately EQUAL payload, distinct spelling
+
+
+class Shade(Enum):
+    RED = 1
+    BLUE = 2
+
+
+class Level(IntEnum):
+    LOW = 1
+    HIGH = 2
+
+
+class Cyclic:
+    """A frozen-looking value that can be knotted after construction."""
+
+
+@dataclass(frozen=True)
+class Knot:
+    other: object
+
+
+class WireOnly:
+    """Exposes ``.wire()`` and nothing authenticated. V1 walked it; V2 will not."""
+
+    def wire(self):
+        return {"anything": "at all"}
+
+
+class ClaimsCid:
+    """Claims a ``cid`` its ``preimage`` does not hash to."""
+
+    preimage = {"kind": "not-really"}
+    cid = "blake3-512:" + "0" * 8
+
+
+class HonestCid:
+    """A genuinely self-authenticating value: ``cid_of_json(preimage) == cid``."""
+
+    preimage = {"kind": "honest", "schemaVersion": "1", "payload": [1, 2, 3]}
+
+    @property
+    def cid(self):
+        return cid_of_json(self.preimage)
+
+
+# ---------------------------------------------------------------------------
+# Domain separation and namespace disjointness
+# ---------------------------------------------------------------------------
+
+
+def test_every_preimage_names_its_domain_schema_and_child_cid_algorithm():
+    """A child slot's string can never be read as a leaf or a foreign CID."""
+    preimage = BS._cv2_preimage("tuple", 0, [], [], {})
+    assert preimage["domain"] == CONSTRUCTED_VALUE_V2_DOMAIN
+    assert preimage["schema"] == CONSTRUCTED_VALUE_V2_SCHEMA
+    assert preimage["childCidAlgorithm"] == CONSTRUCTED_VALUE_V2_CHILD_CID_ALGORITHM
+    assert set(preimage) == {
+        "domain",
+        "schema",
+        "childCidAlgorithm",
+        "semanticType",
+        "arity",
+        "localFields",
+        "children",
+    }
+
+
+def test_v1_and_v2_envelopes_are_disjoint_identity_namespaces():
+    envelope = _constructed_preimage(Pair(1, 2))
+    assert envelope["schemaVersion"] == "2"
+    assert envelope["valueSchema"] == CONSTRUCTED_VALUE_V2_SCHEMA
+    assert envelope["childCidAlgorithm"] == CONSTRUCTED_VALUE_V2_CHILD_CID_ALGORITHM
+    # The V1 envelope carried NEITHER key and said "1". Reconstructing it and
+    # hashing it can never collide with the V2 envelope for the same value.
+    v1_shaped = {
+        "kind": "constructed-semantic-value",
+        "schemaVersion": "1",
+        "value": {"constructedType": "x", "fields": {}},
+    }
+    assert cid_of_json(v1_shaped) != cid_of_json(envelope)
+
+
+def test_a_leaf_carrying_a_cid_string_is_not_a_child_carrying_that_cid():
+    """Leaves and children live under different keys, so they cannot collide."""
+    inner = Pair(1, 2)
+    inner_cid = constructed_value_cid_v2(inner)
+    as_child = constructed_value_cid_v2(Chain(inner))
+    as_leaf_string = constructed_value_cid_v2(Chain(inner_cid))
+    assert as_child != as_leaf_string
+    assert constructed_value_slot_v2(inner) == {"constructedValueCid": inner_cid}
+    assert constructed_value_slot_v2(inner_cid) == {"leaf": {"str": inner_cid}}
+
+
+# ---------------------------------------------------------------------------
+# No embedded child preimages; bottom-up construction
+# ---------------------------------------------------------------------------
+
+
+def test_a_parent_preimage_embeds_child_CIDS_never_child_content():
+    left, right = Pair(1, 2), Pair(3, 4)
+    parent = Pair(left, right)
+    semantic_type, arity, local_fields, children = BS._cv2_classify(parent)
+    child_cid = {
+        id(left): constructed_value_cid_v2(left),
+        id(right): constructed_value_cid_v2(right),
+    }
+    preimage = BS._cv2_preimage(semantic_type, arity, local_fields, children, child_cid)
+    assert preimage["localFields"] == []
+    assert preimage["children"] == [
+        {"at": "left", "childConstructedValueCid": child_cid[id(left)]},
+        {"at": "right", "childConstructedValueCid": child_cid[id(right)]},
+    ]
+    # A child slot carries a CID and NOTHING else -- no fragment of the child's
+    # own preimage (its semanticType, its localFields, its own children) leaks
+    # into its parent. That absence IS the linear form.
+    for entry in preimage["children"]:
+        assert set(entry) == {"at", "childConstructedValueCid"}
+    child_preimage = BS._cv2_preimage(*BS._cv2_classify(left), {})
+    assert child_preimage["localFields"] == [
+        {"at": "left", "leaf": {"int": 1}},
+        {"at": "right", "leaf": {"int": 2}},
+    ]
+    for key in ("semanticType", "localFields", "children", "arity"):
+        assert key not in str(preimage["children"])
+    # The parent's OWN preimage stays O(its own arity): two entries, two CIDs.
+    assert preimage["arity"] == 2 and len(preimage["children"]) == 2
+
+
+def test_construction_is_bottom_up_and_survives_a_tree_deeper_than_recursion():
+    """3,000 deep: a recursive encoder dies here; the iterative one does not."""
+    import sys
+
+    assert sys.getrecursionlimit() < 3000
+    value = Pair(0, 0)
+    for _ in range(3000):
+        value = Chain(value)
+    assert constructed_value_cid_v2(value).startswith("blake3-512:")
+
+
+def _encoded_bytes(presented):
+    """Total bytes hashed while PRESENTING every value in a construction.
+
+    ``present_construction`` mints a semantic-value CID for EVERY node's
+    constructed value, never only the root -- and that is exactly where V1's
+    cost lived: each presentation re-encoded its whole subtree, so total work
+    was the sum of all subtree sizes. The memo stays warm across presentations,
+    as in the census loop.
+    """
+    from sugar_lift_python_source import canonical as CANON
+
+    CC._CONSTRUCTED_VALUE_CIDS_V2.clear()
+    total = [0]
+    original = CANON.canonical_json_bytes
+
+    def counting(value):
+        out = original(value)
+        total[0] += len(out)
+        return out
+
+    CANON.canonical_json_bytes = counting
+    try:
+        for value in presented:
+            BS.cid_of_json(_constructed_preimage(value))
+    finally:
+        CANON.canonical_json_bytes = original
+    return total[0]
+
+
+def _slope(points):
+    import math
+
+    xs = [math.log(n) for n, _ in points]
+    ys = [math.log(b) for _, b in points]
+    mx, my = sum(xs) / len(xs), sum(ys) / len(ys)
+    return sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / sum(
+        (x - mx) ** 2 for x in xs
+    )
+
+
+def test_depth_sweep_total_encoded_work_is_linear():
+    """Measured fitted log-log slope: V1 = 1.96 (quadratic), V2 = 0.99."""
+
+    def depth_case(n):
+        value = Pair(0, 0)
+        presented = [value]
+        for _ in range(n):
+            value = Chain(value)
+            presented.append(value)
+        return presented
+
+    points = [(n, _encoded_bytes(depth_case(n))) for n in (50, 100, 200, 400)]
+    slope = _slope(points)
+    assert 0.85 <= slope <= 1.15, f"depth encoded-work slope {slope:.2f} is not linear"
+
+
+def test_breadth_sweep_total_encoded_work_is_linear():
+    """Breadth was already linear in V1 (slope 1.00); V2 must not lose that."""
+
+    def breadth_case(n):
+        kids = tuple(Pair(i, f"k{i}") for i in range(n))
+        return [*kids, Holder(kids)]
+
+    points = [(n, _encoded_bytes(breadth_case(n))) for n in (50, 100, 200, 400)]
+    slope = _slope(points)
+    assert (
+        0.85 <= slope <= 1.15
+    ), f"breadth encoded-work slope {slope:.2f} is not linear"
+
+
+def test_a_shared_dag_child_is_hashed_once_per_content_coordinate():
+    CC._CONSTRUCTED_VALUE_CIDS_V2.clear()
+    shared = Pair(1, 2)
+    calls = []
+    original = BS.cid_of_json
+
+    def counting(value):
+        calls.append(value.get("semanticType"))
+        return original(value)
+
+    BS.cid_of_json = counting
+    try:
+        constructed_value_cid_v2(Pair(Pair(shared, shared), Pair(shared, shared)))
+    finally:
+        BS.cid_of_json = original
+    # 1 shared + 2 middles + 1 root == 4 preimages, not 4 + 4 paths to `shared`.
+    assert len(calls) == 4
+
+
+# ---------------------------------------------------------------------------
+# Every perturbation BITES
+# ---------------------------------------------------------------------------
+
+
+def test_reordered_tuple_children_change_the_parent_cid():
+    a, b = Pair(1, 2), Pair(3, 4)
+    assert constructed_value_cid_v2((a, b)) != constructed_value_cid_v2((b, a))
+
+
+def test_omitted_and_duplicated_children_change_the_parent_cid():
+    a, b = Pair(1, 2), Pair(3, 4)
+    both = constructed_value_cid_v2((a, b))
+    omitted = constructed_value_cid_v2((a,))
+    duplicated = constructed_value_cid_v2((a, b, b))
+    assert len({both, omitted, duplicated}) == 3
+    assert constructed_value_cid_v2((a, a)) != constructed_value_cid_v2((a,))
+
+
+def test_renamed_fields_change_the_cid_even_with_identical_field_values():
+    assert constructed_value_cid_v2(Pair(1, 2)) != constructed_value_cid_v2(
+        Renamed(1, 2)
+    )
+
+
+def test_changed_mapping_pairing_changes_the_cid():
+    a, b = Pair(1, 2), Pair(3, 4)
+    straight = constructed_value_cid_v2(Holder({"x": a, "y": b}))
+    swapped = constructed_value_cid_v2(Holder({"x": b, "y": a}))
+    assert straight != swapped
+    # The same VALUES under different KEYS also bite.
+    renamed = constructed_value_cid_v2(Holder({"p": a, "q": b}))
+    assert renamed != straight
+
+
+def test_changed_leaf_values_and_semantic_types_bite():
+    assert constructed_value_cid_v2(Pair(1, 2)) != constructed_value_cid_v2(Pair(1, 3))
+    assert constructed_value_cid_v2(Holder(())) != constructed_value_cid_v2(Holder({}))
+    assert constructed_value_cid_v2(()) != constructed_value_cid_v2({})
+
+
+def test_a_bool_is_not_an_int_and_an_intenum_is_not_its_integer():
+    assert constructed_value_cid_v2(Holder(True)) != constructed_value_cid_v2(Holder(1))
+    # V1 tested ``int`` BEFORE ``Enum``, so an IntEnum member encoded as a bare
+    # integer and the member was LOST. V2 keeps the member.
+    assert constructed_value_cid_v2(Holder(Level.LOW)) != constructed_value_cid_v2(
+        Holder(1)
+    )
+
+
+def test_enum_members_with_equal_payloads_stay_distinguishable():
+    """``Colour.RED`` and ``Colour.BLUE`` share the payload 1; V1 encoded the
+    payload, so it could not tell two same-payload members apart. V2 encodes the
+    member TAG."""
+    assert Colour.BLUE is Colour.RED  # Python aliases them: one member, two spellings
+    # Two DIFFERENT enum types whose members carry the same payload must differ.
+    assert constructed_value_cid_v2(Holder(Colour.RED)) != constructed_value_cid_v2(
+        Holder(Shade.RED)
+    )
+    assert constructed_value_cid_v2(Holder(Shade.RED)) != constructed_value_cid_v2(
+        Holder(Shade.BLUE)
+    )
+
+
+def test_a_frozenset_authenticates_membership_not_iteration_order():
+    a, b, c = Pair(1, 2), Pair(3, 4), Pair(5, 6)
+    one = constructed_value_cid_v2(frozenset({a, b, c}))
+    two = constructed_value_cid_v2(frozenset({c, a, b}))
+    assert one == two
+    assert one != constructed_value_cid_v2(frozenset({a, b}))
+
+
+# ---------------------------------------------------------------------------
+# Content identity WITHOUT occurrence identity
+# ---------------------------------------------------------------------------
+
+
+def test_equal_content_shares_the_semantic_cid_and_never_the_occurrence():
+    one, two = Pair(1, 2), Pair(1, 2)
+    assert one is not two
+    assert constructed_value_cid_v2(one) == constructed_value_cid_v2(two)
+    # Two DISTINCT rows in the registry -- one per live object -- carrying the
+    # same value. Content-addressing the VALUE must never merge the OCCURRENCES.
+    rows = [
+        key
+        for key in CC._CONSTRUCTED_VALUE_CIDS_V2
+        if key[1] is Pair and key[2] in (id(one), id(two))
+    ]
+    assert len(rows) == 2
+    assert CC.constructed_value_cid_v2_for(one) == CC.constructed_value_cid_v2_for(two)
+    # And they still occupy DISTINCT ordered coordinates in a parent.
+    _, entries = BS._cv2_entries((one, two))
+    assert [at for at, _child in entries] == [0, 1]
+
+
+def test_two_equal_children_do_not_collapse_their_parents_arity():
+    one, two = Pair(1, 2), Pair(1, 2)
+    assert constructed_value_cid_v2((one, two)) != constructed_value_cid_v2((one,))
+
+
+def test_a_dead_objects_address_is_never_read_for_a_live_one():
+    """The registry row is honored only while its weakref resolves to the SAME
+    object, so a recycled address misses instead of reading a dead value's CID."""
+    victim = Pair(1, 2)
+    coordinate = ("constructed-value-v2", Pair, id(victim))
+    constructed_value_cid_v2(victim)
+    assert coordinate in CC._CONSTRUCTED_VALUE_CIDS_V2
+    del victim
+    assert coordinate not in CC._CONSTRUCTED_VALUE_CIDS_V2
+
+
+def test_only_frozen_values_take_a_registry_row():
+    # A mapping is MUTABLE: the same object can encode two ways over its
+    # lifetime, so identity is not a content coordinate and it gets no row. A
+    # tuple is immutable but its preimage is exactly its children's already
+    # memoized CIDs, so a row would buy the walk of one value's own arity.
+    assert CC._constructed_value_coordinate({"a": 1}) is None
+    assert CC._constructed_value_coordinate((1, 2)) is None
+    assert CC._constructed_value_coordinate(Mutable(1)) is None
+    assert CC._constructed_value_coordinate(1) is None
+    # The frozen ones DO -- held live, so the weakref-bounded table keeps them.
+    inner = Pair(9, 9)
+    outer = Holder({"a": inner})
+    constructed_value_cid_v2(outer)
+    assert CC.constructed_value_cid_v2_for(outer) is not None
+    assert CC.constructed_value_cid_v2_for(inner) is not None
+
+
+# ---------------------------------------------------------------------------
+# Classification is CLOSED: typed gaps, never reflection
+# ---------------------------------------------------------------------------
+
+
+def test_a_mutable_container_is_a_typed_gap_never_an_opportunistic_snapshot():
+    for mutable in ([1, 2], {1, 2}, bytearray(b"ab")):
+        with pytest.raises(ConstructedValueCategoryGap) as caught:
+            constructed_value_cid_v2(Holder(mutable))
+        assert "MUTABLE container" in str(caught.value)
+
+
+def test_a_mutable_dataclass_is_a_typed_gap():
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2(Holder(Mutable(1)))
+    assert "MUTABLE dataclass" in str(caught.value)
+
+
+def test_an_unnameable_category_is_a_typed_gap_never_reflection():
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2(Holder(object()))
+    assert "will not invent a preimage by reflection" in str(caught.value).replace(
+        "\n", " "
+    ).replace("  ", " ")
+
+
+def test_a_bare_wire_method_earns_nothing():
+    """V1 called ``.wire()`` generically. V2 never does: an arbitrary method's
+    inputs cannot be enumerated, so it cannot authenticate anything."""
+    with pytest.raises(ConstructedValueCategoryGap):
+        constructed_value_cid_v2(Holder(WireOnly()))
+
+
+def test_a_cycle_is_a_typed_gap_never_a_truncation():
+    knot = Knot(None)
+    inner = Knot(knot)
+    object.__setattr__(knot, "other", inner)
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2(knot)
+    assert "CYCLIC" in str(caught.value)
+
+
+def test_a_non_string_mapping_key_is_a_typed_gap():
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2(Holder({1: "x"}))
+    assert "string keys" in str(caught.value)
+
+
+def test_the_gap_travels_the_existing_typed_testimony_door():
+    """``present_construction`` catches ``(TypeError, ValueError)`` to mint the
+    loud ``ConstructedValueTestimonyNotWritten``; the category gap must reach
+    it."""
+    assert issubclass(ConstructedValueCategoryGap, TypeError)
+
+
+# ---------------------------------------------------------------------------
+# The native-CID arm is VALIDATED, never trusted
+# ---------------------------------------------------------------------------
+
+
+def test_a_native_cid_is_referenced_only_when_it_authenticates_its_preimage():
+    honest = HonestCid()
+    assert BS._validated_native_cid(honest) == honest.cid
+    assert constructed_value_slot_v2(honest) == {
+        "leaf": {
+            "authenticatedValueCid": {
+                "type": BS._cv2_type_tag(honest),
+                "cid": honest.cid,
+            }
+        }
+    }
+    # A claimed CID that does not hash its own preimage earns nothing, and the
+    # value falls through to the closed classifier -- which refuses it.
+    assert BS._validated_native_cid(ClaimsCid()) is None
+    with pytest.raises(ConstructedValueCategoryGap):
+        constructed_value_cid_v2(Holder(ClaimsCid()))
+
+
+def test_a_natively_authenticated_child_is_never_walked():
+    """Its whole document is replaced by its own CID: that is the linear form."""
+    honest = HonestCid()
+    semantic_type, arity, local_fields, children = BS._cv2_classify(Holder(honest))
+    preimage = BS._cv2_preimage(semantic_type, arity, local_fields, children, {})
+    assert preimage["children"] == []
+    assert "payload" not in str(preimage)

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_testimony_conservation.py
@@ -42,9 +42,10 @@ _SCOPE_CID = "blake3-512:" + "0" * 8
 class Unserializable:
     """A constructed value category canonicalization has not been taught.
 
-    Not a dataclass, no ``wire()`` -- exactly the shape that made
-    ``_canonical_constructed_value`` raise ``TypeError`` in production
-    (``unserializable constructed value LineTable``).
+    Not a dataclass, no authenticated native CID -- exactly the shape that
+    made canonicalization raise in production (``unserializable constructed
+    value LineTable``), and that ConstructedValueV2 reports as the typed
+    ``ConstructedValueCategoryGap`` rather than reflecting over.
     """
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -433,7 +433,7 @@ class ConstructionTestimonyReporterV1:
             requested="content-addressable constructed-value testimony",
             fix=(
                 "teach canonicalization the general value category "
-                "(_canonical_constructed_value) or keep the coordinate loud"
+                "(_cv2_leaf / _cv2_entries) or keep the coordinate loud"
             ),
         )
         if shape is not None:
@@ -683,7 +683,7 @@ def _node_shape_v2_preimage(ref: object, child_cid: "dict[int, str]") -> dict[st
         elif isinstance(slot, Children):
             value = {"children": [child_cid[id(h)] for h in slot.handles]}
         elif isinstance(slot, Leaf):
-            value = {"leaf": _canonical_constructed_value(slot.value)}
+            value = {"leaf": constructed_value_slot_v2(slot.value)}
         elif isinstance(slot, OpLeaf):
             value = {"operator": slot.op.kind}
         elif isinstance(slot, OpsLeaf):
@@ -757,146 +757,176 @@ def backend_node_shape_cid_v2(ref: object) -> str:
     return result
 
 
-def _constructed_preimage(value: object) -> dict[str, Any]:
-    return {
-        "kind": "constructed-semantic-value",
-        "schemaVersion": "1",
-        "value": _canonical_constructed_value(value),
-    }
-
-
-# Canonicalization is content-addressed WORK over a shared value DAG that the
-# recursion below walks as a TREE. Measured on pandas
-# ``core/indexes/base.py::_join_level``: 758,852 calls over 1,544 distinct value
-# objects -- 491x recomputation, and the cost the silent testimony skip used to
-# hide by aborting canonicalization early. Same ruling as the static
-# ``_SHAPE_CIDS`` registry: the work is content-addressed, so it is done once at
-# its coordinate and read thereafter. Never skip testimony to buy speed.
+# ---------------------------------------------------------------------------
+# ConstructedValueV2 -- the Merkle preimage of a CONSTRUCTED SEMANTIC VALUE.
 #
-# THE KEY IS THE COORDINATE, NOT THE ADDRESS. The key must cover every input
-# that determines the canonical output, so a row is written only for value
-# categories whose canonicalization this module can NAME the inputs of:
+# THE DEFECT V2 CLOSES. V1 built one JSON document per presented value by
+# recursively INLINING every child value's full canonical form. The constructed
+# graph is a DAG (substitution shares sugar objects), and V1 walked it as a
+# TREE, so the same descendant content was encoded once for every ancestor path
+# above it: total encoded work was the sum of all subtree sizes. Measured
+# consequence after NodeShapeV2 (#6253) had already fixed the node layer:
+# ``cid_of_json`` 2,736s cumulative over only 1,482 calls out of
+# ``present_construction`` -- ~39,100 JSON nodes per call -- on pandas
+# ``core/reshape/pivot.py::__internal_pivot_table``. Same disease as #6253, one
+# layer up.
 #
-#   Node             -> keyed by the AUTHENTICATED construction-shape CID, with
-#                       no identity component at all. The Node arm's output is
-#                       exactly ``{"nodeShape": node_construction_shape_cid(v)}``,
-#                       a pure function of that CID: two different node views of
-#                       the same content are the same coordinate and must share
-#                       the answer.
-#   frozen dataclass -> keyed by (type, live object). The output is the type's
-#                       module/qualname plus the canonicalization of each field,
-#                       and ``frozen=True`` is what makes the field tuple a
-#                       function of the object. Type is IN the key because it is
-#                       IN the output; identity is a component, never the whole.
-#   Enum             -> keyed by (type, member). The output is the enum type's
-#                       module/qualname plus its canonicalized ``.value``; the
-#                       member is the coordinate and members are singletons.
+# T'S CHILD IDENTITY LAW. A child constructed semantic value is referenced by a
+# DOMAIN-SEPARATED CID of that child's immutable semantic content. Its
+# OCCURRENCE identity remains separate and is never inferred from the content
+# CID. Two identities stay explicit and are never collapsed into one:
 #
-# Everything else is deliberately NOT memoized, because its canonical output is
-# NOT a function of the value object alone (or is too cheap to be worth a row):
+#     semantic content CID    answers "what value?"
+#     construction occurrence answers "which construction/site produced it?"
 #
-#   list / dict / set / non-frozen dataclass -- MUTABLE. The same object can
-#       canonicalize two ways over its lifetime, so identity is not a
-#       coordinate. (These are also the arms that cannot be weakref'd.)
-#   objects canonicalized via ``.wire()`` -- ``wire()`` is a method call that
-#       may read state beyond the value; this module cannot enumerate its
-#       inputs, so it does not claim a coordinate for it.
-#   tuple -- immutable, but its answer is exactly its elements' answers, which
-#       ARE memoized individually; a row would buy the walk of one tuple.
-#   None / bool / int / float / str / bytes -- the answer is a constant-time
-#       spelling of the value; a row costs more than it saves.
-#   SourceFragment / SourceMemento -- delegated to ``seal()`` / ``to_dict()``,
-#       which own their own authentication; not this module's coordinate.
+# Equal immutable values MAY share the semantic CID -- that is what makes the
+# form linear. They must NOT merge roll-call seats, effect occurrences,
+# bindings, or source sites, and they do not: occurrence identity is carried by
+# BindingCoordinateV1, by the node shape CID keyed presentation registry, and by
+# the ordered ``at`` coordinate a child occupies inside its parent -- never by
+# this content CID.
 #
-# The id-reuse hazard (#6212) is closed by construction wherever identity IS a
-# key component: the row holds a WEAK reference to the object it keyed and a hit
-# is honored only when that weakref still resolves to the SAME object, so a
-# recycled address misses instead of reading a dead value's JSON. The weakref
-# callback drops the row, bounding the table by LIVE values rather than pinning
-# every constructed value for the life of a corpus census.
-_CANONICAL_VALUES: dict[Any, tuple[Any, Any]] = {}
+# THE FORM.
+#
+#     ConstructedValueV2 {
+#         domain, schema, childCidAlgorithm,   -- total domain separation
+#         semanticType,                        -- stable semantic type tag
+#         arity,                               -- authenticated slot count
+#         localFields: [ {at, leaf}, ... ],    -- authenticated scalar leaves
+#         children:    [ {at, childConstructedValueCid}, ... ],
+#     }
+#
+# Each value encodes a preimage of its OWN arity; the whole DAG is O(n) and each
+# distinct content coordinate is hashed exactly once.
+#
+# CLASSIFICATION IS EXHAUSTIVE AND CLOSED. Every category is NAMED. There is no
+# generic reflective fallback and no generic ``.wire()`` call: a value whose
+# category this schema cannot name is a TYPED TESTIMONY GAP
+# (``ConstructedValueCategoryGap``), reported loudly through the one testimony
+# gap door, never an invented preimage.
+#
+# V1 AND V2 NEVER SHARE AN IDENTITY NAMESPACE. The outer envelope carries
+# ``schemaVersion: "2"`` plus ``valueSchema``/``childCidAlgorithm``, which no V1
+# preimage ever carried, so no V1 CID is reinterpretable as V2 and vice versa.
+#
+# This migration DOES change every constructed-value CID, deliberately and
+# pinned. Constructed-value CIDs are REPRESENTATION identity, never meaning: the
+# formulas, bindings, effects, gaps, ExitSets and terminal fingerprints the
+# census reads are CID-INDEPENDENT and are what the equivalence proof measures.
+# ---------------------------------------------------------------------------
 
-_NO_COORDINATE = object()
-
-
-def _canonicalization_coordinate(value: object) -> Any:
-    """This value's canonical-testimony coordinate, or ``_NO_COORDINATE``."""
-    from sugar_source_tree.nodes import Node
-
-    if isinstance(value, Node):
-        return ("node-shape", node_construction_shape_cid(value))
-    if isinstance(value, Enum):
-        return ("enum", type(value), value)
-    if (
-        is_dataclass(value)
-        and not isinstance(value, type)
-        and getattr(value, "__dataclass_params__", None) is not None
-        and value.__dataclass_params__.frozen
-    ):
-        return ("frozen-dataclass", type(value), id(value))
-    return _NO_COORDINATE
-
-
-def _canonical_constructed_value(value: object) -> Any:
-    """The value's canonical JSON: computed once per coordinate, read after."""
-    coordinate = _canonicalization_coordinate(value)
-    if coordinate is _NO_COORDINATE:
-        return _compute_canonical_constructed_value(value)
-
-    remembered = _CANONICAL_VALUES.get(coordinate)
-    if remembered is not None:
-        keyed, canonical = remembered
-        # An identity-bearing key is honored only while the object it named is
-        # alive and the SAME object; a content coordinate carries no identity to
-        # check (``keyed`` is None) and is honored unconditionally.
-        if keyed is None or keyed() is value:
-            return canonical
-
-    canonical = _compute_canonical_constructed_value(value)
-    _memoize_canonical(coordinate, value, canonical)
-    return canonical
+CONSTRUCTED_VALUE_V2_SCHEMA = "ConstructedValueV2"
+CONSTRUCTED_VALUE_V2_DOMAIN = "sugar/construction/constructed-value/v2"
+# The child slot carries a CID, and THIS names the algorithm that minted it: the
+# same ConstructedValueV2 preimage under the repository canonical JSON CID. A
+# child slot's string can therefore never be read as an opaque leaf, nor as a
+# CID minted by NodeShapeV2 or by any other schema.
+CONSTRUCTED_VALUE_V2_CHILD_CID_ALGORITHM = (
+    "sugar/construction/constructed-value/v2+cid_of_json"
+)
 
 
-def _memoize_canonical(coordinate: Any, value: object, canonical: Any) -> None:
-    if coordinate[0] == "node-shape":
-        # Pure content coordinate: no address, nothing to outlive.
-        _CANONICAL_VALUES[coordinate] = (None, canonical)
-        return
+class ConstructedValueCategoryGap(TypeError):
+    """A value category ConstructedValueV2 will NOT invent a preimage for.
+
+    A ``TypeError`` subclass so it travels the SAME typed door every other
+    canonicalization failure travels (``present_construction`` catches
+    ``(TypeError, ValueError)`` and mints the loud
+    ``ConstructedValueTestimonyNotWritten`` gap). Raising it is the schema
+    saying "I cannot NAME this value's category", which is testimony, not a
+    reason to reach for reflection.
+    """
+
+
+def _cv2_type_tag(value: object) -> str:
+    """The stable semantic type tag of ``value``'s class."""
+    cls = type(value)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+_NOT_A_LEAF = object()
+
+# (type, cid) pairs whose ``cid_of_json(preimage) == cid`` has been checked once.
+# Validation is the whole warrant for the native-CID arm, so it is CHECKED, not
+# trusted -- but it is a pure function of the pair, so it is checked once.
+_VALIDATED_NATIVE_CIDS: set[tuple[type, str]] = set()
+
+
+def _validated_native_cid(value: object) -> str | None:
+    """``value``'s own CID, iff that CID already authenticates its content.
+
+    T's rule: reference an existing wire/CID-owning value's validated native CID
+    *where that CID already authenticates the complete semantic content*. The
+    warrant is checkable and is CHECKED here -- ``cid_of_json(value.preimage)``
+    must reproduce ``value.cid``, exactly the admission test
+    ``seal_binding_state_v1`` applies. A value that merely *has* a ``.cid``
+    attribute earns nothing.
+
+    This is deliberately NOT ``.wire()``: ``wire()`` is an arbitrary method call
+    whose inputs this module cannot enumerate. ``preimage``/``cid`` is a
+    self-authenticating pair, and its failure mode is a miss, never a guess.
+    """
+    cid = getattr(value, "cid", None)
+    if not isinstance(cid, str):
+        return None
+    key = (type(value), cid)
+    if key in _VALIDATED_NATIVE_CIDS:
+        return cid
     try:
+        preimage = value.preimage  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 -- an unreadable preimage authenticates nothing
+        return None
+    if not isinstance(preimage, (dict, list)):
+        return None
+    try:
+        recomputed = cid_of_json(preimage)
+    except (TypeError, ValueError):
+        return None
+    if recomputed != cid:
+        return None
+    _VALIDATED_NATIVE_CIDS.add(key)
+    return cid
 
-        def _forget(_dead: Any, coordinate: Any = coordinate) -> None:
-            _CANONICAL_VALUES.pop(coordinate, None)
 
-        reference = weakref.ref(value, _forget)
-    except TypeError:
-        # Cannot hold the live identity its key names -> no row, rather than a
-        # row a recycled address could read.
-        return
-    _CANONICAL_VALUES[coordinate] = (reference, canonical)
+def _cv2_leaf(value: object) -> Any:
+    """``value``'s INLINE leaf encoding, or ``_NOT_A_LEAF``.
 
+    A leaf is a value whose complete semantic content is already authenticated
+    by a bounded, non-recursive spelling. Every leaf carries its own category
+    key, so a leaf can never be confused with another leaf category and a leaf
+    string can never be read as a child CID (children live under a different
+    key entirely).
 
-def _compute_canonical_constructed_value(value: object) -> Any:
+    ``Enum`` is tested BEFORE ``int``: an ``IntEnum`` member IS an ``int``, and
+    V1's arm order encoded it as a bare integer, losing the member. V2 keeps the
+    enum type and member tags and never recurses into ``.value``.
+    """
     from sugar_source_tree.fragment import SourceFragment, SourceMemento
 
-    if value is None or isinstance(value, (bool, int, str)):
-        return value
+    if value is None:
+        return {"null": None}
+    if isinstance(value, Enum):
+        # Stable enum type + MEMBER tags. Never the member's payload: two
+        # members can carry equal payloads, and the member is the meaning.
+        return {"enum": {"enumType": _cv2_type_tag(value), "member": value.name}}
+    if isinstance(value, bool):
+        return {"bool": value}
+    if isinstance(value, int):
+        return {"int": value}
+    if isinstance(value, str):
+        return {"str": value}
     if isinstance(value, float):
         from decimal import Decimal
 
         # The one canonical float spelling the system already uses (see
         # term_value.to_term / ir.real_lit): a fixed-point decimal string, never
-        # a Python float text form. str(float) is the shortest exact decimal
-        # that reparses to the same double; non-finite becomes Infinity / NaN.
+        # a Python float text form.
         return {"float": format(Decimal(str(value)), "f")}
     if isinstance(value, bytes):
-        # Bytes canonicalize by hex, matching bytes_value / sequence_repetition.
         return {"bytes": value.hex()}
-    if isinstance(value, Enum):
-        return {
-            "enumType": f"{type(value).__module__}.{type(value).__qualname__}",
-            "value": _canonical_constructed_value(value.value),
-        }
     if isinstance(value, SourceFragment):
+        # Reference its EXISTING authenticated identity, unreinterpreted. The
+        # sealed memento is five flat fields -- bounded, never a subtree.
         return {"sourceFragment": value.seal().to_dict()}
     if isinstance(value, SourceMemento):
         return {"sourceMemento": value.to_dict()}
@@ -904,41 +934,212 @@ def _compute_canonical_constructed_value(value: object) -> Any:
 
     if isinstance(value, Node):
         # A Node is a tree VIEW, not content. Its content identity is its
-        # construction-shape CID (fragment + subtree preimage); its unit/span
-        # are positional infrastructure that must never enter a content CID.
-        # A constructed value can legitimately carry a Node (e.g. a
-        # SourceVisibleCallFrameV1 holding the Lambda it will construct when
-        # called), but field-walking it drags in unit -> SourceUnit ->
-        # LineTable and fails to serialize (core/groupby/generic.value_counts).
-        # Represent the node by its content key, like every other node view.
-        return {"nodeShape": node_construction_shape_cid(value)}
-    if isinstance(value, (tuple, list)):
-        return [_canonical_constructed_value(item) for item in value]
-    if isinstance(value, (set, frozenset)):
-        items = [_canonical_constructed_value(item) for item in value]
-        return sorted(items, key=lambda item: cid_of_json(item))
+        # NodeShapeV2 construction-shape CID; its unit/span are the positional
+        # OCCURRENCE coordinate and must never enter a content CID.
+        return {"nodeShapeCid": node_construction_shape_cid(value)}
+    native = _validated_native_cid(value)
+    if native is not None:
+        return {"authenticatedValueCid": {"type": _cv2_type_tag(value), "cid": native}}
+    return _NOT_A_LEAF
+
+
+def _cv2_entries(value: object) -> tuple[str, list[tuple[Any, object]]]:
+    """``value``'s semantic type tag and its ordered ``(at, child)`` slots.
+
+    Called only for values ``_cv2_leaf`` declined. Every arm is NAMED; the final
+    arm is a typed gap, never reflection over ``__dict__`` and never
+    ``.wire()``.
+    """
+    if isinstance(value, tuple):
+        # Length and position are authenticated: ``at`` is the index, and
+        # ``arity`` is encoded, so reordering, duplicating or omitting a child
+        # changes the preimage.
+        return ("tuple", [(index, item) for index, item in enumerate(value)])
+    if isinstance(value, frozenset):
+        # An unordered frozen collection: ``at`` is deliberately absent and the
+        # entries are sorted by their own encoding at emit time, so the CID is a
+        # function of the MEMBERSHIP, never of Python's hash iteration order.
+        return ("frozenset", [(None, item) for item in value])
     if isinstance(value, dict):
         if not all(isinstance(key, str) for key in value):
-            raise TypeError("constructed testimony dictionaries require string keys")
-        return {
-            key: _canonical_constructed_value(item)
-            for key, item in sorted(value.items())
-        }
+            raise ConstructedValueCategoryGap(
+                "constructed testimony mappings require string keys; "
+                f"{_cv2_type_tag(value)} carries "
+                f"{sorted({type(k).__name__ for k in value})}"
+            )
+        # Key/value PAIRING is authenticated (``at`` is the key, carried beside
+        # its own value) under a deterministic (sorted) order.
+        return ("mapping", [(key, value[key]) for key in sorted(value)])
     if is_dataclass(value) and not isinstance(value, type):
-        return {
-            "constructedType": f"{type(value).__module__}.{type(value).__qualname__}",
-            "fields": {
-                field.name: _canonical_constructed_value(getattr(value, field.name))
-                for field in fields(value)
-            },
-        }
-    wire = getattr(value, "wire", None)
-    if callable(wire):
-        return {
-            "wireType": f"{type(value).__module__}.{type(value).__qualname__}",
-            "wire": _canonical_constructed_value(wire()),
-        }
-    raise TypeError(f"unserializable constructed value {type(value).__name__}")
+        params = getattr(value, "__dataclass_params__", None)
+        if params is not None and params.frozen:
+            return (
+                _cv2_type_tag(value),
+                [(field.name, getattr(value, field.name)) for field in fields(value)],
+            )
+        raise ConstructedValueCategoryGap(
+            f"{_cv2_type_tag(value)} is a MUTABLE dataclass: its content can "
+            "change after testimony, so it has no content coordinate. Make the "
+            "semantic value frozen, or keep the coordinate loud."
+        )
+    if isinstance(value, (list, set, bytearray)):
+        raise ConstructedValueCategoryGap(
+            f"{_cv2_type_tag(value)} is a MUTABLE container: snapshotting it "
+            "would authenticate a moment, not a value. Carry a tuple/frozenset "
+            "semantic value, or keep the coordinate loud."
+        )
+    raise ConstructedValueCategoryGap(
+        f"unclassified constructed value category {_cv2_type_tag(value)}: "
+        "ConstructedValueV2 names its categories and will not invent a preimage "
+        "by reflection. Name the category, or keep the coordinate loud."
+    )
+
+
+def _cv2_classify(
+    value: object,
+) -> tuple[str, int, list[dict[str, Any]], list[tuple[Any, object]]]:
+    """``value``'s semantic type, arity, inline leaves and child values.
+
+    Classification happens exactly ONCE per value: ``_cv2_leaf`` is not free
+    (a ``SourceFragment`` leaf seals its segment, which hashes text), so the
+    bottom-up loop caches this and never re-asks a slot's category.
+    """
+    semantic_type, entries = _cv2_entries(value)
+    local_fields: list[dict[str, Any]] = []
+    children: list[tuple[Any, object]] = []
+    for at, child in entries:
+        leaf = _cv2_leaf(child)
+        if leaf is _NOT_A_LEAF:
+            children.append((at, child))
+        else:
+            local_fields.append({"at": at, "leaf": leaf})
+    return semantic_type, len(entries), local_fields, children
+
+
+def _cv2_preimage(
+    semantic_type: str,
+    arity: int,
+    local_fields: list[dict[str, Any]],
+    children: list[tuple[Any, object]],
+    child_cid: dict[int, str],
+) -> dict[str, Any]:
+    """ONE value's V2 preimage: its own arity, never a child's subtree."""
+    child_entries = [
+        {"at": at, "childConstructedValueCid": child_cid[id(child)]}
+        for at, child in children
+    ]
+    if semantic_type == "frozenset":
+        # Membership, not iteration order. Sorting by the entry's own canonical
+        # encoding is total and deterministic.
+        local_fields = sorted(local_fields, key=cid_of_json)
+        child_entries.sort(key=lambda entry: entry["childConstructedValueCid"])
+    return {
+        "domain": CONSTRUCTED_VALUE_V2_DOMAIN,
+        "schema": CONSTRUCTED_VALUE_V2_SCHEMA,
+        "childCidAlgorithm": CONSTRUCTED_VALUE_V2_CHILD_CID_ALGORITHM,
+        "semanticType": semantic_type,
+        "arity": arity,
+        "localFields": local_fields,
+        "children": child_entries,
+    }
+
+
+def constructed_value_cid_v2(value: object) -> str:
+    """The ConstructedValueV2 content CID of ``value``, built BOTTOM-UP.
+
+    Explicit post-order over an iterative stack: no recursion, no recursive
+    embedding of a child's preimage, and no Python recursion limit on deep
+    constructed graphs. Each distinct content coordinate encodes exactly ONE
+    preimage of its own arity, so a shared DAG child is hashed once per content
+    coordinate rather than once per incoming path.
+
+    A value reached while it is still being expanded is a CYCLE: a typed gap,
+    loudly, never a truncation or a placeholder.
+    """
+    from .construction_cache import (
+        constructed_value_cid_v2_for,
+        remember_constructed_value_cid_v2,
+    )
+
+    cached = constructed_value_cid_v2_for(value)
+    if cached is not None:
+        return cached
+
+    child_cid: dict[int, str] = {}
+    classified: dict[int, tuple[str, int, list[dict[str, Any]], list[Any]]] = {}
+    # ``child_cid`` and ``classified`` are keyed by id(); pin every keyed
+    # value for the duration so a dead value's address can never be recycled
+    # onto another's row.
+    pinned: list[object] = []
+    # Values whose expansion has begun and not finished -- the DFS "gray" set,
+    # which is exactly the cycle predicate.
+    expanding: dict[int, object] = {}
+    stack: list[tuple[object, bool]] = [(value, False)]
+    while stack:
+        current, expanded = stack.pop()
+        if id(current) in child_cid:
+            continue
+        known = constructed_value_cid_v2_for(current)
+        if known is not None:
+            child_cid[id(current)] = known
+            pinned.append(current)
+            continue
+        row = classified.get(id(current))
+        if row is None:
+            row = _cv2_classify(current)
+            classified[id(current)] = row
+        semantic_type, arity, local_fields, children = row
+        pinned.append(current)
+        if not expanded:
+            expanding[id(current)] = current
+            stack.append((current, True))
+            for _at, child in children:
+                if id(child) in child_cid:
+                    continue
+                if id(child) in expanding:
+                    raise ConstructedValueCategoryGap(
+                        "constructed value graph is CYCLIC through "
+                        f"{_cv2_type_tag(child)}: a cycle has no content "
+                        "coordinate. Keep the coordinate loud."
+                    )
+                stack.append((child, False))
+            continue
+        expanding.pop(id(current), None)
+        cid = cid_of_json(
+            _cv2_preimage(semantic_type, arity, local_fields, children, child_cid)
+        )
+        child_cid[id(current)] = cid
+        remember_constructed_value_cid_v2(current, cid)
+    result = child_cid[id(value)]
+    del pinned
+    return result
+
+
+def constructed_value_slot_v2(value: object) -> dict[str, Any]:
+    """One value as it appears in a slot: an inline leaf, or a child CID.
+
+    The two forms live under DIFFERENT keys, so a leaf string can never be read
+    as a child CID and a child CID can never be read as a leaf.
+    """
+    leaf = _cv2_leaf(value)
+    if leaf is not _NOT_A_LEAF:
+        return {"leaf": leaf}
+    return {"constructedValueCid": constructed_value_cid_v2(value)}
+
+
+def _constructed_preimage(value: object) -> dict[str, Any]:
+    """The envelope a presented construction's semantic-value CID is taken of.
+
+    ``schemaVersion: "2"`` plus the named value schema and child-CID algorithm
+    put V2 in an identity namespace disjoint from V1's.
+    """
+    return {
+        "kind": "constructed-semantic-value",
+        "schemaVersion": "2",
+        "valueSchema": CONSTRUCTED_VALUE_V2_SCHEMA,
+        "childCidAlgorithm": CONSTRUCTED_VALUE_V2_CHILD_CID_ALGORITHM,
+        "value": constructed_value_slot_v2(value),
+    }
 
 
 def _snapshot(scope: BindingMap) -> tuple[tuple[str, BindingEntryV1], ...]:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -62,6 +62,93 @@ def remember_shape_cid_v2(ref: object, cid: str) -> None:
     _SHAPE_CIDS_V2[ref] = cid
 
 
+# The ConstructedValueV2 (Merkle) content CID of one constructed SEMANTIC
+# VALUE: a pure function of the value's own semantic type, its authenticated
+# scalar leaves, and its children's V2 CIDs. This is the registry bottom-up
+# construction reads and fills, so each memoizable value encodes ONE preimage of
+# its own arity, once, ever -- the difference between O(sum of subtree sizes)
+# and O(n) over the shared constructed DAG.
+#
+# A SEPARATE NAMESPACE from ``_SHAPE_CIDS`` and ``_SHAPE_CIDS_V2``. Those hold
+# node-SHAPE identities; this holds constructed-VALUE identities. Three
+# registries, three identity namespaces, never read for each other.
+#
+# ONLY FROZEN DATACLASSES GET A ROW, because only they have a coordinate whose
+# inputs this module can NAME:
+#
+#   * frozen dataclass -> keyed by (type, id(value)). ``frozen=True`` is what
+#     makes the field tuple a function of the object, so the live object IS the
+#     coordinate; type is in the key because the semantic type tag is in the
+#     output. The id-reuse hazard (#6212) is closed by construction: the row
+#     holds a WEAK reference to the object it keyed and a hit is honored only
+#     when that weakref still resolves to the SAME object, so a recycled address
+#     misses instead of reading a dead value's CID. The weakref callback drops
+#     the row, bounding the table by LIVE values.
+#
+#   * tuple / frozenset / mapping -> deliberately NO row. A mapping is MUTABLE,
+#     so identity is not a coordinate at all. A tuple/frozenset is immutable but
+#     its preimage is exactly its children's already-memoized CIDs, so a row
+#     would buy the walk of ONE value's own arity -- which is precisely the work
+#     the linear form is allowed to do.
+#
+#   * every leaf category (primitive, enum, Node, SourceFragment/Memento,
+#     natively-authenticated CID owner) -> no row: they never mint a
+#     ConstructedValueV2 CID at all, they inline.
+#
+# CONTENT IDENTITY WITHOUT OCCURRENCE IDENTITY. Two distinct-but-equal frozen
+# values get two ROWS carrying the SAME CID. They share content identity -- that
+# is what content-addressing means and what makes the form linear -- and stay
+# distinct occurrences: two live objects, two rows, and distinct ordered ``at``
+# coordinates in their parents.
+_CONSTRUCTED_VALUE_CIDS_V2: dict[Any, tuple[Any, str]] = {}
+
+
+def _constructed_value_coordinate(value: object) -> Any:
+    """``value``'s content-CID coordinate, or ``None`` if it has no row."""
+    from dataclasses import is_dataclass
+
+    if not is_dataclass(value) or isinstance(value, type):
+        return None
+    params = getattr(value, "__dataclass_params__", None)
+    if params is None or not params.frozen:
+        return None
+    return ("constructed-value-v2", type(value), id(value))
+
+
+def constructed_value_cid_v2_for(value: object) -> str | None:
+    """The memoized ConstructedValueV2 CID for ``value``, or None if unseen."""
+    coordinate = _constructed_value_coordinate(value)
+    if coordinate is None:
+        return None
+    remembered = _CONSTRUCTED_VALUE_CIDS_V2.get(coordinate)
+    if remembered is None:
+        return None
+    keyed, cid = remembered
+    # The identity-bearing key is honored only while the object it named is
+    # alive and is the SAME object.
+    if keyed() is not value:
+        return None
+    return cid
+
+
+def remember_constructed_value_cid_v2(value: object, cid: str) -> None:
+    """Record ``value``'s ConstructedValueV2 CID in its own static registry."""
+    coordinate = _constructed_value_coordinate(value)
+    if coordinate is None:
+        return
+    try:
+
+        def _forget(_dead: Any, coordinate: Any = coordinate) -> None:
+            _CONSTRUCTED_VALUE_CIDS_V2.pop(coordinate, None)
+
+        reference = weakref.ref(value, _forget)
+    except TypeError:
+        # Cannot hold the live identity its key names -> no row, rather than a
+        # row a recycled address could read.
+        return
+    _CONSTRUCTED_VALUE_CIDS_V2[coordinate] = (reference, cid)
+
+
 class ConstructionCache:
     """Shared field rows keyed by backend site + reporter + control context."""
 

--- a/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
@@ -168,25 +168,35 @@ def test_loop_projection_rejects_lying_target_and_cid_as_runtime_value():
         )
 
 
-def test_canonical_constructed_value_seals_float_and_bytes():
+def test_constructed_value_v2_seals_float_and_bytes():
     # Float and bytes literal testimony must enter the closed canonical wire.
-    from sugar_source_tree.binding_state import _canonical_constructed_value
+    from sugar_source_tree.binding_state import (
+        ConstructedValueCategoryGap,
+        _cv2_leaf,
+    )
 
     # Float -> the ONE canonical fixed-point decimal string the system uses
     # (ir.real_lit), tagged so a float never collides with the str "1.5".
-    assert _canonical_constructed_value(1.5) == {"float": "1.5"}
-    assert _canonical_constructed_value(0.0) == {"float": "0.0"}
-    assert _canonical_constructed_value(-2.25) == {"float": "-2.25"}
-    assert _canonical_constructed_value(1e-05) == {"float": "0.00001"}
+    assert _cv2_leaf(1.5) == {"float": "1.5"}
+    assert _cv2_leaf(0.0) == {"float": "0.0"}
+    assert _cv2_leaf(-2.25) == {"float": "-2.25"}
+    assert _cv2_leaf(1e-05) == {"float": "0.00001"}
     # Bytes -> hex, matching bytes_value / sequence_repetition.
-    assert _canonical_constructed_value(b"\xde\xad\xbe\xef") == {"bytes": "deadbeef"}
+    assert _cv2_leaf(b"\xde\xad\xbe\xef") == {"bytes": "deadbeef"}
+    # A tagged float can never be read as the string that spells it.
+    assert _cv2_leaf(1.5) != _cv2_leaf("1.5")
 
     # Both must be canonical-JSON admissible and deterministic.
     for value in (1.5, 0.0, b"\x00\xff"):
-        encoded = _canonical_constructed_value(value)
+        encoded = _cv2_leaf(value)
         assert cid_of_json({"v": encoded}) == cid_of_json({"v": encoded})
 
     # Bad twin: a value with no canonical spelling stays LOUD, never silently
-    # collapses to a fabricated testimony.
-    with pytest.raises(TypeError, match="unserializable"):
-        _canonical_constructed_value(1 + 2j)
+    # collapses to a fabricated testimony, and never falls back to reflection.
+    from sugar_source_tree.binding_state import constructed_value_cid_v2
+
+    from sugar_source_tree.binding_state import _NOT_A_LEAF
+
+    assert _cv2_leaf(1 + 2j) is _NOT_A_LEAF
+    with pytest.raises(ConstructedValueCategoryGap, match="unclassified"):
+        constructed_value_cid_v2(1 + 2j)


### PR DESCRIPTION
`_canonical_constructed_value` inlined the whole constructed DAG walked as a tree — the same defect `NodeShapeV2` (#6253) removed from the *shape* preimage, one layer up in the *semantic testimony* layer. After #6253, `cid_of_json` was still **2736s cumulative over 1,482 calls** (~39,100 JSON nodes per call).

## Form
```
{domain: "sugar/construction/constructed-value/v2",
 schema: "ConstructedValueV2",
 childCidAlgorithm: "sugar/construction/constructed-value/v2+cid_of_json",
 semanticType, arity,
 localFields: [{at, leaf}, ...],
 children:    [{at, childConstructedValueCid}, ...]}
```
Envelope carries `schemaVersion:"2"` + `valueSchema` + `childCidAlgorithm` — keys no V1 preimage ever had, so namespaces are disjoint. Registry is a **third** namespace, `_CONSTRUCTED_VALUE_CIDS_V2`, separate from `_SHAPE_CIDS` and `_SHAPE_CIDS_V2`; only frozen dataclasses take a row, weakref-guarded against #6212 address reuse.

## Classification — measured on the live corpus first, not guessed
Instrumented V1's arms before writing anything. Reachable in the corpus: primitives, frozen dataclasses, tuples, mappings, `SourceFragment`, and exactly one mutable container.

- **primitive / enum** → tagged inline leaf. `Enum` is now tested **before** `int` — **V1's arm order encoded an `IntEnum` member as a bare integer and lost the member.**
- **frozen dataclass / tuple / frozenset / mapping** → child CIDs; `at` = field name / index / key. Frozenset sorts by its own encoding (membership, not iteration order).
- **`Node`** → inlines its NodeShapeV2 content CID; unit/span occurrence never enters.
- **`SourceFragment` / `SourceMemento`** → existing sealed identity, unreinterpreted.
- **CID-owning value** → native `.cid`, but only where `cid_of_json(preimage) == cid` is **checked**, memoized per `(type, cid)`.
- **mutable container / mutable dataclass / cycle / unnameable** → `ConstructedValueCategoryGap`, travelling the existing loud testimony door. No reflection, no generic `.wire()`.

The one gap that had to be resolved rather than accepted: `LoopConstructionV1._graph`, a raw dict-of-lists, was the sole reachable mutable container. Snapshotting it would violate the rule; leaving it a gap raised R. It is an already-sealed Merkle wire document, so V2 references it by the validated native CID `loop_construction_cid` already authenticates and never walks it. R identical.

## Equivalence — CID-independent
173 pandas modules, 2,307 functions; every CID-shaped string in constructed sugar, desugar outcome, gap families and terminal shape replaced by a positional placeholder in first-encounter order.

- **4,692,391 masked CID occurrences — DIFFS: 0**
- **distinct CID identities V1 82,056 = V2 82,056** — nothing merged, nothing split
- gap families identical (`With` 23, `Assign` 4, `Try` 2, `AnnAssign` 2), **R = 31 both sides**

## Linearity — fitted log-log slopes
| sweep | V1 | V2 |
|---|---|---|
| depth | **1.96** | **0.99** |
| breadth | 1.00 | 0.99 |

Measured as total encoded bytes while **presenting every value** — what `present_construction` actually does. The single-root metric is linear even in V1 and would have hidden the defect entirely. Breadth was already linear; reported, not averaged away.

## Timings
| | V1 | V2 | |
|---|---|---|---|
| `__internal_pivot_table` | 496.08s | **11.77s** | 42× — no longer timeout-class |
| `value_counts` | 229.43s | **7.27s** | 32× — recovers the NodeShapeV2 regression and then some |
| `to_numeric` | 72.48s | **0.60s** | 121× |
| `_where` | 2.38s | **0.63s** | no regression |

`_constructed_preimage` JSON-node visits on pivot, **267 calls both sides**: 28,962,097 → 1,869 (avg 108,472 → 7; worst call 2,152,944 → 7). Bytes hashed: 1,456,858,830 → 2,253,076 (**647×**).

## Twins — 30
Domain/schema/child-algorithm present · V1/V2 envelopes never collide · a leaf carrying a CID string ≠ a child carrying it · parent embeds only CIDs · 3,000-deep bottom-up (recursion limit is 1,000) · both linearity sweeps · shared DAG child hashed once (4 preimages, not 8) · reordered/omitted/duplicated tuple children, renamed fields, changed mapping pairing, changed leaf values and semantic types all bite · `bool ≠ int`, `IntEnum ≠ its integer`, same-payload enums distinct · frozenset = membership · equal content shares the CID with **two** registry rows and distinct `at` coordinates · recycled address misses · every gap category loud · native CID validated, not trusted.

## Regressions
- `sugar-source-tree`: **538 passed, 3 skipped, 0 failed**
- `sugar-lift-py-tests`: 135 failed / 5 errors — **byte-identical failure name set to `origin/main`, zero delta**; 1,048 passed
- targeted suites: **153 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace ConstructedValueV1 recursive embedding with bottom-up CID-authenticating ConstructedValueV2
> - Introduces `constructed_value_cid_v2` in [binding_state.py](https://github.com/TSavo/sugar/pull/6269/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40): a value's preimage now authenticates only its direct children's CIDs (not their full subtrees), enabling linear encoding proportional to DAG size rather than tree size.
> - Adds `_cv2_leaf`, `_cv2_entries`, `_cv2_classify`, and `_cv2_preimage` helpers to classify values into typed leaves (None, Enum, bool, int, str, float, bytes, Node, etc.) and child references; mutable/unnameable categories raise `ConstructedValueCategoryGap` instead of being silently reflected.
> - Adds a weakref-keyed memo registry `_CONSTRUCTED_VALUE_CIDS_V2` in [construction_cache.py](https://github.com/TSavo/sugar/pull/6269/files#diff-fec1dbfe7718a35848f37642330b8df50429df86eae284a72524c6bf8352972f), scoped to frozen dataclasses, to avoid redundant hashing across calls.
> - Updates `_node_shape_v2_preimage` to embed constructed value slots via `constructed_value_slot_v2` (leaf inline or child CID) instead of full canonical JSON.
> - Behavioral Change: V2 CID namespace is disjoint from V1; any downstream schemas that stored V1 constructed-value CIDs (e.g. NodeShapeV2 slots) will produce different CIDs after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a4358b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ConstructedValueV2 authentication for structured values, using child content identifiers for secure, deterministic construction.
  * Added support for retrieving loop construction preimages and authenticated CIDs.
  * Added semantic handling for nested values, shared structures, frozen dataclasses, enums, mappings, and native authenticated values.

* **Bug Fixes**
  * Improved rejection of unsupported, mutable, cyclic, or unclassifiable values with typed errors.
  * Prevented stale or recycled cached entries from being reused.

* **Tests**
  * Expanded coverage for determinism, identity, namespace separation, deep structures, performance, and value-type distinctions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->