### PR TITLE
Floor: GuardedValue distributes attribute and contains

### DIFF
--- a/docs/ledgers/pass3-full-dump-board.json
+++ b/docs/ledgers/pass3-full-dump-board.json
@@ -1,0 +1,229 @@
+{
+  "source": "full-dump.json untruncated DesugarAxis",
+  "commit_pin": "d94f67a31 (installed pandas tree measurement)",
+  "R_construction": 5088,
+  "constructionFamilies": [
+    [
+      "With",
+      5021
+    ],
+    [
+      "Try",
+      33
+    ],
+    [
+      "Assign",
+      25
+    ],
+    [
+      "AnnAssign",
+      6
+    ],
+    [
+      "Constant",
+      3
+    ]
+  ],
+  "R_desugar": 8624,
+  "desugarConstructionPanicOwners": [
+    [
+      "contains",
+      705
+    ],
+    [
+      "attribute",
+      229
+    ],
+    [
+      "add",
+      44
+    ],
+    [
+      "guarded",
+      32
+    ],
+    [
+      "ListValue.multiply",
+      19
+    ],
+    [
+      "ground_index_error",
+      14
+    ],
+    [
+      "SetValue.contains",
+      7
+    ],
+    [
+      "RuntimeEffect",
+      6
+    ],
+    [
+      "multiply",
+      5
+    ],
+    [
+      "bitwise_and",
+      2
+    ],
+    [
+      "subtract",
+      2
+    ],
+    [
+      "bitwise_or",
+      2
+    ],
+    [
+      "bitwise_invert",
+      1
+    ],
+    [
+      "truth",
+      1
+    ],
+    [
+      "ground_type_error",
+      1
+    ],
+    [
+      "divide",
+      1
+    ],
+    [
+      "unary_plus",
+      1
+    ],
+    [
+      "dict.subscript",
+      1
+    ],
+    [
+      "<SourceFragment '/usr/local/lib/python3.14/site-packages/pandas/tests/indexes/period/test_period.py' [3823, 3839) node=Call>",
+      1
+    ]
+  ],
+  "desugarDefectKinds": [
+    [
+      "desugar-exception:AttributeError: 'ContractConditionalConstructionV1' object has no attribute 'guarded'",
+      93
+    ],
+    [
+      "desugar-exception:NotImplementedError: a conditional-expression arm that reduces to an effect is not lifted yet: both arms must be values to form the guarded value",
+      78
+    ],
+    [
+      "desugar-exception:AttributeError: 'ExitSet' object has no attribute 'value'",
+      53
+    ],
+    [
+      "desugar-exception:AttributeError: 'SourceFragment' object has no attribute 'compare_left'",
+      32
+    ],
+    [
+      "desugar-exception:AssertionError: ",
+      29
+    ],
+    [
+      "desugar-exception:AttributeError: 'Incomplete' object has no attribute 'value'",
+      4
+    ],
+    [
+      "desugar-exception:TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>",
+      2
+    ],
+    [
+      "desugar-exception:NotImplementedError: condition folded without a symbolic formula: NamedExpressionValue",
+      2
+    ],
+    [
+      "desugar-exception:BindingStateWireGap: loop outward face did not construct return or raise testimony",
+      1
+    ],
+    [
+      "desugar-exception:TypeError: <class 'sugar_lift_py_tests.sugar.binding_projection.LoopGuardedProjection'>",
+      1
+    ]
+  ],
+  "files": 1421,
+  "cleanFiles": 621,
+  "wallSeconds": 2724.8,
+  "contains_by_observed": [
+    [
+      "CallSiteValue",
+      254
+    ],
+    [
+      "ListValue",
+      183
+    ],
+    [
+      "TupleValue",
+      155
+    ],
+    [
+      "StringValue",
+      94
+    ],
+    [
+      "GuardedValue",
+      9
+    ],
+    [
+      "ComprehensionValue",
+      5
+    ],
+    [
+      "DictValue",
+      5
+    ]
+  ],
+  "attribute_by_observed": [
+    [
+      "GuardedValue",
+      197
+    ],
+    [
+      "StringValue",
+      19
+    ],
+    [
+      "PredicateValue",
+      7
+    ],
+    [
+      "DictValue",
+      5
+    ],
+    [
+      "ListValue",
+      1
+    ]
+  ],
+  "guarded_by_observed": [
+    [
+      "UniverseValue",
+      26
+    ],
+    [
+      "SymbolicValue",
+      2
+    ],
+    [
+      "TrueBoolLiteralSugar",
+      1
+    ],
+    [
+      "StringValue",
+      1
+    ],
+    [
+      "ClassDefinitionValue",
+      1
+    ],
+    [
+      "PredicateValue",
+      1
+    ]
+  ]
+}

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
@@ -32,6 +32,69 @@ class ComprehensionValue(FloorValue):
         del owner
         return self.term
 
