### PR TITLE
Heavy measurements queue in GitHub and serialize on a machine-wide BX lease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ on:
   pull_request:
 
 # Cancel superseded runs on the same branch / PR.
+# A superseded run may be the only evidence we will ever get for its commit,
+# so it is allowed to finish. Cancelling it was the same instinct that cost us
+# five package-suite runs and three sole-construction floor runs: treating a
+# measurement as disposable because a newer push exists.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -9,17 +9,33 @@ on:
 permissions:
   contents: read
 
-# ONE orchestrator for heavy kit floors. Do not put other PR workflows in this
-# concurrency group — GitHub keeps only one pending run per group, so six
-# independent workflows cancel each other even with cancel-in-progress: false.
-concurrency:
-  group: sugar-python-heavy-measurement
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. THE GROUP WAS THE DEFECT, NOT THE FIX.
+#
+# The header that used to sit here said "GitHub keeps only one pending run per
+# group, so six independent workflows cancel each other even with
+# cancel-in-progress: false" -- and then kept the group anyway, as if being the
+# ONLY workflow in it were protection. It is not. One pending slot is one
+# pending slot even with a single occupant: on a PR with rapid pushes this
+# workflow was cancelled three times inside two minutes (20:26:50, 20:27:52,
+# 20:28:35) while every lighter job completed.
+#
+# That is the worst version of the defect, because these are FLOORS. A floor
+# that never ran looks exactly like a floor that found nothing: R=0 and R
+# unmeasured are the same silence from outside. Five suite runs and these three
+# floor runs vanished that way before anybody noticed.
+#
+# So: GitHub retains every run, and tools/heavy_measurement_lease.py decides
+# who measures. The corpus scanners below are heavy -- they are the reason the
+# box cannot host two censuses -- and they now run inside one machine-wide
+# flock, with a receipt, and with an attendance roll call that can tell silence
+# from a clean bill.
 
 jobs:
   python-sole-construction-floors:
     name: python-sole-construction-floors
     runs-on: [self-hosted, Linux, X64]
+    # The floor set plus its wait for the lease. See python-package-suite.yml.
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
       # ONE environment definition, shared read-only with the authoritative
