### PR TITLE
fix(import-binding): the revalidation snapshot's value is now unwritable (#6273)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
-from typing import Any, Iterable
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping
 
 from .canonicalizer import blake3_512_of, encode_jcs
 from .context_manager_contract import _json_value
@@ -183,7 +184,7 @@ class AuthenticatedImportUseV1:
         identity is unchanged — only recompute frequency (see
         docs/audits/pandas-recensus-latency-bisect.md).
         """
-        rows, outcomes = _lexical_revalidation_snapshot(
+        snapshot = _lexical_revalidation_snapshot(
             self.root,
             self.path,
             self.source,
@@ -197,7 +198,9 @@ class AuthenticatedImportUseV1:
             site["endLine"],
             site["endCol"],
         )
-        if outcomes.get(key) != "authenticated-import-use" or self.demand not in rows:
+        if snapshot.outcome_at(key) != "authenticated-import-use" or not (
+            snapshot.contains_row(self.demand)
+        ):
             raise ValueError(
                 "authenticated import use is not byte-identical to lexical revalidation"
             )
@@ -674,12 +677,40 @@ def _final_module_state(
     return prepass.statements(module.body, {}, module)
 
 
+@dataclass(frozen=True, eq=False)
+class _LexicalRevalidationSnapshotV1:
+    """The served revalidation value: content-addressed and unwritable.
+
+    #6273: the cache key was already complete (consumer ``source_cid`` plus a
+    hash of ``module_identities``), so the residual was the value.  A shared
+    ``(list, dict)`` pair handed out by reference lets one consumer's write
+    corrupt every later hit at that key.  Both faces are closed here: rows are
+    served as a ``frozenset`` of row CIDs (membership is the only question the
+    consumer asks) and outcomes as a read-only view over the pass's map.
+    Every write path raises; see
+    ``tests/test_revalidation_snapshot_immutability.py``.
+    """
+
+    row_cids: frozenset[str]
+    outcomes: Mapping[tuple[int, int, int, int], str]
+
+    @staticmethod
+    def row_cid(row: dict[str, Any]) -> str:
+        return _hash(row)
+
+    def contains_row(self, row: dict[str, Any]) -> bool:
+        """Byte identity against the pass's rows, by content address."""
+        return _hash(row) in self.row_cids
+
+    def outcome_at(self, site: tuple[int, int, int, int]) -> str | None:
+        return self.outcomes.get(site)
+
+
 # Shared #6090 snapshot for revalidation only.  Keyed by consumer module
 # content + identities map so many receipts share one full-module pass.
 # See docs/audits/pandas-recensus-latency-bisect.md.
 _REVALIDATION_SNAPSHOTS: dict[
-    tuple[str, str, str, str],
-    tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]],
+    tuple[str, str, str, str], _LexicalRevalidationSnapshotV1
 ] = {}
 
 
@@ -694,7 +725,7 @@ def _lexical_revalidation_snapshot(
     source: str,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]],
-) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+) -> _LexicalRevalidationSnapshotV1:
     """One full-module #6090 pass per consumer module for revalidation."""
     cache_key = (
         str(root.resolve()),
@@ -712,8 +743,12 @@ def _lexical_revalidation_snapshot(
         source_cid,
         module_identities=module_identities,
     )
-    _REVALIDATION_SNAPSHOTS[cache_key] = (rows, outcomes)
-    return rows, outcomes
+    snapshot = _LexicalRevalidationSnapshotV1(
+        row_cids=frozenset(_hash(row) for row in rows),
+        outcomes=MappingProxyType(dict(outcomes)),
+    )
+    _REVALIDATION_SNAPSHOTS[cache_key] = snapshot
+    return snapshot
 
 
 def authenticated_import_uses(

--- a/implementations/python/sugar-lift-py-tests/tests/test_revalidation_snapshot_immutability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_revalidation_snapshot_immutability.py
@@ -1,0 +1,214 @@
+"""#6273 — the revalidation snapshot's *value* must be unwritable.
+
+The key of ``_REVALIDATION_SNAPSHOTS`` was never the bug: it already carries
+both determining inputs (consumer ``source_cid`` plus a hash of
+``module_identities``) and a ``clear`` door.  The residual was one rung down —
+the served value was a mutable ``(list, dict)`` pair handed out by reference,
+so a consumer that mutated a returned row would corrupt every later hit at
+that key.
+
+These twins pin the second condition PR #6271 named for a content-addressed
+registry: the key is complete *and the value is immutable*.  Each write path
+is asserted to raise; none of it is claimed in prose.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_py_tests.import_binding import (
+    _REVALIDATION_SNAPSHOTS,
+    _lexical_revalidation_snapshot,
+    authenticated_import_use_receipts,
+    authenticated_import_uses,
+    clear_lexical_revalidation_snapshots,
+)
+
+_SOURCE = "import example_pkg\nexample_pkg.build(1)\nexample_pkg.build(2)\n"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_cache():
+    clear_lexical_revalidation_snapshots()
+    yield
+    clear_lexical_revalidation_snapshots()
+
+
+def _module(tmp_path: Path, source: str = _SOURCE):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    return tmp_path, path, source, blake3_512_of(source.encode("utf-8"))
+
+
+def _snapshot(tmp_path: Path, source: str = _SOURCE, identities=None):
+    root, path, text, cid = _module(tmp_path, source)
+    return _lexical_revalidation_snapshot(root, path, text, cid, identities or {})
+
+
+def _receipts(tmp_path: Path, source: str = _SOURCE):
+    root, path, text, cid = _module(tmp_path, source)
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, text, cid, module_identities={}
+    )
+    assert receipts, "fixture must mint at least one receipt"
+    return receipts
+
+
+# --- twin 1: the served value cannot be mutated -------------------------
+
+
+def test_served_snapshot_has_no_write_path(tmp_path: Path) -> None:
+    snapshot = _snapshot(tmp_path)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        snapshot.row_cids = frozenset()  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        snapshot.outcomes = {}  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        del snapshot.outcomes  # type: ignore[misc]
+
+    # The outcomes mapping is served as a read-only view, not the live dict.
+    site = next(iter(snapshot.outcomes))
+    with pytest.raises(TypeError):
+        snapshot.outcomes[site] = "forged"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        del snapshot.outcomes[site]  # type: ignore[attr-defined]
+    for mutator in ("clear", "update", "pop", "popitem", "setdefault"):
+        assert not hasattr(snapshot.outcomes, mutator), mutator
+
+    # The row surface is a frozenset of row CIDs: no add/discard/update at all.
+    for mutator in ("add", "discard", "remove", "clear", "update"):
+        assert not hasattr(snapshot.row_cids, mutator), mutator
+
+
+# --- twin 2: two consumers cannot observe each other's writes -----------
+
+
+def test_two_consumers_cannot_observe_each_others_writes(tmp_path: Path) -> None:
+    first = _snapshot(tmp_path)
+    second = _snapshot(tmp_path)
+    assert first is second, "the amortized hit must still be served"
+
+    site = next(iter(first.outcomes))
+    before_outcome = first.outcomes[site]
+    before_rows = set(first.row_cids)
+
+    # Every write a first consumer could attempt raises rather than landing.
+    with pytest.raises(TypeError):
+        first.outcomes[site] = "forged"  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        first.row_cids.add("forged")  # type: ignore[attr-defined]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        first.outcomes = {site: "forged"}  # type: ignore[misc]
+
+    assert second.outcomes[site] == before_outcome
+    assert set(second.row_cids) == before_rows
+
+
+def test_receipts_from_one_module_share_a_snapshot_and_all_revalidate(
+    tmp_path: Path,
+) -> None:
+    receipts = _receipts(tmp_path)
+    assert len(receipts) >= 2, "fixture must exercise sharing across receipts"
+    for receipt in receipts:
+        receipt.revalidate()
+    assert len(_REVALIDATION_SNAPSHOTS) == 1, "one full-module pass, not N"
+
+
+# --- twin 3: a real change to either determining input invalidates -------
+
+
+def test_change_to_source_invalidates(tmp_path: Path) -> None:
+    original = _snapshot(tmp_path / "a")
+    changed = _snapshot(
+        tmp_path / "b", source=_SOURCE + "example_pkg.build(3)\n"
+    )
+    assert original is not changed
+    assert set(original.row_cids) != set(changed.row_cids)
+    assert len(_REVALIDATION_SNAPSHOTS) == 2
+
+
+def test_change_to_module_identities_invalidates(tmp_path: Path) -> None:
+    original = _snapshot(tmp_path, identities={})
+    changed = _snapshot(
+        tmp_path,
+        identities={"example_pkg": {"kind": "python-module-identity", "cid": "x"}},
+    )
+    assert original is not changed
+    assert len(_REVALIDATION_SNAPSHOTS) == 2
+
+
+# --- twin 4: the clear door still works ---------------------------------
+
+
+def test_clear_door_drops_every_snapshot(tmp_path: Path) -> None:
+    first = _snapshot(tmp_path)
+    assert _REVALIDATION_SNAPSHOTS
+    clear_lexical_revalidation_snapshots()
+    assert not _REVALIDATION_SNAPSHOTS
+    second = _snapshot(tmp_path)
+    assert second is not first, "clear must force a fresh full-module pass"
+    assert set(second.row_cids) == set(first.row_cids), "and an identical answer"
+
+
+# --- twin 5: disabling the cache changes speed only ---------------------
+
+
+def test_disabling_the_cache_changes_no_row_outcome_or_verdict(
+    tmp_path: Path,
+) -> None:
+    root, path, text, cid = _module(tmp_path)
+
+    cached = _lexical_revalidation_snapshot(root, path, text, cid, {})
+    uncached_rows, uncached_outcomes = authenticated_import_uses(
+        root, path, text, cid, module_identities={}
+    )
+
+    # Same answer, whether or not the amortized value was served.
+    assert dict(cached.outcomes) == uncached_outcomes
+    assert set(cached.row_cids) == {cached.row_cid(row) for row in uncached_rows}
+    for row in uncached_rows:
+        assert cached.contains_row(row)
+
+    # And every receipt verdict is identical with the cache defeated between
+    # each call (clear == "cache disabled": recompute every time).
+    receipts = _receipts(tmp_path)
+    with_cache = []
+    for receipt in receipts:
+        try:
+            receipt.revalidate()
+            with_cache.append("ok")
+        except ValueError as error:  # pragma: no cover - verdict is the datum
+            with_cache.append(str(error))
+
+    without_cache = []
+    for receipt in receipts:
+        clear_lexical_revalidation_snapshots()
+        try:
+            receipt.revalidate()
+            without_cache.append("ok")
+        except ValueError as error:  # pragma: no cover - verdict is the datum
+            without_cache.append(str(error))
+
+    assert with_cache == without_cache == ["ok"] * len(receipts)
+
+
+def test_a_forged_row_still_fails_revalidation(tmp_path: Path) -> None:
+    """The panic floor is unweakened: a row the pass never minted is refused."""
+    receipt = _receipts(tmp_path)[0]
+    receipt.revalidate()
+    snapshot = _lexical_revalidation_snapshot(
+        receipt.root,
+        receipt.path,
+        receipt.source,
+        receipt.source_cid,
+        receipt.module_identities,
+    )
+    forged = dict(receipt.demand)
+    forged["targetSymbol"] = "forged"
+    assert not snapshot.contains_row(forged)


### PR DESCRIPTION
Closes #6273.

## The residual

`_REVALIDATION_SNAPSHOTS` had a **sound key** already: consumer `source_cid` plus a hash of `module_identities` — both determining inputs — plus a `clear` door. This was never a staleness bug, and the key is untouched here.

The residual was one rung down: the **served value** was a mutable `(rows: list, outcomes: dict)` pair handed out by reference. The sole consumer today (`revalidate`) only reads, so nothing was broken *right now* — but a future caller that mutated a returned row would corrupt every later hit at that key. T's ruling: mutable cached values shared by reference are a correctness risk.

PR #6271 named the two conditions a content-addressed registry needs: **the key is complete AND the value is immutable.** The key was already complete. This closes only the second condition.

## The shape, and why

Not a session (#6266's shape) — a session is the repair when the value *is* a live construction context bound to Nodes. Here the value is a finished answer at a complete key, so #6271's registry shape is right; only its immutability condition was missing.

`_LexicalRevalidationSnapshotV1`, a frozen dataclass, with **both faces closed**:

- **rows → `frozenset` of row CIDs.** Membership is the only question the consumer asks (`self.demand not in rows`), so the value answers `contains_row(row)` by content address instead of handing out the list. Nothing to mutate, and the comparison gets *stricter*, not looser (canonical-JCS identity).
- **outcomes → `MappingProxyType`** over the pass's map: a read-only view, never the live dict.

Every write path **raises** rather than landing: `FrozenInstanceError` on set/delattr, `TypeError` on item assignment or deletion through the outcomes view, and `frozenset` has no mutator to call. Asserted, not claimed.

The consumer change (`revalidate` reads through `outcome_at` / `contains_row`) ships in this PR with its own evidence, per the constraint. It is the sole consumer — verified by grep across `implementations/python`.

## Twins, each with its bite

`implementations/python/sugar-lift-py-tests/tests/test_revalidation_snapshot_immutability.py` — 8 tests.

| Twin | Bite (perturb → red → revert) |
|---|---|
| 1. served value has no write path | **Bite A** — remove the repair (stash the source change): **6 failed / 2 passed** |
| 2. two consumers cannot observe each other's writes | Bite A (same): red |
| 3. a change to either determining input still invalidates | **Bite B** — replace the `module_identities` hash in the key with a constant: `test_change_to_module_identities_invalidates` **FAILED** (1 failed / 7 passed) |
| 4. the `clear` door still works | **Bite C** — make `clear_lexical_revalidation_snapshots` a no-op: `test_clear_door_drops_every_snapshot` **FAILED** (4 failed / 4 passed) |
| 5. disabling the cache changes speed only | **Bite D** — serve `rows[:1]` in the snapshot: `test_disabling_the_cache_changes_no_row_outcome_or_verdict` + the sharing twin **FAILED** (2 failed / 6 passed) |
| 6. panic floor unweakened: a forged row is refused | Bite A: red |

All bites reverted; final state green.

## Epsilon R

**Axis:** cached values served by mutable reference. **Predicted Epsilon R: zero verdict change** — a correctness-risk removal, not a behavior change. **Observed: zero.**

Bounded slices, per-package rootdir, `-p no:cacheprovider -p no:randomly`. Failure sets compared with `comm` in **both** directions:

- `sugar-lift-py-tests` slice (call-contract resolution, construction side-door law, context-manager edge transport, import-binding statement totality): before **42 passed / 0 failed** → after **50 passed / 0 failed** (+8 = exactly the new twins). `comm -23` and `comm -13`: **both empty.**
- `sugar-lift-python-source` slice (dependency-artifact graph, external call-target construction, resolution-session authority, sole-path manager construction, source oracle) — this is where `revalidate()` is actually called: before **1 failed / 94 passed** → after **1 failed / 94 passed**. `comm` both directions: **empty**; the shared failure is the pre-existing `test_real_pandas_ensure_clean_export_resolves_without_name_authority`, red at the parent too.

Load recorded with every run (`uptime`): load average **29–69** throughout — a saturated box, so no timing claim is made here. The snapshot's purpose is amortization; twin 5 pins that its *only* effect is speed.

## Floors preserved

No test deleted or skipped. No panic weakened — twin 6 shows a row the pass never minted is still refused. The cache is not disabled. `_SPLIT_CACHE` (#6272) is untouched.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the revalidation snapshot value immutable in `_lexical_revalidation_snapshot`
> - Introduces `_LexicalRevalidationSnapshotV1`, a frozen dataclass that wraps `row_cids` as a `frozenset` and `outcomes` as a `MappingProxyType`, replacing the previous mutable `(list, dict)` tuple returned by `_lexical_revalidation_snapshot`.
> - Adds `contains_row`, `outcome_at`, and `row_cid` methods to the snapshot, and updates `AuthenticatedImportUseV1.revalidate` to use these instead of direct dict/list access.
> - Adds a test module asserting immutability, cache invalidation, snapshot sharing between receipts, and that forged rows fail revalidation.
> - Behavioral Change: any code that previously mutated the returned rows list or outcomes dict will now raise an error at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa03a55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->