### PR TITLE
ci: one authoritative Python-package-suite job (measurement ownership)

### DIFF
--- a/.github/actions/python-test-environment/action.yml
+++ b/.github/actions/python-test-environment/action.yml
@@ -1,0 +1,135 @@
+name: Prepare Python test environment
+description: >-
+  The ONE definition of the sugar Python test environment. Builds an immutable
+  wheel-installed venv from the package's declared dependency authority, mints
+  its environment identity, and puts it on PATH read-only.
+
+# WHY THIS EXISTS
+#
+# Before this action, five workflows each independently decided what "the
+# Python environment" was: which interpreter, which packages, editable or not.
+# Five definitions is zero definitions -- nothing measured under one of them
+# was comparable to anything measured under another, and `sugar-lift-py-tests`
+# ended up with no PR-gate coverage at all while every workflow looked busy.
+#
+# There is now one definition and it lives here. The authoritative suite job
+# consumes it. Every zero-tolerance floor consumes it. No caller installs its
+# own dependency list: `sugar-lift-py-tests[test]` is the sole dependency
+# authority (#6275), and the only names below are FIRST-PARTY PATHS, which are
+# the packages themselves rather than a hand-list of their requirements.
+#
+# The venv is built from wheels and then made read-only. Editable installs let
+# a later job silently change what an earlier job measured; a wheel install
+# plus `chmod a-w` makes that attempt fail loudly instead.
+
+inputs:
+  python-version:
+    description: Interpreter to install. Pinned to a patch version on purpose.
+    required: false
+    default: "3.12.13"
+  identity-artifact:
+    description: >-
+      When "true", upload the environment identity and resolved distribution
+      list as an artifact named by `identity-artifact-name`.
+    required: false
+    default: "false"
+  identity-artifact-name:
+    description: Artifact name used when `identity-artifact` is true.
+    required: false
+    default: python-test-environment-identity
+
+outputs:
+  identity-path:
+    description: Path to environment-identity.json.
+    value: ${{ steps.identity.outputs.path }}
+  identity-hash:
+    description: environmentIdentityHash -- two runs sharing it are comparable.
+    value: ${{ steps.identity.outputs.hash }}
+  python:
+    description: Absolute path to the prepared interpreter.
+    value: ${{ steps.install.outputs.python }}
+  env-dir:
+    description: Root of the prepared environment.
+    value: ${{ steps.install.outputs.env-dir }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+
+    # Identity is derived from INPUTS (interpreter, platform, sourceStamp,
+    # declared test extras, package sources), never from install output, so it
+    # is knowable before a single wheel is built and is not perturbed by
+    # resolver nondeterminism.
+    - name: Mint environment identity
+      id: identity
+      shell: bash
+      run: |
+        set -euo pipefail
+        env_dir="$RUNNER_TEMP/sugar-python-test-environment"
+        mkdir -p "$env_dir"
+        identity="$env_dir/environment-identity.json"
+        hash="$(python tools/python_test_environment_identity.py \
+          --repo-root . --output "$identity")"
+        echo "path=$identity" >> "$GITHUB_OUTPUT"
+        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+        echo "SUGAR_PYTHON_ENV_IDENTITY=$identity" >> "$GITHUB_ENV"
+        echo "environment identity: $hash"
+
+    - name: Build wheelhouse from the declared dependency authority
+      shell: bash
+      run: |
+        set -euo pipefail
+        env_dir="$RUNNER_TEMP/sugar-python-test-environment"
+        rm -rf "$env_dir/wheelhouse"
+        # `[test]` is the sole dependency authority. The three paths are the
+        # first-party packages themselves; every third-party requirement is
+        # resolved transitively FROM that table, never named here.
+        python -m pip wheel --quiet --wheel-dir "$env_dir/wheelhouse" \
+          './implementations/python/sugar-lift-py-tests[test]' \
+          ./implementations/python/sugar-lift-python-source \
+          ./implementations/python/sugar-source-tree
+
+    - name: Install immutable environment
+      id: install
+      shell: bash
+      run: |
+        set -euo pipefail
+        env_dir="$RUNNER_TEMP/sugar-python-test-environment"
+        venv="$env_dir/venv"
+        # A previous job's leftovers are read-only by construction; clear the
+        # write bit before removing so a re-run is not blocked by its own law.
+        if [ -d "$venv" ]; then chmod -R u+w "$venv"; rm -rf "$venv"; fi
+        python -m venv "$venv"
+        "$venv/bin/python" -m pip install --quiet --upgrade pip wheel
+        "$venv/bin/python" -m pip install --quiet \
+          --no-index --find-links "$env_dir/wheelhouse" \
+          'sugar-lift-py-tests[test]' \
+          sugar-lift-python-source \
+          sugar-source-tree
+        "$venv/bin/python" -m pip freeze --all > "$env_dir/resolved-distributions.txt"
+
+        # Consumers share this environment READ-ONLY. No job may mutate it:
+        # adding a package to an already-measured environment is how a floor
+        # quietly stops measuring what the suite measured. Make the attempt
+        # fail loudly rather than succeed silently.
+        chmod -R a-w "$venv/lib"
+        echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
+
+        echo "$venv/bin" >> "$GITHUB_PATH"
+        echo "python=$venv/bin/python" >> "$GITHUB_OUTPUT"
+        echo "env-dir=$env_dir" >> "$GITHUB_OUTPUT"
+
+    - name: Upload environment identity
+      if: inputs.identity-artifact == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.identity-artifact-name }}
+        path: |
+          ${{ runner.temp }}/sugar-python-test-environment/environment-identity.json
+          ${{ runner.temp }}/sugar-python-test-environment/resolved-distributions.txt
+        if-no-files-found: error

--- a/.github/workflows/bare-exception-zero-tolerance.yml
+++ b/.github/workflows/bare-exception-zero-tolerance.yml
@@ -19,17 +19,13 @@ jobs:
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
-      # hand-list a package here: a hand-list is one module-scope import away
-      # from the #6260 collection abort this floor exists to catch.
-      - name: Install Python lift kit and test runner
-        run: >-
-          python -m pip install
-          -e ./implementations/python/sugar-lift-python-source
-          -e './implementations/python/sugar-lift-py-tests[test]'
+      # ONE environment definition, shared read-only with the authoritative
+      # suite. `sugar-lift-py-tests[test]` remains the sole dependency
+      # authority (#6275) — the action installs from that table and this floor
+      # hand-lists nothing. This floor stays a distinct instrument: one
+      # discrimination file, never a second whole-package sweep.
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
       - name: R_bare_exceptions discrimination
         run: >-
           python -m pytest --noconftest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,33 @@
 # Sugar CI: the acid test
 #
 # Drop sugar into a project, prove correctness with zero code changes.
-# `make ci` runs the two suites that actually do that: `test-rust` (the rust
-# workspace, including the crate-pair inheritance E2E, exercising the ts
-# / python realize kits over RPC) and `test-python` (the python kit, including
-# the numpy proof). No federation conformance gate; the Makefile is the
-# contract.
+#
+# WHAT THIS WORKFLOW ACTUALLY RUNS -- read the `jobs:` block, not a slogan.
+# It runs `make ${{ matrix.target }}` over the `core` matrix plus sharded
+# `make test-showcases`. That is `make ci` decomposed for parallelism:
+# check-lift-refusal-vocabulary, check-fleet-claim-contract,
+# test-python-format, test-claim-mass-tripwires, test-showcases, self-attest,
+# coretests-invariants.
+#
+# IT DOES NOT RUN `test-rust` OR `test-python`, AND `make ci` DOES NOT EITHER.
+# This comment used to claim it did. It was false for both halves, and the
+# cost of the lie was concrete: `sugar-lift-py-tests` had no PR-gate coverage
+# at all, so the unit tests for `ExitSet.and_exit` did not run against #6270,
+# the PR that rewrote that algebra. A comment describing wiring nobody built
+# is worse than no comment -- it is a green light with no circuit behind it.
+#
+# Both suites are deliberately out of `make ci`, and each has a named owner:
+#   - `test-rust` / `test-python` are the development frontier, run by
+#     `make test-all`. They include intentionally red audits and ratchets;
+#     see the `ci:` target's comment in the Makefile.
+#   - the Python package suite is measured by
+#     .github/workflows/python-package-suite.yml, on every PR and push, as
+#     ONE authoritative cold whole-package sweep. It REPORTS -- ~131 known
+#     failures are recorded as node-ID evidence, not converted into a gate.
+#     Promoting it to a gate is a merge-policy decision and must be made
+#     explicitly, by driving those node IDs to zero and then wiring it here.
+#
+# No federation conformance gate; the Makefile is the contract.
 
 name: CI
 

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -22,9 +22,13 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      # ONE environment definition, shared read-only with the authoritative
+      # suite job. The floors stay distinct instruments — they measure R on
+      # their own axes and stay red-with-teeth — but they no longer define,
+      # install, or sweep their own idea of the package. See
+      # .github/workflows/python-package-suite.yml.
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
       # Permanent floors — baseline-free. R > 0 ⇒ CI red on every axis.
       # See docs/contributing/python-sole-construction.md
       # factory_zero_tolerance.py retired with factory/ (#6028): no dual
