### PR TITLE
fix: an override that contradicts the requested profile is refused, not served

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -1172,6 +1172,34 @@ pull_from_filesystem_shelf() {
   materialize_cached_artifact "$candidate" "$stamp" "$identity"
 }
 
+# An override path names the profile it was built under whenever it sits in a
+# cargo target directory or carries a shelf artifact name. Read that evidence
+# back out; print nothing when the path claims neither.
+override_profile_evidence() {
+  local path="$1"
+  case "$path" in
+    */target/debug/*|*/debug/"$bin_name") printf 'debug\n'; return 0 ;;
+    */target/release/*|*/release/"$bin_name") printf 'release\n'; return 0 ;;
+  esac
+  case "$(basename "$path")" in
+    *-debug-*) printf 'debug\n' ;;
+    *-release-*) printf 'release\n' ;;
+  esac
+}
+
+# The override rungs answer "which binary" and the caller asked "which
+# profile". Serving a release binary to a debug request is not a cache
+# decision, it is a different program: debug assertions, overflow checks and
+# debug-only panics are all present or absent by profile. Refuse the pairing
+# the path itself contradicts rather than resolving it silently.
+refuse_profile_contradiction() {
+  local path="$1" source="$2" evidence
+  evidence="$(override_profile_evidence "$path")"
+  [[ -n "$evidence" && "$evidence" != "$profile" ]] || return 0
+  log "crime=profile-blind-override owner=bin/sugarbin source=$source path=$path requested=$profile evidence=$evidence replacement=point $source at a $profile binary, or ask for --profile $evidence"
+  return 1
+}
+
 main() {
   if [[ "$print_source_stamp" == "1" ]]; then
     source_stamp
@@ -1179,10 +1207,12 @@ main() {
   fi
 
   if [[ -n "${SUGAR_BINARY_DIR:-}" && -x "${SUGAR_BINARY_DIR}/$bin_name" ]]; then
+    refuse_profile_contradiction "${SUGAR_BINARY_DIR}/$bin_name" SUGAR_BINARY_DIR || return 1
     printf '%s\n' "${SUGAR_BINARY_DIR}/$bin_name"
     return 0
   fi
   if [[ -n "${SUGAR_BIN:-}" && ( "$bin_name" == sugar || "$(basename "$SUGAR_BIN")" == "$bin_name" ) ]]; then
+    refuse_profile_contradiction "$SUGAR_BIN" SUGAR_BIN || return 1
     printf '%s\n' "$SUGAR_BIN"
     return 0
   fi

--- a/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
@@ -147,6 +147,7 @@ def _run_sugarbin(env: dict[str, str], *args: str) -> subprocess.CompletedProces
         "SUGAR_BIN",
         "SUGAR_BINARY_ALLOW_BUILD",
         "SUGAR_BINARY_CACHE_DIR",
+        "SUGAR_BINARY_DIR",
         "SUGAR_BINARY_NO_SHELF",
         "SUGAR_BINARY_REPO",
         "SUGAR_BINARY_SOURCE_STAMP",
@@ -245,6 +246,89 @@ def test_sugarbin_prints_explicit_sugar_bin_without_resolving(tmp_path: Path) ->
     )
     assert completed.returncode == 0, completed.stderr
     assert completed.stdout.strip() == os.fspath(explicit)
+
+
+def _write_profiled_fake_sugar(tmp_path: Path, profile: str) -> Path:
+    binary = tmp_path / "target" / profile / "sugar"
+    binary.parent.mkdir(parents=True)
+    _write_fake_sugar(binary, "not-the-workspace")
+    return binary
+
+
+def test_sugarbin_refuses_sugar_bin_whose_path_contradicts_the_profile(
+    tmp_path: Path,
+) -> None:
+    release_binary = _write_profiled_fake_sugar(tmp_path, "release")
+    completed = _run_sugarbin(
+        {
+            "SUGAR_BIN": os.fspath(release_binary),
+            "SUGAR_BINARY_ALLOW_BUILD": "0",
+            "SUGAR_BINARY_NO_SHELF": "1",
+        },
+        "--profile",
+        "debug",
+    )
+    assert completed.returncode != 0
+    assert completed.stdout.strip() == ""
+    assert "crime=profile-blind-override" in completed.stderr
+    assert "requested=debug" in completed.stderr
+    assert "evidence=release" in completed.stderr
+
+
+def test_sugarbin_serves_sugar_bin_whose_path_agrees_with_the_profile(
+    tmp_path: Path,
+) -> None:
+    debug_binary = _write_profiled_fake_sugar(tmp_path, "debug")
+    completed = _run_sugarbin(
+        {
+            "SUGAR_BIN": os.fspath(debug_binary),
+            "SUGAR_BINARY_ALLOW_BUILD": "0",
+            "SUGAR_BINARY_NO_SHELF": "1",
+        },
+        "--profile",
+        "debug",
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == os.fspath(debug_binary)
+
+
+def test_sugarbin_refuses_shelf_named_override_that_contradicts_the_profile(
+    tmp_path: Path,
+) -> None:
+    shelved = tmp_path / "sugar-darwin-x86_64-release-abcdef"
+    _write_fake_sugar(shelved, "not-the-workspace")
+    completed = _run_sugarbin(
+        {
+            "SUGAR_BIN": os.fspath(shelved),
+            "SUGAR_BINARY_ALLOW_BUILD": "0",
+            "SUGAR_BINARY_NO_SHELF": "1",
+        },
+        "--profile",
+        "debug",
+        "--bin",
+        "sugar",
+    )
+    assert completed.returncode != 0
+    assert "crime=profile-blind-override" in completed.stderr
+
+
+def test_sugarbin_refuses_binary_dir_override_that_contradicts_the_profile(
+    tmp_path: Path,
+) -> None:
+    release_binary = _write_profiled_fake_sugar(tmp_path, "release")
+    release_binary.chmod(0o755)
+    completed = _run_sugarbin(
+        {
+            "SUGAR_BINARY_DIR": os.fspath(release_binary.parent),
+            "SUGAR_BINARY_ALLOW_BUILD": "0",
+            "SUGAR_BINARY_NO_SHELF": "1",
+        },
+        "--profile",
+        "debug",
+    )
+    assert completed.returncode != 0
+    assert completed.stdout.strip() == ""
+    assert "source=SUGAR_BINARY_DIR" in completed.stderr
 
 
 def test_sugarbin_skips_stale_local_and_pulls_matching_shelf(


### PR DESCRIPTION
## The bug

`bin/sugarbin` has two override rungs — `SUGAR_BINARY_DIR` and `SUGAR_BIN` — and both returned a path **without ever comparing it to the requested profile**:

```bash
if [[ -n "${SUGAR_BIN:-}" && ( "$bin_name" == sugar || ... ) ]]; then
  printf '%s\n' "$SUGAR_BIN"   # profile never consulted
```

Meanwhile `witness_harness.py:90` asks for `resolve_sugar_binary(profile="debug")`, and `sugar_binary.py:33` forwards `os.environ` straight into the child. A release pin therefore satisfies a debug request in silence.

This is not a cache decision — debug and release are different programs. Debug assertions, overflow checks and debug-only panics are all present or absent by profile.

**This already cost us a receipt.** The #6277 baseline attributes 138 red nodes to a debug-expecting harness; it was produced by a pinned release binary. It was only auditable because the invocation was recorded by hand. The resolver said nothing.

## The fix

An override path names its own profile whenever it sits under a cargo target directory (`.../target/debug/sugar`) or carries a shelf artifact name (`sugar-darwin-x86_64-release-<stamp>`). Read that evidence back and refuse the contradiction:

```
crime=profile-blind-override owner=bin/sugarbin source=SUGAR_BIN path=... \
  requested=debug evidence=release \
  replacement=point SUGAR_BIN at a debug binary, or ask for --profile debug
```

Conservative by construction: a path claiming no profile — a deliberate hand-pin at an arbitrary location — still passes through untouched. Only a *demonstrable* contradiction is refused, which is why the existing `test_sugarbin_prints_explicit_sugar_bin_without_resolving` stays green.

## Receipts

Four tests, driving `bin/sugarbin` as a real subprocess.

**Bite** — new tests against **unpatched** `56bf370`:

| test | unpatched | patched |
|---|---|---|
| `..._sugar_bin_whose_path_contradicts_the_profile` | RED (`assert 0 != 0`, override served) | GREEN |
| `..._shelf_named_override_that_contradicts_the_profile` | RED | GREEN |
| `..._binary_dir_override_that_contradicts_the_profile` | RED | GREEN |
| `..._serves_sugar_bin_whose_path_agrees_with_the_profile` | GREEN | GREEN |

The agreement test is green on both faces, as it must be — it guards against over-refusing.

**Paired file run**, `tests/test_binary_handoff_policy.py`:

```
56bf370 unpatched -> 8 failed,  8 passed
this commit       -> 8 failed, 12 passed
```

Same eight failures on both faces, none touched here: pre-existing Windows-path and blake3/publish defects. Baseline was run in a detached worktree at `56bf370`, not by mutating this one.

Follows #6276 (debug builds work again) and #6278 (the caveat on the affected baseline).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse override binaries whose path contradicts the requested build profile
> - Adds `override_profile_evidence` to [sugarbin](https://github.com/TSavo/sugar/pull/6282/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b), which infers a Rust build profile (`debug` or `release`) from a binary path by matching patterns like `*/target/debug/*` or basenames containing `-release-`.
> - Adds `refuse_profile_contradiction`, which calls `override_profile_evidence` and returns non-zero with a `crime=profile-blind-override` log line when the inferred profile differs from the requested `--profile`.
> - Guards both `SUGAR_BINARY_DIR` and `SUGAR_BIN` override paths with this check in `main`; sugarbin now exits non-zero and emits nothing on stdout when a contradiction is detected.
> - Behavioral Change: previously, override paths were served unconditionally; they now fail if their path implies a different profile than requested.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d9db3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->