### PR TITLE
chore: black 26.5.1 across implementations/python (unblocks `core (Python format)`)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -129,9 +129,7 @@ def construct_manager_behavior(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
 
-    frame_result = resolve_source_visible_frame(
-        resolved, graph=graph, session=session
-    )
+    frame_result = resolve_source_visible_frame(resolved, graph=graph, session=session)
     if isinstance(frame_result, ManagerConstructionGapV1):
         return frame_result
     frame, _target = frame_result

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -304,8 +304,8 @@ def test_one_project_cannot_warm_another_projects_result(tmp_path: Path) -> None
     # CID, and that is what content addressing means.  What must never coincide
     # is the VALUE: a projected node carries a live construction context, and
     # project B must own its own.
-    (a_frame, a_target), = session_a.frame_results.values()
-    (b_frame, b_target), = session_b.frame_results.values()
+    ((a_frame, a_target),) = session_a.frame_results.values()
+    ((b_frame, b_target),) = session_b.frame_results.values()
     assert a_target is not b_target
     assert a_frame is not b_frame
     assert a_target.unit.construction_context is not b_target.unit.construction_context
@@ -410,18 +410,18 @@ def authority_blind_key(monkeypatch):
     monkeypatch.setattr(
         SourceResolutionSession,
         "export_hit",
-        lambda self, key: self.export_resolutions.get(strip(key))
-        if self.enabled
-        else None,
+        lambda self, key: (
+            self.export_resolutions.get(strip(key)) if self.enabled else None
+        ),
     )
     monkeypatch.setattr(
         SourceResolutionSession,
         "remember_export",
-        lambda self, key, result: self.export_resolutions.__setitem__(
-            strip(key), result
-        )
-        if self.enabled
-        else None,
+        lambda self, key, result: (
+            self.export_resolutions.__setitem__(strip(key), result)
+            if self.enabled
+            else None
+        ),
     )
     monkeypatch.setattr(
         SourceResolutionSession,
@@ -431,11 +431,9 @@ def authority_blind_key(monkeypatch):
     monkeypatch.setattr(
         SourceResolutionSession,
         "remember_frame",
-        lambda self, key, result, hold=None: self.frame_results.__setitem__(
-            strip(key), result
-        )
-        if self.enabled
-        else None,
+        lambda self, key, result, hold=None: (
+            self.frame_results.__setitem__(strip(key), result) if self.enabled else None
+        ),
     )
 
 

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -83,6 +83,7 @@ def test_accumulator_referencing_assert_constructs_as_loop_recurrence():
     ).sugar()
     assert any(type(s).__name__ == "LoopRecurrenceSugar" for s in sugar.statements)
 
+
 def test_loop_carried_accumulator_folds_over_a_concrete_iterable():
     # t = 0; for x in [1,2,3]: t = t + x; return t  -- the carried accumulator is
     # threaded through the unroll (t reads the previous iteration's value), so it

--- a/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
@@ -198,7 +198,13 @@ def test_no_name_based_fallback_behind_the_coordinate_door() -> None:
     # authenticated coordinate carries scope owner, binding site, and
     # projection path — no identifier.  A name-keyed route has nothing to key.
     fields = set(type(ref.coordinate).__dataclass_fields__)
-    assert fields == {"scope_owner_cid", "binding_site", "projection_path", "cid", "_interned"}
+    assert fields == {
+        "scope_owner_cid",
+        "binding_site",
+        "projection_path",
+        "cid",
+        "_interned",
+    }
     assert not any("name" in field for field in fields)
 
 
@@ -356,9 +362,7 @@ def test_two_call_occurrences_retain_distinct_occurrences() -> None:
     # Discrimination: the shared coordinate is not a shared *value* cell.  If
     # occurrence identity collapsed, reducing the second would have rewritten
     # the first.
-    replayed = first_value.force_floor(
-        None, owner="occurrence", project_callsite=False
-    )
+    replayed = first_value.force_floor(None, owner="occurrence", project_callsite=False)
     assert replayed.statements[0].value == TermValue(7)
 
 

--- a/implementations/python/sugar-source-tree/tests/test_slice_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_slice_sugar.py
@@ -17,9 +17,7 @@ def _sub(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    universe = (
-        next(SourceFile(path_source(path)).functions()).sugar().desugar().value
-    )
+    universe = next(SourceFile(path_source(path)).functions()).sugar().desugar().value
     for entry in universe.record.statements:
         if type(entry).__name__ == "ReturnValue":
             return entry.value.term

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -452,9 +452,7 @@ def test_discrimination_the_reconstructed_resource_route_matches_production(tmp_
 
     produced = resource.desugar()
     incompletes = [
-        entry
-        for entry in produced.value.statements
-        if isinstance(entry, Incomplete)
+        entry for entry in produced.value.statements if isinstance(entry, Incomplete)
     ]
     assert len(incompletes) == 1
     assert incompletes[0].effect == expected.effect
@@ -785,9 +783,7 @@ def _router_text():
     import sugar_lift_py_tests
 
     root = pathlib.Path(sugar_lift_py_tests.__file__).parent.parent
-    return {
-        name: (root / name).read_text(encoding="utf-8") for name in ROUTER_SOURCES
-    }
+    return {name: (root / name).read_text(encoding="utf-8") for name in ROUTER_SOURCES}
 
 
 def test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling():
@@ -852,9 +848,9 @@ def test_discrimination_the_routing_probe_observes_a_real_call(tmp_path, monkeyp
 
     assert calls, "the probe does not observe ExitSet.and_exit at all"
     for _incoming, _exit_es, disposition in calls:
-        assert not isinstance(disposition, EffectBoundaryDisposition), (
-            "the resource with reached the algebra carrying an assertion contract"
-        )
+        assert not isinstance(
+            disposition, EffectBoundaryDisposition
+        ), "the resource with reached the algebra carrying an assertion contract"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`core (Python format)` is red on **every** open PR, not on any one change. I hit
it on #6270, checked `fix/authenticate-graph-cache-authority`, and found the
identical failure there — so the gate has been failing independently of what a
branch touches, which makes it useless as a signal.

Cause: `black==26.5.1` is pinned in `sugar-lift-py-tests[test]`, and six files
under `implementations/python` predate the style that version emits.

Mechanical only — `black implementations/python`, no hand edits:

```
manager_construction.py                      |  4 +---
test_resolution_session_authority.py         | 28 ++++++++++------------
test_for_unroll.py                           |  1 +
test_formal_substitution_coordinate.py       | 12 ++++++----
test_slice_sugar.py                          |  4 +---
test_with_partition_shared_algebra.py        | 14 ++++-------
```

`black --check implementations/python` now reports 826 files unchanged.

I did not trust that a formatter is semantics-preserving — the reformatted test
files were re-run:

- `sugar-source-tree`: `test_with_partition_shared_algebra`, `test_for_unroll`,
  `test_slice_sugar`, `test_formal_substitution_coordinate` — **51 passed**
- `sugar-lift-python-source`: `test_resolution_session_authority`,
  `test_sole_path_manager_construction` — **44 passed**

## Not addressed here

These are red on main too and belong to other subsystems — flagging, not fixing:

- `core (refusal vocabulary)` — fails at step *Check Rust formatting*; also red
  on `fix/authenticate-graph-cache-authority`.
- `showcases (0-3/4)` — `surface 'python-bind' / 'rust-test-assertions' does not
  advertise sugar.enumerate` (retired `lift` JSON-RPC method), plus a numpy
  ProofIR free-var panic (`illegal free var(s): np`).
- `core (coretests invariants)` — `cargo metadata failed` against the rustup
  toolchain source tree, in the Rust coretests lifter.

## Epsilon R

Axis: CI signal quality. Predicted change: R unchanged — no production Python
semantics touched, formatter output only. Floors preserved: no panic text, no
refusal vocabulary, no assertion altered; the two suites covering every
reformatted test file re-run green. This restores one gate to honest, and names
three that are still lying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply black 26.5.1 formatting across implementations/python
> Runs black 26.5.1 over the Python implementations directory to unblock the `core (Python format)` CI check. Changes are purely cosmetic: line wrapping, tuple unpacking syntax, and inline reformatting of lambdas and comprehensions. No logic, data flow, or behavior is altered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c276710.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->