### PR TITLE
Restore black on the retained-obligation test #6298 added

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -916,9 +916,7 @@ def test_undecidable_message_predicate_is_retained_as_an_obligation(tmp_path):
     consumed = _on_guard(routed, and_([body_halt.guard, obligation]))
     assert isinstance(consumed, Completed)
     # Never dropped: the other face restores the EXACT incoming effect.
-    retained = _on_guard(
-        routed, and_([body_halt.guard, complement_guard(obligation)])
-    )
+    retained = _on_guard(routed, and_([body_halt.guard, complement_guard(obligation)]))
     assert isinstance(retained, Halted)
     assert retained.effect == body_halt.effect
     assert retained.effect.occurrence == body_halt.effect.occurrence


### PR DESCRIPTION
`core (Python format)` is red on **origin/main itself**, not on any branch above it. Every PR opened on top of main inherits the failure, so it reads as that PR's red.

Verified on a clean `origin/main` worktree:

```
$ black --check implementations/python
would reformat implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
1 file would be reformatted, 833 files would be left unchanged.
```

The offender is a single call in the test `a0d38afca` (#6298) added, split across three lines where black joins it into one:

```python
-    retained = _on_guard(
-        routed, and_([body_halt.guard, complement_guard(obligation)])
-    )
+    retained = _on_guard(routed, and_([body_halt.guard, complement_guard(obligation)]))
```

**Whitespace only.** The assertion, the guard, the complement, and the restored-effect checks are untouched — #6298's retained-obligation tooth keeps both faces exactly as it had them.

Validation: `black --check implementations/python` → "834 files would be left unchanged" on this branch (`make test-python-format` runs the same command).

Landed separately from the ExitSet repair (#6307) so that PR's attribution stays clean and so the shared format gate stops blocking every branch above main. Does not close #6309.

Confirmed with fmt-repair that this was outside their dispatch (`cargo fmt` on sugar-linker/sugar-compiler only) — no collision.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reformat `test_undecidable_message_predicate_is_retained_as_an_obligation` with black
> Collapses a multi-line `_on_guard(and_([...]))` call into a single line in [test_with_partition_shared_algebra.py](https://github.com/TSavo/sugar/pull/6310/files#diff-4c2dc084662d16aaa82b994deee4c8e6f1a999e1d2e90bfbc1c64be73b88e1b5). No functional or logical changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6671aeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->