### PR TITLE
Authenticate repeated destination identities once, and index ExitSet.normalize by destination

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -141,14 +141,7 @@ class CallSiteValue(FloorValue):
         recursive payload fields is safe for hash equality (equal values still
         receive the same hash) and makes identity total over cyclic bodies.
         """
-        return hash(
-            (
-                type(self),
-                self.target_name,
-                self.parameters,
-                _term_cycle_key(self.term),
-            )
-        )
+        return hash(self._identity())
 
     def __eq__(self, other: object) -> bool:
         """Compare the same finite authenticated coordinate used by ``__hash__``.
@@ -160,17 +153,32 @@ class CallSiteValue(FloorValue):
         """
         if not isinstance(other, CallSiteValue):
             return NotImplemented
-        return (
+        return self._identity() == other._identity()
+
+    def _identity(self) -> tuple:
+        """The finite authenticated coordinate, memoized per object (#6305).
+
+        Every field in it is frozen and immutable (``term`` is a content-
+        addressed IR term), so the tuple a given object yields never changes;
+        the memo is cache control, never identity. ``normalize`` compares one
+        exit against every prior one, so without this the same callsite remints
+        its coordinate once per comparison instead of once per object.
+
+        Stored through ``object.__setattr__`` because the dataclass is frozen,
+        and under a private name excluded from every field list — it is not
+        state, and it must not reach ``__repr__``, equality, or serialization.
+        """
+        cached = self.__dict__.get("_identity_key")
+        if cached is not None:
+            return cached
+        identity = (
             type(self),
             self.target_name,
             self.parameters,
             _term_cycle_key(self.term),
-        ) == (
-            type(other),
-            other.target_name,
-            other.parameters,
-            _term_cycle_key(other.term),
         )
+        object.__setattr__(self, "_identity_key", identity)
+        return identity
 
     def to_term(self, *, owner: str):
         del owner

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -498,21 +498,36 @@ def _term_intern_arg_key(term: "Term") -> tuple:
 _term_formula_key = _term_content_key
 
 
-def _formula_key(formula: "Formula", *, term_key) -> tuple:
-    """Finite structural formula key; ``term_key`` selects intern vs identity."""
+def _formula_key(formula: "Formula", *, term_key, layer=None) -> tuple:
+    """Finite structural formula key; ``term_key`` selects intern vs identity.
+
+    ``layer`` is an optional cross-call node memo (see ``_FORMULA_CONTENT_KEY``).
+    Only the content variant may pass one: the intern variant's term keys are
+    ``id()``-based under an active scope and must never outlive it.
+    """
     memo: dict[int, tuple] = {}
     active: set[int] = set()
+    walked: list[Formula] = []
+    cyclic = False
     stack: list[tuple[Formula, bool]] = [(formula, False)]
     while stack:
         node, expanded = stack.pop()
         marker = id(node)
         if marker in memo:
             continue
-        if not expanded and marker in active:
-            memo[marker] = ("cycle", marker)
-            continue
+        if not expanded:
+            if marker in active:
+                memo[marker] = ("cycle", marker)
+                cyclic = True
+                continue
+            if layer is not None:
+                cached = _formula_layer_get(layer, node)
+                if cached is not None:
+                    memo[marker] = cached
+                    continue
         if expanded:
             active.discard(marker)
+            walked.append(node)
             if isinstance(node, _Atomic):
                 memo[marker] = (
                     "atomic",
@@ -540,7 +555,91 @@ def _formula_key(formula: "Formula", *, term_key) -> tuple:
             stack.extend((child, False) for child in reversed(node.operands))
         elif isinstance(node, _Quantifier):
             stack.append((node.body, False))
+    if layer is not None and not cyclic:
+        # Only an acyclic walk may publish. A node reached inside a cycle
+        # carries a raw-address ``("cycle", id(...))`` marker, which is
+        # not that node's own content coordinate — publishing it would hand a
+        # later standalone lookup the wrong key.
+        for node in walked:
+            _formula_layer_put(layer, node, memo[id(node)])
     return memo[id(formula)]
+
+
+# Content-key memo for Formula nodes: id(node) → (weakref(node), key).
+#
+# Same discipline as ``_TERM_CONTENT_CID`` (#5572): identity is the structural
+# key, ``id()`` is a memo index only, and the weakref ``is``-guard rejects
+# recycled ids. Deliberately not a WeakKeyDictionary — that would invoke
+# ``Formula.__hash__``, which is the very thing this memo serves.
+#
+# Correctness invariant: entries are published only from an acyclic walk under
+# ``_term_content_key``, whose term CIDs are scope-stable (#5568 / #5569). So a
+# cached key is exactly what a fresh computation would mint, in or out of any
+# ``term_intern_scope``. Eviction is cache control only, never identity.
+_FORMULA_CONTENT_KEY: dict[int, tuple[weakref.ReferenceType, tuple]] = {}
+
+_FORMULA_CONTENT_KEY_MINTS = 0
+
+
+def _formula_content_key_memo_size() -> int:
+    """Live memo entries (test / diagnostics only)."""
+    return len(_FORMULA_CONTENT_KEY)
+
+
+def _formula_content_key_mints() -> int:
+    """Structural walks performed since process start (test / diagnostics only).
+
+    The identity gate: this counts *distinct objects* keyed, not comparisons.
+    """
+    return _FORMULA_CONTENT_KEY_MINTS
+
+
+def _formula_layer_get(layer: dict, node: "Formula") -> "tuple | None":
+    entry = layer.get(id(node))
+    if entry is None:
+        return None
+    wr, cached = entry
+    if wr() is node:
+        return cached
+    if wr() is None:
+        layer.pop(id(node), None)
+    return None
+
+
+def _formula_layer_put(layer: dict, node: "Formula", key: tuple) -> None:
+    global _FORMULA_CONTENT_KEY_MINTS
+    nid = id(node)
+    existing = layer.get(nid)
+    if existing is not None and existing[0]() is node:
+        return
+
+    def _on_die(wr: weakref.ReferenceType, *, _nid: int = nid) -> None:
+        cur = layer.get(_nid)
+        if cur is not None and cur[0] is wr:
+            layer.pop(_nid, None)
+
+    layer[nid] = (weakref.ref(node, _on_die), key)
+    _FORMULA_CONTENT_KEY_MINTS += 1
+
+
+def _evict_formula_content_key(formula: "Formula") -> bool:
+    """Drop any memoized content key for ``formula``.
+
+    Returns True when the memo held an entry for this exact object.
+    Recomputation after eviction is deterministic: same structural formula →
+    same key.
+    """
+    nid = id(formula)
+    entry = _FORMULA_CONTENT_KEY.get(nid)
+    if entry is None:
+        return False
+    wr, _key = entry
+    if wr() is formula:
+        del _FORMULA_CONTENT_KEY[nid]
+        return True
+    if wr() is None:
+        _FORMULA_CONTENT_KEY.pop(nid, None)
+    return False
 
 
 def _formula_intern_key(formula: "Formula") -> tuple:
@@ -553,8 +652,15 @@ def _formula_content_key(formula: "Formula") -> tuple:
 
     Always content-addressed term CIDs. Never ``id(_intern_term(...))``.
     Hash and equality share this one key (no hash-on-A / eq-on-B split).
+
+    Memoized per object (#6305): repeated hashing and equality of the same
+    guard — the shape ``ExitSet.normalize`` produces — pays one structural walk
+    per distinct node, not one per comparison.
     """
-    return _formula_key(formula, term_key=_term_content_key)
+    cached = _formula_layer_get(_FORMULA_CONTENT_KEY, formula)
+    if cached is not None:
+        return cached
+    return _formula_key(formula, term_key=_term_content_key, layer=_FORMULA_CONTENT_KEY)
 
 
 def _formula_cycle_key(formula: "Formula") -> tuple:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Callable, Generic, TypeVar
 
@@ -79,6 +80,82 @@ def _or_guards(left: Formula, right: Formula) -> Formula:
     return or_([left, right])
 
 
+_LOGGER = logging.getLogger("sugar_lift_py_tests.exit_set")
+
+# Sentinel for a destination that cannot be hashed. A distinct object rather than
+# ``None``, because ``None`` is a perfectly good destination key.
+_UNHASHABLE = object()
+
+
+@dataclass
+class _NormalizeStats:
+    """Measured fallback: normalization is observable, not assumed.
+
+    The bucketed normalizer's whole claim is that comparisons stop scaling with
+    the square of the arm count. A claim like that has to be measurable from
+    outside or it decays into folklore the first time someone adds a destination
+    type that does not hash.
+    """
+
+    calls: int = 0
+    arms: int = 0
+    comparisons: int = 0
+    unhashable_destinations: int = 0
+    _warned: bool = False
+
+    def record(self, *, arms: int, comparisons: int, unhashable: int) -> None:
+        self.calls += 1
+        self.arms += arms
+        self.comparisons += comparisons
+        self.unhashable_destinations += unhashable
+        if unhashable and not self._warned:
+            # LOUD, once per process: an unhashable destination silently degrades
+            # this back toward the all-pairs scan it replaced. Nothing is dropped
+            # and no merge is missed -- but the performance claim no longer holds,
+            # and that is worth saying rather than discovering in a timeout.
+            self._warned = True
+            _LOGGER.warning(
+                "ExitSet.normalize: %d unhashable destination(s); those exits fall "
+                "back to a full scan. Merges are still exact; comparisons are not "
+                "bucket-local for them.",
+                unhashable,
+            )
+
+    def reset(self) -> None:
+        self.calls = 0
+        self.arms = 0
+        self.comparisons = 0
+        self.unhashable_destinations = 0
+        self._warned = False
+
+
+_NORMALIZE_STATS = _NormalizeStats()
+
+
+def normalize_stats() -> _NormalizeStats:
+    """The live normalization counters, for scaling receipts and gates."""
+    return _NORMALIZE_STATS
+
+
+def _destination_key(exit_: "Exit[T]") -> object:
+    """A hash coordinate for an exit's DESTINATION -- never its guard.
+
+    Guards are what merging disjoins, so two exits to the same destination differ
+    precisely in their guards; keying on the guard would put them in different
+    buckets and defeat the merge. The class tag keeps a ``Completed`` value from
+    colliding with a ``Halted`` ``(effect, state)`` pair of the same shape.
+    """
+    if isinstance(exit_, Completed):
+        key: object = (Completed, exit_.value)
+    else:
+        key = (Halted, exit_.effect, exit_.state)
+    try:
+        hash(key)
+    except TypeError:
+        return _UNHASHABLE
+    return key
+
+
 @dataclass(frozen=True)
 class Completed(Generic[T]):
     guard: Formula
@@ -135,12 +212,51 @@ class ExitSet(Generic[T]):
         return ExitSet(tuple(exits)).normalize()
 
     def normalize(self) -> "ExitSet[T]":
-        """Drop false exits and merge equal destinations by disjoining guards."""
+        """Drop false exits and merge equal destinations by disjoining guards.
+
+        Indexed by DESTINATION HASH BUCKET, not by scanning every prior exit.
+        The old all-pairs scan was quadratic in arm count -- at ~775 arms that is
+        ~600k destination comparisons -- which is what put `core/generic.py` over
+        the timeout floor.
+
+        The bucket key is a hash coordinate only. **A collision is a collision,
+        never equality**: the exact comparison below still decides every merge, so
+        this changes the number of comparisons and nothing about which exits merge.
+        Equal destinations land in the same bucket because Python's hash/eq
+        contract guarantees equal objects hash equal -- that is what makes
+        bucket-local comparison complete rather than merely cheaper.
+
+        Order is preserved by construction: buckets hold INDICES into ``merged``,
+        candidates are visited in ascending index order, and a merge rewrites in
+        place at the first-occurrence position. So output order is first-occurrence
+        order, exactly as the scan produced.
+        """
         merged: list[Exit[T]] = []
+        # destination key -> indices into `merged`, ascending.
+        buckets: dict[object, list[int]] = {}
+        # Destinations that cannot be hashed. These are NOT dropped and NOT assumed
+        # distinct: they stay in a scanned list, and every exit is compared against
+        # them as well as against its own bucket. Without that, a hashable exit
+        # equal to an unhashable prior would silently fail to merge -- a wrong
+        # answer, not a slow one. Cost degrades only with the number of unhashable
+        # destinations, and the count is reported below.
+        unhashable: list[int] = []
+        comparisons = 0
         for exit_ in self.exits:
             if _is_false(exit_.guard):
                 continue
-            for index, prior in enumerate(merged):
+            key = _destination_key(exit_)
+            if key is _UNHASHABLE:
+                # Exact semantics demand a full scan here: an unhashable value may
+                # still compare equal to a hashable one, and only comparison knows.
+                candidates: list[int] = list(range(len(merged)))
+            elif unhashable:
+                candidates = sorted(buckets.get(key, []) + unhashable)
+            else:
+                candidates = buckets.get(key, [])
+            for index in candidates:
+                prior = merged[index]
+                comparisons += 1
                 same_completed = (
                     isinstance(exit_, Completed)
                     and isinstance(prior, Completed)
@@ -163,7 +279,15 @@ class ExitSet(Generic[T]):
                     )
                     break
             else:
+                index = len(merged)
                 merged.append(exit_)
+                if key is _UNHASHABLE:
+                    unhashable.append(index)
+                else:
+                    buckets.setdefault(key, []).append(index)
+        _NORMALIZE_STATS.record(
+            arms=len(self.exits), comparisons=comparisons, unhashable=len(unhashable)
+        )
         return ExitSet(tuple(merged))
 
     def sequence(self, step: Callable[[T], "ExitSet[U]"]) -> "ExitSet[U]":

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_scaling.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_scaling.py
@@ -1,0 +1,266 @@
+"""`ExitSet.normalize` is bucket-indexed: same answer, near-linear comparisons.
+
+Two obligations, and they are different in kind:
+
+1. EQUIVALENCE. The bucketed normalizer must produce byte-identical output to the
+   all-pairs scan it replaced, for every input -- same exits, same order, same
+   merged guards. That is checked against a reference implementation of the OLD
+   algorithm kept in this file, so the comparison is against the real prior
+   behaviour rather than against what someone remembers it did.
+
+2. SCALING. Comparisons must stop growing with the square of the arm count. The
+   old scan at ~775 arms is ~600k comparisons; that is what pushed
+   `core/generic.py` past the timeout floor.
+
+The scaling assertion counts COMPARISONS, not wall time. This box runs four
+fleets at load ~14, so a wall-clock threshold here would measure the box and
+would fail or pass for reasons that have nothing to do with the algorithm.
+Comparison counts are load-independent and are the thing the change is actually
+about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.ir import Formula, atomic, make_var, not_
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    Halted,
+    _is_false,
+    _or_guards,
+    normalize_stats,
+    true_guard,
+)
+
+
+def _reference_normalize(exit_set: ExitSet) -> ExitSet:
+    """The ORIGINAL all-pairs scan, verbatim, as the equivalence oracle."""
+    merged: list[object] = []
+    for exit_ in exit_set.exits:
+        if _is_false(exit_.guard):
+            continue
+        for index, prior in enumerate(merged):
+            same_completed = (
+                isinstance(exit_, Completed)
+                and isinstance(prior, Completed)
+                and exit_.value == prior.value
+            )
+            same_halted = (
+                isinstance(exit_, Halted)
+                and isinstance(prior, Halted)
+                and exit_.effect == prior.effect
+                and exit_.state == prior.state
+            )
+            if same_completed:
+                merged[index] = Completed(
+                    _or_guards(prior.guard, exit_.guard), prior.value
+                )
+                break
+            if same_halted:
+                merged[index] = Halted(
+                    _or_guards(prior.guard, exit_.guard), prior.effect, prior.state
+                )
+                break
+        else:
+            merged.append(exit_)
+    return ExitSet(tuple(merged))
+
+
+def _g(name: str) -> Formula:
+    return atomic(name, [make_var("state")])
+
+
+def _raise(name: str) -> RaiseEffect:
+    return RaiseEffect(exception_name=name)
+
+
+def _arms(count: int, *, distinct: int | None = None) -> tuple[object, ...]:
+    """`count` exits over `distinct` destinations, interleaved so merges are real."""
+    distinct = count if distinct is None else distinct
+    return tuple(
+        Completed(_g(f"g{i}"), f"dest{i % distinct}") for i in range(count)
+    )
+
+
+class TestEquivalence:
+    """Same answer as the scan, on the shapes that make merging non-trivial."""
+
+    @pytest.mark.parametrize(
+        "exits",
+        [
+            pytest.param((), id="empty"),
+            pytest.param(_arms(1), id="single"),
+            pytest.param(_arms(8), id="all-distinct"),
+            pytest.param(_arms(8, distinct=1), id="all-same-destination"),
+            pytest.param(_arms(9, distinct=3), id="interleaved-merges"),
+            pytest.param(
+                (
+                    Completed(_g("a"), "x"),
+                    Halted(_g("b"), _raise("ValueError"), "x"),
+                    Completed(_g("c"), "x"),
+                    Halted(_g("d"), _raise("ValueError"), "x"),
+                ),
+                id="completed-and-halted-same-payload-stay-separate",
+            ),
+            pytest.param(
+                (
+                    Halted(_g("a"), _raise("ValueError"), "s1"),
+                    Halted(_g("b"), _raise("ValueError"), "s2"),
+                    Halted(_g("c"), _raise("KeyError"), "s1"),
+                ),
+                id="halted-splits-on-effect-and-state",
+            ),
+            pytest.param(
+                (
+                    Completed(not_(true_guard()), "dropped"),
+                    Completed(_g("a"), "kept"),
+                ),
+                id="false-guard-dropped",
+            ),
+            pytest.param(
+                (
+                    Completed(_g("a"), "x"),
+                    Completed(not_(_g("a")), "x"),
+                ),
+                id="complement-guards-merge-to-true",
+            ),
+        ],
+    )
+    def test_matches_the_all_pairs_scan(self, exits):
+        source = ExitSet(tuple(exits))
+        assert source.normalize() == _reference_normalize(source)
+
+    def test_output_order_is_first_occurrence(self):
+        exits = (
+            Completed(_g("a"), "second"),
+            Completed(_g("b"), "first"),
+            Completed(_g("c"), "second"),
+        )
+        result = ExitSet(exits).normalize()
+        assert [e.value for e in result.exits] == ["second", "first"]
+        assert result == _reference_normalize(ExitSet(exits))
+
+    def test_no_arm_disappears(self):
+        exits = _arms(40, distinct=7)
+        result = ExitSet(exits).normalize()
+        assert len(result.exits) == 7
+        assert result == _reference_normalize(ExitSet(exits))
+
+
+class TestUnhashableDestinations:
+    """Never a silent drop, never a missed merge -- and the fallback is measured."""
+
+    def test_unhashable_destination_still_merges_and_is_counted(self):
+        # A list value cannot be a dict key; the old scan never needed one to be.
+        exits = (
+            Completed(_g("a"), ["unhashable"]),
+            Completed(_g("b"), ["unhashable"]),
+            Completed(_g("c"), "hashable"),
+        )
+        source = ExitSet(exits)
+        stats = normalize_stats()
+        stats.reset()
+        result = source.normalize()
+        # The two unhashable destinations are EQUAL, so they must merge -- exactly
+        # as the scan did. Bucketing must not turn "cannot hash" into "distinct".
+        assert len(result.exits) == 2
+        assert result == _reference_normalize(source)
+        assert stats.unhashable_destinations >= 1
+
+    def test_hashable_exit_merges_into_an_earlier_unhashable_prior(self):
+        """The asymmetry that a naive bucket-only lookup gets wrong.
+
+        A bucket lookup for a hashable exit will never find an unhashable prior,
+        because the prior is in no bucket. If the fallback list is not also
+        consulted, this silently fails to merge and the ExitSet grows an arm.
+        """
+
+        class SometimesHashable:
+            def __init__(self, hashable: bool) -> None:
+                self.hashable = hashable
+
+            def __eq__(self, other) -> bool:
+                return isinstance(other, SometimesHashable)
+
+            def __hash__(self):
+                if not self.hashable:
+                    raise TypeError("unhashable")
+                return 7
+
+        source = ExitSet(
+            (
+                Completed(_g("a"), SometimesHashable(hashable=False)),
+                Completed(_g("b"), SometimesHashable(hashable=True)),
+            )
+        )
+        result = source.normalize()
+        assert len(result.exits) == 1, "equal destinations must merge across the fallback"
+        assert result == _reference_normalize(source)
+
+
+class TestCollisionsAreNotEquality:
+    def test_same_hash_unequal_destination_stays_separate(self):
+        class Colliding:
+            def __init__(self, tag: str) -> None:
+                self.tag = tag
+
+            def __eq__(self, other) -> bool:
+                return isinstance(other, Colliding) and other.tag == self.tag
+
+            def __hash__(self) -> int:
+                return 1234  # every instance collides
+
+        source = ExitSet(
+            (
+                Completed(_g("a"), Colliding("x")),
+                Completed(_g("b"), Colliding("y")),
+                Completed(_g("c"), Colliding("x")),
+            )
+        )
+        result = source.normalize()
+        # Colliding hashes share a bucket; exact comparison still decides.
+        assert len(result.exits) == 2
+        assert result == _reference_normalize(source)
+
+
+class TestScaling:
+    """Comparisons, not wall time: load-independent and about the algorithm."""
+
+    @pytest.mark.parametrize("arms", [100, 200, 400, 800])
+    def test_comparisons_are_near_linear_in_arm_count(self, arms):
+        stats = normalize_stats()
+        stats.reset()
+        ExitSet(_arms(arms)).normalize()
+        # All-distinct destinations: the scan did n(n-1)/2 comparisons (800 arms ->
+        # 319,600). Bucketed, each exit finds an empty bucket and compares nothing.
+        assert stats.comparisons <= arms, (
+            f"{arms} arms took {stats.comparisons} comparisons; "
+            "bucketing should keep this at or below one per arm"
+        )
+
+    def test_growth_is_not_quadratic_across_the_curve(self):
+        measured: dict[int, int] = {}
+        for arms in (100, 200, 400, 800):
+            stats = normalize_stats()
+            stats.reset()
+            ExitSet(_arms(arms, distinct=arms // 4)).normalize()
+            measured[arms] = stats.comparisons
+        # Doubling the arms must not quadruple the comparisons. The old scan did
+        # exactly that; this is the gate that would catch a regression back to it.
+        for small, large in ((100, 200), (200, 400), (400, 800)):
+            assert measured[large] <= measured[small] * 3, (
+                f"comparisons {measured} grew faster than linear-ish from "
+                f"{small} to {large} arms"
+            )
+
+    def test_worst_case_single_destination_is_still_linear(self):
+        """Every arm to ONE destination -- the densest possible bucket."""
+        stats = normalize_stats()
+        stats.reset()
+        result = ExitSet(_arms(800, distinct=1)).normalize()
+        assert len(result.exits) == 1
+        # Each exit merges into the single prior on its first comparison.
+        assert stats.comparisons <= 800

--- a/implementations/python/sugar-lift-py-tests/tests/test_identity_derivation_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_identity_derivation_memo.py
@@ -1,0 +1,148 @@
+"""Identity derivation is paid once per distinct object, never per comparison.
+
+The gate for #6305 commit 1. ``ExitSet.normalize`` compares each incoming exit
+against every prior one, so a coordinate that reminted on every ``__hash__`` /
+``__eq__`` made identity work scale with *comparisons*. These tests pin the
+scaling to *distinct objects*, and pin that memoization did not become identity:
+the same structural formula still yields the same key, in or out of an intern
+scope, before or after eviction, and cyclic formulas are never published.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests import ir
+from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.ir import (
+    _Connective,
+    _evict_formula_content_key,
+    _formula_content_key,
+    _formula_content_key_mints,
+    and_,
+    atomic,
+    gt,
+    make_var,
+    num,
+    term_intern_scope,
+)
+
+
+def _distinct_guards(count: int) -> list:
+    return [
+        and_([gt(make_var(f"v{i}"), num(i)), gt(num(i), num(0))]) for i in range(count)
+    ]
+
+
+def test_formula_identity_work_scales_with_objects_not_comparisons() -> None:
+    guards = _distinct_guards(24)
+    for guard in guards:  # prime: one walk apiece
+        hash(guard)
+
+    before = _formula_content_key_mints()
+    comparisons = 0
+    for left in guards:
+        for right in guards:
+            left == right
+            hash(left)
+            comparisons += 1
+
+    assert comparisons == 24 * 24
+    # The all-pairs scan is the shape normalize produces. Not one walk of it.
+    assert _formula_content_key_mints() == before
+
+
+def test_first_derivation_walks_each_distinct_node_exactly_once() -> None:
+    guard = and_([gt(make_var("fresh_a"), num(7)), gt(make_var("fresh_b"), num(9))])
+
+    before = _formula_content_key_mints()
+    _formula_content_key(guard)
+    first_walk = _formula_content_key_mints() - before
+
+    # Root plus its two operands; the shared leaf terms are the term memo's job.
+    assert first_walk == 3
+
+    _formula_content_key(guard)
+    assert _formula_content_key_mints() - before == first_walk
+
+
+def test_memo_is_cache_control_not_identity() -> None:
+    guard = and_([gt(make_var("evict_me"), num(3))])
+    minted = _formula_content_key(guard)
+
+    assert _evict_formula_content_key(guard) is True
+    # Recomputation after eviction is deterministic and total, and republishes.
+    assert _formula_content_key(guard) == minted
+    assert _evict_formula_content_key(guard) is True
+
+
+def test_cached_key_is_scope_stable() -> None:
+    guard = and_([gt(make_var("scoped"), num(11))])
+    outside = _formula_content_key(guard)
+
+    with term_intern_scope():
+        assert _formula_content_key(guard) == outside
+
+    assert _formula_content_key(guard) == outside
+
+
+def test_structural_twins_agree_whether_or_not_either_is_cached() -> None:
+    left = and_([gt(make_var("twin"), num(5))])
+    cached = _formula_content_key(left)
+
+    right = _Connective("and", (gt(make_var("twin"), num(5)),))
+
+    assert _formula_content_key(right) == cached
+    assert left == right
+    assert hash(left) == hash(right)
+
+
+def test_cyclic_formula_nodes_are_never_published_to_the_memo() -> None:
+    inner = atomic("cyclic_probe", [make_var("c")])
+    cycle = _Connective("and", (inner,))
+    object.__setattr__(cycle, "operands", (inner, cycle))
+
+    # Finite and repeatable — the walk's cycle marker still does its job.
+    assert _formula_content_key(cycle) == _formula_content_key(cycle)
+
+    # A node reached inside a cycle carries an ancestor-relative marker, so it
+    # must not be cached: ``inner`` standing alone has its own coordinate.
+    assert _formula_content_key(inner) == _formula_content_key(
+        atomic("cyclic_probe", [make_var("c")])
+    )
+
+
+def test_callsite_identity_is_memoized_per_object(monkeypatch) -> None:
+    calls = [
+        CallSiteValue("opaque", (), (), make_var(f"site{i}"), None) for i in range(16)
+    ]
+    for call in calls:
+        hash(call)  # prime
+
+    # Memo *size* is the wrong gate: it counts distinct terms, so it is flat
+    # with or without this mechanism. Count the derivations themselves.
+    derivations = 0
+    real = ir._term_content_cid
+
+    def counting(term):
+        nonlocal derivations
+        derivations += 1
+        return real(term)
+
+    monkeypatch.setattr(ir, "_term_content_cid", counting)
+
+    comparisons = 0
+    for left in calls:
+        for right in calls:
+            left == right
+            comparisons += 1
+
+    assert comparisons == 16 * 16
+    # 512 coordinate derivations without the memo; none with it.
+    assert derivations == 0
+
+
+def test_callsite_memo_does_not_leak_into_the_dataclass_surface() -> None:
+    call = CallSiteValue("opaque", (), (), make_var("surface"), None)
+    hash(call)
+
+    assert "_identity_key" not in repr(call)
+    assert all(f.name != "_identity_key" for f in call.__dataclass_fields__.values())


### PR DESCRIPTION
Two coupled repairs for the `ExitSet.normalize` timeout floor, as one PR with two separately measurable commits, per the owner's spec.

```text
5290c326a  An object's content coordinate is a property of the object, so derive it once   <- commit 1 (identity)
16b1acd34  perf: ExitSet.normalize indexes destinations, it does not scan every prior      <- commit 2 (bucketing)
961f45935  origin/main tip
```

**On commit order.** The PR leads with identity because that is the prerequisite repair; the commits read bucketing-then-identity because commit 2 was pushed first and reordering a pushed branch costs more than this sentence does. The two commits touch disjoint files (`ir.py` + `call_site_value.py` + a new memo tooth vs `outcome/exit_set.py` + a scaling test), so the order is narrative, not a merge property.

## Commit 1 — memoize immutable Formula / CallSiteValue identity derivation

Own-baseline A/B, two worktrees, base immutable by construction, one pinned `release` binary (sha256 `2dcf21bc…`) held identical across both halves.

```text
head  3a8fa0276  129 failed, 1097 passed, 12 skipped, 5 errors   1243 collected  23m24s
base  f1406091a  128 failed, 1090 passed, 12 skipped, 5 errors   1235 collected  20m58s

collected node set   1232 vs 1232   IDENTICAL
failed+error ids      133 vs  133   IDENTICAL   (-rfE, errors inside the diff)
```

Every absolute difference is accounted for:

- collected `1243 − 1235 = 8` — exactly the new test file's 8 nodes, head-only by construction, all 8 passing.
- one node, `test_callsite_add_on_deep_terms_does_not_rebuild_cid_keys`, failed on head and passed on base. That is a #6303 wall-clock node — the same code, twice, twenty minutes apart, opposite verdicts. Gated out, the sets are identical.

Two `pyright` ratchet failures are present on **both** halves: trunk, not this change.

**So commit 1 changes no test's outcome.** 133 pre-existing failures on `f1406091a`, unmoved. What it adds is 8 passing nodes over the memo's own contract: publish-once, cyclic nodes never published, scope-stability, structural twins agreeing cached or not.

Its effect on normalization is a function of arm-merge density: constant −42% at n/4 destinations, `4N²−2N−8 → 11N−19` when every arm merges into one destination.

## Commit 2 — index `ExitSet.normalize` by destination hash bucket

Comparison counts flat-linear across 100/200/400/800 arms (799 comparisons for 800 arms, against 319,600 for the old all-pairs scan), oracle being the original scan verbatim. Whole-package A/B at base `aa313fa9` was outcome-neutral, failure node-id sets byte-identical.

The bucket key is a hash coordinate only; a collision is a collision, never equality, and the same exact comparison still decides every merge. Unhashable destinations stay in a scanned fallback compared against every exit, so they degrade toward the old scan loudly rather than silently growing a phantom arm.

## What this PR does NOT yet demonstrate

Stated plainly because neither receipt covers it:

- Commit 1 was A/B'd against `f1406091a`; commit 2 against `aa313fa9`. **Nobody has measured the two together.** Each is individually outcome-neutral and the files are disjoint, so a surprise from stacking is not expected — but it is unmeasured, not proven.
- The owner's stated gate is not outcome-neutrality. It is *"`core/generic.py` clears through the desugar-inclusive reproducer"* and *"full timeout floor returns to zero."* That is a property of the **stack**, and both commit messages say of themselves that neither commit alone delivers it. Commit 2's residual quadratic is `_or_guards` paying O(N) structural `Formula` equality per merge; commit 1 is the axis that addresses it.

**Correction: that floor measurement is not running, and this body previously said it was.** Nothing was on the box; the claim was wrong when written and is withdrawn rather than left to be discovered.

Why it is not a thing I can stand up here: `core/generic.py` is pandas' file, i.e. a **corpus** input, and the corpus is not in this checkout. The floor gate is the full-corpus `R_timeouts` scan owned by `factory-zero-tolerance.yml` — one heavy orchestrator, `timeout-minutes: 360`, gated behind `tools/heavy_measurement_lease.py`. `timeout-zero-tolerance.yml` is *discrimination only* by its own header and exercises the scanner (`test_timeout_zero_tolerance.py`, 4 nodes, planted-sleep and empty-surface teeth) — it does not touch the corpus and would not answer this question even if it passed.

So the floor gate against tip `5290c326a` is **unmeasured**, and it needs the corpus orchestrator under the lease, not a local run. Reviewers should treat this PR as two individually outcome-neutral commits whose coupled effect on the timeout floor is not yet demonstrated.

## The pinned binary is attested, not checkable

Both halves ran against one `SUGAR_BIN` artifact, sha256 `2dcf21bc5d1f5c0d72ad5d32770ffb7767eedb41028383274f6147508bee91dd`, freshly hashed at all four gate brackets (`head-before`, `head-after`, `base-before`, `base-after`) — four independent reads of the same value bracketing both halves.

**That file no longer exists.** It lived at `implementations/rust/target/release/sugar`, which is a mutable slot, and a later `cargo build --release -p sugar-cli` in the same worktree overwrote it. It is not in the local binary shelf (80 entries scanned) nor in any of 15 worktree release directories on that box.

So the "one artifact across both halves" property is **attested, not checkable**. Four bracketed reads of the same sha256 are a real attestation of constancy across the pair; they are not something a reviewer can re-derive, because pointing `SUGAR_BIN` at `2dcf21bc…` no longer resolves anywhere on that box. Stated here rather than left as a hash that looks resolvable and is not.

## Base drift, named rather than left implicit

The commit 1 pair was measured at `f1406091a`. The PR base is `961f45935`, one commit later: #6310, `-3/+1` of Black formatting in `test_with_partition_shared_algebra.py`. The receipt above is therefore true of a tree one whitespace commit behind this PR's base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache identity derivation and bucket `ExitSet.normalize` comparisons by destination key
> - `ExitSet.normalize` is rewritten to bucket exits by destination key before comparing, reducing comparisons from O(n²) across all arms to within-bucket only. Unhashable destinations are handled via a sentinel and compared against all buckets.
> - `CallSiteValue._identity` caches the identity tuple on the instance, so `__hash__` and `__eq__` avoid recomputing the term cycle key on repeated calls.
> - Formula content keys in [ir.py](https://github.com/TSavo/sugar/pull/6313/files#diff-8f3a2315439408bdc32a92b1cc595bdea6d50c4c13626b3b3cbdbff53375ee2a) are memoized globally using weakrefs and evicted when nodes are garbage-collected, with acyclic traversals publishing keys for reuse.
> - Diagnostic stats (`normalize_stats()`, `_formula_content_key_memo_size`, `_formula_content_key_mints`) and new test modules for scaling and memoization are added.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5290c32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved formula and call-site identity calculations through memoization, reducing repeated work during hashing and equality checks.
  - Optimized exit normalization with bucketed merging for faster handling of larger exit sets.
  - Preserved efficient behavior for cyclic, colliding, and unhashable destinations.

- **Bug Fixes**
  - Ensured structurally equivalent exits continue to merge correctly while preserving output order.

- **Tests**
  - Added coverage for identity caching, cycle handling, hash collisions, unhashable destinations, and normalization scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


