### PR TITLE
EffectBoundaryWith: retain undecidable message predicates instead of deciding them

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sugar_lift_py_tests.ir import Formula
+
 
 def matches_raise_effect(effect, expected) -> bool:
     """Match by constructed exception coordinates and authenticated ancestry.
@@ -28,24 +34,99 @@ def matches_raise_effect(effect, expected) -> bool:
     return raised_mro is not None and expected_identity in raised_mro
 
 
-def matches_raise_effect_with_message(effect, expected, pattern) -> bool:
-    """Authenticated identity match, then the contract's optional message pattern.
+@dataclass(frozen=True)
+class MatchDecided:
+    """The contract's predicate is settled at lift, on constructed operands."""
 
-    The identity half is ``matches_raise_effect`` -- the one matcher. The
-    pattern half reads the constructed message of the raised value; a contract
-    that states no pattern (``pattern is None``) asserts nothing about it.
+    value: bool
+
+
+@dataclass(frozen=True)
+class MatchRetained:
+    """The predicate is real but undecidable here; it leaves as an obligation.
+
+    ``obligation`` is the FOL formula that IS the vendor's message predicate
+    over the constructed operands. It is never evaluated at lift, never
+    admitted as true, and never dropped as false: the router partitions the
+    incoming exit by it, so both faces survive into the emitted FOL.
+    """
+
+    obligation: "Formula"
+
+
+MessageVerdict = MatchDecided | MatchRetained
+
+
+def _ground_string(term):
+    """The Python ``str`` this term IS, or ``None`` when it is not ground.
+
+    Groundness is asked of the emitted TERM, never of the value's species. Every
+    floor value answers ``to_term``; a ground string arrives as ``_ConstStr``
+    and anything else -- a variable, a call, an opaque projection -- does not.
+    That keeps this a one-line property of the shared codomain instead of a
+    ladder over floor kinds that would need a new arm per value class.
+    """
+    from sugar_lift_py_tests.ir import _ConstStr
+
+    return term.value if isinstance(term, _ConstStr) else None
+
+
+def _message_term(effect, *, owner):
+    """The term of the raised call's message operand, or the ground empty message.
+
+    ``raise E()`` constructs no argument, and the message of such a value is
+    exactly ``""`` -- a ground fact, not an absence. Anything that is not a
+    constructed call has no authenticated message operand at all and is loud.
+    """
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.ir import str_const
+    from sugar_source_tree.panic import SugarNotWritten
+
+    raised = effect.raised_value
+    if not isinstance(raised, CallSiteValue):
+        raise SugarNotWritten(
+            owner="authenticated_exception_matching._message_term",
+            observed="raised value is not a constructed call occurrence",
+            requested="a CallSiteValue whose first actual is the message operand",
+            fix=(
+                "construct the raised exception through its call site; never "
+                "read a message off an unconstructed value"
+            ),
+        )
+    args = raised.arg_values
+    return args[0].to_term(owner=owner) if args else str_const("")
+
+
+def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
+    """Authenticated identity match, then the contract's optional message predicate.
+
+    The identity half is ``matches_raise_effect`` -- the one matcher, and it is
+    total: a missing identity is loud there, never a quiet ``False``.
+
+    The message half has THREE outcomes, not two. A contract that states no
+    pattern asserts nothing about the message (``MatchDecided(True)``). Two
+    ground strings settle the predicate here. Anything else -- a symbolic
+    message, a computed pattern -- is a predicate this compiler cannot decide,
+    and deciding it either way would be a fabricated fact. It leaves as
+    ``MatchRetained`` carrying ``py.re_search(pattern, message)``, which is the
+    vendor's own predicate spelled on the membrane.
     """
     import re
 
+    from sugar_lift_py_tests.ir import atomic
+
     if not matches_raise_effect(effect, expected):
-        return False
+        return MatchDecided(False)
     if pattern is None:
-        return True
-    pattern_value = getattr(pattern, "value", None)
-    args = getattr(effect.raised_value, "arg_values", ())
-    message_value = getattr(args[0], "value", None) if args else None
-    return (
-        isinstance(pattern_value, str)
-        and isinstance(message_value, str)
-        and re.search(pattern_value, message_value) is not None
-    )
+        return MatchDecided(True)
+
+    owner = "authenticated_exception_matching.raise_effect_message_verdict"
+    pattern_term = pattern.to_term(owner=owner)
+    message_term = _message_term(effect, owner=owner)
+
+    ground_pattern = _ground_string(pattern_term)
+    ground_message = _ground_string(message_term)
+    if ground_pattern is not None and ground_message is not None:
+        return MatchDecided(re.search(ground_pattern, ground_message) is not None)
+
+    return MatchRetained(atomic("py.re_search", [pattern_term, message_term]))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -21,16 +21,40 @@ by ad-hoc name checks outside these types.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetainedObligation:
+    """A verdict this compiler cannot settle, kept as an explicit FOL partition.
+
+    Returned instead of an effect when the contract's predicate is real but
+    undecidable at lift. ``obligation`` is the predicate; ``held`` is the
+    verdict under it and ``failed`` the verdict under its complement, each in
+    the same codomain as an ordinary verdict (an ``Effect`` to halt with, or
+    ``None`` to complete).
+
+    This is the only shape that lets a router honour "never admitted, never
+    dropped": the incoming exit leaves as two exits under complementary
+    guards, so both faces reach the emitted FOL and neither was decided by
+    silence.
+    """
+
+    obligation: object
+    held: object
+    failed: object
+
 
 def exit_disposition_effect(disposition: object, incoming: object):
-    """The effect the outgoing exit halts with, or None to complete.
+    """The verdict for one body exit: an ``Effect``, ``None``, or a retention.
 
     ``incoming`` is one body exit — ``Completed`` or ``Halted``. The outgoing
     exit always carries the incoming exit's state; the *only* thing a contract
     decides is whether that state leaves as a completion or as a halt, and with
     which effect. Returning ``incoming.effect`` therefore restores, returning
     ``None`` consumes, and returning a fresh effect is the boundary halting on
-    its own behalf.
+    its own behalf. A ``RetainedObligation`` says the contract's predicate did
+    not settle and hands the router both faces plus the predicate.
 
     Never invents True/False for runtime-selected faces.
     """
@@ -56,7 +80,9 @@ def exit_disposition_effect(disposition: object, incoming: object):
 def _boundary_halted_edge(disposition, incoming):
     """Consume the halt this boundary was written to observe; restore the rest."""
     from sugar_lift_py_tests.authenticated_exception_matching import (
-        matches_raise_effect_with_message,
+        MatchDecided,
+        MatchRetained,
+        raise_effect_message_verdict,
     )
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_source_tree.panic import SugarNotWritten
@@ -64,10 +90,14 @@ def _boundary_halted_edge(disposition, incoming):
     matcher = disposition.matcher
     if not isinstance(incoming.effect, RaiseEffect):
         return incoming.effect
-    if not matches_raise_effect_with_message(
+    verdict = raise_effect_message_verdict(
         incoming.effect, matcher.expected, matcher.message_pattern
-    ):
+    )
+    if isinstance(verdict, MatchDecided) and not verdict.value:
         return incoming.effect
+    # Consuming this halt means the boundary claims the body reached the raise
+    # and stopped there, so the pre-halt state is load-bearing on BOTH the
+    # settled and the retained face. Demand it before either.
     if incoming.state is None:
         raise SugarNotWritten(
             owner="EffectBoundaryDisposition",
@@ -75,7 +105,18 @@ def _boundary_halted_edge(disposition, incoming):
             requested="ExitSet Halted face carrying the real pre-halt state",
             fix="repair the block reducer; never fabricate a continuation state",
         )
-    return None
+    if isinstance(verdict, MatchDecided):
+        return None
+    if isinstance(verdict, MatchRetained):
+        # The identity matched; only the message predicate is open. Under it
+        # the boundary consumes, under its complement the ORIGINAL halt stands.
+        return RetainedObligation(
+            obligation=verdict.obligation, held=None, failed=incoming.effect
+        )
+    raise TypeError(
+        "message verdict must be MatchDecided or MatchRetained; "
+        f"got {type(verdict).__name__}"
+    )
 
 
 def _authenticate(disposition: object) -> None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -251,6 +251,7 @@ class ExitSet(Generic[T]):
         expression.
         """
         from sugar_lift_py_tests.outcome.exit_disposition import (
+            RetainedObligation,
             exit_disposition_effect,
         )
 
