### PR TITLE
fix: a stalled binary resolution is one honest error, not a whole-suite red

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py
@@ -12,9 +12,36 @@ SUGARBIN_WINDOWS = ROOT / "bin" / "sugarbin.ps1"
 
 subprocess_run = subprocess.run
 
+# How long the suite waits for `bin/sugarbin` to hand back a binary. The wait is
+# real work only on the build rung: every worktree owns its own cargo build
+# directory but the box is shared, so a peer holding that directory's lock
+# ("Blocking waiting for file lock") stalls resolution for the whole budget.
+DEFAULT_RESOLVE_TIMEOUT_SECONDS = 600.0
+
 
 class SugarBinaryResolutionError(RuntimeError):
     pass
+
+
+def resolve_timeout_seconds(env: Mapping[str, str] | None = None) -> float:
+    """The resolution budget, overridable for sweeps that must bound the wait."""
+    source = os.environ if env is None else env
+    raw = source.get("SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS")
+    if raw is None or not raw.strip():
+        return DEFAULT_RESOLVE_TIMEOUT_SECONDS
+    try:
+        seconds = float(raw)
+    except ValueError as exc:
+        raise SugarBinaryResolutionError(
+            "SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS must be a positive number of "
+            f"seconds, got {raw!r}"
+        ) from exc
+    if seconds <= 0:
+        raise SugarBinaryResolutionError(
+            "SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS must be a positive number of "
+            f"seconds, got {raw!r}"
+        )
+    return seconds
 
 
 def sugarbin_route(*, os_name: str, hostname: str) -> str:
@@ -55,15 +82,33 @@ def resolve_sugar_binary(
         ]
     else:
         command = [str(SUGARBIN), "--profile", profile]
