### PR TITLE
Authenticate identity once, index the ExitSet merge (R(timeout)=1 before and after; arm growth remains)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -31,7 +31,6 @@ def _callsite_coordinate_memo_size() -> int:
     return len(_CALLSITE_COORDINATE)
 
 
-
 def _term_cycle_key(term: Term) -> str:
     """Return a permanent content coordinate for an arbitrarily deep term.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
+import weakref
 from dataclasses import dataclass, field as dataclass_field
 from typing import Any, NoReturn
 
@@ -16,6 +17,19 @@ _NESTED_DIG_DEMAND_BUDGET = 8
 _ACTIVE_DIG_DEMAND: ContextVar[int] = ContextVar(
     "sugar_callsite_active_dig_demand", default=0
 )
+
+# Authenticated-coordinate memo: id(CallSiteValue) -> (weakref, coordinate).
+# Weakrefs only, so a dead callsite is never pinned for process lifetime and a
+# recycled address cannot inherit its identity (the ``is``-guard rejects it).
+# Not a WeakKeyDictionary: that would call ``CallSiteValue.__hash__``, which is
+# the seat being memoized.
+_CALLSITE_COORDINATE: dict[int, tuple["weakref.ReferenceType", tuple]] = {}
+
+
+def _callsite_coordinate_memo_size() -> int:
+    """Live memo entries (test / diagnostics only)."""
+    return len(_CALLSITE_COORDINATE)
+
 
 
 def _term_cycle_key(term: Term) -> str:
@@ -130,6 +144,51 @@ class CallSiteValue(FloorValue):
 
         return Complete(SymbolicValue(ctor("py.getattr", [self.term, str_const(name)])))
 
+    def _identity(self) -> tuple:
+        """Authenticate this immutable callsite's finite coordinate once.
+
+        ``__hash__`` and ``__eq__`` both read this one seat, so they cannot
+        disagree. Before the memo, every comparison rebuilt the coordinate —
+        including ``_term_cycle_key``, a full content CID of the term. The
+        pandas reproducer measured 35,339,381 ``_term_content_cid`` calls
+        arriving through this path on a single file, because ``ExitSet``
+        merging compares the same callsites repeatedly.
+
+        A ``CallSiteValue`` is a frozen dataclass, so a coordinate computed
+        once cannot go stale. The memo carries the same discipline as
+        ``ir._TERM_CONTENT_CID``: identity is the coordinate, ``id()`` only
+        indexes, and a weakref ``is``-guard rejects recycled addresses so a
+        reused id can never inherit a dead callsite's identity.
+        """
+        cid = id(self)
+        entry = _CALLSITE_COORDINATE.get(cid)
+        if entry is not None:
+            ref, coordinate = entry
+            if ref() is self:
+                return coordinate
+            if ref() is None:
+                _CALLSITE_COORDINATE.pop(cid, None)
+
+        coordinate = (
+            type(self),
+            self.target_name,
+            self.parameters,
+            _term_cycle_key(self.term),
+        )
+
+        def _on_die(ref: weakref.ReferenceType, *, _cid: int = cid) -> None:
+            current = _CALLSITE_COORDINATE.get(_cid)
+            if current is not None and current[0] is ref:
+                _CALLSITE_COORDINATE.pop(_cid, None)
+
+        try:
+            _CALLSITE_COORDINATE[cid] = (weakref.ref(self, _on_die), coordinate)
+        except TypeError:
+            # Not weak-referenceable: recompute every time rather than pin the
+            # object for process lifetime.
+            pass
+        return coordinate
+
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.
 
@@ -141,14 +200,7 @@ class CallSiteValue(FloorValue):
         recursive payload fields is safe for hash equality (equal values still
         receive the same hash) and makes identity total over cyclic bodies.
         """
-        return hash(
-            (
-                type(self),
-                self.target_name,
-                self.parameters,
-                _term_cycle_key(self.term),
-            )
-        )
+        return hash(self._identity())
 
     def __eq__(self, other: object) -> bool:
         """Compare the same finite authenticated coordinate used by ``__hash__``.
@@ -160,17 +212,9 @@ class CallSiteValue(FloorValue):
         """
         if not isinstance(other, CallSiteValue):
             return NotImplemented
-        return (
-            type(self),
-            self.target_name,
-            self.parameters,
-            _term_cycle_key(self.term),
-        ) == (
-            type(other),
-            other.target_name,
-            other.parameters,
-            _term_cycle_key(other.term),
-        )
+        if self is other:
+            return True
+        return self._identity() == other._identity()
 
     def to_term(self, *, owner: str):
         del owner

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -566,6 +566,103 @@ def _formula_cycle_key(formula: "Formula") -> tuple:
     return _formula_content_key(formula)
 
 
