### PR TITLE
ExitSet.normalize: bucket the lookup, memoize content identity (fixes the core/generic.py timeout floor)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -409,6 +409,10 @@ def _evict_term_content_cid(term: "Term") -> bool:
 
 def _remember_term_content_cid(term: "Term", cid: str) -> None:
     tid = id(term)
+    live = _TERM_CONTENT_CID.get(tid)
+    if live is not None and live[0]() is term:
+        # Already memoized for this exact object; do not mint a second weakref.
+        return
 
     def _on_die(wr: weakref.ReferenceType, *, _tid: int = tid) -> None:
         cur = _TERM_CONTENT_CID.get(_tid)
@@ -436,6 +440,22 @@ def _term_content_cid(term: "Term") -> str:
     Eviction (explicit or GC) must never change the coordinate; recompute is
     deterministic.
     """
+    # Identity-guarded memo on the *caller's* object, consulted BEFORE intern.
+    # ``_intern_term`` is a full heap walk of the spine; under a live scope the
+    # old order paid that walk on every lookup, so repeated identity questions
+    # about ONE term object scaled with the term's size instead of being O(1)
+    # (35.3M ``_term_content_cid`` calls on pandas/core/generic.py). The CID is
+    # a pure function of immutable content, so memoizing the pre-intern object
+    # is the same coordinate; the weakref ``is``-guard rejects a recycled id.
+    incoming = term
+    entry = _TERM_CONTENT_CID.get(id(incoming))
+    if entry is not None:
+        wr, cached = entry
+        if wr() is incoming:
+            return cached
+        if wr() is None:
+            _TERM_CONTENT_CID.pop(id(incoming), None)
+
     tables = _TERM_INTERN_TABLE.get()
     if tables is not None:
         _by_key, by_id, cid_by_id = tables
@@ -443,17 +463,9 @@ def _term_content_cid(term: "Term") -> str:
         tid = id(term)
         cached = cid_by_id.get(tid)
         if cached is not None and by_id.get(tid) is term:
+            _remember_term_content_cid(incoming, cached)
             return cached
         # Fall through to mint; fill both layers below.
-    else:
-        tid = id(term)
-        entry = _TERM_CONTENT_CID.get(tid)
-        if entry is not None:
-            wr, cached = entry
-            if wr() is term:
-                return cached
-            if wr() is None:
-                _TERM_CONTENT_CID.pop(tid, None)
 
     # Under scope, also consult weak memo for a term that outlived a prior scope.
     if tables is not None:
@@ -465,10 +477,13 @@ def _term_content_cid(term: "Term") -> str:
                 _by_key, by_id, cid_by_id = tables
                 if by_id.get(id(term)) is term:
                     cid_by_id[id(term)] = cached
+                _remember_term_content_cid(incoming, cached)
                 return cached
 
     cid = TermTableBuilder().reference(term)["cid"]
     _remember_term_content_cid(term, cid)
+    if incoming is not term:
+        _remember_term_content_cid(incoming, cid)
     if tables is not None:
         _by_key, by_id, cid_by_id = tables
         if by_id.get(id(term)) is term:
@@ -498,10 +513,77 @@ def _term_intern_arg_key(term: "Term") -> tuple:
 _term_formula_key = _term_content_key
 
 
-def _formula_key(formula: "Formula", *, term_key) -> tuple:
-    """Finite structural formula key; ``term_key`` selects intern vs identity."""
+# Content-key memo for Formula identity: id(formula) → (weakref, key).
+# Same contract as ``_TERM_CONTENT_CID``: the key is a pure function of
+# immutable content, ``id()`` is only a memo index, and the weakref ``is``-guard
+# rejects a recycled id while GC reclaims dead entries. Without it, every
+# ``Formula.__hash__``/``__eq__`` re-walked the whole formula spine and asked
+# every leaf term for its CID again — the identity half of the ExitSet
+# normalization blowup.
+_FORMULA_CONTENT_KEY: dict[int, tuple[weakref.ReferenceType, tuple]] = {}
+
+
+def _formula_content_key_memo_size() -> int:
+    """Live memo entries (test / diagnostics only)."""
+    return len(_FORMULA_CONTENT_KEY)
+
+
+def _lookup_formula_content_key(formula: "Formula") -> tuple | None:
+    entry = _FORMULA_CONTENT_KEY.get(id(formula))
+    if entry is None:
+        return None
+    wr, key = entry
+    if wr() is formula:
+        return key
+    if wr() is None:
+        _FORMULA_CONTENT_KEY.pop(id(formula), None)
+    return None
+
+
+def _remember_formula_content_key(formula: "Formula", key: tuple) -> None:
+    fid = id(formula)
+    live = _FORMULA_CONTENT_KEY.get(fid)
+    if live is not None and live[0]() is formula:
+        return
+
+    def _on_die(wr: weakref.ReferenceType, *, _fid: int = fid) -> None:
+        cur = _FORMULA_CONTENT_KEY.get(_fid)
+        if cur is not None and cur[0] is wr:
+            _FORMULA_CONTENT_KEY.pop(_fid, None)
+
+    try:
+        ref = weakref.ref(formula, _on_die)
+    except TypeError:
+        return
+    _FORMULA_CONTENT_KEY[fid] = (ref, key)
+
+
+def _evict_formula_content_key(formula: "Formula") -> bool:
+    """Drop any memoized content key for ``formula`` (cache control only)."""
+    fid = id(formula)
+    entry = _FORMULA_CONTENT_KEY.get(fid)
+    if entry is None:
+        return False
+    wr, _key = entry
+    if wr() is formula:
+        del _FORMULA_CONTENT_KEY[fid]
+        return True
+    if wr() is None:
+        _FORMULA_CONTENT_KEY.pop(fid, None)
+    return False
+
+
+def _formula_key(formula: "Formula", *, term_key, shared: bool = False) -> tuple:
+    """Finite structural formula key; ``term_key`` selects intern vs identity.
+
+    ``shared`` opts into the process-wide content-key memo. It is legal only
+    for the identity key (``_term_content_key``): the intern key may spell a
+    term as ``id(...)`` under a request scope, which must never outlive it.
+    """
     memo: dict[int, tuple] = {}
     active: set[int] = set()
+    completed: list[Formula] = []
+    saw_cycle = False
     stack: list[tuple[Formula, bool]] = [(formula, False)]
     while stack:
         node, expanded = stack.pop()
@@ -510,8 +592,15 @@ def _formula_key(formula: "Formula", *, term_key) -> tuple:
             continue
         if not expanded and marker in active:
             memo[marker] = ("cycle", marker)
+            saw_cycle = True
             continue
+        if not expanded and shared:
+            cached = _lookup_formula_content_key(node)
+            if cached is not None:
+                memo[marker] = cached
+                continue
         if expanded:
+            completed.append(node)
             active.discard(marker)
             if isinstance(node, _Atomic):
                 memo[marker] = (
@@ -540,6 +629,11 @@ def _formula_key(formula: "Formula", *, term_key) -> tuple:
             stack.extend((child, False) for child in reversed(node.operands))
         elif isinstance(node, _Quantifier):
             stack.append((node.body, False))
+    if shared and not saw_cycle:
+        # A cycle marker is an id from THIS walk and means nothing in the next
+        # one, so a walk that hit one publishes nothing.
+        for node in completed:
+            _remember_formula_content_key(node, memo[id(node)])
     return memo[id(formula)]
 
 
@@ -554,7 +648,10 @@ def _formula_content_key(formula: "Formula") -> tuple:
     Always content-addressed term CIDs. Never ``id(_intern_term(...))``.
     Hash and equality share this one key (no hash-on-A / eq-on-B split).
     """