@@ -39,16 +43,6 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
-      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
-      # hand-list a package here: a hand-list is one module-scope import away
-      # from the #6260 collection abort these floors exist to catch.
-      - name: Install Python lift kit and static-floor test runner
-        if: always()
-        run: >-
-          python -m pip install
-          -e ./implementations/python/sugar-lift-python-source
-          -e ./implementations/python/sugar-source-tree
-          -e './implementations/python/sugar-lift-py-tests[test]'
       # Heavy supervised enum floors — sequential under this one job so the
       # complete floor set is always from one pinned run.
       - name: R_native_crashes = 0

--- a/.github/workflows/native-crash-zero-tolerance.yml
+++ b/.github/workflows/native-crash-zero-tolerance.yml
@@ -17,18 +17,13 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
-      # hand-list a package here: a hand-list is one module-scope import away
-      # from the #6260 collection abort this floor exists to catch.
-      - name: Install Python lift kit
-        run: >-
-          python -m pip install
-          -e ./implementations/python/sugar-lift-python-source
-          -e ./implementations/python/sugar-source-tree
-          -e './implementations/python/sugar-lift-py-tests[test]'
+      # ONE environment definition, shared read-only with the authoritative
+      # suite. `sugar-lift-py-tests[test]` remains the sole dependency
+      # authority (#6275) — the action installs from that table and this floor
+      # hand-lists nothing. This floor stays a distinct instrument: one
+      # discrimination file, never a second whole-package sweep.
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
       - name: R_native_crashes discrimination
         run: >-
           python -m pytest --noconftest

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -1,0 +1,232 @@
+name: Python package suite (authoritative)
+
+# THE DEFECT THIS FIXES
+#
+# `sugar-lift-py-tests` had no PR-gate coverage. `python-sole-construction-floors`
+# runs targeted law scripts with `--noconftest` -- not the suite. The only
+# workflow that touched the whole `sugar-lift-py-tests/tests` directory was
+# `restored-suite-scoreboard`, nightly cron / manual dispatch only. `make
+# test-python` was in no workflow at all. So the unit tests for
+# `ExitSet.and_exit` did not run against #6270, the PR that rewrote that
+# algebra.
+#
+# This workflow is the ONE authoritative whole-package sweep. Nothing else may
+# define, install, or run "the Python suite": the environment comes from
+# ./.github/actions/python-test-environment, and the zero-tolerance floors
+# consume that same action rather than building their own.
+#
+# IT REPORTS; IT DOES NOT GATE. ~131 known failures exist. Turning that red
+# into a merge gate is a merge-policy change and this wiring is a measurement-
+# ownership change. The `suite` job therefore records pytest's exit status as
+# evidence and exits 0. The SCHEDULED discrimination job DOES fail, because
+# order-dependence is not a known failure -- it is a claim that our verdicts
+# are not verdicts.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Discrimination cadence: canonical vs reversed vs shuffled, each cold.
+    - cron: "41 7 * * *"
+  workflow_dispatch:
+    inputs:
+      discrimination:
+        description: Also run the reversed/shuffled discrimination arms.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Repository-wide, ref-independent, and NEVER cancelling: a run already
+# producing evidence outlives the push that superseded it. New runs queue.
+#
+# Deliberately NOT the `sugar-python-heavy-measurement` group that
+# factory-zero-tolerance.yml owns. GitHub keeps only ONE pending run per group,
+# so a third queued run evicts the second -- sharing that group with the floors
+# would make the authoritative sweep the first thing dropped on a busy day,
+# which is the no-coverage defect this workflow exists to end. One heavy group
+# per heavy instrument, each ref-independent and each cancel-in-progress: false.
+concurrency:
+  group: sugar-python-package-suite
+  cancel-in-progress: false
+
+jobs:
+  prepare-python-test-environment:
+    name: prepare-python-test-environment
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
+    outputs:
+      identity-hash: ${{ steps.env.outputs.identity-hash }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare immutable Python test environment
+        id: env
+        uses: ./.github/actions/python-test-environment
+        with:
+          identity-artifact: "true"
+      - name: Publish environment identity to the run summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "### Python test environment"
+            echo
+            echo '`environmentIdentityHash`: `${{ steps.env.outputs.identity-hash }}`'
+            echo
+            echo 'Runs that do not share this hash are not comparable measurements.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  python-package-suite:
+    name: python-package-suite (canonical)
+    needs: prepare-python-test-environment
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prepare immutable Python test environment
+        id: env
+        uses: ./.github/actions/python-test-environment
+
+      # ONE cold process. Whole package. Canonical collection order.
+      # `-p no:cacheprovider` so no run inherits another's cache; `-p
+      # no:randomly` so canonical means canonical.
+      - name: Whole-package sweep
+        id: sweep
+        shell: bash
+        working-directory: implementations/python
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tools
+        run: |
+          set -uo pipefail
+          set +e
+          python -m pytest sugar-lift-py-tests/tests -q \
+            -p no:cacheprovider -p no:randomly \
+            -p python_package_suite_report \
+            --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
+            --suite-identity="${{ steps.env.outputs.identity-path }}" \
+            --suite-order=canonical \
+            --suite-label=python-package-suite-canonical \
+            2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
+          pytest_exit=${PIPESTATUS[0]}
+          set -e
+          echo "pytest_exit=$pytest_exit" >> "$GITHUB_OUTPUT"
+          test -s "$GITHUB_WORKSPACE/suite.log"
+          test -s "$GITHUB_WORKSPACE/suite-report.json"
+
+      - name: Publish the node-ID vector
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python tools/python_package_suite_summary.py \
+            --report suite-report.json \
+            --pytest-exit '${{ steps.sweep.outputs.pytest_exit }}' \
+            --node-id-dir suite-node-ids \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Artifacts carry the node-ID lists. The step summary carries counts.
+      # Counts are summaries of the lists; the lists are the evidence.
+      - name: Upload authoritative suite artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-suite-canonical
+          path: |
+            suite.log
+            suite-report.json
+            suite-node-ids/
+          if-no-files-found: error
+
+      # Deliberately no `exit $pytest_exit`. See the header: this job reports.
+      - name: Report, do not gate
+        if: always()
+        shell: bash
+        run: |
+          echo "pytest exit status ${{ steps.sweep.outputs.pytest_exit }} recorded as evidence."
+          echo "This job does not gate merges; it owns the measurement."
+
+  python-package-suite-discrimination:
+    name: python-package-suite (${{ matrix.order }})
+    # Scheduled cadence only -- plus explicit dispatch. Per-merge CI pays for
+    # exactly one sweep; order-dependence is caught nightly, not by tripling
+    # every merge's cost.
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.discrimination)
+    needs: prepare-python-test-environment
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        order: [reversed, shuffled]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prepare immutable Python test environment
+        id: env
+        uses: ./.github/actions/python-test-environment
+
+      # A SEPARATE COLD PROCESS per order. Sharing a process would let the
+      # first order warm exactly the caches whose influence we are measuring.
+      - name: Whole-package sweep (${{ matrix.order }})
+        shell: bash
+        working-directory: implementations/python
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tools
+        run: |
+          set -uo pipefail
+          set +e
+          python -m pytest sugar-lift-py-tests/tests -q \
+            -p no:cacheprovider -p no:randomly \
+            -p python_package_suite_report \
+            --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
+            --suite-identity="${{ steps.env.outputs.identity-path }}" \
+            --suite-order='${{ matrix.order }}' \
+            --suite-shuffle-seed="$GITHUB_RUN_ID" \
+            --suite-label='python-package-suite-${{ matrix.order }}' \
+            2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
+          echo "pytest exit ${PIPESTATUS[0]}"
+          set -e
+          test -s "$GITHUB_WORKSPACE/suite-report.json"
+
+      - name: Upload discrimination artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-suite-${{ matrix.order }}
+          path: |
+            suite.log
+            suite-report.json
+          if-no-files-found: error
+
+  discrimination-verdict:
+    name: identical verdict sets across orders
+    if: >-
+      always() && !cancelled() && (
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && inputs.discrimination)
+      )
+    needs: [python-package-suite, python-package-suite-discrimination]
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-package-suite-*
+          path: runs
+      # THIS ONE HAS TEETH. A verdict that changes with execution order is not
+      # a verdict. Red here means one of the two runs lied and we do not know
+      # which; fix the dependence, do not re-run for green.
+      - name: Require identical verdict sets
+        shell: bash
+        run: |
+          set -euo pipefail
+          python tools/python_suite_discrimination.py \
+            --baseline runs/python-package-suite-canonical/suite-report.json \
+            --candidate runs/python-package-suite-reversed/suite-report.json \
+            --candidate runs/python-package-suite-shuffled/suite-report.json \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -90,11 +90,12 @@ jobs:
         id: env
         uses: ./.github/actions/python-test-environment
 
