### PR TITLE
A try handler begins from its routed halt edge's temporal state (#6283)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1153,7 +1153,9 @@ class Node(Typed):
             return candidates[ordinal]
         return self.fragment, ("constructed-projection", ordinal)
 
-    def _substitute_body_tracked(self, statements: tuple, scope: BindingMap):
+    def _substitute_body_tracked(
+        self, statements: tuple, scope: BindingMap, *, edge_states: list | None = None
+    ):
         """Substitute a statement sequence, THREADING each statement's binding:
         an assignment binds its name to its substituted rhs for the rest of the
         block. This is the temporal that used to live in ``ctx.temporal`` -- now
@@ -1161,7 +1163,16 @@ class Node(Typed):
         assignment form (each binding a fresh entry; a rebind shadows the old
         for the tail). A walrus (``NamedExpr``) nested anywhere in the statement
         also leaks its binding to the rest of the block. Returns
-        ``(new_statements, changed)``."""
+        ``(new_statements, changed)``.
+
+        ``edge_states`` is an out-parameter: pass a list and this loop appends
+        ``(statement, state_in_effect_when_that_statement_begins)`` for every
+        statement it threads. That is not a second mechanism and not a
+        snapshot of the block -- it is the SAME threading, reported at each
+        occurrence instead of only at the block's end. An exit that leaves the
+        block *at* a statement (a raise, or an opaque step that may halt)
+        carries exactly the state recorded for that statement, which is what
+        exception routing must begin the selected handler from."""
         from sugar_lift_py_tests.engine_log import reduction_span
 
         initial = dict(scope)
@@ -1170,6 +1181,8 @@ class Node(Typed):
         changed = False
         for stmt in statements:
             pre_statement_scope = dict(scope)
+            if edge_states is not None:
+                edge_states.append((stmt, pre_statement_scope))
             lc = stmt.line_col_span()
             with reduction_span(
                 sugar="SubstituteStatement",
@@ -4982,9 +4995,14 @@ class Try(Statement):
             return self if not changed else rewrite(self, **changed)
 
         changed = {}
-        new_body, d, body_net = self._substitute_body_tracked(self.body, scope)
+        body_edge_states: list = []
+        new_body, d, body_net = self._substitute_body_tracked(
+            self.body, scope, edge_states=body_edge_states
+        )
         if d:
             changed["body"] = new_body
+        halt_edges = self._body_halt_edges(body_edge_states, scope)
+        routed = self._route_halt_edges(halt_edges)
         body_state = {**scope, **body_net}
         new_orelse, d, else_net = self._substitute_body_tracked(self.orelse, body_state)
         if d:
@@ -4993,12 +5011,18 @@ class Try(Statement):
 
         handler_nets = []
         new_handlers = []
-        for handler in self.handlers:
+        for handler_index, handler in enumerate(self.handlers):
             handler_changed = {}
             new_type, type_changed = handler._substitute_field(handler.type_, scope)
             if type_changed:
                 handler_changed["type_"] = new_type
-            handler_scope = dict(scope)
+            # THE LAW: the handler begins from the state its routed halt edges
+            # carry, never from a snapshot of the pre-try scope and never from
+            # a union of everything the body could have bound.  ``incoming`` is
+            # what every edge that reaches THIS handler agrees on; an edge that
+            # halted before an assignment simply does not carry it.
+            incoming = self._incoming_halt_state(routed.get(handler_index))
+            handler_scope = {**scope, **incoming}
             if handler.name:
                 handler_scope[handler.name] = handler._make_effect_ref(
                     handler._effect_slot_id()
@@ -5019,7 +5043,10 @@ class Try(Statement):
                         name=handler.name, cause=handler.fragment
                     ),
                 }
-            handler_nets.append(handler_net)
+            # The handler edge leaves the try carrying the state it arrived
+            # with, updated by the handler's own threading -- same law, one
+            # layer in.
+            handler_nets.append({**incoming, **handler_net})
         if any(new is not old for new, old in zip(new_handlers, self.handlers)):
             changed["handlers"] = tuple(new_handlers)
 
@@ -5057,6 +5084,118 @@ class Try(Statement):
 
         node = self if not changed else rewrite(self, **changed)
         return _Splice((node,), merged) if merged else node
+
+    #: Node classes whose evaluation cannot itself raise.  A statement built
+    #: only from these leaves the block by completing -- it contributes no
+    #: halt edge.  Everything else (a call, an attribute, a subscript, an
+    #: operator, a comprehension, a nested block) may halt at an occurrence
+    #: this layer cannot name, so it contributes an UNTYPED halt edge that
+    #: every handler must be prepared to receive.
+    _HALT_FREE_NODES = ("Assign", "Name", "Constant", "Tuple_", "List", "Pass")
+
+    def _halt_free_classes(self, *extra):
+        return tuple(extra) + tuple(
+            cls
+            for cls in (globals().get(name) for name in self._HALT_FREE_NODES)
+            if isinstance(cls, type)
+        )
+
+    def _statement_cannot_halt(self, statement) -> bool:
+        allowed = self._halt_free_classes()
+        return all(isinstance(node, allowed) for node in statement.walk())
+
+    def _raise_testimony_of(self, statement):
+        """The (identity, mro) a single ``raise`` occurrence testifies to, or
+        ``None`` when the raised expression is not a resolvable type name."""
+        node = statement.exc
+        if isinstance(node, Call):
+            node = node.func
+        if not isinstance(node, Name):
+            return None
+        return (
+            self.unit.exception_type_identity(node),
+            self.unit.exception_type_mro(node),
+        )
+
+    def _body_halt_edges(self, edge_states, scope):
+        """The body's halted exits, each paired with the temporal state in
+        effect at its own occurrence.
+
+        This does not compute a scope: ``edge_states`` is the threading the
+        block already performed, reported per statement.  Each entry is
+        ``(exception_identity, exception_mro, state)`` where ``state`` is the
+        block-local net at that occurrence -- what an exit leaving *here*
+        carries.  ``exception_identity is None`` means the occurrence is not
+        type-testified (an opaque step), so every handler may receive it."""
+        edges = []
+        for statement, pre_statement_scope in edge_states:
+            net = {
+                name: state
+                for name, state in pre_statement_scope.items()
+                if scope.get(name) is not state
+            }
+            edges.extend(self._statement_halt_edges(statement, net))
+        return edges
+
+    def _statement_halt_edges(self, statement, net):
+        """The halted exits ONE statement contributes, all carrying ``net`` --
+        the state in effect when that statement begins."""
+        if self._statement_cannot_halt(statement):
+            return []
+        if isinstance(statement, Raise) and all(
+            isinstance(node, self._halt_free_classes(Raise))
+            for node in statement.walk()
+        ):
+            testimony = self._raise_testimony_of(statement)
+            if testimony is not None:
+                return [(testimony[0], testimony[1], net)]
+            return [(None, None, net)]
+        if isinstance(statement, If) and self._statement_cannot_halt(statement.test):
+            # A partition halts on whichever branch is taken; both branches
+            # begin from the same incoming state, so each branch's own exits
+            # are edges of this statement.
+            return [
+                edge
+                for branch in (statement.body, statement.orelse)
+                for inner in branch
+                for edge in self._statement_halt_edges(inner, net)
+            ]
+        return [(None, None, net)]
+
+    def _route_halt_edges(self, halt_edges):
+        """Send each halted edge to the handler that receives it: source order,
+        first match only -- the same arm selection the router already applies.
+        An untyped edge could be any exception, so it reaches every arm."""
+        routed: dict[int, list] = {}
+        for identity, mro, state in halt_edges:
+            if identity is None:
+                for index in range(len(self.handlers)):
+                    routed.setdefault(index, []).append(state)
+                continue
+            for index, handler in enumerate(self.handlers):
+                if self._handler_matches(handler, identity, mro):
+                    routed.setdefault(index, []).append(state)
+                    break
+        return routed
+
+    def _incoming_halt_state(self, states):
+        """What the edges reaching one handler AGREE on.
+
+        Not a union: a name survives only if every routed edge carries it, and
+        carries the same entry.  A handler with no routed edge (the body's
+        halts are all typed elsewhere, or the body cannot halt at all) begins
+        from the pre-try state -- there is no occurrence to inherit from."""
+        if not states:
+            return {}
+        first, rest = states[0], states[1:]
+        return {
+            name: entry
+            for name, entry in first.items()
+            if all(
+                name in other and (other[name] is entry or other[name] == entry)
+                for other in rest
+            )
+        }
 
     def _handler_matches(self, handler, exception_identity, exception_mro) -> bool:
         if handler.type_ is None:

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -49,12 +49,13 @@ Laws pinned here, each with a discrimination arm that bites:
   through the same reducer produce identical arm structure, and a matched halt
   is replaced by exactly the handler body's own arms
 
-KNOWN GAP (not pinned here, deliberately -- see the PR body): a binding
-established in the ``try`` body before the raise is not visible in the
-handler; ``handler_scope`` is built from the pre-try scope in
-``sugar_source_tree.nodes.Try.substitute``.  That is a definite-assignment
-question in the source tree, not a hole in this control algebra, and a twin
-asserting the current outcome would be asserting the defect.
+CLOSED (#6283): the gap this file deliberately left unpinned -- a binding
+established in the ``try`` body before the raise not being visible in the
+handler, because ``handler_scope`` was the pre-try scope in
+``sugar_source_tree.nodes.Try.substitute`` -- is repaired.  The handler now
+begins from the temporal state its routed halt edge carries.  The law and its
+nine twins live in ``test_try_handler_temporal_state.py``; the control algebra
+pinned here was never the defect and is unchanged.
 """
 
 from __future__ import annotations

