### PR TITLE
test: key the roll-call twin the way the report keys

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -141,10 +141,23 @@ def _script_roll_call(monkeypatch: pytest.MonkeyPatch, answer: str) -> None:
     def scripted_discharge(source_file):
         list(source_file.nodes())
         reporter = source_file.reporter
-        by_cid = {}
+        # Key the twin the way MinorityReport._by_coordinate keys the real
+        # roll: the authenticated source coordinate alongside the CID. Equal
+        # source text shares a CID at distinct loci -- a load-site Name can
+        # carry its Param's CID -- and deduping on the CID alone silently
+        # drops the second locus the reporter is obliged to keep.
+        by_coordinate = {}
         for node in reporter.registered:
-            by_cid.setdefault(node.fragment.seal().cid, node)
-        nodes = list(by_cid.values())
+            entry = roll_call.roster_entry_for(node)
+            key = (
+                entry.file,
+                entry.start_line,
+                entry.start_col,
+                entry.kind,
+                entry.cid,
+            )
+            by_coordinate.setdefault(key, node)
+        nodes = list(by_coordinate.values())
         assert nodes
         absent = nodes[-1]
         present = nodes if answer in {"truthful", "lying"} else nodes[:-1]


### PR DESCRIPTION
## What

`_script_roll_call` in `test_enumerate_rpc.py` deduped the registered roll on the fragment CID alone:

```python
by_cid = {}
for node in reporter.registered:
    by_cid.setdefault(node.fragment.seal().cid, node)
```

`MinorityReport._by_coordinate` (`sugar-source-tree/src/sugar_source_tree/roll_call.py:66`) keys on `(file, start_line, start_col, kind, cid)` — the authenticated source coordinate alongside the content identity — precisely because equal source text shares a CID at distinct loci.

## Why it matters

A load-site `Name` can carry its `Param`'s CID. The real reporter is obliged to keep both entries; the twin silently dropped the second locus. That is not a weaker test of the same thing — it is a test of something else, and it is blind to exactly the case the roll call exists to catch.

This change keys the twin the way the report keys, deriving the key from the same `roster_entry_for` the report uses, so the two cannot drift apart again.

## Verification

Test-only change, no product code touched. Both runs at `449d35e`, same worktree, same invocation:

```
env PYTHONPATH="$SRC" SUGAR_BINARY_ALLOW_BUILD=0 \
  python3 -m pytest tests/test_enumerate_rpc.py -q -p no:cacheprovider
```

| Scope | Before | After |
|---|---|---|
| `-k roll_call` | 4 failed, 3 passed | **7 passed** |
| whole file | 23 failed, 20 passed | **19 failed, 24 passed** |

The four that go green:

```
test_rpc_roll_call_truthful_twin_projects_present_as_warranted
test_rpc_roll_call_lying_twin_does_not_hide_gap_testimony
test_rpc_roll_call_minority_twin_projects_one_absent_everywhere
test_rpc_roll_call_silently_unaccounted_twin_stays_loud
```

Confirmed green with this change **alone** — no product patch applied — so nothing here depends on the #4 substitution-as-discharge work landing first. The remaining 19 reds in the file are pre-existing at `449d35e` and untouched.

## Scope

Keying fidelity only. The minority `6 -> 1` behaviour test is deliberately **not** in this PR — a test-fidelity fix and a product-behaviour claim should be reviewable separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key roll-call deduplication by source coordinate tuple instead of CID only
> In the `_script_roll_call` test helper in [test_enumerate_rpc.py](https://github.com/TSavo/sugar/pull/6288/files#diff-579080ebef2db8fc5e34d0de0893b2759ef8f3b74aff0570a77e3227de57ef41), the monkeypatched `roll_call.discharge` previously deduplicated registered nodes by CID alone. It now keys by `(file, start_line, start_col, kind, cid)`, matching how the report keys nodes. This preserves distinct nodes that share a CID but differ in source coordinate, so `reporter.present_fact` and `reporter.report_gap` are called over the full expanded set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a67ab5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->