### PR TITLE
Try/ExitSet: discharge the stale staging gate in language (#6242 fix-forward)

### DIFF
--- a/docs/plans/try-exitset-staged.md
+++ b/docs/plans/try-exitset-staged.md
@@ -1,7 +1,9 @@
-# Try / ExitSet — staged, do not merge
+# Try / ExitSet — gate discharged, merged
 
-**Status:** STAGED ONLY. Merge waits on the **post-cache authoritative
-baseline and its ledger**. Building against the ExitSet law now costs nothing.
+**Status:** MERGED as `421ef4157` (#6242). The staging gate was discharged on
+the ruling that the landed content is **twins-only, with no production
+capability** — it changes no production behavior, and `Try` already rode the
+shared `ExitSet` algebra this plan describes.
 
 **Region:** `try_sugar.py` + `exit_set_routing.py`.
 **Coordinate with:** Assign (`#6239`) — do not edit the Assign region.

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -1,6 +1,8 @@
-"""STAGED law twins for Try/ExitSet. DO NOT treat green as merge-ready.
+"""Law twins for Try/ExitSet. Gate discharged: twins-only, no production capability.
 
-Merge waits on the post-cache authoritative baseline and its ledger (PR #6242).
+Merged as #6242. The staging gate was discharged on the ruling that this file
+is twins-only, changes no production behavior, and that ``Try`` already rode the
+shared ``ExitSet`` algebra it pins here.
 
 ``Try`` is **not** a third control model.  It inherits the same ``ExitSet``
 algebra ``Store`` established and ``With`` rode:
@@ -49,10 +51,10 @@ Laws pinned here, each with a discrimination arm that bites:
   through the same reducer produce identical arm structure, and a matched halt
   is replaced by exactly the handler body's own arms
 
-CLOSED (#6283): the gap this file deliberately left unpinned -- a binding
-established in the ``try`` body before the raise not being visible in the
-handler, because ``handler_scope`` was the pre-try scope in
-``sugar_source_tree.nodes.Try.substitute`` -- is repaired.  The handler now
+CLOSED (#6283, repaired in #6284): the gap this file deliberately left
+unpinned -- a binding established in the ``try`` body before the raise not
+being visible in the handler, because ``handler_scope`` was the pre-try scope
+in ``sugar_source_tree.nodes.Try.substitute`` -- is repaired.  The handler now
 begins from the temporal state its routed halt edge carries.  The law and its
 nine twins live in ``test_try_handler_temporal_state.py``; the control algebra
 pinned here was never the defect and is unchanged.


### PR DESCRIPTION
Fix-forward on `421ef4157` per the call: the merge was intentional — twins-only, no production behavior change, Try already used the shared ExitSet algebra. The title and staging language were stale, not the semantics. Nothing here touches the algebra.

## Changes

- `test_try_exitset_law.py` module docstring: `"STAGED ... DO NOT treat green as merge-ready"` → `"gate discharged: twins-only, no production capability"`.
- `docs/plans/try-exitset-staged.md`: same, and records `421ef4157` as the merge commit.
- Try-binding gap note now cites its repair in **#6284** alongside the issue #6283.
- `test_with_partition_shared_algebra.py`: Black-formatted.

## Two corrections to the call's premises

**1. "The two Black offenders" is one, and it is not the Try file.**

`test_try_exitset_law.py` *was* an offender at `421ef4157` — I verified by extracting the blob at that commit and running the gated Black against it. It was already reformatted since, in #6284 / #6293, and is clean at `f1406091a`.

The sole remaining offender under the gated scope is `test_with_partition_shared_algebra.py`, introduced by #6298 and unrelated to Try.

**2. That file is unrelated but blocking, so it is included here.**

`PYTHON_FORMAT_PATHS ?= implementations/python` (`Makefile:29`), consumed by `test-python-format` (`Makefile:346`) via `ci.yml:104-105`, pinned at `black==26.5.1`. So `test-python-format` is red on main until this one file is fixed. Bundling it is a judgment call — flagging it explicitly rather than burying it, since it muddies attribution. Say the word and I will split it out.

## Receipt

Own-baseline A/B, one worktree, one venv, full `sugar-source-tree` package suite (not a scoped run):

```
base f1406091a   590 passed, 5 skipped
head d13383cd6   590 passed, 5 skipped
```

Zero delta.

Black gate, gated scope and gated version:

```
before   1 file would be reformatted
after    834 files would be left unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark the Try/ExitSet merge gate as discharged in docs and test module
> Updates [docs/plans/try-exitset-staged.md](https://github.com/TSavo/sugar/pull/6304/files#diff-d4f6ef6ef3b6d1832032e1a1a5fd2ea93d9df5855d83e8fbf4595fa5dc7d496f) and [test_try_exitset_law.py](https://github.com/TSavo/sugar/pull/6304/files#diff-6b72b4ac67bf2ac5b31605e01664ff5991e5efbcc50a284240788e26d755ecbb) to reflect that the staged gate is now discharged and merged as commit 421ef4157 (#6242). Both files clarify that the change is twins-only, has no production capability, and that Try already used the shared ExitSet algebra. The test module also updates the CLOSED note to reference issue #6283 repaired in #6284, and restores the Black formatting gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69a7211.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->