--- a/implementations/python/sugar-source-tree/tests/test_try_handler_temporal_state.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_handler_temporal_state.py
@@ -1,0 +1,515 @@
+"""Law twins for the temporal state a ``try`` handler begins from (#6283).
+
+#6242 proved ``Try`` rides the shared ``ExitSet`` algebra and contributes no
+sequencing of its own.  It deliberately left ONE thing unpinned, because
+pinning it would have asserted a defect: ``Try.substitute`` built the handler's
+scope as ``dict(scope)`` -- the **pre-try** snapshot -- so a binding the body
+established before the raise was invisible in the handler and the lift
+fabricated a ``NameErrorEffect`` for a name Python guarantees is bound.
+
+The law, one layer up from #6239's ``_prefixed`` and in the same shape:
+
+    Each halted edge carries the temporal binding state at its precise halt
+    occurrence; the selected handler begins from that edge's state.
+
+So the repair CONSUMES what the block threading already computes, per
+occurrence -- ``_substitute_body_tracked(..., edge_states=...)`` reports the
+state in effect as each statement begins, ``_body_halt_edges`` turns the
+statements that can halt into edges carrying that state, ``_route_halt_edges``
+sends each edge to the arm that receives it (source order, first match; an
+untyped occurrence reaches every arm), and ``_incoming_halt_state`` is what the
+edges reaching ONE arm agree on.
+
+It is explicitly NOT ``{**scope, **body_net}``.  That repairs the first twin
+and over-claims on every body that can halt before an assignment; twins two,
+three and eight exist to catch exactly that.
+
+Each twin carries a discrimination arm: the production rule is perturbed to
+the defective one, the observation is shown to flip, and the perturbation is
+reverted.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+from sugar_source_tree.nodes import Try
+from with_resolution_fixture import source_file_with_preconstruction
+
+CLASSES = (
+    "class RootFault(Exception):\n"
+    "    pass\n"
+    "class LeafFault(RootFault):\n"
+    "    pass\n"
+)
+
+
+def _fn(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write("import pytest\nimport contextlib\nimport tm\n" + src)
+        path = f.name
+    return next(source_file_with_preconstruction(Path(path)).functions())
+
+
+def _out(src: str):
+    return _fn(src).sugar().desugar()
+
+
+def _incompletes(src: str):
+    """The Incomplete effects the whole function carries, outer or recorded."""
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = _out(src)
+    if isinstance(out, Incomplete):
+        return [out]
+    return [e for e in out.value.record.contribution() if isinstance(e, Incomplete)]
+
+
+def _post(src: str):
+    return _out(src).value.post()
+
+
+def _missing_names(src: str):
+    return sorted(
+        name
+        for name in (
+            getattr(e.effect, "name", None)
+            for e in _incompletes(src)
+            if type(e.effect).__name__ == "NameErrorEffect"
+        )
+        if name
+    )
+
+
+@contextmanager
+def _observed():
+    """Record every halt-edge routing decision the production path makes."""
+    log: dict = {"edges": [], "routed": [], "incoming": []}
+    route, incoming, edges = (
+        Try._route_halt_edges,
+        Try._incoming_halt_state,
+        Try._body_halt_edges,
+    )
+
+    def spy_edges(self, edge_states, scope):
+        result = edges(self, edge_states, scope)
+        log["edges"].append(result)
+        return result
+
+    def spy_route(self, halt_edges):
+        result = route(self, halt_edges)
+        log["routed"].append(result)
+        return result
+
+    def spy_incoming(self, states):
+        result = incoming(self, states)
+        log["incoming"].append((states, result))
+        return result
+
+    Try._body_halt_edges = spy_edges
+    Try._route_halt_edges = spy_route
+    Try._incoming_halt_state = spy_incoming
+    try:
+        yield log
+    finally:
+        Try._body_halt_edges = edges
+        Try._route_halt_edges = route
+        Try._incoming_halt_state = incoming
+
+
+@contextmanager
+def _rewritten():
+    """Capture the rewritten ``Try`` nodes the substitution produces."""
+    log: list = []
+    original = Try.substitute
+
+    def spy(self, scope):
+        result = original(self, scope)
+        log.append(result)
+        return result
+
+    Try.substitute = spy
+    try:
+        yield log
+    finally:
+        Try.substitute = original
+
+
+def _unresolved_reads(src: str):
+    """The names each rewritten handler arm reads WITHOUT a routed binding.
+
+    A name the arm's routed edge carried is substituted away; a name it did
+    not carry survives as a ``GuardedBindingRead`` -- the honest unresolved
+    read that becomes a NameError. This is how the twins show the routed state
+    is CONSUMED, not merely computed.
+    """
+    from sugar_source_tree.nodes import GuardedBindingRead
+
+    with _rewritten() as log:
+        _fn(src).sugar()
+    node = log[0]
+    node = node.statements[0] if hasattr(node, "statements") else node
+    return [
+        sorted({n.name for n in handler.walk() if isinstance(n, GuardedBindingRead)})
+        for handler in node.handlers
+    ]
+
+
+@contextmanager
+def _rule(replacement):
+    """Perturb the incoming-state rule; revert on exit."""
+    original = Try._incoming_halt_state
+    Try._incoming_halt_state = replacement
+    try:
+        yield
+    finally:
+        Try._incoming_halt_state = original
+
+
+def _pre_try_snapshot(self, states):
+    """The #6283 defect: the handler begins from the pre-try scope."""
+    return {}
+
+
+def _static_union(self, states):
+    """The over-claim T ruled out: every binding the body could have made."""
+    merged: dict = {}
+    for state in states or ():
+        merged.update(state)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# 1. assignment before an explicit raise IS available in the handler
+# ---------------------------------------------------------------------------
+
+BOUND_THEN_RAISE = (
+    "def A(z):\n"
+    "    try:\n"
+    "        x = z\n"
+    "        raise ValueError\n"
+    "    except ValueError:\n"
+    "        return x\n"
+)
+
+
+def test_binding_before_an_explicit_raise_is_available_in_the_handler():
+    """``x = z`` cannot fail, so the only halt is the raise -- which carries x."""
+    assert _incompletes(BOUND_THEN_RAISE) == []
+    assert _post(BOUND_THEN_RAISE).args[1].name == "z"
+
+    # BITE: hand the handler the pre-try snapshot and the fabrication returns.
+    with _rule(_pre_try_snapshot):
+        assert _missing_names(BOUND_THEN_RAISE) == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# 2. a halt BEFORE the assignment leaves the name unavailable
+# ---------------------------------------------------------------------------
+
+HALT_THEN_BIND = (
+    "def A(z):\n"
+    "    try:\n"
+    "        tm.step()\n"
+    "        x = z\n"
+    "        raise ValueError\n"
+    "    except ValueError:\n"
+    "        return x\n"
+)
+
+
+def test_a_halt_before_the_assignment_leaves_the_name_unavailable():
+    """``tm.step()`` may halt first; on THAT edge x was never bound.
+
+    Never fabricate a binding: the handler must not see x.
+    """
+    assert _missing_names(HALT_THEN_BIND) == ["x"]
+    with _observed() as log:
+        _fn(HALT_THEN_BIND).sugar()
+    assert [sorted(net) for _i, _m, net in log["edges"][0]] == [[], ["x"]]
+
+    # BITE: the {**scope, **body_net} over-claim invents x on the opaque edge.
+    with _rule(_static_union):
+        assert _missing_names(HALT_THEN_BIND) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. two possible halt sites preserve DIFFERENT prefix states
+# ---------------------------------------------------------------------------
+
+TWO_HALT_SITES = (
+    "def A(z, flag):\n"
+    "    try:\n"
+    "        a = z\n"
+    "        if flag:\n"
+    "            raise ValueError\n"
+    "        b = z\n"
+    "        raise ValueError\n"
+    "    except ValueError:\n"
+    "        c = a\n"
+    "        return b\n"
+)
+
+
+def test_two_halt_sites_preserve_different_prefix_states():
+    """Edge one carries {a}; edge two carries {a, b}.  They are not merged
+    into one state, and the arm both reach may only rely on their agreement --
+    so ``b`` is unavailable while ``a`` would not be."""
+    with _observed() as log:
+        _fn(TWO_HALT_SITES).sugar()
+    assert [sorted(net) for _i, _m, net in log["edges"][0]] == [["a"], ["a", "b"]]
+    states, incoming = log["incoming"][0]
+    assert [sorted(s) for s in states] == [["a"], ["a", "b"]]
+    assert sorted(incoming) == ["a"]
+    # CONSUMED: ``a`` (carried by BOTH edges) resolves; only ``b`` is left as
+    # an unresolved read -- the honest NameError asserted next.
+    assert _unresolved_reads(TWO_HALT_SITES) == [["b"]]
+    assert _missing_names(TWO_HALT_SITES) == ["b"]
+
+    # BITE: union the two prefixes and b is fabricated onto the early edge.
+    # Read structurally, not end-to-end: with b fabricated both arms complete,
+    # and two completed edges reaching ``ExitSet.normalize`` trip a PRE-EXISTING
+    # IR gap (``term_to_value`` cannot encode the ``effect_slot_kind`` atomic
+    # that ``EffectBinding.to_facts`` puts in a term position).  That gap is on
+    # main, independent of this repair, and is left loud rather than papered
+    # over here.
+    with _rule(_static_union):
+        with _observed() as poisoned:
+            _fn(TWO_HALT_SITES).sugar()
+        assert [sorted(r) for _s, r in poisoned["incoming"]] == [["a", "b"]]
+
+
+# ---------------------------------------------------------------------------
+# 4. matched ``as e`` EXTENDS -- not replaces -- the incoming state
+# ---------------------------------------------------------------------------
+
+AS_BINDING = (
+    "def A(z):\n"
+    "    try:\n"
+    "        x = z\n"
+    "        raise ValueError\n"
+    "    except ValueError as error:\n"
+    "        return x\n"
+)
+
+AS_BINDING_SLOT = (
+    "def A(z):\n"
+    "    try:\n"
+    "        x = z\n"
+    "        raise ValueError\n"
+    "    except ValueError as error:\n"
+    "        return error\n"
+)
+
+
+def test_matched_as_binding_extends_the_incoming_state():
+    """The exception slot is added to the routed state, not substituted for it:
+    x still resolves, and ``error`` is still the routed effect slot."""
+    assert _incompletes(AS_BINDING) == []
+    assert _post(AS_BINDING).args[1].name == "z"
+    assert _post(AS_BINDING_SLOT).args[1].name == "python:effect_slot"
+
+    # BITE: replace the incoming state instead of extending it -- x is lost
+    # while the slot survives, which is exactly the asymmetry being pinned.
+    with _rule(_pre_try_snapshot):
+        assert _missing_names(AS_BINDING) == ["x"]
+        assert _post(AS_BINDING_SLOT).args[1].name == "python:effect_slot"
+
+
+# ---------------------------------------------------------------------------
+# 5. an UNMATCHED halt preserves its exact state and effect occurrence
+# ---------------------------------------------------------------------------
+
+UNMATCHED = (
+    CLASSES + "def A(z):\n"
+    "    try:\n"
+    "        x = z\n"
+    "        raise RootFault\n"
+    "    except LeafFault:\n"
+    "        return x\n"
+)
+
+
+def test_unmatched_halt_preserves_its_exact_state_and_occurrence():
+    """A base-class raise does not match a leaf arm.  The edge is not routed,
+    not absorbed, and not reconstructed -- the same RootFault occurrence leaves
+    the try, and the leaf arm receives no edge at all."""
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = _out(UNMATCHED)
+    assert isinstance(out, Incomplete)
+    assert type(out.effect).__name__ == "RaiseEffect"
+    assert out.effect.exception_name == "RootFault"
+
+    with _observed() as log:
+        _fn(UNMATCHED).sugar()
+    assert log["routed"][0] == {}, "an unmatched edge routes to no arm"
+
+    # BITE: route the unmatched edge anyway and the arm absorbs the halt.
+    original = Try._route_halt_edges
+    Try._route_halt_edges = lambda self, edges: {
+        index: [state for _i, _m, state in edges] for index in range(len(self.handlers))
+    }
+    try:
+        absorbed = _out(UNMATCHED)
+        assert not isinstance(absorbed, Incomplete) or absorbed.effect is not out.effect
+    finally:
+        Try._route_halt_edges = original
+
+
+# ---------------------------------------------------------------------------
+# 6. handler failure carries the HANDLER's updated state
+# ---------------------------------------------------------------------------
+
+HANDLER_UPDATES = (
+    "def A(z):\n"
+    "    try:\n"
+    "        x = z\n"
+    "        raise ValueError\n"
+    "    except ValueError:\n"
+    "        y = x\n"
+    "    return y\n"
+)
+
+
+def test_handler_edge_carries_the_handlers_own_updated_state():
+    """The handler starts from its routed edge and then threads its own body;
+    what leaves the try on that edge is the edge's state UPDATED by the
+    handler, so ``y`` -- bound from ``x`` inside the arm -- is available after."""
+    assert _incompletes(HANDLER_UPDATES) == []
+    assert _post(HANDLER_UPDATES).args[1].name == "z"
+
+    # BITE: start the handler from the pre-try snapshot and its own binding is
+    # built from a fabricated NameError instead of the routed state.
+    with _rule(_pre_try_snapshot):
+        assert _missing_names(HANDLER_UPDATES) == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# 7. body COMPLETION alone feeds ``else``
+# ---------------------------------------------------------------------------
+
+ELSE_BODY = (
+    "def A(z):\n"
+    "    try:\n"
+    "        x = z\n"
+    "    except ValueError:\n"
+    "        return 0\n"
+    "    else:\n"
+    "        return x\n"
+)
+
+
+def test_body_completion_alone_feeds_else():
+    """``else`` is the completed edge -- it reads the body's completion state,
+    never a halted edge's, and the handler-routing repair does not touch it."""
+    assert _incompletes(ELSE_BODY) == []
+    assert _post(ELSE_BODY).args[1].name == "z"
+    with _observed() as log:
+        _fn(ELSE_BODY).sugar()
+    assert log["edges"][0] == [], "an all-safe body contributes no halted edge"
+
+    # BITE: withhold the body's completion net and ``else`` loses the binding.
+    original = Try._substitute_body_tracked
+
+    def starved(self, statements, scope, *, edge_states=None):
+        items, changed, net = original(self, statements, scope, edge_states=edge_states)
+        if edge_states is not None:
+            return items, changed, {}
+        return items, changed, net
+
+    Try._substitute_body_tracked = starved
+    try:
+        assert _missing_names(ELSE_BODY) == ["x"]
+    finally:
+        Try._substitute_body_tracked = original
+
+
+# ---------------------------------------------------------------------------
+# 8. NO static union of all body bindings is handed to every handler
+# ---------------------------------------------------------------------------
+
+TWO_ARMS = (
+    CLASSES + "def A(z, flag):\n"
+    "    try:\n"
+    "        a = z\n"
+    "        if flag:\n"
+    "            raise LeafFault\n"
+    "        b = z\n"
+    "        raise RootFault\n"
+    "    except LeafFault:\n"
+    "        return a\n"
+    "    except RootFault:\n"
+    "        return b\n"
+)
+
+
+def test_no_static_union_of_body_bindings_reaches_every_handler():
+    """Each arm receives ONLY the edges routed to it: the leaf arm gets the
+    early raise ({a}), the base arm gets the late one ({a, b}).  A union would
+    have handed both arms {a, b}."""
+    with _observed() as log:
+        _fn(TWO_ARMS).sugar()
+    routed = log["routed"][0]
+    assert {k: [sorted(s) for s in v] for k, v in routed.items()} == {
+        0: [["a"]],
+        1: [["a", "b"]],
+    }
+    incoming = [sorted(result) for _states, result in log["incoming"]]
+    assert incoming == [["a"], ["a", "b"]]
+    assert incoming[0] != ["a", "b"], "the leaf arm is not handed the union"
+    # CONSUMED per arm: the leaf arm resolved ``a``; the base arm resolved both.
+    assert _unresolved_reads(TWO_ARMS) == [[], []]
+
+    # BITE: union every edge into every arm and the leaf arm over-claims b.
+    with _rule(_static_union):
+        with _observed() as poisoned:
+            _fn(TWO_ARMS).sugar()
+        assert [sorted(r) for _s, r in poisoned["incoming"]] == [["a"], ["a", "b"]]
+    # (with a single arm the union is visible directly)
+    with _rule(_static_union):
+        with _observed() as poisoned:
+            _fn(TWO_HALT_SITES).sugar()
+        assert [sorted(r) for _s, r in poisoned["incoming"]] == [["a", "b"]]
+
+
+# ---------------------------------------------------------------------------
+# 9. NO name map and NO reconstructed sugar
+# ---------------------------------------------------------------------------
+
+
+def test_routed_state_is_the_threaded_entry_not_a_name_map():
+    """What reaches the handler is the very entry the body threaded -- the same
+    object, carried along the edge.  Nothing is looked up by name, rebuilt, or
+    re-substituted from source."""
+    with _observed() as log:
+        _fn(BOUND_THEN_RAISE).sugar()
+    edges = log["edges"][0]
+    assert len(edges) == 1
+    _identity, _mro, edge_state = edges[0]
+    _states, incoming = log["incoming"][0]
+    assert set(incoming) == {"x"}
+    assert incoming["x"] is edge_state["x"], "the routed entry is carried, not rebuilt"
+    # And it is CONSUMED: the arm has no unresolved read of x at all.
+    assert _unresolved_reads(BOUND_THEN_RAISE) == [[]]
+
+    # BITE: rebuild the same names into fresh entries -- the identity fails
+    # even though every name and value still matches.
+    original = Try._incoming_halt_state
+
+    def rebuilt(self, states):
+        from copy import copy
+
+        return {name: copy(entry) for name, entry in original(self, states).items()}
+
+    Try._incoming_halt_state = rebuilt
+    try:
+        with _observed() as log2:
+            _fn(BOUND_THEN_RAISE).sugar()
+        _identity, _mro, edge_state2 = log2["edges"][0][0]
+        _states2, incoming2 = log2["incoming"][0]
+        assert incoming2["x"] is not edge_state2["x"]
+    finally:
+        Try._incoming_halt_state = original


