### PR TITLE
docs: bank NameError replay terminal + assertion-With drain board

### DIFF
--- a/docs/ledgers/6284-nameerror-correctness-only.md
+++ b/docs/ledgers/6284-nameerror-correctness-only.md
@@ -1,0 +1,46 @@
+# #6284 NameError — correctness only (pandas)
+
+**Authority:** bounded NameError replay  
+**Pin:** `d94f67a31` → **Replay:** `c11767c5e`  
+**Wall:** ~2434s bound vs ~1041s full census (bound was **not** cheaper here)
+
+## Ledger (target family)
+
+```text
+#6284 semantic correctness: proven by twins
+#6284 pandas NameErrorEffect Δ: 0
+fabricated pandas rows: 0
+legitimate pandas rows: 940
+family subtraction: forbidden
+```
+
+## Scope of observed movements
+
+Exact for the **replayed slice** (305 files that held all 940 NameError occurrences):
+
+| Family | pinned → replay | Δ | Scope |
+|--------|----------------:|--:|-------|
+| NameErrorEffect | 940 → 940 | **0** | corpus-wide for this family (slice contained all occurrences) |
+| SubscriptStoreRuntimeEffect | 1166 → 1161 | −5 | **slice-only** (1116 files not replayed) |
+| YieldSuspensionSugar.desugar | 20 → 17 | −3 | **slice-only** |
+
+No global `pinned − 8` projection. No 10.9% gain.
+
+## Desugar ledger taxonomy
+
+| Bucket | Role |
+|--------|------|
+| Correctly constructed effects | Accounted semantics (e.g. legitimate NameErrorEffect) — **not defects to eliminate** |
+| Explicit incomplete obligations | Typed Incomplete / retained FOL obligations |
+| Construction panics / gaps | Floor gaps, SugarNotWritten, resolution gaps |
+| Implementation defects | Crashes, instrument false-red, hung measurement |
+
+**Python done** does not require deleting legitimate effects. It requires every effect to be correctly constructed, routed, and accounted.
+
+## Operational lesson
+
+Bounded replay is not automatically cheaper. Use it only when the selected slice is demonstrably cheaper **or** uniquely sharp as a discriminator. After `R(timeout)=0` is restored, the next attribution run is a **full authenticated census** at current head — not projection of the unmeasured 1116 files.
+
+## Machine board
+
+See `nameerror-bounded-replay-c11767c5e.json` beside this note.

--- a/docs/ledgers/assertion-with-drain-board-a0d38afca.json
+++ b/docs/ledgers/assertion-with-drain-board-a0d38afca.json
@@ -1,0 +1,48 @@
+{
+  "kind": "assertion-with-drain-board-v1",
+  "mainTip": "a0d38afca",
+  "totalWithSites": 5021,
+  "buckets": {
+    "assertion-effect-boundary": 4125,
+    "resource-protocol": 811,
+    "unclassified": 85
+  },
+  "assertionSites": 4125,
+  "resourceSites": 811,
+  "unclassified": 85,
+  "assertionHeadsByMass": [
+    {
+      "bucket": "assertion-effect-boundary",
+      "head": "pytest.raises",
+      "sites": 3555
+    },
+    {
+      "bucket": "assertion-effect-boundary",
+      "head": "tm.assert_produces_warning",
+      "sites": 499
+    },
+    {
+      "bucket": "assertion-effect-boundary",
+      "head": "tm.raises_chained_assignment_error",
+      "sites": 37
+    },
+    {
+      "bucket": "assertion-effect-boundary",
+      "head": "tm.external_error_raised",
+      "sites": 32
+    }
+  ],
+  "sharedAlgebra": "one ExitSet; EffectBoundaryWith retains undecidable message predicates (#6298) \u2014 soundness, \u0394R unmeasured",
+  "drainOrder": [
+    "structural contract requirements per head (pytest.raises first: 3555)",
+    "authenticated preconstruction of manager contracts at use-site",
+    "route every outgoing edge; retain undecidable message/category obligations",
+    "no vendor-name admission arms",
+    "measure \u0394R on assertion-effect-boundary sites only after each head lands"
+  ],
+  "blockedOn": [
+    "Floor remeasure at a0d38afca (post contains/guarded/residual)",
+    "EffectBoundaryWith coverage \u0394R (not claimed from #6298 alone)"
+  ],
+  "nextOwner": "assertion-With structural contracts for pytest.raises mass"
+}