-      # The suite exercises the real lift over RPC, so it needs the real
-      # binary. Without SUGAR_BIN the sweep still runs and still reports --
-      # it just reports a degraded corpus, which is a worse lie than no
-      # measurement because it looks like one. Resolved through the one door,
-      # bin/sugarbin, by source stamp: shelf hit unless the Rust inputs moved.
+      # The suite exercises the real lift over RPC. `tests/conftest.py` already
+      # resolves the binary in a session fixture and exits(2) if it cannot, so
+      # this step is not what makes the sweep work -- it is what keeps the
+      # sweep's WALL TIME a measurement of the suite rather than of a cold
+      # Rust build that happened to land inside it. Resolved through the one
+      # door, bin/sugarbin, by source stamp: shelf hit unless Rust inputs moved.
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
 
@@ -184,9 +185,9 @@ jobs:
         id: env
         uses: ./.github/actions/python-test-environment
 
-      # Same binary, resolved the same way, so the only difference between the
-      # canonical run and these is the order. Anything else differing would
-      # make a divergence uninterpretable.
+      # Same binary, resolved the same way and warmed the same way, so the only
+      # difference between the canonical run and these is the order. Anything
+      # else differing would make a divergence uninterpretable.
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
 

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -90,6 +90,20 @@ jobs:
         id: env
         uses: ./.github/actions/python-test-environment
 
+      # The suite exercises the real lift over RPC, so it needs the real
+      # binary. Without SUGAR_BIN the sweep still runs and still reports --
+      # it just reports a degraded corpus, which is a worse lie than no
+      # measurement because it looks like one. Resolved through the one door,
+      # bin/sugarbin, by source stamp: shelf hit unless the Rust inputs moved.
+      - name: Set up Rust toolchain
+        uses: ./.github/actions/setup-rust-cache
+
+      - name: Resolve the sugar binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "SUGAR_BIN=$(bin/sugarbin --profile release)" >> "$GITHUB_ENV"
+
       # ONE cold process. Whole package. Canonical collection order.
       # `-p no:cacheprovider` so no run inherits another's cache; `-p
       # no:randomly` so canonical means canonical.
@@ -169,6 +183,18 @@ jobs:
       - name: Prepare immutable Python test environment
         id: env
         uses: ./.github/actions/python-test-environment
+
+      # Same binary, resolved the same way, so the only difference between the
+      # canonical run and these is the order. Anything else differing would
+      # make a divergence uninterpretable.
+      - name: Set up Rust toolchain
+        uses: ./.github/actions/setup-rust-cache
+
+      - name: Resolve the sugar binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "SUGAR_BIN=$(bin/sugarbin --profile release)" >> "$GITHUB_ENV"
 
       # A SEPARATE COLD PROCESS per order. Sharing a process would let the
       # first order warm exactly the caches whose influence we are measuring.

--- a/.github/workflows/restored-suite-scoreboard.yml
+++ b/.github/workflows/restored-suite-scoreboard.yml
@@ -1,5 +1,24 @@
 name: Restored Suite Scoreboard
 
+# SUPERSEDED, NOT YET RETIRED. This workflow still builds its own environment
+# and runs its own whole-package sweep. That is now the SECOND such sweep:
+# .github/workflows/python-package-suite.yml owns the authoritative one, on
+# every PR and push, with an exact node-ID manifest. Two independent sweeps
+# means two sets of numbers that were never guaranteed to be comparable, which
+# is exactly the ownership defect the authoritative job exists to end.
+#
+# It survives this change only because deleting it is not a workflow edit: the
+# file name is pinned by `[tasks.restored-suite-scoreboard]` in
+# sugar-build.toml, by tests/test_sugar_build_contract.py (with a hashed task
+# digest), and by implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs,
+# which asserts this file's SUGAR_AMBIENT_DEPENDENCY_OWNER line verbatim.
+# Retiring it means moving its #4208 telemetry onto the canonical artifact and
+# re-pinning that contract — a deliberate change with its own receipt, not a
+# side effect of wiring the suite job.
+#
+# Until then: when these two disagree, the authoritative job is the measurement
+# and this one is prior art.
+
 on:
   workflow_dispatch:
   schedule:
@@ -59,6 +78,7 @@ jobs:
         run: |
           python -m venv "$RUNNER_TEMP/restored-suite-python"
           "$RUNNER_TEMP/restored-suite-python/bin/python" -m pip install --quiet --upgrade pip
+          # Sole dep authority: sugar-lift-py-tests[test] (pyproject.toml).
           "$RUNNER_TEMP/restored-suite-python/bin/python" -m pip install --quiet --no-cache-dir \
             -e implementations/python/libsugar-py \
             -e implementations/python/sugar-emit-python-hypothesis \

--- a/.github/workflows/timeout-zero-tolerance.yml
+++ b/.github/workflows/timeout-zero-tolerance.yml
@@ -18,17 +18,13 @@ jobs:
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      # `sugar-lift-py-tests[test]` is the sole dependency authority. Never
-      # hand-list a package here: a hand-list is one module-scope import away
-      # from the #6260 collection abort this floor exists to catch.
-      - name: Install Python lift kit and test runner
-        run: >-
-          python -m pip install
-          -e ./implementations/python/sugar-lift-python-source
-          -e './implementations/python/sugar-lift-py-tests[test]'
+      # ONE environment definition, shared read-only with the authoritative
+      # suite. `sugar-lift-py-tests[test]` remains the sole dependency
+      # authority (#6275) — the action installs from that table and this floor
+      # hand-lists nothing. This floor stays a distinct instrument: one
+      # discrimination file, never a second whole-package sweep.
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
       - name: R_timeouts discrimination
         run: >-
           python -m pytest --noconftest

--- a/Makefile
+++ b/Makefile
@@ -665,6 +665,14 @@ test-3809-dod-scoreboard:
 # `coretests-source-audit` is the bulk measuring stick (R = unresolved loci);
 # keep it offline/instrument until R is driven to 0 — a permanent R>0 red in
 # default CI is a gate wearing a scoreboard vest (see docs/analysis/ci-whack-a-mole-*).
+#
+# `test-python` is NOT in this list and must not be added silently. The Python
+# package suite is owned and measured by
+# .github/workflows/python-package-suite.yml — one authoritative cold sweep per
+# merge, reporting the exact collected / failed / error / skipped node-ID
+# vector. It carries ~131 known failures, so adding it here would be a
+# merge-policy change wearing a wiring-fix hat. Drive those node IDs to zero
+# first; then add it here deliberately, in a PR that says so.
 ci: check-lift-refusal-vocabulary check-fleet-claim-contract test-python-format test-claim-mass-tripwires test-showcases self-attest coretests-invariants
 	@echo ""
 	@echo "==== ci: PASS ===="

