### PR TITLE
ci: make `sugar-lift-py-tests[test]` the sole dependency authority

### DIFF
--- a/.github/workflows/bare-exception-zero-tolerance.yml
+++ b/.github/workflows/bare-exception-zero-tolerance.yml
@@ -22,12 +22,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
+      # hand-list a package here: a hand-list is one module-scope import away
+      # from the #6260 collection abort this floor exists to catch.
       - name: Install Python lift kit and test runner
         run: >-
           python -m pip install
-          pytest
-          ./implementations/python/sugar-lift-python-source
-          ./implementations/python/sugar-lift-py-tests
+          -e ./implementations/python/sugar-lift-python-source
+          -e './implementations/python/sugar-lift-py-tests[test]'
       - name: R_bare_exceptions discrimination
         run: >-
           python -m pytest --noconftest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,8 @@ jobs:
         # `[project.optional-dependencies].test` is the single source of truth
         # for what its suite needs to COLLECT.
         run: |
-          python -m pip install --quiet blake3 pynacl cbor2 pytest
           python -m pip install --quiet \
-            -e implementations/python/sugar-lift-py-tests[test]
+            -e 'implementations/python/sugar-lift-py-tests[test]'
 
       - name: Install source-audit system deps
         if: matrix.z3
@@ -176,9 +175,8 @@ jobs:
       - name: Install lift package deps
         run: |
           python -m pip install --quiet \
-            blake3 pynacl cbor2 pytest \
             -e implementations/python/sugar-build-witness \
-            -e implementations/python/sugar-lift-py-tests[test] \
+            -e 'implementations/python/sugar-lift-py-tests[test]' \
             -e implementations/python/sugar-lift-python-source \
             -e implementations/python/sugar-lift-py-pytest-witness
 

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -39,15 +39,16 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
+      # hand-list a package here: a hand-list is one module-scope import away
+      # from the #6260 collection abort these floors exist to catch.
       - name: Install Python lift kit and static-floor test runner
         if: always()
         run: >-
           python -m pip install
-          pytest
-          tqdm
-          ./implementations/python/sugar-lift-python-source
-          ./implementations/python/sugar-source-tree
-          ./implementations/python/sugar-lift-py-tests
+          -e ./implementations/python/sugar-lift-python-source
+          -e ./implementations/python/sugar-source-tree
+          -e './implementations/python/sugar-lift-py-tests[test]'
       # Heavy supervised enum floors — sequential under this one job so the
       # complete floor set is always from one pinned run.
       - name: R_native_crashes = 0
@@ -68,6 +69,12 @@ jobs:
       - name: All permanent axes are bound
         if: always()
         run: python -m pytest tests/test_python_sole_construction_ci.py -q
+      - name: '`sugar-lift-py-tests[test]` is the sole dependency authority'
+        if: always()
+        run: >-
+          python -m pytest
+          tests/test_test_extras_are_the_dependency_authority.py
+          -q
       - name: R_vendor_special_case discrimination
         if: always()
         run: >-

--- a/.github/workflows/native-crash-zero-tolerance.yml
+++ b/.github/workflows/native-crash-zero-tolerance.yml
@@ -20,13 +20,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
+      # hand-list a package here: a hand-list is one module-scope import away
+      # from the #6260 collection abort this floor exists to catch.
       - name: Install Python lift kit
         run: >-
           python -m pip install
-          pytest
-          ./implementations/python/sugar-lift-python-source
-          ./implementations/python/sugar-source-tree
-          ./implementations/python/sugar-lift-py-tests
+          -e ./implementations/python/sugar-lift-python-source
+          -e ./implementations/python/sugar-source-tree
+          -e './implementations/python/sugar-lift-py-tests[test]'
       - name: R_native_crashes discrimination
         run: >-
           python -m pytest --noconftest

--- a/.github/workflows/numpy-wall.yml
+++ b/.github/workflows/numpy-wall.yml
@@ -40,8 +40,6 @@ jobs:
           python -m pip install --quiet \
             -e implementations/python/sugar-lift-python-source \
             -e 'implementations/python/sugar-lift-py-tests[test]'