@@ -267,11 +268,29 @@ class ExitSet(Generic[T]):
                     if isinstance(incoming, Completed)
                     else incoming.state
                 )
-                effect = exit_disposition_effect(disposition, incoming)
-                if effect is None:
+                verdict = exit_disposition_effect(disposition, incoming)
+                if isinstance(verdict, RetainedObligation):
+                    # An undecidable contract predicate is not a verdict. The
+                    # incoming exit leaves as BOTH faces under complementary
+                    # guards, so the predicate reaches the emitted FOL instead
+                    # of being admitted or dropped by silence here.
+                    obligation = verdict.obligation
+                    for sub_guard, sub_verdict in (
+                        (_and_guards(guard, obligation), verdict.held),
+                        (
+                            _and_guards(guard, complement_guard(obligation)),
+                            verdict.failed,
+                        ),
+                    ):
+                        if sub_verdict is None:
+                            exits.append(Completed(sub_guard, carried))
+                        else:
+                            exits.append(Halted(sub_guard, sub_verdict, carried))
+                    continue
+                if verdict is None:
                     exits.append(Completed(guard, carried))
                 else:
-                    exits.append(Halted(guard, effect, carried))
+                    exits.append(Halted(guard, verdict, carried))
         return ExitSet(tuple(exits)).normalize()
 
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -60,6 +60,8 @@ from sugar_lift_py_tests.context_manager_contract import (
     RaiseEffectKindV1,
     RuntimeSelected,
     Suppresses,
+    WarningEffectKindV1,
+    WarningObservationBindingV1,
 )
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerContractRefV1,
@@ -71,7 +73,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
 )
 from sugar_lift_py_tests.effect import ExpectationNotMetEffect, RaiseEffect
 from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