+# Content-key memo: id(formula) → (weakref(formula), key, hash).
+#
+# Formulas are frozen dataclasses with tuple children, so a value that has been
+# authenticated once cannot change. Before this memo, every ``__hash__`` and
+# every ``__eq__`` recomputed ``_formula_content_key`` — a full walk of the
+# formula DAG plus one content CID per term argument. The pandas reproducer
+# measured 3,452,624 content-key walks over 377,167 distinct formula objects on
+# a single file: 9.15 re-authentications of each immutable value.
+#
+# Same discipline as ``_TERM_CONTENT_CID`` above, for the same reasons:
+# - identity is the KEY (content), never ``id()``; ``id()`` indexes the memo
+# - the weakref ``is``-guard rejects recycled ids, so a reused address cannot
+#   inherit a dead formula's identity
+# - not a WeakKeyDictionary: that would call ``Formula.__hash__``, which is the
+#   very thing being memoized
+# - the callback drops the slot when the referent dies, so GC reclaims
+#
+# CYCLES ARE NOT MEMOIZED. ``_formula_key`` encodes a back-edge as
+# ``("cycle", id(node))`` — an occurrence-derived coordinate, not a content
+# one. Caching that would let an id-derived identity outlive the object and
+# silently become another formula's identity. A cyclic formula therefore
+# recomputes every time and stays exactly as loud as it is today.
+_FORMULA_CONTENT_KEY: dict[int, tuple[weakref.ReferenceType, tuple, int]] = {}
+
+
+def _formula_content_key_memo_size() -> int:
+    """Live memo entries (test / diagnostics only)."""
+    return len(_FORMULA_CONTENT_KEY)
+
+
+def _evict_formula_content_key(formula: "Formula") -> bool:
+    """Drop any memoized content key for ``formula``.
+
+    Recomputation after eviction is deterministic: the same structural formula
+    yields the same key. Eviction is cache control only — never identity.
+    """
+    fid = id(formula)
+    entry = _FORMULA_CONTENT_KEY.get(fid)
+    if entry is None:
+        return False
+    wr, _key, _hashed = entry
+    if wr() is formula:
+        del _FORMULA_CONTENT_KEY[fid]
+        return True
+    if wr() is None:
+        _FORMULA_CONTENT_KEY.pop(fid, None)
+    return False
+
+
+def _key_contains_cycle(key: object) -> bool:
+    """True when a content key carries an occurrence-derived back-edge marker."""
+    stack = [key]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, tuple):
+            if len(node) == 2 and node[0] == "cycle":
+                return True
+            stack.extend(node)
+    return False
+
+
+def _formula_identity(formula: "Formula") -> tuple[tuple, int]:
+    """Authenticate one immutable formula object once: (content key, hash).
+
+    Both ``__hash__`` and ``__eq__`` read this one seat, so hash and equality
+    can never disagree about what a formula is.
+    """
+    fid = id(formula)
+    entry = _FORMULA_CONTENT_KEY.get(fid)
+    if entry is not None:
+        wr, key, hashed = entry
+        if wr() is formula:
+            return key, hashed
+        if wr() is None:
+            _FORMULA_CONTENT_KEY.pop(fid, None)
+
+    key = _formula_content_key(formula)
+    hashed = hash(key)
+    if _key_contains_cycle(key):
+        # Occurrence-derived identity: correct for this live object, unsafe to
+        # retain. Recompute forever rather than cache a lie.
+        return key, hashed
+
+    def _on_die(wr: weakref.ReferenceType, *, _fid: int = fid) -> None:
+        current = _FORMULA_CONTENT_KEY.get(_fid)
+        if current is not None and current[0] is wr:
+            _FORMULA_CONTENT_KEY.pop(_fid, None)
+
+    try:
+        _FORMULA_CONTENT_KEY[fid] = (weakref.ref(formula, _on_die), key, hashed)
+    except TypeError:
+        # Not weak-referenceable: authenticate every time rather than pin the
+        # object for process lifetime.
+        pass
+    return key, hashed
+
+
 def make_var(name: str) -> Term:
     return _intern_term(_Var(name))
 
@@ -683,12 +780,14 @@ class _Atomic:
     args: Tuple[Term, ...]
 
     def __hash__(self) -> int:
-        return hash(_formula_cycle_key(self))
+        return _formula_identity(self)[1]
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _Atomic) and _formula_cycle_key(
-            self
-        ) == _formula_cycle_key(other)
+        if not isinstance(other, _Atomic):
+            return False
+        if self is other:
+            return True
+        return _formula_identity(self)[0] == _formula_identity(other)[0]
 
 
 @dataclass(frozen=True)
@@ -697,12 +796,14 @@ class _Connective:
     operands: Tuple["Formula", ...]
 
     def __hash__(self) -> int:
-        return hash(_formula_cycle_key(self))
+        return _formula_identity(self)[1]
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _Connective) and _formula_cycle_key(
-            self
-        ) == _formula_cycle_key(other)
+        if not isinstance(other, _Connective):
+            return False
+        if self is other:
+            return True
+        return _formula_identity(self)[0] == _formula_identity(other)[0]
 
 
 @dataclass(frozen=True)
@@ -713,12 +814,14 @@ class _Quantifier:
     body: "Formula"
 
     def __hash__(self) -> int:
-        return hash(_formula_cycle_key(self))
+        return _formula_identity(self)[1]
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _Quantifier) and _formula_cycle_key(
-            self
-        ) == _formula_cycle_key(other)
+        if not isinstance(other, _Quantifier):
+            return False
+        if self is other:
+            return True
+        return _formula_identity(self)[0] == _formula_identity(other)[0]
 
 
 Formula = Union[_Atomic, _Connective, _Quantifier]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -79,6 +79,37 @@ def _or_guards(left: Formula, right: Formula) -> Formula:
     return or_([left, right])
 
 
