### PR TITLE
fix: WithConstructionGapKind accepts dynamic-export (census instrument)

### DIFF
--- a/docs/ledgers/pass3-pandas-control-effect-d94f67a31.md
+++ b/docs/ledgers/pass3-pandas-control-effect-d94f67a31.md
@@ -1,0 +1,107 @@
+# Pass 3 board — pandas control-effect census @ `d94f67a31`
+
+**Authority:** provisional checkpoint reconstruction  
+**Source:** `.sugar/pandas-four-axis-census-d94f67a31/control-effect/checkpoint.jsonl`  
+**Rows:** 1415 / 1415 (full manifest)  
+**Lease:** completed/findings; `measuredCommit=d94f67a3149ea2aceee4f9a8cff0397b6f6d374a`  
+**Machine board:** `pass3-board.json` beside the checkpoint on battleaxe
+
+## Honest classification (from checkpoint, not pre-Merkle numbers)
+
+### File outcomes
+| category | files |
+|----------|------:|
+| completed | 635 |
+| **backend-defect** | **780** |
+
+### Stop-the-line instrument defect
+**780 files** failed with:
+
+```text
+ValueError: 'dynamic-export' is not a valid WithConstructionGapKind
+```
+
+This is **not** residual silence. Export-resolution kinds rode into
+`ContextManagerResolutionConstructionGap` without enum membership. Construction
+With mass is **understated** until this is fixed and the axis is re-measured.
+
+### Construction residuals (among completed files only)
+| family | count |
+|--------|------:|
+| ContextManagerResolutionConstructionGap | 65 |
+| SugarNotWritten | 38 |
+| UnsupportedWithBindingTarget | 4 |
+| ConstructedValueTestimonyNotWritten | 4 |
+
+**CM membrane axes (R_cm_* sums):** assertion 3 · protocol-resource 8 · derived 0  
+**With partition (from families + cm keys, completed only):**
+- assertion-related: **3**
+- resource-related: **104** (incl. 65 CM resolution + 31 other-manager + 8 protocol)
+- other: **4**
+
+→ Construction endgame is still **With**, but the **true** With count requires
+re-census after the dynamic-export instrument fix (780 files re-enter the board).
+
+### Desugar residuals (occurrence totals)
+| | |
+|--|--:|
+| **R_desugar** | **2508** |
+| AttributeStoreRuntimeEffect | 753 |
+| RaiseEffect | 738 |
+| NameErrorEffect | 386 |
+| SubscriptStoreRuntimeEffect | 296 |
+| DynamicUnpackAssignSugar.desugar | 291 |
+| (store-matching keys sum) | **1340** |
+
+**Desugar construction panics (list length):** **359** across **15 owners**  
+| owner | n |
+|-------|--:|
+| contains | 215 |
+| attribute | 94 |
+| guarded | 20 |
+| ground_index_error | 7 |
+| SetValue.contains | 5 |
+| add / multiply / … | rest |
+
+These are **typed Floor gaps** (“write more Floor”), not one amorphous 1074-blob
+from another instrument. Distinct mechanisms → rank and drain by owner mass.
+**contains + attribute** are ~86% of measured desugar construction panics.
+
+**Desugar defects (list length):** **143**  
+| shape | n |
+|-------|--:|
+| ContractConditionalConstructionV1 missing attr | 49 |
+| conditional-expression arm NotImplementedError | 44 |
+| **ExitSet has no attribute value** | **26** (#6285 family) |
+| SourceFragment.compare_le | 11 |
+| Incomplete has no value | 3 |
+| other | rest |
+
+## Pass 3 priority decision
+
+| Priority | Item | Why |
+|----------|------|-----|
+| **0** | Fix `WithConstructionGapKind` for `dynamic-export` (+ safe parse) | 780/1415 files instrument-crashed; construction board is incomplete |
+| **1** | Re-aggregate construction With after fix (or focused re-census) | Exact assertion vs resource counts for dispatch |
+| **2** | Floor mechanisms: **contains** (215) then **attribute** (94) | Majority of desugar construction panics; typed product gaps |
+| **3** | **ExitSet.value** / term-position (#6285) | Live correctness defect among desugar defects |
+| **4** | With drain — two contracts, one ExitSet algebra | After true With mass is known |
+| **5** | Store desugar (1340) by measured owners | AttributeStore / SubscriptStore / DynamicUnpack |
+| **6** | Remaining desugar defect families | Conditional construction, etc. |
+| **7** | Full re-census pandas → NumPy under authenticated identity (#6290) | Bank ΔR |
+
+## With design (unchanged)
+Two semantic verbs, one control mechanism:
+1. **Assertion / effect-boundary With**
+2. **Resource / protocol With**
+
+## Notes on prior board numbers
+User-reported 5,021 With / 1,074 desugar panics may reflect a different
+occurrence reader or pre-instrument-fix projection. **This pass-3 board uses
+checkpoint list lengths and R_* sums only.** After priority-0 fix, re-measure
+before claiming With partition mass.
+
+## Suite identity
+#6290 landed on main (`df408100e`). Suite reports can now be authoritative when
+identity resolves. Re-run suite after lease quiet; authenticate receipts only
+on exact reconstructability.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -143,6 +143,23 @@ class WithConstructionGapKind(str, Enum):
     UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS = "unsupported-context-manager-semantics"
     UNSUPPORTED_WITH_BINDING_TARGET = "unsupported-with-binding-target"
     ASYNC_CONTEXT_MANAGER_UNSUPPORTED = "async-context-manager-unsupported"
+    # Export-resolution kinds that ride the same preconstruction table into With.
+    # A missing member here crashed the pandas control-effect census for 780/1415
+    # files with ``ValueError: 'dynamic-export' is not a valid WithConstructionGapKind``
+    # — instrument defect, not residual silence.
+    DYNAMIC_EXPORT = "dynamic-export"
+    STATIC_EXPORT_ABSENT = "static-export-absent"
+    UNSUPPORTED_STATEMENT = "unsupported-statement"
+    # Catch-all: never crash the census on a newly minted resolution kind.
+    # The original string is preserved on ``ContextManagerResolutionConstructionGap.resolution_kind``.
+    UNRECOGNIZED_RESOLUTION_KIND = "unrecognized-resolution-kind"
+
+    @classmethod
+    def parse(cls, kind: str) -> "WithConstructionGapKind":
+        try:
+            return cls(kind)
+        except ValueError:
+            return cls.UNRECOGNIZED_RESOLUTION_KIND
 
 
 class WithConstructionGap(SugarNotWritten):
@@ -176,12 +193,21 @@ class ContextManagerResolutionConstructionGap(WithConstructionGap):
         candidate_member_cids: tuple[str, ...],
         **kwargs,
     ) -> None:
+        gap_kind = WithConstructionGapKind.parse(kind)
+        # Preserve the wire kind even when it falls into UNRECOGNIZED_*.
+        self.resolution_kind = kind
         super().__init__(
-            gap_kind=WithConstructionGapKind(kind),
+            gap_kind=gap_kind,
             demand_cid=demand_cid,
             candidate_member_cids=candidate_member_cids,
             **kwargs,
         )
+        # ``self.kind`` is what census buckets on. Prefer the original resolution
+        # kind so ``dynamic-export`` stays ``dynamic-export``, not collapsed.
+        if gap_kind is WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND:
+            self.kind = kind
+        else:
+            self.kind = gap_kind.value
 
 
 class UnsupportedContextManagerSemantics(WithConstructionGap):

--- a/implementations/python/sugar-source-tree/tests/test_with_construction_gap_kind.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_construction_gap_kind.py
@@ -1,0 +1,78 @@
+"""WithConstructionGapKind must accept every preconstruction resolution kind.
+
+Census defect (d94f67a31 control-effect): 780/1415 files aborted as
+``backend-defect`` with::
+
+    ValueError: 'dynamic-export' is not a valid WithConstructionGapKind
+
+That is instrument crash, not residual silence. Export-resolution kinds ride the
+same table into ``ContextManagerResolutionConstructionGap``; the enum must
+parse them without ValueError, and unknown future kinds must stay loud as
+typed gaps rather than kill the file.
+"""
+
+from __future__ import annotations
+
+from sugar_source_tree.panic import (
+    ContextManagerResolutionConstructionGap,
+    WithConstructionGapKind,
+)
+
+
+def test_dynamic_export_is_a_named_with_construction_gap_kind():
+    panic = ContextManagerResolutionConstructionGap(
+        kind="dynamic-export",
+        demand_cid="demand:test",
+        candidate_member_cids=(),
+        owner="With._construct_sugar",
+        observed="authenticated preconstruction resolution gap: dynamic-export",
+        requested="one resolved authenticated ContextManagerContractRefV1",
+        fix="publish or resolve the exact typed CM contract before construction",
+    )
+    assert panic.kind == "dynamic-export"
+    assert panic.gap_kind is WithConstructionGapKind.DYNAMIC_EXPORT
+    assert panic.resolution_kind == "dynamic-export"
+
+
+def test_static_export_absent_and_unsupported_statement_parse():
+    for kind in ("static-export-absent", "unsupported-statement"):
+        panic = ContextManagerResolutionConstructionGap(
+            kind=kind,
+            demand_cid="demand:test",
+            candidate_member_cids=(),
+            owner="test",
+            observed=kind,
+            requested="resolved CM",
+            fix="fix",
+        )
+        assert panic.kind == kind
+
+
+def test_unknown_resolution_kind_stays_loud_not_valueerror():
+    """A newly minted kind must not crash the census with ValueError."""
+    panic = ContextManagerResolutionConstructionGap(
+        kind="brand-new-resolution-kind-2026",
+        demand_cid="demand:test",
+        candidate_member_cids=(),
+        owner="test",
+        observed="new kind",
+        requested="resolved CM",
+        fix="fix",
+    )
+    assert panic.gap_kind is WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND
+    assert panic.kind == "brand-new-resolution-kind-2026"
+    assert panic.resolution_kind == "brand-new-resolution-kind-2026"
+
+
+def test_known_runtime_selected_still_parses():
+    panic = ContextManagerResolutionConstructionGap(
+        kind="runtime-selected",
+        demand_cid="demand:test",
+        candidate_member_cids=(),
+        owner="test",
+        observed="runtime-selected",
+        requested="resolved CM",
+        fix="fix",
+    )
+    assert panic.kind == "runtime-selected"
+    assert panic.gap_kind is WithConstructionGapKind.RUNTIME_SELECTED


### PR DESCRIPTION
## Why

Pass-3 of the pandas control-effect census at `d94f67a31` shows **780/1415 files** classified `backend-defect` with:

```text
ValueError: 'dynamic-export' is not a valid WithConstructionGapKind
```

That is an **instrument crash**, not residual silence. Construction With mass is understated until these files re-enter as typed gaps.

## Fix

- Enum membership for export-resolution kinds that ride the preconstruction table into With
- Safe parse for unknown future kinds (loud gap, not ValueError)
- Preserve original `resolution_kind` on the panic for census buckets
- Twins in `test_with_construction_gap_kind.py`
- Pass-3 board: `docs/ledgers/pass3-pandas-control-effect-d94f67a31.md`

## Priority (pass 3)

0. **This fix** (instrument complete board)
1. Re-measure construction With partition (assertion vs resource exact counts)
2. Floor mechanisms: contains (215) → attribute (94)
3. ExitSet.value / #6285
4. With drain (two contracts, one ExitSet algebra)
5. Store desugar (1340)
6. Remaining desugar defect families
7. Full re-census under authenticated identity

## Validation

```bash
pytest implementations/python/sugar-source-tree/tests/test_with_construction_gap_kind.py -v
# 4 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WithConstructionGapKind` to accept `dynamic-export` and other export resolution kinds
> - Adds `dynamic-export`, `static-export-absent`, and `unsupported-statement` as named members of the `WithConstructionGapKind` enum in [panic.py](https://github.com/TSavo/sugar/pull/6291/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb).
> - Adds a `parse(kind: str)` classmethod that returns `UNRECOGNIZED_RESOLUTION_KIND` instead of raising `ValueError` for unknown kinds.
> - Updates `ContextManagerResolutionConstructionGap.__init__` to use `parse()`, so unknown resolution kinds no longer raise at construction time; the original wire value is preserved on `.kind` and `.resolution_kind`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dceecd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling for dynamic, static, and unsupported construction-gap types.
  - Prevented unknown resolution types from causing errors while preserving their original values.
  - Improved reporting and categorization of construction gaps.

- **Tests**
  - Added coverage for recognized, unsupported, and previously unknown resolution types.

- **Documentation**
  - Added a census report detailing construction-gap findings, residual issues, and recommended follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->