### PR TITLE
Authenticate Python suite binary profile identity

### DIFF
--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -141,7 +141,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sugar_bin="$(bin/sugarbin --profile release)"
+          requested_profile="release"
+          sugar_bin="$(bin/sugarbin --profile "$requested_profile")"
           echo "SUGAR_BIN=$sugar_bin" >> "$GITHUB_ENV"
           manifest="$sugar_bin.sugarbin.json"
           if [ ! -f "$manifest" ]; then
@@ -149,11 +150,30 @@ jobs:
             exit 1
           fi
           stamp="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sourceStamp"])' "$manifest")"
+          resolved_profile="$(
+            python3 - "$manifest" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              manifest = json.load(handle)
+          profile = manifest.get("profile")
+          if profile is None:
+              print(
+                  "resolved binary manifest predates the profile identity boundary; rebuild it",
+                  file=sys.stderr,
+              )
+              raise SystemExit(3)
+          print(profile)
+          PY
+          )"
           case "$stamp" in
             blake3-512_*) ;;
             *) echo "::error::binary manifest sourceStamp is malformed: $stamp"; exit 1 ;;
           esac
           echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
+          echo "requested-profile=$requested_profile" >> "$GITHUB_OUTPUT"
+          echo "resolved-profile=$resolved_profile" >> "$GITHUB_OUTPUT"
           echo "measured binary sourceStamp: $stamp"
 
       # ONE cold process. Whole package. Canonical collection order.
@@ -182,6 +202,8 @@ jobs:
             --suite-identity="$SUITE_IDENTITY_PATH" \
             --suite-commit="$GITHUB_SHA" \
             --suite-binary-stamp="$SUITE_BINARY_STAMP" \
+            --suite-requested-binary-profile="$SUITE_REQUESTED_BINARY_PROFILE" \
+            --suite-resolved-binary-profile="$SUITE_RESOLVED_BINARY_PROFILE" \
             --suite-order=canonical \
             --suite-label=python-package-suite-canonical \
             2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
@@ -190,6 +212,8 @@ jobs:
           set +e
           SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
           SUITE_BINARY_STAMP='${{ steps.binary.outputs.stamp }}' \
+          SUITE_REQUESTED_BINARY_PROFILE='${{ steps.binary.outputs.requested-profile }}' \
+          SUITE_RESOLVED_BINARY_PROFILE='${{ steps.binary.outputs.resolved-profile }}' \
           python3 "$GITHUB_WORKSPACE/tools/heavy_measurement_lease.py" \
             --class python-package-suite \
             --record "$GITHUB_WORKSPACE/lease-record.json" \
@@ -338,7 +362,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sugar_bin="$(bin/sugarbin --profile release)"
+          requested_profile="release"
+          sugar_bin="$(bin/sugarbin --profile "$requested_profile")"
           echo "SUGAR_BIN=$sugar_bin" >> "$GITHUB_ENV"
           manifest="$sugar_bin.sugarbin.json"
           if [ ! -f "$manifest" ]; then
@@ -346,7 +371,26 @@ jobs:
             exit 1
           fi
           stamp="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sourceStamp"])' "$manifest")"
+          resolved_profile="$(
+            python3 - "$manifest" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              manifest = json.load(handle)
+          profile = manifest.get("profile")
+          if profile is None:
+              print(
+                  "resolved binary manifest predates the profile identity boundary; rebuild it",
+                  file=sys.stderr,
+              )
+              raise SystemExit(3)
+          print(profile)
+          PY
+          )"
           echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
+          echo "requested-profile=$requested_profile" >> "$GITHUB_OUTPUT"
+          echo "resolved-profile=$resolved_profile" >> "$GITHUB_OUTPUT"
 
       # A SEPARATE COLD PROCESS per order. Sharing a process would let the
       # first order warm exactly the caches whose influence we are measuring.
@@ -370,6 +414,8 @@ jobs:
             --suite-identity="$SUITE_IDENTITY_PATH" \
             --suite-commit="$GITHUB_SHA" \
             --suite-binary-stamp="$SUITE_BINARY_STAMP" \
+            --suite-requested-binary-profile="$SUITE_REQUESTED_BINARY_PROFILE" \
+            --suite-resolved-binary-profile="$SUITE_RESOLVED_BINARY_PROFILE" \
             --suite-order="$SUITE_ORDER" \
             --suite-shuffle-seed="$GITHUB_RUN_ID" \
             --suite-label="python-package-suite-$SUITE_ORDER" \
@@ -379,6 +425,8 @@ jobs:
           set +e
           SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
           SUITE_BINARY_STAMP='${{ steps.binary.outputs.stamp }}' \
+          SUITE_REQUESTED_BINARY_PROFILE='${{ steps.binary.outputs.requested-profile }}' \
+          SUITE_RESOLVED_BINARY_PROFILE='${{ steps.binary.outputs.resolved-profile }}' \
           SUITE_ORDER='${{ matrix.order }}' \
           python3 "$GITHUB_WORKSPACE/tools/heavy_measurement_lease.py" \
             --class python-package-suite \