--- a/docs/ledgers/assertion-with-drain-board-a0d38afca.json
+++ b/docs/ledgers/assertion-with-drain-board-a0d38afca.json
@@ -32,17 +32,29 @@
       "sites": 32
     }
   ],
-  "sharedAlgebra": "one ExitSet; EffectBoundaryWith retains undecidable message predicates (#6298) \u2014 soundness, \u0394R unmeasured",
+  "sharedAlgebra": "one ExitSet; EffectBoundaryWith retains undecidable message predicates (#6298) — soundness, ΔR unmeasured",
+  "nameErrorDisposition": {
+    "6284": "correctness-only; pandas NameErrorEffect Δ=0; keep all 940 legitimate rows"
+  },
+  "operatingOrder": [
+    "Complete timeout bisect; restore R(timeout)=0",
+    "Record #6284 as correctness-only for pandas (zero target-family Δ)",
+    "Keep all 940 legitimate NameErrorEffect rows",
+    "Full current-head authenticated census (not project unmeasured 1116)",
+    "Measure actual Floor and EffectBoundary ΔR",
+    "Dispatch structural assertion-With from those results (pytest.raises first)"
+  ],
   "drainOrder": [
     "structural contract requirements per head (pytest.raises first: 3555)",
     "authenticated preconstruction of manager contracts at use-site",
     "route every outgoing edge; retain undecidable message/category obligations",
     "no vendor-name admission arms",
-    "measure \u0394R on assertion-effect-boundary sites only after each head lands"
+    "measure ΔR on assertion-effect-boundary sites only after each head lands"
   ],
   "blockedOn": [
-    "Floor remeasure at a0d38afca (post contains/guarded/residual)",
-    "EffectBoundaryWith coverage \u0394R (not claimed from #6298 alone)"
+    "R(timeout)=0 restored",
+    "full authenticated census at current head",
+    "Floor / EffectBoundary ΔR measured (not projected)"
   ],
-  "nextOwner": "assertion-With structural contracts for pytest.raises mass"
+  "nextOwner": "timeout bisect then full authenticated census"
 }

--- a/docs/ledgers/nameerror-bounded-replay-c11767c5e.json
+++ b/docs/ledgers/nameerror-bounded-replay-c11767c5e.json
@@ -1,0 +1,27 @@
+{
+  "kind": "bounded-replay-terminal-v1",
+  "pinnedCommit": "d94f67a3149ea2aceee4f9a8cff0397b6f6d374a",
+  "replayCommit": "c11767c5e48f2e6799d0d4a0d58823ea84486ac6",
+  "targetFamily": "NameErrorEffect",
+  "boundFiles": 305,
+  "notReplayed": 1116,
+  "NameErrorEffect": {
+    "pinned": 940,
+    "replay": 940,
+    "delta": 0
+  },
+  "nonzeroFamilyDeltasInBound": {
+    "SubscriptStoreRuntimeEffect": {
+      "pinned": 1166,
+      "replay": 1161,
+      "delta": -5
+    },
+    "YieldSuspensionSugar.desugar": {
+      "pinned": 20,
+      "replay": 17,
+      "delta": -3
+    }
+  },
+  "verdict": "NameErrorEffect \u0394=0 within bound; #6284 retirement claim NOT measured as reduction at c11767c5e",
+  "measuredDeltaR": "unmeasured for full corpus; bound-only NameErrorEffect \u0394=0"
+}

--- a/docs/ledgers/nameerror-bounded-replay-c11767c5e.json
+++ b/docs/ledgers/nameerror-bounded-replay-c11767c5e.json
@@ -5,23 +5,50 @@
   "targetFamily": "NameErrorEffect",
   "boundFiles": 305,
   "notReplayed": 1116,
+  "corpusFiles": 1421,
+  "wallSeconds": 2434,
+  "fullCensusWallSecondsApprox": 1041,
   "NameErrorEffect": {
     "pinned": 940,
     "replay": 940,
-    "delta": 0
+    "delta": 0,
+    "scope": "corpus-wide for this family: bound files contained all 940 pinned occurrences"
   },
