### PR TITLE
fix: debug sugarbin builds drop a caching rustc-wrapper instead of failing

### DIFF
--- a/tools/sugarbin-build.mk
+++ b/tools/sugarbin-build.mk
@@ -42,11 +42,25 @@ else
 $(error SUGARBIN_PROFILE must be debug or release)
 endif
 
+# rustc wrappers that cache whole-crate outputs (sccache) refuse to run at all
+# under incremental compilation: "incremental compilation is prohibited: Unset
+# CARGO_INCREMENTAL to continue." A wrapper configured in the developer's
+# ~/.cargo/config.toml therefore makes every incremental build fail outright.
+# Incremental is this file's deliberate choice for debug, so the incremental
+# build drops the wrapper for its own invocation instead of losing incremental.
+# Non-incremental builds leave the developer's wrapper untouched.
+ifeq ($(SUGARBIN_INCREMENTAL),1)
+SUGARBIN_WRAPPER_ENV := CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER=
+else
+SUGARBIN_WRAPPER_ENV :=
+endif
+
 .PHONY: sugarbin-build
 sugarbin-build:
 	mkdir -p "$(SUGARBIN_TARGET_DIR)"
 	CARGO_TARGET_DIR="$(SUGARBIN_TARGET_DIR)" \
 	CARGO_INCREMENTAL="$(SUGARBIN_INCREMENTAL)" \
+	$(SUGARBIN_WRAPPER_ENV) \
 	SUGAR_BUILD_STAMP="$(SUGARBIN_BUILD_STAMP)" \
 	SUGAR_BUILD_GIT_HEAD="$(SUGARBIN_MONOREPO_HEAD)" \
 	"$(SUGARBIN_CARGO)" build --locked \


### PR DESCRIPTION
## What

`tools/sugarbin-build.mk:38` sets `SUGARBIN_INCREMENTAL := 1` unconditionally for the debug profile. sccache — configured as `rustc-wrapper` in `~/.cargo/config.toml` — refuses to run at all under incremental compilation, so **every debug sugarbin build fails outright** for anyone with that config:

```
sccache: incremental compilation is prohibited: Unset CARGO_INCREMENTAL to continue.
error: process didn't exit successfully: `sccache .../rustc -vV` (exit status: 1)
make: *** [sugarbin-build] Error 101
```

The incremental invocation now clears the wrapper for its own child process. Release builds are non-incremental and leave the developer's wrapper untouched. Both `CARGO_BUILD_RUSTC_WRAPPER` (the config key's env spelling) and `RUSTC_WRAPPER` are cleared, so an exported var of either name cannot reintroduce the conflict.

## Receipt

A/B at base `798b69b`, same target dir, same package, sccache configured, real runs:

| makefile | profile | result |
|---|---|---|
| unpatched | debug | `make Error 101`, sccache refuses on `rustc -vV` |
| patched | debug | ``Finished `dev` profile in 30.55s``, `test -x` on the output passes |

```
make -f tools/sugarbin-build.mk sugarbin-build SUGARBIN_PROFILE=debug \
  SUGARBIN_PACKAGE=sugar-canonicalizer SUGARBIN_BINARY=compute_fixture_cid \
  SUGARBIN_MANIFEST=implementations/rust/Cargo.toml ...
```

## Scope

One file, one variable. No test added: the failure is a property of the developer's `~/.cargo/config.toml`, which CI does not have, so a CI test would be green on both faces and prove nothing. The A/B above is the honest receipt.

Until now the standing workaround was to export `CARGO_BUILD_RUSTC_WRAPPER=""` by hand — a workaround every agent on this box had to rediscover after losing a run to it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix debug sugarbin builds by dropping rustc wrapper during incremental builds
> When `SUGARBIN_INCREMENTAL=1`, the build environment now explicitly clears `CARGO_BUILD_RUSTC_WRAPPER` and `RUSTC_WRAPPER` to prevent caching wrappers (e.g. `sccache`) from interfering with incremental debug builds. This is done via a new `SUGARBIN_WRAPPER_ENV` variable in [sugarbin-build.mk](https://github.com/TSavo/sugar/pull/6276/files#diff-bc479a4afc04b730f691fef24dd6d39ca0e969488188ed727e610aee1897f7a0) that is injected into the `cargo build` invocation. Non-incremental builds leave wrapper configuration unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84b2912.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Incremental debug builds now bypass configured Rust compiler build wrappers, improving compatibility with incremental compilation.
  * Release and non-incremental builds continue to use existing developer-configured build wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->