### PR DESCRIPTION
Closes #6283.

## The defect

```python
try:
    x = z            # z is a parameter — this cannot fail
    raise ValueError
except ValueError:
    return x         # → NameErrorEffect on x   ← FABRICATED
```

`Try.substitute` built `handler_scope = dict(scope)` — the **pre-try** snapshot — while `orelse` correctly received `{**scope, **body_net}`. The `ExitSet` side was already correct: sequencing carries per-edge state. `Try.substitute` bypassed that testimony with one static scope snapshot.

## The law

> Each halted `ExitSet` edge carries the temporal binding state at its precise halt occurrence; the selected handler begins from that edge's state.

Same temporal law as #6239's `_prefixed`, one layer up, now in exception routing.

## Where the per-edge state is consumed

| Piece | What it does |
|---|---|
| `_substitute_body_tracked(..., edge_states=)` | Out-parameter on the **same** threading loop: appends `(statement, state_in_effect_as_that_statement_begins)`. Not a second mechanism — the same threading, reported at each occurrence instead of only at the block's end. |
| `Try._body_halt_edges` / `_statement_halt_edges` | Turns each statement that can halt into an edge carrying that state. A `raise` of a resolvable type name is **typed** testimony; a statement that may halt at an occurrence this layer cannot name (call, attribute, subscript, operator, nested block) is an **untyped** edge; a statement built only from halt-free nodes contributes **no edge**. An `If` with a halt-free test expands into its branches' edges at the pre-`If` state. |
| `Try._route_halt_edges` | Source order, first match only — the arm selection the router already applies. An untyped edge could be any exception, so it reaches every arm. |
| `Try._incoming_halt_state` | What the edges reaching **one** arm agree on. |
| handler net | `{**incoming, **handler_net}` — the handler edge leaves the try carrying its incoming state updated by the handler's own threading. |