--- a/docs/superpowers/plans/2026-07-25-resolved-binary-profile-identity.md
+++ b/docs/superpowers/plans/2026-07-25-resolved-binary-profile-identity.md
@@ -1,0 +1,610 @@
+# Resolved Binary Profile Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every authoritative Python package-suite report prove that its requested Sugar profile equals the resolved binary manifest profile.
+
+**Architecture:** Extend the existing #6290 serialized suite identity with separate requested and resolved profile fields. The report plugin writes a provisional single-use authority pre-state; the post-serialization identity gate validates the fields and atomically transitions the artifact to either authoritative/resolved or provisional/unresolved. The workflow reads resolved testimony from `<binary>.sugarbin.json`, never from path spelling.
+
+**Tech Stack:** Python 3 standard library, pytest plugin hooks, GitHub Actions YAML, JSON artifact contracts, Bash.
+
+## Global Constraints
+
+- Base every measurement and change on `df408100e74d6ca073a5a6641c9fde94f6822e6a`.
+- Cite path-evident override refusal as #6282; #6276 is the sccache/incremental fix.
+- Profiles are exactly `release` or `debug`.
+- A missing manifest `profile` is `profile-manifest-predates-boundary`, never a mismatch.
+- The only accepted authority pre-state is provisional/unverified with no crimes.
+- Authority transition is one-way, single-shot, and atomically written with a same-directory temporary file plus `os.replace`.
+- Missing authority is refused, never synthesized.
+- Authoritative reports have no `crimes` key; provisional/unresolved reports replace `crimes` with the full current list.
+- Own-baseline A/B governs; trunk CI at `df40810` is independently red.
+- Run the full owning top-level `tests` package, not only the focused identity file.
+
+---
+
+### Task 1: Plant profile and authority discrimination teeth
+
+**Files:**
+- Modify: `tests/test_python_suite_identity_gate_twins.py`
+
+**Interfaces:**
+- Consumes: `python_suite_identity_gate.gate(report, require_commit)` and `python_suite_identity_gate.main(argv)`.
+- Produces: `_report()` fixtures with `requestedBinaryProfile`, `resolvedBinaryProfile`, and the provisional/unverified authority pre-state; exact red/green laws for every new branch.
+
+- [ ] **Step 1: Capture the full owning-package baseline at the design-only HEAD**
+
+Run:
+
+```bash
+git rev-parse HEAD
+python3 -m pytest tests -q -p no:cacheprovider -rf \
+  --junitxml=/tmp/chucky-profile-identity-before.xml
+```
+
+Expected: record the terminal summary and exact failed/error node-ID set. Do not require green; this is the `df40810` own baseline.
+
+- [ ] **Step 2: Extend the green report fixture with profile and authority identity**
+
+Add to `_report()`:
+
+```python
+"requestedBinaryProfile": "release",
+"resolvedBinaryProfile": "release",
+"authority": {
+    "status": "provisional",
+    "profileIdentity": "unverified",
+},
+```
+
+The existing `assert _crimes(_report()) == []` remains the green face.
+
+- [ ] **Step 3: Add distinct profile field teeth**
+
+Add:
+
+```python
+def test_profile_identity_presence_enumeration_and_equality():
+    assert _crimes(_report()) == []
+
+    missing_requested = _report()
+    del missing_requested["requestedBinaryProfile"]
+    crimes = _crimes(missing_requested)
+    assert "crime=profile-identity-absent" in _crime_kinds(crimes)
+
+    missing_resolved = _report()
+    del missing_resolved["resolvedBinaryProfile"]
+    crimes = _crimes(missing_resolved)
+    assert "crime=profile-manifest-predates-boundary" in _crime_kinds(crimes)
+    assert any("predates the profile identity boundary" in crime for crime in crimes)
+    assert not any(
+        crime.startswith("crime=profile-identity-mismatch") for crime in crimes
+    )
+
+    for field in ("requestedBinaryProfile", "resolvedBinaryProfile"):
+        malformed = _report()
+        malformed[field] = "fast"
+        crimes = _crimes(malformed)
+        assert "crime=profile-identity-malformed" in _crime_kinds(crimes)
+
+    mismatch = _report(resolvedBinaryProfile="debug")
+    crimes = _crimes(mismatch)
+    assert "crime=profile-identity-mismatch" in _crime_kinds(crimes)
+```
+
+- [ ] **Step 4: Add single-shot authority transition teeth**
+
+Add:
+
+```python
+def test_authority_prestate_is_single_shot_and_not_synthesized():
+    assert _crimes(_report()) == []
+
+    already = _report(
+        authority={"status": "authoritative", "profileIdentity": "resolved"}
+    )
+    assert "crime=authority-already-decided" in _crime_kinds(_crimes(already))
+
+    absent = _report()
+    del absent["authority"]
+    assert "crime=authority-object-absent" in _crime_kinds(_crimes(absent))
+
+    stale = _report(
+        authority={
+            "status": "provisional",
+            "profileIdentity": "unverified",
+            "crimes": ["crime=old"],
+        }
+    )
+    assert "crime=authority-stale-crimes" in _crime_kinds(_crimes(stale))
+```
+
+- [ ] **Step 5: Add serialized rewrite tests, including atomic replacement**
+
+Add tests that write `_report()` to a temporary `suite-report.json`, invoke `gate.main`, and re-read it:
+
+```python
+def test_gate_atomically_writes_exact_authority_verdict():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "suite-report.json")
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(_report(), handle)
+
+        assert gate.main(["--report", path, "--require-commit", COMMIT]) == 0
+        with open(path, encoding="utf-8") as handle:
+            decided = json.load(handle)
+        assert decided["authority"] == {
+            "status": "authoritative",
+            "profileIdentity": "resolved",
+        }
+        assert "crimes" not in decided["authority"]
+        assert not [
+            name for name in os.listdir(tmp) if name.startswith(".suite-report-")
+        ]
+
+        assert gate.main(["--report", path, "--require-commit", COMMIT]) == 1
+        with open(path, encoding="utf-8") as handle:
+            unchanged = json.load(handle)
+        assert unchanged == decided
+```
+
+Add a provisional arm:
+
+```python
+def test_gate_replaces_provisional_crimes_with_full_current_list():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "suite-report.json")
+        report = _report(resolvedBinaryProfile="debug")
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(report, handle)
+
+        assert gate.main(["--report", path, "--require-commit", COMMIT]) == 1
+        with open(path, encoding="utf-8") as handle:
+            decided = json.load(handle)
+        authority = decided["authority"]
+        assert authority["status"] == "provisional"
+        assert authority["profileIdentity"] == "unresolved"
+        assert authority["crimes"] == [
+            crime.split(" ", 1)[0] for crime in gate.gate(report, COMMIT)
+        ]
+```
+
+Add an absent-authority arm which asserts the file is byte-identical after refusal.
+
+- [ ] **Step 6: Run the twins and verify the intended red state**
+
+Run:
+
+```bash
+python3 tests/test_python_suite_identity_gate_twins.py
+```
+
+Expected: the new profile and authority tests fail because the production gate does not yet validate or rewrite these fields. Existing teeth remain green.
+
+- [ ] **Step 7: Commit the red tests**
+
+```bash
+git add tests/test_python_suite_identity_gate_twins.py
+git commit -m "test: require resolved profile suite identity" \
+  --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+  --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+```
+
+---
+
+### Task 2: Implement profile validation and atomic authority transition
+
+**Files:**
+- Modify: `tools/python_package_suite_report.py`
+- Modify: `tools/python_suite_identity_gate.py`
+- Modify: `tools/python_package_suite_summary.py`
+
+**Interfaces:**
+- Consumes: pytest options `--suite-requested-binary-profile` and `--suite-resolved-binary-profile`.
+- Produces: top-level report fields `requestedBinaryProfile: str | None`, `resolvedBinaryProfile: str | None`, and `authority: dict[str, object]`; `gate()` crime list; atomic `_write_report(path, report)` transition.
+
+- [ ] **Step 1: Add report plugin options**
+
+In `pytest_addoption`, add:
+
+```python
+group.addoption(
+    "--suite-requested-binary-profile",
+    action="store",
+    default=None,
+    choices=("release", "debug"),
+    metavar="PROFILE",
+    help="Sugar profile requested by the suite",
+)
+group.addoption(
+    "--suite-resolved-binary-profile",
+    action="store",
+    default=None,
+    metavar="PROFILE",
+    help="profile read from the resolved binary's .sugarbin.json manifest",
+)
+```
+
+Do not give the resolved option a `choices` constraint: malformed manifest testimony must reach the identity gate and be recorded as provisional, not be converted into argparse prose.
+
+- [ ] **Step 2: Serialize the provisional authority pre-state**
+
+In `pytest_sessionfinish`, add:
+
+```python
+"requestedBinaryProfile": self.config.getoption(
+    "--suite-requested-binary-profile"
+),
+"resolvedBinaryProfile": self.config.getoption(
+    "--suite-resolved-binary-profile"
+),
+"authority": {
+    "status": "provisional",
+    "profileIdentity": "unverified",
+},
+```
+
+The plugin does not infer either value from the binary path.
+
+- [ ] **Step 3: Add authority pre-state validation**
+
+In `tools/python_suite_identity_gate.py`, add:
+
+```python
+PROFILES = frozenset({"release", "debug"})
+
+
+def _check_authority_prestate(report, crimes):
+    authority = report.get("authority")
+    if not isinstance(authority, dict):
+        crimes.append(
+            "crime=authority-object-absent illegal shape=suite-report.json has "
+            "no authority object replacement=produce the report with the current "
+            "suite plugin; the gate does not manufacture testimony"
+        )
+        return
+    if authority.get("status") == "authoritative":
+        crimes.append(
+            "crime=authority-already-decided illegal shape=report was already "
+            "decided replacement=gate each artifact exactly once"
+        )
+        return
+    if authority.get("status") != "provisional" or authority.get(
+        "profileIdentity"
+    ) != "unverified":
+        crimes.append(
+            "crime=authority-prestate-malformed illegal shape=authority is not "
+            "provisional/unverified replacement=start from the plugin's exact "
+            "single-use pre-state"
+        )
+    if "crimes" in authority:
+        crimes.append(
+            "crime=authority-stale-crimes illegal shape=unverified report "
+            "already carries crimes replacement=do not recycle a decided artifact"
+        )
+```
+
+Call it first from `_check_identity`.
+
+- [ ] **Step 4: Add profile validation with distinct missing branches**
+
+Add:
+
+```python
+def _check_profile_identity(report, crimes):
+    requested = report.get("requestedBinaryProfile")
+    resolved_present = "resolvedBinaryProfile" in report
+    resolved = report.get("resolvedBinaryProfile")
+
+    if requested in (None, ""):
+        crimes.append(
+            "crime=profile-identity-absent illegal shape=no "
+            "requestedBinaryProfile replacement=state the requested profile"
+        )
+    elif requested not in PROFILES:
+        crimes.append(
+            f"crime=profile-identity-malformed illegal shape=requested profile "
+            f"{requested!r} replacement=profile is release or debug"
+        )
+
+    if not resolved_present or resolved in (None, ""):
+        crimes.append(
+            "crime=profile-manifest-predates-boundary illegal shape=resolved "
+            "binary manifest has no profile replacement=this manifest predates "
+            "the profile identity boundary; rebuild it"
+        )
+    elif resolved not in PROFILES:
+        crimes.append(
+            f"crime=profile-identity-malformed illegal shape=resolved profile "
+            f"{resolved!r} replacement=profile is release or debug"
+        )
+
+    if requested in PROFILES and resolved in PROFILES and requested != resolved:
+        crimes.append(
+            f"crime=profile-identity-mismatch illegal shape=requested "
+            f"{requested!r} != resolved {resolved!r} replacement=measure the "
+            "profile the report claims"
+        )
+```
+
+Call it after the authority pre-state check.
+
+- [ ] **Step 5: Implement atomic single-shot report rewriting**
+
+Add imports `os` and `tempfile`, then:
+
+```python
+def _crime_ids(crimes):
+    return [crime.split(" ", 1)[0] for crime in crimes]
+
+
+def _write_report_atomic(path, report):
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, temporary = tempfile.mkstemp(prefix=".suite-report-", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+```
+
+In the report CLI path:
+
+- refuse missing authority without writing;
+- refuse already-authoritative without writing;
+- otherwise replace `authority` exactly:
+
+```python
+if crimes:
+    report["authority"] = {
+        "status": "provisional",
+        "profileIdentity": "unresolved",
+        "crimes": _crime_ids(crimes),
+    }
+else:
+    report["authority"] = {
+        "status": "authoritative",
+        "profileIdentity": "resolved",
+    }
+_write_report_atomic(path, report)
+```
+
+Preserve the full human-readable crime output and nonzero exit on provisional.
+
+- [ ] **Step 6: Render profile and authority fields in the summary**
+
+Add summary lines:
+
+```python
+authority = report.get("authority") or {}
+...
+f"- authority: {_field(authority.get('status'))}"
+f" / profile identity {_field(authority.get('profileIdentity'))}",
+f"- Sugar profile: requested {_field(report.get('requestedBinaryProfile'))}"
+f" / resolved {_field(report.get('resolvedBinaryProfile'))}",
+```
+
+Do not infer authority from the absence of crimes.
+
+- [ ] **Step 7: Run standalone twins and verify green**
+
+Run:
+
+```bash
+python3 tests/test_python_suite_identity_gate_twins.py
+```
+
+Expected: zero failing teeth. Re-running the CLI on the authoritative fixture must fail with `crime=authority-already-decided`.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add tools/python_package_suite_report.py \
+  tools/python_suite_identity_gate.py \
+  tools/python_package_suite_summary.py
+git commit -m "feat: gate suite authority on resolved profile" \
+  --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+  --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+```
+
+---
+
+### Task 3: Wire manifest-authenticated profile testimony into CI
+
+**Files:**
+- Modify: `.github/workflows/python-package-suite.yml`
+- Modify: `tests/test_python_suite_identity_gate_twins.py`
+
+**Interfaces:**
+- Consumes: `profile` from `<resolved-binary>.sugarbin.json`.
+- Produces: workflow outputs `requested-profile` and `resolved-profile`, pytest plugin arguments carrying both values, and a pre-pytest missing-field refusal.
+
+- [ ] **Step 1: Add a workflow source-contract test**
+
+Add a test that reads `.github/workflows/python-package-suite.yml` and asserts it contains:
+
+```python
+def test_workflow_carries_manifest_profile_into_suite_report():
+    workflow = open(
+        os.path.join(REPO_ROOT, ".github/workflows/python-package-suite.yml"),
+        encoding="utf-8",
+    ).read()
+    assert 'requested_profile="release"' in workflow
+    assert 'manifest.get("profile")' in workflow
+    assert "predates the profile identity boundary; rebuild it" in workflow
+    assert "--suite-requested-binary-profile=" in workflow
+    assert "--suite-resolved-binary-profile=" in workflow
+```
+
+- [ ] **Step 2: Run the new contract test red**
+
+Run:
+
+```bash
+python3 tests/test_python_suite_identity_gate_twins.py
+```
+
+Expected: only the new workflow source-contract test fails.
+
+- [ ] **Step 3: Read manifest profile with a distinct missing-field refusal**
+
+In the binary resolution step:
+
+```bash
+requested_profile="release"
+sugar_bin="$(bin/sugarbin --profile "$requested_profile")"
+...
+resolved_profile="$(
+  python3 - "$manifest" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    manifest = json.load(handle)
+profile = manifest.get("profile")
+if profile is None:
+    print(
+        "resolved binary manifest predates the profile identity boundary; rebuild it",
+        file=sys.stderr,
+    )
+    raise SystemExit(3)
+print(profile)
+PY
+)"
+echo "requested-profile=$requested_profile" >> "$GITHUB_OUTPUT"
+echo "resolved-profile=$resolved_profile" >> "$GITHUB_OUTPUT"
+```
+
+Keep the existing sourceStamp read and validation.
+
+- [ ] **Step 4: Pass both values into the report plugin**
+
+Add:
+
+```bash
+--suite-requested-binary-profile="$SUITE_REQUESTED_BINARY_PROFILE" \
+--suite-resolved-binary-profile="$SUITE_RESOLVED_BINARY_PROFILE" \
+```
+
+and bind:
+
+```bash
+SUITE_REQUESTED_BINARY_PROFILE='${{ steps.binary.outputs.requested-profile }}' \
+SUITE_RESOLVED_BINARY_PROFILE='${{ steps.binary.outputs.resolved-profile }}' \
+```
+
+- [ ] **Step 5: Run standalone twins green**
+
+Run:
+
+```bash
+python3 tests/test_python_suite_identity_gate_twins.py
+```
+
+Expected: zero failing teeth, including workflow source contract.
+
+- [ ] **Step 6: Commit workflow wiring**
+
+```bash
+git add .github/workflows/python-package-suite.yml \
+  tests/test_python_suite_identity_gate_twins.py
+git commit -m "ci: authenticate suite binary profile" \
+  --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+  --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+```
+
+---
+
+### Task 4: Full own-baseline verification and publication
+
+**Files:**
+- Verify: `tests/`
+- Verify: all files changed by Tasks 1-3
+
+**Interfaces:**
+- Consumes: before JUnit receipt from Task 1.
+- Produces: exact A/B node-ID comparison, clean diff, signed commits, pushed branch, and draft PR.
+
+- [ ] **Step 1: Run the full owning top-level test package**
+
+Run:
+
+```bash
+git rev-parse HEAD
+python3 -m pytest tests -q -p no:cacheprovider -rf \
+  --junitxml=/tmp/chucky-profile-identity-after.xml
+```
+
+Expected: capture terminal summary. Extract sorted failed/error node IDs from both JUnit files and require no additions outside the new intentionally red-before/green-after teeth. If the baseline was red, report retained red identities explicitly.
+
+- [ ] **Step 2: Re-run standalone teeth and structural checks**
+
+Run:
+
+```bash
+python3 tests/test_python_suite_identity_gate_twins.py
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: zero failing teeth, no whitespace errors, no uncommitted source changes.
+
+- [ ] **Step 3: Verify commit trailers**
+
+Run:
+
+```bash
+git log origin/main..HEAD --format=full
+```
+
+Expected: every commit carries matching `Co-authored-by` and `Signed-off-by` trailers for `WOPR <evilgenius@nefariousplan.com>`.
+
+- [ ] **Step 4: Push the branch**
+
+Run:
+
+```bash
+git push -u origin chucky/resolved-profile-identity
+```
+
+- [ ] **Step 5: Open a draft PR**
+
+The PR body must state:
+
+- manifest profile is authenticated testimony; #6282 is only the path-evident fast refusal;
+- missing manifest profile and mismatch are distinct crimes;
+- authority rewrite is one-way, single-shot, and atomic;
+- authoritative reports have no crimes; provisional reports carry the exact full crime identifiers;
+- `df40810` own-baseline A/B receipts and retained trunk reds;
+- no claim that broadly red trunk CI is green.
+
+Use:
+
+```bash
+env -u GH_TOKEN -u GITHUB_TOKEN gh pr create \
+  --repo TSavo/sugar \
+  --base main \
+  --head chucky/resolved-profile-identity \
+  --draft \
+  --title "feat: authenticate suite binary profile identity" \
+  --body-file /tmp/chucky-profile-identity-pr.md
+```
+
+- [ ] **Step 6: Verify the remote handoff**
+
+Run:
+
+```bash
+env -u GH_TOKEN -u GITHUB_TOKEN gh pr view --repo TSavo/sugar \
+  --json url,isDraft,state,headRefOid,baseRefName,files
+```
+
+Expected: OPEN, draft, base `main`, head equals local HEAD, and only the planned files are present.