-    return _formula_key(formula, term_key=_term_content_key)
+    cached = _lookup_formula_content_key(formula)
+    if cached is not None:
+        return cached
+    return _formula_key(formula, term_key=_term_content_key, shared=True)
 
 
 def _formula_cycle_key(formula: "Formula") -> tuple:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, Iterable, TypeVar
 
 from sugar_lift_py_tests.effect import Effect, require_effect
 from sugar_lift_py_tests.ir import Formula, and_, not_, or_
@@ -98,6 +98,38 @@ class Halted:
 Exit = Completed[T] | Halted
 
 
+# Arms whose destination has no ``__hash__`` and therefore kept the full
+# all-pairs scan in ``normalize``. The fallback is exact, but it is the
+# quadratic shape, so it is COUNTED rather than allowed to be quietly slow.
+_UNHASHABLE_DESTINATION_ARMS = 0
+
+
+def unhashable_destination_arms() -> int:
+    """Arms that fell back to the exact all-pairs scan (diagnostics / tests)."""
+    return _UNHASHABLE_DESTINATION_ARMS
+
+
+def reset_unhashable_destination_arms() -> None:
+    global _UNHASHABLE_DESTINATION_ARMS
+    _UNHASHABLE_DESTINATION_ARMS = 0
+
+
+def _destination_key(exit_: "Exit") -> tuple | None:
+    """The destination coordinate ``normalize`` compares, as a hash bucket key.
+
+    ``None`` means the destination is unhashable — never "not equal". Equality
+    is still decided by the exact comparison in ``normalize``; a hash collision
+    is a collision, and this key invents no semantic coordinate: it hashes
+    exactly the fields the existing equality reads.
+    """
+    try:
+        if isinstance(exit_, Completed):
+            return ("completed", hash(exit_.value))
+        return ("halted", hash(exit_.effect), hash(exit_.state))
+    except TypeError:
+        return None
+
+
 @dataclass(frozen=True)
 class ExitSet(Generic[T]):
     """A partition of reachable execution into completed and halted exits."""