+# Sentinel for a destination that cannot be hashed. Not an error and not a
+# reason to drop an arm: such an arm takes the original full scan.
+_UNHASHABLE = object()
+
+# Every unhashable destination that took the scan path, by exit kind. This is
+# the measured-fallback receipt: if this list is ever non-empty in a real run,
+# the slow path is real and someone must see it, rather than the quadratic
+# quietly surviving inside a "fixed" normalizer.
+_UNHASHABLE_DESTINATIONS: list[str] = []
+
+
+def _unhashable_destination_count() -> int:
+    """How many arms took the full-scan path (test / diagnostics only)."""
+    return len(_UNHASHABLE_DESTINATIONS)
+
+
+def _destination_key(exit_: "Exit[T]") -> object:
+    """Bucket key for an exit's DESTINATION, ignoring its guard.
+
+    Two exits merge exactly when their destinations are equal, so the guard —
+    the thing the merge rewrites — must not enter the key. Returns
+    ``_UNHASHABLE`` when the destination cannot be hashed.
+    """
+    try:
+        if isinstance(exit_, Completed):
+            return ("completed", hash(exit_.value))
+        return ("halted", hash(exit_.effect), hash(exit_.state))
+    except TypeError:
+        return _UNHASHABLE
+
+
 @dataclass(frozen=True)
 class Completed(Generic[T]):
     guard: Formula
@@ -135,12 +166,57 @@ class ExitSet(Generic[T]):
         return ExitSet(tuple(exits)).normalize()
 
     def normalize(self) -> "ExitSet[T]":
-        """Drop false exits and merge equal destinations by disjoining guards."""
+        """Drop false exits and merge equal destinations by disjoining guards.
+
+        The merge is indexed by destination hash, not an all-pairs scan.
+
+        The scan was quadratic in ARM COUNT with an expensive comparison: each
+        ``==`` on a callsite destination rebuilt a content coordinate. On
+        ``pandas/core/generic.py`` that reached 128,462 normalize calls over
+        arm sets up to 1,317 wide — an upper bound of 13,147,074 comparisons —
+        to merge away 1.9% of arms. The arm counts are honest; the scan was
+        not.
+
+        This changes cost, never meaning:
+
+        - **first-occurrence output order is preserved.** Buckets index INTO
+          ``merged``; ``merged`` itself is still appended in arrival order and
+          merges still write in place, so the emitted tuple is byte-identical
+          to the scan's.
+        - **hash never decides equality.** A bucket narrows the candidates; the
+          same exact comparison as before decides, so a hash collision costs a
+          comparison and nothing else.
+        - **the first match still wins.** Bucket indices are appended
+          ascending, so the earliest matching prior is found first, exactly as
+          ``break`` did.
+        - **unhashable destinations keep the old behaviour** — a full scan over
+          every prior, counted in ``_UNHASHABLE_DESTINATIONS`` so the slow path
+          is measured rather than silent. Nothing is dropped and nothing is
+          merged that the scan would not have merged.
+        """
         merged: list[Exit[T]] = []
+        buckets: dict[object, list[int]] = {}
+        unhashable: list[int] = []
+
         for exit_ in self.exits:
             if _is_false(exit_.guard):
                 continue
-            for index, prior in enumerate(merged):
+
+            key = _destination_key(exit_)
+            if key is _UNHASHABLE:
+                # Exact previous semantics: compare against every prior.
+                candidates: "list[int]" = list(range(len(merged)))
+                _UNHASHABLE_DESTINATIONS.append(type(exit_).__name__)
+            else:
+                candidates = buckets.get(key, ())
+                # An unhashable prior can still be equal to a hashable arrival
+                # only if equality disagrees with hashability; compare against
+                # those too rather than assume it cannot happen.
+                if unhashable:
+                    candidates = sorted({*candidates, *unhashable})
+
+            for index in candidates:
+                prior = merged[index]
                 same_completed = (
                     isinstance(exit_, Completed)
                     and isinstance(prior, Completed)
@@ -163,7 +239,13 @@ class ExitSet(Generic[T]):
                     )
                     break
             else:
+                index = len(merged)
                 merged.append(exit_)