-  "nonzeroFamilyDeltasInBound": {
+  "sliceOnlyFamilyDeltasInBound": {
     "SubscriptStoreRuntimeEffect": {
       "pinned": 1166,
       "replay": 1161,
-      "delta": -5
+      "delta": -5,
+      "scope": "replayed slice only; not a global projection (1116 files unmeasured)"
     },
     "YieldSuspensionSugar.desugar": {
       "pinned": 20,
       "replay": 17,
-      "delta": -3
+      "delta": -3,
+      "scope": "replayed slice only; not a global projection (1116 files unmeasured)"
     }
   },
-  "verdict": "NameErrorEffect \u0394=0 within bound; #6284 retirement claim NOT measured as reduction at c11767c5e",
-  "measuredDeltaR": "unmeasured for full corpus; bound-only NameErrorEffect \u0394=0"
+  "ledger": {
+    "6284_semantic_correctness": "proven by twins",
+    "6284_pandas_NameErrorEffect_delta": 0,
+    "fabricated_pandas_rows": 0,
+    "legitimate_pandas_rows": 940,
+    "family_subtraction": "forbidden"
+  },
+  "verdict": [
+    "#6284 is correctness-only for pandas NameErrorEffect: Δ=0.",
+    "All 940 NameErrorEffect rows are legitimate accounted semantics — keep them.",
+    "Do not book family subtraction or a fictitious 10.9% gain.",
+    "Slice-only movements (−5 SubscriptStore, −3 YieldSuspension) are real for the bound; not global pinned−8.",
+    "Bounded replay here cost ~2434s vs ~1041s full census and left 79% of files unmeasured — use only when cheaper or uniquely sharp."
+  ],
+  "desugarLedgerTaxonomy": {
+    "correctly_constructed_effects": "accounted semantics (e.g. legitimate NameErrorEffect); not defects to eliminate",
+    "explicit_incomplete_obligations": "typed Incomplete / retained obligations",
+    "construction_panics_gaps": "Floor gaps, SugarNotWritten, resolution gaps",
+    "implementation_defects": "crashes, instrument false-red, hung measurement"
+  },
+  "pythonDoneDoesNotRequire": "deleting legitimate effects",
+  "pythonDoneRequires": "every effect correctly constructed, routed, and accounted",
+  "nextAttributionRun": "full current-head authenticated census after R(timeout)=0 restored; not projection of unmeasured 1116 files"
 }


### PR DESCRIPTION
## Summary
Ledgers only. Records the bounded NameError replay **negative result** that prevents booking fictitious work.

### #6284 (pandas NameErrorEffect)
```text
#6284 semantic correctness: proven by twins
#6284 pandas NameErrorEffect Δ: 0
fabricated pandas rows: 0
legitimate pandas rows: 940
family subtraction: forbidden
```

### Slice-only (not global)
- SubscriptStoreRuntimeEffect −5
- YieldSuspensionSugar.desugar −3  
(NameError Δ=0 is corpus-wide for that family; other deltas remain slice-only because 1116 files were not replayed.)

### Desugar taxonomy
Legitimate effects are accounted semantics, not defects to delete.

### Next
1. Timeout bisect → R(timeout)=0  
2. Full authenticated census at current head  
3. Measure Floor / EffectBoundary ΔR  
4. Structural assertion-With from those results  

## Measured ΔR
NameErrorEffect: **0** (proven). Floor/With: **unmeasured**.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bounded replay terminal ledger notes and drain board for NameError #6284
> Adds three documentation files recording the correctness-only verdict for the pandas `NameErrorEffect` issue (#6284) and its associated replay analysis.
>
> - [6284-nameerror-correctness-only.md](https://github.com/TSavo/sugar/pull/6299/files#diff-5708355bdcbfed7fa9021b1f4696c802b43f1235d2b08db3cee4935bc9923eaa) documents the bounded replay methodology, measured deltas across error families, taxonomy definitions, and operational guidance.
> - [nameerror-bounded-replay-c11767c5e.json](https://github.com/TSavo/sugar/pull/6299/files#diff-c491fe0bf8a306e6e7c9411ef35cf9be61d5a8b28d46d6bcbf567d0376fa6634) is a structured report covering pinned/replay commits, corpus sizing, wall-time comparisons, and next-attribution guidance.
> - [assertion-with-drain-board-a0d38afca.json](https://github.com/TSavo/sugar/pull/6299/files#diff-69f3c29d1167566cf00546255c0866f02b4423e7c6ce483a531ab5596d0c9003) captures the drain board state including bucket counts, assertion heads, blocking conditions, and ownership assignments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ceee54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->