--- a/docs/superpowers/specs/2026-07-25-resolved-binary-profile-identity-design.md
+++ b/docs/superpowers/specs/2026-07-25-resolved-binary-profile-identity-design.md
@@ -103,6 +103,28 @@ Downstream consumers therefore refuse provisional evidence by reading fields,
 not by parsing logs. The existing authoritative/provisional artifact naming
 remains an additional publication boundary, not the only testimony.
 
+### Rewrite law
+
+The rewrite is one-way and single-shot:
+
+- the only accepted pre-state is exactly
+  `status=provisional/profileIdentity=unverified`, with no `crimes` key;
+- the only successful transition is to
+  `status=authoritative/profileIdentity=resolved`, still with no `crimes` key;
+- the only failed transition is to
+  `status=provisional/profileIdentity=unresolved`, with `crimes` replaced by
+  the full current crime list;
+- a report already carrying `status=authoritative` is refused with
+  `crime=authority-already-decided`; the gate never re-decides it;
+- a missing `authority` object is refused with
+  `crime=authority-object-absent`; the gate never manufactures the field it
+  was asked to authenticate;
+- stale `crimes` in the unverified pre-state are refused rather than cleared.
+
+The update uses a temporary file in the report's directory followed by
+`os.replace`. A killed gate therefore leaves either the original parseable
+provisional report or the complete replacement, never a truncated artifact.
+
 ## Files
 
 - `.github/workflows/python-package-suite.yml`
