### PR TITLE
Key the authenticated-artifact-graph memo by the artifact CID

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -28,8 +28,35 @@ class DependencyArtifactAuthenticationError(Exception):
 
 
 _ARTIFACT_INTAKE_AUTHORITY = object()
-# Process-local: same distribution seat should not re-hash/re-parse.
-_AUTHENTICATE_GRAPH_CACHE: dict[tuple[str, ...], "DependencyArtifactGraph"] = {}
+
+# The authenticated-graph memo is CONTENT-ADDRESSED, and that is the whole
+# reason it may be process-global (#6266's distinction, applied here).
+#
+# The key is the ``distribution_artifact_cid`` -- the CID over every recorded
+# file's content CID.  ``h = h(p)``: the key is a pure function of exactly the
+# bytes the value authenticates, so "the installation changed but the memo did
+# not" is not a bug to detect, it is a sentence that cannot be written.  A miss
+# is the only thing a changed byte can produce.
+#
+# It was keyed by dist-info PATH, and that shipped a CID that did not address
+# its bytes: authenticate -> edit the installed source -> authenticate returned
+# the first graph, reporting an artifact CID for content that no longer existed
+# on disk.  The neighbouring disk cache stat'ed ``RECORD``, which is not touched
+# when an installed ``.py`` file is edited, so it served the same stale graph
+# across processes.  Both are now keyed by the artifact CID.
+#
+# The VALUE is legitimately shareable here, which is why this is a registry and
+# not a session: ``DependencyArtifactGraph`` is a frozen dataclass over a tuple
+# of frozen files and a ``MappingProxyType``, holding bytes and str only.  It
+# owns no live construction context, so no caller can write into a served graph
+# and have that write reach another authentication.  (Contrast
+# ``resolution_session``: those memo VALUES were bound to a mutable
+# ``TreeConstructionContextV1``, which is why they needed an owner.)
+_AUTHENTICATE_GRAPH_CACHE: dict[str, "DependencyArtifactGraph"] = {}
+
+# Memoization switch. Flipping it must change SPEED ONLY: never a CID, never a
+# verdict, never a graph. Paying full price is always a legal answer.
+_AUTHENTICATE_CACHE_ENABLED = True
 
 
 def _require_parseable_module_source(
@@ -50,55 +77,33 @@ def _require_parseable_module_source(
         ) from exc
 
 
-def _distribution_authenticate_cache_key(
-    distribution: importlib.metadata.Distribution,
-) -> tuple[str, ...]:
-    """Stable process-local key for one installed distribution seat."""
-    path = getattr(distribution, "_path", None)
-    if path is not None:
-        return ("path", str(Path(path).resolve()))
-    try:
-        name = distribution.metadata["Name"] or ""
-        version = distribution.metadata["Version"] or ""
-    except Exception:
-        name, version = "", ""
-    return ("meta", str(name), str(version), str(type(distribution)))
+def _artifact_disk_cache_path(artifact_cid: str) -> Path:
+    """On-disk seat for one authenticated graph, addressed by its own CID.
 
-
-def _distribution_disk_cache_path(
-    distribution: importlib.metadata.Distribution,
-) -> Path | None:
-    """Content-stable on-disk seat for one installed distribution graph."""
-    path = getattr(distribution, "_path", None)
-    if path is None:
-        return None
-    seat = Path(path).resolve()
-    record = seat / "RECORD" if seat.is_dir() else seat
-    try:
-        st = record.stat()
-    except OSError:
-        return None
-    digest = blake3_512_of(
-        f"{seat}\0{st.st_mtime_ns}\0{st.st_size}".encode("utf-8")
-    ).removeprefix("blake3-512:")[:32]
+    The seat is a pure function of the artifact CID, so a changed installed byte
+    changes the CID, which changes the seat: a stale hit has no filename to live
+    at. The seat this replaced was a digest over ``RECORD``'s ``(mtime, size)``,
+    which does not move when an installed ``.py`` file is edited.
+    """
+    digest = artifact_cid.removeprefix("blake3-512:")[:32]
     root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
     return root / "sugar" / "dependency-artifact-graphs" / f"{digest}.pkl"
 
 
 def _load_authenticate_disk_cache(
-    distribution: importlib.metadata.Distribution,
+    artifact_cid: str,
 ) -> "DependencyArtifactGraph | None":
-    path = _distribution_disk_cache_path(distribution)
-    if path is None or not path.is_file():
+    path = _artifact_disk_cache_path(artifact_cid)
+    if not path.is_file():
         return None
     try:
         import pickle
 
         with path.open("rb") as stream:
             payload = pickle.load(stream)
-        if not isinstance(payload, dict) or payload.get("schema") != "dep-graph-v1":
+        if not isinstance(payload, dict) or payload.get("schema") != "dep-graph-v2":
             return None
-        return DependencyArtifactGraph(
+        graph = DependencyArtifactGraph(
             artifact_kind=payload["artifact_kind"],
             distribution_name=payload["distribution_name"],
             distribution_version=payload["distribution_version"],
@@ -109,22 +114,25 @@ def _load_authenticate_disk_cache(
         )
     except Exception:
         return None
+    # ``__post_init__`` already recomputed the CID from the retained bytes; this
+    # pins that the recomputed CID is the one that was ASKED for, so a payload
+    # parked at the wrong seat cannot answer a question it does not address.
+    if graph.distribution_artifact_cid != artifact_cid:
+        return None
+    return graph
 
 
 def _store_authenticate_disk_cache(
-    distribution: importlib.metadata.Distribution,
     graph: "DependencyArtifactGraph",
 ) -> None:
-    path = _distribution_disk_cache_path(distribution)
-    if path is None:
-        return
+    path = _artifact_disk_cache_path(graph.distribution_artifact_cid)
     try:
         import pickle
         import tempfile
 
         # MappingProxyType is not pickleable; store plain dict modules.
         payload = {
-            "schema": "dep-graph-v1",
+            "schema": "dep-graph-v2",
             "artifact_kind": graph.artifact_kind,
             "distribution_name": graph.distribution_name,
             "distribution_version": graph.distribution_version,
@@ -541,26 +549,22 @@ class DependencyArtifactGraph:
                 "artifact module projection is incomplete or contains invented modules"
             )
 
-    @classmethod
-    def authenticate(
-        cls, distribution: importlib.metadata.Distribution
-    ) -> "DependencyArtifactGraph":
-        """Hash every recorded installed file and publish authenticated modules."""
-        cache_key = _distribution_authenticate_cache_key(distribution)
-        cached = _AUTHENTICATE_GRAPH_CACHE.get(cache_key)
-        if cached is not None:
-            return cached
-        disk = _load_authenticate_disk_cache(distribution)
-        if disk is not None:
-            _AUTHENTICATE_GRAPH_CACHE[cache_key] = disk
-            return disk
+    @staticmethod
+    def _read_recorded_installation(
+        distribution: importlib.metadata.Distribution,
+    ) -> tuple[list[tuple[AuthenticatedArtifactFileV1, str]], str, str, str]:
+        """Read and content-address the installation; mint its artifact CID.
+
+        This is the half that CANNOT be memoized: it is what establishes which
+        bytes are on disk right now, and therefore what the answer is allowed to
+        be addressed by. Everything memoized downstream is keyed by its result.
+        """
         files = distribution.files
         if files is None:
             raise DependencyArtifactAuthenticationError(
                 "installed distribution has no recorded file manifest"
             )
-        authenticated_files: list[AuthenticatedArtifactFileV1] = []
-        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        located: list[tuple[AuthenticatedArtifactFileV1, str]] = []
         for recorded in sorted(files, key=lambda item: str(item)):
             relative = PurePosixPath(str(recorded))
             if relative.is_absolute():
@@ -574,38 +578,19 @@ class DependencyArtifactGraph:
                 raise DependencyArtifactAuthenticationError(
                     f"cannot read recorded distribution file {relative}"
                 ) from exc
-            authenticated_files.append(
-                AuthenticatedArtifactFileV1(
-                    source_seat=relative.as_posix(),
-                    content_cid=content_cid,
-                    content=content,
+            located.append(
+                (
+                    AuthenticatedArtifactFileV1(
+                        source_seat=relative.as_posix(),
+                        content_cid=content_cid,
+                        content=content,
+                    ),
+                    str(path),
                 )
-            )
-            module_name = _module_name(relative)
-            if module_name is None:
-                continue
-            try:
-                source = content.decode("utf-8")
-            except UnicodeError as exc:
-                raise DependencyArtifactAuthenticationError(
-                    f"recorded Python module {module_name} is not parseable UTF-8 source"
-                ) from exc
-            _require_parseable_module_source(
-                source, path=str(path), module_name=module_name
-            )
-            if module_name in modules:
-                raise DependencyArtifactAuthenticationError(
-                    f"distribution contains duplicate module seat {module_name}"
-                )
-            modules[module_name] = AuthenticatedModuleSourceV1(
-                module_name=module_name,
-                source_seat=relative.as_posix(),
-                source_cid=content_cid,
-                source=source,
             )
         metadata_files = [
             item
-            for item in authenticated_files
+            for item, _ in located
             if item.source_seat.endswith(".dist-info/METADATA")
         ]
         if len(metadata_files) != 1:
@@ -626,20 +611,63 @@ class DependencyArtifactGraph:
             "distributionVersion": version,
             "files": [
                 {"path": item.source_seat, "contentCid": item.content_cid}
-                for item in authenticated_files
+                for item, _ in located
             ],
         }
+        return located, name, str(version), cid_of_json(preimage)
+
+    @classmethod
+    def authenticate(
+        cls, distribution: importlib.metadata.Distribution
+    ) -> "DependencyArtifactGraph":
+        """Hash every recorded installed file and publish authenticated modules."""
+        located, name, version, artifact_cid = cls._read_recorded_installation(
+            distribution
+        )
+        if _AUTHENTICATE_CACHE_ENABLED:
+            cached = _AUTHENTICATE_GRAPH_CACHE.get(artifact_cid)
+            if cached is not None:
+                return cached
+            disk = _load_authenticate_disk_cache(artifact_cid)
+            if disk is not None:
+                _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = disk
+                return disk
+        authenticated_files = [item for item, _ in located]
+        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        for item, path in located:
+            relative = PurePosixPath(item.source_seat)
+            module_name = _module_name(relative)
+            if module_name is None:
+                continue
+            try:
+                source = item.content.decode("utf-8")
+            except UnicodeError as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"recorded Python module {module_name} is not parseable UTF-8 source"
+                ) from exc
+            _require_parseable_module_source(source, path=path, module_name=module_name)
+            if module_name in modules:
+                raise DependencyArtifactAuthenticationError(
+                    f"distribution contains duplicate module seat {module_name}"
+                )
+            modules[module_name] = AuthenticatedModuleSourceV1(
+                module_name=module_name,
+                source_seat=relative.as_posix(),
+                source_cid=item.content_cid,
+                source=source,
+            )
         graph = cls(
             artifact_kind="distribution",
             distribution_name=name,
             distribution_version=version,
-            distribution_artifact_cid=cid_of_json(preimage),
+            distribution_artifact_cid=artifact_cid,
             files=tuple(authenticated_files),
             modules=MappingProxyType(modules),
             _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
         )
-        _AUTHENTICATE_GRAPH_CACHE[cache_key] = graph
-        _store_authenticate_disk_cache(distribution, graph)
+        if _AUTHENTICATE_CACHE_ENABLED:
+            _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = graph
+            _store_authenticate_disk_cache(graph)
         return graph
 
     @classmethod

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
@@ -1,0 +1,480 @@
+"""Authority twins for the authenticated-artifact-graph memo.
+
+The law: **an authenticated artifact graph must be invalidated when the bytes it
+authenticates change.** A CID that does not address its bytes is not a weak
+cache, it is a violation of content addressing itself -- ``h = h(p)`` with the
+``p`` swapped out from under it.
+
+``_AUTHENTICATE_GRAPH_CACHE`` was keyed by dist-info PATH, and its disk twin was
+keyed by a digest over ``RECORD``'s ``(mtime, size)`` -- which does not move when
+an installed ``.py`` file is edited. Both served a graph reporting an artifact
+CID for content that no longer existed on disk.
+
+The repair is not a better invalidation check. It is the key: both memos are now
+keyed by the ``distribution_artifact_cid``, which is a pure function of exactly
+the bytes the graph authenticates. Stale is not detected, it is
+UNREPRESENTABLE -- a changed byte changes the key, and a changed key is a miss.
+That is also why this registry may be process-global where #6266's projection
+memos could not be: the key is the complete key, and the value is frozen
+content, not a node bound to somebody's live construction context.
+
+Every twin carries a bite: a discrimination arm that reproduces the OLD
+path-keyed shape and shows it answering wrongly on the same input, so no
+positive assertion can pass vacuously.
+"""
+
+from __future__ import annotations
+
+import csv
+import dataclasses
+import importlib.metadata
+import sys
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source import dependency_artifact as da
+from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+
+_INIT = "from example_pkg.implementation import build\n"
+_IMPL_A = "def build(value):\n    return value\n"
+_IMPL_B = "def build(value):\n    return value + 1\n"
+
+
+def _install(root: Path, *, implementation_source: str, dist: str = "example_dist"):
+    """Install one authenticated distribution seat under ``root``."""
+    root.mkdir(parents=True, exist_ok=True)
+    package = root / "example_pkg"
+    package.mkdir(exist_ok=True)
+    (package / "__init__.py").write_text(_INIT, encoding="utf-8")
+    (package / "implementation.py").write_text(implementation_source, encoding="utf-8")
+    metadata = root / f"{dist}-1.0.dist-info"
+    metadata.mkdir(exist_ok=True)
+    (metadata / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist.replace('_', '-')}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("example_pkg\n", encoding="utf-8")
+    recorded = (
+        "example_pkg/__init__.py",
+        "example_pkg/implementation.py",
+        f"{dist}-1.0.dist-info/METADATA",
+        f"{dist}-1.0.dist-info/top_level.txt",
+        f"{dist}-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    sys.modules.pop("example_pkg", None)
+    sys.modules.pop("example_pkg.implementation", None)
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _mutate(root: Path, implementation_source: str) -> None:
+    """Mutate the INSTALLATION, exactly as `pip install -e` editing would.
+
+    ``RECORD`` is deliberately left untouched: that is the point. An edited
+    installed module does not restat the dist-info, which is why a RECORD-stat
+    key cannot see this and a content key cannot miss it.
+    """
+    (root / "example_pkg" / "implementation.py").write_text(
+        implementation_source, encoding="utf-8"
+    )
+
+
+def _on_disk(root: Path) -> str:
+    return (root / "example_pkg" / "implementation.py").read_text(encoding="utf-8")
+
+
+def _observable(graph: DependencyArtifactGraph) -> dict:
+    """Everything an authentication answer says, flattened for comparison."""
+    return {
+        "artifact_kind": graph.artifact_kind,
+        "distribution_name": graph.distribution_name,
+        "distribution_version": graph.distribution_version,
+        "distribution_artifact_cid": graph.distribution_artifact_cid,
+        "files": [(item.source_seat, item.content_cid) for item in graph.files],
+        "contents": [item.content for item in graph.files],
+        "modules": {
+            name: (module.source_seat, module.source_cid, module.source)
+            for name, module in graph.modules.items()
+        },
+    }
+
+
+# -- the defect, reproduced as a bite -----------------------------------------
+
+
+class _PathKeyedMemo:
+    """The OLD shape: one graph per dist-info path, checking nothing.
+
+    Kept as an executable bite rather than prose. Every twin below runs its
+    input through this too, and asserts the two shapes DISAGREE -- so a twin
+    that stopped discriminating fails loudly instead of passing vacuously.
+    """
+
+    def __init__(self) -> None:
+        self._by_path: dict[str, DependencyArtifactGraph] = {}
+
+    def authenticate(
+        self, distribution: importlib.metadata.Distribution
+    ) -> DependencyArtifactGraph:
+        key = str(Path(distribution._path).resolve())
+        hit = self._by_path.get(key)
+        if hit is not None:
+            return hit
+        graph = _uncached(distribution)
+        self._by_path[key] = graph
+        return graph
+
+
+def _uncached(
+    distribution: importlib.metadata.Distribution,
+) -> DependencyArtifactGraph:
+    """Authenticate paying full price, with every memo out of the way."""
+    enabled = da._AUTHENTICATE_CACHE_ENABLED
+    da._AUTHENTICATE_CACHE_ENABLED = False
+    try:
+        return DependencyArtifactGraph.authenticate(distribution)
+    finally:
+        da._AUTHENTICATE_CACHE_ENABLED = enabled
+
+
+@pytest.fixture(autouse=True)
+def _isolated_memos(tmp_path, monkeypatch):
+    """Give each twin its own disk seat and a cold in-memory table.
+
+    Not a scrub of shared authority -- the in-memory table is content-addressed
+    and could legitimately survive. It is isolation of the MEASUREMENT: a twin
+    about cold-vs-warm cannot be read if a previous twin warmed it.
+    """
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(da, "_AUTHENTICATE_GRAPH_CACHE", {})
+    monkeypatch.setattr(da, "_AUTHENTICATE_CACHE_ENABLED", True)
+    yield
+
+
+# -- twin 1: mutation invalidates ---------------------------------------------
+
+
+def test_mutating_the_installation_invalidates_the_cached_graph(tmp_path):
+    """The reproduction, promoted to a permanent test."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+
+    first = DependencyArtifactGraph.authenticate(distribution)
+    assert first.modules["example_pkg.implementation"].source == _IMPL_A
+
+    _mutate(root, _IMPL_B)
+    second = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+
+    assert second.modules["example_pkg.implementation"].source == _IMPL_B
+    assert second.distribution_artifact_cid != first.distribution_artifact_cid
+
+
+def test_bite_the_path_keyed_memo_serves_the_stale_graph(tmp_path):
+    """Bite for twin 1: same perturbation, old shape, wrong answer."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    memo = _PathKeyedMemo()
+
+    first = memo.authenticate(distribution)
+    _mutate(root, _IMPL_B)
+    second = memo.authenticate(importlib.metadata.Distribution.at(distribution._path))
+
+    # The defect, stated as an assertion so its removal is what fails.
+    assert second is first
+    assert second.modules["example_pkg.implementation"].source == _IMPL_A
+    assert _on_disk(root) == _IMPL_B
+
+
+# -- twin 2: the reported CID always addresses the bytes on disk ---------------
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        (_IMPL_A,),
+        (_IMPL_A, _IMPL_B),
+        (_IMPL_A, _IMPL_B, _IMPL_A),
+        (_IMPL_A, _IMPL_A),
+        (_IMPL_B, "def build(value):\n    return value + 2\n", _IMPL_A),
+    ],
+)
+def test_reported_artifact_cid_always_matches_the_bytes_on_disk(tmp_path, sequence):
+    """h = h(p) is checked against a FRESH read, never against the memo."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=sequence[0])
+
+    for implementation_source in sequence:
+        _mutate(root, implementation_source)
+        graph = DependencyArtifactGraph.authenticate(
+            importlib.metadata.Distribution.at(distribution._path)
+        )
+        truth = _uncached(importlib.metadata.Distribution.at(distribution._path))
+        assert graph.distribution_artifact_cid == truth.distribution_artifact_cid
+        module = graph.modules["example_pkg.implementation"]
+        assert module.source == _on_disk(root)
+        recorded = {item.source_seat: item.content for item in graph.files}
+        assert recorded["example_pkg/implementation.py"] == _on_disk(root).encode()
+
+
+def test_bite_the_path_keyed_memo_reports_a_cid_that_addresses_nothing(tmp_path):
+    """Bite for twin 2: the served CID names bytes that are not on disk."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    memo = _PathKeyedMemo()
+    memo.authenticate(distribution)
+
+    _mutate(root, _IMPL_B)
+    stale = memo.authenticate(importlib.metadata.Distribution.at(distribution._path))
+    truth = _uncached(importlib.metadata.Distribution.at(distribution._path))
+
+    assert stale.distribution_artifact_cid != truth.distribution_artifact_cid
+    assert stale.modules["example_pkg.implementation"].source != _on_disk(root)
+
+
+# -- twin 3: two installations do not alias -----------------------------------
+
+
+def test_two_distinct_installations_at_different_paths_do_not_alias(tmp_path):
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left_graph = DependencyArtifactGraph.authenticate(
+        _install(left, implementation_source=_IMPL_A)
+    )
+    right_graph = DependencyArtifactGraph.authenticate(
+        _install(right, implementation_source=_IMPL_B)
+    )
+
+    assert left_graph.distribution_artifact_cid != right_graph.distribution_artifact_cid
+    assert left_graph.modules["example_pkg.implementation"].source == _IMPL_A
+    assert right_graph.modules["example_pkg.implementation"].source == _IMPL_B
+    assert left_graph.modules["example_pkg.implementation"].source == _on_disk(left)
+    assert right_graph.modules["example_pkg.implementation"].source == _on_disk(right)
+
+
+def test_identical_installations_at_different_paths_are_the_same_artifact(tmp_path):
+    """The other face, and it is the LAW, not a leak.
+
+    Two installations with byte-identical content ARE one artifact: the graph
+    holds relative seats only, so there is no path inside it that could be
+    wrong. Sharing here is ``h = h(p)`` doing its job. This twin exists so that
+    a future agent reading twin 3 does not "fix" the aliasing question by
+    putting the path back into the key -- the path is not part of the answer.
+    """
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left_graph = DependencyArtifactGraph.authenticate(
+        _install(left, implementation_source=_IMPL_A)
+    )
+    right_graph = DependencyArtifactGraph.authenticate(
+        _install(right, implementation_source=_IMPL_A)
+    )
+
+    assert left_graph.distribution_artifact_cid == right_graph.distribution_artifact_cid
+    assert _observable(left_graph) == _observable(right_graph)
+    assert all(
+        not Path(item.source_seat).is_absolute() and "left" not in item.source_seat
+        for item in left_graph.files
+    )
+
+
+def test_bite_distinct_installations_are_only_distinguished_by_content(tmp_path):
+    """Bite for twin 3: the discriminator is CONTENT, and it moves both ways."""
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left_graph = DependencyArtifactGraph.authenticate(
+        _install(left, implementation_source=_IMPL_A)
+    )
+    right_graph = DependencyArtifactGraph.authenticate(
+        _install(right, implementation_source=_IMPL_B)
+    )
+    assert left_graph.distribution_artifact_cid != right_graph.distribution_artifact_cid
+
+    # Converge the content; the artifacts must converge with it.
+    _mutate(right, _IMPL_A)
+    converged = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(right / "example_dist-1.0.dist-info")
+    )
+    assert converged.distribution_artifact_cid == left_graph.distribution_artifact_cid
+
+
+# -- twin 4: the cheap path still works ---------------------------------------
+
+
+def test_unchanged_installation_reauthenticates_to_an_identical_graph(tmp_path):
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+
+    first = DependencyArtifactGraph.authenticate(distribution)
+    second = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+
+    # Not merely equal: the memo answered, which is what makes it a cache.
+    assert second is first
+    assert _observable(second) == _observable(first)
+
+
+def test_bite_the_cheap_path_is_a_memo_and_not_a_rebuild(tmp_path):
+    """Bite for twin 4: with the memo off, the same call rebuilds."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    first = DependencyArtifactGraph.authenticate(distribution)
+
+    rebuilt = _uncached(importlib.metadata.Distribution.at(distribution._path))
+
+    assert rebuilt is not first
+    assert _observable(rebuilt) == _observable(first)
+
+
+# -- twin 5: disablement changes speed only -----------------------------------
+
+
+@pytest.mark.parametrize("implementation_source", [_IMPL_A, _IMPL_B])
+def test_cache_disablement_changes_performance_only(tmp_path, implementation_source):
+    """Never a CID, never a verdict, never a graph."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=implementation_source)
+
+    warm = DependencyArtifactGraph.authenticate(distribution)
+    warm_again = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+    disabled = _uncached(importlib.metadata.Distribution.at(distribution._path))
+
+    assert _observable(warm) == _observable(disabled)
+    assert _observable(warm_again) == _observable(disabled)
+    assert warm.distribution_artifact_cid == disabled.distribution_artifact_cid
+    assert warm is warm_again and warm is not disabled
+
+
+def test_cache_disablement_never_writes_a_memo_that_answers_later(tmp_path):
+    """Disabled means disabled: no seat minted, in memory or on disk."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+
+    graph = _uncached(distribution)
+
+    assert da._AUTHENTICATE_GRAPH_CACHE == {}
+    assert not da._artifact_disk_cache_path(graph.distribution_artifact_cid).exists()
+
+
+def test_bite_the_disk_seat_is_addressed_by_the_artifact_cid(tmp_path):
+    """Bite for twin 5 and the second offender: the RECORD-stat seat is gone.
+
+    A dist-info ``RECORD`` is not rewritten when an installed module is edited,
+    so a seat digested from its stat served the stale graph across PROCESSES --
+    the same defect, one layer down. The seat now moves with the content.
+    """
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    seat = da._artifact_disk_cache_path(graph.distribution_artifact_cid)
+    assert seat.is_file()
+    record = root / "example_dist-1.0.dist-info" / "RECORD"
+    record_stat = record.stat()
+
+    _mutate(root, _IMPL_B)
+    mutated = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+    moved = da._artifact_disk_cache_path(mutated.distribution_artifact_cid)
+
+    # RECORD did not move -- the old key could not have noticed. The seat did.
+    assert record.stat().st_mtime_ns == record_stat.st_mtime_ns
+    assert record.stat().st_size == record_stat.st_size
+    assert moved != seat
+    assert seat.is_file() and moved.is_file()
+
+    # And the old seat still answers only the question it addresses.
+    assert (
+        da._load_authenticate_disk_cache(
+            graph.distribution_artifact_cid
+        ).distribution_artifact_cid
+        == graph.distribution_artifact_cid
+    )
+    assert da._load_authenticate_disk_cache("blake3-512:" + "0" * 128) is None
+
+
+def test_disk_memo_survives_a_cold_process_table(tmp_path):
+    """The cross-process half of the cheap path, keyed by content."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    warm = DependencyArtifactGraph.authenticate(distribution)
+
+    da._AUTHENTICATE_GRAPH_CACHE.clear()
+    from_disk = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+
+    assert from_disk is not warm
+    assert _observable(from_disk) == _observable(warm)
+
+
+# -- twin 6: the value is not mutable, so a writer cannot leak -----------------
+
+
+def test_a_served_graph_cannot_be_written_into(tmp_path):
+    """The mutable-value question, answered as a test rather than a claim.
+
+    #6266's deeper finding was that its memo VALUES were bound to a live
+    mutable context. This one's are not: the graph is frozen, its files are
+    frozen, and ``modules`` is a read-only proxy -- so there is no write a
+    caller can perform that another authentication could observe.
+    """
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        graph.distribution_artifact_cid = "blake3-512:" + "0" * 128
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        graph.files[0].content_cid = "blake3-512:" + "0" * 128
+    with pytest.raises(TypeError):
+        graph.modules["example_pkg.implementation"] = None
+    assert not hasattr(graph.modules, "clear")
+    assert not hasattr(graph.modules, "update")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        graph.modules["example_pkg.implementation"].source = _IMPL_B
+
+    served = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+    assert _observable(served) == _observable(graph)
+
+
+def test_bite_a_forged_graph_cannot_be_minted_or_served(tmp_path):
+    """Bite for twin 6: had the value been writable, THIS is what it would do.
+
+    Constructing a graph whose CID does not address its files is refused at the
+    one door, so the leak this twin guards against has no object to travel in.
+    """
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    with pytest.raises(da.DependencyArtifactAuthenticationError):
+        DependencyArtifactGraph(
+            artifact_kind=graph.artifact_kind,
+            distribution_name=graph.distribution_name,
+            distribution_version=graph.distribution_version,
+            distribution_artifact_cid="blake3-512:" + "0" * 128,
+            files=graph.files,
+            modules=graph.modules,
+            _intake_authority=da._ARTIFACT_INTAKE_AUTHORITY,
+        )
+    with pytest.raises(da.DependencyArtifactAuthenticationError):
+        DependencyArtifactGraph(
+            artifact_kind=graph.artifact_kind,
+            distribution_name=graph.distribution_name,
+            distribution_version=graph.distribution_version,
+            distribution_artifact_cid=graph.distribution_artifact_cid,
+            files=graph.files,
+            modules=graph.modules,
+            _intake_authority=object(),
+        )


### PR DESCRIPTION
Key the authenticated-artifact-graph memo by the artifact CID

`_AUTHENTICATE_GRAPH_CACHE` was keyed by dist-info PATH and its disk twin by a
digest over `RECORD`'s `(mtime, size)`. Neither is a function of the bytes the
graph authenticates, and `RECORD` is not rewritten when an installed `.py` file
is edited -- so both served a graph reporting a `distribution_artifact_cid` for
content that no longer existed on disk. A CID that does not address its bytes is
not a weak cache; it is `h = h(p)` with the `p` swapped out underneath.

Measured on unmodified main: authenticate -> edit the installed module ->
authenticate returns the SAME object, same CID, and `modules[...].source` is the
pre-edit text while the file on disk holds the post-edit text.

The repair is the key, not a better invalidation check. `authenticate` now
splits: `_read_recorded_installation` reads and content-addresses the
installation and mints the artifact CID (the half that cannot be memoized,
because it is what establishes what the answer is allowed to be addressed by),
and both memos are keyed by that CID. Stale is not detected, it is
unrepresentable: a changed byte changes the key, and a changed key is a miss.
The disk seat is the CID's own digest, so a stale hit has no filename to live at,
and the loader additionally refuses a payload whose recomputed CID is not the one
that was asked for.

This registry stays process-global where #6266's projection memos could not,
for the reason #6266 named: the CID is the complete key AND the value is not
mutable. `DependencyArtifactGraph` is a frozen dataclass over a tuple of frozen
files and a `MappingProxyType` of `bytes`/`str`. It owns no live
`TreeConstructionContextV1`, so there is no write a caller can perform that
another authentication could observe. Twin 6 pins that rather than asserting it.

Adds `tests/test_dependency_artifact_cache_authority.py`: 20 twins -- mutation
invalidates, the reported CID always matches a fresh read, distinct
installations do not alias (and byte-identical ones legitimately ARE one
artifact, since the graph holds relative seats only), the unchanged
re-authentication still hits the memo, disablement changes speed only and mints
no seat, and the served value cannot be written into. Each carries a bite.

Discrimination, run both ways: keying the memo by `distribution._path` again and
changing nothing else turns 6 of the 20 red; reverting turns all 20 green.

Cost of paying for `h = h(p)`: the memo hit must now read the bytes it
addresses. Warm authenticate goes from ~0 to 0.71s (numpy, 1336 files, 36MB) and
1.52s (pandas, 2944 files, 68MB), against 8.1s / 18.3s cold. Callers already
hold a per-construction `artifact_graph_cache` keyed by top-level name, so this
is paid once per construction, not per call site.

Epsilon R: 0 changed verdicts in `sugar-lift-python-source`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key the authenticated-artifact-graph memo by artifact CID in `DependencyArtifactGraph.authenticate`
> - Replaces the path/mtime/size-based cache key with a content-addressed key derived from the artifact CID, so mutating installation content produces a cache miss rather than serving a stale graph.
> - Adds `_read_recorded_installation` to compute a deterministic `artifact_cid` (via `cid_of_json` over a preimage of recorded files) before any cache lookup.
> - Both in-memory (`dict[str, DependencyArtifactGraph]`) and on-disk caches (stored under `XDG_CACHE_HOME/sugar/dependency-artifact-graphs/<cid_prefix>.pkl`) are now addressed by this CID.
> - Bumps the on-disk pickle schema from `dep-graph-v1` to `dep-graph-v2`; loaded entries are rejected if the reconstructed graph's CID does not match the requested CID.
> - Adds `_AUTHENTICATE_CACHE_ENABLED` flag to bypass all memo reads and writes for testing or forced recomputation.
> - Behavioral Change: existing `dep-graph-v1` disk cache entries will not be loaded; all caches will be cold until repopulated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c23e14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->