### PR TITLE
A commit that got no CI run was never measured, so no workflow may share a queue slot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,12 @@ on:
       - main
   pull_request:
 
-# Cancel superseded runs on the same branch / PR.
-# A superseded run may be the only evidence we will ever get for its commit,
-# so it is allowed to finish. Cancelling it was the same instinct that cost us
-# five package-suite runs and three sole-construction floor runs: treating a
-# measurement as disposable because a newer push exists.
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. `cancel-in-progress: false` is not enough: GitHub
+# keeps only ONE pending run per group and replaces a queued run with a newer
+# one regardless of that flag. On a merge train into main that silently
+# discarded the CI vector of four merged commits (329576c3d, ef19b8175,
+# c11767c5e, df408100e). Every commit must retain its own run. Runner
+# scheduling provides queuing; GitHub concurrency must not discard evidence.
 
 permissions:
   contents: read

--- a/.github/workflows/datetime-claim-twins.yml
+++ b/.github/workflows/datetime-claim-twins.yml
@@ -8,9 +8,9 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: datetime-claim-twins
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. GitHub keeps only ONE pending run per group and
+# replaces a queued run with a newer one even under cancel-in-progress: false.
+# Every run must survive; tools/heavy_measurement_lease.py serializes the box.
 
 jobs:
   datetime-claim-twins:

--- a/.github/workflows/examples-gate.yml
+++ b/.github/workflows/examples-gate.yml
@@ -5,9 +5,9 @@ on:
     - cron: '17 10 * * *'
   workflow_dispatch:
 
-concurrency:
-  group: examples-gate-${{ github.ref }}
-  cancel-in-progress: false
+# NO `concurrency:` BLOCK. GitHub keeps only ONE pending run per group and
+# replaces a queued run with a newer one even under cancel-in-progress: false.
+# Every run must survive; tools/heavy_measurement_lease.py serializes the box.
 
 permissions:
   contents: read

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -109,6 +109,33 @@ def test_no_heavy_workflow_cancels_a_superseded_run():
         )
 
 
+def test_no_workflow_shares_a_concurrency_group_across_commits():
+    """The eviction hole is not exclusive to the heavy classes.
+
+    `ci.yml` grouped by `github.ref`, so a merge train into main replaced each
+    queued run with the next push's. Four merged commits (329576c3d,
+    ef19b8175, c11767c5e, df408100e) ended up with no CI vector at all, and
+    `cancel-in-progress: false` did nothing about it -- that flag governs
+    STARTED runs, not the pending slot.
+
+    A group is only safe if its key is immutable per commit, i.e. keyed by
+    `github.sha`. Anything else lets a later commit inherit an earlier
+    commit's slot and throw the earlier measurement away.
+    """
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text()
+        match = re.search(r"^concurrency:\n(?:[ \t]+.*\n?)+", text, re.MULTILINE)
+        if match is None:
+            continue
+        assert "github.sha" in match.group(0), (
+            f"{path.name} declares a concurrency group that is not keyed by "
+            f"github.sha. GitHub keeps ONE pending run per group, so a newer "
+            f"commit evicts the queued run of an older one and that commit "
+            f"never gets a CI vector. Drop the block, or key it "
+            f"`ci-${{{{ github.sha }}}}` with cancel-in-progress: false."
+        )
+
+
 def test_attendance_roster_matches_the_heavy_workflows():
     """A heavy workflow missing from the roster is an instrument that can go
     quiet without the roll call noticing -- the exact defect that let eight


### PR DESCRIPTION
## Summary

Main's CI has not produced a completed run since `d94f67a31`. A merge train ate its own telemetry:

```
(running)   063df6c3a
cancelled   df408100e   <- #6290
cancelled   c11767c5e   <- #6284
cancelled   ef19b8175   <- #6286
(no run)    329576c3d   <- #6288
failure     d94f67a31   <- last COMPLETED CI on main
```

Four merged commits have **no CI vector at all**.

`cancel-in-progress: false` did not prevent this and cannot. That flag governs runs that have already STARTED. GitHub keeps exactly ONE *pending* run per concurrency group, and a newer request replaces the queued one regardless of the flag. `ci.yml` grouped by `github.ref`, so every push to main inherited and destroyed the previous commit's queued slot.

Fix: **remove the shared group entirely** from the three workflows that still keyed one across commits.

| workflow | old group | why it was a hole |
| --- | --- | --- |
| `ci.yml` | `ci-${{ github.workflow }}-${{ github.ref }}` | all of main shares one key — the defect above |
| `examples-gate.yml` | `examples-gate-${{ github.ref }}` | same key shape; scheduled + dispatch |
| `datetime-claim-twins.yml` | `datetime-claim-twins` (constant) | one slot for the entire repo, forever |

The five heavy workflows (`python-package-suite`, `factory-zero-tolerance`, `numpy-wall`, `pandas-wall`, `restored-suite-scoreboard`) had already been cleared of groups; the BX lease (`tools/heavy_measurement_lease.py`) serializes the box. Runner scheduling provides queuing. GitHub concurrency provided only evidence disposal.

`tests/test_heavy_measurement_concurrency_topology.py` is why this survived: it forbade concurrency groups **only on the five heavy workflows**, so `ci.yml` was never checked. It now forbids, on *every* workflow, any group whose key is not immutable per commit (`github.sha`). The reported eviction of `Python sole-construction floors` on three pushes to a prior PR is the same mechanism; that workflow is already group-free and is now covered by the broader rule as well.

## Expected one-final-cancellation

**The push of this PR's branch may cancel the currently pending legacy-group run one final time.** The old `ci-CI-<ref>` group is still in force for runs requested before this merges. That is expected, is stated here rather than discovered later, and is the last time it can happen on `main` once this lands.

## Predicted Epsilon R (construction / wall lanes)

n/a — not a construction PR. No construction, recovery, factory, floor, or wall code is touched.

## Validation

`tests/test_heavy_measurement_concurrency_topology.py` — 15 passed.

Discrimination (both arms run): re-appending `concurrency: {group: ci-${{ github.ref }}, cancel-in-progress: false}` to `ci.yml` fails `test_no_workflow_shares_a_concurrency_group_across_commits`; removing it passes. The instrument detects the exact defect that occurred, not a proxy for it.

## Floors preserved

data_loss=0, no secret commit, no test deleted or weakened for green, silent=0. This PR only *adds* a detector and removes configuration that discarded measurements.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove concurrency groups from CI workflows so no queued run is silently dropped
> - Removes `concurrency:` blocks from [ci.yml](https://github.com/TSavo/sugar/pull/6297/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f), [datetime-claim-twins.yml](https://github.com/TSavo/sugar/pull/6297/files#diff-a67f7f6d41c9ee6f8be6f22df2cd9d6589b945eda2b4f6f231b53cf3e9b22e6b), and [examples-gate.yml](https://github.com/TSavo/sugar/pull/6297/files#diff-e14dc59e49f16ee01b341f8761807eafca45da62da853dea265569332ff745e2); GitHub only keeps one pending run per group, meaning commits that lost their slot were never measured.
> - Adds a test in [test_heavy_measurement_concurrency_topology.py](https://github.com/TSavo/sugar/pull/6297/files#diff-e61292725586469f033b307bcad2ed1f9d02cca5a16e90e770e6c8b4d1353c79) that fails if any workflow defines a `concurrency:` block not keyed by `github.sha` with `cancel-in-progress: false`.
> - Behavioral Change: queued runs are no longer collapsed — all commits will now run independently, increasing runner queue depth under load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c780e0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->