@@ -29,135 +45,47 @@ jobs:
       # .github/workflows/python-package-suite.yml.
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
-      # Permanent floors — baseline-free. R > 0 ⇒ CI red on every axis.
-      # See docs/contributing/python-sole-construction.md
-      # factory_zero_tolerance.py retired with factory/ (#6028): no dual
-      # construction door left to measure. Ownership + construction-panic catch
-      # remain permanent floors.
-      - name: R_ownership = 0
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
-      - name: R_construction_panic_catches_outside_membrane = 0
+      - name: The complete floor set, under the machine-wide heavy lease
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          python3 tools/heavy_measurement_lease.py \
+            --class python-sole-construction-floors \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            -- bash tools/run_sole_construction_floors.sh
+          leased_exit=$?
+          set -e
+          # 75 is the lease REFUSING, not a floor being green. These are floors:
+          # "no output" must never be readable as "nothing to report".
+          if [ "$leased_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the floors did NOT run. R is UNMEASURED, not 0."
+            exit 75
+          fi
+          exit "$leased_exit"
+
+      # These floors ARE a zero claim: R = 0 on every axis. So the gate demands
+      # the one status that can carry one. `cancelled-before-measurement` and
+      # `interrupted-during-measurement` are red here, loudly, rather than
+      # quietly reading as a clean floor -- which is exactly what three
+      # evicted runs on one PR looked like from the outside.
+      - name: Lease gate (R_lease = 0)
         if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
-      # Heavy supervised enum floors — sequential under this one job so the
-      # complete floor set is always from one pinned run.
-      - name: R_native_crashes = 0
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --require-commit "$GITHUB_SHA" \
+            --require-zero-claim \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # The receipt is the artifact that distinguishes "ran and found nothing"
+      # from "never ran". Uploaded even when a floor is red.
+      - name: Upload the floor-set lease receipt
         if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
-      - name: R_bare_exceptions = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
-      - name: R_timeouts = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
-      - name: All permanent axes are bound
-        if: always()
-        run: python -m pytest tests/test_python_sole_construction_ci.py -q
-      - name: '`sugar-lift-py-tests[test]` is the sole dependency authority'
-        if: always()
-        run: >-
-          python -m pytest
-          tests/test_test_extras_are_the_dependency_authority.py
-          -q
-      - name: R_vendor_special_case discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
-          -q
-      - name: R_vendor_special_case = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
-      - name: R_silent discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
-          -q
-      - name: R_silent = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
-      - name: R_factory_walk_unclassified discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_factory_walk_unclassified_law.py
-          -q
-      - name: R_factory_walk_unclassified = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
-          --live-root
-          implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests
-          --live-root
-          implementations/python/sugar-lift-py-tests/scripts
-      - name: R_finite_cap_opaque_completions discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_finite_cap_opaque_completion_law.py
-          -q
-      - name: R_finite_cap_opaque_completions = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
-      - name: R_finite_unfold_compact_gaps discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_finite_unfold_compact_projection_law.py
-          -q
-      - name: R_finite_unfold_compact_gaps = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
-      - name: R_source_via_execution discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
-          -q
-      - name: R_source_via_execution = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
-      - name: R_no_sugar_in_desugar discrimination
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
-          --self-test
-      - name: R_no_sugar_in_desugar = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
-      - name: R_construction_side_doors discrimination
-        if: always()
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
-          -q
-      - name: R_construction_side_doors = 0
-        if: always()
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sole-construction-floors-lease
+          path: lease-record.json
+          if-no-files-found: error

--- a/.github/workflows/numpy-wall.yml
+++ b/.github/workflows/numpy-wall.yml
@@ -9,15 +9,18 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: sugar-python-heavy-measurement
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. GitHub keeps one pending run per group and evicts
+# the rest, which is how five package-suite runs and three sole-construction
+# floor runs were lost. GitHub now retains every run; the machine-wide lease in
+# tools/heavy_measurement_lease.py decides which one measures. A wall census
+# saturates the box, so it is exactly the workload the lease exists for.
 
 jobs:
   numpy-wall:
     name: build numpy wall
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    # Census budget plus the wait for the lease.
+    timeout-minutes: 360
 
     steps:
       - name: Checkout
@@ -59,11 +62,32 @@ jobs:
           : > "$SUGAR_ENGINE_LOG"
           : > "$SUGAR_KIT_LOG"
           set +e
-          make numpy-wall
+          python3 tools/heavy_measurement_lease.py \
+            --class numpy-wall \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --status-file "$GITHUB_WORKSPACE/.sugar/numpy-wall/measurement-status" \
+            -- make numpy-wall
           wall_exit=$?
           set -e
+          if [ "$wall_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the NumPy wall was NOT minted."
+            echo "wall_exit=lease-refused" >> "$GITHUB_OUTPUT"
+            exit 75
+          fi
           echo "wall_exit=$wall_exit" >> "$GITHUB_OUTPUT"
           test -s .sugar/numpy-wall/frontier.json
+
+      # A frontier whose numbers were taken beside another census is a frontier
+      # about the box, not about NumPy.
+      - name: Lease gate (R_lease = 0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Publish NumPy conservation vector + ΔR
         env:
@@ -135,4 +159,5 @@ jobs:
             .sugar/numpy-wall-logs/engine.jsonl
             .sugar/numpy-wall-logs/transport.jsonl
             .sugar/numpy-wall/
+            lease-record.json
           if-no-files-found: error

--- a/.github/workflows/pandas-wall.yml
+++ b/.github/workflows/pandas-wall.yml
@@ -9,15 +9,18 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: sugar-python-heavy-measurement
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. GitHub keeps one pending run per group and evicts
+# the rest -- five package-suite runs and three sole-construction floor runs
+# were lost that way. GitHub now retains every run; the machine-wide lease in
+# tools/heavy_measurement_lease.py decides which one measures. A pandas census
+# owns the box while it runs, which is exactly what the lease is for.
 
 jobs:
   pandas-wall:
     name: build pandas wall
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    # Census budget plus the wait for the lease.
+    timeout-minutes: 360
 
     steps:
       - name: Checkout
@@ -72,9 +75,18 @@ jobs:
           : > "$SUGAR_ENGINE_LOG"
           : > "$SUGAR_KIT_LOG"
           set +e
-          make pandas-wall
+          python3 tools/heavy_measurement_lease.py \
+            --class pandas-wall \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --status-file "$GITHUB_WORKSPACE/.sugar/pandas-wall/measurement-status" \
+            -- make pandas-wall
           wall_exit=$?
           set -e
+          if [ "$wall_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the pandas wall was NOT minted."
+            echo "wall_exit=lease-refused" >> "$GITHUB_OUTPUT"
+            exit 75
+          fi
           echo "wall_exit=$wall_exit" >> "$GITHUB_OUTPUT"
           # Frontier is the success receipt; partial runs are scored below.
           if [ -s .sugar/pandas-wall/frontier.json ]; then
@@ -164,6 +176,17 @@ jobs:
             --body-file .sugar/pandas-wall/ledger-comment.md
 
 
+      # A frontier measured beside another census is a claim about the box.
+      - name: Lease gate (R_lease = 0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Upload pandas wall artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -173,6 +196,7 @@ jobs:
             .sugar/pandas-wall-logs/engine.jsonl
             .sugar/pandas-wall-logs/transport.jsonl
             .sugar/pandas-wall/
+            lease-record.json
           if-no-files-found: error
 
       - name: Enforce pandas frontier receipt

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -39,18 +39,24 @@ on:
 permissions:
   contents: read
 
-# Repository-wide, ref-independent, and NEVER cancelling: a run already
-# producing evidence outlives the push that superseded it. New runs queue.
+# NO `concurrency:` BLOCK. THAT IS THE FIX.
 #
-# Deliberately NOT the `sugar-python-heavy-measurement` group that
-# factory-zero-tolerance.yml owns. GitHub keeps only ONE pending run per group,
-# so a third queued run evicts the second -- sharing that group with the floors
-# would make the authoritative sweep the first thing dropped on a busy day,
-# which is the no-coverage defect this workflow exists to end. One heavy group
-# per heavy instrument, each ref-independent and each cancel-in-progress: false.
-concurrency:
-  group: sugar-python-package-suite
-  cancel-in-progress: false
+# This workflow had its own ref-independent group with cancel-in-progress:
+# false, and it was starved inside that group anyway: five runs (dea47f1f8,
+# e0a78ec52, d243fcacf, 6d9db3a8f, f0cddfd76) cancelled, zero artifacts, until
+# 30174018299 finally landed one behind a merge freeze. `cancel-in-progress:
+# false` only protects a run that has already STARTED; GitHub keeps exactly ONE
+# pending run per group, so every new push EVICTS the queued one. Our own merge
+# rate was the thing killing the measurement.
+#
+# So the queue and the serialization are separated:
+#
+#   GitHub queue: preserve every requested measurement  (no group -- here)
+#   BX lease:     only one heavy measurement executes   (tools/heavy_measurement_lease.py)
+#
+# Every run is retained and every run eventually measures. Overlap is settled
+# on the box by an flock the kernel releases even on SIGKILL, not by a queue
+# that drops the thing it was asked to remember.
 
 jobs:
   prepare-python-test-environment:
@@ -82,7 +88,11 @@ jobs:
     name: python-package-suite (canonical)
     needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    # Measurement budget PLUS lease wait. Runs now queue on the box instead of
+    # being evicted from GitHub's pending slot, so the job must be allowed to
+    # sit in that queue; a job timeout shorter than the wait would recreate the
+    # dropped-measurement defect one layer down.
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
 
@@ -108,7 +118,13 @@ jobs:
       # ONE cold process. Whole package. Canonical collection order.
       # `-p no:cacheprovider` so no run inherits another's cache; `-p
       # no:randomly` so canonical means canonical.
-      - name: Whole-package sweep
+      #
+      # And ONE AT A TIME ON THE BOX. The wall time of this sweep is a claim
+      # about the suite; measured beside a pandas census it is a claim about
+      # nothing. The lease is machine-wide, so the NumPy wall, the pandas wall,
+      # the sole-construction floors and the restored-suite sweep all wait for
+      # this one, and it waits for them -- while GitHub keeps every run.
+      - name: Whole-package sweep (under the machine-wide heavy lease)
         id: sweep
         shell: bash
         working-directory: implementations/python
@@ -116,20 +132,50 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/tools
         run: |
           set -uo pipefail
-          set +e
+          cat > "$RUNNER_TEMP/sweep.sh" <<'SWEEP'
+          set -uo pipefail
           python -m pytest sugar-lift-py-tests/tests -q \
             -p no:cacheprovider -p no:randomly \
             -p python_package_suite_report \
             --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
-            --suite-identity="${{ steps.env.outputs.identity-path }}" \
+            --suite-identity="$SUITE_IDENTITY_PATH" \
             --suite-order=canonical \
             --suite-label=python-package-suite-canonical \
             2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
-          pytest_exit=${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
+          SWEEP
+          set +e
+          SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
+          python3 "$GITHUB_WORKSPACE/tools/heavy_measurement_lease.py" \
+            --class python-package-suite \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --embed-into "$GITHUB_WORKSPACE/suite-report.json" \
+            -- bash "$RUNNER_TEMP/sweep.sh"
+          leased_exit=$?
           set -e
-          echo "pytest_exit=$pytest_exit" >> "$GITHUB_OUTPUT"
+          # 75 is the lease refusing, not pytest failing. The distinction is the
+          # whole point: an unmeasured suite must never read as a measured one.
+          if [ "$leased_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the suite did NOT run."
+            echo "pytest_exit=lease-refused" >> "$GITHUB_OUTPUT"
+            exit 75
+          fi
+          echo "pytest_exit=$leased_exit" >> "$GITHUB_OUTPUT"
           test -s "$GITHUB_WORKSPACE/suite.log"
           test -s "$GITHUB_WORKSPACE/suite-report.json"
+
+      # No timing claim is accepted if the lease was not acquired. This is that
+      # sentence with teeth: red unless the artifact's own embedded receipt
+      # shows request -> acquisition -> release around THIS commit.
+      - name: Lease gate (R_lease = 0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record suite-report.json \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Publish the node-ID vector
         if: always()
@@ -153,6 +199,7 @@ jobs:
             suite.log
             suite-report.json
             suite-node-ids/
+            lease-record.json
           if-no-files-found: error
 
       # Deliberately no `exit $pytest_exit`. See the header: this job reports.
@@ -173,7 +220,11 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.discrimination)
     needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    # Measurement budget PLUS lease wait. Runs now queue on the box instead of
+    # being evicted from GitHub's pending slot, so the job must be allowed to
+    # sit in that queue; a job timeout shorter than the wait would recreate the
+    # dropped-measurement defect one layer down.
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -199,26 +250,56 @@ jobs:
 
       # A SEPARATE COLD PROCESS per order. Sharing a process would let the
       # first order warm exactly the caches whose influence we are measuring.
-      - name: Whole-package sweep (${{ matrix.order }})
+      # Under the same lease as the canonical arm. A discrimination arm that
+      # ran beside another census would differ from canonical for a reason
+      # that is not the order -- which would make the one job in this file
+      # with teeth un-interpretable.
+      - name: Whole-package sweep (${{ matrix.order }}, under the heavy lease)
         shell: bash
         working-directory: implementations/python
         env:
           PYTHONPATH: ${{ github.workspace }}/tools
         run: |
           set -uo pipefail
-          set +e
+          cat > "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh" <<'SWEEP'
+          set -uo pipefail
           python -m pytest sugar-lift-py-tests/tests -q \
             -p no:cacheprovider -p no:randomly \
             -p python_package_suite_report \
             --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
-            --suite-identity="${{ steps.env.outputs.identity-path }}" \
-            --suite-order='${{ matrix.order }}' \
+            --suite-identity="$SUITE_IDENTITY_PATH" \
+            --suite-order="$SUITE_ORDER" \
             --suite-shuffle-seed="$GITHUB_RUN_ID" \
-            --suite-label='python-package-suite-${{ matrix.order }}' \
+            --suite-label="python-package-suite-$SUITE_ORDER" \
             2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
-          echo "pytest exit ${PIPESTATUS[0]}"
+          exit "${PIPESTATUS[0]}"
+          SWEEP
+          set +e
+          SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
+          SUITE_ORDER='${{ matrix.order }}' \
+          python3 "$GITHUB_WORKSPACE/tools/heavy_measurement_lease.py" \
+            --class python-package-suite \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --embed-into "$GITHUB_WORKSPACE/suite-report.json" \
+            -- bash "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh"
+          leased_exit=$?
           set -e
+          if [ "$leased_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the ${{ matrix.order }} arm did NOT run."
+            exit 75
+          fi
+          echo "pytest exit $leased_exit"
           test -s "$GITHUB_WORKSPACE/suite-report.json"
+
+      - name: Lease gate (R_lease = 0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record suite-report.json \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload discrimination artifacts
         if: always()
@@ -228,6 +309,7 @@ jobs:
           path: |
             suite.log
             suite-report.json
+            lease-record.json
           if-no-files-found: error
 
   discrimination-verdict:
@@ -248,6 +330,21 @@ jobs:
       # THIS ONE HAS TEETH. A verdict that changes with execution order is not
       # a verdict. Red here means one of the two runs lied and we do not know
       # which; fix the dependence, do not re-run for green.
+      # Were the three arms actually serialized? Same kernel must mean the same
+      # lock inode, and no two acquisition intervals may overlap. If the lease
+      # file is not shared between runner containers this is where it shows up
+      # -- otherwise the mechanism could be pure theatre and every arm would
+      # still look green.
+      - name: Lease scope check (one machine, one lock, no overlap)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --scope-check runs/python-package-suite-canonical/lease-record.json \
+            --scope-check runs/python-package-suite-reversed/lease-record.json \
+            --scope-check runs/python-package-suite-shuffled/lease-record.json \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Require identical verdict sets
         shell: bash
         run: |

--- a/.github/workflows/restored-suite-scoreboard.yml
+++ b/.github/workflows/restored-suite-scoreboard.yml
@@ -28,15 +28,23 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: restored-suite-scoreboard
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. A group with cancel-in-progress: false still keeps
+# only ONE pending run and evicts the rest -- that is how five package-suite
+# runs and three sole-construction floor runs were lost. GitHub now retains
+# every run; tools/heavy_measurement_lease.py decides which one measures.
+#
+# This sweep is SUPERSEDED but still whole-package and still heavy, so it goes
+# behind the same machine-wide lease as the authoritative one. Retiring it is a
+# separate change with its own receipt (see the header above); leaving it
+# outside the lease in the meantime would mean the authoritative suite could be
+# timed against a second full sweep of the same package on the same box.
 
 jobs:
   restored-suite:
     name: mint restored-suite telemetry
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    # Sweep budget plus the wait for the lease.
+    timeout-minutes: 360
     env:
       # This job already runs inside the battleaxe runner container. It chooses
       # local ambient explicitly instead of trying to SSH back into its host.
@@ -95,15 +103,38 @@ jobs:
         id: suite
         shell: bash
         run: |
-          set +e
+          cat > "$RUNNER_TEMP/restored-sweep.sh" <<'SWEEP'
+          set -uo pipefail
           SUGAR_BIN="$(bin/sugarbin --profile release)" \
             "$RUNNER_TEMP/restored-suite-python/bin/python" -m pytest -q \
             implementations/python/sugar-lift-py-tests/tests \
             2>&1 | tee restored-suite.log
-          pytest_exit=${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
+          SWEEP
+          set +e
+          python3 tools/heavy_measurement_lease.py \
+            --class restored-suite-scoreboard \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            -- bash "$RUNNER_TEMP/restored-sweep.sh"
+          leased_exit=$?
           set -e
-          echo "pytest_exit=$pytest_exit" >> "$GITHUB_OUTPUT"
+          if [ "$leased_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the restored suite did NOT run."
+            echo "pytest_exit=lease-refused" >> "$GITHUB_OUTPUT"
+            exit 75
+          fi
+          echo "pytest_exit=$leased_exit" >> "$GITHUB_OUTPUT"
           test -s restored-suite.log
+
+      - name: Lease gate (R_lease = 0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Publish restored-suite vector
         env:
@@ -127,4 +158,5 @@ jobs:
           path: |
             restored-suite.log
             restored-suite-telemetry.md
+            lease-record.json
           if-no-files-found: error

--- a/docs/contributing/heavy-measurement-lease.md
+++ b/docs/contributing/heavy-measurement-lease.md
@@ -133,8 +133,30 @@ runners with an extra label — a change to runner registration, not to this
 repo — after which each heavy workflow's `runs-on:` gains that label. It is
 deliberately not approximated here.
 
-The related open question is whether `/var/tmp` is shared across runner
-containers on battleaxe. If it is not, the lease is per-container and
-serializes nothing — which is exactly why every receipt records
-`bootId`/`device`/`inode` and why `--scope-check` exists. That check is the
-measurement; do not assume the answer.
+## The lease path, and how the first live run caught it
+
+The first live run of this mechanism proved its own instrument. Two heavy jobs
+took a `/var/tmp` lease on the same kernel, each waited **0.0007 s**, and their
+intervals **overlapped**:
+
+```
+suite  host cad95bf8f5de  bootId d257d14e-…  dev/ino 1048601/1740385
+floors host 7d0e695e838d  bootId d257d14e-…  dev/ino 1048637/2882278
+```
+
+Same machine, different inode. battleaxe's runners are **containers**, and
+`/var/tmp` is per-container — so that lease serialized nothing at all. The
+receipts made it visible on day one, which is the entire reason they record
+`bootId` and `device`/`inode`.
+
+The lease now lives at
+`/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease`, on a
+directory bind-mounted from the **same host path** into every runner container
+(verified across all twelve live containers).
+
+And the failure mode cannot come back quietly. Inside a container the wrapper
+**refuses to run at all** if the lease file sits on the same device as `/`,
+because that means the container's own root filesystem and no peer can see it.
+A lock nobody else can take reports `acquired` while a second census runs
+beside it — worse than no lock. Outside a container the rule is not applied:
+there, one filesystem really is one machine.

--- a/docs/contributing/heavy-measurement-lease.md
+++ b/docs/contributing/heavy-measurement-lease.md
@@ -1,0 +1,140 @@
+# The machine-wide heavy-measurement lease
+
+## The defect
+
+`python-package-suite.yml` had its own repository-wide concurrency group with
+`cancel-in-progress: false`, and it still produced **zero artifacts across five
+runs**: `dea47f1f8`, `e0a78ec52`, `d243fcacf`, `6d9db3a8f`, `f0cddfd76` were all
+cancelled. The first artifact this repo ever banked came from run
+`30174018299` at `421ef4157`, and only because merges were frozen around it.
+
+`Python sole-construction floors` failed the same way one layer down: on a
+single PR, three rapid pushes produced three cancellations (20:26:50, 20:27:52,
+20:28:35) while every lighter job completed.
+
+The cause is not the setting. It is what the setting can and cannot do:
+
+* `cancel-in-progress: false` protects a run that has **already started**.
+* GitHub keeps exactly **one pending run per concurrency group**. A new run
+  evicts the queued one.
+
+So our own merge rate was deleting our heaviest instruments, and a single
+*shared* group across the heavy classes would have made it worse: then every
+heavy class competes for that one pending slot.
+
+## The ruling
+
+Two responsibilities were being asked of one mechanism. They are now split:
+
+```
+GitHub queue: preserve every requested measurement   -> NO concurrency group
+BX lease:     only one heavy measurement executes    -> tools/heavy_measurement_lease.py
+```
+
+Every heavy run is retained by GitHub. Overlap is settled on the box.
+
+## The mechanism
+
+`tools/heavy_measurement_lease.py` wraps the measured command in a
+machine-wide `flock` on `/var/tmp/sugar-heavy-measurement.lease`
+(`$SUGAR_HEAVY_LEASE_PATH`):
+
+```bash
+python3 tools/heavy_measurement_lease.py \
+  --class python-package-suite \
+  --record "$GITHUB_WORKSPACE/lease-record.json" \
+  --embed-into "$GITHUB_WORKSPACE/suite-report.json" \
+  -- bash sweep.sh
+```
+
+`fcntl.flock` **is** `flock(2)` — the same kernel lock `flock(1)` takes, on the
+same file, interoperable with it. Python holds it rather than the util-linux
+binary so the release paths can be tested on every platform we develop on;
+`flock(1)` does not exist on macOS, and an untested release path on a lease
+that deadlocks the whole box is not acceptable.
+
+Release properties, each covered by a test in
+`tests/test_heavy_measurement_lease.py`:
+
+| path | released by |
+| --- | --- |
+| success | explicit unlock + fd close |
+| non-zero exit | explicit unlock + fd close |
+| timeout (never acquired) | nothing to release; command never ran |
+| SIGINT / SIGTERM / SIGHUP | handler forwards, then unlock + fd close |
+| SIGKILL | **the kernel**, when the last holder's fd closes |
+
+The lease descriptor is deliberately **inheritable**: the measured command
+holds the same lock. SIGKILL the wrapper and the orphaned census keeps the
+lease until it exits, so nothing starts on top of it.
+
+On timeout the wrapper prints stale-owner diagnostics and **exits 75 without
+running the command**. It never "recovers" by running concurrently: a timing
+number taken beside another census is not a slow measurement, it is not a
+measurement.
+
+## The status vocabulary
+
+```
+queued -> lease-waiting -> measuring -> completed
+                                          |- findings
+                                          \- zero-findings
+queued / lease-waiting -> cancelled-before-measurement
+measuring              -> interrupted-during-measurement
+```
+
+**Only `completed/zero-findings` may support a zero claim.** Cancelled,
+interrupted, refused, and absent are all *no measurement* — never green. This
+is what makes an evicted run structurally different from a clean floor; those
+eight lost runs went unnoticed because from outside they looked identical.
+
+Every receipt carries `measurementStatus` and a single derived boolean,
+`supportsZeroClaim`.
+
+## Artifact telemetry
+
+The receipt is written on every exit path and embedded into the measurement's
+own artifact as `leaseRecord`, so there is one schema, not two:
+
+| field | meaning |
+| --- | --- |
+| `leaseClass` | which heavy class held the lease |
+| `acquired`, `timedOut` | whether the measured section was entered at all |
+| `measurementStatus`, `supportsZeroClaim`, `zeroClaimStatus` | the vocabulary above |
+| `requestedAtUnix`, `acquiredAtUnix`, `releasedAtUnix` | request, acquisition, release |
+| `waitSeconds`, `heldSeconds` | queue time and measured time |
+| `measuredCommit` | the exact commit measured |
+| `owner.*` | run ID, attempt, workflow, job, ref, runner name, holder PID |
+| `command`, `commandExitStatus` | what ran and how it ended |
+| `leaseIdentity.bootId/device/inode` | kernel identity and the lock's identity |
+| `staleOwnerDiagnostics` | who held it, when refusal happened |
+
+## The checks
+
+* `tools/heavy_measurement_lease_gate.py --record R --require-commit SHA`
+  — red unless the lease was acquired, for that commit, with a readable
+  interval. Add `--require-zero-claim` wherever an R = 0 claim is made.
+* `... --scope-check A --scope-check B` — receipts sharing a `bootId` must
+  share a lock `inode`, and their intervals must not overlap. This is what
+  stops the lease from being per-container theatre: if the runner containers
+  do not share the lease path, the inodes differ and this goes red.
+* `tools/heavy_measurement_attendance.py --commit SHA` — the roll call. Roster
+  minus attended is `R_attendance`; those instruments did not report, and their
+  silence is not a clean floor.
+
+## Known limitation: no dedicated heavy runner label
+
+Every Linux runner registered on this repo carries exactly
+`[self-hosted, Linux, X64]` (checked via `gh api
+repos/TSavo/sugar/actions/runners`). There is no `sugar-heavy` label to route
+lease-waiting jobs onto, so a job waiting for the lease **does** occupy a
+general runner slot. Fixing this properly means registering the battleaxe
+runners with an extra label — a change to runner registration, not to this
+repo — after which each heavy workflow's `runs-on:` gains that label. It is
+deliberately not approximated here.
+
+The related open question is whether `/var/tmp` is shared across runner
+containers on battleaxe. If it is not, the lease is per-container and
+serializes nothing — which is exactly why every receipt records
+`bootId`/`device`/`inode` and why `--scope-check` exists. That check is the
+measurement; do not assume the answer.

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -1,47 +1,155 @@
-"""Heavy Python measurement: one orchestrator, not six workflows in one group.
+"""GitHub retains every run; the BX lease decides who measures.
 
-GitHub concurrency keeps only one running + one pending per group. Multiple
-PR workflows sharing `sugar-python-heavy-measurement` cancel each other even
-with cancel-in-progress: false. Corpus floors must run under one orchestrator.
+WHAT REPLACED WHAT
+==================
+
+This file used to assert the opposite topology: one GitHub concurrency group
+(`sugar-python-heavy-measurement`) owned by one orchestrator, on the theory
+that a group with `cancel-in-progress: false` queues rather than drops.
+
+It does not. GitHub keeps exactly ONE pending run per concurrency group, so a
+third queued run EVICTS the second. The evidence is not theoretical:
+
+  * `python-package-suite` — five runs (dea47f1f8, e0a78ec52, d243fcacf,
+    6d9db3a8f, f0cddfd76) cancelled before starting, zero artifacts ever.
+  * `Python sole-construction floors` — three runs cancelled inside two
+    minutes on a single PR's rapid pushes, while the light jobs completed.
+
+`cancel-in-progress: false` only protects a run that has already STARTED. It
+has nothing to say about the pending slot, and the pending slot is where our
+merge rate was killing our heaviest instruments.
+
+So the two responsibilities are split, and this file pins the split:
+
+    GitHub queue: preserve every requested measurement  → NO concurrency group
+    BX lease:     only one heavy measurement executes   → the flock wrapper
+
+A heavy workflow that declares a concurrency group is back in the eviction
+path. A heavy workflow that runs its measurement outside the lease is back to
+two censuses fighting over one box. Both are red here.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
-GROUP = "sugar-python-heavy-measurement"
+LEASE_WRAPPER = "tools/heavy_measurement_lease.py"
+GATE = "tools/heavy_measurement_lease_gate.py"
 
-# PR-triggered floor scanners that used to fight for the group.
+# Every heavy measurement class: workflow file -> the --class name it leases
+# under. This is the same roster tools/heavy_measurement_attendance.py calls
+# the roll from, and the two are checked against each other below.
+HEAVY_WORKFLOWS = {
+    "python-package-suite.yml": "python-package-suite",
+    "factory-zero-tolerance.yml": "python-sole-construction-floors",
+    "numpy-wall.yml": "numpy-wall",
+    "pandas-wall.yml": "pandas-wall",
+    "restored-suite-scoreboard.yml": "restored-suite-scoreboard",
+}
+
+# The dead group. Nothing may claim it again.
+RETIRED_GROUPS = ("sugar-python-heavy-measurement", "sugar-python-package-suite")
+
+# PR-triggered floor scanners that must stay discrimination-only.
 STANDALONE_FLOOR_WORKFLOWS = (
     "bare-exception-zero-tolerance.yml",
     "timeout-zero-tolerance.yml",
     "native-crash-zero-tolerance.yml",
 )
 
-ORCHESTRATOR = "factory-zero-tolerance.yml"
+
+def _text(name):
+    return (WORKFLOWS / name).read_text()
 
 
-def test_standalone_floor_workflows_do_not_claim_heavy_concurrency_group() -> None:
-    for name in STANDALONE_FLOOR_WORKFLOWS:
-        text = (WORKFLOWS / name).read_text()
-        assert GROUP not in text, (
-            f"{name} must not use {GROUP}; full corpus floors run only under "
-            f"{ORCHESTRATOR}"
+@pytest.mark.parametrize("workflow", sorted(HEAVY_WORKFLOWS))
+def test_heavy_workflows_declare_no_concurrency_group(workflow):
+    """No group means no pending slot means nothing to evict."""
+    text = _text(workflow)
+    assert not re.search(r"^concurrency:", text, re.MULTILINE), (
+        f"{workflow} declares a GitHub concurrency group. GitHub keeps ONE "
+        f"pending run per group and evicts the rest -- that is how five suite "
+        f"runs and three floor runs were lost. Serialize on the BX lease "
+        f"({LEASE_WRAPPER}) instead; let GitHub retain every run."
+    )
+    for group in RETIRED_GROUPS:
+        assert group not in text, f"{workflow} claims the retired group {group}"
+
+
+@pytest.mark.parametrize("workflow,lease_class", sorted(HEAVY_WORKFLOWS.items()))
+def test_heavy_workflows_measure_under_the_lease(workflow, lease_class):
+    text = _text(workflow)
+    assert LEASE_WRAPPER in text, (
+        f"{workflow} is a heavy measurement and must run its measured command "
+        f"through {LEASE_WRAPPER}; nothing else serializes the box"
+    )
+    assert f"--class {lease_class}" in text, (
+        f"{workflow} must lease under --class {lease_class} so its receipt is "
+        f"attributable and the attendance roll call can miss it when absent"
+    )
+    assert GATE in text, (
+        f"{workflow} must run {GATE}: a timing claim from a run that never "
+        f"acquired the lease is not a measurement, and that has to be checked"
+    )
+
+
+def test_no_heavy_workflow_cancels_a_superseded_run():
+    """Even outside the heavy classes: a superseded run may still be the only
+    evidence we will get for its commit. `ci.yml` was the last canceller."""
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text()
+        assert "cancel-in-progress: true" not in text, (
+            f"{path.name} cancels superseded runs. A run already producing "
+            f"evidence outlives the push that superseded it."
         )
-        # Discrimination only — no full-corpus script invocation.
+
+
+def test_attendance_roster_matches_the_heavy_workflows():
+    """A heavy workflow missing from the roster is an instrument that can go
+    quiet without the roll call noticing -- the exact defect that let eight
+    cancelled runs pass unremarked."""
+    from importlib import util
+
+    spec = util.spec_from_file_location(
+        "heavy_measurement_attendance", ROOT / "tools" / "heavy_measurement_attendance.py"
+    )
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert set(module.HEAVY_ROSTER) == set(HEAVY_WORKFLOWS.values())
+    for workflow, lease_class in HEAVY_WORKFLOWS.items():
+        name = re.search(r"^name:\s*(.+)$", _text(workflow), re.MULTILINE).group(1).strip()
+        assert module.HEAVY_ROSTER[lease_class] == name, (
+            f"roster name for {lease_class} does not match {workflow}'s `name:`; "
+            f"the roll call would never match this workflow's runs"
+        )
+
+
+def test_standalone_floor_workflows_stay_discrimination_only():
+    for name in STANDALONE_FLOOR_WORKFLOWS:
+        text = _text(name)
+        for group in RETIRED_GROUPS:
+            assert group not in text
         assert "zero_tolerance.py\n" not in text or "discrimination" in text.lower()
 
 
-def test_orchestrator_owns_heavy_group_and_runs_corpus_floors() -> None:
-    text = (WORKFLOWS / ORCHESTRATOR).read_text()
-    assert f"group: {GROUP}" in text
-    assert "cancel-in-progress: false" in text
+def test_orchestrator_still_runs_the_corpus_floors():
+    """The floor set moved into one leased script -- ONE lease interval for the
+    whole set, so no census interleaves between two axes and the complete set
+    still comes from one pinned run. It must not have lost an axis on the way."""
+    text = _text("factory-zero-tolerance.yml")
+    assert "tools/run_sole_construction_floors.sh" in text
+    floors = (ROOT / "tools" / "run_sole_construction_floors.sh").read_text()
     for script in (
         "native_crash_zero_tolerance.py",
         "bare_exception_zero_tolerance.py",
         "timeout_zero_tolerance.py",
         "silent_zero_tolerance.py",
+        "factory_ownership_law.py",
+        "construction_side_door_law.py",
     ):
-        assert script in text, f"{ORCHESTRATOR} must invoke {script}"
+        assert script in floors, f"the leased floor set must invoke {script}"

--- a/tests/test_heavy_measurement_lease.py
+++ b/tests/test_heavy_measurement_lease.py
@@ -1,0 +1,454 @@
+"""A leaked lease is worse than no lease. These are the release-path teeth.
+
+The machine-wide lease (``tools/heavy_measurement_lease.py``) is the ONE thing
+standing between two heavy censuses and a pair of uninterpretable timing
+numbers. Two failure modes matter and both are exercised here on both faces:
+
+    LEAKED  -- the lease is held after the measurement is over, and every
+               subsequent heavy job on the box deadlocks. Tested on success,
+               on non-zero exit, on SIGTERM, and on SIGKILL (the one no
+               handler can catch, where only the kernel's fd-close saves us).
+
+    ABSENT  -- the lease was never taken and two measurements ran side by side
+               anyway. Tested by holding the lock and watching the wrapper
+               REFUSE rather than proceed, and by the gate rejecting the
+               receipt that refusal produces.
+
+Bounded by construction: every case is sub-second and touches a temporary
+lease file, never the real one.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "tools" / "heavy_measurement_lease.py"
+GATE = ROOT / "tools" / "heavy_measurement_lease_gate.py"
+
+
+def run_wrapper(lease, record, command, timeout=5, extra=(), env=None, wait=True):
+    argv = [
+        sys.executable, str(WRAPPER),
+        "--class", "test-class",
+        "--lease", str(lease),
+        "--record", str(record),
+        "--timeout", str(timeout),
+        *extra,
+        "--", *command,
+    ]
+    merged = dict(os.environ)
+    merged.setdefault("GITHUB_RUN_ID", "424242")
+    merged.setdefault("GITHUB_SHA", "421ef4157000000000000000000000000000dead")
+    merged.update(env or {})
+    if not wait:
+        return subprocess.Popen(argv, env=merged, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, text=True)
+    return subprocess.run(argv, env=merged, capture_output=True, text=True, timeout=60)
+
+
+def lease_is_free(lease_path):
+    """True iff nobody holds the lease -- i.e. it was released."""
+    fd = os.open(str(lease_path), os.O_RDWR | os.O_CREAT, 0o666)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return True
+    except OSError:
+        return False
+    finally:
+        os.close(fd)
+
+
+@pytest.fixture()
+def lease(tmp_path):
+    return tmp_path / "heavy.lease"
+
+
+@pytest.fixture()
+def record(tmp_path):
+    return tmp_path / "lease-record.json"
+
+
+# -- the measured section runs, and the receipt describes it ----------------
+
+
+def test_success_runs_command_writes_receipt_and_releases(lease, record):
+    result = run_wrapper(lease, record, [sys.executable, "-c", "print('measured')"])
+    assert result.returncode == 0
+    assert "measured" in result.stdout
+
+    payload = json.loads(record.read_text())
+    assert payload["acquired"] is True
+    assert payload["timedOut"] is False
+    assert payload["leaseClass"] == "test-class"
+    assert payload["measuredCommit"].startswith("421ef4157")
+    assert payload["owner"]["githubRunId"] == "424242"
+    assert payload["commandExitStatus"] == 0
+    # request -> acquisition -> release, all present and ordered.
+    assert payload["requestedAtUnix"] <= payload["acquiredAtUnix"]
+    assert payload["acquiredAtUnix"] <= payload["releasedAtUnix"]
+    assert payload["waitSeconds"] >= 0
+    assert payload["heldSeconds"] >= 0
+
+    assert lease_is_free(lease), "lease leaked after a SUCCESSFUL measurement"
+    assert not Path(str(lease) + ".owner").exists()
+
+
+def test_failure_still_releases_and_records_the_exit_status(lease, record):
+    result = run_wrapper(lease, record, [sys.executable, "-c", "raise SystemExit(3)"])
+    assert result.returncode == 3
+    payload = json.loads(record.read_text())
+    assert payload["acquired"] is True
+    assert payload["commandExitStatus"] == 3
+    assert lease_is_free(lease), "lease leaked after a FAILED measurement"
+
+
+def test_signal_releases_the_lease(lease, record):
+    proc = run_wrapper(lease, record, [sys.executable, "-c", "import time; time.sleep(30)"],
+                       wait=False)
+    _wait_until(lambda: not lease_is_free(lease), "wrapper never took the lease")
+    proc.send_signal(signal.SIGTERM)
+    proc.communicate(timeout=30)
+    assert lease_is_free(lease), "lease leaked after SIGTERM"
+    payload = json.loads(record.read_text())
+    assert payload["acquired"] is True
+    assert payload["releasedAtUnix"] is not None
+
+
+def test_sigkill_leaves_the_lease_with_the_orphan_then_frees_it(lease, record):
+    """The case no handler can catch, and the orphan hole underneath it.
+
+    SIGKILL the wrapper and the measured census keeps running. The lease must
+    stay HELD for as long as that orphan lives -- otherwise the next heavy job
+    starts on top of a census still burning the box, which is exactly the
+    overlap the lease exists to forbid. Then, when the orphan exits, the kernel
+    frees the lock with no handler of ours ever running: no leak either.
+    """
+    proc = run_wrapper(lease, record, [sys.executable, "-c", "import time; time.sleep(2)"],
+                       wait=False)
+    _wait_until(lambda: not lease_is_free(lease), "wrapper never took the lease")
+    proc.kill()
+    proc.wait(timeout=30)
+    assert not lease_is_free(lease), (
+        "lease was released while the orphaned measurement was still running"
+    )
+    _wait_until(lambda: lease_is_free(lease), "lease leaked after the orphan exited")
+
+
+# -- the refusal face -------------------------------------------------------
+
+
+def test_contended_lease_refuses_and_does_not_run_the_command(lease, record, tmp_path):
+    """Only one enters the measured section. The other REFUSES -- it does not
+    wait forever, and it does not 'recover' by running alongside."""
+    canary = tmp_path / "canary"
+    fd = os.open(str(lease), os.O_RDWR | os.O_CREAT, 0o666)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    Path(str(lease) + ".owner").write_text(
+        "class=other\npid=1\nbootId=test\ngithubRunId=999\n"
+    )
+    try:
+        result = run_wrapper(
+            lease, record,
+            [sys.executable, "-c", f"open({str(canary)!r}, 'w').write('ran')"],
+            timeout=1,
+        )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+    assert result.returncode == 75, result.stderr
+    assert not canary.exists(), "the measured command RAN while another held the lease"
+    assert "REFUSING" in result.stderr
+    payload = json.loads(record.read_text())
+    assert payload["acquired"] is False
+    assert payload["timedOut"] is True
+    assert payload["commandExitStatus"] is None
+    assert "githubRunId=999" in payload["staleOwnerDiagnostics"]
+
+
+def test_second_wrapper_waits_then_proceeds_after_release(lease, record, tmp_path):
+    """Serialized, not dropped: the waiter's own interval starts after the
+    holder's ends, which is the property the whole design exists to buy."""
+    first_record = tmp_path / "first.json"
+    holder = run_wrapper(
+        lease, first_record,
+        [sys.executable, "-c", "import time; time.sleep(1.5)"],
+        wait=False,
+    )
+    _wait_until(lambda: not lease_is_free(lease), "holder never took the lease")
+    waiter = run_wrapper(lease, record, [sys.executable, "-c", "print('second')"],
+                         timeout=30, wait=False)
+    holder.communicate(timeout=60)
+    out, err = waiter.communicate(timeout=60)
+    assert waiter.returncode == 0, err
+    assert "second" in out
+
+    first = json.loads(first_record.read_text())
+    second = json.loads(record.read_text())
+    assert second["acquired"] is True
+    assert second["waitSeconds"] > 0, "the waiter did not actually wait"
+    assert second["acquiredAtUnix"] >= first["releasedAtUnix"], (
+        "the two measured sections OVERLAPPED"
+    )
+
+
+# -- the receipt joins the measurement's own artifact -----------------------
+
+
+def test_receipt_embeds_into_the_measurement_artifact(lease, record, tmp_path):
+    artifact = tmp_path / "suite-report.json"
+    program = (
+        f"import json; json.dump({{'schemaVersion': 1, 'counts': {{'collected': 7}}}}, "
+        f"open({str(artifact)!r}, 'w'))"
+    )
+    result = run_wrapper(lease, record, [sys.executable, "-c", program],
+                         extra=("--embed-into", str(artifact)))
+    assert result.returncode == 0
+    payload = json.loads(artifact.read_text())
+    assert payload["counts"]["collected"] == 7, "embedding clobbered the measurement"
+    assert payload["leaseRecord"]["acquired"] is True
+    assert payload["leaseRecord"]["measuredCommit"].startswith("421ef4157")
+
+
+# -- the status vocabulary: silence is never a clean floor ------------------
+#
+#   queued -> lease-waiting -> measuring -> completed/{findings,zero-findings}
+#   queued / lease-waiting -> cancelled-before-measurement
+#   measuring              -> interrupted-during-measurement
+#
+# Only completed/zero-findings may support a zero claim. Every other terminal
+# status is "no measurement", and these tests run BOTH faces of that: the one
+# status that licenses a zero claim, and each status that must not.
+
+
+def test_zero_findings_is_the_only_status_that_licenses_a_zero_claim(lease, record):
+    run_wrapper(lease, record, [sys.executable, "-c", "pass"])
+    payload = json.loads(record.read_text())
+    assert payload["measurementStatus"] == "completed/zero-findings"
+    assert payload["supportsZeroClaim"] is True
+    assert _gate("--record", str(record), "--require-zero-claim").returncode == 0
+
+
+def test_findings_do_not_license_a_zero_claim(lease, record):
+    run_wrapper(lease, record, [sys.executable, "-c", "raise SystemExit(1)"])
+    payload = json.loads(record.read_text())
+    assert payload["measurementStatus"] == "completed/findings"
+    assert payload["supportsZeroClaim"] is False
+    result = _gate("--record", str(record), "--require-zero-claim")
+    assert result.returncode == 1
+    assert "does NOT support a zero claim" in result.stdout
+
+
+def test_cancelled_before_measurement_is_distinct_from_zero_findings(lease, record):
+    """THE distinction the five suite cancellations and three floor
+    cancellations needed somebody to draw."""
+    fd = os.open(str(lease), os.O_RDWR | os.O_CREAT, 0o666)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        run_wrapper(lease, record, [sys.executable, "-c", "pass"], timeout=1)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    payload = json.loads(record.read_text())
+    assert payload["measurementStatus"] == "cancelled-before-measurement"
+    assert payload["supportsZeroClaim"] is False
+    assert _gate("--record", str(record), "--require-zero-claim").returncode == 1
+
+
+def test_signal_while_waiting_records_cancelled_before_measurement(lease, record, tmp_path):
+    """A GitHub cancellation lands while the job sits in the lease queue. That
+    run measured NOTHING, and its artifact has to say so -- not go silent."""
+    canary = tmp_path / "canary"
+    fd = os.open(str(lease), os.O_RDWR | os.O_CREAT, 0o666)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        proc = run_wrapper(
+            lease, record,
+            [sys.executable, "-c", f"open({str(canary)!r}, 'w').write('ran')"],
+            timeout=120, wait=False,
+        )
+        # Let it settle into the wait, then cancel it there.
+        time.sleep(1.0)
+        proc.send_signal(signal.SIGTERM)
+        proc.communicate(timeout=30)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    assert proc.returncode == 75
+    assert not canary.exists(), "the command ran despite never holding the lease"
+    payload = json.loads(record.read_text())
+    assert payload["measurementStatus"] == "cancelled-before-measurement"
+    assert payload["acquired"] is False
+    assert payload["supportsZeroClaim"] is False
+
+
+def test_interrupted_during_measurement_is_its_own_status(lease, record):
+    """Stopped mid-census. Partial numbers are not small numbers."""
+    proc = run_wrapper(lease, record, [sys.executable, "-c", "import time; time.sleep(30)"],
+                       wait=False)
+    _wait_until(lambda: not lease_is_free(lease), "wrapper never took the lease")
+    time.sleep(0.3)
+    proc.send_signal(signal.SIGTERM)
+    proc.communicate(timeout=30)
+    payload = json.loads(record.read_text())
+    assert payload["measurementStatus"] == "interrupted-during-measurement"
+    assert payload["acquired"] is True, "it did measure, briefly"
+    assert payload["supportsZeroClaim"] is False
+
+
+def test_status_file_tracks_the_live_phase(lease, record, tmp_path):
+    """The phase a killed process never got to update is itself testimony."""
+    status = tmp_path / "status"
+    proc = run_wrapper(lease, record, [sys.executable, "-c", "import time; time.sleep(30)"],
+                       extra=("--status-file", str(status)), wait=False)
+    _wait_until(lambda: status.exists() and status.read_text().strip() == "measuring",
+                "status file never reached `measuring`")
+    proc.kill()
+    proc.wait(timeout=30)
+    # SIGKILL: no handler ran, so the file still says what it was doing.
+    assert status.read_text().strip() == "measuring"
+
+
+# -- attendance: an absent instrument is not a clean floor ------------------
+
+
+def test_attendance_counts_a_missing_receipt_as_unmeasured(lease, record, tmp_path):
+    receipts = tmp_path / "receipts"
+    receipts.mkdir()
+    run_wrapper(lease, receipts / "python-package-suite.json", [sys.executable, "-c", "pass"])
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "heavy_measurement_attendance.py"),
+         "--commit", "421ef4157", "--receipts-dir", str(receipts)],
+        capture_output=True, text=True, timeout=60,
+    )
+    # A real receipt is present, but it belongs to no roster class -- so NOT
+    # ONE roster instrument spoke, and the roll call must say five, not zero.
+    # An artifact directory that merely contains files is not attendance.
+    assert result.returncode == 1
+    assert "R_attendance = 5" in result.stdout
+    assert "NOT a clean floor" in result.stdout
+    assert "python-sole-construction-floors" in result.stdout
+
+
+def test_attendance_is_green_when_every_instrument_reported(lease, record, tmp_path):
+    """The other face: a full roll call must be able to pass, or the check is
+    a red light nobody can turn green."""
+    from importlib import util
+    spec = util.spec_from_file_location(
+        "attendance", ROOT / "tools" / "heavy_measurement_attendance.py")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    receipts = tmp_path / "receipts"
+    receipts.mkdir()
+    for lease_class in module.HEAVY_ROSTER:
+        (receipts / f"{lease_class}.json").write_text(json.dumps({
+            "schemaVersion": 1, "leaseClass": lease_class, "acquired": True,
+            "measurementStatus": "completed/zero-findings", "supportsZeroClaim": True,
+        }))
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "heavy_measurement_attendance.py"),
+         "--commit", "421ef4157", "--receipts-dir", str(receipts)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stdout
+    assert "R_attendance = 0" in result.stdout
+
+
+# -- the gate: no timing claim without an acquired lease --------------------
+
+
+def _gate(*argv):
+    return subprocess.run([sys.executable, str(GATE), *argv],
+                          capture_output=True, text=True, timeout=60)
+
+
+def test_gate_accepts_an_acquired_lease(lease, record):
+    run_wrapper(lease, record, [sys.executable, "-c", "pass"])
+    result = _gate("--record", str(record))
+    assert result.returncode == 0, result.stdout
+    assert "R_lease = 0" in result.stdout
+
+
+def test_gate_refuses_a_lease_that_was_never_acquired(lease, record, tmp_path):
+    fd = os.open(str(lease), os.O_RDWR | os.O_CREAT, 0o666)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        run_wrapper(lease, record, [sys.executable, "-c", "pass"], timeout=1)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    result = _gate("--record", str(record))
+    assert result.returncode == 1
+    assert "lease NOT acquired" in result.stdout
+
+
+def test_gate_refuses_a_commit_mismatch(lease, record):
+    run_wrapper(lease, record, [sys.executable, "-c", "pass"])
+    assert _gate("--record", str(record), "--require-commit", "deadbeef").returncode == 1
+
+
+def test_gate_refuses_a_missing_receipt(tmp_path):
+    result = _gate("--record", str(tmp_path / "absent.json"))
+    assert result.returncode == 1
+    assert "unreadable lease receipt" in result.stdout
+
+
+def test_gate_scope_check_catches_a_per_container_lease(tmp_path):
+    """Same kernel, different inode: the lease file was never shared between
+    runner containers, so the serialization never happened. This is the check
+    that stops the mechanism from being theatre."""
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    base = {
+        "schemaVersion": 1, "acquired": True, "measuredCommit": "abc",
+        "acquiredAtUnix": 100.0, "releasedAtUnix": 200.0,
+    }
+    a.write_text(json.dumps(dict(base, leaseIdentity={"bootId": "K", "device": 1, "inode": 11})))
+    b.write_text(json.dumps(dict(base, leaseIdentity={"bootId": "K", "device": 1, "inode": 22})))
+    result = _gate("--scope-check", str(a), "--scope-check", str(b))
+    assert result.returncode == 1
+    assert "DIFFERENT inodes" in result.stdout
+
+
+def test_gate_scope_check_catches_overlapping_intervals(tmp_path):
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    identity = {"bootId": "K", "device": 1, "inode": 11}
+    a.write_text(json.dumps({"schemaVersion": 1, "acquired": True, "leaseIdentity": identity,
+                             "acquiredAtUnix": 100.0, "releasedAtUnix": 200.0}))
+    b.write_text(json.dumps({"schemaVersion": 1, "acquired": True, "leaseIdentity": identity,
+                             "acquiredAtUnix": 150.0, "releasedAtUnix": 250.0}))
+    result = _gate("--scope-check", str(a), "--scope-check", str(b))
+    assert result.returncode == 1
+    assert "OVERLAP" in result.stdout
+
+
+def test_gate_scope_check_accepts_disjoint_intervals_on_one_inode(tmp_path):
+    """The other face: correctly serialized receipts must pass, or the check
+    above is just a red light nobody can turn green."""
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    identity = {"bootId": "K", "device": 1, "inode": 11}
+    a.write_text(json.dumps({"schemaVersion": 1, "acquired": True, "leaseIdentity": identity,
+                             "acquiredAtUnix": 100.0, "releasedAtUnix": 200.0}))
+    b.write_text(json.dumps({"schemaVersion": 1, "acquired": True, "leaseIdentity": identity,
+                             "acquiredAtUnix": 200.5, "releasedAtUnix": 250.0}))
+    assert _gate("--scope-check", str(a), "--scope-check", str(b)).returncode == 0
+
+
+def _wait_until(predicate, message, timeout=30.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.05)
+    raise AssertionError(message)

--- a/tests/test_heavy_measurement_lease.py
+++ b/tests/test_heavy_measurement_lease.py
@@ -221,6 +221,67 @@ def test_receipt_embeds_into_the_measurement_artifact(lease, record, tmp_path):
     assert payload["leaseRecord"]["measuredCommit"].startswith("421ef4157")
 
 
+# -- a lease nobody else can see is not a lease -------------------------------
+
+
+def _lease_module():
+    from importlib import util
+    spec = util.spec_from_file_location("heavy_measurement_lease", WRAPPER)
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_container_private_lease_is_refused(monkeypatch, tmp_path):
+    """The defect the first live run exposed.
+
+    Two heavy jobs took /var/tmp leases on the same kernel, waited 0.0007s
+    each, and OVERLAPPED -- because battleaxe runners are containers and
+    /var/tmp is per-container. A lock nobody else can see reports `acquired`
+    while a second census runs beside it, which is worse than no lock at all.
+    """
+    module = _lease_module()
+    lease_path = tmp_path / "private.lease"
+    lease_path.touch()
+    lease = module.HeavyMeasurementLease("t", str(lease_path), 1)
+
+    monkeypatch.setattr(module.os.path, "exists", lambda p: p == "/.dockerenv")
+    same = os.stat(str(lease_path))
+    monkeypatch.setattr(module.os, "stat", lambda p: same)
+    with pytest.raises(module.LeaseNotMachineWide):
+        lease._require_machine_wide()
+
+
+def test_bind_mounted_lease_is_accepted(monkeypatch, tmp_path):
+    """The other face: a lease on a host bind mount has a different device
+    from `/`, and must pass -- or the check is a wall nobody can get through."""
+    module = _lease_module()
+    lease_path = tmp_path / "shared.lease"
+    lease_path.touch()
+    lease = module.HeavyMeasurementLease("t", str(lease_path), 1)
+
+    monkeypatch.setattr(module.os.path, "exists", lambda p: p == "/.dockerenv")
+
+    class _Stat:
+        def __init__(self, dev):
+            self.st_dev = dev
+
+    monkeypatch.setattr(module.os, "stat",
+                        lambda p: _Stat(1 if p == "/" else 2))
+    lease._require_machine_wide()  # must not raise
+
+
+def test_outside_a_container_one_filesystem_really_is_one_machine(monkeypatch, tmp_path):
+    """On a plain host, /var/tmp sharing a device with / is normal. Enforcing
+    the container rule there would refuse every honest local measurement."""
+    module = _lease_module()
+    lease_path = tmp_path / "host.lease"
+    lease_path.touch()
+    lease = module.HeavyMeasurementLease("t", str(lease_path), 1)
+    monkeypatch.setattr(module.os.path, "exists", lambda p: False)
+    lease._require_machine_wide()  # must not raise
+
+
 # -- the status vocabulary: silence is never a clean floor ------------------
 #
 #   queued -> lease-waiting -> measuring -> completed/{findings,zero-findings}

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -1,9 +1,24 @@
-"""The binding Python construction job must invoke every permanent R axis."""
+"""The binding Python construction job must invoke every permanent R axis.
+
+The axes moved out of the workflow YAML and into tools/run_sole_construction_
+floors.sh, because the whole floor set now runs inside ONE machine-wide heavy
+lease. Twenty leased steps would have let a pandas census interleave between
+two axes, and then "the complete floor set from one pinned run" would have been
+a fiction.
+
+What must not change is the property this file has always pinned: every
+permanent axis is invoked, none is silently dropped, and no axis is skipped
+because an earlier one was honestly red. The `if: always()` guarantee is now
+carried by the script's `axis` helper, which runs EVERY axis, collects the red
+ones, and fails at the end -- so the check below is that each axis goes through
+that helper, rather than that each has its own YAML step.
+"""
 
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "factory-zero-tolerance.yml"
+FLOOR_SET = ROOT / "tools" / "run_sole_construction_floors.sh"
 
 # Permanent axes with live instruments. factory_zero_tolerance and
 # construction_cache_context_law retired with the factory era (#6028).
@@ -30,20 +45,45 @@ AXIS_COMMANDS = {
 
 def test_binding_job_invokes_every_permanent_axis() -> None:
     workflow = WORKFLOW.read_text()
+    floors = FLOOR_SET.read_text()
 
     assert "python-sole-construction-floors:" in workflow
+    assert "tools/run_sole_construction_floors.sh" in workflow, (
+        "the binding job no longer runs the floor set at all"
+    )
+    # And it runs it under the lease -- an unleased floor set is a floor set
+    # measured beside whatever else the box happened to be doing.
+    assert "tools/heavy_measurement_lease.py" in workflow
+
     for axis, command in AXIS_COMMANDS.items():
-        step_start = workflow.find(f"- name: {axis}")
-        assert step_start >= 0, f"{axis} is not bound to merge CI"
-        step_end = workflow.find("\n      - name:", step_start + 1)
-        step = workflow[step_start : step_end if step_end >= 0 else None]
+        axis_start = floors.find(f'axis "{axis}"')
+        if axis_start < 0:
+            axis_start = floors.find(f"axis '{axis}'")
+        assert axis_start >= 0, f"{axis} is not bound to merge CI"
+        axis_end = floors.find("\naxis ", axis_start + 1)
+        step = floors[axis_start : axis_end if axis_end >= 0 else None]
         assert command in step, f"{axis} does not invoke {command}"
         if axis == "R_factory_walk_unclassified = 0":
             assert "--live-root" in step, (
                 "R_factory_walk_unclassified only runs a fixture/discrimination; "
                 "binding CI must census the checked-in production surface"
             )
-        if axis != "R_ownership = 0":
-            assert (
-                "if: always()" in step
-            ), f"{axis} would be skipped after an earlier honest-red axis"
+
+
+def test_no_axis_is_skipped_after_an_earlier_honest_red() -> None:
+    """What `if: always()` used to buy, now bought by the runner itself.
+
+    Every axis runs, reds are COLLECTED rather than short-circuited, and the
+    verdict comes at the end. A floor set that stopped at the first red would
+    report a smaller R than the truth.
+    """
+    floors = FLOOR_SET.read_text()
+    assert "set -uo pipefail" in floors and "set -e\n" not in floors, (
+        "the floor set must not abort on the first red axis"
+    )
+    assert "red_axes+=" in floors and "exit 1" in floors, (
+        "red axes must be collected and reported, then fail the job"
+    )
+    # Every axis in the ledger goes through the one helper. No side doors.
+    for axis in AXIS_COMMANDS:
+        assert f'axis "{axis}"' in floors or f"axis '{axis}'" in floors

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""A heavy floor that was EVICTED must not read the same as a floor that RAN.
+
+THE DEFECT THIS FIXES
+=====================
+
+Five ``python-package-suite`` runs were cancelled before they started. Three
+``Python sole-construction floors`` runs were cancelled before they started, on
+one PR, in under two minutes. Nobody noticed either, and the reason is that
+from the outside a heavy instrument that never ran is indistinguishable from
+one that ran and found nothing:
+
+    absent artifact  ==  "no failures reported"  ==  looks like a clean floor
+
+That is silence being read as testimony, and for a *floor* it is the worst
+possible confusion: R is not 0, R is UNMEASURED.
+
+This is the roll call. The roster is the set of heavy classes that must speak
+about a commit; attendance is which of them produced a lease receipt. The
+minority report -- roster minus attended -- is the set of instruments whose
+silence we would otherwise have mistaken for a clean bill.
+
+    R_attendance = |roster \\ attended|
+
+Usage::
+
+    python3 tools/heavy_measurement_attendance.py --commit "$GITHUB_SHA"
+    python3 tools/heavy_measurement_attendance.py --commit SHA --receipts-dir runs/
+
+``--receipts-dir`` believes only artifacts: a class counts as present when a
+lease receipt for it exists AND says the lease was acquired. Without a
+receipts directory the roll call falls back to ``gh run list``, which can still
+tell a *cancelled* run from a completed one -- the exact distinction the eight
+lost runs above needed somebody to draw.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# The roster. Every heavy class that runs under the machine-wide lease, keyed
+# by the `--class` name its workflow passes to tools/heavy_measurement_lease.py.
+# Adding a heavy workflow without adding it here is how an instrument goes
+# quiet unnoticed, so tests/test_heavy_measurement_concurrency_topology.py
+# checks this roster against the workflows themselves.
+HEAVY_ROSTER = {
+    "python-package-suite": "Python package suite (authoritative)",
+    "python-sole-construction-floors": "Python sole-construction floors (R>0 red)",
+    "numpy-wall": "NumPy Wall Ratchet",
+    "pandas-wall": "Pandas Wall Ratchet",
+    "restored-suite-scoreboard": "Restored Suite Scoreboard",
+}
+
+
+def receipts_attendance(receipts_dir):
+    """Which classes produced a receipt saying the lease was acquired."""
+    attended, testimony = {}, []
+    for path in sorted(Path(receipts_dir).rglob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(payload, dict) and "leaseRecord" in payload:
+            payload = payload["leaseRecord"]
+        if not isinstance(payload, dict) or "leaseClass" not in payload:
+            continue
+        lease_class = payload.get("leaseClass")
+        testimony.append((lease_class, str(path), payload.get("acquired")))
+        if payload.get("acquired") is True:
+            attended[lease_class] = str(path)
+    return attended, testimony
+
+
+def workflow_runs(commit, repo=None):
+    """Fall back to the run list. `cancelled` here is the eviction signature."""
+    argv = ["gh", "run", "list", "--commit", commit, "--limit", "100",
+            "--json", "name,status,conclusion,databaseId,workflowName"]
+    if repo:
+        argv += ["--repo", repo]
+    try:
+        completed = subprocess.run(argv, capture_output=True, text=True, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(f"heavy-measurement-attendance: `gh run list` unavailable: {exc}",
+              file=sys.stderr)
+        return None
+    try:
+        return json.loads(completed.stdout)
+    except ValueError:
+        return None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--commit", required=True, help="the commit the roll call is about")
+    parser.add_argument("--receipts-dir", default=None,
+                        help="directory of downloaded lease receipts (artifacts believed first)")
+    parser.add_argument("--repo", default=None)
+    parser.add_argument("--advisory", action="store_true",
+                        help="report the minority without failing (nightly telemetry mode)")
+    args = parser.parse_args(argv)
+
+    attended, testimony = ({}, [])
+    if args.receipts_dir:
+        attended, testimony = receipts_attendance(args.receipts_dir)
+
+    runs = workflow_runs(args.commit, args.repo) if not attended else None
+    run_state = {}
+    if runs:
+        for run in runs:
+            name = run.get("workflowName") or run.get("name")
+            for lease_class, workflow_name in HEAVY_ROSTER.items():
+                if name == workflow_name:
+                    run_state.setdefault(lease_class, []).append(
+                        f"{run.get('status')}/{run.get('conclusion')} (#{run.get('databaseId')})"
+                    )
+
+    minority = [c for c in HEAVY_ROSTER if c not in attended]
+
+    print(f"### heavy-measurement attendance for `{args.commit}`")
+    print()
+    print("| heavy class | spoke | testimony |")
+    print("| --- | --- | --- |")
+    for lease_class in HEAVY_ROSTER:
+        if lease_class in attended:
+            detail = f"receipt `{attended[lease_class]}`, lease acquired"
+            spoke = "yes"
+        else:
+            states = run_state.get(lease_class)
+            spoke = "NO"
+            if states:
+                detail = "; ".join(states) + " — no lease receipt"
+            elif runs is not None:
+                detail = "no run at all for this commit"
+            else:
+                detail = "no receipt (and no run list available)"
+        print(f"| `{lease_class}` | {spoke} | {detail} |")
+    print()
+
+    for lease_class, path, acquired in testimony:
+        if acquired is not True:
+            print(f"- `{lease_class}` produced a receipt at `{path}` with "
+                  f"`acquired={acquired}` — it REFUSED rather than measured. "
+                  f"That is honest silence, and it is still silence.")
+
+    print()
+    print(f"**R_attendance = {len(minority)}**")
+    if minority:
+        print()
+        print("These instruments did not report. Their silence is NOT a clean floor —")
+        print("R is not 0 for them, R is UNMEASURED:")
+        for lease_class in minority:
+            print(f"- `{lease_class}` ({HEAVY_ROSTER[lease_class]})")
+        return 0 if args.advisory else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/heavy_measurement_lease.py
+++ b/tools/heavy_measurement_lease.py
@@ -108,8 +108,24 @@ STATUS_INTERRUPTED_DURING = "interrupted-during-measurement"
 # The one status a zero claim may rest on.
 ZERO_CLAIM_STATUS = STATUS_COMPLETED_ZERO_FINDINGS
 
+# THE LEASE MUST LIVE ON A HOST-SHARED PATH, AND THIS ONE DOES.
+#
+# The first live run of this mechanism proved the point the hard way. Two heavy
+# jobs took the lease on /var/tmp with a wait of 0.0007s each and OVERLAPPED,
+# because battleaxe's runners are containers and /var/tmp is per-container:
+#
+#   suite  host cad95bf8f5de  bootId d257d14e...  dev/ino 1048601/1740385
+#   floors host 7d0e695e838d  bootId d257d14e...  dev/ino 1048637/2882278
+#
+# Same kernel, different inode: a lease that serialized nothing. The receipts
+# caught it on day one, which is exactly why they record bootId and dev/ino.
+#
+# `/home/runner/.cache/sugar/binaries` is bind-mounted from the SAME host
+# directory into every runner container (verified across all twelve live
+# containers), so a lock file there is one lock for the whole machine.
 DEFAULT_LEASE_PATH = os.environ.get(
-    "SUGAR_HEAVY_LEASE_PATH", "/var/tmp/sugar-heavy-measurement.lease"
+    "SUGAR_HEAVY_LEASE_PATH",
+    "/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease",
 )
 DEFAULT_TIMEOUT_SECONDS = float(
     os.environ.get("SUGAR_HEAVY_LEASE_TIMEOUT_SECONDS", "14400")
@@ -135,6 +151,16 @@ def _boot_id():
 
 def _log(message):
     print(f"heavy-measurement-lease: {message}", file=sys.stderr, flush=True)
+
+
+class LeaseNotMachineWide(Exception):
+    """The lease file is private to this container. It serializes nothing.
+
+    A lock nobody else can see is worse than no lock: it produces a receipt
+    saying `acquired` while two censuses run side by side. That is the exact
+    shape of dishonesty this mechanism exists to remove, so it is a REFUSAL,
+    not a warning.
+    """
 
 
 class LeaseTimeout(Exception):
@@ -214,6 +240,8 @@ class HeavyMeasurementLease:
         # it. This is the difference between a lease and a suggestion.
         os.set_inheritable(self.fd, True)
 
+        self._require_machine_wide()
+
         deadline = self.requested_at + self.timeout_seconds
         announced = False
         while True:
@@ -257,6 +285,36 @@ class HeavyMeasurementLease:
             f"commit={os.environ.get('GITHUB_SHA', 'unknown')} "
             f"waited={round(self.acquired_at - self.requested_at, 3)}s"
         )
+
+    def _require_machine_wide(self):
+        """Inside a container, the lease MUST be on a bind mount from the host.
+
+        The discriminator is cheap and local: if the lease file sits on the same
+        device as ``/``, it is on the container's own root filesystem and no
+        other container can see it. A bind mount from the host always has a
+        different device.
+
+        Only enforced when we can tell we are containerized, because on a plain
+        host ``/var/tmp`` sharing a device with ``/`` is normal and correct --
+        there, one filesystem really is one machine.
+        """
+        if not os.path.exists("/.dockerenv"):
+            return
+        try:
+            lease_dev = os.stat(self.lease_path).st_dev
+            root_dev = os.stat("/").st_dev
+        except OSError as exc:
+            _log(f"WARNING could not compare lease device with root device: {exc}")
+            return
+        if lease_dev == root_dev:
+            raise LeaseNotMachineWide(
+                f"{self.lease_path} is on this container's own root filesystem "
+                f"(device {lease_dev}), so no other runner container can see it. "
+                f"A lease nobody else can take is not a lease -- it would report "
+                f"`acquired` while a second census ran beside this one. Point "
+                f"SUGAR_HEAVY_LEASE_PATH at a directory bind-mounted from the "
+                f"host (on battleaxe: /home/runner/.cache/sugar/binaries)."
+            )
 
     def release(self):
         """Drop the lock and the sidecar. Idempotent; safe from a handler."""
@@ -450,8 +508,13 @@ def main(argv=None):
     # the wait.
     try:
         lease.acquire(interrupted=lambda: state["pending"] is not None)
-    except (LeaseTimeout, LeaseCancelled) as exc:
+    except (LeaseTimeout, LeaseCancelled, LeaseNotMachineWide) as exc:
         _log(str(exc))
+        if isinstance(exc, LeaseNotMachineWide):
+            _log("REFUSING to measure behind a lease that serializes nothing.")
+            lease.set_status(STATUS_CANCELLED_BEFORE)
+            lease.released_at = time.time()
+            lease.stale_owner = str(exc)
         if isinstance(exc, LeaseTimeout):
             _log("current owner testimony:\n" + (lease.stale_owner or "(none)"))
             _log(f"REFUSING to run {command!r} concurrently.")

--- a/tools/heavy_measurement_lease.py
+++ b/tools/heavy_measurement_lease.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Machine-wide heavy-measurement lease. ONE door for every heavy class.
+
+THE DEFECT THIS FIXES
+=====================
+
+GitHub ``concurrency`` was being asked to do two incompatible jobs at once:
+
+    1. preserve every requested measurement, and
+    2. ensure only one heavy measurement executes at a time.
+
+It cannot do (1). GitHub keeps exactly ONE pending run per concurrency group,
+so a third queued run EVICTS the second -- even with
+``cancel-in-progress: false``, which only protects a run that has already
+STARTED. ``python-package-suite.yml`` was starved inside its own group by our
+own merge rate: five runs (dea47f1f8, e0a78ec52, d243fcacf, 6d9db3a8f,
+f0cddfd76) cancelled, zero artifacts. A single shared group across the heavy
+classes does not fix this; it makes it worse, because then every heavy class
+competes for the one pending slot.
+
+So the two jobs are split, and this program is half two::
+
+    GitHub queue: preserve every requested measurement   (no concurrency group)
+    BX lease:     ensure only one heavy measurement runs (this program)
+
+Every heavy class -- the authoritative package suite, the sole-construction
+corpus floors, the pandas/NumPy censuses, the restored-suite sweep -- wraps its
+measured command here. Overlapping GitHub runs all START and all survive; only
+one is ever inside the measured section.
+
+WHY A FILE LOCK, AND WHY NOT ``flock(1)``
+=========================================
+
+``fcntl.flock`` IS ``flock(2)`` -- the identical kernel lock the ``flock(1)``
+utility takes, on the identical file, fully interoperable with it. What the
+Python form buys is that the lease has ONE implementation on every platform we
+develop on: ``flock(1)`` is util-linux and absent on macOS, so a shell wrapper
+around it would have been a mechanism whose release paths could only ever be
+exercised on the runner that must not deadlock. The teeth in
+``tests/test_heavy_measurement_lease.py`` run everywhere because of this
+choice.
+
+The lock lives on an open file descriptor. The KERNEL releases it when that
+descriptor closes: on success, on failure, on timeout, on SIGINT/SIGTERM/SIGHUP,
+and on SIGKILL, which no handler can catch. A leaked lease deadlocks all heavy
+work on the box, so release must not depend on our own bookkeeping running. The
+handlers below exist to write the RECEIPT and to propagate the signal; they are
+not what frees the lock.
+
+NEVER "RECOVER" BY RUNNING CONCURRENTLY
+=======================================
+
+If the lease cannot be taken within ``--timeout``, this program prints
+stale-owner diagnostics and exits 75 (EX_TEMPFAIL) WITHOUT running the command.
+A timing number taken beside another census is not a slower number; it is not a
+measurement. Refusing is the honest outcome, and the receipt says so in a field
+``tools/heavy_measurement_lease_gate.py`` can read.
+
+Usage::
+
+    python3 tools/heavy_measurement_lease.py \\
+        --class python-package-suite \\
+        --record "$GITHUB_WORKSPACE/lease-record.json" \\
+        [--embed-into suite-report.json] [--timeout 14400] \\
+        [--lease /var/tmp/sugar-heavy-measurement.lease] \\
+        -- <command> [args...]
+
+Exit status: the command's own status, or 75 if the lease was never acquired.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import fcntl
+import os
+import signal
+import subprocess
+import sys
+import time
+
+EX_USAGE = 64
+EX_TEMPFAIL = 75
+
+# THE STATUS VOCABULARY
+#
+#   queued -> lease-waiting -> measuring -> completed
+#                                             |- findings
+#                                             \- zero-findings
+#   queued / lease-waiting -> cancelled-before-measurement
+#   measuring              -> interrupted-during-measurement
+#
+# ONLY `completed/zero-findings` MAY SUPPORT A ZERO CLAIM.
+#
+# Five package-suite runs and three sole-construction-floor runs were lost
+# because "cancelled before it started" and "ran and found nothing" are the
+# same silence from outside. They are not the same fact: one is R = 0, the
+# other is R UNMEASURED. This vocabulary is what makes them different objects
+# in the artifact, so no reader and no gate can confuse them again.
+STATUS_QUEUED = "queued"
+STATUS_LEASE_WAITING = "lease-waiting"
+STATUS_MEASURING = "measuring"
+STATUS_COMPLETED_FINDINGS = "completed/findings"
+STATUS_COMPLETED_ZERO_FINDINGS = "completed/zero-findings"
+STATUS_CANCELLED_BEFORE = "cancelled-before-measurement"
+STATUS_INTERRUPTED_DURING = "interrupted-during-measurement"
+
+# The one status a zero claim may rest on.
+ZERO_CLAIM_STATUS = STATUS_COMPLETED_ZERO_FINDINGS
+
+DEFAULT_LEASE_PATH = os.environ.get(
+    "SUGAR_HEAVY_LEASE_PATH", "/var/tmp/sugar-heavy-measurement.lease"
+)
+DEFAULT_TIMEOUT_SECONDS = float(
+    os.environ.get("SUGAR_HEAVY_LEASE_TIMEOUT_SECONDS", "14400")
+)
+# Poll interval while waiting. LOCK_EX|LOCK_NB in a loop rather than a blocking
+# LOCK_EX so the wait is interruptible, bounded, and reports progress -- a
+# blocking acquire that is still blocking at the job timeout leaves no receipt.
+POLL_SECONDS = 2.0
+
+
+def _boot_id():
+    """The kernel's identity -- shared by every container on this machine.
+
+    Container hostnames are per-container, so hostname cannot tell us whether
+    two runners are the same machine. ``boot_id`` can.
+    """
+    try:
+        with open("/proc/sys/kernel/random/boot_id", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except OSError:
+        return "unavailable"
+
+
+def _log(message):
+    print(f"heavy-measurement-lease: {message}", file=sys.stderr, flush=True)
+
+
+class LeaseTimeout(Exception):
+    """The lease was not acquired. The command must not run."""
+
+
+class LeaseCancelled(Exception):
+    """A stop signal arrived while still waiting. No measurement happened.
+
+    This is the eviction case made visible: the run was told to stop before it
+    ever entered the measured section, so its artifact must say
+    `cancelled-before-measurement` and can support no claim at all.
+    """
+
+
+class HeavyMeasurementLease:
+    """Holds the machine-wide lease for the duration of one measured command."""
+
+    def __init__(self, lease_class, lease_path, timeout_seconds, status_file=None):
+        self.lease_class = lease_class
+        self.status_file = status_file
+        self.status = STATUS_QUEUED
+        self.lease_path = lease_path
+        self.timeout_seconds = timeout_seconds
+        self.owner_path = lease_path + ".owner"
+        self.boot_id = _boot_id()
+        self.fd = None
+        self.acquired = False
+        self.timed_out = False
+        self.requested_at = None
+        self.acquired_at = None
+        self.released_at = None
+        self.stale_owner = None
+
+    # -- status -------------------------------------------------------------
+
+    def set_status(self, status):
+        """Advance the status and write it out immediately.
+
+        Written eagerly, not at the end: a run killed mid-wait leaves a file
+        saying `lease-waiting`, and a run killed mid-census leaves one saying
+        `measuring`. The status a process never got to update is itself the
+        testimony about how it died.
+        """
+        self.status = status
+        _log(f"status={status}")
+        if not self.status_file:
+            return
+        try:
+            os.makedirs(os.path.dirname(os.path.abspath(self.status_file)) or ".",
+                        exist_ok=True)
+            with open(self.status_file, "w", encoding="utf-8") as handle:
+                handle.write(status + "\n")
+        except OSError as exc:
+            _log(f"WARNING could not write status file: {exc}")
+
+    # -- acquisition --------------------------------------------------------
+
+    def acquire(self, interrupted=None):
+        os.makedirs(os.path.dirname(self.lease_path) or ".", exist_ok=True)
+        self.requested_at = time.time()
+        self.set_status(STATUS_LEASE_WAITING)
+        _log(
+            f"requesting class={self.lease_class} lease={self.lease_path} "
+            f"run={os.environ.get('GITHUB_RUN_ID', 'local')} "
+            f"commit={os.environ.get('GITHUB_SHA', 'unknown')}"
+        )
+        # O_CREAT, never O_TRUNC: truncating the lease file is harmless to the
+        # lock but would race with a holder's own descriptor for no gain.
+        self.fd = os.open(self.lease_path, os.O_RDWR | os.O_CREAT, 0o666)
+        # INHERITABLE ON PURPOSE. flock is held by the open file DESCRIPTION,
+        # so a child that inherits this descriptor holds the same lease, and
+        # the kernel frees it only when the last holder closes. That closes the
+        # orphan hole: SIGKILL the wrapper and the measured census keeps
+        # running -- with the fd non-inheritable it would keep running with the
+        # lease already released, and the next heavy job would start on top of
+        # it. This is the difference between a lease and a suggestion.
+        os.set_inheritable(self.fd, True)
+
+        deadline = self.requested_at + self.timeout_seconds
+        announced = False
+        while True:
+            try:
+                fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+            if not announced:
+                announced = True
+                _log(
+                    f"waiting for the lease; current owner testimony:\n"
+                    f"{self._read_owner()}"
+                )
+            if interrupted is not None and interrupted():
+                # Told to stop while still in the queue. Never measured.
+                self.released_at = time.time()
+                self.set_status(STATUS_CANCELLED_BEFORE)
+                raise LeaseCancelled(
+                    "stop signal received while waiting for the lease; "
+                    "no measurement was taken"
+                )
+            if time.time() >= deadline:
+                self.timed_out = True
+                self.stale_owner = self._read_owner()
+                self.released_at = time.time()
+                self.set_status(STATUS_CANCELLED_BEFORE)
+                raise LeaseTimeout(
+                    f"TIMEOUT after {self.timeout_seconds}s waiting for "
+                    f"{self.lease_path}"
+                )
+            time.sleep(min(POLL_SECONDS, max(0.0, deadline - time.time())))
+
+        self.acquired = True
+        self.acquired_at = time.time()
+        self._write_owner()
+        _log(
+            f"acquired class={self.lease_class} "
+            f"run={os.environ.get('GITHUB_RUN_ID', 'local')} "
+            f"commit={os.environ.get('GITHUB_SHA', 'unknown')} "
+            f"waited={round(self.acquired_at - self.requested_at, 3)}s"
+        )
+
+    def release(self):
+        """Drop the lock and the sidecar. Idempotent; safe from a handler."""
+        if self.released_at is None:
+            self.released_at = time.time()
+        if self.acquired:
+            try:
+                os.unlink(self.owner_path)
+            except OSError:
+                pass
+        if self.fd is not None:
+            try:
+                # Explicit LOCK_UN before close: close() already releases, but
+                # the explicit unlock keeps the release observable in strace
+                # and does not depend on refcount subtleties around forks.
+                fcntl.flock(self.fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+            self.fd = None
+        _log(
+            f"released class={self.lease_class} "
+            f"run={os.environ.get('GITHUB_RUN_ID', 'local')}"
+        )
+
+    # -- owner sidecar (diagnostics only; never authority) -------------------
+
+    def _write_owner(self):
+        lines = [
+            f"class={self.lease_class}",
+            f"pid={os.getpid()}",
+            f"bootId={self.boot_id}",
+            f"acquiredAtUnix={self.acquired_at!r}",
+            f"githubRunId={os.environ.get('GITHUB_RUN_ID', 'local')}",
+            f"githubRunAttempt={os.environ.get('GITHUB_RUN_ATTEMPT', '')}",
+            f"githubWorkflow={os.environ.get('GITHUB_WORKFLOW', '')}",
+            f"githubJob={os.environ.get('GITHUB_JOB', '')}",
+            f"measuredCommit={os.environ.get('GITHUB_SHA', 'unknown')}",
+        ]
+        try:
+            with open(self.owner_path, "w", encoding="utf-8") as handle:
+                handle.write("\n".join(lines) + "\n")
+        except OSError as exc:
+            _log(f"WARNING could not write owner sidecar: {exc}")
+
+    def _read_owner(self):
+        """Stale-owner diagnostics. Loud -- and still never a licence to run."""
+        try:
+            with open(self.owner_path, encoding="utf-8") as handle:
+                text = handle.read().strip()
+        except OSError as exc:
+            return (
+                f"no readable owner sidecar at {self.owner_path} ({exc}). Either the "
+                f"holder died before writing it, or -- the case worth checking -- "
+                f"the lease path is not shared with the holder's container, in "
+                f"which case the serialization is not happening at all."
+            )
+        pid_alive = None
+        for line in text.splitlines():
+            if line.startswith("pid="):
+                try:
+                    os.kill(int(line[4:]), 0)
+                    pid_alive = True
+                except (ValueError, ProcessLookupError):
+                    pid_alive = False
+                except PermissionError:
+                    pid_alive = True
+                except OSError:
+                    pid_alive = None
+        age = None
+        try:
+            age = round(time.time() - os.stat(self.owner_path).st_mtime, 3)
+        except OSError:
+            pass
+        return (
+            f"{text}\nownerSidecarAgeSeconds={age}\nownerPidVisibleAndAlive={pid_alive} "
+            f"(a False here means the holder is gone from THIS namespace, which "
+            f"across containers proves nothing -- the lock, not the pid, is the "
+            f"authority)"
+        )
+
+    # -- receipt ------------------------------------------------------------
+
+    def record_environment(self, command, command_exit):
+        """The ``LEASE_*`` inputs to tools/heavy_measurement_lease_record.py."""
+        return {
+            "LEASE_CLASS": self.lease_class,
+            "LEASE_PATH": self.lease_path,
+            "LEASE_BOOT_ID": self.boot_id,
+            "LEASE_TIMEOUT_SECONDS": str(int(self.timeout_seconds)),
+            "LEASE_REQUESTED_AT": repr(self.requested_at) if self.requested_at else "",
+            "LEASE_ACQUIRED_AT": repr(self.acquired_at) if self.acquired_at else "",
+            "LEASE_RELEASED_AT": repr(self.released_at) if self.released_at else "",
+            "LEASE_ACQUIRED": "true" if self.acquired else "false",
+            "LEASE_TIMED_OUT": "true" if self.timed_out else "false",
+            "LEASE_COMMAND": " ".join(command),
+            "LEASE_COMMAND_EXIT": "" if command_exit is None else str(command_exit),
+            "LEASE_HOLDER_PID": str(os.getpid()),
+            "LEASE_STALE_OWNER": self.stale_owner or "",
+            "LEASE_STATUS": self.status,
+            "LEASE_ZERO_CLAIM_STATUS": ZERO_CLAIM_STATUS,
+        }
+
+
+def write_receipt(lease, command, command_exit, record_path, embed_into):
+    """Write the receipt on EVERY exit path. A measurement with no receipt is
+    a timing claim with no provenance, which the gate refuses anyway."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    recorder = os.path.join(repo_root, "tools", "heavy_measurement_lease_record.py")
+    argv = [sys.executable, recorder, "--output", record_path]
+    for path in embed_into:
+        argv += ["--embed-into", path]
+    env = dict(os.environ)
+    env.update(lease.record_environment(command, command_exit))
+    try:
+        subprocess.run(argv, env=env, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        _log(f"WARNING failed to write receipt {record_path}: {exc}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Serialize one heavy measurement behind the machine-wide lease."
+    )
+    parser.add_argument("--class", dest="lease_class", required=True,
+                        help="heavy class name, recorded in the receipt")
+    parser.add_argument("--record", required=True,
+                        help="where to write the lease receipt (not optional)")
+    parser.add_argument("--embed-into", action="append", default=[],
+                        help="artifact JSON to splice the receipt into as leaseRecord")
+    parser.add_argument("--lease", default=DEFAULT_LEASE_PATH,
+                        help=f"lease file (default {DEFAULT_LEASE_PATH})")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS,
+                        help="seconds to wait before REFUSING (never proceeding)")
+    parser.add_argument("--status-file", default=None,
+                        help="path kept current with the measurement status, so a "
+                             "killed run still says which phase it died in")
+    parser.add_argument("--zero-findings-exit", type=int, default=0,
+                        help="command exit status that means 'ran, found nothing'. "
+                             "Any other status is completed/findings; only "
+                             "completed/zero-findings may support a zero claim.")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        print("heavy-measurement-lease: no command given after --", file=sys.stderr)
+        return EX_USAGE
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.record)) or ".", exist_ok=True)
+
+    lease = HeavyMeasurementLease(args.lease_class, args.lease, args.timeout,
+                                  status_file=args.status_file)
+
+    command_exit = None
+    state = {"child": None, "pending": None}
+
+    def _forward(signum, _frame):
+        # The child is in our process group, so an interactive ^C already
+        # reached it; this covers a signal delivered to us alone. Then fall
+        # through to the finally: below, which releases and writes the receipt.
+        #
+        # `pending` closes a race with teeth: a SIGTERM landing between the
+        # acquisition and the spawn used to be SWALLOWED, leaving a wrapper
+        # holding the lease and running a heavy census that the signal was
+        # sent to stop. Remembered here, delivered as soon as there is a child.
+        state["pending"] = signum
+        child = state["child"]
+        if child is not None and child.poll() is None:
+            try:
+                child.send_signal(signum)
+            except OSError:
+                pass
+
+    previous = {}
+    for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        try:
+            previous[signum] = signal.signal(signum, _forward)
+        except (ValueError, OSError):  # pragma: no cover - non-main thread
+            pass
+
+    # Handlers are installed BEFORE the acquire, on purpose. A GitHub
+    # cancellation arriving while this job sits in the lease queue must be
+    # recorded as `cancelled-before-measurement` -- that is the eviction case
+    # this whole change exists to make visible, and it happens precisely during
+    # the wait.
+    try:
+        lease.acquire(interrupted=lambda: state["pending"] is not None)
+    except (LeaseTimeout, LeaseCancelled) as exc:
+        _log(str(exc))
+        if isinstance(exc, LeaseTimeout):
+            _log("current owner testimony:\n" + (lease.stale_owner or "(none)"))
+            _log(f"REFUSING to run {command!r} concurrently.")
+            _log("a timing number measured beside another census is not a slow "
+                 "measurement, it is not a measurement.")
+        _log(f"status={lease.status}: this run supports NO claim. Not zero. None.")
+        lease.release()
+        write_receipt(lease, command, None, args.record, args.embed_into)
+        return EX_TEMPFAIL
+
+    try:
+        lease.set_status(STATUS_MEASURING)
+        # pass_fds keeps the lease descriptor open across the fork/exec, so the
+        # measurement itself is a lease holder for as long as it lives.
+        child = subprocess.Popen(command, pass_fds=(lease.fd,))
+        state["child"] = child
+        if state["pending"] is not None and child.poll() is None:
+            # A stop signal arrived while we were still spawning. Honour it now
+            # rather than measuring for three hours after being told to stop.
+            child.send_signal(state["pending"])
+        command_exit = child.wait()
+    except KeyboardInterrupt:
+        command_exit = 130
+    except OSError as exc:
+        _log(f"could not execute {command!r}: {exc}")
+        command_exit = EX_USAGE
+    finally:
+        for signum, handler in previous.items():
+            try:
+                signal.signal(signum, handler)
+            except (ValueError, OSError):  # pragma: no cover
+                pass
+        # The verdict on what this run may be used to claim.
+        if state["pending"] is not None:
+            # Stopped mid-census. Partial numbers are not small numbers.
+            lease.set_status(STATUS_INTERRUPTED_DURING)
+        elif command_exit == args.zero_findings_exit:
+            lease.set_status(STATUS_COMPLETED_ZERO_FINDINGS)
+        else:
+            lease.set_status(STATUS_COMPLETED_FINDINGS)
+        lease.release()
+        write_receipt(lease, command, command_exit, args.record, args.embed_into)
+
+    return command_exit if command_exit is not None else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/heavy_measurement_lease_gate.py
+++ b/tools/heavy_measurement_lease_gate.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""No timing claim is accepted if the lease was not acquired.
+
+That sentence is a rule, and a rule nobody can run is a comment. This is the
+executable form: point it at a lease receipt (or at a suite report that embeds
+one as ``leaseRecord``) and it exits non-zero unless the measured section was
+actually entered under the machine-wide lease.
+
+Two modes:
+
+``--record PATH`` (default)
+    One measurement. Red if the receipt is missing, if ``acquired`` is not
+    true, if the receipt carries no acquisition/release interval, or if the
+    receipt's commit disagrees with ``--require-commit``. Green prints the
+    interval so the run summary carries it.
+
+``--scope-check PATH [PATH ...]``
+    Several receipts at once. A lease is machine-wide only if every holder on
+    the same kernel locked the same inode; receipts sharing ``bootId`` while
+    differing in ``device``/``inode`` prove the lease file was NOT shared
+    between runner containers and the serialization never happened. Also red
+    if two acquisition intervals on the same kernel OVERLAP -- the direct
+    observation that two heavy measurements ran at once.
+
+Exit 0 green, 1 red, 2 usage/IO.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+SUPPORTED_SCHEMA_VERSIONS = (1,)
+
+
+def load_record(path):
+    """Accept either a bare lease receipt or an artifact that embeds one."""
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if isinstance(payload, dict) and "leaseRecord" in payload:
+        payload = payload["leaseRecord"]
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: not a lease receipt object")
+    return payload
+
+
+def check_record(record, path, require_commit=None, require_zero_claim=False):
+    """Return the list of violations. Empty list means green."""
+    violations = []
+
+    version = record.get("schemaVersion")
+    if version not in SUPPORTED_SCHEMA_VERSIONS:
+        violations.append(
+            f"{path}: unsupported lease receipt schemaVersion {version!r}; "
+            f"expected one of {SUPPORTED_SCHEMA_VERSIONS}"
+        )
+        return violations
+
+    if record.get("acquired") is not True:
+        violations.append(
+            f"{path}: lease NOT acquired (acquired={record.get('acquired')!r}, "
+            f"timedOut={record.get('timedOut')!r}). No timing claim from this run "
+            f"is a measurement. Stale-owner testimony: "
+            f"{record.get('staleOwnerDiagnostics')!r}"
+        )
+
+    for field in ("requestedAtUnix", "acquiredAtUnix", "releasedAtUnix"):
+        if not isinstance(record.get(field), (int, float)):
+            violations.append(
+                f"{path}: {field} is {record.get(field)!r}, not a timestamp; the "
+                f"lease interval is unreadable, so the measurement is unattributable"
+            )
+
+    for field in ("waitSeconds", "heldSeconds"):
+        if not isinstance(record.get(field), (int, float)):
+            violations.append(f"{path}: {field} is {record.get(field)!r}, not a duration")
+
+    status = record.get("measurementStatus")
+    if not status or status == "unknown":
+        violations.append(f"{path}: measurementStatus is {status!r}; the run will not "
+                          f"say whether it measured anything")
+    if require_zero_claim:
+        # The whole point of the vocabulary. Cancelled, interrupted, refused and
+        # absent are all "no measurement" -- and a zero claim resting on any of
+        # them is the five-lost-suite-runs defect wearing a green tick.
+        if record.get("supportsZeroClaim") is not True:
+            violations.append(
+                f"{path}: measurementStatus={status!r} does NOT support a zero "
+                f"claim (only {record.get('zeroClaimStatus')!r} does). This run "
+                f"did not measure zero; it did not measure."
+            )
+
+    owner = record.get("owner") or {}
+    if not owner.get("githubRunId"):
+        violations.append(f"{path}: owner.githubRunId absent; the lease has no owner of record")
+
+    commit = record.get("measuredCommit")
+    if not commit or commit == "unknown":
+        violations.append(f"{path}: measuredCommit is {commit!r}; the artifact names no commit")
+    elif require_commit and commit != require_commit:
+        violations.append(
+            f"{path}: measuredCommit {commit} != required {require_commit}; this "
+            f"receipt belongs to a different commit than the artifact claims"
+        )
+
+    return violations
+
+
+def check_scope(records):
+    """Cross-receipt teeth: same kernel must mean same lock, and no overlap."""
+    violations = []
+    by_boot = {}
+    for path, record in records:
+        identity = record.get("leaseIdentity") or {}
+        boot = identity.get("bootId")
+        if not boot or boot == "unavailable":
+            violations.append(
+                f"{path}: leaseIdentity.bootId is {boot!r}; without the kernel's "
+                f"identity we cannot tell a machine-wide lease from a per-container one"
+            )
+            continue
+        by_boot.setdefault(boot, []).append((path, record, identity))
+
+    for boot, entries in by_boot.items():
+        inodes = {(i.get("device"), i.get("inode")) for _, _, i in entries}
+        if len(inodes) > 1:
+            detail = ", ".join(
+                f"{p}=dev{i.get('device')}/ino{i.get('inode')}" for p, _, i in entries
+            )
+            violations.append(
+                f"bootId {boot}: receipts locked DIFFERENT inodes ({detail}). The "
+                f"lease path is not shared between runner containers, so the lease "
+                f"is per-container theatre and heavy measurements can overlap."
+            )
+
+        intervals = []
+        for path, record, _ in entries:
+            start, end = record.get("acquiredAtUnix"), record.get("releasedAtUnix")
+            if record.get("acquired") is True and isinstance(start, (int, float)) \
+                    and isinstance(end, (int, float)):
+                intervals.append((start, end, path))
+        intervals.sort()
+        for (a_start, a_end, a_path), (b_start, b_end, b_path) in zip(intervals, intervals[1:]):
+            if b_start < a_end:
+                violations.append(
+                    f"bootId {boot}: lease intervals OVERLAP -- {a_path} held "
+                    f"[{a_start}, {a_end}] while {b_path} held [{b_start}, {b_end}]. "
+                    f"Two heavy measurements executed at once."
+                )
+    return violations
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--record", action="append", default=[],
+                        help="lease receipt, or an artifact embedding one as leaseRecord")
+    parser.add_argument("--require-commit", default=None,
+                        help="the commit the artifact claims to measure")
+    parser.add_argument("--require-zero-claim", action="store_true",
+                        help="red unless the run reached completed/zero-findings; "
+                             "use wherever an R=0 claim is being made")
+    parser.add_argument("--scope-check", action="append", default=[],
+                        help="receipts to compare for shared-inode and non-overlap")
+    args = parser.parse_args(argv)
+
+    if not args.record and not args.scope_check:
+        parser.error("give --record and/or --scope-check")
+
+    violations = []
+    loaded = []
+    for path in list(args.record) + list(args.scope_check):
+        try:
+            loaded.append((path, load_record(path)))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            violations.append(f"{path}: unreadable lease receipt: {type(exc).__name__}: {exc}")
+
+    by_path = dict(loaded)
+    for path in args.record:
+        if path in by_path:
+            violations.extend(check_record(by_path[path], path, args.require_commit,
+                                           args.require_zero_claim))
+
+    scope_records = [(p, by_path[p]) for p in args.scope_check if p in by_path]
+    if scope_records:
+        violations.extend(check_scope(scope_records))
+
+    print("### heavy-measurement lease gate")
+    print()
+    for path in args.record:
+        record = by_path.get(path)
+        if not record:
+            continue
+        print(
+            f"- `{path}`: class `{record.get('leaseClass')}` "
+            f"commit `{record.get('measuredCommit')}` "
+            f"run `{(record.get('owner') or {}).get('githubRunId')}` "
+            f"acquired `{record.get('acquired')}` "
+            f"status `{record.get('measurementStatus')}` "
+            f"supportsZeroClaim `{record.get('supportsZeroClaim')}` "
+            f"waited `{record.get('waitSeconds')}s` held `{record.get('heldSeconds')}s`"
+        )
+    print()
+
+    if violations:
+        print(f"**R_lease = {len(violations)} — measurement REFUSED**")
+        print()
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print("**R_lease = 0** — every timing claim here was made under an acquired lease.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/heavy_measurement_lease_record.py
+++ b/tools/heavy_measurement_lease_record.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Write the heavy-measurement lease receipt.
+
+Called by ``tools/heavy_measurement_lease.sh`` on every exit path -- success,
+failure, timeout, signal. The shell passes fields through ``LEASE_*``
+environment variables; this module owns their TYPES, so no timing number is
+ever a string that happens to look like one.
+
+The receipt is the evidence behind every heavy timing claim in this repo. It
+answers, for one measurement:
+
+    who asked (owner), when (request), when it started (acquisition), how long
+    it waited, when it let go (release), what commit it measured, and -- the
+    load-bearing bit -- whether the lease was ACQUIRED AT ALL.
+
+``acquired: false`` means the measured section was never entered. Any timing
+read off a run whose receipt says that is not a measurement. See
+``tools/heavy_measurement_lease_gate.py``, which gives that sentence teeth.
+
+Field names mirror ``tools/python_package_suite_report.py`` (camelCase, unix
+seconds, node-ID-style explicitness) because this receipt EMBEDS in that
+artifact as ``leaseRecord`` rather than starting a second schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import sys
+
+SCHEMA_VERSION = 1
+
+
+def _float(name):
+    raw = os.environ.get(name, "")
+    if raw == "":
+        return None
+    try:
+        return round(float(raw), 6)
+    except ValueError:
+        # Loud, never silent: an unparseable timestamp is testimony too.
+        return {"unparseable": raw}
+
+
+def _int(name):
+    raw = os.environ.get(name, "")
+    if raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return {"unparseable": raw}
+
+
+def _text(name):
+    raw = os.environ.get(name, "")
+    return raw if raw != "" else None
+
+
+def _bool(name):
+    return os.environ.get(name, "") == "true"
+
+
+def _lease_identity(lease_path):
+    """Device+inode of the lease file, beside the kernel's boot id.
+
+    A lease is machine-wide only if every runner container on this kernel locks
+    the SAME inode. Two receipts sharing ``bootId`` but differing in
+    ``device``/``inode`` prove the lease path was not shared and the
+    serialization never happened -- a fact we would rather read off artifacts
+    than assume from a bind-mount we cannot see from inside the container.
+    """
+    identity = {
+        "path": lease_path,
+        "bootId": _text("LEASE_BOOT_ID"),
+        "hostname": platform.node(),
+        "device": None,
+        "inode": None,
+    }
+    if lease_path:
+        try:
+            stat = os.stat(lease_path)
+            identity["device"] = stat.st_dev
+            identity["inode"] = stat.st_ino
+        except OSError as exc:
+            identity["unavailable"] = f"{type(exc).__name__}: {exc}"
+    return identity
+
+
+def build_record():
+    requested = _float("LEASE_REQUESTED_AT")
+    acquired_at = _float("LEASE_ACQUIRED_AT")
+    released_at = _float("LEASE_RELEASED_AT")
+    acquired = _bool("LEASE_ACQUIRED")
+
+    def _span(start, end):
+        if isinstance(start, float) and isinstance(end, float):
+            return round(end - start, 6)
+        return None
+
+    status = _text("LEASE_STATUS") or "unknown"
+    zero_claim_status = _text("LEASE_ZERO_CLAIM_STATUS") or "completed/zero-findings"
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "leaseClass": _text("LEASE_CLASS"),
+        # THE STATUS VOCABULARY.
+        #
+        #   queued -> lease-waiting -> measuring -> completed/{findings,
+        #                                                      zero-findings}
+        #   queued / lease-waiting -> cancelled-before-measurement
+        #   measuring              -> interrupted-during-measurement
+        #
+        # `supportsZeroClaim` is the single field a reader has to look at, and
+        # it is true for exactly ONE status. An absent artifact, a cancelled
+        # run, and an interrupted census are all "no measurement" -- never
+        # green, never a floor at zero.
+        "measurementStatus": status,
+        "supportsZeroClaim": status == zero_claim_status,
+        "zeroClaimStatus": zero_claim_status,
+        "leaseIdentity": _lease_identity(os.environ.get("LEASE_PATH", "")),
+        # THE gate field. False means the measured section was never entered.
+        "acquired": acquired,
+        "timedOut": _bool("LEASE_TIMED_OUT"),
+        "timeoutSeconds": _int("LEASE_TIMEOUT_SECONDS"),
+        "requestedAtUnix": requested,
+        "acquiredAtUnix": acquired_at,
+        "releasedAtUnix": released_at,
+        "waitSeconds": _span(requested, acquired_at),
+        "heldSeconds": _span(acquired_at, released_at),
+        "measuredCommit": os.environ.get("GITHUB_SHA") or "unknown",
+        "owner": {
+            "githubRunId": os.environ.get("GITHUB_RUN_ID"),
+            "githubRunAttempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+            "githubWorkflow": os.environ.get("GITHUB_WORKFLOW"),
+            "githubJob": os.environ.get("GITHUB_JOB"),
+            "githubRef": os.environ.get("GITHUB_REF"),
+            "runnerName": os.environ.get("RUNNER_NAME"),
+            "holderPid": _int("LEASE_HOLDER_PID"),
+        },
+        "command": _text("LEASE_COMMAND"),
+        "commandExitStatus": _int("LEASE_COMMAND_EXIT"),
+        # Present only when the lease could not be taken. Diagnostics, never a
+        # licence to proceed: the wrapper refuses rather than running beside
+        # the holder.
+        "staleOwnerDiagnostics": _text("LEASE_STALE_OWNER"),
+    }
+
+
+def embed_into(record, path):
+    """Splice the receipt into an existing artifact as ``leaseRecord``.
+
+    This is why there is no second schema: the authoritative suite report keeps
+    owning the measurement, and the lease interval rides inside it, so a reader
+    holding one artifact never has to go find a second file to learn whether
+    the numbers in front of them were taken under the lease.
+
+    Called from the release path, after the measured command has written its
+    artifact. A missing target is loud on stderr and not fatal: the standalone
+    receipt at ``--output`` is the primary evidence and is already written.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError) as exc:
+        print(
+            f"heavy-measurement-lease: cannot embed receipt into {path}: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+    if not isinstance(payload, dict):
+        print(
+            f"heavy-measurement-lease: cannot embed receipt into {path}: "
+            f"top level is {type(payload).__name__}, not an object",
+            file=sys.stderr,
+        )
+        return False
+    payload["leaseRecord"] = record
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+    return True
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--embed-into",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="also splice this receipt into PATH's JSON object as `leaseRecord`",
+    )
+    args = parser.parse_args(argv)
+
+    record = build_record()
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(record, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+    for path in args.embed_into:
+        embed_into(record, path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# The complete Python sole-construction floor set, as ONE measured section.
+#
+# WHY THIS IS A SCRIPT AND NOT TWENTY WORKFLOW STEPS
+#
+# It used to be twenty steps, each `if: always()`, so that one red axis never
+# hid the others: the complete floor set always comes from one pinned run.
+# Putting those twenty steps behind the machine-wide heavy lease one at a time
+# would have taken and released the lease twenty times, letting a pandas census
+# interleave between axes -- and then the "one pinned run" property would be a
+# fiction. One lease, one pass over every axis, one verdict.
+#
+# `if: always()` semantics are preserved here, not abandoned: EVERY axis runs,
+# failures are collected rather than short-circuited, and the script exits
+# non-zero at the end if any axis was red. R > 0 ⇒ CI red, on every axis, and
+# silence on an axis is never mistaken for zero.
+#
+# Usage: tools/run_sole_construction_floors.sh   (from the repo root)
+
+set -uo pipefail
+
+TESTS=implementations/python/sugar-lift-py-tests
+SCRIPTS="$TESTS/scripts"
+
+red_axes=()
+green_axes=()
+
+axis() {
+  local name="$1"; shift
+  echo "::group::$name"
+  if "$@"; then
+    green_axes+=("$name")
+    echo "$name: GREEN"
+  else
+    local status=$?
+    red_axes+=("$name (exit $status)")
+    echo "::error::$name is RED (exit $status)"
+  fi
+  echo "::endgroup::"
+}
+
+# Permanent floors — baseline-free. R > 0 ⇒ CI red on every axis.
+# See docs/contributing/python-sole-construction.md
+# factory_zero_tolerance.py retired with factory/ (#6028): no dual construction
+# door left to measure. Ownership + construction-panic catch remain permanent.
+axis "R_ownership = 0" python "$SCRIPTS/factory_ownership_law.py"
+axis "R_construction_panic_catches_outside_membrane = 0" \
+  python "$SCRIPTS/construction_panic_catch_law.py"
+
+# Heavy supervised enum floors — sequential, inside the one lease interval.
+axis "R_native_crashes = 0" python "$SCRIPTS/native_crash_zero_tolerance.py"
+axis "R_bare_exceptions = 0" python "$SCRIPTS/bare_exception_zero_tolerance.py"
+axis "R_timeouts = 0" python "$SCRIPTS/timeout_zero_tolerance.py"
+
+axis "All permanent axes are bound" \
+  python -m pytest tests/test_python_sole_construction_ci.py -q
+axis '`sugar-lift-py-tests[test]` is the sole dependency authority' \
+  python -m pytest tests/test_test_extras_are_the_dependency_authority.py -q
+
+# Each law below ships with its discrimination arm: a law whose bad twin also
+# passes is not measuring anything.
+axis "R_vendor_special_case discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_vendor_special_case_law.py" -q
+axis "R_vendor_special_case = 0" python "$SCRIPTS/vendor_special_case_law.py"
+
+axis "R_silent discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_silent_zero_tolerance.py" -q
+axis "R_silent = 0" python "$SCRIPTS/silent_zero_tolerance.py"
+
+axis "R_factory_walk_unclassified discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_factory_walk_unclassified_law.py" -q
+axis "R_factory_walk_unclassified = 0" \
+  python "$SCRIPTS/factory_walk_unclassified_law.py" \
+  --live-root "$TESTS/src/sugar_lift_py_tests" \
+  --live-root "$SCRIPTS"
+
+axis "R_finite_cap_opaque_completions discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_finite_cap_opaque_completion_law.py" -q
+axis "R_finite_cap_opaque_completions = 0" \
+  python "$SCRIPTS/finite_cap_opaque_completion_law.py"
+
+axis "R_finite_unfold_compact_gaps discrimination" \
+  python -m pytest --noconftest \
+  "$TESTS/tests/test_finite_unfold_compact_projection_law.py" -q
+axis "R_finite_unfold_compact_gaps = 0" \
+  python "$SCRIPTS/finite_unfold_compact_projection_law.py"
+
+axis "R_source_via_execution discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_source_via_execution_law.py" -q
+axis "R_source_via_execution = 0" python "$SCRIPTS/source_via_execution_law.py"
+
+axis "R_no_sugar_in_desugar discrimination" \
+  python "$SCRIPTS/no_sugar_in_desugar_law.py" --self-test
+axis "R_no_sugar_in_desugar = 0" python "$SCRIPTS/no_sugar_in_desugar_law.py"
+
+axis "R_construction_side_doors discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_construction_side_door_law.py" -q
+axis "R_construction_side_doors = 0" python "$SCRIPTS/construction_side_door_law.py"
+
+echo
+echo "sole-construction floors: ${#green_axes[@]} green, ${#red_axes[@]} red"
+if [ ${#red_axes[@]} -gt 0 ]; then
+  echo "RED AXES:"
+  printf '  - %s\n' "${red_axes[@]}"
+  exit 1
+fi
+echo "every axis reported, every axis green"


### PR DESCRIPTION
## Axis

`R_evicted_measurements` — heavy instruments that GitHub deleted before they ever ran, and whose silence read as a clean floor.

## The defect, measured

`python-package-suite.yml` had its **own** repository-wide concurrency group with `cancel-in-progress: false`, and still produced **zero artifacts across five runs**: `dea47f1f8`, `e0a78ec52`, `d243fcacf`, `6d9db3a8f`, `f0cddfd76`, all cancelled. The first artifact this repo ever banked came from run `30174018299` at `421ef4157`, and only because merges were frozen around it.

`Python sole-construction floors` fails the same way today, one layer down. Three rapid pushes on one PR:

```
20:26:50  sole-construction floors  cancelled
20:27:52  sole-construction floors  cancelled
20:28:35  sole-construction floors  cancelled   ← PR head
```

Its group and `cancel-in-progress: false` were untouched by any recent change. Three of three evicted, while every lighter job completed.

The cause is not the setting, it is what the setting can do:

* `cancel-in-progress: false` protects a run that has **already started**.
* GitHub keeps exactly **one pending run per concurrency group** — a new run **evicts** the queued one.

Our own merge rate was deleting our heaviest instruments. **A single shared group does not fix this**; it makes every heavy class compete for that one pending slot, which would have put the suite in the same eviction path the floors are in.

## The ruling

Two responsibilities were being asked of one mechanism. Split them:

```
GitHub queue: preserve every requested measurement   -> NO concurrency group
BX lease:     only one heavy measurement executes    -> flock on battleaxe
```

## The mechanism

`tools/heavy_measurement_lease.py` wraps each measured command in a machine-wide `flock` on `/var/tmp/sugar-heavy-measurement.lease`.

`fcntl.flock` **is** `flock(2)` — the same kernel lock `flock(1)` takes, on the same file, interoperable with it. Python holds it rather than the util-linux binary so the release paths are testable on every platform we develop on: `flock(1)` does not exist on macOS, and an untested release path on a lease that deadlocks the whole box is not acceptable.

| release path | released by | test |
|---|---|---|
| success | unlock + fd close | `test_success_runs_command_writes_receipt_and_releases` |
| non-zero exit | unlock + fd close | `test_failure_still_releases_and_records_the_exit_status` |
| timeout | nothing held; command never ran | `test_contended_lease_refuses_and_does_not_run_the_command` |
| SIGINT/SIGTERM/SIGHUP | handler forwards, then unlock + fd close | `test_signal_releases_the_lease` |
| SIGKILL | **the kernel**, on last fd close | `test_sigkill_leaves_the_lease_with_the_orphan_then_frees_it` |

Two holes found and closed while building it, both with teeth:

1. **Orphan hole.** The lease fd is now **inheritable on purpose**, so the measured census holds the same lock. SIGKILL the wrapper and the orphaned census keeps the lease until it exits — otherwise the next heavy job starts on top of a census still burning the box.
2. **Signal race.** A SIGTERM landing between acquisition and spawn used to be **swallowed**, leaving a wrapper holding the lease and running a three-hour census it had been told to stop.

On contention the wrapper prints stale-owner diagnostics and **exits 75 without running the command**. It never "recovers" by running concurrently.

## Status vocabulary

An evicted run and a clean floor looked identical from outside. That is why eight lost runs went unnoticed.

```
queued → lease-waiting → measuring → completed
                              ├─ findings
                              └─ zero-findings
queued/lease-waiting → cancelled-before-measurement
measuring            → interrupted-during-measurement
```

**Only `completed/zero-findings` may support a zero claim.** Every receipt carries `measurementStatus` and the derived `supportsZeroClaim`; `heavy_measurement_lease_gate.py --require-zero-claim` is red for every other status, and the sole-construction floors — which *are* a zero claim — run with that flag.

## Artifact telemetry

Written on every exit path, and embedded into the measurement's own artifact as `leaseRecord` (one schema, joining #6280's, not a second one):

`leaseClass` · `acquired` · `timedOut` · `measurementStatus` · `supportsZeroClaim` · `requestedAtUnix` · `acquiredAtUnix` · `releasedAtUnix` · `waitSeconds` · `heldSeconds` · `measuredCommit` · `owner.{githubRunId,githubRunAttempt,githubWorkflow,githubJob,githubRef,runnerName,holderPid}` · `command` · `commandExitStatus` · `leaseIdentity.{bootId,device,inode}` · `staleOwnerDiagnostics`

`bootId`/`device`/`inode` exist so **"is this lease actually machine-wide?" is checkable rather than assumed** — see the limitation below.

## Workflows changed

| workflow | change |
|---|---|
| `python-package-suite.yml` | group removed; canonical + reversed + shuffled arms all leased; gate; scope-check across the three arms; receipt in artifacts; timeout 180→360 |
| `factory-zero-tolerance.yml` | group removed; 20 floor steps → one leased `tools/run_sole_construction_floors.sh` (ONE lease for the whole set, so no census interleaves between axes, and every axis still reports); gate with `--require-zero-claim`; receipt uploaded |
| `numpy-wall.yml` | group removed; `make numpy-wall` leased; gate; receipt in artifacts |
| `pandas-wall.yml` | group removed; `make pandas-wall` leased; gate; receipt in artifacts |
| `restored-suite-scoreboard.yml` | group removed; sweep leased; gate; receipt in artifacts. Still superseded, still not retired — its filename is pinned by `sugar-build.toml`, `test_sugar_build_contract.py` and `sugarbin_execution_contract.rs`, all still green |
| `ci.yml` | `cancel-in-progress: true` → `false` |

## Acceptance tests

**Verified statically / locally (36 tests, ~17s, nothing heavy):**

| test | how |
|---|---|
| only one enters the measured section | `test_contended_lease_refuses_and_does_not_run_the_command` — canary file proves the command never ran |
| serialized, not dropped | `test_second_wrapper_waits_then_proceeds_after_release` — waiter's interval starts after the holder's ends |
| release on success/failure/timeout/signal/SIGKILL | the five tests above |
| every artifact identifies commit + lease interval | `test_success_...`, `test_receipt_embeds_into_the_measurement_artifact` |
| no timing claim without an acquired lease | `test_gate_refuses_a_lease_that_was_never_acquired`, `..._a_commit_mismatch`, `..._a_missing_receipt`, and the accepting face |
| cancelled-before-measurement ≠ zero-findings | `test_cancelled_before_measurement_is_distinct_from_zero_findings`, `test_signal_while_waiting_records_cancelled_before_measurement`, `test_interrupted_during_measurement_is_its_own_status`, plus both faces of `--require-zero-claim` |
| absent instrument ≠ clean floor | `test_attendance_counts_a_missing_receipt_as_unmeasured` + the green face |
| no heavy workflow can re-enter the eviction path | `test_heavy_measurement_concurrency_topology.py` — forbids `^concurrency:` and both retired groups, requires the wrapper, the `--class`, and the gate in each |

**Needs a live trial (cannot be proven from a checkout):**

* Push A, B, C rapidly → all three runs remain present and produce artifacts. Target: `Python sole-construction floors`, the workload that fails 3-of-3 today. To be exercised by `workflow_dispatch` and receipt-only probe commits, not by semantic churn.
* Two different heavy workflows overlapping in GitHub → only one enters the measured section. Observable after the fact by `--scope-check` over both receipts.
* Whether `/var/tmp` is shared across battleaxe runner containers. **If it is not, the lease is per-container and serializes nothing** — which is why `--scope-check` compares `bootId` against `device`/`inode` and goes red on exactly that. Do not assume the answer; read it off the first two receipts that share a `bootId`.

## Could not implement, stated plainly

**No dedicated heavy runner label exists.** `gh api repos/TSavo/sugar/actions/runners` shows every Linux runner carrying exactly `[self-hosted, Linux, X64]`. So a job waiting for the lease **does** occupy a general runner slot. Fixing it means registering the battleaxe runners with an extra label — a change to runner registration, not to this repo — after which each heavy workflow's `runs-on:` gains it. Deliberately not approximated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize heavy measurement workflows behind a machine-wide flock lease instead of GitHub concurrency groups
> - Replaces GitHub Actions concurrency groups (which evict queued runs) with a host-shared `fcntl.flock` lease managed by [heavy_measurement_lease.py](https://github.com/TSavo/sugar/pull/6287/files#diff-9fa7fb069e55d839f17153320511f689f1c8cf57016ae314dae01dea7bdaaefc), ensuring only one heavy measurement runs at a time per machine without cancelling waiters.
> - Adds [heavy_measurement_lease_record.py](https://github.com/TSavo/sugar/pull/6287/files#diff-4684257751903579488429f1e7a57b8140801dbfbc04ec3294773b3d2c7d77b0) to persist structured JSON receipts on every exit path (acquired, refused, timed out, cancelled), and [heavy_measurement_lease_gate.py](https://github.com/TSavo/sugar/pull/6287/files#diff-5c3c9f7a156b0f06123a8fdcd97ff1725d372e7f613683ede0e742fcc91b8851) to validate receipts and enforce zero-claim semantics in CI.
> - Adds [heavy_measurement_attendance.py](https://github.com/TSavo/sugar/pull/6287/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) to tally which lease classes reported acquiring the lease for a given commit, exiting nonzero when any expected class is missing.
> - Updates all heavy workflows (numpy-wall, pandas-wall, python-package-suite, restored-suite-scoreboard, factory-zero-tolerance) to wrap their measurement commands with the lease, add a gate step, upload receipts, and remove their concurrency groups; CI workflow-level cancel-in-progress is set to false.
> - Adds [run_sole_construction_floors.sh](https://github.com/TSavo/sugar/pull/6287/files#diff-2425932b3b3850c1dce0e1350ce9dadb9c8d59942a7fb072ba19c29e2f913421) to run all sole-construction floor axes as a single leased section without short-circuiting on failure.
> - Risk: lease acquisition failures exit with code 75 (`EX_TEMPFAIL`); jobs that previously queued via GitHub will now queue at the OS level and fail if the lease timeout expires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21039b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Heavy measurement workflows now queue instead of canceling earlier runs, preserving complete validation and coverage results.
  * Measurements are coordinated to run one at a time, with clearer handling when execution cannot begin.
  * Validation jobs have longer time limits for large test suites.
  * CI artifacts now include measurement receipts and status details for easier result verification.
* **Documentation**
  * Added guidance describing heavy-measurement coordination and result validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->