### PR TITLE
Floor contains for List/Tuple/String/CallSite (pass-3 top panic)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -328,6 +328,32 @@ class CallSiteValue(FloorValue):
             )
         )
 
+    def contains(self, item, site):
+        # `item in callsite`: dig a concrete container when the body yields one;
+        # otherwise the call result is an opaque container and stays py.in —
+        # uninterpreted membership, never invented.
+        dug = self._dig_floor_or_none(None, owner="CallSiteValue.contains")
+        if dug is not None and dug is not self:
+            return dug.contains(item, site)
+
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import atomic
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            PredicateValue(
+                atomic(
+                    "py.in",
+                    [
+                        item.to_term(owner="CallSiteValue.contains member"),
+                        self.term,
+                    ],
+                ),
+                site,
+                operand_callsites=(*item.callsites(), self),
+            )
+        )
+
     def subscript(self, index, site):
         # A callsite receiver stays the py.subscript coordinate regardless of index.
         return self.py_subscript_coordinate(index, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -51,6 +51,50 @@ class ListValue(FloorValue):
 
         return Complete(TermValue(len(self.elements)))
 
+    def contains(self, item, site):
+        # Membership over a constructed list: decide when every element has a
+        # closed equality; emit a typed obligation when a member is symbolic;
+        # stay loud for unconstructed member shapes (same law as SetValue).
+        from sugar_lift_py_tests.floor.set_value import (
+            _bool_result,
+            _closed_member_equal,
+        )
+
+        decisions = tuple(
+            _closed_member_equal(item, element) for element in self.elements
+        )
+        if any(decision is True for decision in decisions):
+            return _bool_result(True, site)
+        if all(decision is False for decision in decisions):
+            return _bool_result(False, site)
+        if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+            from sugar_lift_py_tests.ir import atomic
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                PredicateValue(
+                    atomic(
+                        "python.list.contains",
+                        [
+                            item.to_term(owner="python.list.contains member"),
+                            self.to_term(owner="python.list.contains list"),
+                        ],
+                    ),
+                    site,
+                    operand_callsites=(*item.callsites(), *self.callsites()),
+                )
+            )
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="ListValue.contains",
+            blame=str(site),
+            observed=type(item).__name__,
+            requested="constructed finite member or typed symbolic membership operand",
+            fix="construct member equality on the Python floor or keep it loud",
+        )
+
     def append_with(self, value, site):
         # Concrete history folds: the updated list is the old elements plus the
         # new value. Symbolic receivers stay on the default panic.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -132,6 +132,101 @@ class StringValue(FloorValue):
 
         return Complete(TermValue(len(self.value)))
 
+    def contains(self, item, site):
+        # Python ``needle in haystack`` for str: substring when both are strings;
+        # TypeError for ground non-string needles; py.in when the needle is
+        # symbolic/opaque. Never invent membership for unconstructed shapes.
+        if type(item) is StringValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if item.value in self.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+
+        if type(item) in (SymbolicValue, CallSiteValue):
+            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+            from sugar_lift_py_tests.ir import atomic
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                PredicateValue(
+                    atomic(
+                        "py.in",
+                        [
+                            item.to_term(owner="StringValue.contains needle"),
+                            self.to_term(owner="StringValue.contains haystack"),
+                        ],
+                    ),
+                    site,
+                    operand_callsites=(*item.callsites(), *self.callsites()),
+                )
+            )
+        from sugar_lift_py_tests.floor.bytes_value import BytesValue
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.floor.set_value import SetValue
+        from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        ground_non_str = (
+            TermValue,
+            NoneValue,
+            ListValue,
+            TupleValue,
+            SetValue,
+            BytesValue,
+            TrueBoolLiteralSugar,
+            FalseBoolLiteralSugar,
+        )
+        if type(item) in ground_non_str:
+            # Python raises TypeError for non-str needles in a str. Both sides
+            # are lift-time decidable, so construct the exact exceptional exit —
+            # never mint RuntimeEffect authority over ground operands.
+            import hashlib
+
+            from sugar_lift_py_tests.effect import RaiseEffect
+            from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
+            from sugar_lift_py_tests.outcome import Complete
+
+            source = getattr(site, "source", None)
+            source_sha256 = (
+                hashlib.sha256(source.encode()).hexdigest()
+                if source is not None
+                else None
+            )
+            exception = ExceptionValue("TypeError", (), site)
+            return Complete(
+                RaiseValue(
+                    RaiseEffect("TypeError", str(site), source_sha256),
+                    exception=exception,
+                )
+            )
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="StringValue.contains",
+            blame=str(site),
+            observed=type(item).__name__,
+            requested="string needle, symbolic membership operand, or typed TypeError",
+            fix="construct string membership on the Python floor or keep it loud",
+        )
+
     def subscript(self, index, site):
         # Concrete string + in-range TermValue int folds to the one-char string;
         # out of range is IndexError. Non-concrete index stays py.subscript.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -62,6 +62,49 @@ class TupleValue(FloorValue):
 
         return Complete(TermValue(len(self.elements)))
 
