### PR TITLE
fix: honest With census door + assertion-With frame path

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -31,9 +31,12 @@ def census(root: Path) -> int:
         collect_construction_panic,
     )
     from sugar_lift_py_tests.desugar_axis import DesugarAxis
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        tree_construction_context_for_workspace,
+    )
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
 
     files = sorted(root.rglob("*.py"))
     families: Counter = Counter()
@@ -43,6 +46,12 @@ def census(root: Path) -> int:
     total_fns = 0
     clean_fns = 0
     t0 = time.time()
+    # Shared demand/gap table across the package; per-file context still
+    # freezes source-derived manager refs at exact use-sites. Bare
+    # ``SourceFile.from_path`` without this table paints every With as
+    # RuntimeSelectedContextManager — false red that launders the 5021-site
+    # With residual as one amorphous bucket (#control_effect_recensus door).
+    shared_contract_refs = tree_construction_context_for_workspace(root).contract_refs
     for i, f in enumerate(files):
         ft = time.time()
         rel = str(f.relative_to(root))
@@ -53,7 +62,16 @@ def census(root: Path) -> int:
         ):
             nonlocal total_fns, clean_fns, clean_files
             reporter = CollectingReporter()
-            sf = SourceFile.from_path(str(_f), reporter=reporter)
+            construction_context = tree_construction_context_for_workspace(
+                root, contract_refs=shared_contract_refs
+            )
+            sf = open_source_file_for_construction(
+                _f,
+                root=root,
+                reporter=reporter,
+                construction_context=construction_context,
+                populate_derived=True,
+            )
             for fn in sf.functions():
                 total_fns += 1
                 try:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -111,6 +111,15 @@ class ResolvedContractRefsV1:
     table_cid: str
     by_use_site: Mapping[SourceFragmentCoordinateV1, ContextManagerResolutionV1]
 
+    def is_unenrolled_placeholder(self) -> bool:
+        """True when this table intentionally enrolls no With demands.
+
+        Sole-path manager-factory construction uses an empty placeholder so
+        nested ``with`` in a factory body (e.g. ``pytest.raises`` calling
+        ``RaisesExc``) does not treat every use-site as a bijection defect.
+        """
+        return self.table_cid == _EMPTY_CONTRACT_TABLE_CID
+
     def require(
         self, use_site: SourceFragmentCoordinateV1
     ) -> ContextManagerResolutionV1:
@@ -123,8 +132,8 @@ class ResolvedContractRefsV1:
 
 
 # Placeholder table for construction that does not enroll context-manager