+                if key is _UNHASHABLE:
+                    unhashable.append(index)
+                else:
+                    buckets.setdefault(key, []).append(index)
+
         return ExitSet(tuple(merged))
 
     def sequence(self, step: Callable[[T], "ExitSet[U]"]) -> "ExitSet[U]":

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_destination_hash_consistency.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_destination_hash_consistency.py
@@ -1,0 +1,148 @@
+"""The membrane the bucketed merge needs: hash must never be finer than equality.
+
+`ExitSet.normalize` buckets destinations by hash and decides by exact equality.
+That is sound only while ``a == b`` implies ``hash(a) == hash(b)``. The
+dangerous shape is a class that overrides ``__eq__`` and inherits
+object-identity ``__hash__``: two equal destinations would land in different
+buckets, quietly stop merging, and the ExitSet fingerprint would change with
+nothing going red.
+
+The randomized oracle in `test_exit_set_normalize_identity.py` cannot be
+trusted to catch that. It only sees the destination species its generator
+happens to build; a real offender would sit in a class the generator never
+constructs. Destination species arrive from an OPEN boundary — every new
+Effect and FloorValue is a new one — so this is a membrane over that
+boundary, not a fixture over a closed set.
+
+Auditor imported from #6307, which scanned 142 Effect/FloorValue classes with
+zero offenders. Credit to that PR; the merge it protects is #6311's.
+
+Retirement path: deletable the day ``Effect`` and ``FloorValue`` are closed
+hierarchies whose construction door refuses a subclass with an
+``__eq__``/``__hash__`` split. Until then no local type can close it, and the
+auditor earns its keep by naming the offender class and its two lawful fixes.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
+
+
+def _guard(index: int):
+    return atomic("g", [make_var(f"v{index}")])
+
+
+def test_no_destination_species_has_a_finer_hash_than_its_equality() -> None:
+    """Every destination species: custom ``__eq__`` implies a matching ``__hash__``.
+
+    Unhashable is fine — that takes the measured linear fallback.
+    Finer-than-equality is not: it is a silent merge failure.
+    """
+    import importlib
+    import pkgutil
+    import typing
+
+    import sugar_lift_py_tests as package
+    from sugar_lift_py_tests.effect import Effect
+    from sugar_lift_py_tests.floor import FloorValue
+
+    for module in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+        try:
+            importlib.import_module(module.name)
+        except BaseException:  # optional/heavy leaves are not this tooth's job
+            pass
+
+    roots: list[type] = []
+    for base in (Effect, FloorValue):
+        roots.extend(typing.get_args(base) or [base])
+
+    seen: set[type] = set()
+    stack = list(roots)
+    offenders: list[str] = []
+    while stack:
+        cls = stack.pop()
+        if not isinstance(cls, type) or cls in seen:
+            continue
+        seen.add(cls)
+        stack.extend(cls.__subclasses__())
+        if "__eq__" not in cls.__dict__:
+            continue
+        if cls.__dict__.get("__hash__", "inherited") is object.__hash__:
+            offenders.append(f"{cls.__module__}.{cls.__qualname__}")
+
+    assert seen, "destination species scan found no classes — the scan is broken"
+    assert not offenders, (
+        "destination species with custom __eq__ and identity __hash__: "
+        f"{offenders}. ExitSet.normalize buckets by hash and decides by "
+        "equality; a finer hash makes equal arms stop merging without any "
+        "test going red. Give each class a __hash__ over exactly the fields "
+        "its __eq__ compares (as CallSiteValue does), or set __hash__ = None "
+        "so it takes the measured linear fallback."
+    )
+
+
+def test_colliding_hashes_still_merge_when_actually_equal() -> None:
+    """A collision must not prevent a merge that equality demands.
+
+    The companion to `test_same_hash_but_unequal_destination_stays_separate`:
+    that one proves a collision does not force a merge, this one proves it
+    does not prevent one. Both directions, or the bucket is only half checked.
+    """
+
+    class AlwaysColliding:
+        def __init__(self, tag: str) -> None:
+            self.tag = tag
+
+        def __hash__(self) -> int:
+            return 7
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, AlwaysColliding) and self.tag == other.tag
+
+    produced = ExitSet(
+        (
+            Completed(_guard(1), AlwaysColliding("same")),
+            Completed(_guard(2), AlwaysColliding("same")),
+        )
+    ).normalize()
+
+    assert len(produced.exits) == 1, (
+        "two equal destinations sharing a hash must merge; the bucket narrows "
+        "candidates and equality decides"
+    )
+
+
+def test_unhashable_and_hashable_destinations_compare_against_each_other() -> None:
+    """A hashable arrival is still compared against unhashable priors.
+
+    Bucketing must not create two populations that never meet. An arrival with
+    a usable hash still checks the arms that took the fallback, so no pair of
+    equal destinations can be separated by hashability alone.
+    """
+
+    class SometimesHashable:
+        """Equal across instances; hashable only when ``ok`` is set."""
+
+        def __init__(self, ok: bool) -> None:
+            self.ok = ok
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, SometimesHashable)
+
+        def __hash__(self) -> int:
+            if not self.ok:
+                raise TypeError("unhashable by construction")
+            return 11
+
+    produced = ExitSet(
+        (
+            Completed(_guard(1), SometimesHashable(ok=False)),
+            Completed(_guard(2), SometimesHashable(ok=True)),
+        )
+    ).normalize()
+
+    assert len(produced.exits) == 1, (
+        "an unhashable prior and a hashable arrival that are EQUAL must still "
+        "merge; bucketing may narrow candidates but must never partition them"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_complexity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_complexity.py
@@ -1,0 +1,150 @@
+"""The complexity tooth: normalization work must not be quadratic in arms.
+
+`pandas/core/generic.py` timed out because `ExitSet.normalize` merged by
+scanning every prior arm. At 1,317 arms that is 866,586 destination
+comparisons for ONE call, and the corpus reproducer reached an upper bound of
+13,147,074 comparisons — to merge away 1.9% of arms.
+
+This tooth counts DESTINATION COMPARISONS, not wall time. Wall time on a
+shared box measures the box; comparison count measures the algorithm, and it
+is the quantity that regressed.
+
+It fails if the merge returns to quadratic growth, and it does not care how
+fast the machine is.
+
+Read with `test_exit_set_normalize_identity.py`: that file proves the merge
+still computes the same answer, this one proves it stops paying a quadratic
+price for it. Neither is sufficient alone — a merge can be fast and wrong, or
+correct and unusable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
+
+ARM_COUNTS = (100, 200, 400, 800)
+
+
+class CountingDestination:
+    """A destination that reports how often it was compared.
+
+    Hash is constant per tag, so bucketing is exercised honestly: equal
+    destinations land together, distinct ones are distinguished by the exact
+    comparison, never by the hash.
+    """
+
+    comparisons = 0
+
+    def __init__(self, tag: int) -> None:
+        self.tag = tag
+
+    def __hash__(self) -> int:
+        return hash(self.tag)
+
+    def __eq__(self, other: object) -> bool:
+        type(self).comparisons += 1
+        return isinstance(other, CountingDestination) and self.tag == other.tag
+
+
+def _guard(index: int):
+    return atomic("g", [make_var(f"v{index}")])
+
+
+def _workload(arm_count: int) -> tuple:
+    """Half the arms are repeats, so the merge does real work.
+
+    An all-distinct workload would prove nothing here: every arrival lands in
+    an empty bucket and the new merge performs ZERO comparisons, which passes
+    any bound trivially. Drawing from `arm_count // 2` destinations forces
+    every second arrival to find and compare against its prior — the path that
+    must stay cheap.
+    """
+    distinct = max(arm_count // 2, 1)
+    return tuple(
+        Completed(_guard(index), CountingDestination(index % distinct))
+        for index in range(arm_count)
+    )
+
+
+def _comparisons_for(arm_count: int) -> int:
+    """Destination comparisons the shipped merge makes on that workload."""
+    exits = _workload(arm_count)
+    CountingDestination.comparisons = 0
+    normalized = ExitSet(exits).normalize()
+    assert len(normalized.exits) == max(arm_count // 2, 1), "no arm may vanish"
+    return CountingDestination.comparisons
+
+
+def _scan_comparisons_for(arm_count: int) -> int:
+    """What the replaced all-pairs scan costs on the SAME workload.
+
+    Measured rather than assumed, so the curve compares like with like.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import Halted, _is_false, _or_guards
+
+    exits = _workload(arm_count)
+    CountingDestination.comparisons = 0
+    merged: list = []
+    for exit_ in exits:
+        if _is_false(exit_.guard):
+            continue
+        for index, prior in enumerate(merged):
+            if (
+                isinstance(exit_, Completed)
+                and isinstance(prior, Completed)
+                and exit_.value == prior.value
+            ):
+                merged[index] = Completed(
+                    _or_guards(prior.guard, exit_.guard), prior.value
+                )
+                break
+            if (
+                isinstance(exit_, Halted)
+                and isinstance(prior, Halted)
+                and exit_.effect == prior.effect
+                and exit_.state == prior.state
+            ):
+                break
+        else:
+            merged.append(exit_)
+    return CountingDestination.comparisons
+
+
+@pytest.mark.parametrize("arm_count", ARM_COUNTS)
+def test_comparisons_stay_near_linear_in_arm_count(arm_count: int) -> None:
+    """Comparisons scale with arms, not with arms squared.
+
+    The bound is deliberately generous — 8x the arm count — because the point
+    is to catch a return to quadratic growth, not to pin an exact constant. At
+    800 arms the old scan performs 319,600 comparisons; this bound is 6,400.
+    """
+    comparisons = _comparisons_for(arm_count)
+    scan = _scan_comparisons_for(arm_count)
+
+    assert comparisons <= arm_count * 8, (
+        f"{arm_count} arms cost {comparisons} destination comparisons; the "
+        f"all-pairs scan this repair replaced costs {scan} on the same "
+        "workload. normalize has returned to quadratic growth in arm count"
+    )
+
+
+def test_growth_curve_is_not_quadratic_across_the_range() -> None:
+    """Doubling the arms must not quadruple the comparisons.
+
+    A single point cannot distinguish a linear algorithm from a quadratic one
+    with a small constant. The curve can. Each doubling of arm count is
+    allowed to at most triple the comparison count; a quadratic would
+    reliably quadruple it.
+    """
+    measured = {count: _comparisons_for(count) for count in ARM_COUNTS}
+
+    for smaller, larger in zip(ARM_COUNTS, ARM_COUNTS[1:]):
+        low, high = measured[smaller], measured[larger]
+        assert high <= max(low, 1) * 3, (
+            f"comparisons grew {low} -> {high} when arms doubled "
+            f"{smaller} -> {larger}; doubling the arms roughly quadrupled the "
+            f"work, which is the quadratic signature. Full curve: {measured}"
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
@@ -1,0 +1,222 @@
+"""ExitSet.normalize: bucketed merge is the all-pairs scan, exactly.
+
+The repair replaced a quadratic all-pairs merge with a destination-hash
+indexed one. The merge decides which execution arms are the SAME destination,
+so a behaviour change here is a semantic change to every lifted function that
+branches — it would not show up as a crash, it would show up as a wrong
+formula months later. These teeth pin the replacement against the code it
+replaced, on the same inputs, arm for arm.
+
+The reference implementation below IS the pre-repair scan, kept verbatim. It
+is not a second opinion about what normalize should do; it is what normalize
+did. Every randomized case asserts byte-identical output.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from sugar_lift_py_tests.ir import atomic, make_var, not_, or_
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    Halted,
+    false_guard,
+    _is_false,
+    _or_guards,
+    _unhashable_destination_count,
+)
+from sugar_lift_py_tests.effect import RaiseEffect
+
+
+def _reference_normalize(exit_set: ExitSet) -> ExitSet:
+    """The pre-repair all-pairs scan, verbatim. The oracle, not a rewrite."""
+    merged: list = []
+    for exit_ in exit_set.exits:
+        if _is_false(exit_.guard):
+            continue
+        for index, prior in enumerate(merged):
+            same_completed = (
+                isinstance(exit_, Completed)
+                and isinstance(prior, Completed)
+                and exit_.value == prior.value
+            )
+            same_halted = (
+                isinstance(exit_, Halted)
+                and isinstance(prior, Halted)
+                and exit_.effect == prior.effect
+                and exit_.state == prior.state
+            )
+            if same_completed:
+                merged[index] = Completed(
+                    _or_guards(prior.guard, exit_.guard), prior.value
+                )
+                break
+            if same_halted:
+                merged[index] = Halted(
+                    _or_guards(prior.guard, exit_.guard), prior.effect, prior.state
+                )
+                break
+        else:
+            merged.append(exit_)
+    return ExitSet(tuple(merged))
+
+
+def _guard(index: int):
+    return atomic("g", [make_var(f"v{index}")])
+
+
+def _effect(name: str) -> RaiseEffect:
+    return RaiseEffect(exception_name=name)
+
+
+def _random_exits(rng: random.Random, count: int, distinct: int) -> tuple:
+    """Arms drawn from a small destination pool, so merges actually happen."""
+    exits = []
+    for _ in range(count):
+        guard = _guard(rng.randrange(distinct))
+        if rng.random() < 0.5:
+            exits.append(Completed(guard, f"dest{rng.randrange(distinct)}"))
+        else:
+            exits.append(
+                Halted(
+                    guard,
+                    _effect(f"eff{rng.randrange(distinct)}"),
+                    f"state{rng.randrange(distinct)}",
+                )
+            )
+    return tuple(exits)
+
+
+@pytest.mark.parametrize("seed", range(40))
+def test_bucketed_merge_is_byte_identical_to_the_scan(seed: int) -> None:
+    """Same arms in, same tuple out — order, count, guards, destinations."""
+    rng = random.Random(seed)
+    exits = _random_exits(rng, rng.randrange(1, 60), rng.randrange(1, 8))
+    subject = ExitSet(exits)
+
+    produced = ExitSet.normalize(subject)
+    expected = _reference_normalize(subject)
+
+    assert produced.exits == expected.exits
+    assert [type(e) for e in produced.exits] == [type(e) for e in expected.exits]
+    assert [e.guard for e in produced.exits] == [e.guard for e in expected.exits]
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_no_arm_disappears_and_order_is_first_occurrence(seed: int) -> None:
+    """Every distinct destination survives, in the order it first arrived."""
+    rng = random.Random(1000 + seed)
+    exits = _random_exits(rng, 40, 5)
+    kept = [e for e in exits if not _is_false(e.guard)]
+
+    produced = ExitSet(exits).normalize()
+
+    def destination(exit_):
+        if isinstance(exit_, Completed):
+            return ("completed", exit_.value)
+        return ("halted", exit_.effect, exit_.state)
+
+    first_seen: list = []
+    for exit_ in kept:
+        key = destination(exit_)
+        if key not in first_seen:
+            first_seen.append(key)
+
+    assert [destination(e) for e in produced.exits] == first_seen
+
+
+def test_equal_destinations_merge_and_disjoin_guards_exactly_once() -> None:
+    """Two arms, one destination: one output arm carrying the disjunction."""
+    left, right = _guard(1), _guard(2)
+    produced = ExitSet(
+        (Completed(left, "same"), Completed(right, "same"))
+    ).normalize()
+
+    assert len(produced.exits) == 1
+    assert produced.exits[0].value == "same"
+    assert produced.exits[0].guard == or_([left, right])
+
+
+def test_same_hash_but_unequal_destination_stays_separate() -> None:
+    """A collision costs a comparison, never an identity. Hash never decides."""
+
+    class Colliding:
+        def __init__(self, tag: str) -> None:
+            self.tag = tag
+
+        def __hash__(self) -> int:
+            return 4  # every instance collides, deliberately
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, Colliding) and self.tag == other.tag
+
+    subject = ExitSet(
+        (
+            Completed(_guard(1), Colliding("a")),
+            Completed(_guard(2), Colliding("b")),
+            Completed(_guard(3), Colliding("a")),
+        )
+    )
+    produced = subject.normalize()
+
+    assert produced.exits == _reference_normalize(subject).exits
+    assert len(produced.exits) == 2, "colliding-but-unequal arms must not merge"
+    assert produced.exits[0].value == Colliding("a")
+    assert produced.exits[1].value == Colliding("b")
+
+
+def test_unhashable_destination_preserves_behaviour_and_is_counted() -> None:
+    """The slow path stays correct AND stays visible. Never a silent drop."""
+    before = _unhashable_destination_count()
+
+    subject = ExitSet(
+        (
+            Completed(_guard(1), ["unhashable"]),
+            Completed(_guard(2), ["unhashable"]),
+            Completed(_guard(3), ["other"]),
+        )
+    )
+    produced = subject.normalize()
+
+    assert produced.exits == _reference_normalize(subject).exits
+    assert len(produced.exits) == 2
+    assert _unhashable_destination_count() > before, (
+        "an unhashable destination took the scan path and must be measured, "
+        "not silently absorbed into a 'fixed' normalizer"
+    )
+
+
+def test_false_guarded_arms_are_dropped_as_before() -> None:
+    guard = _guard(1)
+    subject = ExitSet(
+        (
+            Completed(false_guard(), "dropped"),
+            Completed(guard, "kept"),
+        )
+    )
+    produced = subject.normalize()
+
+    assert produced.exits == _reference_normalize(subject).exits
+    assert [e.value for e in produced.exits] == ["kept"]
+
+
+def test_both_faces_of_a_partition_survive() -> None:
+    """A retained predicate's truth AND false faces both reach the output.
+
+    #6298's whole point is that an undecidable predicate is not decided. A
+    merge that silently collapsed one face would decide it by omission.
+    """
+    predicate = atomic("undecidable", [make_var("m")])
+    subject = ExitSet(
+        (
+            Completed(predicate, "truth-face"),
+            Completed(not_(predicate), "false-face"),
+        )
+    )
+    produced = subject.normalize()
+
+    assert produced.exits == _reference_normalize(subject).exits
+    assert [e.value for e in produced.exits] == ["truth-face", "false-face"]

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
@@ -131,9 +131,7 @@ def test_no_arm_disappears_and_order_is_first_occurrence(seed: int) -> None:
 def test_equal_destinations_merge_and_disjoin_guards_exactly_once() -> None:
     """Two arms, one destination: one output arm carrying the disjunction."""
     left, right = _guard(1), _guard(2)
