### PR TITLE
docs: name failed-node receipt profile caveat

### DIFF
--- a/docs/receipts/2026-07-25-sugar-lift-py-tests-22e18c69.failed-node-ids.txt
+++ b/docs/receipts/2026-07-25-sugar-lift-py-tests-22e18c69.failed-node-ids.txt
@@ -1,6 +1,9 @@
 # Failed node IDs: sugar-lift-py-tests
 # Pin: 22e18c69e9bae2a3d50f183c26e45b0105854cf3
 # Summary: 133 failed, 1050 passed, 12 skipped, 5 errors in 2141.07s
+# Profile caveat: SUGAR_BIN pinned a release binary while witness_harness requests
+# debug; these 138 reds measure release Sugar under a debug-expecting harness,
+# not the CI debug configuration.
 # Invocation (from implementations/python/sugar-lift-py-tests):
 # env SUGAR_BIN=/Users/tsavo/.buzz/REPOS/sugar-wt-chucky-receipts/implementations/rust/target/release/sugar PYTHONPATH="$PWD/../sugar-source-tree/src:$PWD/../sugar-lift-python-source/src:$PWD/../sugar-lift-py-tests/src" python3 -m pytest tests -q -p no:cacheprovider -rf --junitxml=/Users/tsavo/.buzz/.scratch/chucky-sugar-lift-py-tests-current-main.xml
 # Red nodes: 138 (133 failures + 5 errors)

--- a/docs/receipts/2026-07-25-sugar-source-tree-22e18c69.failed-node-ids.txt
+++ b/docs/receipts/2026-07-25-sugar-source-tree-22e18c69.failed-node-ids.txt
@@ -1,6 +1,9 @@
 # Failed node IDs: sugar-source-tree
 # Pin: 22e18c69e9bae2a3d50f183c26e45b0105854cf3
 # Summary: 533 passed, 5 skipped in 64.02s
+# Profile caveat: this run did not bind SUGAR_BIN; the release-under-debug-
+# expecting-harness mismatch documented in the sibling lift receipt does not
+# apply to this source-tree zero-red measurement.
 # Invocation (from implementations/python/sugar-source-tree):
 # env PYTHONPATH="$PWD/../sugar-source-tree/src:$PWD/../sugar-lift-python-source/src:$PWD/../sugar-lift-py-tests/src" python3 -m pytest tests -q -p no:cacheprovider -rf --junitxml=/Users/tsavo/.buzz/.scratch/chucky-sugar-source-tree-current-main.xml
 # Red nodes: 0


### PR DESCRIPTION
## What changed

Document the binary-profile blind spot in both failed-node receipt headers merged by #6277.

## Caveat

The `sugar-lift-py-tests` invocation bound `SUGAR_BIN` to `implementations/rust/target/release/sugar`, while `witness_harness.py` requests `resolve_sugar_binary(profile="debug")`. `bin/sugarbin` honors inherited `SUGAR_BIN` before checking the requested profile.

The 138-node set therefore measures release Sugar under a debug-expecting harness, not the CI debug configuration. Debug assertions and debug-only panics remain unmeasured. A debug-profile baseline requires a fresh sweep and pin.

The `sugar-source-tree` run did not bind `SUGAR_BIN`; its header states that the mismatch does not apply to its zero-red measurement.

Counts and pin remain unchanged:

- pin `22e18c69e9bae2a3d50f183c26e45b0105854cf3`
- lift: 138 unique red nodes (`133 failed + 5 errors`)
- source-tree: zero red nodes

This is a documentation-only follow-up because #6277 was merged at `5d806ea` before commit `5584a4a` reached its branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add profile caveat comments to failed-node receipt files
> Adds explanatory comments to two receipt files clarifying why test failures occurred. The [py-tests receipt](https://github.com/TSavo/sugar/pull/6278/files#diff-bd989b1e1b2ffc6043d6218e9b787a4c8a2afa1568206c9cd4e695e25a2380d4) notes that `SUGAR_BIN` points to a release binary while the witness harness expects a debug build, explaining the 138 failures. The [source-tree receipt](https://github.com/TSavo/sugar/pull/6278/files#diff-d36b06b146b29323e6d50d9006fe4e7ee6aac41917ff6ba616f1a6c232e3a86b) clarifies that `SUGAR_BIN` was not bound in that run and the release/debug mismatch does not apply.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ff7cc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->