--- a/tests/test_test_extras_are_the_dependency_authority.py
+++ b/tests/test_test_extras_are_the_dependency_authority.py
@@ -20,6 +20,14 @@ Four teeth, and the fourth is the one that keeps the authority honest:
 4. Adding a dependency only to a workflow CANNOT satisfy tooth 3 — the
    resolver reads pyproject and never the workflows, proven on a synthetic
    pair where the workflow supplies what pyproject omits.
+
+THE AUDIT FOLLOWS THE INSTALL, WHEREVER IT LIVES. The environment is now built
+once by the composite action `.github/actions/python-test-environment`, which
+the authoritative suite job and the zero-tolerance floors all consume. Moving
+an install out of a workflow and into an action must NOT move it out of this
+audit's sight, so the action file is audited with the identical teeth and a
+consumer counts as bound either by installing `[test]` itself or by using that
+action. A floor that does neither is still an offender, by name.
 """
 
 from __future__ import annotations
@@ -34,6 +42,11 @@ ROOT = Path(__file__).resolve().parents[1]
 PACKAGE = ROOT / "implementations/python/sugar-lift-py-tests"
 PYPROJECT = PACKAGE / "pyproject.toml"
 WORKFLOWS = ROOT / ".github/workflows"
+
+# The ONE place the Python test environment is defined. Audited exactly like a
+# workflow: an install that hides in a composite action is still an install.
+ENVIRONMENT_ACTION = ROOT / ".github/actions/python-test-environment/action.yml"
+ENVIRONMENT_ACTION_USE = "./.github/actions/python-test-environment"
 
 AUTHORITY = "sugar-lift-py-tests"
 
@@ -138,17 +151,58 @@ def run_blocks(workflow_text: str) -> list[str]:
 
 
 def pip_install_commands(workflow_text: str) -> list[str]:
-    """Every `pip install ...` invocation, one entry per real command."""
+    """Every dependency-acquiring pip invocation, one entry per real command.
+
+    `pip wheel` is included: building a wheelhouse from a requirement is how
+    the immutable environment acquires its dependencies, so a hand-list smuggled
+    into a `pip wheel` line is the same #6260 offence as one in `pip install`.
+    """
     commands = []
     for block in run_blocks(workflow_text):
         block = re.sub(r"\\\s*\n\s*", " ", block)  # shell backslash-newline
         for line in block.split("\n"):
-            for match in re.finditer(r"pip install[^\n]*", line):
+            for match in re.finditer(r"pip (?:install|wheel)[^\n]*", line):
                 command = match.group(0)
                 if "--upgrade pip" in command:
                     continue  # bootstrapping pip itself is not a dependency
                 commands.append(command)
     return commands
+
+
+def is_wheel_build(command: str) -> bool:
+    """`pip wheel` BUILDS the immutable environment's inputs.
+
+    Editability is meaningless for a wheel build — and an editable install is
+    precisely what the immutable environment exists to avoid — so tooth 1's
+    `-e` requirement does not apply here. The `[test]` requirement still does:
+    a wheelhouse built without the extras is an environment missing every
+    package the suite declares, which is #6260 with extra steps.
+    """
+    return command.startswith("pip wheel")
+
+
+def audit_sites() -> list[Path]:
+    """Every file that may acquire this package's dependencies.
+
+    Workflows plus the composite action. Adding a new install site without
+    adding it here is the drift this list exists to make impossible.
+    """
+    sites = sorted(WORKFLOWS.glob("*.yml"))
+    if ENVIRONMENT_ACTION.exists():
+        sites.append(ENVIRONMENT_ACTION)
+    return sites
+
+
+def binds_to_authority(text: str) -> bool:
+    """Does this file draw its Python environment from the authority?
+
+    Two legal ways, and only two: install `[test]` directly, or delegate to the
+    one composite action that does. Anything else is a floor running against an
+    environment nobody defined.
+    """
+    if ENVIRONMENT_ACTION_USE in text:
+        return True
+    return any(AUTHORITY in command for command in pip_install_commands(text))
 
 
 def bare_requirements(command: str) -> list[str]:
@@ -174,7 +228,7 @@ def bare_requirements(command: str) -> list[str]:
 
 def workflows_installing_authority() -> dict[Path, list[str]]:
     hits: dict[Path, list[str]] = {}
-    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+    for workflow in audit_sites():
         commands = [
             command
             for command in pip_install_commands(workflow.read_text(encoding="utf-8"))
@@ -204,6 +258,8 @@ def test_every_authority_install_uses_editable_test_extras() -> None:
                     offenders.append(
                         f"{workflow.name}: installs `{token}` without [test] extras"
                     )
+                elif is_wheel_build(command):
+                    continue  # wheel builds are immutable by construction
                 elif f"-e {token}" not in command and f"-e '{token}'" not in command:
                     offenders.append(
                         f"{workflow.name}: installs `{token}` non-editable"
@@ -224,7 +280,7 @@ def test_no_workflow_hand_lists_a_package_the_authority_owns() -> None:
     owned = authority_packages(PYPROJECT.read_text(encoding="utf-8"))
 
     offenders = []
-    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+    for workflow in audit_sites():
         text = workflow.read_text(encoding="utf-8")
         commands = pip_install_commands(text)
         # Scope is the WORKFLOW, not the single command: `pip install numpy` in
@@ -330,11 +386,13 @@ def test_the_four_zero_tolerance_floors_are_bound_to_the_authority() -> None:
     offenders = []
     for name in floors:
         text = (WORKFLOWS / name).read_text(encoding="utf-8")
-        commands = [c for c in pip_install_commands(text) if AUTHORITY in c]
-        if not commands:
-            offenders.append(f"{name}: never installs {AUTHORITY}")
+        if not binds_to_authority(text):
+            offenders.append(
+                f"{name}: neither installs {AUTHORITY}[test] nor uses "
+                f"{ENVIRONMENT_ACTION_USE}"
+            )
             continue
-        for command in commands:
+        for command in [c for c in pip_install_commands(text) if AUTHORITY in c]:
             if f"{AUTHORITY}[test]" not in command:
                 offenders.append(f"{name}: installs {AUTHORITY} without [test]")
             if bare_requirements(command):
@@ -345,4 +403,58 @@ def test_the_four_zero_tolerance_floors_are_bound_to_the_authority() -> None:
     assert not offenders, (
         "the zero-tolerance floors must draw their entire environment from "
         f"`{AUTHORITY}[test]`:\n  " + "\n  ".join(offenders)
+    )
+
+
+# --------------------------------------------------------------------------
+# Tooth 6: the delegation target is real, and is itself bound
+# --------------------------------------------------------------------------
+def test_the_environment_action_is_the_one_bound_definition() -> None:
+    """`uses:` the action is only a legal binding because the action obeys.
+
+    Tooth 5 accepts delegation to `.github/actions/python-test-environment`.
+    That acceptance is worth exactly as much as this test: if the action stops
+    existing, stops installing `[test]`, or starts hand-listing, then every
+    floor that delegates to it is unbound and tooth 5's green is a lie.
+    """
+    assert ENVIRONMENT_ACTION.exists(), (
+        f"{ENVIRONMENT_ACTION_USE} is the single definition of the Python test "
+        "environment and every zero-tolerance floor delegates to it. It is "
+        "missing — restore it, or re-bind each floor to the authority directly."
+    )
+
+    text = ENVIRONMENT_ACTION.read_text(encoding="utf-8")
+    commands = [c for c in pip_install_commands(text) if AUTHORITY in c]
+    assert commands, (
+        f"{ENVIRONMENT_ACTION.name} never acquires {AUTHORITY}[test]; every "
+        "consumer that delegates to it is running against an environment "
+        "nobody declared"
+    )
+
+    offenders = []
+    for command in commands:
+        if f"{AUTHORITY}[test]" not in command:
+            offenders.append(f"acquires {AUTHORITY} without [test]: {command}")
+    for command in pip_install_commands(text):
+        hand_listed = [
+            requirement
+            for requirement in bare_requirements(command)
+            # The three first-party package NAMES are how the wheelhouse is
+            # installed by name rather than by path; they are the packages
+            # themselves, not requirements of them.
+            if requirement
+            not in {
+                normalize(AUTHORITY),
+                "sugar-lift-python-source",
+                "sugar-source-tree",
+                "wheel",
+            }
+        ]
+        if hand_listed:
+            offenders.append(f"hand-lists {sorted(set(hand_listed))}: {command}")
+
+    assert not offenders, (
+        f"{ENVIRONMENT_ACTION.name} is the ONE definition of the Python test "
+        f"environment; it must draw everything from `{AUTHORITY}[test]`:\n  "
+        + "\n  ".join(offenders)
     )

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -1,0 +1,277 @@
+"""Authoritative Python-package-suite instrument.
+
+One cold pytest process over the whole package produces ONE report: the exact
+collected node-ID manifest in collection order, the exact failed / error /
+skipped node-ID sets, timing, and the environment / runner / resource
+testimony that makes the verdict re-derivable.
+
+Counts are summaries only. The node-ID lists are the evidence; every count in
+the report is derived from a list that is also present in the report.
+
+Usage (as a pytest plugin, never as a conftest):
+
+    python -m pytest <package>/tests -q \
+        -p no:cacheprovider -p no:randomly \
+        -p python_package_suite_report \
+        --suite-report=suite-report.json \
+        --suite-identity=environment-identity.json \
+        --suite-order=canonical
+
+`--suite-order` exists for the SCHEDULED discrimination run: `reversed` and
+`shuffled` execute the identical collected set in a different order, in their
+own cold process, and their verdict sets must match the canonical run's. It is
+not a per-merge cost -- per-merge CI runs `canonical` only.
+
+This module declares no dependency of its own. It imports stdlib and the
+pytest that `sugar-lift-py-tests[test]` already declares -- that table stays
+the sole dependency authority (#6275).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import random
+import sys
+import time
+
+# Phase of a report that failed decides failure-vs-error, the same split the
+# terminal summary shows: a call-phase failure is a FAILED test, a setup- or
+# teardown-phase failure is an ERROR.
+_ERROR_PHASES = ("setup", "teardown")
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("sugar-package-suite")
+    group.addoption(
+        "--suite-report",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help="write the authoritative suite report JSON to PATH",
+    )
+    group.addoption(
+        "--suite-identity",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help="environment-identity JSON to embed verbatim in the report",
+    )
+    group.addoption(
+        "--suite-order",
+        action="store",
+        default="canonical",
+        choices=("canonical", "reversed", "shuffled"),
+        help="execution order; collection order is always recorded canonically",
+    )
+    group.addoption(
+        "--suite-shuffle-seed",
+        action="store",
+        type=int,
+        default=None,
+        metavar="N",
+        help="seed for --suite-order=shuffled (recorded in the report)",
+    )
+    group.addoption(
+        "--suite-label",
+        action="store",
+        default=None,
+        metavar="LABEL",
+        help="free-form label recorded in the report (e.g. the CI job name)",
+    )
+
+
+class SuiteReporter:
+    def __init__(self, config):
+        self.config = config
+        self.collected: list[str] = []
+        self.executed_order: list[str] = []
+        self.failed: list[str] = []
+        self.errored: list[str] = []
+        self.skipped: list[str] = []
+        self.xfailed: list[str] = []
+        self.xpassed: list[str] = []
+        self.passed: list[str] = []
+        self.collection_errors: list[str] = []
+        self._seen_outcome: set[str] = set()
+        self._wall_start = time.perf_counter()
+        self._cpu_start = os.times()
+        self.shuffle_seed = None
+
+    # -- collection ---------------------------------------------------------
+
+    def pytest_collection_modifyitems(self, session, config, items):
+        # Canonical manifest is captured BEFORE any reordering: the collected
+        # set is an order-independent fact about the package.
+        self.collected = [item.nodeid for item in items]
+        order = config.getoption("--suite-order")
+        if order == "reversed":
+            items.reverse()
+        elif order == "shuffled":
+            seed = config.getoption("--suite-shuffle-seed")
+            if seed is None:
+                seed = random.SystemRandom().randrange(2**31)
+            self.shuffle_seed = seed
+            random.Random(seed).shuffle(items)
+        self.executed_order = [item.nodeid for item in items]
+
+    def pytest_collectreport(self, report):
+        # A collection failure is an error with no test node behind it; it is
+        # exactly the #6260 shape, so it must never be summarised away.
+        if report.failed:
+            self._record(self.collection_errors, report.nodeid or "<root>")
+
+    # -- execution ----------------------------------------------------------
+
+    def pytest_runtest_logreport(self, report):
+        nodeid = report.nodeid
+        if report.failed:
+            if report.when in _ERROR_PHASES:
+                self._record(self.errored, nodeid)
+            else:
+                self._record(self.failed, nodeid)
+            self._seen_outcome.add(nodeid)
+        elif report.skipped:
+            if getattr(report, "wasxfail", None) is not None:
+                self._record(self.xfailed, nodeid)
+            else:
+                self._record(self.skipped, nodeid)
+            self._seen_outcome.add(nodeid)
+        elif report.when == "call":
+            if getattr(report, "wasxfail", None) is not None:
+                self._record(self.xpassed, nodeid)
+            else:
+                self._record(self.passed, nodeid)
+            self._seen_outcome.add(nodeid)
+
+    @staticmethod
+    def _record(bucket, nodeid):
+        if nodeid not in bucket:
+            bucket.append(nodeid)
+
+    # -- report -------------------------------------------------------------
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        path = self.config.getoption("--suite-report")
+        if not path:
+            return
+        wall = time.perf_counter() - self._wall_start
+        cpu_end = os.times()
+        report = {
+            "schemaVersion": 1,
+            "label": self.config.getoption("--suite-label"),
+            "order": self.config.getoption("--suite-order"),
+            "shuffleSeed": self.shuffle_seed,
+            "pytestExitStatus": int(exitstatus),
+            "environmentIdentity": self._identity(),
+            "runnerIdentity": _runner_identity(),
+            "resourceTelemetry": _resource_telemetry(),
+            "timing": {
+                "wallSeconds": round(wall, 6),
+                "cpuUserSeconds": round(
+                    (cpu_end.user - self._cpu_start.user)
+                    + (cpu_end.children_user - self._cpu_start.children_user),
+                    6,
+                ),
+                "cpuSystemSeconds": round(
+                    (cpu_end.system - self._cpu_start.system)
+                    + (cpu_end.children_system - self._cpu_start.children_system),
+                    6,
+                ),
+                "startedAtUnix": _start_unix(),
+                "finishedAtUnix": time.time(),
+            },
+            # The evidence. Node-ID lists, never counts alone.
+            "collectedNodeIds": self.collected,
+            "executedOrderNodeIds": self.executed_order,
+            "failedNodeIds": self.failed,
+            "errorNodeIds": self.errored,
+            "skippedNodeIds": self.skipped,
+            "xfailedNodeIds": self.xfailed,
+            "xpassedNodeIds": self.xpassed,
+            "passedNodeIds": self.passed,
+            "collectionErrorNodeIds": self.collection_errors,
+            "notReportedNodeIds": [
+                n for n in self.collected if n not in self._seen_outcome
+            ],
+            # Summaries only. Every one of these is len() of a list above.
+            "counts": {
+                "collected": len(self.collected),
+                "passed": len(self.passed),
+                "failed": len(self.failed),
+                "error": len(self.errored),
+                "skipped": len(self.skipped),
+                "xfailed": len(self.xfailed),
+                "xpassed": len(self.xpassed),
+                "collectionError": len(self.collection_errors),
+                "notReported": len(
+                    [n for n in self.collected if n not in self._seen_outcome]
+                ),
+            },
+        }
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=False)
+            handle.write("\n")
+
+    def _identity(self):
+        path = self.config.getoption("--suite-identity")
+        if not path:
+            return {"unavailable": "no --suite-identity supplied"}
+        try:
+            with open(path, encoding="utf-8") as handle:
+                return json.load(handle)
+        except OSError as exc:
+            # Loud, never silent: an unreadable identity is testimony too.
+            return {"unavailable": f"{type(exc).__name__}: {exc}", "path": path}
+
+
+_START_UNIX = time.time()
+
+
+def _start_unix():
+    return _START_UNIX
+
+
+def _runner_identity():
+    return {
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "githubRunId": os.environ.get("GITHUB_RUN_ID"),
+        "githubRunAttempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "githubJob": os.environ.get("GITHUB_JOB"),
+        "githubWorkflow": os.environ.get("GITHUB_WORKFLOW"),
+        "githubSha": os.environ.get("GITHUB_SHA"),
+        "githubRef": os.environ.get("GITHUB_REF"),
+        "runnerName": os.environ.get("RUNNER_NAME"),
+        "runnerOs": os.environ.get("RUNNER_OS"),
+        "runnerArch": os.environ.get("RUNNER_ARCH"),
+    }
+
+
+def _resource_telemetry():
+    telemetry = {
+        "cpuCount": os.cpu_count(),
+        "pythonExecutable": sys.executable,
+    }
+    try:
+        telemetry["loadAverage1_5_15"] = list(os.getloadavg())
+    except (AttributeError, OSError):
+        telemetry["loadAverage1_5_15"] = None
+    try:
+        telemetry["schedAffinityCount"] = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        telemetry["schedAffinityCount"] = None
+    try:
+        import resource
+
+        usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        telemetry["maxRssChildrenKb"] = usage.ru_maxrss
+    except Exception:  # pragma: no cover - platform dependent
+        telemetry["maxRssChildrenKb"] = None
+    return telemetry
+
+
+def pytest_configure(config):
+    config.pluginmanager.register(SuiteReporter(config), "sugar-suite-reporter")