### Proof it is not a union, a snapshot, or a name map

- **Not a union.** `_incoming_halt_state` keeps a name only if **every** routed edge carries it *and* carries the same entry. Twin 8 observes the production routing directly: for a body raising `LeafFault` early and `RootFault` late, arm 0 receives `{a}` and arm 1 receives `{a, b}`. A union would have handed both arms `{a, b}`.
- **Not a snapshot.** There is no per-`Try` scope computation. `edge_states` is the threading loop's own timeline; each edge's state is the entry recorded at *its* statement. Twin 3 observes two edges of one body carrying `{a}` and `{a, b}` — a snapshot cannot represent two.
- **Not a name map, not reconstructed sugar.** Twin 9 asserts `incoming["x"] is edge_state["x"]` — the very object the body threaded, carried along the edge. Its bite rebuilds the identical names/values with `copy()` and the identity assertion fails.

### Explicitly NOT `{**scope, **body_net}`

Installed in production as a control, that rule turns twins **2 and 3 red** while twin 1 stays green — exactly the signature T described for the wrong rule. Verified and reverted.

## The nine twins and their bites

`implementations/python/sugar-source-tree/tests/test_try_handler_temporal_state.py`

| # | Twin | Bite (run, red, reverted) |
|---|---|---|
| 1 | assignment before an explicit raise **is** available | pre-try snapshot → `NameErrorEffect` on `x` returns |
| 2 | halt **before** the assignment leaves the name unavailable | static union → `x` fabricated onto the opaque edge |
| 3 | two halt sites preserve **different** prefix states (`{a}` vs `{a,b}`; agreement `{a}`; `b` unavailable; only `b` left as an unresolved read) | static union → incoming becomes `{a,b}` |
| 4 | matched `as e` **extends** — not replaces — the incoming state (`x` resolves *and* `error` is still `python:effect_slot`) | pre-try snapshot → `x` lost while the slot survives |
| 5 | unmatched halt preserves its **exact** state and effect occurrence (`RootFault` leaves the try; the leaf arm receives no edge) | route the unmatched edge anyway → the arm absorbs the halt |
| 6 | handler failure carries the **handler's** updated state (`y = x` in the arm, `y` available after) | pre-try snapshot → arm's own binding built from a fabricated NameError |
| 7 | body completion alone feeds `else`; an all-safe body contributes no halted edge | starve the body's completion net → `else` loses the binding |
| 8 | **no static union** reaches every handler (per-arm routing observed) | union every edge into every arm → the leaf arm over-claims `b` |
| 9 | **no name map, no reconstructed sugar** (entry identity, and the arm has no unresolved read of `x`) | rebuild entries with `copy()` → identity fails |