@@ -115,16 +137,22 @@ remains an additional publication boundary, not the only testimony.
   - serialize the two fields and initial provisional authority object.
 - `tools/python_suite_identity_gate.py`
   - validate profile presence, enumeration, and equality;
-  - write the machine-readable authority verdict back to the report.
+  - enforce the single-shot authority pre-state;
+  - atomically write the machine-readable authority verdict back to the report.
 - `tools/python_package_suite_summary.py`
   - display requested/resolved profile and authority status without turning
     prose into the gate.
 - `tests/test_python_suite_identity_gate_twins.py`
   - green equal-profile face;
   - distinct missing-manifest-profile face and message;
-  - malformed requested/resolved faces;
-  - release/debug mismatch face;
-  - serialized provisional and authoritative verdict faces.
+   - malformed requested/resolved faces;
+   - release/debug mismatch face;
+   - serialized provisional and authoritative verdict faces;
+   - already-authoritative refusal;
+   - missing-authority-object refusal;
+   - stale-crimes refusal;
+   - atomic replacement preserving parseability and clearing-or-replacing
+     `crimes` exactly.
 
 ## Testing
 
@@ -134,10 +162,11 @@ remains an additional publication boundary, not the only testimony.
    python3 tests/test_python_suite_identity_gate_twins.py
    ```
 
-2. Run the full repository package for the touched top-level identity tooling:
+2. Run the full owning top-level test package before and after the change,
+   retaining exact sorted node-ID sets for the A/B comparison:
 
    ```bash
