### PR TITLE
fix: one lifter gap costs one file, not the whole ledger

### DIFF
--- a/implementations/rust/coretests-invariants.json
+++ b/implementations/rust/coretests-invariants.json
@@ -6,6 +6,7 @@
   "unclassified": 0,
   "inactive": 65,
   "prev_unclassified": 0,
+  "panicked_files": 0,
   "note": "RE-PIN 2026-06-19 (main 72f566294): the recursive Sugar factory grew ~10x in callsite expansion across the prior 89 commits -- MethodSugar now recurses through visible source methods, method-contract DFS bridged through vendor proofs, contract-edge emission, and #2284 'add remaining coretests sugar'. callsite-expanded obligations 488->4945; discharged 6098->10544, refused 705->1125, inactive 62->65. unclassified and SILENT stay 0 (total accounting holds; the identity 6789 raw surfaces + 4945 expanded - 0 missing = 11734 closes). The assertion_multiset_cid changed ee0c6d92->9500ba70 because the assertion surface grew (raw surfaces 6377->6789). Soundness re-verified before re-pin: the assertion_lift teeth suite is 404/404 green -- every dischargeable shape's bad-twin goes z3-UNSAT, so the discharge growth is constrained digging, not fake-dig. This is a deliberate re-pin to the grown engine, not a rust-version bump or a corpus change; no hidden bucket introduced (unclassified/silent/missing all 0).",
   "missing_assertions": 0,
   "callsite_expansion": 4945

--- a/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
@@ -250,6 +250,9 @@ struct Totals {
     refused: usize,
     unclassified: usize,
     inactive: usize,
+    // Files whose lift panicked and were binned whole by the per-file panic
+    // boundary. Non-zero means the ledger below is a floor, not a full reading.
+    panicked_files: usize,
 }
 
 fn main() {
@@ -472,14 +475,61 @@ fn main() {
                 census_rows.push((rel.clone(), row));
             }
         }
-        let out = lift_file_with_all_source_imports(
-            &file,
-            &rel,
-            &options,
-            &registry,
-            &const_registry,
-            &fn_registry,
-        );
+        // Per-file panic boundary. A lifter gap (`iter_terminal_gap` and friends) is a
+        // deliberate `-> !` loud refusal, but without a boundary here the FIRST such file
+        // aborts the process and no accounting is ever written -- one gap costs the whole
+        // ledger, and every file after it goes unobserved. Bin the panicking file as a
+        // named refusal instead: its assertions are refused with the panic string as the
+        // reason, so they stay accounted for and `silent` still cannot hide anything.
+        let lifted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            lift_file_with_all_source_imports(
+                &file,
+                &rel,
+                &options,
+                &registry,
+                &const_registry,
+                &fn_registry,
+            )
+        }));
+        let out = match lifted {
+            Ok(out) => out,
+            Err(payload) => {
+                let panic_msg = payload
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .or_else(|| payload.downcast_ref::<&str>().copied())
+                    .unwrap_or("<non-string panic payload>")
+                    .replace('\n', " ");
+                let reason = format!("lifter panic: {panic_msg}");
+                warn!(
+                    file = %rel,
+                    panic = %panic_msg,
+                    asserts = census.total,
+                    "coretests sweep file panicked; binning its assertions as unclassified"
+                );
+                // UNCLASSIFIED, not `refused`. `refused` is reserved for a terminal
+                // close with a source-property reason, and the sweep cannot show that
+                // here: the panic unwound before any per-assert disposition existed, so
+                // we do not know which of this file's assertions the gap actually hit.
+                // Unclassified is the honest bucket -- it says "work", it keeps the gap
+                // loud in the gate rather than parked in an earned-refusal bucket, and
+                // it holds the `silent = 0` identity because the assertions stay counted.
+                totals.assert_macros += census.total;
+                totals.unclassified += census.total;
+                totals.panicked_files += 1;
+                let b = format!("[unclassified] {}", bucket(&reason));
+                *reasons.entry(b.clone()).or_insert(0) += census.total;
+                let samples = reason_samples.entry(b).or_default();
+                if samples.len() < 12 {
+                    samples.push(format!("{}: {}", rel, reason));
+                }
+                for _ in 0..census.total {
+                    all_reasons.push(reason.clone());
+                }
+                rows.push((rel, census.total, 0, census.total, 0, false));
+                continue;
+            }
+        };
         let discharged = out.assertions_lifted;
         let refused_total = out.assertions_refused;
 