Reverting production to the defect (`handler_scope = dict(scope)`) turns **7 of 9** red. Twins 5 and 7 do not depend on that line by construction; each carries its own perturbation, exercised inside the test.

## Axis and Epsilon R

**Axis:** `R(handler-state-fabrication)` — try handlers reading a name the body bound before the halt, answered with a fabricated `NameErrorEffect`.

**Predicted `Epsilon R`:** the fabricated `NameErrorEffect` on the `bound-then-raise` shape disappears; verdicts on that shape change from `Incomplete(NameErrorEffect)` to a resolved post. No verdict may move in the other direction (a name that was resolved must not become unresolved).

**Observed, `sugar-source-tree` package (rootdir `sugar-source-tree`, `-p no:randomly`):**

- baseline `origin/main`: **570 passed, 5 skipped, 0 failed**
- this branch: **579 passed, 5 skipped, 0 failed**

Δ = **+9, exactly the new twins**. **Zero pre-existing verdicts changed.** Every changed verdict is therefore attributable to a twin this PR adds; there is no unexplained movement.

Floors preserved: `test_try_exitset_law.py` (31), `test_with_partition_shared_algebra.py` (28), `test_with_multiple_managers.py` (16) — all green, production of that algebra untouched. No test deleted or skipped; no panic weakened; `except*` untouched and still typed-loud.