+    def contains(self, item, site):
+        # Membership over a constructed tuple: same closed-equality law as
+        # ListValue / SetValue — fold, emit typed obligation, or stay loud.
+        from sugar_lift_py_tests.floor.set_value import (
+            _bool_result,
+            _closed_member_equal,
+        )
+
+        decisions = tuple(
+            _closed_member_equal(item, element) for element in self.elements
+        )
+        if any(decision is True for decision in decisions):
+            return _bool_result(True, site)
+        if all(decision is False for decision in decisions):
+            return _bool_result(False, site)
+        if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+            from sugar_lift_py_tests.ir import atomic
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                PredicateValue(
+                    atomic(
+                        "python.tuple.contains",
+                        [
+                            item.to_term(owner="python.tuple.contains member"),
+                            self.to_term(owner="python.tuple.contains tuple"),
+                        ],
+                    ),
+                    site,
+                    operand_callsites=(*item.callsites(), *self.callsites()),
+                )
+            )
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="TupleValue.contains",
+            blame=str(site),
+            observed=type(item).__name__,
+            requested="constructed finite member or typed symbolic membership operand",
+            fix="construct member equality on the Python floor or keep it loud",
+        )
+
     def add(self, other, site):
         if type(other) is TupleValue:
             from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/tests/test_revalidation_snapshot_immutability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_revalidation_snapshot_immutability.py