@@ -135,12 +167,37 @@ class ExitSet(Generic[T]):
         return ExitSet(tuple(exits)).normalize()
 
     def normalize(self) -> "ExitSet[T]":
-        """Drop false exits and merge equal destinations by disjoining guards."""
+        """Drop false exits and merge equal destinations by disjoining guards.
+
+        The merge is all-pairs in MEANING and bucketed in LOOKUP. ``merged``
+        stays in insertion order and the exact equality below still decides
+        every merge; the hash index only narrows which priors are asked. A
+        bucketing that reordered the output would break the byte-identical
+        ExitSet fingerprint silently, so the index maps a destination key to
+        ascending indices INTO ``merged`` and never holds the exits itself.
+        """
+        global _UNHASHABLE_DESTINATION_ARMS
         merged: list[Exit[T]] = []
+        buckets: dict[tuple, list[int]] = {}
+        unhashable: list[int] = []
         for exit_ in self.exits:
             if _is_false(exit_.guard):
                 continue
-            for index, prior in enumerate(merged):
+            key = _destination_key(exit_)
+            if key is None:
+                # No quiet degrade: an unhashable destination keeps the exact
+                # all-pairs scan AND is counted, so the species that owes a
+                # ``__hash__`` is measurable instead of merely slow.
+                _UNHASHABLE_DESTINATION_ARMS += 1
+                candidates: Iterable[int] = range(len(merged))
+            elif unhashable:
+                # An unhashable destination can still compare equal to a
+                # hashable one, so it is never excluded by a hash bucket.
+                candidates = sorted(set(buckets.get(key, ())) | set(unhashable))
+            else:
+                candidates = buckets.get(key, ())
+            for index in candidates:
+                prior = merged[index]
                 same_completed = (
                     isinstance(exit_, Completed)
                     and isinstance(prior, Completed)
@@ -164,6 +221,10 @@ class ExitSet(Generic[T]):
                     break
             else:
                 merged.append(exit_)
+                if key is None:
+                    unhashable.append(len(merged) - 1)
+                else:
+                    buckets.setdefault(key, []).append(len(merged) - 1)
         return ExitSet(tuple(merged))
 
     def sequence(self, step: Callable[[T], "ExitSet[U]"]) -> "ExitSet[U]":
@@ -394,4 +455,6 @@ __all__ = [
     "sole_completed_outcome",
     "true_guard",
     "outcome_to_exitset",
+    "unhashable_destination_arms",
+    "reset_unhashable_destination_arms",
 ]

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_index.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_index.py
@@ -1,0 +1,362 @@
+"""ExitSet.normalize: bucketed LOOKUP, all-pairs MEANING.
+
+``normalize`` used to ask every arm about every prior arm. On
+``pandas/core/generic.py`` #6296 raised the honest guarded-exit population to a
+1,317-arm maximum (mean 4.17 over 128,462 calls), and the all-pairs scan bounded
+13.1M destination comparisons for a merge that removes under 2% of arms. The
+arm population is not the defect; asking O(n^2) questions to answer it is.
+
+This file is the tooth for the repair. Two axes, kept apart on purpose:
+
+- **fidelity**: the bucketed normalizer must produce the byte-identical exit
+  tuple, in the identical order, that the all-pairs normalizer produced.
+- **complexity**: destination comparisons must scale near-linearly in the arm
+  count, and identity work must scale with distinct objects, not comparisons.
+
+The reference all-pairs implementation below is a verbatim copy of the shape
+``normalize`` had before the index. It is the "old" side of the fingerprint
+comparison and must not be edited to match a new output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.ir import and_, atomic, make_var, not_
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    Halted,
+    _is_false,
+    _or_guards,
+    reset_unhashable_destination_arms,
+    unhashable_destination_arms,
+)
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def _all_pairs_normalize(exit_set: ExitSet) -> ExitSet:
+    """The pre-index normalizer, kept verbatim as the fingerprint reference."""
+    merged: list = []
+    for exit_ in exit_set.exits:
+        if _is_false(exit_.guard):
+            continue
+        for index, prior in enumerate(merged):
+            same_completed = (
+                isinstance(exit_, Completed)
+                and isinstance(prior, Completed)
+                and exit_.value == prior.value
+            )
+            same_halted = (
+                isinstance(exit_, Halted)
+                and isinstance(prior, Halted)
+                and exit_.effect == prior.effect
+                and exit_.state == prior.state
+            )
+            if same_completed:
+                merged[index] = Completed(
+                    _or_guards(prior.guard, exit_.guard), prior.value
+                )
+                break
+            if same_halted:
+                merged[index] = Halted(
+                    _or_guards(prior.guard, exit_.guard), prior.effect, prior.state
+                )
+                break
+        else:
+            merged.append(exit_)
+    return ExitSet(tuple(merged))
+
+
+class _CountingValue:
+    """A destination whose equality questions are countable.
+
+    ``__hash__`` hashes exactly the field ``__eq__`` compares — the same
+    relationship ``CallSiteValue`` already has, and the reason the bucket key
+    invents no new coordinate.
+    """
+
+    comparisons = 0
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _CountingValue):
+            return NotImplemented
+        type(self).comparisons += 1
+        return self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __repr__(self) -> str:
+        return f"_CountingValue({self.name!r})"
+
+
+class _CollidingValue(_CountingValue):
+    """Distinct destinations that share one hash bucket."""
+
+    def __hash__(self) -> int:
+        return 0
+
+
+class _UnhashableValue:
+    """A destination species that owes a ``__hash__`` and does not have one."""
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _UnhashableValue) and self.name == other.name
+
+
+def _population(arm_count: int, *, distinct: int, value_cls=_CountingValue) -> ExitSet:
+    """``arm_count`` arms cycling over ``distinct`` destinations, all distinct guards."""
+    return ExitSet(
+        tuple(
+            Completed(_guard(f"g{index}"), value_cls(f"d{index % distinct}"))
+            for index in range(arm_count)
+        )
+    )
+
+
+# --- fidelity -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("arm_count", [1, 2, 7, 64, 257])
+@pytest.mark.parametrize("distinct", [1, 3, 64])
+def test_normalized_fingerprint_is_byte_identical_to_all_pairs(arm_count, distinct):
+    population = _population(arm_count, distinct=distinct)
+    assert population.normalize().exits == _all_pairs_normalize(population).exits
+
+
+def test_mixed_completed_and_halted_fingerprint_is_byte_identical():
+    effects = [RaiseEffect(exception_name=name) for name in ("ValueError", "KeyError")]
+    exits = []
+    for index in range(120):
+        guard = _guard(f"g{index}")
+        if index % 3 == 0:
+            exits.append(Completed(guard, _CountingValue(f"d{index % 5}")))
+        else:
+            exits.append(
+                Halted(guard, effects[index % 2], _CountingValue(f"s{index % 4}"))
+            )
+    population = ExitSet(tuple(exits))
+    normalized = population.normalize()
+    assert normalized.exits == _all_pairs_normalize(population).exits
+    # Neither edge disappears: both species survive the index.
+    assert any(isinstance(exit_, Completed) for exit_ in normalized.exits)
+    assert any(isinstance(exit_, Halted) for exit_ in normalized.exits)
+
+
+def test_output_order_is_insertion_order_of_first_arrival():
+    population = ExitSet(
+        (
+            Completed(_guard("a"), _CountingValue("z")),
+            Completed(_guard("b"), _CountingValue("y")),
+            Completed(_guard("c"), _CountingValue("z")),
+            Completed(_guard("d"), _CountingValue("y")),
+        )
+    )
+    normalized = population.normalize()
+    assert [exit_.value.name for exit_ in normalized.exits] == ["z", "y"]
+
+
+def test_no_arm_disappears_when_every_destination_is_distinct():
+    population = _population(200, distinct=200)
+    assert len(population.normalize().exits) == 200
+
+
+def test_equal_destinations_merge_and_disjoin_guards_exactly_once():
+    left, right = _guard("left"), _guard("right")
+    population = ExitSet(
+        (
+            Completed(left, _CountingValue("d")),
+            Completed(right, _CountingValue("d")),
+            Completed(_guard("third"), _CountingValue("d")),
+        )
+    )
+    normalized = population.normalize()
+    assert len(normalized.exits) == 1
+    assert normalized.exits[0].guard == _or_guards(
+        _or_guards(left, right), _guard("third")
+    )
+
+
+def test_false_guarded_arms_are_dropped_exactly_as_before():
+    population = ExitSet(
+        (
+            Completed(not_(and_([])), _CountingValue("dropped")),
+            Completed(_guard("kept"), _CountingValue("kept")),
+        )
+    )
+    normalized = population.normalize()
+    assert [exit_.value.name for exit_ in normalized.exits] == ["kept"]
+    assert normalized.exits == _all_pairs_normalize(population).exits
+
+
+def test_same_hash_but_unequal_destination_stays_separate():
+    population = ExitSet(
+        tuple(
+            Completed(_guard(f"g{index}"), _CollidingValue(f"d{index}"))
+            for index in range(16)
+        )
+    )
+    normalized = population.normalize()
+    # A collision is a collision, not equality: the exact comparison decides.
+    assert len(normalized.exits) == 16
+    assert normalized.exits == _all_pairs_normalize(population).exits
+
+
+def test_colliding_hashes_still_merge_when_actually_equal():
+    population = _population(32, distinct=4, value_cls=_CollidingValue)
+    normalized = population.normalize()
+    assert len(normalized.exits) == 4
+    assert normalized.exits == _all_pairs_normalize(population).exits
+
+
+def test_unhashable_destinations_preserve_behavior_and_are_counted():
+    population = ExitSet(
+        tuple(
+            Completed(_guard(f"g{index}"), _UnhashableValue(f"d{index % 3}"))
+            for index in range(12)
+        )
+    )
+    reset_unhashable_destination_arms()
+    normalized = population.normalize()
+    assert normalized.exits == _all_pairs_normalize(population).exits
+    assert len(normalized.exits) == 3
+    # Measured, not quiet: the fallback names how many arms took it.
+    assert unhashable_destination_arms() == 12
+
+
+def test_unhashable_and_hashable_destinations_still_compare_against_each_other():
+    """An unhashable arm is never hidden from a hashable one by the index."""
+
+    class _Bridge:
+        """Hashable, and equal to an ``_UnhashableValue`` of the same name."""
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def __eq__(self, other: object) -> bool:
+            return getattr(other, "name", object()) == self.name
+
+        def __hash__(self) -> int:
+            return hash(self.name)
+
+    population = ExitSet(
+        (
+            Completed(_guard("a"), _UnhashableValue("d")),
+            Completed(_guard("b"), _Bridge("d")),
+            Completed(_guard("c"), _UnhashableValue("d")),
+        )
+    )
+    assert population.normalize().exits == _all_pairs_normalize(population).exits
+
+
+# --- complexity -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("arm_count", [100, 200, 400, 800])
+def test_destination_comparisons_scale_near_linearly(arm_count):
+    """The complexity tooth: comparisons per arm must not grow with arm count.
+
+    All-pairs over ``arm_count`` arms with ``arm_count // 2`` distinct
+    destinations bounds ~arm_count^2/4 comparisons (100 -> 2,500;
+    800 -> 160,000). Bucketed lookup asks ~1 per arm.
+    """
+    population = _population(arm_count, distinct=arm_count // 2)
+    _CountingValue.comparisons = 0
+    population.normalize()
+    bucketed = _CountingValue.comparisons
+
+    _CountingValue.comparisons = 0
+    _all_pairs_normalize(population)
+    all_pairs = _CountingValue.comparisons
+
+    assert bucketed <= 2 * arm_count, (
+        f"{arm_count} arms asked {bucketed} destination comparisons; "
+        "bucketed lookup must stay near-linear in the arm count"
+    )
+    assert all_pairs > 4 * bucketed, (
+        "reference all-pairs scan is not quadratic here — the population no "
+        "longer exercises the shape this tooth measures"
+    )
+
+
+def test_comparison_growth_is_sublinear_in_the_quadratic_ratio():
+    """Show the curve: doubling arms must not quadruple comparisons."""
+    curve = {}
+    for arm_count in (100, 200, 400, 800):
+        population = _population(arm_count, distinct=arm_count // 2)
+        _CountingValue.comparisons = 0
+        population.normalize()
+        curve[arm_count] = _CountingValue.comparisons
+    for smaller, larger in ((100, 200), (200, 400), (400, 800)):
+        ratio = curve[larger] / max(curve[smaller], 1)
+        assert ratio < 3.0, f"comparison curve {curve} grew {ratio:.2f}x from doubling"
+
+
+def test_no_destination_species_has_a_finer_hash_than_its_equality():
+    """The membrane over an OPEN boundary: destination species keep arriving.
+
+    A bucket index is exact only while ``a == b`` implies
+    ``hash(a) == hash(b)``. The dangerous shape is a class that overrides
+    ``__eq__`` and keeps object-identity ``__hash__``: two equal destinations
+    would land in different buckets, stop merging, and the ExitSet fingerprint
+    would change SILENTLY. Unhashable is fine (measured linear fallback);
+    finer-than-equality is not.
+
+    Retirement path: this auditor is deletable the day ``Effect`` and
+    ``FloorValue`` are closed hierarchies whose construction door refuses a
+    subclass with an ``__eq__``/``__hash__`` split.
+    """
+    import importlib
+    import pkgutil
+    import typing
+
+    import sugar_lift_py_tests as package
+    from sugar_lift_py_tests.effect import Effect
+    from sugar_lift_py_tests.floor import FloorValue
+
+    for module in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+        try:
+            importlib.import_module(module.name)
+        except BaseException:  # optional/heavy leaves are not this tooth's job
+            pass
+
+    roots: list[type] = []
+    for base in (Effect, FloorValue):
+        roots.extend(typing.get_args(base) or [base])
+
+    seen: set[type] = set()
+    stack = list(roots)
+    offenders: list[str] = []
+    while stack:
+        cls = stack.pop()
+        if not isinstance(cls, type) or cls in seen:
+            continue
+        seen.add(cls)
+        stack.extend(cls.__subclasses__())
+        if "__eq__" not in cls.__dict__:
+            continue
+        if cls.__dict__.get("__hash__", "inherited") is object.__hash__:
+            offenders.append(f"{cls.__module__}.{cls.__qualname__}")
+
+    assert seen, "destination species scan found no classes — the scan is broken"
+    assert not offenders, (
+        "destination species with custom __eq__ and identity __hash__: "
+        f"{offenders}. ExitSet.normalize buckets by hash and decides by "
+        "equality; a finer hash makes equal arms stop merging without any "
+        "test going red. Give each class a __hash__ over exactly the fields "
+        "its __eq__ compares (as CallSiteValue does), or set __hash__ = None "
+        "so it takes the measured linear fallback."
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_ir_content_identity_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ir_content_identity_memo.py
@@ -1,0 +1,77 @@
+"""Content identity is asked once per object, not once per comparison.
+
+``Formula.__hash__``/``__eq__`` and ``CallSiteValue.__hash__``/``__eq__`` both
+resolve to content coordinates: a formula content key, and a term wire CID.
+Both used to re-walk the whole spine on every question. On
+``pandas/core/generic.py`` that arrived as 35,339,381 ``_term_content_cid``
+calls over 377,167 distinct Formula objects — identity work scaling with
+COMPARISONS instead of with distinct OBJECTS.
+
+The memos here are caches, never identity: ``id()`` is a memo index only, the
+weakref ``is``-guard rejects a recycled id, and GC reclaims dead entries. The
+coordinate is unchanged — no new digest, no wire identity, no repin.
+"""
+
+from __future__ import annotations
+
+import gc
+
+from sugar_lift_py_tests.ir import (
+    _formula_content_key,
+    _formula_content_key_memo_size,
+    _term_content_cid,
+    and_,
+    atomic,
+    ctor,
+    make_var,
+    not_,
+    num,
+)
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def test_formula_identity_work_scales_with_distinct_objects():
+    guard = and_([_guard("p"), not_(_guard("q"))])
+    first = _formula_content_key(guard)
+    before = _formula_content_key_memo_size()
+    for _ in range(500):
+        assert _formula_content_key(guard) is first
+    # Repeated identity questions about ONE object add no memo entries and
+    # re-walk nothing: the key is the same object, not merely an equal tuple.
+    assert _formula_content_key_memo_size() == before
+
+
+def test_formula_identity_memo_survives_equal_but_distinct_objects():
+    left = and_([_guard("p"), not_(_guard("q"))])
+    right = and_([_guard("p"), not_(_guard("q"))])
+    assert _formula_content_key(left) == _formula_content_key(right)
+    assert left == right
+    assert hash(left) == hash(right)
+
+
+def test_term_content_cid_is_one_object_one_answer():
+    term = ctor("call:f", [make_var("x"), num(3)])
+    first = _term_content_cid(term)
+    for _ in range(500):
+        assert _term_content_cid(term) is first
+
+
+def test_term_content_cid_is_the_same_coordinate_for_structural_twins():
+    left = ctor("call:f", [make_var("x"), num(3)])
+    right = ctor("call:f", [make_var("x"), num(3)])
+    assert _term_content_cid(left) == _term_content_cid(right)
+
+
+def test_identity_memo_does_not_pin_dead_formulas():
+    before = _formula_content_key_memo_size()
+    for index in range(200):
+        _formula_content_key(and_([_guard(f"transient{index}"), not_(_guard("q"))]))
+    gc.collect()
+    after = _formula_content_key_memo_size()
+    assert after <= before + 400, (
+        f"memo grew from {before} to {after} over 200 discarded formulas; "
+        "the weak memo must let GC reclaim dead entries"
+    )


### PR DESCRIPTION
## What broke, and what actually owns it

A pandas census file, `pandas/core/generic.py` (corpus index 121), crosses the
180s per-file deadline and still fails at 300s. A four-point bisect already did
the diagnosis:

| commit | | wall | outcome |
|---|---|---|---|
| `063df6c3a` | parent | 14.81s | CLEARED (406 files clean) |
| `8c6ee6333` | #6293 | 16.53s | CLEARED (126 files clean) |
| `256618357` | #6296 | — | **TIMEOUT — first crossing** |
| `a0d38afca` | head | — | TIMEOUT |

**Attribution splits in two, and this is the whole point of the PR.**

- The commit that turns it red is **#6296**. It raised ExitSet arm counts.
- The code that OWNS the mechanism is **`outcome/exit_set.py` `ExitSet.normalize`**
  and **`floor/call_site_value.py` `CallSiteValue.__eq__`**. Both are
  **pre-existing, below the entire bisect range**: `exit_set.py` is
  byte-identical from `d94f67a31` through `256618357`, first touched by #6298
  — *after* the crossing.

**#6296 is not reverted or narrowed. It is the messenger.** It exposed the
defect by honestly increasing guarded exits. Reverting would disarm the
trigger, not the mechanism, and would reduce real coverage.

Measured, #6293 → #6296 on the same file:

| metric | #6293 | #6296 | ratio |
|---|---|---|---|
| ExitSet arms_in max | 3 | **1,317** | 439x |
| normalize calls | 5,262 | 128,462 | 24x |
| pairwise comparison bound | 2,287 | 13,147,074 | 5,749x |
| distinct Formula objects | 4,222 | 377,167 | 89x |
| `_term_content_cid` | 11,504 | **35,339,381** | **3,072x** |
| GuardedValue built | 372 | 572 | 1.5x |
| max guard depth | 4 | 4 | — |

**Guard nesting did NOT explode (depth stayed 4). The ExitSet arm population
did.** The distribution is a **heavy tail**: 128,462 normalize calls, mean 4.17
arms, max 1,317. A single 1,317-arm set alone bounds 866,586 comparisons. A fix
that only handled the largest set would not have done it.

And `normalize` merges away only **1.42%–1.90% of arms**. A quadratic merge
that discards 2% is near-pure overhead even at healthy arm counts.

## The repair — two separately measurable commits

### 1. Content identity is asked once per object, never once per comparison

`Formula.__hash__`/`__eq__` and `CallSiteValue.__hash__`/`__eq__` both resolve
to content coordinates and both re-walked the whole spine on every question.
Worse: under an active `term_intern_scope`, `_term_content_cid` interned FIRST
and consulted its memo SECOND, so every repeat identity question about one term
object paid a full heap walk of that term's spine before finding the answer it
already had. That is how 377,167 distinct Formula objects became 35,339,381
`_term_content_cid` calls.

Two identity-guarded weak memos, both caches and neither identity:

- `_term_content_cid` consults the weak memo on the **caller's** object before
  interning, and remembers the pre-intern object too. The CID is a pure function
  of immutable content, so it is the same coordinate either way.
- `_formula_content_key` memoizes per formula object and shares subtree keys
  across walks.

In both: `id()` is a memo index only, the weakref `is`-guard rejects a recycled
id, GC reclaims dead entries. A walk that hits a formula cycle publishes
nothing (a cycle marker is an id from that walk alone). Request-local intern
identity stays separate from permanent content identity. **No new digest, no
wire identity, no repin.**

This commit alone is worth ~9.15x of a 3,072x regression. It is correct and it
is **not the fix**.

### 2. `ExitSet.normalize` buckets its LOOKUP; the exact equality still decides

`CallSiteValue.__hash__` already computes exactly the tuple `__eq__` compares.
The key existed and was being discarded.

- The index maps a destination key to **ascending indices INTO `merged`**, never
  holding exits. **`merged` stays in insertion order** — a bucketing that
  reordered output would break the byte-identical fingerprint *silently*.
- Destination key: completed `(Completed, value)`, halted
  `(Halted, effect, state)` — exactly the fields the existing equality reads.
  **No new semantic coordinate.**
- **A hash collision is a collision, not equality.** The exact comparison
  decides every merge.
- `normalize` merges arbitrary `value`/`effect`/`state`, not only
  `CallSiteValue`. An **unhashable** destination keeps the exact all-pairs scan,
  is **counted** (`unhashable_destination_arms()`), and is still compared
  against hashable priors — an unhashable value can compare equal to a hashable
  one, so it is never excluded by a bucket. The fallback is **measured, never
  quiet**.

## Gates

| gate | evidence |
|---|---|
| old/new normalized fingerprints byte-identical | `test_normalized_fingerprint_is_byte_identical_to_all_pairs` (15 populations) + mixed completed/halted, against a verbatim copy of the pre-index all-pairs loop |
| output order identical | `test_output_order_is_insertion_order_of_first_arrival` |
| no completed or halted arm disappears | `test_no_arm_disappears_when_every_destination_is_distinct`, mixed-species assertions |
| equal destinations merge + disjoin guards exactly once | `test_equal_destinations_merge_and_disjoin_guards_exactly_once` |
| same hash, unequal destination stays separate | `test_same_hash_but_unequal_destination_stays_separate` (both arms: `test_colliding_hashes_still_merge_when_actually_equal`) |
| unhashable destinations preserve behavior | `test_unhashable_destinations_preserve_behavior_and_are_counted`, `test_unhashable_and_hashable_destinations_still_compare_against_each_other` |
| identity work scales with distinct objects, not comparisons | `test_formula_identity_work_scales_with_distinct_objects`, `test_term_content_cid_is_one_object_one_answer`, `test_identity_memo_does_not_pin_dead_formulas` |
| comparisons scale near-linearly 100/200/400/800 | `test_destination_comparisons_scale_near_linearly` + `test_comparison_growth_is_sublinear_in_the_quadratic_ratio` (the curve) |
| `core/generic.py` clears via the **desugar-inclusive** reproducer | `DesugarAxis.measure`, not construction-only — a `fn.sugar()`-only sweep reports a FALSE ZERO here |

New auditor over an **open** boundary:
`test_no_destination_species_has_a_finer_hash_than_its_equality`. A class that
overrides `__eq__` and keeps identity `__hash__` would make equal arms stop
merging with no test going red. **0 offenders across 142 Effect/FloorValue
classes today.** Retirement path: deletable the day those hierarchies close
their construction door against an `__eq__`/`__hash__` split.

## Arm population is reported SEPARATELY from normalization work

A 775-arm ExitSet may be semantically correct and the normalizer must handle
it. But if per-function arm counts grow exponentially with retained predicates,
**that is a second algebra defect and a faster normalizer must not hide it.**
The two numbers stay distinct in every report.

**Open question, deliberately NOT settled here:** can a retained predicate stay
attached as an obligation without eagerly materialising both truth faces into
separate arms?

## Floors preserved

No detector weakened, no test deleted or skipped, no rule loosened for green.
No size cap, no comparison shortcut, no equality fallback, no swallowed gap.
#6296's drained Floor rows and #6298's FOL obligations are untouched — neither
commit changes what is emitted, only how many times identity is asked.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bucket and memoize `ExitSet.normalize` and formula content-key lookups to fix timeout floor in `core/generic.py`
> - Reworks `ExitSet.normalize` in [exit_set.py](https://github.com/TSavo/sugar/pull/6307/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716) to index merged exits by a hash-derived destination key, limiting candidate comparisons to the relevant bucket instead of scanning all pairs.
> - Introduces weakref-backed memoization for formula content keys in [ir.py](https://github.com/TSavo/sugar/pull/6307/files#diff-8f3a2315439408bdc32a92b1cc595bdea6d50c4c13626b3b3cbdbff53375ee2a), short-circuiting repeated structural walks for the same formula object.
> - Extends term CID memoization to cache results keyed by the caller's object identity, avoiding re-interning on repeated queries.
> - Adds diagnostic counters (`unhashable_destination_arms`, `_formula_content_key_memo_size`) and reset helpers to support testing and observability.
> - Behavioral Change: arms with unhashable destinations still fall back to the all-pairs scan; hashable and unhashable candidates are now compared together to maintain correct merging semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 603179f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved normalization of exit sets, reducing unnecessary destination comparisons while preserving existing merge behavior.
  - Improved memoization for IR terms and formulas to avoid repeated identity and equality calculations.

- **Bug Fixes**
  - Preserved correct handling of unhashable destinations, hash collisions, cyclic formulas, and structurally equivalent IR objects.
  - Ensured temporary identity data does not retain discarded formulas.

- **Tests**
  - Added comprehensive coverage for normalization behavior, performance, guard merging, destination equality, and identity memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->