**Corpus ΔR: unmeasured.** A focused token cannot run the corpus; this is stated as unmeasured, not claimed as zero. `sugar-lift-py-tests` was deliberately not run locally (its session-autouse `resolve_sugar_binary` fixture triggers a full `cargo build --release -p sugar-cli` on a shelf miss, and #6282 makes a profile-contradicting `SUGAR_BIN` override a refusal). CI is the latent telemetry for both.

## Findings to report, not papered over

1. **Pre-existing IR gap, reachable from `Try`, on `main` independent of this PR.** Any `try` whose body has **two** halted edges reaching handlers crashes in `ExitSet.normalize`:

   ```
   TypeError: unknown Term: <class 'sugar_lift_py_tests.ir._Atomic'>
   ```

   `EffectBinding.to_facts` puts `atomic("effect_slot_kind", [slot])` in a **term** position (`eq(...)`), and `term_to_value` cannot encode an `_Atomic` as a term. It is reached when `normalize` compares two completed exits by value. Reproduced on `origin/main` with production untouched:

   ```python
   def A(z, flag):
       try:
           if flag:
               raise ValueError
           raise ValueError
       except ValueError:
           return 1
   ```

   Left loud. Twin 3's bite is read structurally rather than end-to-end for exactly this reason, and the reason is written into the twin. Worth its own issue.

2. **Residual on this axis (R > 0, honestly declared).** A binding established *inside* a compound statement before a nested raise (`if flag: x = 1; raise E`) is not claimed — the branch's edges carry the pre-`If` state. That is the current behaviour, unchanged, not a regression; it is a fabricated-*missing*-binding in the narrower shape. Not pinned here, because pinning it would assert the defect.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Initialize try handler scope from routed halt-edge temporal state
> - `Try.substitute` now initializes each except-handler's scope from the state in effect at the specific halt edge(s) routed to that handler, rather than the pre-try snapshot. Bindings assigned before a `raise` are visible in the handler; bindings not yet assigned are absent.
> - `Node._substitute_body_tracked` gains an optional `edge_states` out-parameter that records `(statement, pre-state)` tuples during body substitution, enabling per-statement state threading.
> - New helpers (`_body_halt_edges`, `_statement_halt_edges`, `_route_halt_edges`, `_incoming_halt_state`) compute which halt edges reach each handler and intersect their incoming states.
> - Nine new tests in [`test_try_handler_temporal_state.py`](https://github.com/TSavo/sugar/pull/6284/files#diff-af42cbf2fb631070764f7a96a091b00714c2c99369b93d13b7709c827d64d7e4) cover routing, prefix-state correctness, unmatched halts, `except ... as e` extension, else-block isolation, and handler failure propagation.
> - Behavioral Change: handlers that previously inherited the full pre-try scope now only see bindings provably established before the halt site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eddee5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->