-      - name: Install Python wall inputs
-        run: python -m pip install --quiet numpy
 
       - name: Mint recovered NumPy frontier
         id: wall

--- a/.github/workflows/pandas-wall.yml
+++ b/.github/workflows/pandas-wall.yml
@@ -40,8 +40,6 @@ jobs:
           python -m pip install --quiet \
             -e implementations/python/sugar-lift-python-source \
             -e 'implementations/python/sugar-lift-py-tests[test]'
-      - name: Install Python wall inputs
-        run: python -m pip install --quiet pandas
 
       - name: Mint recovered pandas frontier
         id: wall

--- a/.github/workflows/restored-suite-scoreboard.yml
+++ b/.github/workflows/restored-suite-scoreboard.yml
@@ -60,7 +60,6 @@ jobs:
           python -m venv "$RUNNER_TEMP/restored-suite-python"
           "$RUNNER_TEMP/restored-suite-python/bin/python" -m pip install --quiet --upgrade pip
           "$RUNNER_TEMP/restored-suite-python/bin/python" -m pip install --quiet --no-cache-dir \
-            pandas \
             -e implementations/python/libsugar-py \
             -e implementations/python/sugar-emit-python-hypothesis \
             -e implementations/python/sugar-emit-python-pytest \

--- a/.github/workflows/timeout-zero-tolerance.yml
+++ b/.github/workflows/timeout-zero-tolerance.yml
@@ -21,12 +21,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
+      # hand-list a package here: a hand-list is one module-scope import away
+      # from the #6260 collection abort this floor exists to catch.
       - name: Install Python lift kit and test runner
         run: >-
           python -m pip install
-          pytest
-          ./implementations/python/sugar-lift-python-source
-          ./implementations/python/sugar-lift-py-tests
+          -e ./implementations/python/sugar-lift-python-source
+          -e './implementations/python/sugar-lift-py-tests[test]'
       - name: R_timeouts discrimination
         run: >-
           python -m pytest --noconftest