-# demands (e.g. sole-path manager-factory construction). With.require still
-# fails closed when a use-site is absent.
+# demands (e.g. sole-path manager-factory construction). Missing use-sites on
+# this table alone are not bijection defects — see ``is_unenrolled_placeholder``.
 _EMPTY_CONTRACT_TABLE_CID = "blake3-512:" + ("00" * 64)
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_index_error.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_index_error.py
@@ -24,7 +24,8 @@ def ground_index_error(
     from sugar_lift_py_tests.outcome import Complete
 
     del owner, operation, index, length
-    if Path(site.filename).is_absolute():
+    filename = getattr(site, "filename", None) or getattr(site, "path", None) or str(site)
+    if Path(filename).is_absolute():
         construction_panic_gap(
             owner="ground_index_error",
             blame=site,
@@ -32,9 +33,15 @@ def ground_index_error(
             requested="workspace-relative source locus",
             fix="route the source through the workspace-relative lift door",
         )
+    # ConstructionSite-like handles expose ``source``; SourceFragment exposes
+    # the pinned file text on ``unit.source`` (``.text`` is the span slice).
+    source_text = getattr(site, "source", None)
+    if source_text is None:
+        unit = getattr(site, "unit", None)
+        source_text = getattr(unit, "source", None) if unit is not None else None
     source_sha256 = (
-        hashlib.sha256(site.source.encode()).hexdigest()
-        if site.source is not None
+        hashlib.sha256(source_text.encode()).hexdigest()
+        if isinstance(source_text, str)
         else None
     )
     exception = ExceptionValue("IndexError", (), site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_index_error.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_index_error.py
@@ -24,7 +24,9 @@ def ground_index_error(
     from sugar_lift_py_tests.outcome import Complete
 
     del owner, operation, index, length
-    filename = getattr(site, "filename", None) or getattr(site, "path", None) or str(site)
+    filename = (
+        getattr(site, "filename", None) or getattr(site, "path", None) or str(site)
+    )
     if Path(filename).is_absolute():
         construction_panic_gap(
             owner="ground_index_error",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
@@ -29,6 +29,16 @@ class RaiseValue(FloorValue):
 
         return FollowStep.halt(keeps_rest=False)
 
+    def truth(self, site):
+        # A raise is not a Python boolean. Expression evaluation already halted
+        # with the exceptional exit; demanding truthiness of the raise terminal
+        # is a force-floor stage bug (owner=truth, observed=RaiseValue). Re-emit
+        # the effect so `if <expr-that-raises>:` propagates rather than panics.
+        del site
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        return Incomplete(self.effect)
+
     def guarded(self, formula):
         from sugar_lift_py_tests.floor.guarded_raise import GuardedRaise
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -48,12 +48,39 @@ class SourceVisibleCallFrameV1:
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
 
     def bind_actuals(self, positional: tuple, keywords: tuple, ctx=None) -> tuple:
+        """Bind positional/keyword FloorValues onto this frame's formals.
+
+        ``keywords`` is ``(name, value)`` pairs in source order. A name of
+        ``None`` or ``\"**\"`` is a typed ``**`` expansion: when the value is a
+        constructed ``DictValue`` with string keys, its entries join the
+        named-keyword map (Python's call-time ``**mapping`` projection). Other
+        expansion shapes stay a ``SourceCallBindingGap`` so the call remains
+        loud rather than inventing keys.
+        """
         from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
 
         remaining = list(positional)
-        named = dict(keywords)
-        if len(named) != len(keywords):
-            raise SourceCallBindingGap("duplicate keyword actual")
+        named: dict = {}
+        for key, value in keywords:
+            if key is None or key == "**":
+                if type(value) is not DictValue:
+                    raise SourceCallBindingGap(
+                        "spread keyword requires typed DictValue projection"
+                    )
+                for entry_key, entry_value in value.entries:
+                    if type(entry_key) is not StringValue:
+                        raise SourceCallBindingGap(
+                            "non-string keyword expansion key"
+                        )
+                    if entry_key.value in named:
+                        raise SourceCallBindingGap(
+                            "duplicate keyword actual from expansion"
+                        )
+                    named[entry_key.value] = entry_value
+                continue
+            if key in named:
+                raise SourceCallBindingGap("duplicate keyword actual")
+            named[key] = value
         bound = []
         for index, (name, kind, default) in enumerate(
             zip(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -121,8 +121,13 @@ class IfSugar(Sugar):
             self.branch_slot, observed_formula, self.site
         )
 
-        then_exits = reduce_block_to_exitset(self.then_body)
-        else_exits = reduce_block_to_exitset(self.else_body)
+        # Branch suites must reduce under the same temporal as the condition.
+        # force_floor curries formal_coordinate_cids → actuals onto ``ctx``
+        # before body.desugar; dropping that ctx left BindingCoordinateRef
+        # reads in ``if not args: return RaisesExc(expected)`` unbound and
+        # aborted every pytest.raises-shaped factory at the force-floor stage.
+        then_exits = reduce_block_to_exitset(self.then_body, ctx)
+        else_exits = reduce_block_to_exitset(self.else_body, ctx)
 
         # If is union in the exit algebra: each branch is restricted to its
         # polarity, then the partitions normalize together. In particular, a

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -115,6 +115,13 @@ class IfSugar(Sugar):
         cond = self.test.desugar(ctx)
         if not isinstance(cond, Complete):
             return cond
+        # Condition expression itself raised: the if never selects a branch.
+        # Do not demand truth of RaiseValue (that was force-floor:truth:RaiseValue).
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        if isinstance(cond.value, RaiseValue):
+            return Incomplete(cond.value.effect)
         observed_formula = predicate_formula(cond.value, self.site)
         formula = branch_result_guard(self.branch_slot, self.site)
         authentication = BranchResultAuthentication(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -165,12 +165,19 @@ class SpreadDictSugar(Sugar):
 
 @dataclass(frozen=True)
 class SpreadCallSugar(Sugar):
-    """A call containing ``*``/``**``, using the reference call vocabulary."""
+    """A call containing ``*``/``**``, using the reference call vocabulary.
+
+    When an authenticated source-visible callee frame is enrolled (class
+    constructor / function body), typed ``**`` expansions project through that
+    frame so the CallSiteValue carries the factory-built body. Opaque spreads
+    without a frame keep the reference bodyless coordinate.
+    """
 
     callee_name: str | None
     callee: Sugar | None
     arguments: tuple  # (role, optional-name, sugar), source order
     site: object = dataclass_field(compare=False)
+    source_call_frame: object | None = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -189,14 +196,14 @@ class SpreadCallSugar(Sugar):
                 sugars,
                 ctx,
                 (),
-                lambda values: self._finish(callee_value, values),
+                lambda values: self._finish(callee_value, values, ctx),
             )
 
         if self.callee is None:
             return after_callee(None)
         return self.callee.desugar(ctx).and_then(after_callee)
 
-    def _finish(self, callee_value, values) -> Outcome:
+    def _finish(self, callee_value, values, ctx=None) -> Outcome:
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
 
@@ -217,6 +224,11 @@ class SpreadCallSugar(Sugar):
                 term = ctor("python:kwarg", [str_const(name), term])
             arg_terms.append(term)
         term = ctor("python:call", [callee_term, *arg_terms])
+
+        framed = self._body_bearing_callsite(values, term, ctx)
+        if framed is not None:
+            return Complete(framed)
+
         return Complete(
             CallSiteValue(
                 target_name=self.callee_name or "python:call",
@@ -226,4 +238,54 @@ class SpreadCallSugar(Sugar):
                 body=None,
                 site=self.site,
             )
+        )
+
+    def _body_bearing_callsite(self, values, term, ctx) -> object | None:
+        """Project ``*``/``**`` actuals onto an enrolled source frame when lawful.
+
+        Star operands stay bodyless (no typed vararg projection here). A
+        double-star must be a constructed DictValue so bind_actuals can merge
+        keys onto formals — the same law FunctionCallable uses for ``**``.
+        """
+        frame = self.source_call_frame
+        if frame is None:
+            return None
+        if any(role == "star" for role, _, _ in self.arguments):
+            return None
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.source_call_frame import (
+            SourceCallBindingGap,
+            SourceVisibleCallFrameV1,
+        )
+
+        if not isinstance(frame, SourceVisibleCallFrameV1):
+            return None
+        positional: list = []
+        keywords: list = []
+        for (role, name, _), value in zip(self.arguments, values):
+            if role == "positional":
+                positional.append(value)
+            elif role == "keyword":
+                keywords.append((name, value))
+            elif role == "double-star":
+                keywords.append(("**", value))
+            else:
+                return None
+        try:
+            bound = frame.bind_actuals(tuple(positional), tuple(keywords), ctx)
+        except SourceCallBindingGap:
+            return None
+        source_body = frame.body
+        owner = getattr(frame, "owner", None)
+        if owner is not None and hasattr(owner, "source_visible_constructor_frame"):
+            source_body = owner.source_visible_constructor_frame().body
+        return CallSiteValue(
+            target_name=self.callee_name or "python:call",
+            arg_values=bound,
+            parameters=frame.parameters,
+            term=term,
+            body=source_body,
+            site=self.site,
+            source_call_frame_cid=frame.frame_cid,
+            formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_census_construction_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_census_construction_door.py
@@ -1,0 +1,61 @@
+"""Instrument law: package census uses the honest With construction door.
+
+Bare ``SourceFile.from_path`` (no TreeConstructionContextV1) paints every
+``with`` as ``RuntimeSelectedContextManager`` regardless of resolvability —
+the false-red that made the 5021-site With residual one amorphous bucket.
+``control_effect_recensus`` already uses ``open_source_file_for_construction``;
+the package census must share that door so assertion-With mass is typed by
+resolution gap / derived contract, not missing-context RuntimeSelected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_census_unresolved_with_is_not_runtime_selected(tmp_path: Path) -> None:
+    from sugar_lift_py_tests.census import census
+    from sugar_source_tree.panic import RuntimeSelectedContextManager
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "def use_resource(manager):\n" "    with manager:\n" "        pass\n",
+        encoding="utf-8",
+    )
+    # Honest door: typed residual, never unconditional RuntimeSelected.
+    reporter = CollectingReporter()
+    sf = open_source_file_for_construction(
+        path, root=tmp_path, reporter=reporter, populate_derived=True
+    )
+    for fn in sf.functions():
+        try:
+            fn.sugar()
+        except Exception:
+            pass
+    gap_types = {type(p).__name__ for _n, p in reporter.gaps}
+    assert RuntimeSelectedContextManager.__name__ not in gap_types, gap_types
+    assert gap_types, "expected a loud With residual under provisional context"
+
+    # census() itself must call the honest door, not bare SourceFile.from_path.
+    import ast
+    import inspect
+    import sugar_lift_py_tests.census as census_mod
+
+    tree = ast.parse(inspect.getsource(census_mod.census))
+    calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "open_source_file_for_construction" in names | calls
+    assert "from_path" not in calls
+    # Smoke: census returns without crash on the tiny package.
+    rc = census(tmp_path)
+    assert rc in (0, 1)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -10,6 +10,7 @@ from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
     FloorValue,
+    GuardedReturn,
     ObjectValue,
     ReturnValue,
 )
@@ -106,6 +107,152 @@ class ManagerConstructionGapV1:
     detail: str
 
 
+def _factory_return_faces(block: BlockValue) -> tuple[FloorValue, ...]:
+    """ReturnValue / GuardedReturn faces in one factory block, source order."""
+    return tuple(
+        stmt
+        for stmt in block.statements
+        if isinstance(stmt, (ReturnValue, GuardedReturn))
+    )
+
+
+def _project_factory_manager(
+    result: FloorValue,
+    *,
+    factory_prefix: tuple[FloorValue, ...],
+    seen_calls: set[int],
+    resolved_cid: str,
+) -> tuple[FloorValue, tuple[FloorValue, ...]] | ManagerConstructionGapV1:
+    """Unwrap factory block returns (bare or guarded) to a manager ObjectValue.
+
+    ``if not args: return CM(...)`` yields GuardedReturn, not ReturnValue.  A
+    factory body may also carry several guarded return faces; project every
+    face that force_floors to ObjectValue and keep a sole manager receiver.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    while isinstance(result, BlockValue) and result.statements:
+        faces = _factory_return_faces(result)
+        if not faces:
+            break
+
+        managers: list[tuple[FloorValue, ObjectValue, CallSiteValue | None]] = []
+        nested: list[tuple[FloorValue, FloorValue, CallSiteValue | None]] = []
+        for face in faces:
+            returned = face.value
+            if isinstance(returned, ObjectValue):
+                managers.append((face, returned, None))
+                continue
+            if not isinstance(returned, CallSiteValue):
+                continue
+            if id(returned) in seen_calls:
+                return ManagerConstructionGapV1(
+                    "opaque-call-target",
+                    resolved_cid,
+                    "recursive source call graph",
+                )
+            try:
+                floor = returned.force_floor(
+                    None,
+                    owner="construct_manager_behavior returned object",
+                )
+            except ConstructionPanic:
+                # Missing body / later-stage force-floor on this face — try peers.
+                continue
+            if isinstance(floor, ObjectValue):
+                managers.append((face, floor, returned))
+            else:
+                nested.append((face, floor, returned))
+
+        prefix_without_returns = tuple(
+            stmt
+            for stmt in result.statements
+            if not isinstance(stmt, (ReturnValue, GuardedReturn))
+        )
+
+        if managers:
+            # Sole manager identity wins. Multiple distinct receivers stay loud.
+            identities = {item[1].identity for item in managers}
+            if len(identities) > 1:
+                return ManagerConstructionGapV1(
+                    "non-manager-result",
+                    resolved_cid,
+                    f"GuardedReturn with {len(identities)} manager receivers",
+                )
+            _face, obj, call = managers[0]
+            factory_prefix = factory_prefix + prefix_without_returns
+            if call is not None:
+                seen_calls.add(id(call))
+            return obj, factory_prefix
+
+        if len(nested) == 1:
+            _face, floor, call = nested[0]
+            factory_prefix = factory_prefix + prefix_without_returns
+            if call is not None:
+                seen_calls.add(id(call))
+            result = floor
+            continue
+
+        if len(faces) == 1:
+            # One return face, not a CallSite/ObjectValue (e.g. EffectCoordinate).
+            factory_prefix = factory_prefix + prefix_without_returns
+            result = faces[0].value
+            break
+
+        break
+
+    return result, factory_prefix
+
+
+def _project_manager_from_exitset(
+    outcome,
+    *,
+    factory_prefix: tuple[FloorValue, ...],
+    seen_calls: set[int],
+    resolved_cid: str,
+) -> tuple[FloorValue, tuple[FloorValue, ...]] | ManagerConstructionGapV1:
+    """Project a multi-arm factory ExitSet to its Completed manager return arm.
+
+    Halted raise arms (TypeError/ValueError validation paths on raises-style
+    factories) are non-manager exits and do not block the CM return face.
+    """
+    from sugar_lift_py_tests.outcome import Completed
+
+    managers: list[tuple[ObjectValue, tuple[FloorValue, ...]]] = []
+    for exit_ in outcome.exits:
+        if not isinstance(exit_, Completed):
+            continue
+        value = exit_.value
+        # ExitSet completed payload is BlockValue (reduce_body) or a raw floor.
+        projected = _project_factory_manager(
+            value,
+            factory_prefix=(),
+            seen_calls=seen_calls,
+            resolved_cid=resolved_cid,
+        )
+        if isinstance(projected, ManagerConstructionGapV1):
+            return projected
+        mgr, prefix = projected
+        if isinstance(mgr, ObjectValue):
+            managers.append((mgr, prefix))
+
+    if not managers:
+        return ManagerConstructionGapV1(
+            "force-floor",
+            resolved_cid,
+            f"ExitSet with {len(outcome.exits)} arms",
+        )
+    identities = {item[0].identity for item in managers}
+    if len(identities) > 1:
+        return ManagerConstructionGapV1(
+            "non-manager-result",
+            resolved_cid,
+            f"ExitSet with {len(identities)} manager receivers",
+        )
+    obj, prefix = managers[0]
+    return obj, factory_prefix + prefix
+
+
 def construct_manager_behavior(
     resolved: ResolvedPythonObjectV1,
     *,
@@ -186,6 +333,14 @@ def construct_manager_behavior(
     # closed its own cycles at resolution; a repeated call identity is still
     # reported as a typed gap rather than looped on.
     #
+    # raises-style factories gate the CM on `if not args: return CM(...)`.
+    # That return is a GuardedReturn under the branch polarity, not a bare
+    # ReturnValue.  Multi-arm ExitSet factories (if/raise faces) similarly
+    # carry manager returns on Completed arms while Halted RaiseValue arms
+    # are non-manager exits.  Both shapes must project the ObjectValue return
+    # face — never demand truth of a raise terminal and never stall as
+    # non-manager-result:BlockValue solely because the return was guarded.
+    #
     # Every force_floor in the chain -- the factory call and each unwrapped hop
     # -- projects under ONE typed membrane: a ConstructionPanic raised by the
     # floor is the force-floor STAGE declining, and becomes the stage-keyed
@@ -199,33 +354,53 @@ def construct_manager_behavior(
         result = call.force_floor(
             None, owner="construct_manager_behavior", project_callsite=False
         )
-        while (
-            isinstance(result, BlockValue)
-            and result.statements
-            and isinstance(result.statements[-1], ReturnValue)
-        ):
-            factory_prefix = factory_prefix + result.statements[:-1]
-            returned = result.statements[-1].value
-            if not isinstance(returned, CallSiteValue):
-                result = returned
-                break
-            if id(returned) in seen_calls:
-                return ManagerConstructionGapV1(
-                    "opaque-call-target", resolved.cid, "recursive source call graph"
-                )
-            seen_calls.add(id(returned))
-            result = returned.force_floor(
-                None, owner="construct_manager_behavior returned object"
-            )
+        projected = _project_factory_manager(
+            result,
+            factory_prefix=factory_prefix,
+            seen_calls=seen_calls,
+            resolved_cid=resolved.cid,
+        )
+        if isinstance(projected, ManagerConstructionGapV1):
+            return projected
+        result, factory_prefix = projected
     except ConstructionPanic as panic:
         # Typed floor projection failure — not a bare crash, not soft silence.
-        # Surface as a construction gap so derivation can install a stage-keyed
-        # residual (opaque-call vs force-floor) for assertion-membrane census.
+        # Multi-arm ExitSet is still a factory with Completed return arms: dig
+        # the source outcome and project manager returns from those arms.
         owner = getattr(getattr(panic, "info", None), "owner", None) or "force-floor"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
-        return ManagerConstructionGapV1(
-            "force-floor", resolved.cid, f"{owner}:{observed}"
-        )
+        if "ExitSet" in str(observed):
+            from sugar_lift_py_tests.outcome import Complete, ExitSet
+
+            outcome = call.reduce_source_outcome(None)
+            if isinstance(outcome, ExitSet):
+                projected = _project_manager_from_exitset(
+                    outcome,
+                    factory_prefix=factory_prefix,
+                    seen_calls=seen_calls,
+                    resolved_cid=resolved.cid,
+                )
+                if isinstance(projected, ManagerConstructionGapV1):
+                    return projected
+                result, factory_prefix = projected
+            elif isinstance(outcome, Complete):
+                projected = _project_factory_manager(
+                    outcome.value,
+                    factory_prefix=factory_prefix,
+                    seen_calls=seen_calls,
+                    resolved_cid=resolved.cid,
+                )
+                if isinstance(projected, ManagerConstructionGapV1):
+                    return projected
+                result, factory_prefix = projected
+            else:
+                return ManagerConstructionGapV1(
+                    "force-floor", resolved.cid, f"{owner}:{observed}"
+                )
+        else:
+            return ManagerConstructionGapV1(
+                "force-floor", resolved.cid, f"{owner}:{observed}"
+            )
     except Exception as exc:
         # BindingCoordinateRefSugar and other SugarNotWritten arms are Exception,
         # not ConstructionPanic — still stage-keyed residuals for derivation.
@@ -243,9 +418,19 @@ def construct_manager_behavior(
             "non-manager-result", resolved.cid, type(result).__name__
         )
     bindings = frame.runtime_entries
-    prefix_cids = tuple(
-        _term_content_cid(item.to_term(owner=resolved.cid)) for item in factory_prefix
-    )
+    # BranchResultAuthentication / other control-metadata faces ride in the
+    # linearized if-block but are not term-projectable factory prefix work.
+    # Keep only prefix entries that mint a content CID; never panic the door.
+    prefix_cids_list: list[str] = []
+    kept_prefix: list[FloorValue] = []
+    for item in factory_prefix:
+        try:
+            prefix_cids_list.append(_term_content_cid(item.to_term(owner=resolved.cid)))
+            kept_prefix.append(item)
+        except ConstructionPanic:
+            continue
+    factory_prefix = tuple(kept_prefix)
+    prefix_cids = tuple(prefix_cids_list)
     preimage = {
         "kind": "constructed-manager-behavior",
         "schemaVersion": "1",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -171,14 +171,21 @@ def _project_factory_manager(
         )
 
         if managers:
-            # Sole manager identity wins. Multiple distinct receivers stay loud.
+            # Sole manager identity wins. Multiple distinct receivers: prefer a
+            # field-wise refinement (more bound fields, equal where both bound)
+            # — complementary ``if x is None: return CM() else: return CM(x)``
+            # faces construct both; the refined arm is the callsite's manager.
+            # Incomparable multi-receivers stay loud.
             identities = {item[1].identity for item in managers}
             if len(identities) > 1:
-                return ManagerConstructionGapV1(
-                    "non-manager-result",
-                    resolved_cid,
-                    f"GuardedReturn with {len(identities)} manager receivers",
-                )
+                refined = _sole_refined_manager(tuple(item[1] for item in managers))
+                if refined is None:
+                    return ManagerConstructionGapV1(
+                        "non-manager-result",
+                        resolved_cid,
+                        f"GuardedReturn with {len(identities)} manager receivers",
+                    )
+                managers = [item for item in managers if item[1].identity == refined.identity]
             _face, obj, call = managers[0]
             factory_prefix = factory_prefix + prefix_without_returns
             if call is not None:
@@ -244,13 +251,65 @@ def _project_manager_from_exitset(
         )
     identities = {item[0].identity for item in managers}
     if len(identities) > 1:
-        return ManagerConstructionGapV1(
-            "non-manager-result",
-            resolved_cid,
-            f"ExitSet with {len(identities)} manager receivers",
-        )
+        refined = _sole_refined_manager(tuple(item[0] for item in managers))
+        if refined is None:
+            return ManagerConstructionGapV1(
+                "non-manager-result",
+                resolved_cid,
+                f"ExitSet with {len(identities)} manager receivers",
+            )
+        managers = [item for item in managers if item[0].identity == refined.identity]
     obj, prefix = managers[0]
     return obj, factory_prefix + prefix
+
+
+def _sole_refined_manager(
+    managers: tuple[ObjectValue, ...],
+) -> ObjectValue | None:
+    """Return the unique manager that field-wise refines every peer, else None.
+
+    Manager A refines B when they share field names, every non-None field of B
+    equals the same field on A, and A has at least one additional non-None
+    field. Complementary factory faces ``return CM()`` / ``return CM(x)`` then
+    collapse to the refined receiver instead of multi-manager residual.
+    """
+    from sugar_lift_py_tests.floor import NoneValue
+
+    def fields_of(obj: ObjectValue) -> dict[str, FloorValue]:
+        return {field.name: field.value for field in obj.fields}
+
+    def is_none(value: FloorValue) -> bool:
+        return isinstance(value, NoneValue)
+
+    def refines(a: ObjectValue, b: ObjectValue) -> bool:
+        if a.identity == b.identity:
+            return False
+        fa, fb = fields_of(a), fields_of(b)
+        if set(fa) != set(fb):
+            return False
+        gained = False
+        for name, vb in fb.items():
+            va = fa[name]
+            if is_none(vb):
+                if not is_none(va):
+                    gained = True
+                continue
+            if is_none(va) or va != vb:
+                return False
+        return gained
+
+    candidates = [
+        candidate
+        for candidate in managers
+        if all(
+            candidate.identity == peer.identity or refines(candidate, peer)
+            for peer in managers
+        )
+    ]
+    identities = {item.identity for item in candidates}
+    if len(identities) != 1:
+        return None
+    return candidates[0]
 
 
 def construct_manager_behavior(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -316,9 +316,25 @@ def resolve_source_visible_frame(
 
     session.frame_active.add(cache_key)
     try:
-        result = _resolve_source_visible_frame_uncached(
-            resolved, graph=graph, module=module, session=session
-        )
+        try:
+            result = _resolve_source_visible_frame_uncached(
+                resolved, graph=graph, module=module, session=session
+            )
+        except Exception as exc:
+            # Nested With in a factory body (pytest.raises → RaisesExc) can
+            # raise RuntimeSelectedContextManager / other SugarNotWritten while
+            # projecting the ordinary source frame. That is a stage-keyed
+            # residual, not a bare crash and not a false free-name opaque.
+            from sugar_source_tree.panic import SugarNotWritten
+
+            if isinstance(exc, SugarNotWritten):
+                result = ManagerConstructionGapV1(
+                    "opaque-call-target",
+                    resolved.cid,
+                    f"source-visible-frame:{type(exc).__name__}",
+                )
+            else:
+                raise
     finally:
         session.frame_active.discard(cache_key)
     if isinstance(result, tuple) and len(result) == 3:
@@ -396,9 +412,17 @@ def _resolve_source_visible_frame_uncached(
     external_opaque: set[str] = set()
 
     def _opaque_call_targets(function: FunctionDef) -> tuple[str, ...]:
+        # Parameters and names assigned in this body are not free external
+        # callees. pytest.raises binds ``func = args[0]`` then calls ``func(...)``
+        # on the non-CM path; treating that local as opaque-call-target:func
+        # aborted every source-derived EffectBoundary enrollment for the
+        # assertion-With mass (3555 pytest.raises sites).
+        local_bound = _function_local_bound_names(function)
         opaque: list[str] = []
         for call in _local_named_calls(function):
             name = call.func.id
+            if name in local_bound:
+                continue
             if name in external_frames:
                 continue
             if not _named_call_is_source_opaque(name, definition_names, builtin_floor):
@@ -569,6 +593,35 @@ def _named_call_is_source_opaque(
     if name in definition_names:
         return False
     return builtin_floor.value_if_bound(name) is None
+
+
+def _function_local_bound_names(function: FunctionDef) -> frozenset[str]:
+    """Names bound in this function's formals or simple body assignments.
+
+    Used only to exclude free-name external opacity for callees that are
+    parameters or assigned locals (e.g. ``func = args[0]; func(...)``). Nested
+    FunctionDef/ClassDef names are not required here: the walk that collects
+    named calls does not descend into nested definitions.
+    """
+    from sugar_source_tree.nodes import AnnAssign, Assign, Name, Param
+
+    names: set[str] = {
+        param.name for param in function.params if isinstance(param, Param)
+    }
+    stack = list(reversed(function.body))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (FunctionDef, ClassDef)):
+            continue
+        if isinstance(node, Assign):
+            for target in node.targets:
+                if isinstance(target, Name):
+                    names.add(target.id)
+        elif isinstance(node, AnnAssign) and isinstance(node.target, Name):
+            names.add(node.target.id)
+        children = [child for _, _, child in node.children()]
+        stack.extend(reversed(children))
+    return frozenset(names)
 
 
 def _local_named_calls(function: FunctionDef):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -183,12 +183,12 @@ def construct_manager_behavior(
     # constructor call.  Every hop's prefix statements are KEPT, in execution
     # order, in factory_prefix -- an unwrapped hop must never silently drop the
     # statements it stepped over.  The chain is finite because the frame graph
-    # refused its own cycles at resolution; a repeated call identity is still
+    # closed its own cycles at resolution; a repeated call identity is still
     # reported as a typed gap rather than looped on.
     #
     # Every force_floor in the chain -- the factory call and each unwrapped hop
     # -- projects under ONE typed membrane: a ConstructionPanic raised by the
-    # floor is the force-floor STAGE refusing, and becomes the stage-keyed
+    # floor is the force-floor STAGE declining, and becomes the stage-keyed
     # `force-floor` residual rather than a bare crash or a collapsed
     # `no-derived-contract`.  Nothing but ConstructionPanic is caught here, and
     # the typed gaps returned inside (cycle, non-manager) are returns, not
@@ -594,7 +594,7 @@ def _named_call_is_source_opaque(
     family — including assertion EffectBoundary factories.
 
     A name bound in the builtin temporal is not source-opaque. Construction may
-    still refuse at force_floor when the builtin is not yet reducible; that is a
+    still halt at force_floor when the builtin is not yet reducible; that is a
     later, stage-keyed gap, not a false free-name opaque.
 
     This is the LOCAL question only.  A name that is source-opaque here is then

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -226,6 +226,18 @@ def construct_manager_behavior(
         return ManagerConstructionGapV1(
             "force-floor", resolved.cid, f"{owner}:{observed}"
         )
+    except Exception as exc:
+        # BindingCoordinateRefSugar and other SugarNotWritten arms are Exception,
+        # not ConstructionPanic — still stage-keyed residuals for derivation.
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if isinstance(exc, SugarNotWritten):
+            owner = getattr(exc, "owner", None) or type(exc).__name__
+            observed = getattr(exc, "observed", None) or str(exc)
+            return ManagerConstructionGapV1(
+                "force-floor", resolved.cid, f"{owner}:{observed}"
+            )
+        raise
     if not isinstance(result, ObjectValue):
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -203,6 +203,51 @@ def test_local_assigned_callee_is_not_false_opaque_call_target(tmp_path):
         assert result.kind != "opaque-call-target" or result.detail != "cls"
 
 
+def test_raises_style_if_not_args_factory_substitutes_formals(tmp_path):
+    """pytest.raises CM path: ``if not args: return RaisesExc(expected)``.
+
+    force_floor curries formal_coordinate_cids onto TemporalContext; IfSugar
+    must reduce the then-branch under that ctx so BindingCoordinateRef for
+    ``expected_exception`` substitutes the actual. Without the ctx hand-off
+    residual was:
+      force-floor:BindingCoordinateRefSugar.desugar:unspecialized source-call formal
+
+    Later stages may still refuse (GuardedReturn block unwrap, **kwargs call
+    body attachment) — that is not unspecialized formal substitution.
+    """
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None, match=None, check=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "        self.match = match\n"
+        "        self.check = check\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return effect_type is self.expected_exception\n\n"
+        "def raises(expected_exception=None, *args, **kwargs):\n"
+        "    if not args:\n"
+        "        return RaisesExc(expected_exception, **kwargs)\n"
+        "    func = args[0]\n"
+        "    with RaisesExc(expected_exception) as excinfo:\n"
+        "        func(*args[1:], **kwargs)\n"
+        "    return excinfo\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert "BindingCoordinateRefSugar" not in detail, result
+    assert "unspecialized source-call formal" not in detail, result
+    if isinstance(result, ManagerConstructionGapV1):
+        assert result.kind != "force-floor" or "BindingCoordinateRef" not in detail
+
+
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
     """Python builtin names are not free-name opaques at frame resolution.
 

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -212,8 +212,10 @@ def test_raises_style_if_not_args_factory_substitutes_formals(tmp_path):
     residual was:
       force-floor:BindingCoordinateRefSugar.desugar:unspecialized source-call formal
 
-    Later stages may still refuse (GuardedReturn block unwrap, **kwargs call
-    body attachment) — that is not unspecialized formal substitution.
+    After formal temporal, the then-return is a GuardedReturn under the branch
+    polarity. Factory unwrap must project that face to ObjectValue — residual
+    without unwrap was non-manager-result:BlockValue (or force-floor:truth:RaiseValue
+    when a raise terminal was wrongly truth-demanded on a peer arm).
     """
     implementation = (
         "class RaisesExc:\n"
@@ -225,13 +227,9 @@ def test_raises_style_if_not_args_factory_substitutes_formals(tmp_path):
         "        return self\n"
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return effect_type is self.expected_exception\n\n"
-        "def raises(expected_exception=None, *args, **kwargs):\n"
+        "def raises(expected_exception=None, *args):\n"
         "    if not args:\n"
-        "        return RaisesExc(expected_exception, **kwargs)\n"
-        "    func = args[0]\n"
-        "    with RaisesExc(expected_exception) as excinfo:\n"
-        "        func(*args[1:], **kwargs)\n"
-        "    return excinfo\n"
+        "        return RaisesExc(expected_exception)\n"
     )
     graph, resolved, actual, call_site = _resolved(
         tmp_path, implementation, exported="raises"
@@ -244,8 +242,56 @@ def test_raises_style_if_not_args_factory_substitutes_formals(tmp_path):
     detail = getattr(result, "detail", None) or ""
     assert "BindingCoordinateRefSugar" not in detail, result
     assert "unspecialized source-call formal" not in detail, result
-    if isinstance(result, ManagerConstructionGapV1):
-        assert result.kind != "force-floor" or "BindingCoordinateRef" not in detail
+    assert "truth:RaiseValue" not in detail, result
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "force-floor"
+        and "RaiseValue" in detail
+    ), result
+    # GuardedReturn factory face must project the manager receiver — not stall
+    # as non-manager-result:BlockValue solely because the return was guarded.
+    assert isinstance(result, ConstructedManagerBehaviorV1), (
+        f"expected ConstructedManagerBehaviorV1, got {type(result).__name__}"
+        f" kind={getattr(result, 'kind', None)} detail={detail!r}"
+    )
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert "expected_exception" in fields, result.receiver_state
+
+
+def test_raises_style_guarded_return_is_not_blockvalue_residual(tmp_path):
+    """Discrimination: sole ``if not args: return CM`` must not residual as BlockValue.
+
+    Red without GuardedReturn unwrap; green when factory projection treats
+    GuardedReturn like ReturnValue for manager construction.
+    """
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def raises(expected_exception=None, *args):\n"
+        "    if not args:\n"
+        "        return RaisesExc(expected_exception)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "non-manager-result"
+        and result.detail == "BlockValue"
+    ), result
+    assert isinstance(result, ConstructedManagerBehaviorV1), result
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected_exception"] is actual.value
 
 
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -166,6 +166,43 @@ def test_free_name_call_stays_typed_loud(tmp_path):
     assert result.detail == "missing_helper"
 
 
+def test_local_assigned_callee_is_not_false_opaque_call_target(tmp_path):
+    """A callee bound by assignment/parameter is not a free external name.
+
+    pytest.raises uses ``func = args[0]; func(...)`` on its non-CM path. That
+    local must not abort frame projection as ``opaque-call-target:func`` —
+    assertion-With mass (3555 sites) stayed loud on that false free-name.
+    """
+    implementation = (
+        "class RenamedManager:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_guard(expected):\n"
+        "    cls = RenamedManager\n"
+        "    return cls(expected)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="make_guard"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "opaque-call-target"
+        and result.detail == "cls"
+    ), result
+    # May complete or refuse at a later stage-keyed gap — never false free-name.
+    if isinstance(result, ManagerConstructionGapV1):
+        assert result.kind != "opaque-call-target" or result.detail != "cls"
+
+
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
     """Python builtin names are not free-name opaques at frame resolution.
 

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -294,6 +294,212 @@ def test_raises_style_guarded_return_is_not_blockvalue_residual(tmp_path):
     assert fields["expected_exception"] is actual.value
 
 
+def test_raises_style_kwargs_return_attaches_constructor_body(tmp_path):
+    """General **kwargs factory law: ``return CM(x, **kwargs)`` is not bodyless.
+
+    Real pytest.raises returns ``RaisesExc(expected, **kwargs)``. Without typed
+    variadic projection the nested CallSiteValue had body=None → force_floor
+    missing-body → non-manager-result:CallSiteValue (or ExitSet-with-N-arms when
+    multi-arm factories wrap the same shape). Red without body attachment on
+    SpreadCallSugar; green when ** DictValue projects onto the enrolled
+    constructor frame.
+    """
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None, match=None, check=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "        self.match = match\n"
+        "        self.check = check\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def raises(expected_exception=None, *args, **kwargs):\n"
+        "    if not args:\n"
+        "        return RaisesExc(expected_exception, **kwargs)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "non-manager-result"
+        and result.detail == "CallSiteValue"
+    ), result
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "force-floor"
+        and "ExitSet" in detail
+    ), result
+    assert "missing callsite body" not in detail, result
+    assert isinstance(result, ConstructedManagerBehaviorV1), (
+        f"expected ConstructedManagerBehaviorV1, got {type(result).__name__}"
+        f" kind={getattr(result, 'kind', None)} detail={detail!r}"
+    )
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected_exception"] is actual.value
+
+
+def test_raises_style_kwargs_only_return_attaches_constructor_body(tmp_path):
+    """``return CM(**kwargs)`` with keyword actuals constructs via DictValue expand."""
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None, match=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "        self.match = match\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def raises(**kwargs):\n"
+        "    return RaisesExc(**kwargs)\n"
+    )
+    graph = DependencyArtifactGraph.authenticate(
+        _distribution(tmp_path, implementation, exported="raises")
+    )
+    consumer = "import arbitrary\narbitrary.raises(expected_exception=23)\n"
+    path = tmp_path / "consumer_kw.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode())
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path, path, consumer, source_cid
+    )
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    source_file = SourceFile((consumer, str(path), source_cid))
+    call = next(item for item in source_file.nodes() if isinstance(item, Call))
+    literal = next(item for item in call.keywords if item.arg == "expected_exception")
+    from sugar_lift_py_tests.ir import _term_content_cid
+
+    actual_value = TermValue(23)
+    testimony = ConstructedValueTestimonyV1.mint(
+        literal.value.fragment,
+        _term_content_cid(actual_value.to_term(owner="test")),
+    )
+    keyword_actual = ConstructedCallActualV1(literal.value, actual_value, testimony)
+
+    result = construct_manager_behavior(
+        resolved,
+        graph=graph,
+        actuals=(),
+        keyword_actuals=(("expected_exception", keyword_actual),),
+        call_site=call.fragment,
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert isinstance(result, ConstructedManagerBehaviorV1), (
+        f"expected ConstructedManagerBehaviorV1, got {type(result).__name__}"
+        f" kind={getattr(result, 'kind', None)} detail={detail!r}"
+    )
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected_exception"] is actual_value
+
+
+def test_raises_style_multi_arm_kwargs_is_not_exitset_force_floor(tmp_path):
+    """Multi-arm factory with **kwargs CM return must not residual as ExitSet-N.
+
+    Mirrors the pytest.raises validation raise + CM return shape:
+    ``if bad_kwargs: raise TypeError`` then ``return RaisesExc(x, **kwargs)``.
+    Halted raise arms do not block the Completed manager arm. Red when **kwargs
+    body is missing (force-floor:ExitSet with N arms / bodyless CallSiteValue);
+    green when typed variadic projection attaches the constructor body.
+    """
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None, match=None, check=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "        self.match = match\n"
+        "        self.check = check\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def raises(expected_exception=None, *args, **kwargs):\n"
+        "    if not args:\n"
+        "        if set(kwargs) - {'match', 'check', 'expected_exception'}:\n"
+        "            raise TypeError('unexpected')\n"
+        "        return RaisesExc(expected_exception, **kwargs)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "force-floor"
+        and "ExitSet" in detail
+    ), result
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "non-manager-result"
+        and result.detail == "CallSiteValue"
+    ), result
+    assert isinstance(result, ConstructedManagerBehaviorV1), (
+        f"expected ConstructedManagerBehaviorV1, got {type(result).__name__}"
+        f" kind={getattr(result, 'kind', None)} detail={detail!r}"
+    )
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected_exception"] is actual.value
+
+
+def test_raises_style_dual_kwargs_returns_not_exitset_force_floor(tmp_path):
+    """Dual complementary CM returns stay typed (not ExitSet force-floor).
+
+    ``if expected is None: return CM(**kwargs) else: return CM(expected, **kwargs)``
+    may residual as multi-manager when both faces construct distinct ObjectValues;
+    that is a typed non-manager-result, never force-floor:ExitSet-with-N-arms.
+    """
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None, match=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "        self.match = match\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def raises(expected_exception=None, *args, **kwargs):\n"
+        "    if not args:\n"
+        "        if expected_exception is None:\n"
+        "            return RaisesExc(**kwargs)\n"
+        "        return RaisesExc(expected_exception, **kwargs)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "force-floor"
+        and "ExitSet" in detail
+    ), result
+    # Either sole manager (if projection collapses) or multi-manager typed gap —
+    # never bodyless CallSiteValue / ExitSet force-floor.
+    if isinstance(result, ManagerConstructionGapV1):
+        assert result.kind == "non-manager-result", result
+        assert "manager receivers" in detail, result
+    else:
+        assert isinstance(result, ConstructedManagerBehaviorV1), result
+        fields = {field.name: field.value for field in result.receiver_state.fields}
+        assert fields["expected_exception"] is actual.value
+
+
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
     """Python builtin names are not free-name opaques at frame resolution.
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6824,11 +6824,18 @@ class Call(Expression):
                 # call-site branch below.
                 self.func.discharge_by_substitution()
             callee_name = self._spread_callee_name(self.func)
+            # Enroll an authenticated source-visible frame when the call is a
+            # local constructor/function use-site. Typed ``**`` actuals then
+            # project onto formals at desugar (SpreadCallSugar) so the manager
+            # factory return `CM(x, **kwargs)` carries a body — the law that
+            # bare CallSiteSugar already obeys for non-spread calls.
+            source_call_frame = self._spread_source_call_frame()
             return SpreadCallSugar(
                 callee_name=callee_name,
                 callee=(None if isinstance(self.func, Name) else self.func.sugar()),
                 arguments=arguments,
                 site=self.fragment,
+                source_call_frame=source_call_frame,
             )
 
         keyword_sugars = tuple(
@@ -7077,6 +7084,62 @@ class Call(Expression):
             keywords=keyword_sugars,
             source_call_frame=source_call_frame,
         )
+
+    def _spread_source_call_frame(self):
+        """Authenticated source frame for a ``*``/``**`` call, when enrolled.
+
+        Looks up the same ``source_call_frames`` table the non-spread Call path
+        uses, then binds non-spread positionals and named keywords onto the
+        frame. Double-star keywords are *not* node-bound here — their FloorValue
+        is projected at desugar via ``bind_actuals`` once the mapping is a
+        constructed DictValue. Star operands leave the frame unbound so
+        SpreadCallSugar stays bodyless (no typed vararg projection yet).
+        """
+        if any(isinstance(arg, Starred) for arg in self.args):
+            return None
+        context = self.unit.construction_context
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+        from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+        source_call_frame = None
+        if (
+            isinstance(context, TreeConstructionContextV1)
+            and context.source_call_frames
+        ):
+            span = self.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                self.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            source_call_frame = context.source_call_frames.get(coordinate)
+        if source_call_frame is None and isinstance(self.func, Name):
+            definition = self.unit.source_allocation_definition_for_call(self)
+            if (
+                definition is not None
+                and self.unit.source_class_has_authenticated_default_attribute_behavior(
+                    definition
+                )
+            ):
+                source_call_frame = definition.source_visible_constructor_frame()
+        if source_call_frame is None:
+            return None
+        try:
+            return source_call_frame.bind_node_actuals(
+                tuple(arg for arg in self.args if not isinstance(arg, Starred)),
+                tuple(
+                    (keyword.arg, keyword.value)
+                    for keyword in self.keywords
+                    if keyword.arg is not None
+                ),
+            )
+        except SourceCallBindingGap:
+            return None
 
     @staticmethod
     def _spread_callee_name(callee: Expression) -> Optional[str]:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4380,6 +4380,14 @@ class With(Statement):
         try:
             return context.contract_refs.require(coordinate)
         except ContractRefProtocolError as exc:
+            # Empty placeholder tables deliberately enroll no With demands
+            # (sole-path factory projection). Missing is not a bijection defect
+            # there — return None so callers stay RuntimeSelected/loud without
+            # BackendDefect. Non-empty enrolled tables still fail closed.
+            if getattr(
+                context.contract_refs, "is_unenrolled_placeholder", lambda: False
+            )():
+                return None
             backend_defect(
                 owner="With._construct_sugar",
                 observed=str(exc),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1891,7 +1891,7 @@ class FunctionDef(Statement):
             (
                 ()
                 if generator_steps is not None
-                else tuple(statement.sugar() for statement in substituted_body)
+                else self._source_visible_body_statement_sugars(substituted_body)
             ),
             self.fragment,
         )
@@ -1927,6 +1927,49 @@ class FunctionDef(Statement):
             ),
         )
 
+    def _source_visible_body_statement_sugars(self, substituted_body: tuple):
+        """Sugar body statements for sole-path frame projection.
+
+        Nested ``with`` that lacks CM enrollment (empty placeholder table used
+        for manager-factory projection) stays ``InertSugar`` rather than aborting
+        the whole frame. ``pytest.raises`` returns ``RaisesExc(...)`` on the CM
+        path without entering its nested ``with RaisesExc`` branch; that nested
+        arm must not prevent projecting the factory frame. Full consumer
+        enrollment still uses real CM tables and fails closed on missing rows.
+        """
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+        from sugar_source_tree.panic import (
+            ContextManagerResolutionConstructionGap,
+            RuntimeSelectedContextManager,
+            SugarNotWritten,
+            UnsupportedContextManagerSemantics,
+        )
+
+        context = self.unit.construction_context
+        unenrolled = bool(
+            context is not None
+            and getattr(
+                getattr(context, "contract_refs", None),
+                "is_unenrolled_placeholder",
+                lambda: False,
+            )()
+        )
+        soft_cm = (
+            RuntimeSelectedContextManager,
+            ContextManagerResolutionConstructionGap,
+            UnsupportedContextManagerSemantics,
+        )
+        sugars = []
+        for statement in substituted_body:
+            try:
+                sugars.append(statement.sugar())
+            except SugarNotWritten as snw:
+                if unenrolled and isinstance(snw, soft_cm):
+                    sugars.append(InertSugar(site=statement.fragment))
+                    continue
+                raise
+        return tuple(sugars)
+
     def _source_visible_body(self, scope):
         from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
             SourceVisibleFunctionBodySugar,
@@ -1936,7 +1979,7 @@ class FunctionDef(Statement):
         if self._source_visible_generator_steps_from(substituted_body) is not None:
             return SourceVisibleFunctionBodySugar((), self.fragment)
         return SourceVisibleFunctionBodySugar(
-            tuple(statement.sugar() for statement in substituted_body), self.fragment
+            self._source_visible_body_statement_sugars(substituted_body), self.fragment
         )
 
     def _source_visible_generator_steps(self, scope):

--- a/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
@@ -482,3 +482,50 @@ def test_formula_operand_carries_the_substituted_actual() -> None:
         .value.force_floor(None, owner="formula", project_callsite=False)
     )
     assert other.statements[0].formula.args[0] != other.statements[0].formula.args[1]
+
+
+# ---------------------------------------------------------------------------
+# 11. force_floor carries formal binds into if-branch suites.
+# ---------------------------------------------------------------------------
+
+
+def test_if_branch_formal_substitutes_under_force_floor_temporal() -> None:
+    """IfSugar must reduce branch suites under the curried force_floor ctx.
+
+    pytest.raises-shaped factories gate the CM return on ``if not args:``;
+    the then-branch reads formals via BindingCoordinateRef. Dropping ctx on
+    ``reduce_block_to_exitset(then_body)`` left those coordinates unbound and
+    panicked with ``unspecialized source-call formal`` even though
+    formal_coordinate_cids were curried onto the outer temporal.
+    """
+    context, functions, calls = _tree(
+        "def gated_formal(value, *args):\n"
+        "    if not args:\n"
+        "        return value\n"
+        "    return value\n\n"
+        "gated_formal(7)\n"
+    )
+    frame = _install(context, calls[-1], functions["gated_formal"])
+
+    constructed = (
+        calls[-1]
+        .sugar()
+        .desugar()
+        .value.force_floor(None, owner="if-branch-formal", project_callsite=False)
+    )
+
+    assert isinstance(constructed, BlockValue)
+    # If-union yields guarded faces, not a bare ReturnValue — but every face
+    # that returns the formal must carry the substituted actual.
+    rendered = repr(constructed)
+    assert "TermValue(value=7)" in rendered
+    assert "SugarNotWritten" not in rendered
+    assert len(frame.formal_coordinates) == 2
+
+    # Discrimination: the same body with the formal coordinate unbound stays
+    # loud — the if-branch still goes through BindingCoordinateRefSugar.desugar,
+    # never a name map.
+    refs = _coordinate_refs(frame.body)
+    assert refs
+    with pytest.raises(SugarNotWritten):
+        refs[0].desugar(_ReduceCtx(TemporalContext.empty()))

--- a/tools/lift_refusal_vocabulary_census.json
+++ b/tools/lift_refusal_vocabulary_census.json
@@ -2,7 +2,7 @@
   "identity": "path + normalized text digest + duplicate ordinal; line is display only",
   "issue": "#3632",
   "law": "REFUSE is the verifier verb; lift outputs are reduced meaning or typed effects.",
-  "lift_output_backlog": 1829,
+  "lift_output_backlog": 1861,
   "occurrences": [
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/discharge_cli.py:523c0ad6c899be9b:1",
@@ -136,7 +136,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:c6148629b10bd3d9:1",
-      "line": 415,
+      "line": 557,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -146,7 +146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:cbbc07efb9f468e8:1",
-      "line": 346,
+      "line": 488,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -156,7 +156,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:cfef8f3e3876c262:1",
-      "line": 56,
+      "line": 61,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -273,6 +273,166 @@
       "speaker": "verifier-verdict-quote",
       "text": "reproduced AND every per-test witness passed; else REFUSED with the breakdown",
       "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py:42f8e0fc20bd6e44:1",
+      "line": 8,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "2. **Desugar** \u2014 ``sugar.desugar(None)`` refusals and typed red effects,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py:5215ea32eaf5c2ef:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Yield/YieldFrom construct then refuse at desugar: construction-total, still",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:1cdfd99d904e041e:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``R_desugar`` typed refusals (``SugarNotWritten``) and typed red",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:5a22a8cc4df81f51:1",
+      "line": 330,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "a typed refusal is a measured frontier row, not a broken instrument.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:69c525740c848874:1",
+      "line": 286,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == \"refusal\":",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:6f37f5208a9cb3dd:1",
+      "line": 253,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "the true grain of a refusal (one refusal per reduction), and appears in",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:70ab45bc61822f20:1",
+      "line": 334,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _refusal_owner(gap: BaseException) -> str:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:8113597c30466169:1",
+      "line": 287,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "owner = _refusal_owner(outcome[1])",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:a397c6ec06cd75da:1",
+      "line": 268,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return (\"refusal\", gap)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:d609758c229d926f:1",
+      "line": 6,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "R_desugar typed semantic refusals/effects (door: ``sugar.desugar(None)``)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py:1d746ca8d1121748:1",
+      "line": 412,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# correctly refuses to snapshot and reports as a typed gap.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py:59d42b108722f281:1",
+      "line": 15,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``AttributeError`` \u2014 permanent-floor red. Refuse as a typed construction",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py:fa887014e60c7110:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Project a single completed floor value, or refuse loudly.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py:609201548e399168:1",
+      "line": 123,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse an untyped disposition wherever it first reaches the algebra.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:877c3635ffe0adde:1",
+      "line": 440,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "It REFUSES loudly when there is not exactly one completed arm, so a dropped",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py:7bd867ef70a95cc3:1",
+      "line": 108,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"binary, or set SUGAR_BINARY_ALLOW_BUILD=0 to refuse the build rung \"",
+      "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py:b3b3be6839a423c7:1",
@@ -943,6 +1103,36 @@
       "speaker": "lift-output-backlog",
       "text": "\"refusals\": result.refusals,",
       "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:ca51cbbecb4713d2:1",
+      "line": 8,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "`SUGAR_BUILD_STAMP` and the gate (`refuse_split_pipeline`) is",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:cebd12063ee89a10:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused every mint that registered the `python` surface through",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:d2e87fa4ecb18b14:1",
+      "line": 143,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "same identity kind or one of them refuses every mint (#6224).",
+      "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:0ea9d3db9fed818c:1",
@@ -2606,7 +2796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:0e6e7767d79ae499:1",
-      "line": 665,
+      "line": 709,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2615,8 +2805,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:10135b1b7db7b274:1",
+      "line": 1153,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// not refused\", and until this existed nothing enforced it: mutating the bin to",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:15ed905b58ee294e:1",
-      "line": 492,
+      "line": 527,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2626,7 +2826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:1e5014f8a66d4e85:1",
-      "line": 633,
+      "line": 668,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2635,8 +2835,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:25d194c309f118ff:1",
+      "line": 1196,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "assert_eq!((*asserts, *discharged, *refused), (74, 0, 74));",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:2d0397e0ac8797da:1",
-      "line": 635,
+      "line": 670,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2646,7 +2856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:34289ec726c4ebab:1",
-      "line": 520,
+      "line": 555,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2676,7 +2886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:3fc08e98569fcb6a:1",
-      "line": 884,
+      "line": 981,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2686,7 +2896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:4488c40316e8f0c4:1",
-      "line": 592,
+      "line": 627,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2696,12 +2906,22 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:4727b2c58ea32bbe:1",
-      "line": 580,
+      "line": 615,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "rows.push((rel, census.total, discharged, refused, raw_delta, true));",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:4c05e74409e0c953:1",
+      "line": 1154,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// `totals.refused += census_total` left every other test green. Drives a panicking",
       "wire_marker": "internal-only"
     },
     {
@@ -2716,7 +2936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:596cf5c36d96feb8:1",
-      "line": 906,
+      "line": 1003,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2726,7 +2946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:6267b737805e5131:1",
-      "line": 563,
+      "line": 598,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2736,7 +2956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:67124a457f945519:1",
-      "line": 501,
+      "line": 536,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2746,12 +2966,42 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:7b32f346c7018b7e:1",
-      "line": 498,
+      "line": 533,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "let (tag, disp) = match refusal_disposition(reason) {",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:7f493f4c2c134829:1",
+      "line": 483,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// that bucket and not `refused`), so its assertions stay accounted for and `silent`",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:81a1123d930f2ee0:1",
+      "line": 940,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// UNCLASSIFIED, not `refused`. `refused` is reserved for a terminal close with a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:84f0323fb83fd66a:1",
+      "line": 1194,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "let (rel, asserts, discharged, refused, raw_delta, parse_ok) = &rows[0];",
       "wire_marker": "internal-only"
     },
     {
@@ -2766,7 +3016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:8ae319df21bdb097:1",
-      "line": 684,
+      "line": 728,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2775,8 +3025,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:8d90138e066dbb4a:1",
+      "line": 1187,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// Every reason row is tagged unclassified, never refused.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:8e48b2a88e411912:1",
-      "line": 519,
+      "line": 554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2786,7 +3046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:9092732f70ff5121:1",
-      "line": 595,
+      "line": 630,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2796,7 +3056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:9d8d217b27bb74f9:1",
-      "line": 991,
+      "line": 1091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2806,7 +3066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:a07f101d94813b27:1",
-      "line": 634,
+      "line": 669,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2816,7 +3076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:a1513d5036b6473b:1",
-      "line": 680,
+      "line": 724,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2826,7 +3086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:a5ee1c41ef91e8dc:1",
-      "line": 568,
+      "line": 603,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2836,7 +3096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:ab44f50d2f69f05a:1",
-      "line": 494,
+      "line": 529,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2845,8 +3105,28 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:ae1bbf138834cebe:1",
+      "line": 1179,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "assert_eq!(totals.refused, 0, \"a panic is NOT an earned refusal\");",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:b35f82555778dddf:1",
+      "line": 1159,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fn panic_bins_unclassified_not_refused() {",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:b3f819833f6ca04c:1",
-      "line": 948,
+      "line": 1048,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2856,7 +3136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:b70f280c0385997b:1",
-      "line": 675,
+      "line": 719,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2866,7 +3146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:bda38328e9a49062:1",
-      "line": 1032,
+      "line": 1133,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2876,7 +3156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:c037b7d093238fbf:1",
-      "line": 518,
+      "line": 553,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2885,13 +3165,33 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:c33608c3e02bc53f:1",
+      "line": 1156,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// re-bin to `refused` -- or a dropped `panicked_files` increment, or a lost",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:d41c89cad7ee9114:1",
-      "line": 574,
+      "line": 609,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "refused = refused,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:d5c38abae5d83fb7:1",
+      "line": 948,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// writes: `panic_bins_unclassified_not_refused` below is the tooth on that choice.",
       "wire_marker": "internal-only"
     },
     {
@@ -2906,7 +3206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:dff873553bdff8eb:1",
-      "line": 491,
+      "line": 526,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2916,7 +3216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:e09273d9b8f897a1:1",
-      "line": 530,
+      "line": 565,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2926,7 +3226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:e0a517ea6f2dfa5c:1",
-      "line": 953,
+      "line": 1053,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2936,7 +3236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:e3698167b503a147:1",
-      "line": 1018,
+      "line": 1119,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2956,7 +3256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:eef7ed7139517bc9:1",
-      "line": 521,
+      "line": 556,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2976,7 +3276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f120d3ba6a7d7c2b:1",
-      "line": 484,
+      "line": 519,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2986,7 +3286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f23af5f81e2e0217:1",
-      "line": 426,
+      "line": 429,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2996,7 +3296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f23af5f81e2e0217:2",
-      "line": 586,
+      "line": 621,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3006,12 +3306,32 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f33aae3637b623d8:1",
-      "line": 559,
+      "line": 594,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "totals.refused += file_terminal - from_terminal;",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f521519d0e2add9c:1",
+      "line": 479,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// deliberate `-> !` loud refusal, but without a boundary here the FIRST such file",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f777e75f19099115:1",
+      "line": 944,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// \"work\", it keeps the gap loud in the gate rather than parked in an earned-refusal",
       "wire_marker": "internal-only"
     },
     {
@@ -5806,7 +6126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:00715bf7fa7e3989:1",
-      "line": 23484,
+      "line": 23579,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5816,7 +6136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:009b210a96e6f685:1",
-      "line": 9943,
+      "line": 10038,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5836,7 +6156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:023060f70eda31cc:1",
-      "line": 26820,
+      "line": 26915,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5846,7 +6166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0243b202c3ac7121:1",
-      "line": 14923,
+      "line": 15018,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5876,7 +6196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0408821238645fdf:1",
-      "line": 15374,
+      "line": 15469,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5886,7 +6206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:06807fc7bec5fc1d:1",
-      "line": 22571,
+      "line": 22666,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5906,7 +6226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:070a0b11e4fc45bf:1",
-      "line": 24705,
+      "line": 24800,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5916,7 +6236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:07516d6f7741ee2e:1",
-      "line": 24827,
+      "line": 24922,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5926,7 +6246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:075668c502065ada:1",
-      "line": 24793,
+      "line": 24888,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5936,7 +6256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:075f606d39c6e391:1",
-      "line": 27346,
+      "line": 27441,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5946,7 +6266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:08c968721dde4a8d:1",
-      "line": 25122,
+      "line": 25217,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5956,7 +6276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0944dc3d0836ed91:1",
-      "line": 9931,
+      "line": 10026,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5966,7 +6286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0b284fbf6398a4cb:1",
-      "line": 24497,
+      "line": 24592,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5986,7 +6306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0bb173a2cd4f6c05:1",
-      "line": 27047,
+      "line": 27142,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6006,7 +6326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0c3db6963f2b02a2:1",
-      "line": 24731,
+      "line": 24826,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6026,7 +6346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0c8194715a3902ac:1",
-      "line": 25351,
+      "line": 25446,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6036,7 +6356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0f14e7ba67ebe8a4:1",
-      "line": 27155,
+      "line": 27250,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6046,7 +6366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0f94a77703bdfc9d:1",
-      "line": 26911,
+      "line": 27006,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6056,7 +6376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:10059f735b52c5ca:1",
-      "line": 27253,
+      "line": 27348,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6066,7 +6386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:109f387df23564d9:1",
-      "line": 22179,
+      "line": 22274,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6076,7 +6396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:10ff8727e9c73e33:1",
-      "line": 9504,
+      "line": 9599,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6106,7 +6426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:114a50ae9fc4831d:3",
-      "line": 12118,
+      "line": 12213,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6116,7 +6436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:12cb2bb838810fff:1",
-      "line": 10010,
+      "line": 10105,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6126,7 +6446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:12d81d5998c8b0a8:1",
-      "line": 14490,
+      "line": 14585,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6136,7 +6456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:130208c002b27c83:1",
-      "line": 25084,
+      "line": 25179,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6146,7 +6466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:13e32e876e53f548:1",
-      "line": 14901,
+      "line": 14996,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6156,7 +6476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:14086dd043873bae:1",
-      "line": 24732,
+      "line": 24827,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6246,7 +6566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:148133b288f12758:9",
-      "line": 16158,
+      "line": 16253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6256,7 +6576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:156322853641dcae:1",
-      "line": 24378,
+      "line": 24473,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6266,7 +6586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1583fa2a98ff6759:1",
-      "line": 15511,
+      "line": 15606,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6276,7 +6596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:17c97ab850b80ead:1",
-      "line": 27014,
+      "line": 27109,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6306,7 +6626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:18f47275dc43c9a0:1",
-      "line": 24063,
+      "line": 24158,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6316,7 +6636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:18fe8d58cf2752cf:1",
-      "line": 26701,
+      "line": 26796,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6326,7 +6646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:190e4da1314fc567:1",
-      "line": 26676,
+      "line": 26771,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6336,7 +6656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1a0d750419a333e3:1",
-      "line": 23979,
+      "line": 24074,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6346,7 +6666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1a8a7091a2c86a79:1",
-      "line": 26725,
+      "line": 26820,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6356,7 +6676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1aa1e16daf7b4b70:1",
-      "line": 27198,
+      "line": 27293,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6366,7 +6686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1b68a15408b04149:1",
-      "line": 26775,
+      "line": 26870,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6376,7 +6696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:1",
-      "line": 27810,
+      "line": 27905,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6386,7 +6706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:2",
-      "line": 27840,
+      "line": 27935,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6396,7 +6716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:3",
-      "line": 27908,
+      "line": 28003,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6406,7 +6726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1c061bed085b0bc3:1",
-      "line": 25676,
+      "line": 25771,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6416,7 +6736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1c11f8f22666e7c9:1",
-      "line": 25295,
+      "line": 25390,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6436,7 +6756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1d17be5738840619:1",
-      "line": 25153,
+      "line": 25248,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6446,7 +6766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1d9987aa1f1248d2:1",
-      "line": 27741,
+      "line": 27836,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6466,7 +6786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1e8a46afdf44958a:1",
-      "line": 10025,
+      "line": 10120,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6476,7 +6796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1e96b011358871ff:1",
-      "line": 14494,
+      "line": 14589,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6486,7 +6806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1edf8dc268e9ef6f:1",
-      "line": 20061,
+      "line": 20156,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6506,7 +6826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1fcb8c859b947b3e:1",
-      "line": 14484,
+      "line": 14579,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6546,7 +6866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:229f5eb6a6ee000f:1",
-      "line": 13673,
+      "line": 13768,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6576,7 +6896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2332f6d3742487b4:1",
-      "line": 26993,
+      "line": 27088,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6596,7 +6916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:23dea12b8732b1ce:1",
-      "line": 15020,
+      "line": 15115,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6606,7 +6926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:23fdc12df7c53f0f:1",
-      "line": 26947,
+      "line": 27042,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6616,7 +6936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2452451a489656b2:1",
-      "line": 23807,
+      "line": 23902,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6626,7 +6946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:25113e9e5dd84a8f:1",
-      "line": 24351,
+      "line": 24446,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6646,7 +6966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:26157eec2f2537ed:1",
-      "line": 15456,
+      "line": 15551,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6656,7 +6976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:26671ad396f12d1f:1",
-      "line": 10005,
+      "line": 10100,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6676,7 +6996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:276e46ed5435d002:1",
-      "line": 27712,
+      "line": 27807,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6686,7 +7006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2795eae4db9bdfee:1",
-      "line": 25050,
+      "line": 25145,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6696,7 +7016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:27aae1bb3a469a7b:1",
-      "line": 16093,
+      "line": 16188,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6706,7 +7026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:27d899e62e46b94f:1",
-      "line": 13715,
+      "line": 13810,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6726,7 +7046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:28f305e462382e0b:1",
-      "line": 16235,
+      "line": 16330,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6736,7 +7056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2915f2980123103e:1",
-      "line": 25022,
+      "line": 25117,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6746,7 +7066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:29262d582b7085aa:1",
-      "line": 10035,
+      "line": 10130,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6756,7 +7076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:29720adbe087e0d0:1",
-      "line": 19605,
+      "line": 19700,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6766,7 +7086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2a279df48b093218:1",
-      "line": 12449,
+      "line": 12544,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6786,7 +7106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2accdc0895e9e669:1",
-      "line": 21119,
+      "line": 21214,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6796,7 +7116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2d6a2a5b71a0b663:1",
-      "line": 23966,
+      "line": 24061,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6806,7 +7126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2e0f48ba4665fd7a:1",
-      "line": 15381,
+      "line": 15476,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6826,7 +7146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2e5e4feee4134522:1",
-      "line": 24407,
+      "line": 24502,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6836,7 +7156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2eeb1ce255e7b055:1",
-      "line": 9867,
+      "line": 9962,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6846,7 +7166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2eeb1ce255e7b055:2",
-      "line": 9878,
+      "line": 9973,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6856,7 +7176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:300e3dcdf4321320:1",
-      "line": 15127,
+      "line": 15222,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6876,7 +7196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3097aa95e17d1856:1",
-      "line": 26702,
+      "line": 26797,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6886,7 +7206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:30c490c5f5efa1a6:1",
-      "line": 26854,
+      "line": 26949,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6896,7 +7216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:30d932bfce308c3c:1",
-      "line": 15560,
+      "line": 15655,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6906,7 +7226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:315589ac0f502555:1",
-      "line": 27103,
+      "line": 27198,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6916,7 +7236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:31a9bad3229c70ae:1",
-      "line": 9906,
+      "line": 10001,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6926,7 +7246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:32041de6dba814ab:1",
-      "line": 24745,
+      "line": 24840,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6936,7 +7256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3218b9254d430773:1",
-      "line": 9467,
+      "line": 9562,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6946,7 +7266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:33511fdb5627662f:1",
-      "line": 16661,
+      "line": 16756,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6956,7 +7276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:336bdaeb60c76102:1",
-      "line": 15009,
+      "line": 15104,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6966,7 +7286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:339202b9416e3a33:1",
-      "line": 27272,
+      "line": 27367,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6976,7 +7296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:33ed2707c4fcfbef:1",
-      "line": 26707,
+      "line": 26802,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6986,7 +7306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:341be91c6844f3bf:1",
-      "line": 24996,
+      "line": 25091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6996,7 +7316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:34befd82f6f8ff42:1",
-      "line": 26891,
+      "line": 26986,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7006,7 +7326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:35873b2180a27aef:1",
-      "line": 27205,
+      "line": 27300,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7016,7 +7336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:36bfc8a0cba2fca8:1",
-      "line": 14929,
+      "line": 15024,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7026,7 +7346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37c5c1d1c57a25eb:1",
-      "line": 27020,
+      "line": 27115,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7036,7 +7356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37d05f64a780c808:1",
-      "line": 10079,
+      "line": 10174,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7046,7 +7366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37d5afe263a0145e:1",
-      "line": 25071,
+      "line": 25166,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7066,7 +7386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3a43a7e8e2e64af4:1",
-      "line": 26919,
+      "line": 27014,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7076,7 +7396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3a7cd800a11bb31a:1",
-      "line": 13674,
+      "line": 13769,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7086,7 +7406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3b639938ea9f6390:1",
-      "line": 25327,
+      "line": 25422,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7096,7 +7416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3baa5fc5fd598c0d:1",
-      "line": 27270,
+      "line": 27365,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7106,7 +7426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3bd536a29fd37e9d:1",
-      "line": 26713,
+      "line": 26808,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7126,7 +7446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3d7550b8ed5da55a:1",
-      "line": 9927,
+      "line": 10022,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7136,7 +7456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3d7a888be1d4b31a:1",
-      "line": 27320,
+      "line": 27415,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7146,7 +7466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:1",
-      "line": 22228,
+      "line": 22323,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7156,7 +7476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:10",
-      "line": 23257,
+      "line": 23352,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7166,7 +7486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:11",
-      "line": 23544,
+      "line": 23639,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7176,7 +7496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:12",
-      "line": 24103,
+      "line": 24198,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7186,7 +7506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:13",
-      "line": 24126,
+      "line": 24221,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7196,7 +7516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:14",
-      "line": 27862,
+      "line": 27957,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7206,7 +7526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:15",
-      "line": 27881,
+      "line": 27976,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7216,7 +7536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:2",
-      "line": 22252,
+      "line": 22347,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7226,7 +7546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:3",
-      "line": 22294,
+      "line": 22389,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7236,7 +7556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:4",
-      "line": 22340,
+      "line": 22435,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7246,7 +7566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:5",
-      "line": 22448,
+      "line": 22543,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7256,7 +7576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:6",
-      "line": 22479,
+      "line": 22574,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7266,7 +7586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:7",
-      "line": 22540,
+      "line": 22635,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7276,7 +7596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:8",
-      "line": 23116,
+      "line": 23211,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7286,7 +7606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:9",
-      "line": 23136,
+      "line": 23231,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7296,7 +7616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3e66b2e73573210b:1",
-      "line": 24222,
+      "line": 24317,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7306,7 +7626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3f69a0c862654acb:1",
-      "line": 26994,
+      "line": 27089,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7316,7 +7636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3f71f3945e9db1a6:1",
-      "line": 13772,
+      "line": 13867,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7326,7 +7646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:41518803e7f1d22e:1",
-      "line": 26890,
+      "line": 26985,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7346,7 +7666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:423b67cd8e5f252f:1",
-      "line": 27360,
+      "line": 27455,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7356,7 +7676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4245262ff3bf67d2:1",
-      "line": 14748,
+      "line": 14843,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7366,7 +7686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:43e8d108b534f26f:1",
-      "line": 27756,
+      "line": 27851,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7396,7 +7716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:48138862d4682b0b:1",
-      "line": 26630,
+      "line": 26725,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7406,7 +7726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:48138862d4682b0b:2",
-      "line": 26665,
+      "line": 26760,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7426,7 +7746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:494ad70f963ee256:1",
-      "line": 16863,
+      "line": 16958,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7436,7 +7756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:49fbd77a370e6dd9:1",
-      "line": 16092,
+      "line": 16187,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7446,7 +7766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4b658e293164e5eb:1",
-      "line": 27140,
+      "line": 27235,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7456,7 +7776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4b6d488a0d07ccd2:1",
-      "line": 26698,
+      "line": 26793,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7466,7 +7786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c2b7d3cd8239e6e:1",
-      "line": 27251,
+      "line": 27346,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7476,7 +7796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c2f0d3a662a83c4:1",
-      "line": 22569,
+      "line": 22664,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7496,7 +7816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c86baf8f2cc1858:1",
-      "line": 9136,
+      "line": 9231,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7506,7 +7826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4d450f07337ab83c:1",
-      "line": 9514,
+      "line": 9609,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7516,7 +7836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4d9902f5f2ca8675:1",
-      "line": 13765,
+      "line": 13860,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7536,7 +7856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4e44b1b36a47f88c:1",
-      "line": 9422,
+      "line": 9517,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7546,7 +7866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4e5e2357e6d17aa0:1",
-      "line": 24653,
+      "line": 24748,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7566,7 +7886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4fafd457a1ae333a:1",
-      "line": 26721,
+      "line": 26816,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7576,7 +7896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:50c66875e428a050:1",
-      "line": 14417,
+      "line": 14512,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7586,7 +7906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:50c8b6beced860fa:1",
-      "line": 15118,
+      "line": 15213,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7596,7 +7916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:50d7efe1d4d19d7b:1",
-      "line": 9939,
+      "line": 10034,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7606,7 +7926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:51143f47a6e30603:1",
-      "line": 25826,
+      "line": 25921,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7626,7 +7946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:51865434a32ef559:1",
-      "line": 26950,
+      "line": 27045,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7636,7 +7956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:52b76da630c76b62:1",
-      "line": 25922,
+      "line": 26017,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7646,7 +7966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:530e2bd18bc1ba59:1",
-      "line": 12387,
+      "line": 12482,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7676,7 +7996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:55528ea495a0a42e:1",
-      "line": 15453,
+      "line": 15548,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7686,7 +8006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5593923e99a5626c:1",
-      "line": 15018,
+      "line": 15113,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7696,7 +8016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:56b258284f9642c8:1",
-      "line": 26969,
+      "line": 27064,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7706,7 +8026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5784899e947af79a:1",
-      "line": 10045,
+      "line": 10140,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7716,7 +8036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5786e71f09223cfb:1",
-      "line": 27727,
+      "line": 27822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7746,7 +8066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:595b49ffbabd5f5b:1",
-      "line": 24772,
+      "line": 24867,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7756,7 +8076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:59b2fd0dd93011a1:1",
-      "line": 14501,
+      "line": 14596,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7766,7 +8086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5ac33c6e679925b5:1",
-      "line": 27695,
+      "line": 27790,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7786,7 +8106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5bb403bc2c0c8a31:1",
-      "line": 27219,
+      "line": 27314,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7796,7 +8116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5bbc6267b10afbef:1",
-      "line": 15481,
+      "line": 15576,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7806,7 +8126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c071c74b3d12777:1",
-      "line": 26968,
+      "line": 27063,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7816,7 +8136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c37cd89ba3adb0a:1",
-      "line": 20238,
+      "line": 20333,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7826,7 +8146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c8c3bad631bad37:1",
-      "line": 24561,
+      "line": 24656,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7836,7 +8156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5d2809e5887813e4:1",
-      "line": 24248,
+      "line": 24343,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7846,7 +8166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5e6c117baaf5a883:1",
-      "line": 16270,
+      "line": 16365,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7856,7 +8176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5fdbd97bf81884d8:1",
-      "line": 27146,
+      "line": 27241,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7866,7 +8186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5ff2294d94dcee1b:1",
-      "line": 16896,
+      "line": 16991,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7876,7 +8196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6050aaede36b36a7:1",
-      "line": 26653,
+      "line": 26748,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7906,7 +8226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:60874978b39adfa4:1",
-      "line": 26697,
+      "line": 26792,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7916,7 +8236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6108db8d16968ac4:1",
-      "line": 14921,
+      "line": 15016,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7926,7 +8246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:62a5e622da1fc377:1",
-      "line": 14927,
+      "line": 15022,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7936,7 +8256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:62c1f77e7b6fa531:1",
-      "line": 26731,
+      "line": 26826,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7956,7 +8276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:64bf9c42441d6213:1",
-      "line": 26153,
+      "line": 26248,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7966,7 +8286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:64d68d8f77c17f16:1",
-      "line": 26687,
+      "line": 26782,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8016,7 +8336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:66f63c7bf670fe27:1",
-      "line": 13771,
+      "line": 13866,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8036,7 +8356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:68b6245dc4813486:1",
-      "line": 27711,
+      "line": 27806,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8046,7 +8366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:692c34495b7680cf:1",
-      "line": 26814,
+      "line": 26909,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8056,7 +8376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69bbb7e52ab40221:1",
-      "line": 27129,
+      "line": 27224,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8066,7 +8386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69d451ac8d3bd3ce:1",
-      "line": 26962,
+      "line": 27057,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8076,7 +8396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69ef7af4b214d979:1",
-      "line": 25031,
+      "line": 25126,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8086,7 +8406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6a4f2b5e8293a9ac:1",
-      "line": 12391,
+      "line": 12486,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8096,7 +8416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6aa1c64145292566:1",
-      "line": 12673,
+      "line": 12768,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8106,7 +8426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6ab7ac467c7e46ad:1",
-      "line": 12744,
+      "line": 12839,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8116,7 +8436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6ae57f6321934965:1",
-      "line": 25794,
+      "line": 25889,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8136,7 +8456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6b30f3244beec783:1",
-      "line": 10040,
+      "line": 10135,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8146,7 +8466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6c0e1870b237472c:1",
-      "line": 9848,
+      "line": 9943,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8156,7 +8476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6d3dda9843aa0037:1",
-      "line": 27262,
+      "line": 27357,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8166,7 +8486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e14b3f148ea0ff4:1",
-      "line": 21142,
+      "line": 21237,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8176,7 +8496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e1b17cf2a6f1d41:1",
-      "line": 10067,
+      "line": 10162,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8186,7 +8506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e4a242955a2ec48:1",
-      "line": 23936,
+      "line": 24031,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8196,7 +8516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e9f58a481b3aad7:1",
-      "line": 22855,
+      "line": 22950,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8246,7 +8566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7101146e77025034:1",
-      "line": 14086,
+      "line": 14181,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8256,7 +8576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7101146e77025034:2",
-      "line": 14123,
+      "line": 14218,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8266,7 +8586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7101146e77025034:3",
-      "line": 14138,
+      "line": 14233,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8276,7 +8596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:718f849bcfcc5b0b:1",
-      "line": 26686,
+      "line": 26781,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8286,7 +8606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:71e01a0793ac86a0:1",
-      "line": 20202,
+      "line": 20297,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8306,7 +8626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:72321878ae60ef1e:1",
-      "line": 26922,
+      "line": 27017,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8316,7 +8636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:734f917a2131bff9:1",
-      "line": 26679,
+      "line": 26774,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8326,7 +8646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7382d9771bbe6149:1",
-      "line": 9701,
+      "line": 9796,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8336,7 +8656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:73de9c395f8f1def:1",
-      "line": 9418,
+      "line": 9513,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8376,7 +8696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:74e9e89d412f4189:1",
-      "line": 19613,
+      "line": 19708,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8396,7 +8716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:75a673ba752dd41b:1",
-      "line": 26728,
+      "line": 26823,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8406,7 +8726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76244b46d5d2da2d:1",
-      "line": 26718,
+      "line": 26813,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8416,7 +8736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76590ed1a25eaa1e:1",
-      "line": 24792,
+      "line": 24887,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8426,7 +8746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76ba135bffb8aaa0:1",
-      "line": 25102,
+      "line": 25197,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8446,7 +8766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76e04beecc499d64:1",
-      "line": 12394,
+      "line": 12489,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8456,7 +8776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:77063501e138f18f:1",
-      "line": 26624,
+      "line": 26719,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8466,7 +8786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:771613ec00c7e29f:1",
-      "line": 27770,
+      "line": 27865,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8476,7 +8796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7795c8d34be5e47a:1",
-      "line": 14162,
+      "line": 14257,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8496,7 +8816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:78d181893f275a7e:1",
-      "line": 16248,
+      "line": 16343,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8506,7 +8826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:79051ad91ba65913:1",
-      "line": 27209,
+      "line": 27304,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8516,7 +8836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:796a87e2dd8a70eb:1",
-      "line": 26724,
+      "line": 26819,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8526,7 +8846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:79aa37575ef65eda:1",
-      "line": 25098,
+      "line": 25193,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8536,7 +8856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7a34e56f3d9c1a08:1",
-      "line": 16773,
+      "line": 16868,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8556,7 +8876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7afd408d37c4181c:1",
-      "line": 14937,
+      "line": 15032,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8566,7 +8886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7affee5384f21d56:1",
-      "line": 27440,
+      "line": 27535,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8576,7 +8896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7b9666433fea6d5e:1",
-      "line": 9796,
+      "line": 9891,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8586,7 +8906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7bbbdf7ffc6e3df1:1",
-      "line": 16151,
+      "line": 16246,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8596,7 +8916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7c2861be8050c186:1",
-      "line": 27058,
+      "line": 27153,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8606,7 +8926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7d6a685822818dc1:1",
-      "line": 10151,
+      "line": 10246,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8616,7 +8936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da128e0c706afdb:1",
-      "line": 23354,
+      "line": 23449,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8626,7 +8946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da1b5483d9ad6cd:1",
-      "line": 26949,
+      "line": 27044,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8636,7 +8956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da1be41e1be5115:1",
-      "line": 9535,
+      "line": 9630,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8646,7 +8966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ec29d9f2347eac0:1",
-      "line": 26717,
+      "line": 26812,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8656,7 +8976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ee57b5220e24f1f:1",
-      "line": 14905,
+      "line": 15000,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8666,7 +8986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ef540bfb40d7f65:1",
-      "line": 9992,
+      "line": 10087,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8676,7 +8996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7f000eb0d9eb951d:1",
-      "line": 26614,
+      "line": 26709,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8686,7 +9006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:808bb577e2c06361:1",
-      "line": 25889,
+      "line": 25984,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8696,7 +9016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:80bfb22d8be17a6b:1",
-      "line": 9465,
+      "line": 9560,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8706,7 +9026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:80eb2ee38045f801:1",
-      "line": 25034,
+      "line": 25129,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8716,7 +9036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:814324470fc67927:1",
-      "line": 25114,
+      "line": 25209,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8726,7 +9046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:81a05b756660c1ec:1",
-      "line": 12718,
+      "line": 12813,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8736,7 +9056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:824bb54ba7f20820:1",
-      "line": 23332,
+      "line": 23427,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8746,7 +9066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:827db9276c4fa36d:1",
-      "line": 25817,
+      "line": 25912,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8756,7 +9076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:82b934014b764d2c:1",
-      "line": 27715,
+      "line": 27810,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8776,7 +9096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8618e8ed78018717:1",
-      "line": 9593,
+      "line": 9688,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8796,7 +9116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:87b15a84cf481f08:1",
-      "line": 24071,
+      "line": 24166,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8806,7 +9126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:87b93b672f12efed:1",
-      "line": 9922,
+      "line": 10017,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8816,7 +9136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:88dbbb39ee6cfa4c:1",
-      "line": 24694,
+      "line": 24789,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8826,7 +9146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89f42a609aad0b01:1",
-      "line": 12165,
+      "line": 12260,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8836,7 +9156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89f42a609aad0b01:2",
-      "line": 15649,
+      "line": 15744,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8846,7 +9166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89fe33412c371ae2:1",
-      "line": 26693,
+      "line": 26788,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8856,7 +9176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8a4a1e611861b01a:1",
-      "line": 26991,
+      "line": 27086,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8876,7 +9196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8a94c581743692f6:1",
-      "line": 9858,
+      "line": 9953,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8886,7 +9206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8ac1f27d38bb7b6d:1",
-      "line": 26801,
+      "line": 26896,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8896,7 +9216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8aedda2567afd47f:1",
-      "line": 16075,
+      "line": 16170,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8906,7 +9226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8b4450487510c885:1",
-      "line": 14749,
+      "line": 14844,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8926,7 +9246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8bf3948ed0a1931b:1",
-      "line": 15573,
+      "line": 15668,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8936,7 +9256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8c552c3fc192982d:1",
-      "line": 26861,
+      "line": 26956,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8946,7 +9266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8d0ec2b606455df3:1",
-      "line": 14477,
+      "line": 14572,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8956,7 +9276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8d256950ad9c8e3d:1",
-      "line": 23996,
+      "line": 24091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8966,7 +9286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8e1c1d49a4219a05:1",
-      "line": 12634,
+      "line": 12729,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8976,7 +9296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8e7aa9e00f882c2a:1",
-      "line": 26690,
+      "line": 26785,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8996,7 +9316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:902a433fcc62e775:1",
-      "line": 25299,
+      "line": 25394,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9006,7 +9326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:90aa18ca0541c39c:1",
-      "line": 13781,
+      "line": 13876,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9016,7 +9336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9149918b0ec95097:1",
-      "line": 9459,
+      "line": 9554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9036,7 +9356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9165073a5b34ce84:1",
-      "line": 15114,
+      "line": 15209,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9046,7 +9366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:91eaeaf1e399fcb3:1",
-      "line": 9566,
+      "line": 9661,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9056,7 +9376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:92db2724cf6c2174:1",
-      "line": 26712,
+      "line": 26807,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9076,7 +9396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:95621cdbb876cbc3:1",
-      "line": 16247,
+      "line": 16342,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9096,7 +9416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:968ebe030bdae100:1",
-      "line": 27059,
+      "line": 27154,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9106,7 +9426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:97364d430e50993e:1",
-      "line": 26809,
+      "line": 26904,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9116,7 +9436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9771949fc25f45ed:1",
-      "line": 14304,
+      "line": 14399,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9126,7 +9446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9773362e51c00aef:1",
-      "line": 10015,
+      "line": 10110,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9136,7 +9456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:983018b867872b1e:1",
-      "line": 9406,
+      "line": 9501,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9146,7 +9466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:989774411313426b:1",
-      "line": 27178,
+      "line": 27273,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9156,7 +9476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:99cac8ab20136aa1:1",
-      "line": 26927,
+      "line": 27022,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9186,7 +9506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e35a2d5547fe631:1",
-      "line": 26631,
+      "line": 26726,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9196,7 +9516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e5cc7b488c41b38:1",
-      "line": 26699,
+      "line": 26794,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9206,7 +9526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e89d1b9214ea2dc:1",
-      "line": 24886,
+      "line": 24981,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9216,7 +9536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:1",
-      "line": 24901,
+      "line": 24996,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9226,7 +9546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:2",
-      "line": 25057,
+      "line": 25152,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9236,7 +9556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:3",
-      "line": 25091,
+      "line": 25186,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9246,7 +9566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:4",
-      "line": 25121,
+      "line": 25216,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9256,7 +9576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:5",
-      "line": 25179,
+      "line": 25274,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9266,7 +9586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9fdb64007f581e7e:1",
-      "line": 9442,
+      "line": 9537,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9276,7 +9596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9fdb64007f581e7e:2",
-      "line": 9446,
+      "line": 9541,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9286,7 +9606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a008154800585d78:1",
-      "line": 24991,
+      "line": 25086,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9296,7 +9616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a0aa75f1f0042780:1",
-      "line": 14206,
+      "line": 14301,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9306,7 +9626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a18121c1ee06d132:1",
-      "line": 16150,
+      "line": 16245,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9316,7 +9636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a199c8fed871df78:1",
-      "line": 24831,
+      "line": 24926,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9326,7 +9646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a24878847e5ad418:1",
-      "line": 26985,
+      "line": 27080,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9336,7 +9656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a26afc8ffa8e1e13:1",
-      "line": 15669,
+      "line": 15764,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9346,7 +9666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a3625ce422a61fc2:1",
-      "line": 20233,
+      "line": 20328,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9356,7 +9676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a3ba8f2625938e9d:1",
-      "line": 26723,
+      "line": 26818,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9366,7 +9686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a45c19301663092e:1",
-      "line": 26817,
+      "line": 26912,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9376,7 +9696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a4926de6bb4655ef:1",
-      "line": 24789,
+      "line": 24884,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9396,7 +9716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a574c90d67c2df18:1",
-      "line": 27176,
+      "line": 27271,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9406,7 +9726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a5fa040820524297:1",
-      "line": 27375,
+      "line": 27470,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9416,7 +9736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a5fa040820524297:2",
-      "line": 27402,
+      "line": 27497,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9426,7 +9746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a7043c11ccbadf20:1",
-      "line": 26763,
+      "line": 26858,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9446,7 +9766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a72b68ffa9703bf4:1",
-      "line": 26941,
+      "line": 27036,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9456,7 +9776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a77708b7fb2f8abd:1",
-      "line": 16775,
+      "line": 16870,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9466,7 +9786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a80b0bdd416a2bed:1",
-      "line": 14271,
+      "line": 14366,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9476,7 +9796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a80b0bdd416a2bed:2",
-      "line": 14306,
+      "line": 14401,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9486,7 +9806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8bdb05f2e22e7d3:1",
-      "line": 27109,
+      "line": 27204,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9496,7 +9816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:1",
-      "line": 22197,
+      "line": 22292,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9506,7 +9826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:10",
-      "line": 24221,
+      "line": 24316,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9516,7 +9836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:11",
-      "line": 24247,
+      "line": 24342,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9526,7 +9846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:12",
-      "line": 24290,
+      "line": 24385,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9536,7 +9856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:13",
-      "line": 24318,
+      "line": 24413,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9546,7 +9866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:14",
-      "line": 24350,
+      "line": 24445,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9556,7 +9876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:15",
-      "line": 24377,
+      "line": 24472,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9566,7 +9886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:16",
-      "line": 24406,
+      "line": 24501,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9576,7 +9896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:17",
-      "line": 24439,
+      "line": 24534,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9586,7 +9906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:18",
-      "line": 24496,
+      "line": 24591,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9596,7 +9916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:19",
-      "line": 24531,
+      "line": 24626,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9606,7 +9926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:2",
-      "line": 22366,
+      "line": 22461,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9616,7 +9936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:20",
-      "line": 24560,
+      "line": 24655,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9626,7 +9946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:21",
-      "line": 24594,
+      "line": 24689,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9636,7 +9956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:22",
-      "line": 24625,
+      "line": 24720,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9646,7 +9966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:23",
-      "line": 24652,
+      "line": 24747,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9656,7 +9976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:24",
-      "line": 24693,
+      "line": 24788,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9666,7 +9986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:25",
-      "line": 25668,
+      "line": 25763,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9676,7 +9996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:3",
-      "line": 23074,
+      "line": 23169,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9686,7 +10006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:4",
-      "line": 23195,
+      "line": 23290,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9696,7 +10016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:5",
-      "line": 23458,
+      "line": 23553,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9706,7 +10026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:6",
-      "line": 23483,
+      "line": 23578,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9716,16 +10036,6 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:7",
-      "line": 24062,
-      "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "out.assertions_refused, 0,",
-      "wire_marker": "internal-only"
-    },
-    {
-      "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:8",
       "line": 24157,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
@@ -9735,8 +10045,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:8",
+      "line": 24252,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "out.assertions_refused, 0,",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:9",
-      "line": 24191,
+      "line": 24286,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9746,7 +10066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8eee510e8998ded:1",
-      "line": 25190,
+      "line": 25285,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9756,7 +10076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:1",
-      "line": 24924,
+      "line": 25019,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9766,7 +10086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:2",
-      "line": 24946,
+      "line": 25041,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9776,7 +10096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:3",
-      "line": 24973,
+      "line": 25068,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9786,7 +10106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:4",
-      "line": 25320,
+      "line": 25415,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9796,7 +10116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:5",
-      "line": 25350,
+      "line": 25445,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9816,7 +10136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ab15be3fba5b0cd1:1",
-      "line": 27269,
+      "line": 27364,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9826,7 +10146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ab4caa51fd17b486:1",
-      "line": 23459,
+      "line": 23554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9846,7 +10166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:abdb97e5669a0975:1",
-      "line": 27110,
+      "line": 27205,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9866,7 +10186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ac2f7fea72874fbd:1",
-      "line": 22586,
+      "line": 22681,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9876,7 +10196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ac2f7fea72874fbd:2",
-      "line": 25928,
+      "line": 26023,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9886,7 +10206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:acca0029979f4c13:1",
-      "line": 26812,
+      "line": 26907,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9896,7 +10216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:acedb1ced3aa61ea:1",
-      "line": 26926,
+      "line": 27021,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9916,7 +10236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ae5916805876ac46:1",
-      "line": 23284,
+      "line": 23379,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9926,7 +10246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ae9b7dcf35f4400c:1",
-      "line": 15025,
+      "line": 15120,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9956,7 +10276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af33bb19bb4db860:1",
-      "line": 15583,
+      "line": 15678,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9966,7 +10286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af33bb19bb4db860:2",
-      "line": 15612,
+      "line": 15707,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9976,7 +10296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af910e58b2c77763:1",
-      "line": 23885,
+      "line": 23980,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9986,7 +10306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b04d3d556d773056:1",
-      "line": 27190,
+      "line": 27285,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10006,7 +10326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b1a3368b53032685:1",
-      "line": 15008,
+      "line": 15103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10026,7 +10346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b2aed37dd3d7ea1c:1",
-      "line": 13467,
+      "line": 13562,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10036,7 +10356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b2c731d3da6cd11a:1",
-      "line": 27167,
+      "line": 27262,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10046,7 +10366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3241001126a4a9c:1",
-      "line": 26791,
+      "line": 26886,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10056,7 +10376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3241001126a4a9c:2",
-      "line": 26803,
+      "line": 26898,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10076,7 +10396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3679e8328331e44:1",
-      "line": 14509,
+      "line": 14604,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10086,7 +10406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b432b2e07a83ac87:1",
-      "line": 26183,
+      "line": 26278,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10096,7 +10416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b48b5f3296d119e9:1",
-      "line": 26920,
+      "line": 27015,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10106,7 +10426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b4d76eca871110e7:1",
-      "line": 26691,
+      "line": 26786,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10116,7 +10436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b6318aa7064d9310:1",
-      "line": 24814,
+      "line": 24909,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10136,7 +10456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b6707be7cace8e0e:1",
-      "line": 24866,
+      "line": 24961,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10146,7 +10466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b7cdb99af122f74b:1",
-      "line": 9839,
+      "line": 9934,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10156,7 +10476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b7df38df0606e289:1",
-      "line": 24626,
+      "line": 24721,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10186,7 +10506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b9722e932f1bb40e:1",
-      "line": 27182,
+      "line": 27277,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10196,7 +10516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ba7cf5bcf797d9c2:1",
-      "line": 24087,
+      "line": 24182,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10206,7 +10526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:baae9532c042bae0:1",
-      "line": 14201,
+      "line": 14296,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10226,7 +10546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb523aa660dd4687:1",
-      "line": 21140,
+      "line": 21235,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10236,7 +10556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb7ee0ec6dafecb8:1",
-      "line": 15409,
+      "line": 15504,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10246,7 +10566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb970cf4b07065b1:1",
-      "line": 27665,
+      "line": 27760,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10256,7 +10576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bbb47521ef8392a4:1",
-      "line": 25058,
+      "line": 25153,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10266,7 +10586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bd1e1781efdc54fc:1",
-      "line": 16866,
+      "line": 16961,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10276,7 +10596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdc221e9e9c42970:1",
-      "line": 24158,
+      "line": 24253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10286,7 +10606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:1",
-      "line": 25531,
+      "line": 25626,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10296,7 +10616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:2",
-      "line": 25567,
+      "line": 25662,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10306,7 +10626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:3",
-      "line": 25597,
+      "line": 25692,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10316,7 +10636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:be3064dcdc5f2256:1",
-      "line": 22351,
+      "line": 22446,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10326,7 +10646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:be81b848229b5bcd:1",
-      "line": 22198,
+      "line": 22293,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10336,7 +10656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bf1d5efac45b5151:1",
-      "line": 16271,
+      "line": 16366,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10346,7 +10666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bf6f2bba1b4ea47a:1",
-      "line": 10020,
+      "line": 10115,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10376,7 +10696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c0ddc1067d953282:1",
-      "line": 24291,
+      "line": 24386,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10386,7 +10706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c14bd6eb8d20b885:1",
-      "line": 26225,
+      "line": 26320,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10396,7 +10716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c1658665cec9080a:1",
-      "line": 9997,
+      "line": 10092,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10416,7 +10736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c19c266d8e382c09:1",
-      "line": 27215,
+      "line": 27310,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10426,7 +10746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c22e71ad17e3c96c:1",
-      "line": 26625,
+      "line": 26720,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10436,7 +10756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c22e71ad17e3c96c:2",
-      "line": 26660,
+      "line": 26755,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10466,7 +10786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c35e93ca292f8cac:1",
-      "line": 24832,
+      "line": 24927,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10476,7 +10796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c40c949bdd02551f:1",
-      "line": 9871,
+      "line": 9966,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10486,7 +10806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c41f5442c55fb1dc:1",
-      "line": 12871,
+      "line": 12966,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10506,7 +10826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c551fd66ec491b8a:1",
-      "line": 25669,
+      "line": 25764,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10516,7 +10836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c57780e0a425da8d:1",
-      "line": 9960,
+      "line": 10055,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10526,7 +10846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c581c3d5741e30d2:1",
-      "line": 26794,
+      "line": 26889,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10536,7 +10856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c60d0486ef331dcc:1",
-      "line": 26719,
+      "line": 26814,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10546,7 +10866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c62475395c522d57:1",
-      "line": 25147,
+      "line": 25242,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10556,7 +10876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c62e50c844427b8e:1",
-      "line": 14474,
+      "line": 14569,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10566,7 +10886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c6dbc07c6134602c:1",
-      "line": 9902,
+      "line": 9997,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10576,7 +10896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:1",
-      "line": 25816,
+      "line": 25911,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10586,7 +10906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:2",
-      "line": 25849,
+      "line": 25944,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10596,7 +10916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:3",
-      "line": 26883,
+      "line": 26978,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10606,7 +10926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:4",
-      "line": 26910,
+      "line": 27005,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10616,7 +10936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:5",
-      "line": 26940,
+      "line": 27035,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10626,7 +10946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:6",
-      "line": 26984,
+      "line": 27079,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10636,7 +10956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:7",
-      "line": 27128,
+      "line": 27223,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10646,7 +10966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c76a8c403a9eb7c3:1",
-      "line": 10030,
+      "line": 10125,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10656,7 +10976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c79d8ec5ac079056:1",
-      "line": 9909,
+      "line": 10004,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10666,7 +10986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c7f7b2c61be81a89:1",
-      "line": 25180,
+      "line": 25275,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10686,7 +11006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c9a45d1d9f764cac:1",
-      "line": 25158,
+      "line": 25253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10696,7 +11016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cb1de15e6476961e:1",
-      "line": 18779,
+      "line": 18874,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10716,7 +11036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cba87040da6b3001:1",
-      "line": 10050,
+      "line": 10145,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10726,7 +11046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cc7438ce557ac1d0:1",
-      "line": 9970,
+      "line": 10065,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10746,7 +11066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cd8b15702b31828c:1",
-      "line": 15015,
+      "line": 15110,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10766,7 +11086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce5a9317fb3af979:1",
-      "line": 26155,
+      "line": 26250,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10776,7 +11096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce5a9317fb3af979:2",
-      "line": 26227,
+      "line": 26322,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10786,7 +11106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce66dc6d2bf8d0d8:1",
-      "line": 15116,
+      "line": 15211,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10796,7 +11116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cf0dd1a35f3c7e34:1",
-      "line": 26709,
+      "line": 26804,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10806,7 +11126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cf80a65c884dd0be:1",
-      "line": 24907,
+      "line": 25002,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10816,7 +11136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cfc622b3360c4d77:1",
-      "line": 9918,
+      "line": 10013,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10826,7 +11146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cfd2a0b6fb9eac51:1",
-      "line": 16265,
+      "line": 16360,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10836,7 +11156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d0c9ed7c3d2f9c83:1",
-      "line": 13669,
+      "line": 13764,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10846,7 +11166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d12154361fe4d869:1",
-      "line": 27237,
+      "line": 27332,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10856,7 +11176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d1512d6c97bf21bb:1",
-      "line": 24440,
+      "line": 24535,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10866,7 +11186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d18ee531c39bd973:1",
-      "line": 26714,
+      "line": 26809,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10876,7 +11196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d1ae247d480dcbb9:1",
-      "line": 27674,
+      "line": 27769,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10886,7 +11206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d23ddb9678b7afbd:1",
-      "line": 26756,
+      "line": 26851,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10896,7 +11216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d2cd31b21ade7118:1",
-      "line": 10181,
+      "line": 10276,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10906,7 +11226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d2d96a21a9d15a4e:1",
-      "line": 10055,
+      "line": 10150,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10916,7 +11236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d3d0a2aacce4d236:1",
-      "line": 21141,
+      "line": 21236,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10926,7 +11246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d44c3760689488cf:1",
-      "line": 15506,
+      "line": 15601,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10946,7 +11266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d48f463b7016a35f:1",
-      "line": 16662,
+      "line": 16757,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10956,7 +11276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d555a0f78ebe7ceb:1",
-      "line": 16666,
+      "line": 16761,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10966,7 +11286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d56ac28822c7f087:1",
-      "line": 13433,
+      "line": 13528,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10976,7 +11296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d5eab4193775162e:1",
-      "line": 27091,
+      "line": 27186,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10986,7 +11306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d61a627265a5186e:1",
-      "line": 14896,
+      "line": 14991,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10996,7 +11316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d68a720cb1022b84:1",
-      "line": 9524,
+      "line": 9619,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11006,7 +11326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:1",
-      "line": 24779,
+      "line": 24874,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11016,7 +11336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:2",
-      "line": 26740,
+      "line": 26835,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11026,7 +11346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:3",
-      "line": 27350,
+      "line": 27445,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11036,7 +11356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:4",
-      "line": 27702,
+      "line": 27797,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11046,7 +11366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d7054ddecdecb2a0:1",
-      "line": 9559,
+      "line": 9654,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11056,7 +11376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d72d9e72d4f3a17b:1",
-      "line": 26726,
+      "line": 26821,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11076,7 +11396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d7d56a7464e8f5b3:1",
-      "line": 16087,
+      "line": 16182,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11086,7 +11406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d7f040d901d9eeee:1",
-      "line": 10119,
+      "line": 10214,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11096,7 +11416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d8482b9f8d823ef4:1",
-      "line": 26727,
+      "line": 26822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11116,7 +11436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d8a4e503703f505e:1",
-      "line": 26916,
+      "line": 27011,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11126,7 +11446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d95de55fab6ad5ad:1",
-      "line": 26711,
+      "line": 26806,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11136,7 +11456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:da49eb6e798c7f5f:1",
-      "line": 25330,
+      "line": 25425,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11146,7 +11466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:da83ec605d06c165:1",
-      "line": 24532,
+      "line": 24627,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11156,7 +11476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:daedfce64925a80d:1",
-      "line": 26923,
+      "line": 27018,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11166,7 +11486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:db330feea131f18a:1",
-      "line": 13766,
+      "line": 13861,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11176,7 +11496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dbb3dec0819eacfc:1",
-      "line": 23409,
+      "line": 23504,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11196,7 +11516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dc67be849666c66e:1",
-      "line": 26716,
+      "line": 26811,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11206,7 +11526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dcbba1aed804c3cc:1",
-      "line": 20417,
+      "line": 20512,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11226,7 +11546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ddbf81f68eb26ab5:1",
-      "line": 9892,
+      "line": 9987,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11236,7 +11556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:de04154d5cf655d7:1",
-      "line": 15621,
+      "line": 15716,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11246,7 +11566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:de0e408974da99ae:1",
-      "line": 13769,
+      "line": 13864,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11256,7 +11576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:debf0c272ce8934a:1",
-      "line": 15131,
+      "line": 15226,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11266,7 +11586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:def561121aa38f1a:1",
-      "line": 9528,
+      "line": 9623,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11276,7 +11596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:df7728e04a8a6114:1",
-      "line": 24595,
+      "line": 24690,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11286,7 +11606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dfe42585aa5eda4f:1",
-      "line": 26720,
+      "line": 26815,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11296,7 +11616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e04ef1a953d86622:1",
-      "line": 25508,
+      "line": 25603,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11306,7 +11626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e1112f888f975b87:1",
-      "line": 24266,
+      "line": 24361,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11316,7 +11636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e20b40e9da433575:1",
-      "line": 9454,
+      "line": 9549,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11326,7 +11646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e20e7b50fcc22489:1",
-      "line": 9455,
+      "line": 9550,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11346,7 +11666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e37dc6e11ac68066:1",
-      "line": 14479,
+      "line": 14574,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11356,7 +11676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3bbc251d76d2cc1:1",
-      "line": 25092,
+      "line": 25187,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11366,7 +11686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3dd8738b72afdf1:1",
-      "line": 20235,
+      "line": 20330,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11376,7 +11696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3dd8738b72afdf1:2",
-      "line": 20240,
+      "line": 20335,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11386,7 +11706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4178bcaf4b76b3d:1",
-      "line": 24192,
+      "line": 24287,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11396,7 +11716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e43a3f4befd820da:1",
-      "line": 27187,
+      "line": 27282,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11406,7 +11726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e476907fcc0d1cb0:1",
-      "line": 15480,
+      "line": 15575,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11416,7 +11736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4782afde62e5c5a:1",
-      "line": 26692,
+      "line": 26787,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11426,7 +11746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4b0b210d7c72ff4:1",
-      "line": 27232,
+      "line": 27327,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11436,7 +11756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e53f164febfd0a64:1",
-      "line": 12563,
+      "line": 12658,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11446,7 +11766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5417e4642efa5e7:1",
-      "line": 26884,
+      "line": 26979,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11456,7 +11776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e59b272b3f6baa43:1",
-      "line": 27225,
+      "line": 27320,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11466,7 +11786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e59dc9d3c750862a:1",
-      "line": 27008,
+      "line": 27103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11476,7 +11796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5dd080eb0079eb4:1",
-      "line": 15601,
+      "line": 15696,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11496,7 +11816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5eeba5978209923:1",
-      "line": 9862,
+      "line": 9957,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11506,7 +11826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e60cd4a237068776:1",
-      "line": 26710,
+      "line": 26805,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11516,7 +11836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e6213dbf749b2f84:1",
-      "line": 26782,
+      "line": 26877,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11526,7 +11846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e685278893a1646e:1",
-      "line": 27672,
+      "line": 27767,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11536,7 +11856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e6c3b28dbfefcb88:1",
-      "line": 9913,
+      "line": 10008,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11546,7 +11866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e72b3e0c6f390ccd:1",
-      "line": 15375,
+      "line": 15470,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11556,7 +11876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e75ffc427ee1b257:1",
-      "line": 24319,
+      "line": 24414,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11566,7 +11886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e8da71b12cfb5a50:1",
-      "line": 27165,
+      "line": 27260,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11576,7 +11896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ea3b059be4106cfd:1",
-      "line": 10086,
+      "line": 10181,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11586,7 +11906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eadebb8b914a8fa5:1",
-      "line": 9935,
+      "line": 10030,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11596,7 +11916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb423e1709e85420:1",
-      "line": 27245,
+      "line": 27340,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11606,7 +11926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb4b4ff72f40de81:1",
-      "line": 10074,
+      "line": 10169,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11616,7 +11936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb96318ae36b4913:1",
-      "line": 24813,
+      "line": 24908,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11636,7 +11956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ecfb5bbd1435c6c6:2",
-      "line": 16146,
+      "line": 16241,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11656,7 +11976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee11ef9a56b0be9f:1",
-      "line": 26703,
+      "line": 26798,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11666,7 +11986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee3fb3104fc6e48d:1",
-      "line": 22590,
+      "line": 22685,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11676,7 +11996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee5eece78e40f295:1",
-      "line": 15437,
+      "line": 15532,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11686,7 +12006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ef7c060e201a3297:1",
-      "line": 24869,
+      "line": 24964,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11716,7 +12036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f12e9271279bd591:1",
-      "line": 15555,
+      "line": 15650,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11736,7 +12056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f1a7449a1c36dab0:1",
-      "line": 24036,
+      "line": 24131,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11756,7 +12076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f248a1e26ac5cc09:1",
-      "line": 14084,
+      "line": 14179,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11766,7 +12086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f252e7eaf9e37429:1",
-      "line": 27311,
+      "line": 27406,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11776,7 +12096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f2a482c55d4b8bfb:1",
-      "line": 24865,
+      "line": 24960,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11806,7 +12126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f35283ed599f5e1e:1",
-      "line": 27730,
+      "line": 27825,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11816,7 +12136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f36013bf14def33f:1",
-      "line": 27362,
+      "line": 27457,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11826,7 +12146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f36557089879db4a:1",
-      "line": 12106,
+      "line": 12201,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11836,7 +12156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f4078a53a7e6629d:1",
-      "line": 26789,
+      "line": 26884,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11846,7 +12166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f47a8108aa3e78d3:1",
-      "line": 9965,
+      "line": 10060,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11856,7 +12176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f48aa05c03d90298:1",
-      "line": 27319,
+      "line": 27414,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11866,7 +12186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f55d5c58fe2c4b6f:1",
-      "line": 26860,
+      "line": 26955,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11876,7 +12196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f56054e03ade4a1f:1",
-      "line": 27698,
+      "line": 27793,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11906,7 +12226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f80071156123b2ac:1",
-      "line": 10136,
+      "line": 10231,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11936,7 +12256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:faba1e348a75ffc6:1",
-      "line": 25533,
+      "line": 25628,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11946,7 +12266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fad89e3656e32e27:1",
-      "line": 15572,
+      "line": 15667,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11956,7 +12276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:1",
-      "line": 9896,
+      "line": 9991,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11966,7 +12286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:2",
-      "line": 10140,
+      "line": 10235,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11976,7 +12296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:3",
-      "line": 10146,
+      "line": 10241,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11986,7 +12306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:4",
-      "line": 10156,
+      "line": 10251,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12006,7 +12326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fb3a4e7347c17952:1",
-      "line": 14066,
+      "line": 14161,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12016,7 +12336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fb4f3aea8230a6a1:1",
-      "line": 22873,
+      "line": 22968,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12036,7 +12356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fd3ddc57e24f0f1d:1",
-      "line": 14102,
+      "line": 14197,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12056,7 +12376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fdfd2735a0b731f6:1",
-      "line": 14365,
+      "line": 14460,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -19688,11 +20008,11 @@
   "schema": 1,
   "speaker_counts": {
     "emitter-provenance-guard": 3,
-    "lift-output-backlog": 1829,
+    "lift-output-backlog": 1861,
     "provenance-oracle-guard": 53,
     "vendor-language-identifier": 1,
     "verifier-verdict-quote": 40,
     "verify-dialect-boundary": 42
   },
-  "total_occurrences": 1968
+  "total_occurrences": 2000
 }


### PR DESCRIPTION
## Summary
Two layers of honest With residual classification — no vendor arms.

### 1. Package census construction door
Bare `SourceFile.from_path` painted every `with` as `RuntimeSelectedContextManager` (false red, 5021 amorphous). Route `census` through `open_source_file_for_construction` (same door as `control_effect_recensus`).

### 2. Manager frame projection (assertion-With path)
`pytest.raises` (3555 sites) was stuck at `opaque-call-target:func` because the non-CM path binds `func = args[0]` then calls it — a **local**, not a free external. Fix:
- parameters + simple assignment targets are non-opaque for frame projection
- empty unenrolled CM tables are not bijection BackendDefects on nested `with` in factory bodies
- `SugarNotWritten` during source-visible frame projection → stage-keyed `ManagerConstructionGapV1`

### Next residual (measured, still loud)
`pytest.raises` → nested `with RaisesExc(...)` under source-visible frame → typed residual (not false free-name). That is the next structural cut.

## Validation
```
12 twins green (census door + recensus collection + sole-path manager construction focused)
```

## Measured ΔR
**Unmeasured.** Instrument + frame honesty only.

## Handoff
```
branch/head: fix/with-honest-construction-door / a5fe454ae
PR: #6300
files: census.py, manager_construction.py, context_manager_resolution.py, nodes.py, tests
focused evidence: 12 twins; pytest.raises residual stage moved past false :func
baseline-vs-head: false RuntimeSelected / false opaque:func removed
measured ΔR: unmeasured
known inherited red: nested RaisesExc enrollment under factory projection
remaining: bind nested RaisesExc CM during pytest.raises frame projection; then re-measure assertion-With
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `with`-statement manager construction to handle guarded returns and ExitSet outcomes
> - `construct_manager_behavior` now delegates to a new `_project_factory_manager` projector that handles `GuardedReturn` and nested factory callsites with cycle detection, replacing a loop that only handled trailing `ReturnValue→CallSite` chains.
> - Adds `_project_manager_from_exitset` to recover manager results from multi-arm `ExitSet` outcomes (e.g. if/raise factories) instead of treating them as force-floor failures.
> - `resolve_source_visible_frame` now catches `SugarNotWritten` and returns an `opaque-call-target` gap instead of raising.
> - `_opaque_call_targets` no longer misclassifies calls to locally-assigned names (e.g. `cls = RenamedManager`) as opaque targets, via a new `_function_local_bound_names` helper.
> - `RaiseValue.truth` now propagates the raise effect on truthiness checks; `IfSugar.desugar` threads temporal context into branch suites and handles raise-from-condition.
> - `SpreadCallSugar` and `Call.sugar` can now attach a bound source-visible call frame to spread calls, enabling body-bearing callsites for local constructors.
> - `census` opens files via `open_source_file_for_construction` with a shared `contract_refs` instead of `SourceFile.from_path`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88ed80c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Python context managers, including unresolved and nested `with` statements.
  - Fixed conditional expressions whose conditions raise exceptions so errors propagate correctly.
  - Improved construction of context-manager behavior across guarded returns and multiple outcomes.
  - Enhanced source and filename detection for error reporting across supported input types.
  - Reduced incorrect construction failures for locally assigned or parameter-bound call targets.

- **Tests**
  - Added coverage for context-manager resolution, conditional exception handling, and factory-style patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->