-from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.ir import PrimitiveSort, and_, atomic, make_var, str_const
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_py_tests.outcome.exit_set import (
     Completed,
@@ -762,6 +764,7 @@ ROUTER_SOURCES = (
     "sugar_lift_py_tests/outcome/exit_set.py",
     "sugar_lift_py_tests/outcome/exit_disposition.py",
     "sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+    "sugar_lift_py_tests/authenticated_exception_matching.py",
 )
 
 FORBIDDEN_IN_ROUTERS = (
@@ -851,6 +854,230 @@ def test_discrimination_the_routing_probe_observes_a_real_call(tmp_path, monkeyp
         assert not isinstance(
             disposition, EffectBoundaryDisposition
         ), "the resource with reached the algebra carrying an assertion contract"
+
+
+# ---------------------------------------------------------------------------
+# Law 12 -- an undecidable message predicate is RETAINED, not admitted, not dropped
+# ---------------------------------------------------------------------------
+
+# Same manager, same contract, same `match="boom"`. The only change is that the
+# raised message is a formal parameter instead of a literal, so "does this
+# message match this pattern" is a real predicate this compiler cannot settle.
+UNDECIDABLE_MESSAGE_BODY = (
+    "from contracts import scope as hold\n"
+    "def f(flag, note):\n"
+    '    with hold(ValueError, match="boom"):\n'
+    "        if flag:\n"
+    "            raise ValueError(note)\n"
+)
+
+
+def _retained_atoms(formula):
+    """Every ``py.re_search`` atom reachable in a guard."""
+    name = getattr(formula, "name", None)
+    if name is not None:
+        return {formula} if name == "py.re_search" else set()
+    found = set()
+    for operand in getattr(formula, "operands", ()):
+        found |= _retained_atoms(operand)
+    return found
+
+
+def test_undecidable_message_predicate_is_retained_as_an_obligation(tmp_path):
+    """The open predicate survives into the guards, on BOTH of its faces.
+
+    The body partitions into one halt (``flag``) and one completion. The halt
+    carries a ``ValueError`` whose identity the contract matches, so the only
+    open question is the message. A router that answered it would emit two
+    exits; retaining it emits three, and the two new ones stand on complementary
+    guards over the SAME predicate.
+    """
+    resource, boundary = _both_arms(
+        tmp_path, source=UNDECIDABLE_MESSAGE_BODY, stem="undecidable"
+    )
+    body_halt = _sole(_body_exitset(resource.body), Halted)
+
+    routed = _assertion_route(boundary)
+    on_halt = [
+        exit_
+        for exit_ in routed.exits
+        if _retained_atoms(exit_.guard) and exit_.guard != body_halt.guard
+    ]
+    assert len(on_halt) == 2, f"expected exactly 2 retained faces, got {on_halt}"
+
+    obligations = set()
+    for exit_ in on_halt:
+        obligations |= _retained_atoms(exit_.guard)
+    assert len(obligations) == 1, "the two faces do not share ONE predicate"
+    obligation = next(iter(obligations))
+
+    # Never admitted: the consumed face stands under the predicate, not under
+    # the incoming guard alone.
+    consumed = _on_guard(routed, and_([body_halt.guard, obligation]))
+    assert isinstance(consumed, Completed)
+    # Never dropped: the other face restores the EXACT incoming effect.
+    retained = _on_guard(
+        routed, and_([body_halt.guard, complement_guard(obligation)])
+    )
+    assert isinstance(retained, Halted)
+    assert retained.effect == body_halt.effect
+    assert retained.effect.occurrence == body_halt.effect.occurrence
+    assert retained.state == body_halt.state
+
+    # The predicate is the vendor's own, over the two constructed operands.
+    assert obligation.name == "py.re_search"
+    assert obligation.args[0] == str_const("boom")
+    assert obligation.args[1] == make_var("note")
+
+
+def test_discrimination_a_ground_message_is_decided_and_not_retained(tmp_path):
+    """The same law, same shape, literal message: NOTHING is retained.
+
+    Without this arm the law above is satisfied by a router that retains every
+    predicate, which would be a different lie (an obligation invented where the
+    fact was available). Assert exact cardinality on both sides: two exits, zero
+    retained atoms.
+    """
+    resource, boundary = _both_arms(tmp_path, stem="ground_message")
+    body_halt = _sole(_body_exitset(resource.body), Halted)
+
+    routed = _assertion_route(boundary)
+    assert len(routed.exits) == 2
+    assert not any(_retained_atoms(exit_.guard) for exit_ in routed.exits)
+    assert isinstance(_on_guard(routed, body_halt.guard), Completed)
+
+
+# ---------------------------------------------------------------------------
+# Law 13 -- a missing expected observation never becomes an absence fact
+# ---------------------------------------------------------------------------
+
+# The completed-edge disposition of the SAME one mechanism: the contract expects
+# an effect the body EMITS rather than one it halts on, so the observation rides
+# the completed edge. Everything else -- mode, operands, binding, signature,
+# source -- is the raise arm's.
+OBSERVATION_SEMANTICS = EffectBoundarySemanticsV1(
+    ExpectsModeV1(),
+    WarningEffectKindV1(),
+    FormalArgumentProjectionV1(0),
+    OptionalFormalArgumentProjectionV1(1),
+    WarningObservationBindingV1(),
+)
+
+
+def test_expected_observation_with_no_constructed_occurrence_stays_loud(tmp_path):
+    """No observation model, no routing -- and above all, no absence fact.
+
+    This compiler constructs no occurrence for an effect the body EMITS, so it
+    cannot say whether the expected observation happened. The one forbidden
+    output is the quiet one: a ``Completed`` exit, which would assert on the
+    record that the body ran and the expectation was met, or an
+    ``ExpectationNotMet`` halt, which would assert the opposite. Both are facts
+    about an observation nobody constructed. The site stays loud instead.
+
+    The refusal lands one rung earlier than a desugar gap: the contract never
+    installs a boundary sugar at all, so there is no object that could later be
+    routed into a completion by a hopeful arm.
+    """
+    from sugar_source_tree.panic import UnsupportedContextManagerSemantics
+
+    with pytest.raises(UnsupportedContextManagerSemantics) as raised:
+        _with_statement(
+            tmp_path, MATCHING_BODY, OBSERVATION_SEMANTICS, stem="observation"
+        )
+    assert raised.value.owner == "With._construct_sugar"
+    # The refusal names the observation as the missing thing, not the manager.
+    assert "semantics" in raised.value.observed
+
+
+def test_discrimination_the_same_site_routes_under_a_constructed_effect_kind(tmp_path):
+    """The refusal is about the observation, not about the fixture.
+
+    Byte-identical source, same signature, same operands, same binding shape --
+    only ``effect_kind`` differs. That arm routes and produces exactly two
+    exits, so the law above cannot be passing because the ``with`` failed to
+    construct.
+    """
+    boundary = _with_statement(
+        tmp_path, MATCHING_BODY, ASSERTION_SEMANTICS, stem="observation_control"
+    )
+    routed = boundary.desugar()
+    assert isinstance(routed, ExitSet)
+    assert len(routed.exits) == 2
+
+
+# ---------------------------------------------------------------------------
+# Law 14 -- arm conservation: every output arm traces to one input arm
+# ---------------------------------------------------------------------------
+
+
+def _conservation_report(body_es, routed):
+    """Map each output arm to the input arms whose guard it refines.
+
+    An output arm is *conserved* when its guard entails exactly one input
+    guard: either the input guard itself (the arm passed through, possibly with
+    its verdict changed) or that guard conjoined with a named retained
+    predicate (the arm was partitioned by an obligation the contract could not
+    settle). Anything else is an arm this router grew or lost.
+    """
+    report = []
+    for out in routed.exits:
+        atoms = _retained_atoms(out.guard)
+        sources = []
+        for incoming in body_es.exits:
+            if out.guard == incoming.guard:
+                sources.append((incoming, None))
+                continue
+            for atom in atoms:
+                for face in (atom, complement_guard(atom)):
+                    if out.guard == and_([incoming.guard, face]):
+                        sources.append((incoming, atom))
+        report.append((out, sources))
+    return report
+
+
+def test_every_output_arm_conserves_exactly_one_input_arm(tmp_path):
+    """Both the settled body and the retained body conserve their arms.
+
+    Run the law over the ground source (no retention) and the undecidable
+    source (one retention), because a conservation check that only ever sees
+    pass-through arms cannot see a fabricated one.
+    """
+    for source, stem, expected_arms in (
+        (MATCHING_BODY, "conserve_ground", 2),
+        (UNDECIDABLE_MESSAGE_BODY, "conserve_open", 3),
+    ):
+        resource, boundary = _both_arms(tmp_path, source=source, stem=stem)
+        body_es = _body_exitset(resource.body)
+        routed = _assertion_route(boundary)
+
+        assert len(routed.exits) == expected_arms
+        for out, sources in _conservation_report(body_es, routed):
+            assert len(sources) == 1, (
+                f"output arm {out.guard} traces to {len(sources)} input arms; "
+                "an arm was fabricated or two were merged"
+            )
+
+
+def test_discrimination_the_conservation_report_can_see_an_unconserved_arm(tmp_path):
+    """Arm the detector: a hand-added arm must trace to zero input arms.
+
+    ``!= 1`` is satisfied by 0 and by 2, so the law asserts exact cardinality
+    and this arm proves the 0 case is reachable by the same report.
+    """
+    resource, boundary = _both_arms(tmp_path, stem="conserve_probe")
+    body_es = _body_exitset(resource.body)
+    routed = _assertion_route(boundary)
+
+    invented = ExitSet(
+        (
+            *routed.exits,
+            Completed(atomic("py.truthy", [make_var("invented")]), None),
+        )
+    )
+    counts = sorted(
+        len(sources) for _out, sources in _conservation_report(body_es, invented)
+    )
+    assert counts == [0, 1, 1], counts
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`EffectBoundaryWith` is **one** mechanism with two dispositions. Most of it already stood on `main`: the authenticated `EffectBoundarySemanticsV1` contract, `EffectBoundaryDisposition`, and the shared `ExitSet.and_exit` algebra that lets one typed contract decide **both** edges. This PR closes the law the mechanism was still breaking, and pins the three laws that had no twin.

### The bug: an undecidable predicate was silently decided

`matches_raise_effect_with_message` returned `bool`. Given `with hold(ValueError, match="boom"):` over `raise ValueError(note)` — `note` a formal — the message predicate is not decidable at lift. The old code returned `False`, and the router restored the halt **as if the pattern had been checked and had not matched**. That is a fabricated fact in the emitted FOL, and it is silent.

Measured before/after on that source (the twin's fixture):

| | exits under `flag` |
|---|---|
| before | `Halted(ValueError)` — the predicate decided, one way |
| after | `Completed` under `py.re_search("boom", note)`, `Halted(ValueError)` under its complement |

### The mechanism

- **`raise_effect_message_verdict`** replaces the bool matcher (one caller; no compat shell). Codomain is closed: `MatchDecided(bool) | MatchRetained(obligation)`.
- **Groundness is read off the emitted term**, not off the floor value's species: `to_term(owner=...)` then `isinstance(term, _ConstStr)`. No kind ladder, no new arm per value class.
- **`RetainedObligation(obligation, held, failed)`** joins the exit-disposition codomain. `ExitSet.and_exit` is exhaustive over `Effect | None | RetainedObligation`; a retention emits the incoming exit's two faces under `g ∧ P` and `g ∧ ¬P`.
- `_boundary_halted_edge` demands the pre-halt state **before** either face, so consumption cannot proceed on a fabricated continuation.

## The nine laws, and what enforces each

| Law | Mechanism |
|---|---|
| `halted_consumed` consumes only the matching halted edge | `_boundary_halted_edge`: identity via `matches_raise_effect`, which is **total** — missing identity is `SugarNotWritten`, never a quiet `False` |
| A nonmatching halt remains halted and red | `MatchDecided(False)` → `return incoming.effect`; twin Law 8 (pre-existing) |
| `completed_observed` routes the completed edge carrying the observation | `EffectBoundaryDisposition.unmet` on the `Completed` incoming — the only contract that can name an effect on the completed edge |
| A missing expected observation never becomes an absence fact by silence | `With._construct_sugar` refuses `WarningEffectKindV1` outright; no sugar installs, so nothing downstream can route it to a completion. **New twin, Law 13** |
| An undecidable message/pattern remains an explicit obligation | `MatchRetained` → `RetainedObligation` → guard partition. **New twin, Law 12** |
| Category-from-value requires authenticated value testimony | `matches_raise_effect` reads `exception_type_coordinate` / `exception_type_mro`; absent → loud |
| Additional exits remain separate ExitSet arms | `and_exit` folds per incoming exit; `normalize` merges only on equal destination |
| Effect binding projects the routed occurrence coordinate, never fabricates `E()` | `_bind_real_actuals` + `project_formal_selector_v1` over the real `CallSiteValue`; a non-`CallSiteValue` manager is loud |
| Every output arm conserves one input arm or a named consumption | **New twin, Law 14**: each output guard must entail exactly one input guard, alone or conjoined with one named retained predicate |

## No name/spelling arm in production

`test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling` scans the real router sources for `pytest`, `unittest`, `contextlib`, `pandas`, `numpy`, `hypothesis`, `"with"`, `AsyncWith`. **This PR adds `authenticated_exception_matching.py` to that scanned set** — it was previously unscanned. Contract acquisition is `decode_context_manager_semantics_v1` over the authenticated wire payload; there is no manager-name table anywhere on the path.

## Twins — both faces, and the perturbation each survived

Every law below runs with its discrimination arm.

| Twin | Positive | Discriminating | Perturbation → result |
|---|---|---|---|
| Undecidable predicate retained | 3 exits, 2 sharing one `py.re_search` atom; consumed face under it, **exact** incoming effect + state restored under its complement | ground message → **exactly 2** exits, **zero** retained atoms | P1 force `MatchDecided(False)` → **FAILED** (+ conservation). P3 drop the restored face → **FAILED** (+ conservation). P2 force retention → discrimination arm **FAILED** |
| Absence fact refused | warning-kind contract raises `UnsupportedContextManagerSemantics` at construction | byte-identical site, raise-kind → routes, **exactly 2** exits | P4 admit `WarningEffectKindV1` → **FAILED** |
| Arm conservation | ground body (2 arms) and open body (3 arms); every output arm traces to **exactly 1** input arm | hand-added arm → report yields `[0, 1, 1]` | detector self-armed by the `0` case; `!= 1` would have been satisfied by 0 and 2, so cardinality is exact |
| Nonmatching halt stays halted | pre-existing Law 8 | pre-existing | — |
| Contract unconstructible stays loud | pre-existing (`test_effect_boundary_without_exception_identity_stays_loud`, `test_unresolved_ref_stays_typed_loud`) | pre-existing | — |

Fixtures are renamed (`from contracts import scope as hold`) — real shape, no vendor named.

## What stays loud, and why

- **`completed_observed` / `WarningEffectKindV1`** — this compiler constructs no occurrence for an effect the body *emits*. Routing it either way would state a fact about an observation nobody constructed. The refusal is the correct output; Law 13 now prevents a future arm from quietly turning it into a completion.
- **The contract has no `absence_expectation` or `additional_exit_policy` field yet.** Both are named in the design; neither is constructible from present testimony, and adding an unbacked field would be worse than its absence. Naming the gap here rather than shipping a placeholder.
- **The 85 unclassified spellings** are untouched and remain unclassified.
- **Resource/protocol With (811 sites)** is out of scope and nothing here blocks it: `RetainedObligation` is additive to the disposition codomain, and the resource path is untouched.

## R accounting

- **`Epsilon R` on the 4,125: 0.** This PR does not lower the census count. Every site it touches already routed; what changed is that one class of them stopped emitting a fabricated predicate. The 4,125 are not structurally closed and this does not close them — the missing work remains **authenticated contract acquisition**, not more manager names.
- **Predicted new red:** re-census may surface sites where the raised message is symbolic. Those now emit a `py.re_search` obligation instead of a wrong fact, which is a **correctness** delta, not a count delta. Any solver work on `py.re_search` is genuinely new obligation mass that was previously being hidden — expect a small increase in emitted atoms, not in `R`.
- **Floors preserved:** no test deleted, no test skipped, no detector weakened, no panic suppressed. The `SugarNotWritten` and `UnsupportedContextManagerSemantics` refusals on this path are unchanged or strengthened.

## Shell retired

None yet, and that is the honest answer. `RetainedObligation` is a closed dataclass in an `isinstance`-dispatched codomain — Python cannot make the missing arm a compile error. **Retirement path:** when the exit-disposition codomain moves behind a closed visitor (as the floor kinds did), a router that fails to handle a retention becomes an unimplemented-method failure at construction rather than a `TypeError` at run time. That is the next rung.

## Validation

```
implementations/python$ PYTHONPATH=... pytest sugar-source-tree/tests/test_with_partition_shared_algebra.py -q
34 passed
```
(28 before this PR.) Perturbation runs are in the table above. Broader `sugar-source-tree/tests/` sweep running; results will be reported as measured impact.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain undecidable message predicates as obligations in `EffectBoundaryWith` instead of deciding them
> - Replaces the boolean `matches_raise_effect_with_message` with `raise_effect_message_verdict` in [authenticated_exception_matching.py](https://github.com/TSavo/sugar/pull/6298/files#diff-b708c62aea2f4d18c3905c4cf348081f6c83d00d7864779eedc94b32ad948d03), which returns either `MatchDecided` (ground strings) or `MatchRetained` (a `py.re_search` obligation when the message or pattern is not ground).
> - Updates [exit_disposition.py](https://github.com/TSavo/sugar/pull/6298/files#diff-76129a966576d0bf8e6154295bc1ae8dc5b58eb63e5dd6e3f562a97d826dfc6c) to handle the tri-state verdict: decided-false restores the incoming effect, decided-true consumes the halt, and retained produces a `RetainedObligation` carrying both faces partitioned under the vendor predicate.
> - Adds tests in [test_with_partition_shared_algebra.py](https://github.com/TSavo/sugar/pull/6298/files#diff-4c2dc084662d16aaa82b994deee4c8e6f1a999e1d2e90bfbc1c64be73b88e1b5) covering undecidable predicates, ground message discrimination, arm conservation, and constructed effect kind routing.
> - Behavioral Change: callers previously received a single boolean; they now receive a `MatchDecided` or `MatchRetained` verdict, and undecidable predicates produce two output arms instead of one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8306d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->