### PR TITLE
docs: clippy is recommended, not gated -- state the actual Rust lint surface

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -54,7 +54,7 @@ See [porting-to-a-new-language.md](porting-to-a-new-language.md).
 
 ## Code style and review
 
-Per-language idiomatic. The Rust workspace follows `cargo fmt` and `clippy -- -D warnings`. The TypeScript workspace uses Prettier. Each kit's directory has its own conventions; follow what's there.
+Per-language idiomatic. In the Rust workspace, `cargo fmt` is enforced -- CI runs `cargo fmt --all -- --check` (`.github/workflows/ci.yml`). `cargo clippy` is recommended but **not gated**: there is no clippy step in any Makefile target or workflow, and the workspace does not currently pass `-D warnings`. Do not read a clean CI run as a clippy-clean tree. The TypeScript workspace uses Prettier. Each kit's directory has its own conventions; follow what's there.
 
 Reviews focus on three questions, in order:
 


### PR DESCRIPTION
`docs/contributing/overview.md:57` asserted the Rust workspace "follows `cargo fmt` and `clippy -- -D warnings`". Only the first half is true.

- CI's single cargo lint step is `cargo fmt --all -- --check` (`.github/workflows/ci.yml:138`).
- There is **no** clippy step in any Makefile target or workflow, and the workspace does not currently pass `-D warnings` (sugar-ir-types alone carries `result_large_err`, `large_enum_variant`, `doc_overindented_list_items`, `should_implement_trait`).
- `docs/_surface/journeys.md:325` already says `make ci` runs no clippy, so the two docs contradicted each other.

**Scope of the check:** Makefile targets, `.github/workflows`, and a repo-wide `git grep -ln clippy -- ':!*.rs'` — which finds only prose, a shell comment in `examples/java-panama-bridge/run.sh`, and the journeys.md line. A runner config outside the repo would not have been visible to this search.

A stated invariant with nothing behind it reads as coverage that does not exist. This states the enforced surface and marks clippy as recommended-not-gated. Wiring a real clippy lane is separate work and is **not** attempted here — no `-D warnings` is added.

Docs-only; no code or gate behavior changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify that `cargo clippy` is recommended but not CI-gated in contributing docs
> Updates the Rust section of [docs/contributing/overview.md](https://github.com/TSavo/sugar/pull/6306/files#diff-cdbcd9dc4ddad15938940da3acc9a2c9c4f066d6779b6675b3e52f2b6c8d8e49) to accurately reflect the actual lint policy. `cargo fmt` is enforced by CI via `cargo fmt --all -- --check`, but `cargo clippy` is only recommended — there is no clippy step in any Makefile or workflow, and the workspace does not currently pass `-D warnings`. Adds a note that a clean CI run should not be interpreted as clippy-clean.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a93c66a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->