-    produced = ExitSet(
-        (Completed(left, "same"), Completed(right, "same"))
-    ).normalize()
+    produced = ExitSet((Completed(left, "same"), Completed(right, "same"))).normalize()
 
     assert len(produced.exits) == 1
     assert produced.exits[0].value == "same"


### PR DESCRIPTION
> ## `R(timeout) = 1 BEFORE AND AFTER THIS PR`
>
> **`pandas/core/generic.py` still crosses a 300s deadline with every commit here applied.** This PR removes one of two causes and locates the other. It does not restore the timeout floor and must not be read as doing so.
>
> **Files 122–1420 of the pandas corpus remain UNMEASURED at every commit.** No full-corpus dump was run. No completion percentage is claimed.
>
> #6305 stays open. #6309 (factored ExitSet / exit-DAG) is the remaining critical path.

## What this is

Bisected `R(timeout) = 0 -> 1` to `256618357` (#6296) — but #6296 is the **messenger, not the mechanism**. `exit_set.py` is byte-identical from `d94f67a31` through `256618357`. #6296 honestly increased the number of guarded exits, and a pre-existing quadratic merge then bit.

Landing as infrastructure: it removes an independently measured defect, substantially lowers the cost of the remaining reproducer, and establishes the authenticated identity the factored representation will need. Holding it would force the arm-population repair to be built on top of known quadratic comparison work.

## Bisect

Reproducer measured through the census's own per-file body — `open_source_file_for_construction` -> `fn.sugar()` -> `DesugarAxis.measure` — with a hard per-file SIGALRM.

| commit | | generic.py | `Formula.__eq__` | `_term_content_cid` | contains | unique operand pairs |
|---|---|---|---|---|---|---|
| `063df6c3a` | parent | 14.81s | 16,512 | 10,993 | 24 | 24 |
| `8c6ee6333` | #6293 | 16.53s | 17,472 | 11,504 | 25 | 25 |
| `256618357` | #6296 | **TIMEOUT** | 364,910+ | 5,620,856+ | 34 | 32 |
| `a0d38afca` | head | **TIMEOUT** | 993,904+ | 16,194,589+ | 34 | 32 |

Parent ran 406 files clean; #6293 ran 126 clean.

Two attractive fixes were rejected **on measurement, not taste**:

- **A membership cache.** 304 `contains` calls against 298 unique authenticated operand pairs across the measured prefix — ratio 1.02, identical at every commit. A perfect cache saves six calls out of 304.
- **A Formula identity memo alone.** Distinct Formula objects grew 89x between #6293 and #6296, so authentication count and distinct-object count do not converge. Per-object memoization is worth ~9.15x of a ~3,072x regression.

## Commits

**`edd8325af` — authenticate identity once per immutable object.** `Formula.__hash__`/`__eq__` recomputed `_formula_content_key` every call; `CallSiteValue.__eq__` rebuilt its coordinate through `_term_cycle_key` every comparison. Both types are frozen. Memoized per object with the discipline `ir._TERM_CONTENT_CID` already uses: identity is the content key, `id()` only indexes, a weakref `is`-guard rejects recycled addresses, GC reclaims via callback. No new digest, no wire identity, no repin.

**Cyclic formulas are not memoized.** `_formula_key` encodes a back-edge as `("cycle", id(node))` — occurrence-derived, not content. Caching it would let an id-derived identity outlive its object. Cycles recompute and stay exactly as loud as today.

**`05b363799` — index `ExitSet.normalize` by destination hash.** First-occurrence output order preserved (buckets index *into* `merged`), hash never decides equality, first match still wins, unhashable destinations keep the full scan and are counted in `_UNHASHABLE_DESTINATIONS` so the slow path is measured, never silent.

**`a8e3223ba` — audit destination species (imported from #6307).** The bucket is exact only while `a == b` implies `hash(a) == hash(b)`. A class with custom `__eq__` and inherited identity `__hash__` would land equal destinations in different buckets, stop merging, and change the fingerprint **with nothing going red** — and the randomized oracle cannot be relied on to catch it, because it only sees the species its generator builds. Scans **142** Effect/FloorValue species, 141 carrying a custom `__eq__`, **zero offenders**. Retirement path stated in the module: deletable when those hierarchies are closed against an `__eq__`/`__hash__` split.

## Teeth

**Semantic identity.** `test_exit_set_normalize_identity.py` keeps the pre-repair scan **verbatim as the oracle** and asserts byte-identical output over 40 randomized arm sets, plus first-occurrence order, no vanished arm, guards disjoined exactly once, same-hash-unequal staying separate, colliding-hashes still merging when equal, hashable arrivals still compared against unhashable priors, and **both faces of a retained predicate surviving**.

**Complexity.** Counts destination comparisons, not wall time — wall time on a shared box measures the box. Half the arms are repeats, because an all-distinct workload makes the new merge do **zero** comparisons and would pass any bound trivially.

| arms | new | old scan | speedup |
|---|---|---|---|
| 100 | 50 | 2,500 | 50x |
| 200 | 100 | 10,000 | 100x |
| 400 | 200 | 40,000 | 200x |
| 800 | 400 | 160,000 | 400x |

Doubling the arms doubles the new cost and quadruples the old.

**105 tests pass** on the rebased tree, including `test_exit_set.py`, `test_sequence_membership_floor.py`, `test_guarded_attribute_membership.py`, `test_residual_panic_floors.py` — #6293's and #6296's drained Floor rows remain drained.

Corroboration on the real corpus file: arms in/out are **1,317 / 1,305 both before and after**. Same arms, same merge result, far less work.

## Arm population versus normalization work — kept separate on purpose

| | `256618357` @300s | this PR @300s |
|---|---|---|
| `_term_content_cid` | 9,587,129 | **1,125,936** |
| normalize calls reached | 39,760 | **57,617** |
| arms processed | 153,749 | **231,105** |
| **max arms per set** | **1,317** | **1,317** |

~8.5x less content-CID work at ~1.5x more progress — roughly 12x cheaper per unit of progress — and still not enough, because **arm count is unchanged. A normalizer cannot change how many arms it is handed.**

### Where the arms come from

Histogram over 45,871 normalize calls on the reproducer:

```
arms <=    1 : 29,019  (63.26%)
arms <=   16 : 14,272  (31.11%)
arms <=   32 :     96  ( 0.21%)
arms <=  256 :     23  ( 0.05%)
arms <= 2048 :      3  ( 0.01%)
```

Three calls carry the quadratic. Construction site captured live from the interrupted frame: `SpreadCollectionSugar._collect` (`sugar/spread_sugar.py:16`) chains `and_then` once per spread element, and **`ExitSet.sequence` is a Cartesian product** — for each completed exit it appends every exit of `step(value)`. A spread over *k* elements each yielding *m* arms produces ***m^k***. #6296 made elements yield two faces instead of one, which turned a latent multiplication into 1,317 arms.

It is a **heavy tail, not one large set**: a single 1,317-arm set carries a pairwise bound of 866,586 alone. And it is already exponential in the spread algebra, independent of the With frontier.

The open question this PR deliberately does not answer, left to #6309: can a spread element retain its complete ExitSet as a **factor** so sequencing composes factors instead of distributing them into *m^k* concrete arms? Both faces must remain represented — no pruning, no assumed success, no bounded cap. "Collapse one arm" is not available.

## Measurement conditions

Load was **not** exclusive — ~40 sibling agents, load average 4.7 to 61 across runs, recorded per commit in `bisect-meta-<commit>.txt`. Counter ratios (55x to 3,072x) and hang-vs-complete survive that; fine wall-time comparisons do not, and none are claimed.

One instrument finding worth its own tooth: a **construction-only sweep returns a false zero here**, because the floor arms execute solely inside `DesugarAxis.measure`. My first reproducer did exactly that and found nothing. Any timeout floor that only constructs will read clean through this entire class of defect.

Supersedes #6307, whose `CallSiteValue` identity seat was absent and whose timeout-floor claim the end-to-end measurement contradicts. Its auditor is imported here with credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved exit normalization performance, reducing unnecessary destination comparisons while preserving existing merge behavior.
  * Added efficient memoization for repeated formula and call-site identity checks.

* **Bug Fixes**
  * Preserved correct merging for equal, colliding, and unhashable destinations.
  * Maintained exit ordering, guard handling, and partition behavior.

* **Tests**
  * Added coverage for normalization correctness, performance scaling, hashing consistency, and identity preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Index `ExitSet.normalize` by destination key to reduce pairwise comparisons
> - Replaces the all-pairs scan in `ExitSet.normalize` with a bucketed approach: exits are grouped by a `_destination_key` hash, so only exits in the same bucket are compared for merging.
> - Adds a `_UNHASHABLE` sentinel and fallback full-scan path for destinations whose hash raises; unhashable destinations are tracked via `_unhashable_destination_count()`.
> - Memoizes `__hash__`/`__eq__` for `_Atomic`, `_Connective`, and `_Quantifier` IR nodes using weakref-guarded identity caches in [ir.py](https://github.com/TSavo/sugar/pull/6311/files#diff-8f3a2315439408bdc32a92b1cc595bdea6d50c4c13626b3b3cbdbff53375ee2a) and [call_site_value.py](https://github.com/TSavo/sugar/pull/6311/files#diff-8c40ae10c3e0722cf284a5e0bb43d2d29524ce10b6eb590893ccfcab4785689a).
> - Adds test modules covering output identity vs. the prior all-pairs scan, hash collision safety, mixed hashability, and near-linear complexity shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8482b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->