@@ -643,6 +693,15 @@ fn main() {
         "  inactive (cfg-disabled):     {:>6}  ({:.1}%)   <-- not in this target's universe",
         totals.inactive,
         pct(totals.inactive)
+    );
+    println!(
+        "  panicked files (LIFTER GAP): {:>6}           <-- {}",
+        totals.panicked_files,
+        if totals.panicked_files == 0 {
+            "0 = every file's lift ran to a disposition"
+        } else {
+            "the buckets above are a FLOOR: these files were binned whole, unclassified"
+        }
     );
     println!(
         "  missing assertions (SILENT): {:>6}  ({:.1}%)   <-- delta target = 0",
@@ -906,6 +965,9 @@ fn build_ledger_json(
     obj.insert("refused".into(), totals.refused.into());
     obj.insert("unclassified".into(), totals.unclassified.into());
     obj.insert("inactive".into(), totals.inactive.into());
+    // Non-zero => the buckets above are a FLOOR. Emitted unconditionally so a
+    // reader of the ledger alone can tell a full reading from a floored one.
+    obj.insert("panicked_files".into(), totals.panicked_files.into());
     obj.insert("missing_assertions".into(), missing_assertions.into());
     obj.insert("callsite_expansion".into(), callsite_expansion.into());
     obj.insert(
@@ -991,6 +1053,7 @@ mod tests {
             refused: 1,
             unclassified: 1,
             inactive: 0,
+            panicked_files: 0,
         };
         let reasons = BTreeMap::from([("closure argument".to_string(), 2usize)]);
         let samples = BTreeMap::from([(
@@ -1046,6 +1109,20 @@ mod tests {
             Some(3)
         );
         assert!(v.get("unaccounted").is_none());
+    }
+
+    // A ledger that floored some files must SAY so on its face. Without this
+    // field a reader cannot tell "every lift ran" from "seven lifts panicked
+    // and their whole surface was binned", and the two ledgers otherwise look
+    // alike -- the counts just sit lower.
+    #[test]
+    fn ledger_json_always_carries_panicked_files() {
+        let (mut totals, reasons, samples, all, rows) = fixture();
+        let v = build_ledger_json("corpus", &totals, &reasons, &samples, &all, &rows, "x");
+        assert_eq!(v.get("panicked_files").and_then(|n| n.as_u64()), Some(0));
+        totals.panicked_files = 7;
+        let v = build_ledger_json("corpus", &totals, &reasons, &samples, &all, &rows, "x");
+        assert_eq!(v.get("panicked_files").and_then(|n| n.as_u64()), Some(7));
     }
 
     #[test]

--- a/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
@@ -478,9 +478,10 @@ fn main() {
         // Per-file panic boundary. A lifter gap (`iter_terminal_gap` and friends) is a
         // deliberate `-> !` loud refusal, but without a boundary here the FIRST such file
         // aborts the process and no accounting is ever written -- one gap costs the whole
-        // ledger, and every file after it goes unobserved. Bin the panicking file as a
-        // named refusal instead: its assertions are refused with the panic string as the
-        // reason, so they stay accounted for and `silent` still cannot hide anything.
+        // ledger, and every file after it goes unobserved. Bin the panicking file whole as
+        // UNCLASSIFIED with the panic string as the reason (see `bin_panicked_file` for why
+        // that bucket and not `refused`), so its assertions stay accounted for and `silent`
+        // still cannot hide anything.
         let lifted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             lift_file_with_all_source_imports(
                 &file,
@@ -494,39 +495,23 @@ fn main() {
         let out = match lifted {
             Ok(out) => out,
             Err(payload) => {
-                let panic_msg = payload
-                    .downcast_ref::<String>()
-                    .map(String::as_str)
-                    .or_else(|| payload.downcast_ref::<&str>().copied())
-                    .unwrap_or("<non-string panic payload>")
-                    .replace('\n', " ");
-                let reason = format!("lifter panic: {panic_msg}");
+                let panic_msg = panic_payload_message(&payload);
                 warn!(
                     file = %rel,
                     panic = %panic_msg,
                     asserts = census.total,
                     "coretests sweep file panicked; binning its assertions as unclassified"
                 );
-                // UNCLASSIFIED, not `refused`. `refused` is reserved for a terminal
-                // close with a source-property reason, and the sweep cannot show that
-                // here: the panic unwound before any per-assert disposition existed, so
-                // we do not know which of this file's assertions the gap actually hit.
-                // Unclassified is the honest bucket -- it says "work", it keeps the gap
-                // loud in the gate rather than parked in an earned-refusal bucket, and
-                // it holds the `silent = 0` identity because the assertions stay counted.
-                totals.assert_macros += census.total;
-                totals.unclassified += census.total;
-                totals.panicked_files += 1;
-                let b = format!("[unclassified] {}", bucket(&reason));
-                *reasons.entry(b.clone()).or_insert(0) += census.total;
-                let samples = reason_samples.entry(b).or_default();
-                if samples.len() < 12 {
-                    samples.push(format!("{}: {}", rel, reason));
-                }
-                for _ in 0..census.total {
-                    all_reasons.push(reason.clone());
-                }
-                rows.push((rel, census.total, 0, census.total, 0, false));
+                bin_panicked_file(
+                    &rel,
+                    &panic_msg,
+                    census.total,
+                    &mut totals,
+                    &mut reasons,
+                    &mut reason_samples,
+                    &mut all_reasons,
+                    &mut rows,
+                );
                 continue;
             }
         };
@@ -943,6 +928,59 @@ fn report_callsite_census(rows: &[(String, sugar_lift_rust_tests::CallsiteCensus
 /// binned into discharged/refused/missing or expanded through callsites), the
 /// reason histogram, and the per-file rows. Pure so the shape -- and the CID
 /// over it -- is testable.
+/// The panic payload's message, flattened to one line so it survives a reason
+/// histogram row. A non-string payload is NAMED, never dropped silently.
+fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic payload>")
+        .replace('\n', " ")
+}
+
+/// Bin a file whose lift PANICKED, whole, into the ledger.
+///
+/// UNCLASSIFIED, not `refused`. `refused` is reserved for a terminal close with a
+/// source-property reason, and the sweep cannot show that here: the panic unwound
+/// before any per-assert disposition existed, so we do not know which of this file's
+/// assertions the gap actually hit. Unclassified is the honest bucket -- it says
+/// "work", it keeps the gap loud in the gate rather than parked in an earned-refusal
+/// bucket, and it holds the `silent = 0` identity because the assertions stay counted.
+///
+/// Extracted from the sweep loop so the BINNING is testable, not just the field it
+/// writes: `panic_bins_unclassified_not_refused` below is the tooth on that choice.
+#[allow(clippy::too_many_arguments)]
+fn bin_panicked_file(
+    rel: &str,
+    panic_msg: &str,
+    census_total: usize,
+    totals: &mut Totals,
+    reasons: &mut BTreeMap<String, usize>,
+    reason_samples: &mut BTreeMap<String, Vec<String>>,
+    all_reasons: &mut Vec<String>,
+    rows: &mut Vec<(String, usize, usize, usize, i64, bool)>,
+) {
+    let reason = format!("lifter panic: {panic_msg}");
+    totals.assert_macros += census_total;
+    totals.unclassified += census_total;
+    totals.panicked_files += 1;
+    let b = format!("[unclassified] {}", bucket(&reason));
+    *reasons.entry(b.clone()).or_insert(0) += census_total;
+    let samples = reason_samples.entry(b).or_default();
+    if samples.len() < 12 {
+        samples.push(format!("{rel}: {reason}"));
+    }
+    for _ in 0..census_total {
+        all_reasons.push(reason.clone());
+    }
+    // `parse_ok = true`: this file PARSED and then panicked during the lift. Those are
+    // two different failures and the flag only means the first one -- reporting
+    // `[parse_fail]` here would name the wrong defect in the top-files table.
+    // `raw_delta = 0` keeps `missing_assertions` unmoved: nothing was silently dropped.
+    rows.push((rel.to_string(), census_total, 0, census_total, 0, true));
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_ledger_json(
     corpus: &str,
@@ -1109,6 +1147,55 @@ mod tests {
             Some(3)
         );
         assert!(v.get("unaccounted").is_none());
+    }
+
+    // THE TOOTH on the bucket choice. The PR this landed in rests on "unclassified,
+    // not refused", and until this existed nothing enforced it: mutating the bin to
+    // `totals.refused += census_total` left every other test green. Drives a panicking
+    // file through the real binning and asserts the whole counter set, so a silent
+    // re-bin to `refused` -- or a dropped `panicked_files` increment, or a lost
+    // assertion -- goes red here.
+    #[test]
+    fn panic_bins_unclassified_not_refused() {
+        let mut totals = Totals::default();
+        let mut reasons = BTreeMap::new();
+        let mut samples = BTreeMap::new();
+        let mut all = Vec::new();
+        let mut rows = Vec::new();
+
+        bin_panicked_file(
+            "num/ops.rs",
+            "enumerate did not reach a lawful floor: inner reduced to non-sequence",
+            74,
+            &mut totals,
+            &mut reasons,
+            &mut samples,
+            &mut all,
+            &mut rows,
+        );
+
+        // The bucket choice itself.
+        assert_eq!(totals.unclassified, 74, "panic must bin UNCLASSIFIED");
+        assert_eq!(totals.refused, 0, "a panic is NOT an earned refusal");
+        assert_eq!(totals.discharged, 0);
+        assert_eq!(totals.inactive, 0);
+        // The floor marker, and the surface conservation that keeps `silent` at 0.
+        assert_eq!(totals.panicked_files, 1);
+        assert_eq!(totals.assert_macros, 74, "the file's surface stays counted");
+        assert_eq!(all.len(), 74, "one named reason per assertion");
+        assert!(all[0].starts_with("lifter panic: "));
+        // Every reason row is tagged unclassified, never refused.
+        assert!(
+            reasons.keys().all(|k| k.starts_with("[unclassified] ")),
+            "{reasons:?}"
+        );
+        assert_eq!(reasons.values().sum::<usize>(), 74);
+        // The row: parsed fine, panicked in the lift, nothing silently dropped.
+        let (rel, asserts, discharged, refused, raw_delta, parse_ok) = &rows[0];
+        assert_eq!(rel, "num/ops.rs");
+        assert_eq!((*asserts, *discharged, *refused), (74, 0, 74));
+        assert_eq!(*raw_delta, 0, "raw_delta 0 keeps missing_assertions unmoved");
+        assert!(*parse_ok, "the file PARSED; it panicked during the lift");
     }
 
     // A ledger that floored some files must SAY so on its face. Without this

--- a/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
@@ -495,7 +495,7 @@ fn main() {
         let out = match lifted {
             Ok(out) => out,
             Err(payload) => {
-                let panic_msg = panic_payload_message(&payload);
+                let panic_msg = panic_payload_message(&*payload);
                 warn!(
                     file = %rel,
                     panic = %panic_msg,
@@ -924,13 +924,9 @@ fn report_callsite_census(rows: &[(String, sugar_lift_rust_tests::CallsiteCensus
     eprintln!("==== end census ====");
 }
 
-/// The sweep ledger as a JSON value: the total accounting (every assertion
-/// binned into discharged/refused/missing or expanded through callsites), the
-/// reason histogram, and the per-file rows. Pure so the shape -- and the CID
-/// over it -- is testable.
 /// The panic payload's message, flattened to one line so it survives a reason
 /// histogram row. A non-string payload is NAMED, never dropped silently.
-fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
     payload
         .downcast_ref::<String>()
         .map(String::as_str)
@@ -981,6 +977,10 @@ fn bin_panicked_file(
     rows.push((rel.to_string(), census_total, 0, census_total, 0, true));
 }
 
+/// The sweep ledger as a JSON value: the total accounting (every assertion
+/// binned into discharged/refused/missing or expanded through callsites), the
+/// reason histogram, and the per-file rows. Pure so the shape -- and the CID
+/// over it -- is testable.
 #[allow(clippy::too_many_arguments)]
 fn build_ledger_json(
     corpus: &str,

--- a/scripts/check-coretests-invariants.py
+++ b/scripts/check-coretests-invariants.py
@@ -47,6 +47,7 @@ def parse_headline(text: str) -> dict:
         "discharged": i(grab(r"discharged \(lifted to FOL\):\s*(-?\d+)")),
         "refused": i(grab(r"refused\s+\(TERMINAL[^:]*:\s*(-?\d+)")),
         "unclassified": i(grab(r"unclassified \(lifter[^:]*:\s*(-?\d+)")),
+        "panicked_files": i(grab(r"panicked files \(LIFTER GAP\):\s*(-?\d+)")),
         "silent": i(grab(r"missing assertions \(SILENT\):\s*(-?\d+)")),
         "missing_assertions": i(grab(r"missing assertions \(SILENT\):\s*(-?\d+)")),
         "callsite_expansion": i(grab(r"callsite-expanded obligations:\s*(-?\d+)")),
@@ -70,6 +71,9 @@ EXACT = [
      "terminal-refused count is not what the commit claimed"),
     ("unclassified", "unclassified",
      "unclassified is not what the commit claimed it would move to"),
+    ("panicked_files", "panicked_files",
+     "a file's lift PANICKED and was binned whole -- every count above is a floor, "
+     "not a reading; fix the lifter gap or the ledger is not what it says it is"),
 ]
 
 
@@ -81,8 +85,20 @@ def main() -> int:
     pin = json.load(open(sys.argv[2], encoding="utf-8"))
 
     failures = []
+    # A sweep binary predating the per-file panic boundary prints no `panicked
+    # files` line at all. That is not "0 panics" -- it is a sweep that cannot
+    # tell you either way, so say that instead of blaming a lifter gap.
+    if "panicked_files" in pin and got.get("panicked_files") is None:
+        failures.append(
+            "panicked_files: the sweep output has no `panicked files (LIFTER GAP)` line -- "
+            "this binary predates the per-file panic boundary and cannot show whether the "
+            "ledger is a reading or a floor; rebuild coretests_sweep"
+        )
     for sweep_key, pin_key, why in EXACT:
         if pin_key not in pin:
+            continue
+        # Already reported above with the accurate cause.
+        if sweep_key == "panicked_files" and got.get(sweep_key) is None:
             continue
         if got.get(sweep_key) != pin[pin_key]:
             failures.append(
@@ -112,6 +128,7 @@ def main() -> int:
         f"coretests invariants: OK  (unclassified={got['unclassified']}, "
         f"refused={got['refused']}, discharged={got['discharged']}, SILENT={got['silent']}, "
         f"missing={got['missing_assertions']}, expanded={got['callsite_expansion']}, "
+        f"panicked_files={got['panicked_files']}, "
         f"CID pinned{moved})"
     )
     return 0


### PR DESCRIPTION
## What breaks today

The coretests sweep calls the lift bare in its file loop. A lifter gap is a deliberate `-> !` loud refusal, but with no boundary the **first** gap aborts the process before any accounting is written — one gap costs the entire ledger, and every file after it goes unobserved. `make coretests-invariants` then pins `unclassified: 0` against a sweep that cannot finish.

## Scope of the numbers in this PR — read this first

An earlier version of this description reported a census of the corpus (`11/140` files not reaching a disposition, `7` panics, a collapse to `5` mechanism families). **Those figures are retracted.** They were produced by running each file as its own single-file corpus, which builds a macro registry of `0` definitions where the real sweep builds `54`. That is a different lift, so the results are not measurements of the sweep's behaviour:

- a file can be cleared that really panics (`num/u128.rs` is a confirmed case), and
- a file can be flagged that is clean under the real registry, since an unknown macro is itself a shape that drives a lift to a `-> !` floor.

The error runs in **both directions**, so no floor and no ceiling can be claimed from it. **Counts are unknown until the repaired 140-file sweep completes.** That sweep needs the per-file bound (separate PR) to run at all, and its receipt will carry the per-file rows.

Nothing in this PR depends on those counts. The defect it fixes is structural: without a boundary, one gap ends the run.

## Boundary placement is load-bearing, and it is measured

`catch_unwind` wraps **the lift only**, not the loop body. `assertion_surface_census` runs *before* the lift and populates the assertion multiset; wrapping the loop body would skip the census for a panicking file and silently shrink the corpus identity.

The multiset CID is a **sorted** multiset of site CIDs — order-independent — so a panicking file's contribution shows up as a CID delta on a two-file corpus:

```
{bool.rs}           -> blake3-512:3710e306...   unclassified 0
{bool.rs, ops.rs}   -> blake3-512:7baa15a1...   unclassified 74
                       74  [unclassified] lifter panic: enumerate did not
                       reach a lawful floor: inner reduced to non-sequence
```

`ops.rs` panics and its 74 sites still move the CID. Under the wrong placement the two CIDs would be identical. (This is a *placement* test, not a soundness proof for `silent = 0` — the CID is built pre-lift and is recomputable from source either way.)

## Why `unclassified` and not `refused`

`refused` is a terminal close with a source-property reason. The panic unwound before any per-assert disposition existed, so the sweep does not know which of the file's assertions the gap hit. Binning it `refused` would push the pinned `1125` up — a number that reads as "we earned another refusal" when what happened was a panic. Unclassified is louder in the gate and honest about what is known.

`silent` stays 0: the assertions remain counted with the panic string as their reason, and the `continue` fires before the `out.assertions_refused` reconciliation that no longer has a value to read.

Enforced by `panic_bins_unclassified_not_refused`, which drives a panicking file through the real binning and asserts the whole counter set. Verified to bite: with the bin mutated to `totals.refused`, it fails `panic must bin UNCLASSIFIED, left: 0, right: 74`.

## `panicked_files` is emitted unconditionally

Headline line and ledger JSON, at 0 as well as non-zero — a floored ledger that does not say it is floored is precisely the failure the field exists to prevent. Unit test covers both directions.

It is also pinned and exact-matched by the gate, **at zero**, and stays there. `panicked_files` is a named floor axis whose expectation is `0`; a completed sweep that reports a nonzero value must go red under that name. Raising it to an observed baseline would convert missing floors into accepted behaviour.

Gate verified in three directions:

```
0 panics     -> exit 0, OK line states panicked_files=0
7 panics     -> exit 1, "a file's lift PANICKED ... every count above is a floor"
old binary   -> exit 1, "output has no `panicked files (LIFTER GAP)` line ...
(no line)             this binary predates the boundary; rebuild coretests_sweep"
```

Without that third case a pre-boundary binary parses as `None` and gets blamed for a lifter gap that never happened.

## What this makes visible, and the decision it forces

This PR does not green the gate. It makes a pre-existing redness observable for the first time.

The live pin carries `unclassified: 0` as an EXACT field **and** `prev_unclassified: 0` behind a direction guard (`check-coretests-invariants.py:95-97`). Every panicking file bins its whole surface unclassified, so once the sweep can complete it reports a nonzero `unclassified` and the gate fails twice — once for "not what the commit claimed", once for "a regression; we only move toward 0".

That is the gate working. The redness was always there, hidden behind a process abort. Re-pinning `unclassified` upward would require also raising `prev_unclassified`, the field whose only job is to forbid that — **someone would have to deliberately dismantle the ratchet.** The ruling is that we do not: `unclassified`, `panicked_files` and `timed_out_files` all stay pinned at `0`, the gate stays red by named axis, and the observed values live in the receipt until the floors are genuinely drained.

Separately: the pin's `note` cites base commit `72f566294`. **Correction to an earlier version of this description, which called that commit nonexistent — it is real**: `72f566294606404f9308e25928f67a0e77fc609d`, "add remaining coretests sugar (#2284)", Fri Jun 19 2026, matching the pin's stated date. It resolves only after `git fetch origin --prune --tags`; a plain `git fetch origin` does not produce it.

The provenance problem is real but different from what was claimed. That commit is **not an ancestor of `origin/main` and no branch contains it** — it is reachable only via `refs/tags/sugar-binary-shelf*`. So the pin is checkout-able but cannot be re-derived from branch history. It should be retired for *that* reason, and replaced with a pin derived from a commit on main carrying the full per-file receipt.

## Known, and not hidden

The printed `ledger cid` shifts by one key in the JCS object. It is **not** pinned in `coretests-invariants.json`, so nothing goes red on it.

## Testing

Paired run at base `063df6c`, same target dir, sequential:

```
clean 063df6c        928 passed; 1 failed
063df6c + this PR    928 passed; 1 failed
```

Identical. The failure is `sugar::term_dispatch::tests::predicate_visitor_folds_nested_deref_bitand_comparison_floor` (`term_dispatch.rs:1072`) — **pre-existing on main, not introduced here.**

That lib failure fail-stops the suite before the bin target runs (`cargo test -p` aborts at the first failing target without `--no-fail-fast`), so the bin tests were run explicitly:

```
cargo test --release -p sugar-lift-rust-tests --bin coretests_sweep
test tests::panic_bins_unclassified_not_refused ... ok
test tests::ledger_json_always_carries_panicked_files ... ok
test result: ok. 13 passed; 0 failed
```

Worth knowing while `term_dispatch` is red: any suite run on this package that stops at the lib failure has not exercised the bin targets at all, so `--no-fail-fast` with per-target lines is the only honest A/B here.

Diff is 3 files (`coretests_sweep.rs`, the gate script, the pin JSON) — nothing under the lift path, so no helper shared with `discharge_sweep` / `rust_test_assertions_rpc` changes behaviour. The examples gate's pinned `factory-gap/rust-coretests-composite-for-loop` shape is resolved through `discharge_sweep` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reporting for files that encounter processing panics during Rust test sweeps.
  * Panicked files are recorded separately, with affected assertions marked as unresolved and associated reasons included in the results.
  * JSON and human-readable summaries now clearly indicate when results may represent a lower-bound count.

* **Bug Fixes**
  * A panic in one file no longer stops the entire sweep; processing continues with subsequent files.

* **Validation**
  * Added checks to ensure panic counts and ledger reporting remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