-    completed = subprocess_run(
-        command,
-        cwd=ROOT,
-        env=child_env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=600,
-    )
+    timeout = resolve_timeout_seconds(child_env)
+    try:
+        completed = subprocess_run(
+            command,
+            cwd=ROOT,
+            env=child_env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A bare TimeoutExpired escaping here is the worst failure this module
+        # has. `resolve_sugar_binary` is called from a session-scoped autouse
+        # fixture, so an exception type the fixture does not catch errors EVERY
+        # collected test with one identical traceback -- a whole-suite red that
+        # reads like a mass regression and is really one stalled subprocess.
+        # Name it as a resolution failure so the fixture exits once, loudly.
+        raise SugarBinaryResolutionError(
+            f"bin/sugarbin did not resolve a {profile} sugar binary within "
+            f"{timeout:g}s.\n"
+            "The build rung waits on the Rust build-directory lock, which a "
+            "peer process on this box may hold for minutes. Prebuild the "
+            "binary, or set SUGAR_BINARY_ALLOW_BUILD=0 to refuse the build rung "
+            "and fail fast on a missing artifact, or raise "
+            "SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS if the wait is expected."
+        ) from exc
     if completed.returncode != 0:
         raise SugarBinaryResolutionError(
             "bin/sugarbin platform entrypoint failed to resolve a sugar binary\n"

--- a/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
@@ -10,6 +10,8 @@ import time
 import tokenize
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.filename import cid_filename_stem
 
 ROOT = Path(__file__).resolve().parents[4]
@@ -706,3 +708,63 @@ def test_witness_harness_resolves_sugar_once_for_parallel_callers(
     assert errors == []
     assert results == [resolved, resolved, resolved, resolved]
     assert calls == 1
+
+
+def test_resolution_timeout_is_a_resolution_error_not_a_bare_timeout(
+    monkeypatch,
+) -> None:
+    """A stalled sugarbin must not error every collected test with one traceback.
+
+    `resolve_sugar_binary` runs inside a session-scoped autouse fixture that
+    only catches `SugarBinaryResolutionError`. Any other exception type escapes
+    the fixture and is attributed to every test in the run.
+    """
+    from sugar_lift_py_tests import sugar_binary
+
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(sugar_binary.platform, "node", lambda: "MapLaptop")
+    monkeypatch.setattr(sugar_binary, "subprocess_run", fake_run)
+
+    with pytest.raises(sugar_binary.SugarBinaryResolutionError) as excinfo:
+        sugar_binary.resolve_sugar_binary(env={}, profile="debug")
+
+    message = str(excinfo.value)
+    assert "did not resolve a debug sugar binary within 600s" in message
+    assert "SUGAR_BINARY_ALLOW_BUILD=0" in message
+    assert isinstance(excinfo.value.__cause__, subprocess.TimeoutExpired)
+
+
+def test_resolution_timeout_budget_is_overridable(monkeypatch) -> None:
+    from sugar_lift_py_tests import sugar_binary
+
+    seen: list[float] = []
+
+    def fake_run(command, **kwargs):
+        seen.append(kwargs["timeout"])
+        return subprocess.CompletedProcess(command, 0, "/tmp/sugar\n", "")
+
+    monkeypatch.setattr(sugar_binary.platform, "node", lambda: "MapLaptop")
+    monkeypatch.setattr(sugar_binary, "subprocess_run", fake_run)
+
+    sugar_binary.resolve_sugar_binary(
+        env={"SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS": "45"}
+    )
+
+    assert seen == [45.0]
+
+
+def test_resolution_timeout_budget_refuses_nonsense(monkeypatch) -> None:
+    from sugar_lift_py_tests import sugar_binary
+
+    for raw in ("0", "-1", "soon"):
+        with pytest.raises(sugar_binary.SugarBinaryResolutionError):
+            sugar_binary.resolve_timeout_seconds(
+                {"SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS": raw}
+            )
+
+    assert (
+        sugar_binary.resolve_timeout_seconds({})
+        == sugar_binary.DEFAULT_RESOLVE_TIMEOUT_SECONDS
+    )


### PR DESCRIPTION
## The defect

`resolve_sugar_binary` ran `bin/sugarbin` with a hard-coded `timeout=600` and let `subprocess.TimeoutExpired` escape.

It is called from the **session-scoped autouse** fixture `sugar_binary_handoff` (`tests/conftest.py`), which catches only `SugarBinaryResolutionError`:

```python
@pytest.fixture(scope="session", autouse=True)
def sugar_binary_handoff() -> str:
    try:
        sugar = resolve_sugar_binary()
    except SugarBinaryResolutionError as exc:
        pytest.exit(str(exc), returncode=2)
```

Any other exception type escapes the fixture and is attributed to **every collected test**. That is the 1149/1151-errors-sharing-one-identical-timeout signature we have been reading as a mass regression. It is one stalled subprocess.

The stall is not exotic. Resolution only waits on the build rung, and while every worktree owns its own Rust build directory, the box is shared — a peer holding that directory's lock (`Blocking waiting for file lock`) burns the entire 600s budget before anything is reported.

## The change

Two narrow edits to `sugar_binary.py`:

1. `TimeoutExpired` is converted to `SugarBinaryResolutionError`. The fixture then exits **once**, loudly, with a message that names the lock, `SUGAR_BINARY_ALLOW_BUILD=0`, and the budget knob. `__cause__` keeps the original timeout.
2. The budget becomes `SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS`, defaulting to the same 600s. A sweep that must bound its wait can; a caller that sets nothing sees no change.

**The build rung's default policy is deliberately untouched.** Refusing to build by default would break a cold worktree. The defect here is the *shape* of the failure, not the policy.

## Verification

Own-baseline pair, worktree at `421ef41`, `SUGAR_BIN` pinned to a shelf release artifact, `SUGAR_BINARY_ALLOW_BUILD=0`:

| | result |
|---|---|
| baseline (`origin/main`) | 8 failed, 12 passed |
| patched | 8 failed, **15** passed |

Same eight failures in both, +3 new tests. The pre-existing eight are environment-dependent on this box (the `os.name` monkeypatch leaking `WindowsPath` across tests, and sugarbin fixtures needing tools not present here) and none are touched by this change.

New tests in `test_binary_handoff_policy.py`:

- `test_resolution_timeout_is_a_resolution_error_not_a_bare_timeout` — the whole point: pins the exception type the session fixture depends on
- `test_resolution_timeout_budget_is_overridable`
- `test_resolution_timeout_budget_refuses_nonsense`

Not run locally: `black` (repo pins `26.5.1`, not installed on this box) — lines are hand-kept under 88 chars, and the one 93-char line in the file is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert stalled binary resolution timeout from bare `subprocess.TimeoutExpired` to `SugarBinaryResolutionError`
> - `resolve_sugar_binary` now catches `subprocess.TimeoutExpired` and re-raises it as `SugarBinaryResolutionError` with a message naming the profile and timeout budget, so a stalled resolution fails one test rather than the whole suite.
> - Adds `resolve_timeout_seconds()` to read `SUGAR_BINARY_RESOLVE_TIMEOUT_SECONDS` from the environment; invalid or non-positive values raise `SugarBinaryResolutionError` immediately.
> - Default timeout remains 600 seconds via the new `DEFAULT_RESOLVE_TIMEOUT_SECONDS` constant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e3c3bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->