+    def contains(self, item, site):
+        # Finite comprehension testimony folds like a list; otherwise membership
+        # stays the py.in coordinate over the comprehension term.
+        if self.finite_elements is not None:
+            from sugar_lift_py_tests.floor.set_value import (
+                _bool_result,
+                _closed_member_equal,
+            )
+
+            decisions = tuple(
+                _closed_member_equal(item, element) for element in self.finite_elements
+            )
+            if any(decision is True for decision in decisions):
+                return _bool_result(True, site)
+            if all(decision is False for decision in decisions):
+                return _bool_result(False, site)
+            if any(decision is None for decision in decisions):
+                from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+                from sugar_lift_py_tests.ir import atomic
+                from sugar_lift_py_tests.outcome import Complete
+
+                return Complete(
+                    PredicateValue(
+                        atomic(
+                            "py.in",
+                            [
+                                item.to_term(
+                                    owner="ComprehensionValue.contains member"
+                                ),
+                                self.term,
+                            ],
+                        ),
+                        site,
+                        operand_callsites=(*item.callsites(),),
+                    )
+                )
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="ComprehensionValue.contains",
+                blame=str(site),
+                observed=type(item).__name__,
+                requested="constructed finite member or typed symbolic membership",
+                fix="construct comprehension membership on the Python floor or keep it loud",
+            )
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import atomic
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            PredicateValue(
+                atomic(
+                    "py.in",
+                    [
+                        item.to_term(owner="ComprehensionValue.contains member"),
+                        self.term,
+                    ],
+                ),
+                site,
+                operand_callsites=(*item.callsites(),),
+            )
+        )
+
     def truth(self, site):
         """Opaque comprehensions stand as conditions via ``py.truthy``.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -39,6 +39,47 @@ class DictValue(FloorValue):
 
         return Complete(TermValue(len(self.entries)))
 
+    def contains(self, item, site):
+        # Python ``k in d`` is key membership over constructed entry keys.
+        from sugar_lift_py_tests.floor.set_value import (
+            _bool_result,
+            _closed_member_equal,
+        )
+
+        keys = tuple(key for key, _value in self.entries)
+        decisions = tuple(_closed_member_equal(item, key) for key in keys)
+        if any(decision is True for decision in decisions):
+            return _bool_result(True, site)
+        if all(decision is False for decision in decisions):
+            return _bool_result(False, site)
+        if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+            from sugar_lift_py_tests.ir import atomic
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                PredicateValue(
+                    atomic(
+                        "python.dict.contains",
+                        [
+                            item.to_term(owner="python.dict.contains key"),
+                            self.to_term(owner="python.dict.contains dict"),
+                        ],
+                    ),
+                    site,
+                    operand_callsites=(*item.callsites(), *self.callsites()),
+                )
+            )
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="DictValue.contains",
+            blame=str(site),
+            observed=type(item).__name__,
+            requested="constructed finite key or typed symbolic membership operand",
+            fix="construct key equality on the Python floor or keep it loud",
+        )
+
     def bitwise_or(self, other, site):
         if type(other) is not DictValue:
             return super().bitwise_or(other, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -174,6 +174,20 @@ class GuardedValue(FloorValue):
     def subscript(self, index, site):
         return self._map("subscript", index, site)
 
+    def attribute(self, name, site):
+        """Distribute attribute projection over both branch faces.
+
+        Pass-3 / full-dump desugar panics rank ``attribute`` second only to
+        ``contains``; observed receiver is almost always GuardedValue (197 of
+        229). The arms own what ``.name`` means; this face only threads the
+        existing guard.
+        """
+        return self._map("attribute", name, site)
+
+    def contains(self, item, site):
+        """Distribute membership over both branch faces as a joined predicate."""
+        return self._predicate("contains", item, site)
+
     def setitem(self, index, value, site):
         """Rebind both statically known receiver faces after a subscript store."""
         return self._map("setitem", index, value, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -49,6 +49,26 @@ class PredicateValue(FloorValue):
             )
         return super().to_term(owner=owner)
 
+    def attribute(self, name, site):
+        # A boolean formula is not a field-bearing object; attribute projection
+        # stays py.getattr over the predicate term (never invent a field).
+        del site
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "py.getattr",
+                    [
+                        self.to_term(owner="PredicateValue.attribute"),
+                        str_const(name),
+                    ],
+                )
+            )
+        )
+
     def negate(self):
         # A predicate flips by wrapping its formula in not_ -- the formula owns
         # the polarity, the carrier stays PredicateValue; operand callsites ride.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -132,6 +132,26 @@ class StringValue(FloorValue):
 
         return Complete(TermValue(len(self.value)))
 
+    def attribute(self, name, site):
+        # Bound methods and fields on a constructed string (``"{:.2f}".format``,
+        # ``"%.5f".__mod__``, …) stay the py.getattr coordinate — same EUF
+        # vocabulary as SymbolicValue / CallSiteValue. Never invent a method
+        # body; call_method_with still owns static folds when the call site is
+        # known.
+        del site
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "py.getattr",
+                    [self.to_term(owner="StringValue.attribute"), str_const(name)],
+                )
+            )
+        )
+
     def contains(self, item, site):
         # Python ``needle in haystack`` for str: substring when both are strings;
         # TypeError for ground non-string needles; py.in when the needle is

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -20,6 +20,28 @@ class UniverseValue(FloorValue):
     bridge_source_symbol: str | None = None
     formal_coordinates: tuple = ()
 
+    def guarded(self, formula):
+        """Ride under a branch by guarding every body record entry.
+
+        Nested ``def`` under ``if`` places this universe as a block entry; the
+        if/exit-set router then calls ``entry.guarded(guard)``. Each statement
+        already owns its own guarded arm (InvValue → implication, ReturnValue →
+        GuardedReturn, …); reassemble the same universe shape over the guarded
+        entries. Full-dump: 26 of 32 ``guarded`` panics were UniverseValue.
+        """
+        from dataclasses import replace
+
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        guarded_entries = tuple(
+            entry.guarded(formula) for entry in self.record.statements
+        )
+        if isinstance(self.record, BlockValue):
+            record = replace(self.record, statements=guarded_entries)
+        else:
+            record = BlockValue(guarded_entries)
+        return replace(self, record=record)
+
     def derived_companions(self) -> tuple[Formula, ...]:
         return tuple(
             formula

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
@@ -1,0 +1,63 @@
+"""GuardedValue distributes attribute and membership over both faces.
+
+Full-dump (pandas untruncated): attribute panics 229 with GuardedValue 197;
+contains residual after sequence floors still names GuardedValue. These twins
+pin the distribution law so the default FloorValue.attribute/contains panics
+cannot reappear on a guarded receiver.
+"""
+
+from sugar_lift_py_tests.floor import GuardedValue, ListValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+def _guard():
+    return atomic("choose", [])
+
+
+def test_guarded_attribute_distributes_to_symbolic_faces():
+    true_face = SymbolicValue(make_var("t"))
+    false_face = SymbolicValue(make_var("f"))
+    guarded = GuardedValue(_guard(), true_face, false_face)
+    outcome = guarded.attribute("x", "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, GuardedValue)
+    assert outcome.value.when_true.term.name == "py.getattr"
+    assert outcome.value.when_false.term.name == "py.getattr"
+
+
+def test_guarded_list_membership_opposite_faces_emit_predicate():
+    true_face = ListValue((TermValue(1), TermValue(2)))
+    false_face = ListValue((TermValue(3),))
+    guarded = GuardedValue(_guard(), true_face, false_face)
+    outcome = guarded.contains(TermValue(2), "site")
+    assert isinstance(outcome, Complete)
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+    # 2 ∈ true, 2 ∉ false → joined formula is the guard itself.
+    assert isinstance(outcome.value, PredicateValue)
+    assert outcome.value.formula == _guard()
+
+
+def test_guarded_list_membership_both_true_is_decidable():
+    true_face = ListValue((TermValue(1), TermValue(2)))
+    false_face = ListValue((TermValue(2), TermValue(3)))
+    guarded = GuardedValue(_guard(), true_face, false_face)
+    outcome = guarded.contains(TermValue(2), "site")
+    assert isinstance(outcome, Complete)
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+    assert isinstance(outcome.value, (TrueBoolLiteralSugar, PredicateValue))
+
+
+def test_guarded_list_membership_both_false_is_decidable():
+    true_face = ListValue((TermValue(1),))
+    false_face = ListValue((TermValue(3),))
+    guarded = GuardedValue(_guard(), true_face, false_face)
+    outcome = guarded.contains(TermValue(9), "site")
+    assert isinstance(outcome, Complete)
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+    assert isinstance(outcome.value, (FalseBoolLiteralSugar, PredicateValue))

--- a/implementations/python/sugar-lift-py-tests/tests/test_residual_panic_floors.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_residual_panic_floors.py
@@ -1,0 +1,66 @@
+"""Residual full-dump panic floors after sequence contains + GuardedValue.
+
+Covers the next measured owners:
+- StringValue.attribute (19) — bound methods as py.getattr
+- UniverseValue.guarded (26) — nested def under if
+- DictValue.contains (5) — key membership
+- ComprehensionValue.contains (5) — py.in / finite fold
+- PredicateValue.attribute (7) — py.getattr
+"""
+
+import tempfile
+
+from sugar_lift_py_tests.floor import (
+    DictValue,
+    StringValue,
+    SymbolicValue,
+    TermValue,
+)
+from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+from sugar_lift_py_tests.ir import atomic, ctor, make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+def test_string_attribute_is_py_getattr_coordinate():
+    outcome = StringValue("{:.2f}").attribute("format", "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+    assert outcome.value.term.name == "py.getattr"
+
+
+def test_predicate_attribute_is_py_getattr_coordinate():
+    pred = PredicateValue(atomic("choose", []), "site")
+    outcome = pred.attribute("dtype", "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+    assert outcome.value.term.name == "py.getattr"
+
+
+def test_dict_key_membership_folds():
+    d = DictValue(((TermValue(1), TermValue(10)), (TermValue(2), TermValue(20))))
+    assert isinstance(d.contains(TermValue(2), "site").value, TrueBoolLiteralSugar)
+    assert isinstance(d.contains(TermValue(9), "site").value, FalseBoolLiteralSugar)
+
+
+def test_opaque_comprehension_membership_emits_py_in():
+    comp = ComprehensionValue(ctor("py.listcomp", [make_var("xs")]))
+    result = comp.contains(TermValue(1), "site").value
+    assert isinstance(result, PredicateValue)
+    assert result.formula.name == "py.in"
+
+
+def test_nested_function_def_under_if_does_not_panic_on_universe_guarded():
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    src = "def outer():\n    if True:\n        def inner():\n            return 1\n    return 2\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    fn = next(SourceFile(path_source(path)).functions())
+    outcome = fn.sugar().desugar()
+    # Must complete without ConstructionPanic on UniverseValue.guarded.
+    assert outcome is not None


### PR DESCRIPTION
## Summary
Stacked floor drain for measured full-dump desugar construction panics (1074 untruncated).

### Base (depends on #6293)
- Sequence `contains`: List/Tuple/String/CallSite (~686 of 705)
- `GuardedValue.attribute` + `contains` (197 of 229 attribute; residual contains faces)

### This PR adds residual owners
| Owner | n | Fix |
|-------|--:|-----|
| StringValue.attribute | 19 | `py.getattr` |
| PredicateValue.attribute | 7 | `py.getattr` |
| UniverseValue.guarded | 26 | map body entries under guard |
| DictValue.contains | 5 | key membership |
| ComprehensionValue.contains | 5 | finite fold / `py.in` |

### Predicted εR (full-dump basis)
- contains ≈ **−705** (sequence + guarded + dict + comprehension)
- attribute ≈ **−229** (guarded + string + predicate)
- guarded ≈ **−26** (UniverseValue)
- Remaining panics: add 44, ListValue.multiply 19, ground_index_error 14, …

### Validation
```text
20/20 twins green (sequence + guarded + residual)
nested def under if no longer ConstructionPanic on UniverseValue.guarded
```

Board: `docs/ledgers/pass3-full-dump-board.json`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distribute `attribute` and `contains` over `GuardedValue` branches
> - `GuardedValue.attribute` now delegates to both branch faces via `_map`, returning a joined value instead of being unsupported.
> - `GuardedValue.contains` distributes membership to both faces via `_predicate`, folding to True/False when both branches agree.
> - `StringValue.attribute` and `PredicateValue.attribute` now produce a symbolic `py.getattr` term instead of being unsupported.
> - `DictValue.contains` and `ComprehensionValue.contains` are added: both fold to a boolean when decidable, or emit a typed symbolic predicate (`python.dict.contains` / `py.in`) otherwise.
> - `UniverseValue.guarded` is added to produce a guarded variant whose record statements are individually guarded, enabling desugaring of nested function definitions under a conditional.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1e6491.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->