--- a/tools/python_package_suite_summary.py
+++ b/tools/python_package_suite_summary.py
@@ -1,0 +1,109 @@
+"""Render the authoritative suite report: node-ID files plus a counts summary.
+
+The node-ID files are the artifact. The markdown is a reading aid. If the two
+ever disagree, the files are right -- every count printed here is `len()` of a
+list that is written out in full beside it, so no count can drift away from its
+evidence.
+
+Usage:
+    python tools/python_package_suite_summary.py \
+        --report suite-report.json --pytest-exit 1 --node-id-dir suite-node-ids
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+# Every axis is written out in FULL. Never truncated, never `head`/`tail`-ed:
+# a prior agent's `tail -25` dropped 4 of 28 node IDs and produced a false
+# "4 fixed" claim. Truncation of an evidence list is fabrication.
+AXES = (
+    ("collectedNodeIds", "collected.txt"),
+    ("executedOrderNodeIds", "executed-order.txt"),
+    ("failedNodeIds", "failed.txt"),
+    ("errorNodeIds", "error.txt"),
+    ("skippedNodeIds", "skipped.txt"),
+    ("xfailedNodeIds", "xfailed.txt"),
+    ("xpassedNodeIds", "xpassed.txt"),
+    ("passedNodeIds", "passed.txt"),
+    ("collectionErrorNodeIds", "collection-error.txt"),
+    ("notReportedNodeIds", "not-reported.txt"),
+)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--pytest-exit", default=None)
+    parser.add_argument("--node-id-dir", required=True)
+    args = parser.parse_args(argv)
+
+    with open(args.report, encoding="utf-8") as handle:
+        report = json.load(handle)
+
+    os.makedirs(args.node_id_dir, exist_ok=True)
+    for axis, filename in AXES:
+        node_ids = report.get(axis, [])
+        with open(
+            os.path.join(args.node_id_dir, filename), "w", encoding="utf-8"
+        ) as handle:
+            for nodeid in node_ids:
+                handle.write(nodeid + "\n")
+
+    identity = report.get("environmentIdentity", {})
+    runner = report.get("runnerIdentity", {})
+    resources = report.get("resourceTelemetry", {})
+    timing = report.get("timing", {})
+    counts = report.get("counts", {})
+
+    lines = [
+        "### Python package suite (authoritative)",
+        "",
+        f"- order: `{report.get('order')}`"
+        + (
+            f" (seed `{report.get('shuffleSeed')}`)"
+            if report.get("shuffleSeed") is not None
+            else ""
+        ),
+        f"- pytest exit status: `{args.pytest_exit if args.pytest_exit is not None else report.get('pytestExitStatus')}`"
+        " (recorded as evidence; this job reports, it does not gate)",
+        f"- environmentIdentityHash: `{identity.get('environmentIdentityHash')}`",
+        f"- sourceStamp: `{(identity.get('sourceStamp') or {}).get('value')}`",
+        f"- testExtraInputHash: `{(identity.get('dependencyAuthority') or {}).get('testExtraInputHash')}`",
+        f"- packageBuildInputs: `{(identity.get('packageBuildInputs') or {}).get('hash')}`",
+        f"- python: `{identity.get('pythonImplementation')} {identity.get('pythonVersion')}`"
+        f" abi `{(identity.get('pythonAbi') or {}).get('soabi')}`",
+        f"- runner: `{runner.get('hostname')}` / `{runner.get('runnerName')}`"
+        f" run `{runner.get('githubRunId')}` attempt `{runner.get('githubRunAttempt')}`",
+        f"- cpus: `{resources.get('cpuCount')}` affinity `{resources.get('schedAffinityCount')}`"
+        f" load `{resources.get('loadAverage1_5_15')}`",
+        f"- wall: `{timing.get('wallSeconds')}s`"
+        f" cpu user `{timing.get('cpuUserSeconds')}s`"
+        f" sys `{timing.get('cpuSystemSeconds')}s`",
+        "",
+        "Counts are summaries only; the node-ID lists in the artifact are the evidence.",
+        "",
+        "| axis | count |",
+        "| --- | ---: |",
+    ]
+    for key in (
+        "collected",
+        "passed",
+        "failed",
+        "error",
+        "skipped",
+        "xfailed",
+        "xpassed",
+        "collectionError",
+        "notReported",
+    ):
+        lines.append(f"| {key} | {counts.get(key)} |")
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_suite_discrimination.py
+++ b/tools/python_suite_discrimination.py
@@ -1,0 +1,117 @@
+"""Order-discrimination check for the authoritative Python package suite.
+
+The per-merge cadence runs ONE canonical whole-package sweep. That is cheap and
+it is the number we report. What it cannot see on its own is cache- or
+order-dependence: a verdict that changes because of what ran before it is not a
+verdict about the test, it is a verdict about the schedule.
+
+So a SCHEDULED run executes the same package in canonical order and in
+reversed / shuffled order, each in its own cold process, and this script
+requires the verdict sets to be IDENTICAL. Sets, not sequences -- order is
+exactly what is allowed to differ.
+
+Divergence is red and names every diverging node ID. It is never summarised
+into a count, and never tolerated as flake: an order-dependent verdict means
+one of the two runs told the truth and we do not know which.
+
+Usage:
+    python tools/python_suite_discrimination.py \
+        --baseline canonical/suite-report.json \
+        --candidate reversed/suite-report.json \
+        --candidate shuffled/suite-report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# Verdict axes compared as sets. `collectedNodeIds` is here because a package
+# whose collected SET depends on execution order has a collection-time
+# dependence, which is strictly worse than an ordering-dependent verdict.
+VERDICT_AXES = (
+    "collectedNodeIds",
+    "failedNodeIds",
+    "errorNodeIds",
+    "skippedNodeIds",
+    "collectionErrorNodeIds",
+)
+
+
+def _load(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _identity_hash(report):
+    return (report.get("environmentIdentity") or {}).get("environmentIdentityHash")
+
+
+def compare(baseline, candidate):
+    """Return a list of divergence strings; empty means identical verdicts."""
+    divergences = []
+
+    base_id = _identity_hash(baseline)
+    cand_id = _identity_hash(candidate)
+    if base_id != cand_id:
+        # Not a flake and not a divergence -- it is an invalid comparison.
+        divergences.append(
+            "environmentIdentityHash differs: "
+            f"baseline={base_id} candidate={cand_id} -- these two runs are not "
+            "comparable measurements; re-measure both at one identity"
+        )
+
+    for axis in VERDICT_AXES:
+        base = set(baseline.get(axis, []))
+        cand = set(candidate.get(axis, []))
+        only_base = sorted(base - cand)
+        only_cand = sorted(cand - base)
+        for nodeid in only_base:
+            divergences.append(f"{axis}: only in {baseline_label(baseline)}: {nodeid}")
+        for nodeid in only_cand:
+            divergences.append(f"{axis}: only in {baseline_label(candidate)}: {nodeid}")
+    return divergences
+
+
+def baseline_label(report):
+    return report.get("label") or report.get("order") or "<unlabelled>"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--candidate", action="append", required=True)
+    args = parser.parse_args(argv)
+
+    baseline = _load(args.baseline)
+    failures = 0
+    for path in args.candidate:
+        candidate = _load(path)
+        divergences = compare(baseline, candidate)
+        header = (
+            f"{baseline_label(baseline)} (order={baseline.get('order')}) vs "
+            f"{baseline_label(candidate)} (order={candidate.get('order')}, "
+            f"seed={candidate.get('shuffleSeed')})"
+        )
+        if divergences:
+            failures += 1
+            print(f"ORDER-DEPENDENCE: {header}")
+            for line in divergences:
+                print(f"  {line}")
+        else:
+            print(f"identical verdict sets: {header}")
+
+    if failures:
+        print(
+            f"\ndiscrimination FAILED: {failures} candidate run(s) disagreed with "
+            "the canonical run. The suite's verdicts depend on execution order "
+            "or on cache state. Fix the dependence; do not re-run until green."
+        )
+        return 1
+    print("\ndiscrimination PASSED: every order produced identical verdict sets.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/python_test_environment_identity.py
+++ b/tools/python_test_environment_identity.py
@@ -1,0 +1,213 @@
+"""Immutable environment identity for the authoritative Python package suite.
+
+One environment, one identity. Two runs that print the same
+`environmentIdentityHash` ran the same interpreter, on the same platform,
+against the same package sources, with the same declared test extras. Two runs
+that print different hashes are not comparable measurements, and any claim that
+compares them is a stale-measurement claim.
+
+Fields (all load-bearing, all hashed into `environmentIdentityHash`):
+
+  pythonImplementation / pythonVersion / pythonAbi   the interpreter
+  platform                                            the machine + libc/OS
+  sourceStamp                                         the Rust+Python build
+                                                      inputs, from the same
+                                                      preimage `bin/sugarbin`
+                                                      hashes (tools/sugar_source_stamp.py)
+  testExtraInputHash                                  hash of the [test] table
+                                                      and `dependencies` of the
+                                                      package's pyproject.toml
+                                                      -- the SOLE dependency
+                                                      authority (#6275)
+  packageBuildInputHash                               hash of every packaged
+                                                      source file of the
+                                                      packages installed
+
+Usage:
+    python tools/python_test_environment_identity.py \
+        --repo-root . --output environment-identity.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import sysconfig
+
+# The packages that make up the Python test environment. These are PATH
+# installs of first-party packages, not a dependency list: every third-party
+# requirement still comes from `sugar-lift-py-tests[test]`, which remains the
+# sole dependency authority (#6275). Adding a third-party name here would be
+# the regression that table exists to prevent.
+ENVIRONMENT_PACKAGES = (
+    "sugar-lift-py-tests",
+    "sugar-lift-python-source",
+    "sugar-source-tree",
+)
+
+AUTHORITY_PACKAGE = "sugar-lift-py-tests"
+
+# Directories that never change what the suite means.
+_SKIP_DIRS = {"__pycache__", ".git", ".venv", ".pytest_cache", "build", "dist"}
+
+
+def _hash_tree(root, digest):
+    """Fold every file under `root` into `digest`, path-sorted and labelled."""
+    if not os.path.isdir(root):
+        return 0
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        for name in sorted(filenames):
+            if name.endswith((".pyc", ".pyo")):
+                continue
+            full = os.path.join(dirpath, name)
+            rel = os.path.relpath(full, root)
+            digest.update(b"path\x00")
+            digest.update(rel.encode("utf-8"))
+            digest.update(b"\x00")
+            with open(full, "rb") as handle:
+                digest.update(hashlib.sha256(handle.read()).digest())
+            count += 1
+    return count
+
+
+def _test_extra_input_hash(pyproject_path):
+    """Hash the declared dependency authority: `dependencies` + `[test]`.
+
+    Hashed from the parsed tables rather than the raw file so that a comment
+    edit does not invalidate a measurement, while any change to what the suite
+    is allowed to import does.
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+        import tomli as tomllib
+
+    with open(pyproject_path, "rb") as handle:
+        data = tomllib.load(handle)
+    project = data.get("project", {})
+    authority = {
+        "dependencies": project.get("dependencies", []),
+        "optional-dependencies": project.get("optional-dependencies", {}),
+        "requires-python": project.get("requires-python"),
+        "build-system": data.get("build-system", {}),
+    }
+    payload = json.dumps(authority, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest(), authority
+
+
+def _source_stamp(repo_root):
+    """The same sourceStamp `bin/sugarbin` resolves binaries by.
+
+    Failure is recorded, never swallowed: a missing stamp makes the identity
+    say so out loud rather than quietly hashing a hole.
+    """
+    script = os.path.join(repo_root, "tools", "sugar_source_stamp.py")
+    if not os.path.isfile(script):
+        return {"unavailable": f"missing {script}"}
+    try:
+        stream = subprocess.run(
+            [sys.executable, script, "--repo-root", repo_root, "--stream"],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError) as exc:
+        detail = getattr(exc, "stderr", b"") or b""
+        return {
+            "unavailable": f"{type(exc).__name__}: {exc}",
+            "stderr": detail.decode("utf-8", "replace")[-2000:],
+        }
+    return {
+        "algorithm": "sha256-of-sugar_source_stamp-preimage",
+        "value": hashlib.sha256(stream).hexdigest(),
+        "preimageBytes": len(stream),
+    }
+
+
+def build_identity(repo_root):
+    repo_root = os.path.abspath(repo_root)
+    python_root = os.path.join(repo_root, "implementations", "python")
+
+    package_inputs = {}
+    build_digest = hashlib.sha256()
+    for package in ENVIRONMENT_PACKAGES:
+        package_dir = os.path.join(python_root, package)
+        digest = hashlib.sha256()
+        files = _hash_tree(os.path.join(package_dir, "src"), digest)
+        pyproject = os.path.join(package_dir, "pyproject.toml")
+        if os.path.isfile(pyproject):
+            with open(pyproject, "rb") as handle:
+                digest.update(hashlib.sha256(handle.read()).digest())
+            files += 1
+        package_inputs[package] = {"fileCount": files, "hash": digest.hexdigest()}
+        build_digest.update(package.encode("utf-8"))
+        build_digest.update(b"\x00")
+        build_digest.update(digest.digest())
+
+    authority_pyproject = os.path.join(
+        python_root, AUTHORITY_PACKAGE, "pyproject.toml"
+    )
+    extra_hash, authority = _test_extra_input_hash(authority_pyproject)
+
+    identity = {
+        "schemaVersion": 1,
+        "pythonImplementation": platform.python_implementation(),
+        "pythonVersion": platform.python_version(),
+        "pythonAbi": {
+            "soabi": sysconfig.get_config_var("SOABI"),
+            "apiVersion": sysconfig.get_config_var("VERSION"),
+            "maxUnicode": sys.maxunicode,
+            "hexVersion": sys.hexversion,
+            "platformTag": sysconfig.get_platform(),
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "platform": platform.platform(),
+            "libc": list(platform.libc_ver()),
+        },
+        "sourceStamp": _source_stamp(repo_root),
+        "dependencyAuthority": {
+            "package": AUTHORITY_PACKAGE,
+            "pyprojectPath": os.path.relpath(authority_pyproject, repo_root),
+            "testExtraInputHash": extra_hash,
+            "declared": authority,
+        },
+        "packageBuildInputs": {
+            "packages": package_inputs,
+            "hash": build_digest.hexdigest(),
+        },
+    }
+
+    # The identity hash covers everything above except itself.
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+    identity["environmentIdentityHash"] = hashlib.sha256(
+        payload.encode("utf-8")
+    ).hexdigest()
+    return identity
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output", default=None, help="write JSON here")
+    args = parser.parse_args(argv)
+
+    identity = build_identity(args.repo_root)
+    text = json.dumps(identity, indent=2) + "\n"
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    print(identity["environmentIdentityHash"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The defect

`sugar-lift-py-tests` had **no PR-gate coverage**.

- `python-sole-construction-floors` runs targeted law scripts with `--noconftest` — not the suite.
- The only workflow covering the whole `sugar-lift-py-tests/tests` directory was `restored-suite-scoreboard`, **nightly cron / manual dispatch only**.
- `make test-python` exists, is **not** in `make ci`, and no workflow invoked it.
- Yet `ci.yml`'s header comment asserted *"`make ci` runs the two suites that actually do that: `test-rust` and `test-python`"* — describing wiring that did not exist.

Consequence: the 22 unit tests for `ExitSet.and_exit` did not gate #6270, the PR that rewrote that algebra.

## What this builds

**One authoritative Python-package-suite job.** Nothing else defines, installs, or runs "the Python suite".

```
.github/actions/python-test-environment      ← the ONE environment definition
    pip wheel from sugar-lift-py-tests[test]   (sole dependency authority, #6275)
    → venv installed --no-index from that wheelhouse (immutable, non-editable)
    → chmod a-w: consumers share it read-only; no job may mutate it
    → mints environment identity

.github/workflows/python-package-suite.yml
    prepare-python-test-environment  → identity + resolved distributions artifact
    python-package-suite             → ONE cold process, whole package,
                                       canonical collection order
    [schedule] discrimination        → reversed + shuffled, separate cold
                                       processes, identical verdict sets required
```

### Environment identity

`pythonImplementation` · `pythonVersion` · `pythonAbi` (SOABI, platform tag, hexversion) · `platform` (system/release/machine/libc) · `sourceStamp` (same preimage `bin/sugarbin` hashes, via `tools/sugar_source_stamp.py`) · `testExtraInputHash` (the `[test]` table + `dependencies` + `requires-python` + build-system) · `packageBuildInputs` (per-package hash of every packaged source file) → folded into one `environmentIdentityHash`.

Two runs that do not share that hash are **not comparable measurements**, and the discrimination comparator says so out loud rather than diffing them anyway.

### Artifact schema

`suite-report.json` plus one file per axis under `suite-node-ids/`:

`collectedNodeIds` · `executedOrderNodeIds` · `failedNodeIds` · `errorNodeIds` · `skippedNodeIds` · `xfailedNodeIds` · `xpassedNodeIds` · `passedNodeIds` · `collectionErrorNodeIds` · `notReportedNodeIds` · wall time · CPU user/system (incl. children) · `sourceStamp` · environment identity · runner identity (host, runner name, run id, attempt) · resource telemetry (cpu count, sched affinity, load average, max RSS).

**Counts are summaries only.** Every count in the report is `len()` of a list shipped beside it. Node-ID lists are written in full, never `head`/`tail`-ed.

### Cadence

Per-merge CI runs **one** canonical sweep. The **scheduled** run adds reversed and shuffled arms in **separate cold processes** and requires identical verdict *sets* (order is exactly what may differ). That catches future cache/order dependence without tripling every merge's cost.

### Concurrency

`group: sugar-python-package-suite`, repository-wide, ref-independent, `cancel-in-progress: false`.

**Flagging one deviation up front:** this is deliberately *not* the existing `sugar-python-heavy-measurement` group. GitHub keeps only ONE pending run per group, so a third queued run evicts the second — sharing that group with the floors would make the authoritative sweep the first thing dropped on a busy day, i.e. the no-coverage defect this workflow exists to end. One heavy group per heavy instrument, each ref-independent, each never-cancelling.

## Floors

The four zero-tolerance floors stay **distinct instruments**, stay red-with-teeth, and now consume the same environment via the composite action. They install nothing of their own and run no second whole-package sweep. `sugar-lift-py-tests[test]` remains the sole dependency authority — #6275 is not regressed.

`tests/test_test_extras_are_the_dependency_authority.py` is **extended, not weakened**: the audit follows the install into the composite action and audits it with identical teeth, `pip wheel` is now in scope (a hand-list smuggled into a wheel build is the same #6260 offence), and a sixth tooth makes delegation legal only while the delegate obeys. Both faces exercised: action missing → red; action drops `[test]` → red; bound action → green.

## `make ci` and the header comment

`make ci` is **unchanged**. `test-python` is deliberately not added — with ~131 known failures that would be a merge-policy change wearing a wiring-fix hat.

What is fixed is the lie: `ci.yml`'s header now describes the jobs that actually run, names what it does *not* run, and names the owner of the Python suite measurement. The Makefile's `ci:` target says out loud why `test-python` is absent and what would have to be true to add it.

`restored-suite-scoreboard.yml` is marked **superseded in place**. Its file name is pinned by `sugar-build.toml`, `tests/test_sugar_build_contract.py` (hashed task digest) and `sugarbin_execution_contract.rs`, so retiring its duplicate sweep is a deliberate change with its own receipt, not a side effect of this one. Until then the header says which of the two is the measurement.

## Epsilon R

- **Axis:** ownership of the `sugar-lift-py-tests` whole-package measurement.
- **Predicted verdict change: 0.** No test, floor, law, or threshold is altered. The same node IDs pass and fail before and after; they are now *recorded* on every PR instead of nightly-or-never.
- **Floors preserved:** all four zero-tolerance floors intact and unweakened; the dependency-authority audit gains a tooth and loses none.
- **Honest shape:** this changes measurement ownership, not merge policy. The suite job reports; it does not gate.

---

## First authoritative artifact

Run [30173652905](https://github.com/TSavo/sugar/actions/runs/30173652905), job `python-package-suite (canonical)`, checked in under `docs/receipts/2026-07-25-python-package-suite/`.

| axis | count |
| --- | ---: |
| collected | 1200 |
| passed | 1051 |
| failed | 132 |
| error | 5 |
| skipped | 12 |
| xfailed / xpassed | 0 / 0 |
| collectionError | 0 |
| notReported | 0 |

385.34s wall, 304.86s user, 34.54s system, 32 cpus, runner load 23.08. `notReported` 0 and `collectionError` 0: every collected node produced a verdict and no module aborted collection.

**Against the prior art** (`docs/receipts/2026-07-25-sugar-lift-py-tests.failed-node-ids.txt`, 136 entries, explicitly not truth). Compared whole-file with `comm`, never truncated:

- **136 shared** — every prior-art entry reproduces
- **0 in prior art only** — nothing silently "fixed"
- **1 new** — `test_numpy_pandas_panic_audit.py::test_missing_sugar_binary_counts_as_unexpected`, `PermissionError` on `$HOME/.cache/sugar/python-panic-audit-workspaces`. Environment-induced, recorded red rather than excused; it names a runner cache-ownership defect, not a lift regression. Not caused by this PR's read-only venv, which covers `$RUNNER_TEMP/.../venv/lib` and never touches `$HOME/.cache`.

**Two things this first run exposed, both fixed in-branch rather than left:**

1. `sourceStamp` minted as `unavailable` — `tools/sugar_source_stamp.py` shells out to cargo and the Rust toolchain was not yet on PATH. It recorded the failure with stderr instead of hashing a hole, which is right, but a stampless identity is a weaker measurement than specified. The toolchain step now precedes the environment action in all three jobs, and a new `Every identity field resolved` step fails the prepare job if `sourceStamp`, `testExtraInputHash` or `packageBuildInputs.hash` is missing, so the ordering cannot regress quietly.
2. A comment claiming the sweep would report a degraded corpus without `SUGAR_BIN` was false — `tests/conftest.py` resolves the binary itself and `exit(2)`s if it cannot. Corrected to the true reason: warming the shelf keeps a cold Rust build out of the sweep's wall-time measurement.

Correction to the εR line above: predicted verdict change 0 holds for the wiring — no test, floor, law or threshold is altered. The +1 versus prior art is prior art being stale plus one runner-environment red, exactly the reason the brief called that file prior art rather than truth.