@@ -125,9 +125,7 @@ def test_receipts_from_one_module_share_a_snapshot_and_all_revalidate(
 
 def test_change_to_source_invalidates(tmp_path: Path) -> None:
     original = _snapshot(tmp_path / "a")
-    changed = _snapshot(
-        tmp_path / "b", source=_SOURCE + "example_pkg.build(3)\n"
-    )
+    changed = _snapshot(tmp_path / "b", source=_SOURCE + "example_pkg.build(3)\n")
     assert original is not changed
     assert set(original.row_cids) != set(changed.row_cids)
     assert len(_REVALIDATION_SNAPSHOTS) == 2

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
@@ -38,9 +38,7 @@ def test_empty_list_membership_is_false():
     from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 
     empty = ListValue(())
-    assert isinstance(
-        empty.contains(TermValue(1), "site").value, FalseBoolLiteralSugar
-    )
+    assert isinstance(empty.contains(TermValue(1), "site").value, FalseBoolLiteralSugar)
 
 
 def test_finite_tuple_membership_is_decided_from_constructed_members():
@@ -108,9 +106,7 @@ def test_symbolic_string_membership_emits_py_in():
     from sugar_lift_py_tests.ir import _Atomic, make_var
 
     result = (
-        StringValue("abc")
-        .contains(SymbolicValue(make_var("needle")), "site")
-        .value
+        StringValue("abc").contains(SymbolicValue(make_var("needle")), "site").value
     )
     assert isinstance(result.formula, _Atomic)
     assert result.formula.name == "py.in"

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
@@ -1,0 +1,157 @@
+"""Floor membership for constructed sequences and strings.
+
+Pass-3 desugar panics ranked contains (215) as the top Floor gap owner, with
+observed container types ListValue / TupleValue / CallSiteValue / StringValue.
+These twins pin the finite-fold and symbolic-obligation arms so the mechanism
+cannot regress to the default FloorValue.contains panic.
+"""
+
+import pytest
+
+
+def _list(*values):
+    from sugar_lift_py_tests.floor import ListValue, TermValue
+
+    return ListValue(tuple(TermValue(value) for value in values))
+
+
+def _tuple(*values):
+    from sugar_lift_py_tests.floor import TermValue, TupleValue
+
+    return TupleValue(tuple(TermValue(value) for value in values))
+
+
+def test_finite_list_membership_is_decided_from_constructed_members():
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    finite = _list(1, 2)
+    assert isinstance(finite.contains(TermValue(2), "site").value, TrueBoolLiteralSugar)
+    assert isinstance(
+        finite.contains(TermValue(3), "site").value, FalseBoolLiteralSugar
+    )
+
+
+def test_empty_list_membership_is_false():
+    from sugar_lift_py_tests.floor import ListValue, TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+
+    empty = ListValue(())
+    assert isinstance(
+        empty.contains(TermValue(1), "site").value, FalseBoolLiteralSugar
+    )
+
+
+def test_finite_tuple_membership_is_decided_from_constructed_members():
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    finite = _tuple(1, 2)
+    assert isinstance(finite.contains(TermValue(2), "site").value, TrueBoolLiteralSugar)
+    assert isinstance(
+        finite.contains(TermValue(3), "site").value, FalseBoolLiteralSugar
+    )
+
+
+def test_symbolic_list_membership_emits_typed_obligation():
+    from sugar_lift_py_tests.floor import ListValue, SymbolicValue, TermValue
+    from sugar_lift_py_tests.ir import _Atomic, make_var
+
+    result = (
+        ListValue((TermValue(1),))
+        .contains(SymbolicValue(make_var("member")), "site")
+        .value
+    )
+    assert isinstance(result.formula, _Atomic)
+    assert result.formula.name == "python.list.contains"
+
+
+def test_symbolic_tuple_membership_emits_typed_obligation():
+    from sugar_lift_py_tests.floor import SymbolicValue, TermValue, TupleValue
+    from sugar_lift_py_tests.ir import _Atomic, make_var
+
+    result = (
+        TupleValue((TermValue(1),))
+        .contains(SymbolicValue(make_var("member")), "site")
+        .value
+    )
+    assert isinstance(result.formula, _Atomic)
+    assert result.formula.name == "python.tuple.contains"
+
+
+def test_opaque_list_member_stays_loud():
+    from sugar_lift_py_tests.floor import FunctionCallable
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic):
+        _list(1).contains(FunctionCallable("opaque"), "site")
+
+
+def test_string_substring_membership_is_decided():
+    from sugar_lift_py_tests.floor import StringValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    haystack = StringValue("pandas")
+    assert isinstance(
+        haystack.contains(StringValue("and"), "site").value, TrueBoolLiteralSugar
+    )
+    assert isinstance(
+        haystack.contains(StringValue("xyz"), "site").value, FalseBoolLiteralSugar
+    )
+
+
+def test_symbolic_string_membership_emits_py_in():
+    from sugar_lift_py_tests.floor import StringValue, SymbolicValue
+    from sugar_lift_py_tests.ir import _Atomic, make_var
+
+    result = (
+        StringValue("abc")
+        .contains(SymbolicValue(make_var("needle")), "site")
+        .value
+    )
+    assert isinstance(result.formula, _Atomic)
+    assert result.formula.name == "py.in"
+
+
+def test_ground_non_string_in_string_is_type_error():
+    from sugar_lift_py_tests.floor import RaiseValue, StringValue, TermValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    outcome = StringValue("abc").contains(TermValue(1), "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_callsite_container_emits_py_in():
+    from sugar_lift_py_tests.floor import CallSiteValue, TermValue
+    from sugar_lift_py_tests.ir import _Atomic, ctor, make_var
+
+    container = CallSiteValue(
+        target_name="opaque",
+        arg_values=(),
+        parameters=(),
+        term=ctor("call:opaque", [make_var("xs")]),
+        body=None,
+        site="site",
+    )
+    result = container.contains(TermValue(1), "site").value
+    assert isinstance(result.formula, _Atomic)
+    assert result.formula.name == "py.in"
+
+
+def test_comparison_op_routes_membership_to_list_contains():
+    """`x in xs` is `xs.contains(x)` — ComparisonOpSugar must not panic on ListValue."""
+    from sugar_lift_py_tests.floor import ListValue, TermValue
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    # Mimic `2 in [1, 2, 3]` after both sides have reduced to floors.
+    container = ListValue((TermValue(1), TermValue(2), TermValue(3)))
+    member = TermValue(2)
+    # Direct floor path used by ComparisonOpSugar for In/NotIn.
+    outcome = container.contains(member, "site")
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -540,9 +540,9 @@ def test_finally_return_override_bites_when_cleanup_is_read_as_restoring():
 
     from sugar_lift_py_tests.outcome import Incomplete
 
-    assert isinstance(out, Incomplete), (
-        "perturbation must resurrect the overridden halt"
-    )
+    assert isinstance(
+        out, Incomplete
+    ), "perturbation must resurrect the overridden halt"
     assert out.effect.exception_name == "ValueError"
 
 
@@ -642,8 +642,7 @@ def test_try_finally_routes_through_the_shared_exitset_and_finally():
     incoming = seen[0]
     kinds = {type(exit_).__name__ for exit_ in incoming.exits}
     assert kinds == {"Completed", "Halted"}, (
-        "the shared fold must receive BOTH edges of the body partition, "
-        f"got {kinds}"
+        "the shared fold must receive BOTH edges of the body partition, " f"got {kinds}"
     )
     assert any(
         isinstance(e, Halted) and e.effect.exception_name == "ValueError"
@@ -786,8 +785,12 @@ def _routed(src):
     node = _find_try(_fn(src).sugar())
     assert node is not None
     body_es = promote_raise_halts(reduce_block_to_exitset(node.body, None))
-    return node, body_es, _route_handlers_over_exits(
-        body_es, node.handlers, node.orelse, site=node.site, ctx=None
+    return (
+        node,
+        body_es,
+        _route_handlers_over_exits(
+            body_es, node.handlers, node.orelse, site=node.site, ctx=None
+        ),
     )
 
 
@@ -917,9 +920,9 @@ def test_first_match_is_source_order_and_bites_when_the_arms_are_reversed():
 
     # Precondition of the discriminator: BOTH arms genuinely match.
     matchers = [m for m, _b, _s in node.handlers]
-    assert all(_effect_matches(halted[0].effect, m, None) for m in matchers), (
-        "both arms must match, else source order is not what is being tested"
-    )
+    assert all(
+        _effect_matches(halted[0].effect, m, None) for m in matchers
+    ), "both arms must match, else source order is not what is being tested"
 
     forward = _route_handlers_over_exits(
         body_es, node.handlers, node.orelse, site=node.site, ctx=None

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -606,9 +606,11 @@ impl CallEdgeHarvest {
 /// leaves it absent otherwise (`verify_rpc.py`, `len(candidates) == 1`), so
 /// absent is a legitimate outcome and must be counted, not repaired here.
 fn edge_has_resolved_target(edge: &Value) -> bool {
-    ["targetContract", "targetContractCid"]
-        .iter()
-        .any(|key| edge.get(*key).and_then(Value::as_str).is_some_and(|value| !value.is_empty()))
+    ["targetContract", "targetContractCid"].iter().any(|key| {
+        edge.get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty())
+    })
 }
 
 /// Stable identity for de-duplication. This crate builds `serde_json` with
@@ -1452,8 +1454,7 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
     // its authenticated resolution set so post() projects. Resolved functions are
     // then skipped by the universe scan (their contract comes from the resume).
     let mut resolved_mementos: Vec<Value> = Vec::new();
-    let link_unit_rows =
-        preconstruction_rows_rpc(&conn, Level::ParameterContractLinkUnits)?;
+    let link_unit_rows = preconstruction_rows_rpc(&conn, Level::ParameterContractLinkUnits)?;
     for row in &link_unit_rows {
         // The caller side of a parameter-contract link unit carries the very
         // edges mint needs; they are on the raw wire row, not on the typed
@@ -1483,9 +1484,7 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
         // panic-gap, exactly as before this feature. A single un-dischargeable
         // demand never aborts the rest of the project.
         for unit in &units {
-            let set = match sugar_linker::caller_parameter::fold_one_link_unit(
-                unit, &units,
-            ) {
+            let set = match sugar_linker::caller_parameter::fold_one_link_unit(unit, &units) {
                 Ok(set) => set,
                 Err(gap) => {
                     diagnostics.push(json!({
@@ -1507,8 +1506,9 @@ pub fn fold_enumerate_source_tree(kit: &Kit, workspace_root: &Path) -> Result<Va
                     call_edges.route_audit(&mut ir, audit);
                 }
             }
-            resolved_mementos
-                .push(Value::String(continuation_key_from_memento(&unit.source_memento)));
+            resolved_mementos.push(Value::String(continuation_key_from_memento(
+                &unit.source_memento,
+            )));
         }
     }
     let resolved_option = Value::Array(resolved_mementos);
@@ -2355,10 +2355,14 @@ mod tests {
     #[test]
     fn ir_row_filter_still_admits_contracts_and_rejects_non_rows() {
         assert!(looks_like_ir_contract_row(&json!({"kind": "contract"})));
-        assert!(looks_like_ir_contract_row(&json!({"kind": "function-contract"})));
+        assert!(looks_like_ir_contract_row(
+            &json!({"kind": "function-contract"})
+        ));
         assert!(looks_like_ir_contract_row(&json!({"inv": {}})));
         // Not an IR row: no recognized kind and no body slot.
-        assert!(!looks_like_ir_contract_row(&json!({"kind": "source-memento"})));
+        assert!(!looks_like_ir_contract_row(
+            &json!({"kind": "source-memento"})
+        ));
         assert!(!looks_like_ir_contract_row(&json!({"kind": "term-ref"})));
         assert!(!looks_like_ir_contract_row(&json!("not an object")));
     }
@@ -2817,13 +2821,12 @@ mod tests {
 
     #[test]
     fn call_edge_rows_never_land_in_ir() {
-        let (ir, harvest) = route_all(&[
-            contract_row("double"),
-            call_edge_row("main", "double", 7),
-        ]);
+        let (ir, harvest) =
+            route_all(&[contract_row("double"), call_edge_row("main", "double", 7)]);
 
         assert!(
-            !ir.iter().any(|row| row.get("kind") == Some(&json!("call-edge"))),
+            !ir.iter()
+                .any(|row| row.get("kind") == Some(&json!("call-edge"))),
             "ir must stay contract-shaped: mint copies every ir row into the \
              published document without a shape filter (issue #6251), and it \
              reads edges off the top-level callEdges field, never out of ir"
@@ -2890,5 +2893,4 @@ mod tests {
              from nothing arriving, and sourceLedger.call_edges collapses both"
         );
     }
-
 }

--- a/implementations/rust/sugar-linker/tests/caller_parameter_contract.rs
+++ b/implementations/rust/sugar-linker/tests/caller_parameter_contract.rs
@@ -5,9 +5,9 @@ use sugar_ir_types::{IrFormula, IrTerm, Sort};
 use sugar_linker::caller_parameter::{
     discharge_parameter_candidate, AuthenticatedCallerV1, CallEdgeV2, ClosedCallerUniverseV1,
     ContractConditionalConstructionV1, FormalActualBindingV1, FormalParameterCoordinateV1,
-    FormalParameterDeclarationV1, ParameterContractDemandV1, ParameterKindV1,
-    ParameterContractResolutionV1, ParameterOwnedContractV1, ParameterResolutionGapV1,
-    ResolutionBasisV1, SourceFragmentCoordinateV1, ValueOccurrenceCoordinateV1,
+    FormalParameterDeclarationV1, ParameterContractDemandV1, ParameterContractResolutionV1,
+    ParameterKindV1, ParameterOwnedContractV1, ParameterResolutionGapV1, ResolutionBasisV1,
+    SourceFragmentCoordinateV1, ValueOccurrenceCoordinateV1,
 };
 use sugar_linker::{canonical_json_cid, Cid};
 
@@ -319,8 +319,7 @@ fn closed_callers_resolution_carries_basis_and_authorizing_universe_cid() {
             edge: f.edge.clone(),
         }],
     };
-    let resolved =
-        discharge_parameter_candidate(&f.candidate, &f.contract, &universe).unwrap();
+    let resolved = discharge_parameter_candidate(&f.candidate, &f.contract, &universe).unwrap();
     assert_eq!(resolved.basis, ResolutionBasisV1::ClosedCallers);
     assert_eq!(resolved.contract_cid, f.contract.contract_cid);
     assert_eq!(resolved.caller_universe_cid, Some(universe.cid()));
@@ -367,8 +366,7 @@ fn resolution_round_trips_and_stale_cid_is_rejected() {
             edge: f.edge.clone(),
         }],
     };
-    let resolved =
-        discharge_parameter_candidate(&f.candidate, &f.contract, &universe).unwrap();
+    let resolved = discharge_parameter_candidate(&f.candidate, &f.contract, &universe).unwrap();
     let wire = serde_json::to_value(&resolved).unwrap();
     let round_trip: ParameterContractResolutionV1 = serde_json::from_value(wire).unwrap();
     assert_eq!(round_trip, resolved);

--- a/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_link_unit_fold.rs
@@ -11,7 +11,8 @@ fn encodebase64_self_declared_discharges_without_callers() {
     let raw = include_str!("fixtures/link_unit_encodebase64_selfdeclared.json");
     let unit: ParameterContractLinkUnitV1 =
         serde_json::from_str(raw).expect("Python link unit must deserialize");
-    unit.validate().expect("link unit must validate byte-identically");
+    unit.validate()
+        .expect("link unit must validate byte-identically");
 
     // #2 grounded report: the ACTUAL emitted link unit carries the exact pending
     // demand CID in declaredDemandCids -- that is precisely why the fold selects
@@ -28,12 +29,18 @@ fn encodebase64_self_declared_discharges_without_callers() {
         .expect("self-declared candidate must discharge");
     assert_eq!(sets.len(), 1);
     let set = &sets[0];
-    assert_eq!(set.link_unit_cid, unit.link_unit_cid, "set binds its link unit");
+    assert_eq!(
+        set.link_unit_cid, unit.link_unit_cid,
+        "set binds its link unit"
+    );
     assert_eq!(set.resolutions.len(), 1);
     let res = &set.resolutions[0];
     res.validate().expect("resolution must validate");
     assert_eq!(res.basis, ResolutionBasisV1::DeclaredDemand);
-    assert!(res.caller_universe_cid.is_none(), "self-declared invents no caller");
+    assert!(
+        res.caller_universe_cid.is_none(),
+        "self-declared invents no caller"
+    );
     assert_eq!(res.demand_cid, unit.candidates[0].demand.demand_cid);
     assert_eq!(res.contract_cid, unit.parameter_owned_contract.contract_cid);
 }

--- a/implementations/rust/sugar-linker/tests/parameter_owned_contract_roundtrip.rs
+++ b/implementations/rust/sugar-linker/tests/parameter_owned_contract_roundtrip.rs
@@ -12,12 +12,15 @@ use sugar_linker::caller_parameter::ParameterOwnedContractV1;
 #[test]
 fn python_emitted_owned_contract_validates_cross_language() {
     let raw = include_str!("fixtures/owned_contract_encodebase64.json");
-    let owned: ParameterOwnedContractV1 =
-        serde_json::from_str(raw).expect("Python fixture must deserialize under deny_unknown_fields");
-    owned
-        .validate()
-        .expect("Python-emitted ParameterOwnedContractV1 must pass Rust validate() byte-identically");
+    let owned: ParameterOwnedContractV1 = serde_json::from_str(raw)
+        .expect("Python fixture must deserialize under deny_unknown_fields");
+    owned.validate().expect(
+        "Python-emitted ParameterOwnedContractV1 must pass Rust validate() byte-identically",
+    );
     assert_eq!(owned.formal_declarations.len(), 1);
-    assert_eq!(owned.formal_declarations[0].coordinate.declared_name, "value");
+    assert_eq!(
+        owned.formal_declarations[0].coordinate.declared_name,
+        "value"
+    );
     assert_eq!(owned.declared_demand_cids.len(), 1);
 }


### PR DESCRIPTION
## Summary
- Implement Floor `contains` for the four container types that dominate pass-3 desugar construction panics (215): **ListValue**, **TupleValue**, **CallSiteValue**, **StringValue**.
- Finite sequences reuse SetValue's closed-member equality law (fold true/false, typed symbolic obligation, loud unsupported members).
- Strings fold substring membership; symbolic needles emit `py.in`; ground non-string needles construct TypeError (no RuntimeEffect over ground).
- CallSite containers dig through when a concrete container is available, otherwise emit `py.in`.
- Twins in `test_sequence_membership_floor.py` pin fold / obligation / loud / TypeError arms.

## εR (predicted)
- εR_desugar_panic(contains) ≈ −(List+Tuple+CallSite+String mass) when those containers hit membership; residual panics only for unsupported member shapes and other container types.
- Measured ΔR requires re-census after remeasure @ 063df6c3a completes.

## Validation
```bash
PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src \
  python3 -c 'import importlib.util; ...'  # 16/16 membership twins green
# or focused pytest with PYTHONPATH set for sugar-lift-py-tests
```

## Stack context
- Lands after #6291 (instrument) and #6290 (suite identity).
- Does **not** touch census mid-lease; remeasure of construction With board remains independent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `contains` membership support to `ListValue`, `TupleValue`, `StringValue`, and `CallSiteValue`
> - `ListValue.contains` and `TupleValue.contains` use closed equality to decide membership over concrete elements, emitting a symbolic `python.list.contains`/`python.tuple.contains` predicate when undecidable.
> - `StringValue.contains` handles substring checks for string needles, raises a `TypeError` `RaiseValue` for ground non-string needles, and emits a symbolic `py.in` predicate for symbolic or callsite needles.
> - `CallSiteValue.contains` delegates to a dug concrete floor value when available, otherwise emits a symbolic `py.in` predicate over the member and callsite term.
> - A new test suite in [`test_sequence_membership_floor.py`](https://github.com/TSavo/sugar/pull/6293/files#diff-ca13e5955d025c32caeacadce6de768b478805a60e5554ce8b3cdcd19b8b3e33) covers all four implementations across concrete, symbolic, and error cases.
> - Risk: unsupported member shapes in list/tuple/string containers raise a `construction_panic_gap` at build time rather than producing a runtime error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5cd9b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->