### PR TITLE
Substitution is a discharge: the node a rewrite replaces answers the roll call

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -892,13 +892,30 @@ class Node(Typed):
                     "_substitute_body (a block), never _substitute_children -- "
                     "give the containing node a block-aware substitute"
                 )
+            if new is not value:
+                value.discharge_by_substitution()
             return new, new is not value
         items = tuple(value)
         new_items = tuple(
             item.substitute(scope) if isinstance(item, Node) else item for item in items
         )
         changed = any(new is not old for new, old in zip(new_items, items))
+        if changed:
+            for new, old in zip(new_items, items):
+                if new is not old and isinstance(old, Node):
+                    old.discharge_by_substitution()
         return (new_items if changed else value), changed
+
+    def discharge_by_substitution(self) -> None:
+        """Answer the roll call for a node the rewrite replaced.
+
+        Substitution IS this node's discharge: it constructs nothing of its own,
+        so it answers ``present_inert`` -- showed up, nothing built -- and the
+        node that replaced it answers separately for what it constructs. Without
+        this the replaced node stays registered with no answer at all, which the
+        minority report reads (correctly) as a silent unaccounted construction.
+        """
+        self.reporter.present_inert(self)
 
     def _substitute_children(self, scope: BindingMap) -> "Node":
         """The structural recurse a NON-binding compound opts into: substitute
@@ -2116,6 +2133,10 @@ class FunctionDef(Statement):
         from .shadow import ShadowNode
 
         formal = self._formal_coordinate(parameter, ordinal)
+        # The FormalRef stands in the Param's place for the whole body, so the
+        # Param's discharge is this substitution -- otherwise it registers and
+        # never answers.
+        parameter.discharge_by_substitution()
         return materialize(
             self.unit,
             ShadowNode("FormalRef", parameter.span, (("coordinate", Leaf(formal)),)),
@@ -6722,6 +6743,10 @@ class Call(Expression):
                 )
                 for kw in self.keywords
             )
+            if isinstance(self.func, Name):
+                # Absorbed as a spelling, never constructed -- see the
+                # call-site branch below.
+                self.func.discharge_by_substitution()
             callee_name = self._spread_callee_name(self.func)
             return SpreadCallSugar(
                 callee_name=callee_name,
@@ -6857,6 +6882,11 @@ class Call(Expression):
             )
         if isinstance(self.func, Name):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+            # The call-site coordinate absorbs the callee's spelling instead of
+            # its sugar, so the callee never constructs. That absorption IS its
+            # discharge; without it the Name registers and never answers.
+            self.func.discharge_by_substitution()
 
             contract_ref = None
             contract_resolution_gap = None

--- a/implementations/python/sugar-source-tree/tests/test_roll_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_roll_call.py
@@ -185,3 +185,92 @@ def test_discharge_produces_the_true_minority_written_vs_not() -> None:
     assert "Return" in kinds_present  # a's body desugared
     assert "Delete" in kinds_absent  # the unwritten construct is minority
     assert not report.is_clean  # R > 0 while anything is unwritten
+
+
+_SUBSTITUTED = (
+    "def add(a, b):\n"
+    "    return a + b\n"
+    "\n"
+    "\n"
+    "def use():\n"
+    "    return add(1, 2)\n"
+)
+
+
+def test_substitution_discharges_the_node_it_replaces() -> None:
+    # A node the rewrite replaces constructs nothing of its own, so it used to
+    # sit on the roster with no answer at all -- which the report read, quite
+    # correctly, as a silent unaccounted construction. Substitution IS that
+    # node's discharge: it answers present_inert (showed up, built nothing) and
+    # whatever replaced it answers separately for what it builds.
+    #
+    # This source exercises all three substitution seams: the two Params
+    # replaced by FormalRefs, the two body Names substituted for their bound
+    # values, and the callee Name absorbed as a spelling by the call site.
+    from sugar_source_tree.roll_call import discharge
+
+    r = CollectingReporter()
+    report = discharge(_sf(_SUBSTITUTED, r))
+
+    # Every source construct in this file is written, so the only honest absence
+    # left is Module. This is the presently unwritten, explicitly accounted
+    # frontier -- Module.sugar raises SugarNotWritten by design -- NOT a
+    # permanent truth. When Module.sugar is implemented this expectation should
+    # turn red, and that red is the good kind: it means the frontier moved.
+    assert [(e.kind, e.name) for e in report.minority] == [("Module", "Module")]
+
+    # The discharge is an ANSWER, not a deletion: the replaced nodes are still
+    # enrolled on the roster, they simply answered. A fix that shrank the
+    # minority by shrinking the roster would satisfy a count check and destroy
+    # the accounting, so pin the roster by exact coordinate rather than by
+    # count. A histogram of kinds is not enough -- it is satisfied by dropping
+    # Name(2,11) and gaining a spurious Name(9,99).
+    assert sorted(
+        (e.kind, e.name, e.start_line, e.start_col) for e in report.roster
+    ) == [
+        ("BinOp", "BinOp", 2, 11),
+        ("Call", "Call", 6, 11),
+        ("Constant", "Constant", 6, 15),
+        ("Constant", "Constant", 6, 18),
+        ("FormalRef", "FormalRef", 1, 8),
+        ("FormalRef", "FormalRef", 1, 11),
+        ("FunctionDef", "add", 1, 0),
+        ("FunctionDef", "use", 5, 0),
+        ("Module", "Module", 1, 0),
+        ("Name", "Name", 2, 11),
+        ("Name", "Name", 2, 15),
+        ("Name", "Name", 6, 11),
+        ("Param", "a", 1, 8),
+        ("Param", "b", 1, 11),
+        ("Return", "Return", 2, 4),
+        ("Return", "Return", 6, 4),
+    ]
+
+    # Every roster entry except the Module frontier answered present, by exact
+    # coordinate -- the five substituted nodes among them.
+    assert sorted(
+        (e.kind, e.name, e.start_line, e.start_col) for e in report.present
+    ) == sorted(
+        (e.kind, e.name, e.start_line, e.start_col)
+        for e in report.roster
+        if e.kind != "Module"
+    )
+
+    # The tooth. These five are the ONLY nodes in this file that answer by
+    # substitution rather than by building something: the two Params their
+    # FormalRefs replaced, the two body Names replaced by their bound values,
+    # and the callee Name the call site absorbed as a spelling. Remove the
+    # ``discharge_by_substitution`` call and these five stop answering -- the
+    # minority goes 1 -> 6, and it is exactly this set that comes back. Pinning
+    # the set, not the number, is what makes this test bite on the mechanism:
+    # a 6 that is any OTHER six nodes is a different bug and must not pass here.
+    substituted = {
+        ("Param", 1, 8),
+        ("Param", 1, 11),
+        ("Name", 2, 11),
+        ("Name", 2, 15),
+        ("Name", 6, 11),
+    }
+    present_coordinates = {(e.kind, e.start_line, e.start_col) for e in report.present}
+    assert substituted <= present_coordinates
+    assert report.R == 1


### PR DESCRIPTION
## The defect

A node the rewrite replaces constructs nothing of its own, so it sat enrolled on the roster with **no answer at all** — which the minority report read, correctly, as a silent unaccounted construction.

## The fix

Substitution *is* that node's discharge. It answers `present_inert` (showed up, built nothing) and whatever replaced it answers separately for what it builds. **The roster does not shrink.**

Five seams answer this way:

- the two `Param`s their `FormalRef`s replace,
- the two body `Name`s replaced by their bound values,
- the callee `Name` a call site absorbs as a spelling (both the spread and call-site branches).

## The tooth

The test pins the roster **by exact coordinate, not by count** — a "fix" that shrank the minority by shrinking the roster would satisfy a count check and destroy the accounting. It also pins the substituted set itself: remove the mechanism and the minority goes `1 -> 6` with exactly

`Param a(1,8)`, `Param b(1,11)`, `Name(2,11)`, `Name(2,15)`, `Name(6,11)`

coming back, into a roster that is still 16 entries. Any *other* six is a different bug and must not pass here.

## The remaining minority entry

`Module` — the presently unwritten, **explicitly accounted** frontier (`Module.sugar` raises `SugarNotWritten` by design). Commented as such: when `Module.sugar` lands this expectation should turn red, and that red is the good kind.

## Receipts

Own-baseline A/B. **Not gated on CI** — trunk is broadly red independently. Base is stated, not implied current: `origin/main` moved several times while this was measured, and a delta is valid at the base it was measured on.

### `sugar-source-tree` — the package the change lives in

| half | tree | result |
|---|---|---|
| A | mechanism reverted, new test deselected | 583 passed, 5 skipped, 0 failed |
| B | patched | **584 passed, 5 skipped, 0 failed** |

Delta exactly +1, zero regressions.

### `sugar-lift-py-tests` — the consuming suite, no-regression check

Two fresh detached worktrees, stamps pre-resolved under `SUGAR_BINARY_ALLOW_BUILD=0` before either half started.

| | A | B |
|---|---|---|
| `git rev-parse HEAD` | `2566183571cba676…` | `fde816e9bf9d3511…` |
| sourceStamp (before / after) | `blake3-512_8fea7f12…` / identical | `blake3-512_a2daaa35…` / identical |
| package / profile | `sugar-cli` / release | `sugar-cli` / release |
| passed | 1089 | 1090 |
| failed | 129 | 128 |
| skipped / errors | 12 / 5 | 12 / 5 |
| **collected** | **1235** | **1235** |

`1089 + 129 + 12 + 5 = 1235` both sides.

The single differing node — `test_callsite_term_cycle_key_volume.py::test_callsite_add_on_deep_terms_does_not_rebuild_cid_keys` — is a **wall-clock budget assertion** (`budget_seconds = 0.15`), not a behavioural one. It fails on **both bases under both conditions**: inside the sweep, in isolation, at node scope and at file scope. Measured elapsed clusters just above the budget on this machine — `0.189s` in the A sweep, `0.171s` isolated, against a `0.150s` budget.

The lone pass observed in the B sweep is **unexplained and tracked separately**. The attribution does not depend on explaining it: there is no condition in which this test separates the two trees.

**Claim: zero attributable regressions and zero attributable improvements across 1235 collected.** The change is confined to the roll-call accounting proven by the `sugar-source-tree` tooth.

`black --check` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