-   python3 -m pytest tests/test_python_suite_identity_gate_twins.py -q
+   python3 -m pytest tests -q -p no:cacheprovider -rf
    ```
 
 3. Validate workflow syntax and source contracts through the existing tests,

--- a/docs/superpowers/specs/2026-07-25-resolved-binary-profile-identity-design.md
+++ b/docs/superpowers/specs/2026-07-25-resolved-binary-profile-identity-design.md
@@ -1,0 +1,152 @@
+# Resolved Binary Profile as Suite Identity
+
+## Goal
+
+Make the authoritative Python package-suite artifact prove which Sugar build
+profile it requested and which profile the measured binary actually carries.
+A report is provisional unless both values are present, are members of
+`{"release", "debug"}`, and are equal.
+
+## Existing boundaries
+
+- `bin/sugarbin` already rejects a path that visibly contradicts the requested
+  profile (#6282). That protects path-evident overrides, but an opaque override
+  path carries no authenticated profile evidence.
+- `<resolved-binary>.sugarbin.json` is written by the binary producer and
+  already carries `sourceStamp`, `buildIdentity`, `profile`, and the binary
+  checksum. The authoritative workflow already reads `sourceStamp` from this
+  manifest.
+- `tools/python_package_suite_report.py` serializes suite identity into
+  `suite-report.json`.
+- `tools/python_suite_identity_gate.py` re-reads the serialized report and
+  decides whether it is authoritative or provisional (#6290).
+
+## Design
+
+### Resolution testimony
+
+The workflow requests one explicit profile, currently `release`, and stores it
+as `requestedBinaryProfile`. After `bin/sugarbin` resolves the binary, the
+workflow reads `profile` from `<binary>.sugarbin.json` and stores it separately
+as `resolvedBinaryProfile`.
+
+The workflow must not derive the resolved value from the binary path. The
+manifest is the authenticated producer testimony; path spelling remains only
+the earlier #6282 fast refusal.
+
+### Missing manifest-profile boundary
+
+A manifest without a `profile` key predates this identity boundary. Resolution
+must stop before pytest and emit a distinct diagnostic:
+
+> resolved binary manifest predates the profile identity boundary; rebuild it
+
+This is not a mismatch. A missing value cannot contradict another value because
+it provides no testimony at all. The missing-field and mismatch branches have
+separate discrimination tests and separate crime identifiers.
+
+### Serialized report fields
+
+`suite-report.json` carries:
+
+```json
+{
+  "requestedBinaryProfile": "release",
+  "resolvedBinaryProfile": "release",
+  "authority": {
+    "status": "authoritative",
+    "profileIdentity": "resolved"
+  }
+}
+```
+
+The report plugin accepts `--suite-requested-binary-profile` and
+`--suite-resolved-binary-profile`. It serializes the two values exactly as
+provided; it does not infer or repair them.
+
+### Gate law
+
+The post-serialization gate applies these checks in order:
+
+1. If `requestedBinaryProfile` is missing, emit
+   `crime=profile-identity-absent` naming the requested field.
+2. If `resolvedBinaryProfile` is missing, emit
+   `crime=profile-manifest-predates-boundary` with the rebuild instruction.
+3. If either populated field is outside `release|debug`, emit
+   `crime=profile-identity-malformed`.
+4. If both populated fields are valid but unequal, emit
+   `crime=profile-identity-mismatch`.
+5. Only equal valid values earn profile authority.
+
+The gate continues to return every crime it finds rather than stopping at the
+first failure.
+
+### Machine-readable provisional verdict
+
+`suite-report.json` must carry an `authority` object. Before the post-run gate,
+the plugin writes:
+
+```json
+{
+  "status": "provisional",
+  "profileIdentity": "unverified"
+}
+```
+
+The gate rewrites the serialized artifact after checking it:
+
+- no crimes: `status=authoritative`, `profileIdentity=resolved`;
+- any crime: `status=provisional`, `profileIdentity=unresolved`, plus a
+  `crimes` list containing the exact machine-readable crime identifiers.
+
+Downstream consumers therefore refuse provisional evidence by reading fields,
+not by parsing logs. The existing authoritative/provisional artifact naming
+remains an additional publication boundary, not the only testimony.
+
+## Files
+
+- `.github/workflows/python-package-suite.yml`
+  - declare the requested profile once;
+  - read `sourceStamp` and `profile` from the resolved binary manifest;
+  - refuse a manifest that predates the profile boundary;
+  - pass both profile values to the report plugin.
+- `tools/python_package_suite_report.py`
+  - add the two command-line options;
+  - serialize the two fields and initial provisional authority object.
+- `tools/python_suite_identity_gate.py`
+  - validate profile presence, enumeration, and equality;
+  - write the machine-readable authority verdict back to the report.
+- `tools/python_package_suite_summary.py`
+  - display requested/resolved profile and authority status without turning
+    prose into the gate.
+- `tests/test_python_suite_identity_gate_twins.py`
+  - green equal-profile face;
+  - distinct missing-manifest-profile face and message;
+  - malformed requested/resolved faces;
+  - release/debug mismatch face;
+  - serialized provisional and authoritative verdict faces.
+
+## Testing
+
+1. Run the standalone identity twins red before implementation and green after:
+
+   ```bash
+   python3 tests/test_python_suite_identity_gate_twins.py
+   ```
+
+2. Run the full repository package for the touched top-level identity tooling:
+
+   ```bash
+   python3 -m pytest tests/test_python_suite_identity_gate_twins.py -q
+   ```
+
+3. Validate workflow syntax and source contracts through the existing tests,
+   then run:
+
+   ```bash
+   git diff --check
+   ```
+
+No Python verdict baseline is changed. This gate decides whether a measurement
+is authoritative; it does not reinterpret failed, error, skipped, or passed
+nodes.

--- a/tests/test_python_suite_identity_gate_twins.py
+++ b/tests/test_python_suite_identity_gate_twins.py
@@ -20,6 +20,8 @@ Runs with pytest, or standalone with no dependency at all:
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import stat
@@ -73,6 +75,12 @@ def _report(**overrides):
         "testExtraInputHash": EXTRAS_HASH,
         "environmentIdentityHash": ENV_HASH,
         "binarySourceStamp": STAMP,
+        "requestedBinaryProfile": "release",
+        "resolvedBinaryProfile": "release",
+        "authority": {
+            "status": "provisional",
+            "profileIdentity": "unverified",
+        },
         "environmentIdentity": _identity_blob(),
         "runnerIdentity": {"githubSha": COMMIT},
         "collectedNodeIds": collected,
@@ -292,7 +300,7 @@ def test_tooth5_fully_populated_is_green():
         with open(path, "w", encoding="utf-8") as handle:
             json.dump(report, handle)
         assert gate.main(["--report", path, "--require-commit", COMMIT]) == 0
-        assert gate.main(["--report", path, "--require-commit", "0" * 40]) == 1
+        assert gate.main(["--report", path, "--require-commit", COMMIT]) == 1
 
 
 # --- tooth 6: the {"unavailable": ...} object is UNRESOLVED, not truthy -----
@@ -407,6 +415,141 @@ def test_conservation_is_checked_on_the_artifact():
     bare = _report()
     del bare["conservation"]
     assert "crime=conservation-absent" in _crime_kinds(_crimes(bare))
+
+
+# --- resolved profile is authenticated testimony ---------------------------
+
+
+def test_profile_identity_presence_enumeration_and_equality():
+    assert _crimes(_report()) == []
+
+    missing_requested = _report()
+    del missing_requested["requestedBinaryProfile"]
+    crimes = _crimes(missing_requested)
+    assert "crime=profile-identity-absent" in _crime_kinds(crimes), crimes
+
+    missing_resolved = _report()
+    del missing_resolved["resolvedBinaryProfile"]
+    crimes = _crimes(missing_resolved)
+    assert "crime=profile-manifest-predates-boundary" in _crime_kinds(crimes), crimes
+    assert any("predates the profile identity boundary" in crime for crime in crimes)
+    assert not any(
+        crime.startswith("crime=profile-identity-mismatch") for crime in crimes
+    )
+
+    for field in ("requestedBinaryProfile", "resolvedBinaryProfile"):
+        malformed = _report()
+        malformed[field] = "fast"
+        crimes = _crimes(malformed)
+        assert "crime=profile-identity-malformed" in _crime_kinds(crimes), crimes
+
+    mismatch = _report(resolvedBinaryProfile="debug")
+    crimes = _crimes(mismatch)
+    assert "crime=profile-identity-mismatch" in _crime_kinds(crimes), crimes
+
+
+# --- authority is a one-way, single-shot artifact transition ---------------
+
+
+def test_authority_prestate_is_single_shot_and_not_synthesized():
+    assert _crimes(_report()) == []
+
+    already = _report(
+        authority={"status": "authoritative", "profileIdentity": "resolved"}
+    )
+    crimes = _crimes(already)
+    assert "crime=authority-already-decided" in _crime_kinds(crimes), crimes
+
+    absent = _report()
+    del absent["authority"]
+    crimes = _crimes(absent)
+    assert "crime=authority-object-absent" in _crime_kinds(crimes), crimes
+
+    stale = _report(
+        authority={
+            "status": "provisional",
+            "profileIdentity": "unverified",
+            "crimes": ["crime=old"],
+        }
+    )
+    crimes = _crimes(stale)
+    assert "crime=authority-stale-crimes" in _crime_kinds(crimes), crimes
+
+
+def _write_json(path, value):
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(value, handle)
+
+
+def _read_json(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_gate_atomically_writes_exact_authority_verdict():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "suite-report.json")
+        _write_json(path, _report())
+
+        first_returncode = gate.main(
+            ["--report", path, "--require-commit", COMMIT]
+        )
+        decided = _read_json(path)
+        assert decided["authority"] == {
+            "status": "authoritative",
+            "profileIdentity": "resolved",
+        }
+        assert "crimes" not in decided["authority"]
+        assert not [
+            name for name in os.listdir(tmp) if name.startswith(".suite-report-")
+        ]
+        assert first_returncode == 0
+
+        with contextlib.redirect_stderr(io.StringIO()) as captured:
+            second_returncode = gate.main(
+                ["--report", path, "--require-commit", COMMIT]
+            )
+        unchanged = _read_json(path)
+        assert unchanged == decided
+        assert "crime=authority-already-decided" in captured.getvalue()
+        assert second_returncode == 1
+
+
+def test_gate_replaces_provisional_crimes_with_full_current_list():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "suite-report.json")
+        report = _report(resolvedBinaryProfile="debug")
+        _write_json(path, report)
+
+        returncode = gate.main(["--report", path, "--require-commit", COMMIT])
+        decided = _read_json(path)
+        authority = decided["authority"]
+        assert authority["status"] == "provisional"
+        assert authority["profileIdentity"] == "unresolved"
+        assert authority["crimes"] == [
+            crime.split(" ", 1)[0] for crime in gate.gate(report, COMMIT)
+        ]
+        assert returncode == 1
+
+
+def test_gate_refuses_absent_authority_without_rewriting():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "suite-report.json")
+        report = _report()
+        del report["authority"]
+        _write_json(path, report)
+        before = open(path, "rb").read()
+
+        with contextlib.redirect_stderr(io.StringIO()) as captured:
+            returncode = gate.main(
+                ["--report", path, "--require-commit", COMMIT]
+            )
+        assert open(path, "rb").read() == before
+        assert "crime=authority-object-absent" in captured.getvalue()
+        assert not [
+            name for name in os.listdir(tmp) if name.startswith(".suite-report-")
+        ]
+        assert returncode == 1
 
 
 def main():

--- a/tests/test_python_suite_identity_gate_twins.py
+++ b/tests/test_python_suite_identity_gate_twins.py
@@ -552,6 +552,18 @@ def test_gate_refuses_absent_authority_without_rewriting():
         assert returncode == 1
 
 
+def test_workflow_carries_manifest_profile_into_suite_report():
+    workflow = open(
+        os.path.join(REPO_ROOT, ".github/workflows/python-package-suite.yml"),
+        encoding="utf-8",
+    ).read()
+    assert 'requested_profile="release"' in workflow
+    assert 'manifest.get("profile")' in workflow
+    assert "predates the profile identity boundary; rebuild it" in workflow
+    assert "--suite-requested-binary-profile=" in workflow
+    assert "--suite-resolved-binary-profile=" in workflow
+
+
 def main():
     failures = 0
     for name, function in sorted(globals().items()):

--- a/tests/test_python_suite_identity_gate_twins.py
+++ b/tests/test_python_suite_identity_gate_twins.py
@@ -552,6 +552,28 @@ def test_gate_refuses_absent_authority_without_rewriting():
         assert returncode == 1
 
 
+def test_gate_refuses_stale_authority_without_rewriting():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "suite-report.json")
+        report = _report(
+            authority={
+                "status": "provisional",
+                "profileIdentity": "unverified",
+                "crimes": ["crime=old"],
+            }
+        )
+        _write_json(path, report)
+        before = open(path, "rb").read()
+
+        with contextlib.redirect_stderr(io.StringIO()) as captured:
+            returncode = gate.main(
+                ["--report", path, "--require-commit", COMMIT]
+            )
+        assert open(path, "rb").read() == before
+        assert "crime=authority-stale-crimes" in captured.getvalue()
+        assert returncode == 1
+
+
 def test_workflow_carries_manifest_profile_into_suite_report():
     workflow = open(
         os.path.join(REPO_ROOT, ".github/workflows/python-package-suite.yml"),

--- a/tests/test_python_suite_identity_gate_twins.py
+++ b/tests/test_python_suite_identity_gate_twins.py
@@ -526,9 +526,7 @@ def test_gate_replaces_provisional_crimes_with_full_current_list():
         authority = decided["authority"]
         assert authority["status"] == "provisional"
         assert authority["profileIdentity"] == "unresolved"
-        assert authority["crimes"] == [
-            crime.split(" ", 1)[0] for crime in gate.gate(report, COMMIT)
-        ]
+        assert authority["crimes"] == ["crime=profile-identity-mismatch"]
         assert returncode == 1
 
 

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -110,6 +110,21 @@ def pytest_addoption(parser):
         ),
     )
     group.addoption(
+        "--suite-requested-binary-profile",
+        action="store",
+        default=None,
+        choices=("release", "debug"),
+        metavar="PROFILE",
+        help="Sugar profile requested by the suite",
+    )
+    group.addoption(
+        "--suite-resolved-binary-profile",
+        action="store",
+        default=None,
+        metavar="PROFILE",
+        help="profile read from the resolved binary's .sugarbin.json manifest",
+    )
+    group.addoption(
         "--suite-label",
         action="store",
         default=None,
@@ -219,6 +234,16 @@ class SuiteReporter:
             ).get("testExtraInputHash"),
             "environmentIdentityHash": self.identity.get("environmentIdentityHash"),
             "binarySourceStamp": self.config.getoption("--suite-binary-stamp"),
+            "requestedBinaryProfile": self.config.getoption(
+                "--suite-requested-binary-profile"
+            ),
+            "resolvedBinaryProfile": self.config.getoption(
+                "--suite-resolved-binary-profile"
+            ),
+            "authority": {
+                "status": "provisional",
+                "profileIdentity": "unverified",
+            },
             "environmentIdentity": self.identity,
             "runnerIdentity": _runner_identity(),
             "resourceTelemetry": _resource_telemetry(),

--- a/tools/python_package_suite_summary.py
+++ b/tools/python_package_suite_summary.py
@@ -70,6 +70,7 @@ def main(argv=None):
     resources = report.get("resourceTelemetry", {})
     timing = report.get("timing", {})
     counts = report.get("counts", {})
+    authority = report.get("authority") or {}
 
     lines = [
         "### Python package suite (authoritative)",
@@ -87,6 +88,10 @@ def main(argv=None):
         f"- sourceStamp: {_field(report.get('sourceStamp'))}"
         f" (binary: {_field(report.get('binarySourceStamp'))})",
         f"- testExtraInputHash: {_field(report.get('testExtraInputHash'))}",
+        f"- authority: {_field(authority.get('status'))}"
+        f" / profile identity {_field(authority.get('profileIdentity'))}",
+        f"- Sugar profile: requested {_field(report.get('requestedBinaryProfile'))}"
+        f" / resolved {_field(report.get('resolvedBinaryProfile'))}",
         f"- packageBuildInputs: `{(identity.get('packageBuildInputs') or {}).get('hash')}`",
         f"- python: `{identity.get('pythonImplementation')} {identity.get('pythonVersion')}`"
         f" abi `{(identity.get('pythonAbi') or {}).get('soabi')}`",

--- a/tools/python_suite_identity_gate.py
+++ b/tools/python_suite_identity_gate.py
@@ -54,12 +54,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import tempfile
 
 STAMP_PATTERN = re.compile(r"blake3-512_[0-9a-f]{128}")
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{7,40}")
+PROFILES = frozenset({"release", "debug"})
 
 # The fields that make a report authoritative. Absent, malformed or marked
 # unavailable, any one of them makes the artifact a provisional receipt.
@@ -97,7 +100,75 @@ def unavailable_marker(node, path="$"):
     return None
 
 
+def _check_authority_prestate(report, crimes):
+    authority = report.get("authority")
+    if not isinstance(authority, dict):
+        crimes.append(
+            "crime=authority-object-absent illegal shape=suite-report.json has "
+            "no authority object replacement=produce the report with the current "
+            "suite plugin; the gate does not manufacture testimony"
+        )
+        return
+    if authority.get("status") == "authoritative":
+        crimes.append(
+            "crime=authority-already-decided illegal shape=report was already "
+            "decided replacement=gate each artifact exactly once"
+        )
+        return
+    if authority.get("status") != "provisional" or authority.get(
+        "profileIdentity"
+    ) != "unverified":
+        crimes.append(
+            "crime=authority-prestate-malformed illegal shape=authority is not "
+            "provisional/unverified replacement=start from the plugin's exact "
+            "single-use pre-state"
+        )
+    if "crimes" in authority:
+        crimes.append(
+            "crime=authority-stale-crimes illegal shape=unverified report "
+            "already carries crimes replacement=do not recycle a decided artifact"
+        )
+
+
+def _check_profile_identity(report, crimes):
+    requested = report.get("requestedBinaryProfile")
+    resolved_present = "resolvedBinaryProfile" in report
+    resolved = report.get("resolvedBinaryProfile")
+
+    if requested in (None, ""):
+        crimes.append(
+            "crime=profile-identity-absent illegal shape=no "
+            "requestedBinaryProfile replacement=state the requested profile"
+        )
+    elif requested not in PROFILES:
+        crimes.append(
+            f"crime=profile-identity-malformed illegal shape=requested profile "
+            f"{requested!r} replacement=profile is release or debug"
+        )
+
+    if not resolved_present or resolved in (None, ""):
+        crimes.append(
+            "crime=profile-manifest-predates-boundary illegal shape=resolved "
+            "binary manifest has no profile replacement=this manifest predates "
+            "the profile identity boundary; rebuild it"
+        )
+    elif resolved not in PROFILES:
+        crimes.append(
+            f"crime=profile-identity-malformed illegal shape=resolved profile "
+            f"{resolved!r} replacement=profile is release or debug"
+        )
+
+    if requested in PROFILES and resolved in PROFILES and requested != resolved:
+        crimes.append(
+            f"crime=profile-identity-mismatch illegal shape=requested "
+            f"{requested!r} != resolved {resolved!r} replacement=measure the "
+            "profile the report claims"
+        )
+
+
 def _check_identity(report, require_commit, crimes):
+    _check_authority_prestate(report, crimes)
+    _check_profile_identity(report, crimes)
     marker = unavailable_marker(report)
     if marker is not None:
         crimes.append(
@@ -300,6 +371,28 @@ def gate(report, require_commit=None):
     return crimes
 
 
+def _crime_ids(crimes):
+    return [crime.split(" ", 1)[0] for crime in crimes]
+
+
+def _write_report_atomic(path, report):
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, temporary = tempfile.mkstemp(prefix=".suite-report-", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def gate_environment_identity(identity):
     """The same law, applied to environment-identity.json on its own.
 
@@ -392,6 +485,24 @@ def main(argv=None):
 
     report = document
     crimes = gate(report, args.require_commit)
+    authority = report.get("authority")
+    authority_is_absent = not isinstance(authority, dict)
+    authority_is_decided = isinstance(authority, dict) and authority.get(
+        "status"
+    ) == "authoritative"
+    if not authority_is_absent and not authority_is_decided:
+        if crimes:
+            report["authority"] = {
+                "status": "provisional",
+                "profileIdentity": "unresolved",
+                "crimes": _crime_ids(crimes),
+            }
+        else:
+            report["authority"] = {
+                "status": "authoritative",
+                "profileIdentity": "resolved",
+            }
+        _write_report_atomic(path, report)
     if crimes:
         print("### Suite identity gate: UNRESOLVED — not authoritative\n")
         for crime in crimes:

--- a/tools/python_suite_identity_gate.py
+++ b/tools/python_suite_identity_gate.py
@@ -486,11 +486,11 @@ def main(argv=None):
     report = document
     crimes = gate(report, args.require_commit)
     authority = report.get("authority")
-    authority_is_absent = not isinstance(authority, dict)
-    authority_is_decided = isinstance(authority, dict) and authority.get(
-        "status"
-    ) == "authoritative"
-    if not authority_is_absent and not authority_is_decided:
+    authority_is_exact_prestate = authority == {
+        "status": "provisional",
+        "profileIdentity": "unverified",
+    }
+    if authority_is_exact_prestate:
         if crimes:
             report["authority"] = {
                 "status": "provisional",


### PR DESCRIPTION
## What changed

- Carry the resolved `release`/`debug` binary profile from the sugarbin manifest into `suite-report.json`.
- Make the suite identity gate authenticate requested versus resolved profile testimony before granting authority.
- Rewrite the provisional authority object atomically and exactly once; malformed, absent, already-decided, and stale-crime prestates stay loud.
- Add report/summary support, workflow wiring, discrimination twins, and the implementation design/plan.

## Why

A complete, conserved Python-package-suite report was able to omit which binary profile actually produced its verdicts. That made a profile-blind artifact look eligible for authority. The artifact now carries authenticated profile testimony, and the gate owns a one-way rewrite from `provisional/unverified` to either `authoritative/resolved` or `provisional/unresolved` with the complete current crime set.

## Verification

**HOLD:** This PR remains draft pending a completed `Python package suite (authoritative)` workflow whose final serialized `suite-report.json` carries matching requested/resolved profile identity. The rebased workflow is run [30187155053](https://github.com/TSavo/sugar/actions/runs/30187155053).

Rebased cleanly onto live `origin/main` `f1406091`; rebased head is `4a2d7b71`, and `f1406091` is an ancestor of the branch.

Historical same-worktree A/B pair, base `df40810` versus implementation `13bc817`:

| measurement | base | head | delta |
|---|---:|---:|---:|
| collected nodes | 112 | 119 | +7 |
| passed nodes | 111 | 118 | +7 |
| failed nodes | 1 | 1 | 0 |

Both historical halves have the same single inherited red: `wall_workflow_prerequisites_test`. Totals reconcile with no escape bucket. This table makes no claim about current trunk CI.

Final review hardening, now at rebased commit `4a2d7b71`, replaces a self-derived provisional crime expectation with the literal exact list `["crime=profile-identity-mismatch"]`. Pre-rebase verification:

```text
python3 tests/test_python_suite_identity_gate_twins.py
0 failing
```
