### PR TITLE
build: stop sugarbin debug builds failing under an sccache rustc-wrapper

### DIFF
--- a/tools/sugarbin-build.mk
+++ b/tools/sugarbin-build.mk
@@ -42,9 +42,22 @@ else
 $(error SUGARBIN_PROFILE must be debug or release)
 endif
 
+# sccache refuses to run at all under incremental compilation ("incremental
+# compilation is prohibited: Unset CARGO_INCREMENTAL to continue"), and the
+# repo's own advice in ~/.cargo/config.toml is that it cannot cache incremental
+# builds anyway. A wrapper configured there therefore makes every debug build
+# fail outright rather than merely go uncached. Drop the wrapper for the
+# incremental profile: nothing is lost, because there was no caching to lose.
+ifeq ($(SUGARBIN_INCREMENTAL),1)
+SUGARBIN_RUSTC_WRAPPER_ARG := CARGO_BUILD_RUSTC_WRAPPER=""
+else
+SUGARBIN_RUSTC_WRAPPER_ARG :=
+endif
+
 .PHONY: sugarbin-build
 sugarbin-build:
 	mkdir -p "$(SUGARBIN_TARGET_DIR)"
+	$(SUGARBIN_RUSTC_WRAPPER_ARG) \
 	CARGO_TARGET_DIR="$(SUGARBIN_TARGET_DIR)" \
 	CARGO_INCREMENTAL="$(SUGARBIN_INCREMENTAL)" \
 	SUGAR_BUILD_STAMP="$(SUGARBIN_BUILD_STAMP)" \


### PR DESCRIPTION
## The bug

`tools/sugarbin-build.mk` sets `CARGO_INCREMENTAL=1` for the debug profile (line 40). sccache refuses to run at all under incremental compilation:

```
sccache: incremental compilation is prohibited: Unset CARGO_INCREMENTAL to continue.
make: *** [sugarbin-build] Error 101
```

On any box whose `~/.cargo/config.toml` sets `rustc-wrapper = "sccache"` — the configuration this repo's own tuning notes in that file describe — **`bin/sugarbin --profile debug` cannot succeed at all.** Not slow: dead.

## Why it matters beyond one build

Every fixture that resolves a debug binary hits this. `sugar_lift_py_tests/witness_harness.py:90` calls `resolve_sugar_binary(profile="debug")`, so a debug shelf miss means a build attempt, and the build attempt fails on this box every time.

It also interacts badly with `SUGAR_BINARY_ALLOW_BUILD=0`, which is the recommended way to keep sweeps off the shared cargo build-directory lock: with building disabled the debug path refuses, and with building enabled it errors. Neither branch produces a working debug binary until someone discovers the workaround by hand.

## The fix

Clear the wrapper for the incremental profile only. Nothing is forfeited — the same `~/.cargo/config.toml` already documents that sccache cannot cache incremental builds, so there was no caching to lose. Release keeps its wrapper untouched.

## Verification

Clean worktree at `449d35e`, driving the make target directly:

| Profile | Before | After |
|---|---|---|
| debug | `Error 101` in ~4s | **`Finished dev profile in 4m 22s`** |

Recipe expansion, confirming the override is scoped to the incremental path:

```
$ make -n ... SUGARBIN_PROFILE=debug
CARGO_BUILD_RUSTC_WRAPPER="" \
CARGO_INCREMENTAL="1" \

$ make -n ... SUGARBIN_PROFILE=release
CARGO_INCREMENTAL="0" \
```

Release is byte-identical to before.

## Provenance

Found while publishing a debug artifact for an A/B sweep — the workaround was `CARGO_BUILD_RUSTC_WRAPPER=""` on the command line, which is what this PR moves into the makefile so nobody has to rediscover it at ~5 minutes a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sugarbin debug builds failing when an sccache rustc-wrapper is configured
> sccache refuses to operate under incremental compilation, causing debug builds to fail when `CARGO_BUILD_RUSTC_WRAPPER` is set. In [sugarbin-build.mk](https://github.com/TSavo/sugar/pull/6289/files#diff-bc479a4afc04b730f691fef24dd6d39ca0e969488188ed727e610aee1897f7a0), a new `SUGARBIN_RUSTC_WRAPPER_ARG` variable explicitly clears `CARGO_BUILD_RUSTC_WRAPPER` for the cargo invocation when `SUGARBIN_INCREMENTAL=1`, leaving non-incremental builds unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbab3e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->