--- a/implementations/python/sugar-lift-py-tests/pyproject.toml
+++ b/implementations/python/sugar-lift-py-tests/pyproject.toml
@@ -18,11 +18,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# `numpy` is imported at MODULE scope by tests/test_vendor_special_case_law.py
-# and tests/test_numpy_pandas_panic_audit.py; `pandas` is imported inside tests
-# in the same file. Both are required by this package's ordinary suite, so they
-# are declared here rather than hand-listed at each call site — an undeclared
-# module-scope import aborts collection for the WHOLE package.
+# THIS TABLE IS THE SOLE DEPENDENCY AUTHORITY for every CI job that touches this
+# package. No workflow may hand-list any package named here (or in `dependencies`
+# above); workflows install `-e '...sugar-lift-py-tests[test]'` and nothing else.
+# Enforced by tests/test_test_extras_are_the_dependency_authority.py.
+#
+# `numpy` is imported at MODULE scope by tests/test_numpy_pandas_panic_audit.py;
+# `pandas` is imported inside tests in that same file. Both are required by this
+# package's ordinary suite, so they are declared here rather than hand-listed at
+# each call site — an undeclared module-scope import aborts collection for the
+# WHOLE package (#6260).
 # `itsdangerous` stays declared for the claim-mass tripwire corpus tooling.
 test = [
     "pytest>=7",

--- a/tests/test_test_extras_are_the_dependency_authority.py
+++ b/tests/test_test_extras_are_the_dependency_authority.py
@@ -1,0 +1,348 @@
+"""`sugar-lift-py-tests[test]` is the SOLE dependency authority across CI.
+
+#6260 found `itsdangerous` and `numpy` declared in `[test]` but never installed
+by CI, because CI maintained its own hand-list. The four zero-tolerance floors
+were the worst offenders: they installed the package WITHOUT `[test]` and
+hand-listed `pytest`. A hand-list is one module-scope import away from the
+collection abort those very floors exist to catch.
+
+This is a static audit over `pyproject.toml` + the workflow YAMLs. It asserts a
+property of the CONFIG, not of a run, so it is red the moment the config drifts
+— no CI round trip required.
+
+Four teeth, and the fourth is the one that keeps the authority honest:
+
+1. Every workflow that installs the package installs `-e ...[test]`.
+2. No workflow duplicates a dependency owned by the authority.
+3. Removing a required package from the authority makes its consumer fail:
+   every third-party MODULE-SCOPE import in the package's collected tests must
+   be declared in the authority.
+4. Adding a dependency only to a workflow CANNOT satisfy tooth 3 — the
+   resolver reads pyproject and never the workflows, proven on a synthetic
+   pair where the workflow supplies what pyproject omits.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "implementations/python/sugar-lift-py-tests"
+PYPROJECT = PACKAGE / "pyproject.toml"
+WORKFLOWS = ROOT / ".github/workflows"
+
+AUTHORITY = "sugar-lift-py-tests"
+
+# Import name -> distribution name, where they differ.
+IMPORT_TO_DIST = {"nacl": "pynacl"}
+
+# Sibling modules importable because conftest puts the package's own scripts/
+# and tests/ on sys.path. These are first-party, not dependencies.
+FIRST_PARTY_PREFIXES = ("sugar_", "libsugar_", "conftest", "test_")
+
+
+def normalize(name: str) -> str:
+    """PEP 503 canonical form, minus any version specifier or extra."""
+    name = re.split(r"[<>=!~\[;]", name, maxsplit=1)[0].strip()
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def authority_packages(pyproject_text: str) -> set[str]:
+    """Every distribution the authority declares: runtime deps + [test] extras.
+
+    Reads ONLY pyproject. Never reads a workflow — that is tooth 4.
+    """
+    data = tomllib.loads(pyproject_text)
+    project = data["project"]
+    declared = list(project.get("dependencies", []))
+    declared += list(project.get("optional-dependencies", {}).get("test", []))
+    return {normalize(dep) for dep in declared}
+
+
+def module_scope_third_party_imports(package: Path) -> dict[str, list[str]]:
+    """Third-party distributions imported at MODULE scope by collected tests.
+
+    tests/vendor/** and tests/fixtures/** are LIFT CORPUS — files Sugar reads as
+    input, never collected or executed by pytest — so their imports are not
+    dependencies of this package.
+    """
+    stdlib = set(sys.stdlib_module_names)
+    found: dict[str, list[str]] = {}
+
+    for path in sorted(package.glob("tests/**/*.py")):
+        rel = path.relative_to(package).as_posix()
+        if rel.startswith(("tests/vendor/", "tests/fixtures/")):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in tree.body:  # module scope only — the collection-abort class
+            if isinstance(node, ast.Import):
+                roots = [alias.name.split(".")[0] for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                roots = [node.module.split(".")[0]]
+            else:
+                continue
+            for root in roots:
+                if root in stdlib or root.startswith(FIRST_PARTY_PREFIXES):
+                    continue
+                if (package / "scripts" / f"{root}.py").exists():
+                    continue  # sibling script module, first-party
+                if (package / "tests" / f"{root}.py").exists():
+                    continue
+                dist = IMPORT_TO_DIST.get(root, normalize(root))
+                found.setdefault(dist, []).append(rel)
+
+    return found
+
+
+def run_blocks(workflow_text: str) -> list[str]:
+    """Every `run:` script in a workflow, with its YAML scalar style honoured.
+
+    `run: >-` folds every line into ONE command; `run: |` keeps lines separate.
+    Getting this wrong merges neighbouring commands and silently swallows
+    offenders, so the two styles are handled apart rather than regex-folded.
+    """
+    lines = workflow_text.split("\n")
+    blocks: list[str] = []
+
+    index = 0
+    while index < len(lines):
+        header = re.match(r"^(\s*)-?\s*run:\s*(\S*)\s*$", lines[index])
+        if header is None:
+            # `run: some-inline-command`
+            inline = re.match(r"^\s*-?\s*run:\s+(\S.*)$", lines[index])
+            if inline and inline.group(1) not in {"|", ">-", ">", "|-"}:
+                blocks.append(inline.group(1))
+            index += 1
+            continue
+
+        indent, style = len(header.group(1)), header.group(2)
+        body: list[str] = []
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+                break
+            body.append(line.strip())
+            index += 1
+
+        blocks.append(" ".join(body) if style in {">-", ">"} else "\n".join(body))
+
+    return blocks
+
+
+def pip_install_commands(workflow_text: str) -> list[str]:
+    """Every `pip install ...` invocation, one entry per real command."""
+    commands = []
+    for block in run_blocks(workflow_text):
+        block = re.sub(r"\\\s*\n\s*", " ", block)  # shell backslash-newline
+        for line in block.split("\n"):
+            for match in re.finditer(r"pip install[^\n]*", line):
+                command = match.group(0)
+                if "--upgrade pip" in command:
+                    continue  # bootstrapping pip itself is not a dependency
+                commands.append(command)
+    return commands
+
+
+def bare_requirements(command: str) -> list[str]:
+    """Requirement tokens that are NOT path installs — i.e. hand-listed."""
+    tokens = command.replace("'", " ").replace('"', " ").split()
+    bare = []
+    skip_next = False
+    for token in tokens[2:]:  # drop "pip install"
+        if skip_next:
+            skip_next = False
+            continue
+        if token.startswith("-"):
+            if token in {"--index-url", "--extra-index-url", "-r", "-c"}:
+                skip_next = True
+            continue
+        if "/" in token or token.startswith(".") or token.endswith(".txt"):
+            continue  # path install
+        if token in {"pip", "install", "python", "-m"}:
+            continue
+        bare.append(normalize(token))
+    return bare
+
+
+def workflows_installing_authority() -> dict[Path, list[str]]:
+    hits: dict[Path, list[str]] = {}
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        commands = [
+            command
+            for command in pip_install_commands(workflow.read_text(encoding="utf-8"))
+            if AUTHORITY in command
+        ]
+        if commands:
+            hits[workflow] = commands
+    return hits
+
+
+# --------------------------------------------------------------------------
+# Tooth 1: every relevant install uses `-e ...[test]`
+# --------------------------------------------------------------------------
+def test_every_authority_install_uses_editable_test_extras() -> None:
+    installs = workflows_installing_authority()
+    assert installs, "no workflow installs the authority package — audit is blind"
+
+    offenders = []
+    for workflow, commands in installs.items():
+        for command in commands:
+            for token in command.replace("'", " ").replace('"', " ").split():
+                if not token.endswith(AUTHORITY) and AUTHORITY not in token:
+                    continue
+                if "/" not in token:
+                    continue
+                if not token.endswith(f"{AUTHORITY}[test]"):
+                    offenders.append(
+                        f"{workflow.name}: installs `{token}` without [test] extras"
+                    )
+                elif f"-e {token}" not in command and f"-e '{token}'" not in command:
+                    offenders.append(
+                        f"{workflow.name}: installs `{token}` non-editable"
+                    )
+
+    assert not offenders, (
+        "every install of the dependency authority must be `-e "
+        f"'...{AUTHORITY}[test]'`; installing it without the extras silently "
+        "drops every package the suite declares.\nfix=append [test] and -e:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# --------------------------------------------------------------------------
+# Tooth 2: no workflow duplicates a dependency owned by [test]
+# --------------------------------------------------------------------------
+def test_no_workflow_hand_lists_a_package_the_authority_owns() -> None:
+    owned = authority_packages(PYPROJECT.read_text(encoding="utf-8"))
+
+    offenders = []
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        text = workflow.read_text(encoding="utf-8")
+        commands = pip_install_commands(text)
+        # Scope is the WORKFLOW, not the single command: `pip install numpy` in
+        # a later step of the same job supplements the authority just as much as
+        # naming numpy on the authority's own install line.
+        if not any(AUTHORITY in command for command in commands):
+            continue
+        for command in commands:
+            for requirement in bare_requirements(command):
+                if requirement in owned:
+                    offenders.append(f"{workflow.name}: hand-lists `{requirement}`")
+
+    assert not offenders, (
+        f"`{AUTHORITY}[test]` is the SOLE dependency authority: a workflow that "
+        "installs [test] AND hand-lists a package it owns is supplementing, not "
+        "delegating, and the hand-list drifts out of date exactly the way #6260 "
+        "did.\nfix=DELETE the hand-listed token; [test] already provides it:\n  "
+        + "\n  ".join(sorted(set(offenders)))
+    )
+
+
+# --------------------------------------------------------------------------
+# Tooth 3: removing a required package from [test] makes its consumer fail
+# --------------------------------------------------------------------------
+def test_every_module_scope_import_is_declared_by_the_authority() -> None:
+    declared = authority_packages(PYPROJECT.read_text(encoding="utf-8"))
+    imported = module_scope_third_party_imports(PACKAGE)
+    assert imported, "import census found nothing — the audit walked the wrong tree"
+
+    offenders = [
+        f"`{dist}` imported at module scope by {consumers[0]}"
+        f" ({len(consumers)} file(s)) but not declared"
+        for dist, consumers in sorted(imported.items())
+        if dist not in declared
+    ]
+
+    assert not offenders, (
+        "an undeclared module-scope import aborts collection for the WHOLE "
+        f"package (#6260). Declare it in {AUTHORITY}'s [project] dependencies "
+        "or [project.optional-dependencies].test — never in a workflow:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# --------------------------------------------------------------------------
+# Tooth 4: a workflow-only addition CANNOT satisfy the authority law
+# --------------------------------------------------------------------------
+def test_adding_a_dependency_only_to_a_workflow_cannot_satisfy_the_law() -> None:
+    """Both faces of the discriminator, on a synthetic pyproject/workflow pair.
+
+    Positive face: declared in pyproject   -> resolver sees it.
+    Negative face: declared ONLY in a workflow -> resolver still does not see it.
+    """
+    without = """
+[project]
+name = "synthetic"
+version = "0"
+dependencies = ["blake3"]
+[project.optional-dependencies]
+test = ["pytest"]
+"""
+    with_declaration = without.replace('test = ["pytest"]', 'test = ["pytest", "numpy"]')
+
+    # Positive face: pyproject is the only thing that can grant authority.
+    assert "numpy" in authority_packages(with_declaration)
+
+    # Negative face: a workflow that installs numpy explicitly, and installs the
+    # authority WITH [test], still cannot make the resolver believe numpy is
+    # declared — because the resolver never reads the workflow at all.
+    workflow_supplying_numpy = (
+        "      - name: Install\n"
+        "        run: |\n"
+        "          python -m pip install --quiet numpy\n"
+        f"          python -m pip install -e 'implementations/python/{AUTHORITY}[test]'\n"
+    )
+    supplied = {
+        requirement
+        for command in pip_install_commands(workflow_supplying_numpy)
+        for requirement in bare_requirements(command)
+    }
+    assert "numpy" in supplied, (
+        "fixture is inert: the synthetic workflow does not actually install numpy"
+    )
+
+    assert "numpy" not in authority_packages(without), (
+        "a workflow-only `pip install numpy` must NEVER satisfy the authority "
+        "law — otherwise the hand-list papers over a missing declaration and "
+        "#6260 recurs the moment that workflow is copied without the hand-list"
+    )
+
+
+def test_the_four_zero_tolerance_floors_are_bound_to_the_authority() -> None:
+    """The floors are the instruments that catch the collection abort. They are
+    the LAST place a hand-list may live, so they are named explicitly here: a
+    new floor that forgets [test] is caught by name, not by luck."""
+    floors = [
+        "bare-exception-zero-tolerance.yml",
+        "factory-zero-tolerance.yml",
+        "native-crash-zero-tolerance.yml",
+        "timeout-zero-tolerance.yml",
+    ]
+
+    offenders = []
+    for name in floors:
+        text = (WORKFLOWS / name).read_text(encoding="utf-8")
+        commands = [c for c in pip_install_commands(text) if AUTHORITY in c]
+        if not commands:
+            offenders.append(f"{name}: never installs {AUTHORITY}")
+            continue
+        for command in commands:
+            if f"{AUTHORITY}[test]" not in command:
+                offenders.append(f"{name}: installs {AUTHORITY} without [test]")
+            if bare_requirements(command):
+                offenders.append(
+                    f"{name}: hand-lists {sorted(set(bare_requirements(command)))}"
+                )
+
+    assert not offenders, (
+        "the zero-tolerance floors must draw their entire environment from "
+        f"`{AUTHORITY}[test]`:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Axis

`R_hand_listed_dependencies` — CI jobs that decide their own Python environment instead of delegating to the package that declares it.

**Predicted Epsilon R: 0 change to every floor's row.** The win is environment *authority*, not a moved number. Measured before/after, not asserted — see below.

## Why this is a defect, not tidiness

#6260 found `itsdangerous` and `numpy` declared in `[test]` but **never installed by CI**, because CI maintained its own list. The four zero-tolerance floors were the worst case: they installed `sugar-lift-py-tests` **without `[test]`** and hand-listed `pytest`. Any hand-list is one module-scope import away from the same collection abort — and these four are the *instruments that exist to catch exactly that class*.

Live proof, collection census over the package in a clean 3.12 venv:

```
pre-migration  (pytest + tqdm + bare package)   1145 tests collected, 1 error
               E   ModuleNotFoundError: No module named 'numpy'
               ERROR .../tests/test_numpy_pandas_panic_audit.py
               !!!! Interrupted: 1 error during collection !!!!
post-migration (-e ...[test])                   1171 tests collected
```

## Offenders replaced (replace, not supplement)

| workflow | hand-listed | replaced by |
|---|---|---|
| `bare-exception-zero-tolerance.yml` | `pytest` | `-e '...sugar-lift-py-tests[test]'` |
| `factory-zero-tolerance.yml` | `pytest`, `tqdm` | `-e '...sugar-lift-py-tests[test]'` |
| `native-crash-zero-tolerance.yml` | `pytest` | `-e '...sugar-lift-py-tests[test]'` |
| `timeout-zero-tolerance.yml` | `pytest` | `-e '...sugar-lift-py-tests[test]'` |
| `ci.yml` (python job) | `blake3 pynacl cbor2 pytest` | deleted; `[test]` already there |
| `ci.yml` (lift job) | `blake3 pynacl cbor2 pytest` | deleted; `[test]` already there |
| `restored-suite-scoreboard.yml` | `pandas` | deleted; `[test]` already there |
| `numpy-wall.yml` | `numpy` (separate step) | deleted; `[test]` already there |
| `pandas-wall.yml` | `pandas` (separate step) | deleted; `[test]` already there |

The last three were **not** in the original survey — the audit found them. Every deleted token was already owned by the authority, so each deletion is a **no-op on the resolved environment** and a real change to who decides.

No package needed to be added to `[test]`: the authority already declared everything every workflow was hand-listing.

## The five teeth, with their bites

`tests/test_test_extras_are_the_dependency_authority.py` is a static audit over `pyproject.toml` + the workflow YAMLs — it asserts a property of the **config**, not of a run, so it is red the moment the config drifts. Modelled on `tests/test_python_sole_construction_ci.py`.

1. **Every relevant install uses `-e ...[test]`** — `test_every_authority_install_uses_editable_test_extras`
2. **No workflow duplicates a dependency owned by `[test]`** — `test_no_workflow_hand_lists_a_package_the_authority_owns`. Scope is the **workflow**, not the single command: `pip install numpy` in a *later step* supplements just as much as naming it on the authority's own line. (The first draft scoped per-command and missed all three wall/scoreboard offenders; widening the scope is what surfaced them.)
3. **Removing a required package from `[test]` makes its consumer fail** — `test_every_module_scope_import_is_declared_by_the_authority`. Censuses third-party **module-scope** imports across the package's collected tests (`tests/vendor/**` and `tests/fixtures/**` are lift *corpus*, not collected tests) and requires each to be declared.
4. **A workflow-only addition cannot satisfy the authority law** — `test_adding_a_dependency_only_to_a_workflow_cannot_satisfy_the_law`. Both faces on a synthetic pyproject/workflow pair: declared-in-pyproject is seen; declared-only-in-workflow is still not seen, because the resolver never reads a workflow. The fixture asserts it is not inert before asserting the negative.
5. **All zero-tolerance floor rows identical** — the merge gate, measured below. Plus `test_the_four_zero_tolerance_floors_are_bound_to_the_authority` names the four floors explicitly, so a new floor that forgets `[test]` is caught by name rather than by luck.

Bites — **both faces run on every discriminator**:

| mutation | result |
|---|---|
| `origin/main` config | **RED** — names all 9 offenders by file and package |
| migrated config | **GREEN** (5 passed) |
| delete `numpy` from `[test]` | **RED** — `` `numpy` imported at module scope by tests/test_numpy_pandas_panic_audit.py … but not declared `` |
| delete `pytest` from `[test]` | **RED** — `` `pytest` imported at module scope by tests/conftest.py (67 file(s)) … but not declared `` |
| one floor loses `[test]` | **RED** — `timeout-zero-tolerance.yml: installs sugar-lift-py-tests without [test]` |
| re-add `pandas` to scoreboard | **RED** — `restored-suite-scoreboard.yml: hand-lists 'pandas'` |
| re-add `numpy`/`pandas` to walls | **RED** — `numpy-wall.yml: hand-lists 'numpy'`, `pandas-wall.yml: hand-lists 'pandas'` |

The audit is bound to CI in `factory-zero-tolerance.yml` under `if: always()`, beside the existing `All permanent axes are bound` step.

## Floors preserved — occurrence-identity

Cannot run GitHub Actions locally, so: two clean `uv`-built CPython **3.12** venvs (matching `setup-python`), one from the **exact pre-migration** install line, one from the **exact post-migration** line. Then every floor's **real command**, read out of each workflow.

**Environment delta is a strict superset with zero version drift.** `pip list --format=freeze` diff is pure additions — no shared package changes version:

```
> black==26.5.1           > numpy==2.5.1           > pyright==1.1.411
> click==8.4.2            > pandas==3.0.5          > python-dateutil==2.9.0.post0
> itsdangerous==2.2.0     > pathspec==1.1.1        > pytokens==0.4.1
> mypy_extensions==1.1.0  > platformdirs==4.11.0   > six==1.17.0
> nodeenv==1.10.0                                  > typing_extensions==4.16.0
```

**22 floor invocations, all 22 exit codes identical, 21 occurrence-identical** (byte-identical modulo wall-clock durations):

```
bare_exception_discrimination                 OCCURRENCE-IDENTICAL
bare_exception_panic_catch                    OCCURRENCE-IDENTICAL
construction_side_door_discrimination         OCCURRENCE-IDENTICAL
construction_side_door                        OCCURRENCE-IDENTICAL
factory_axes_bound                            OCCURRENCE-IDENTICAL
factory_ownership                             OCCURRENCE-IDENTICAL
factory_panic_catch                           OCCURRENCE-IDENTICAL
factory_walk_unclassified_discrimination      OCCURRENCE-IDENTICAL
finite_cap_opaque_discrimination              OCCURRENCE-IDENTICAL
finite_cap_opaque                             OCCURRENCE-IDENTICAL
finite_unfold_compact_discrimination          OCCURRENCE-IDENTICAL
finite_unfold_compact                         OCCURRENCE-IDENTICAL
native_crash_discrimination                   OCCURRENCE-IDENTICAL
no_sugar_in_desugar_discrimination            OCCURRENCE-IDENTICAL
no_sugar_in_desugar                           OCCURRENCE-IDENTICAL
silent_discrimination                         OCCURRENCE-IDENTICAL
source_via_execution_discrimination           OCCURRENCE-IDENTICAL
source_via_execution                          OCCURRENCE-IDENTICAL
timeout_discrimination                        OCCURRENCE-IDENTICAL
vendor_special_case_discrimination            OCCURRENCE-IDENTICAL
vendor_special_case                           OCCURRENCE-IDENTICAL
factory_walk_unclassified                     *** see below ***
```

### The one row that moved, named loudly

`R_factory_walk_unclassified` differed on `timeouts`:

```
pre  {"R_factory_walk_unclassified": 0, "rows_measured": 174713, "files_completed": 391, "construction_panics": 0, "timeouts": 3, "native_crashes": 0, "auditor_errors": 0}
post {"R_factory_walk_unclassified": 0, "rows_measured": 162996, "files_completed": 388, "construction_panics": 0, "timeouts": 6, "native_crashes": 0, "auditor_errors": 0}
```

`timeouts` is a category the ruling names, so it does not get absorbed — it gets discriminated. **Re-running the SAME pre-migration environment** four times:

```
envA run 1: R=0  files_completed 391  timeouts 3
envA run 2: R=0  files_completed 379  timeouts 15
envA run 3: R=0  files_completed 380  timeouts 14
envA run 4: R=0  files_completed 386  timeouts 8
```

The within-environment spread (3→15) strictly contains the across-environment difference (3→6). This is a wall-clock per-file timeout on a loaded measurement box, not migration signal. **The load-bearing row, `R_factory_walk_unclassified = 0`, is identical in every run of both environments**, as are `construction_panics`, `native_crashes`, `auditor_errors`, and the exit code.

No enrollment, panic, finding, or terminal category moved anywhere.

## Two adjacent findings — reported, not absorbed

1. **`tests/wall_workflow_prerequisites_test.py` is an orphan and is RED.** No workflow or Makefile target runs it. Running it: `wall workflows must apt-install b3sum before make invokes bin/sugarbin; fix prerequisite ordering in: numpy-wall.yml, pandas-wall.yml`. Pre-existing and unrelated to this PR — the test greps for a literal `apt-get install`, but the walls call `tools/ci-apt-install.sh b3sum`, so the **regex** is stale, not the workflows. Confirmed red on `origin/main`. Not fixed here: whether the instrument or the workflow is wrong is a ruling.

2. **`examples-gate.yml:35` hand-lists `blake3 pynacl cbor2` — left alone, needs a ruling.** It is the same defect class, but it does **not** install `sugar-lift-py-tests` at all, so `[test]` is not its authority. Those three are declared by several packages (`libsugar-py`, `sugar-lift-python-source`, the emit packages). Making it install `-e '...sugar-lift-py-tests[test]'` would work but drags `pyright`, `black`, `numpy`, and `pandas` into a Rust+Java gate and changes an environment whose rows are not in the measured floor set. **Which package is examples-gate's authority is a ruling, not my call.**

## Also

Corrects a misattribution in `pyproject.toml`: the comment claimed `numpy` is imported at module scope by `test_vendor_special_case_law.py`. That `import numpy` is inside a **planted fixture string** written to `tmp_path`, not a real import — that file collects fine without numpy. The real module-scope consumer is `test_numpy_pandas_panic_audit.py`, which is what actually aborts collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `sugar-lift-py-tests[test]` the sole dependency authority for CI workflows
> - Replaces hand-listed pip installs of `pytest`, `blake3`, `pynacl`, `cbor2`, `tqdm`, `numpy`, `pandas`, etc. across all CI workflows with editable installs of `sugar-lift-py-tests[test]`, making it the single source of truth for test dependencies.
> - Adds [test_test_extras_are_the_dependency_authority.py](https://github.com/TSavo/sugar/pull/6275/files#diff-d5e05060eaf78839fabd9c4375d0eab0803565a31b3952faae3824d2b1c648ea) to enforce the policy: workflows must install the authority package as editable with `[test]`, must not hand-list packages declared by the authority, and all module-scope third-party imports must be declared by the authority.
> - The `factory-zero-tolerance` workflow runs this new test explicitly to assert the dependency authority contract during CI.
> - Behavioral Change: `numpy` and `pandas` are no longer explicitly installed in their respective wall workflows; availability depends entirely on the `[test]` extras of `sugar-lift-py-tests`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4612dfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->