### PR TITLE
Spread: compose operand ExitSets as factors instead of their product (#6309)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -57,6 +57,42 @@ def complement_guard(guard: Formula) -> Formula:
     return not_(guard)
 
 
+class ExitSetFactoringGap(ValueError):
+    """A completed face that a guarded-value chain cannot faithfully carry.
+
+    Loud on contact, in the same shape as ``SourceCallBindingGap``: the message
+    names the two guards, why the collapse would lose an outcome, and the fix.
+    """
+
+
+def _conjuncts(guard: Formula) -> tuple[Formula, ...]:
+    """Flatten a conjunction into its literals; anything else is one literal."""
+    if getattr(guard, "kind", None) == "and":
+        flattened: list[Formula] = []
+        for operand in getattr(guard, "operands", ()):
+            flattened.extend(_conjuncts(operand))
+        return tuple(flattened)
+    return (guard,)
+
+
+def _are_exclusive(left: Formula, right: Formula) -> bool:
+    """Whether two guards provably cannot hold together, syntactically.
+
+    Branch joins produce guards that carry a literal and its negation (``g``
+    against ``not g``), which is why one level of literal comparison is enough
+    for the shapes the tower builds. This is a SOUND-ONLY test: a False answer
+    means "not provably exclusive", never "provably overlapping". Factoring
+    refuses on a False answer rather than assuming a partition.
+    """
+    if _is_false(left) or _is_false(right):
+        return True
+    right_literals = frozenset(_conjuncts(right))
+    for literal in _conjuncts(left):
+        if complement_guard(literal) in right_literals:
+            return True
+    return False
+
+
 def _and_guards(left: Formula, right: Formula) -> Formula:
     if _is_false(left) or _is_false(right) or _is_negation(left, right):
         return false_guard()
@@ -164,6 +200,82 @@ class ExitSet(Generic[T]):
             else:
                 exits.append(Halted(combined, exit_.effect, exit_.state))
         return ExitSet(tuple(exits)).normalize()
+
+    def factor_completed(self) -> "ExitSet[T]":
+        """Collapse the completed FACE into one arm carrying a guarded value.
+
+        This is the factoring primitive #6309 is built on. An ExitSet with
+        several completed arms is a partition of the completed face over guards;
+        the SAME partition can live at the exit level (m arms, one value each)
+        or at the value level (one arm, a ``GuardedValue`` chain). Both retain
+        every arm's guard and every arm's value — nothing is pruned, nothing is
+        assumed to succeed, nothing is capped.
+
+        The difference is what happens when such a face is SEQUENCED. Exit-level
+        arms multiply: k steps of m arms distribute into m ** k arms, because
+        ``sequence`` appends every exit of the tail under every completed exit of
+        the prefix. Value-level arms compose: k steps contribute k guarded values
+        to one arm, so both work and storage grow linearly in k. Same denotation,
+        different growth — which is the whole fix.
+
+        Halted arms are untouched: the halted face is not part of the value, so
+        it stays at the exit level where it already grows linearly.
+
+        REFUSES loudly when the completed arms are not provably pairwise
+        exclusive. A ``GuardedValue`` chain is first-match-wins, so it denotes
+        the same face as the arms only when at most one arm's guard can hold.
+        Two overlapping completed arms with different values mean both values are
+        reachable together — a set, not a selection — and quietly picking the
+        first would be a silent semantic change. There is no materializing
+        fallback here on purpose: the exponential is the defect, so the honest
+        answer is a named gap, not a return to it.
+        """
+        completed = [e for e in self.exits if isinstance(e, Completed)]
+        if len(completed) <= 1:
+            return self
+
+        for index, arm in enumerate(completed):
+            for other in completed[index + 1 :]:
+                if not _are_exclusive(arm.guard, other.guard):
+                    raise ExitSetFactoringGap(
+                        "ExitSet.factor_completed cannot factor a completed face "
+                        "whose arms are not provably exclusive.\n"
+                        f"  owner: {type(arm.value).__name__} / "
+                        f"{type(other.value).__name__}\n"
+                        f"  arm A guard: {arm.guard!r}\n"
+                        f"  arm B guard: {other.guard!r}\n"
+                        "  why this is a gap: a GuardedValue chain selects ONE "
+                        "face, so it can only carry a partition. Overlapping "
+                        "arms with different values are two simultaneously "
+                        "reachable outcomes, and collapsing them would drop one.\n"
+                        "  fix: give the producing sugar complementary guards "
+                        "(the branch join shape ``g`` / ``not g``), or extend "
+                        "_are_exclusive to see the exclusion these two guards "
+                        "already carry. Do NOT re-materialize the product: that "
+                        "is the m ** k blow-up #6309 removed."
+                    )
+
+        from sugar_lift_py_tests.floor import GuardedValue
+
+        chain = completed[-1].value
+        for arm in reversed(completed[:-1]):
+            chain = GuardedValue(arm.guard, arm.value, chain)
+
+        face_guard = completed[0].guard
+        for arm in completed[1:]:
+            face_guard = _or_guards(face_guard, arm.guard)
+
+        factored = Completed(face_guard, chain)
+        exits: list[Exit[T]] = []
+        placed = False
+        for exit_ in self.exits:
+            if isinstance(exit_, Halted):
+                exits.append(exit_)
+                continue
+            if not placed:
+                exits.append(factored)
+                placed = True
+        return ExitSet(tuple(exits))
 
     def normalize(self) -> "ExitSet[T]":
         """Drop false exits and merge equal destinations by disjoining guards.
@@ -470,6 +582,7 @@ def outcome_to_exitset(outcome) -> ExitSet:
 __all__ = [
     "Completed",
     "ExitSet",
+    "ExitSetFactoringGap",
     "Halted",
     "complement_guard",
     "false_guard",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -10,12 +10,75 @@ from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 def _collect(sugars: tuple, ctx, done: tuple, finish):
-    if not sugars:
-        return finish(done)
-    head, *tail = sugars
-    return head.desugar(ctx).and_then(
-        lambda value: _collect(tuple(tail), ctx, (*done, value), finish)
+    """Sequence spread operands by COMPOSING factors, never distributing them.
+
+    #6309. The previous body chained ``and_then`` once per operand, and
+    ``ExitSet.sequence`` appends every exit of the tail under every completed
+    exit of the prefix. With k operands of m arms each that is m ** k
+    materialized arms — and it is the arm POPULATION, not the per-merge cost,
+    that walled ``pandas/core/generic.py``: an observed 1,317-wide arm set with
+    a heavy tail (63% of normalize calls at one arm, three above 256), at guard
+    nesting depth only 4.
+
+    Each operand keeps its complete ExitSet as a FACTOR:
+
+    - its completed face is factored to one arm carrying a guarded value
+      (``ExitSet.factor_completed``), so k operands contribute k guarded values
+      to ONE arm instead of one arm per tuple in the product;
+    - its halted arms are lifted to the exit level under the prefix's completed
+      guard, where one arm per operand per effect is already linear;
+    - ``finish`` runs ONCE, on the factored value tuple, under the conjunction of
+      the operands' completed guards.
+
+    Both faces are retained in full. Nothing is pruned, no arm is capped, and
+    success is never assumed: an operand whose every path halts ends the fold
+    with only halted arms, which is exactly what the product said.
+
+    ``finish`` is also invoked once rather than once per completed tuple. The old
+    chain re-``desugar``ed each tail operand once per prefix arm; the fold walks
+    the operands in the same source order, once each.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import (
+        ExitSet,
+        Halted,
+        _and_guards,
+        _is_true,
+        outcome_to_exitset,
+        true_guard,
     )
+
+    prefix_guard = true_guard()
+    values = list(done)
+    halted: list = []
+
+    for sugar in sugars:
+        factors = outcome_to_exitset(sugar.desugar(ctx)).factor_completed()
+        completed = None
+        for exit_ in factors.exits:
+            if isinstance(exit_, Halted):
+                halted.append(
+                    Halted(
+                        _and_guards(prefix_guard, exit_.guard),
+                        exit_.effect,
+                        exit_.state,
+                    )
+                )
+            else:
+                completed = exit_
+        if completed is None:
+            # Every path through this operand halts: there is no completed
+            # continuation to hand to ``finish``, and the halted face is the
+            # whole meaning.
+            return ExitSet(tuple(halted)).normalize().collapse()
+        prefix_guard = _and_guards(prefix_guard, completed.guard)
+        values.append(completed.value)
+
+    tail = outcome_to_exitset(finish(tuple(values)))
+    if not _is_true(prefix_guard):
+        tail = tail.guarded(prefix_guard)
+    # ``collapse`` restores the linear ``Outcome`` for the unconditional case, so
+    # a spread with no guarded operand desugars to exactly what it did before.
+    return ExitSet((*halted, *tail.exits)).normalize().collapse()
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
@@ -1,0 +1,384 @@
+"""#6309 — spread sequencing keeps each element's ExitSet as a FACTOR.
+
+The defect this pins: ``SpreadCollectionSugar._collect`` chained ``and_then``
+once per spread element, and ``ExitSet.sequence`` appends every exit of
+``step(value)`` under every completed exit of the prefix.  With ``k`` elements
+of ``m`` arms each that is ``m ** k`` materialized arms — the population, not
+the per-merge cost, is what timed out ``pandas/core/generic.py``.
+
+These laws are deliberately REPRESENTATION-INDEPENDENT.  They do not pin the
+arm tuple, its order, or a byte fingerprint of it, because #6309 is licensed to
+change exactly that.  What may not change is the DENOTATION: which outcomes are
+reachable under which truth assignment to the guard atoms, and with which
+resolved value.  ``_denotation`` below is the legacy-expansion oracle: it
+expands both the old materialized arms and the new factored arms down to
+concrete per-assignment outcomes and compares those.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.ir import (
+    _Atomic,
+    _Connective,
+    _ConstStr,
+    _Ctor,
+    _Var,
+    and_,
+    atomic,
+    ctor,
+    make_var,
+    not_,
+)
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    Halted,
+    outcome_to_exitset,
+    true_guard,
+)
+from sugar_lift_py_tests.sugar.spread_sugar import SpreadCollectionSugar
+
+# --- the corpus shape: k elements, each with its own completed partition -----
+
+
+def _atom(name: str):
+    return atomic(name, [make_var("state")])
+
+
+class _TwoFacedElement:
+    """One spread element whose value depends on a guard, and which can halt.
+
+    Three arms, pairwise contradictory: halted under ``h``, and two completed
+    faces under ``not h and g`` / ``not h and not g``.  This is the shape a
+    branch join or a guarded binding hands to a spread operand, and it is the
+    shape whose Cartesian product exploded.
+    """
+
+    def __init__(self, index: int) -> None:
+        self.index = index
+        self.guard = _atom(f"g{index}")
+        self.halt_guard = _atom(f"h{index}")
+        self.effect = RaiseEffect(exception_name=f"E{index}")
+
+    def desugar(self, ctx=None):
+        del ctx
+        live = not_(self.halt_guard)
+        return ExitSet(
+            (
+                Halted(self.halt_guard, self.effect, None),
+                Completed(
+                    and_([live, self.guard]),
+                    SymbolicValue(ctor(f"true{self.index}", [])),
+                ),
+                Completed(
+                    and_([live, not_(self.guard)]),
+                    SymbolicValue(ctor(f"false{self.index}", [])),
+                ),
+            )
+        )
+
+
+class _SingleFacedElement:
+    """One spread element with exactly one completed arm and no halt."""
+
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(SymbolicValue(ctor(f"only{self.index}", [])))
+
+
+def _spread(elements) -> ExitSet:
+    sugar = SpreadCollectionSugar(
+        kind="list",
+        elements=tuple((None, element) for element in elements),
+        site="spread-site",
+    )
+    return outcome_to_exitset(sugar.desugar())
+
+
+# --- the legacy-expansion oracle: denotation, not representation ------------
+
+
+def _atoms(formula, seen: set) -> set:
+    if isinstance(formula, _Atomic):
+        seen.add(formula)
+    elif isinstance(formula, _Connective):
+        for operand in formula.operands:
+            _atoms(operand, seen)
+    return seen
+
+
+def _guard_atoms(exit_set: ExitSet) -> tuple:
+    seen: set = set()
+    for exit_ in exit_set.exits:
+        _atoms(exit_.guard, seen)
+    return tuple(sorted(seen, key=lambda a: a.name))
+
+
+def _holds(formula, assignment: dict) -> bool:
+    if isinstance(formula, _Atomic):
+        return assignment[formula]
+    if isinstance(formula, _Connective):
+        operands = formula.operands
+        if formula.kind == "and":
+            return all(_holds(operand, assignment) for operand in operands)
+        if formula.kind == "or":
+            return any(_holds(operand, assignment) for operand in operands)
+        if formula.kind == "not":
+            return not _holds(operands[0], assignment)
+        if formula.kind == "implies":
+            return (not _holds(operands[0], assignment)) or _holds(
+                operands[1], assignment
+            )
+    raise AssertionError(f"oracle cannot evaluate {formula!r}")
+
+
+def _formula_from_term(term):
+    """Read back a ``formula_term``-reified guard so a value can be resolved."""
+    assert isinstance(term, _Ctor) and term.name.startswith("formula:"), term
+    tag = term.name[len("formula:") :]
+    if tag in ("and", "or", "not", "implies"):
+        return _Connective(tag, tuple(_formula_from_term(a) for a in term.args))
+    return _Atomic(tag, tuple(term.args))
+
+
+def _resolve_term(term, assignment: dict):
+    """Drive every ``py.conditional`` in a term down to the selected face."""
+    if isinstance(term, _Ctor):
+        if term.name == "py.conditional" and len(term.args) == 3:
+            guard, when_true, when_false = term.args
+            chosen = (
+                when_true
+                if _holds(_formula_from_term(guard), assignment)
+                else when_false
+            )
+            return _resolve_term(chosen, assignment)
+        return ("ctor", term.name, tuple(_resolve_term(a, assignment) for a in term.args))
+    if isinstance(term, _Var):
+        return ("var", term.name)
+    if isinstance(term, _ConstStr):
+        return ("str", term.value)
+    return ("leaf", repr(term))
+
+
+def _denotation(exit_set: ExitSet, atoms: tuple) -> dict:
+    """Map every truth assignment to the SET of outcomes reachable under it.
+
+    Representation-independent by construction: guards are evaluated, values are
+    resolved through their conditionals, and the result is a frozenset of
+    ``("completed", resolved-term)`` / ``("halted", effect, state)`` pairs.  Two
+    ExitSets with the same denotation mean the same thing however they are
+    stored.
+    """
+    table = {}
+    for bits in itertools.product((False, True), repeat=len(atoms)):
+        assignment = dict(zip(atoms, bits))
+        reachable = set()
+        for exit_ in exit_set.exits:
+            if not _holds(exit_.guard, assignment):
+                continue
+            if isinstance(exit_, Completed):
+                term = exit_.value.to_term(owner="oracle")
+                reachable.add(("completed", _resolve_term(term, assignment)))
+            else:
+                reachable.add(("halted", exit_.effect, exit_.state))
+        table[bits] = frozenset(reachable)
+    return table
+
+
+def _legacy_collect(sugars, ctx, done, finish):
+    """The materialized Cartesian ``_collect`` this PR replaces, kept as oracle.
+
+    This is the pre-#6309 body verbatim.  It is the reference denotation, and it
+    is the thing that grows as ``m ** k``; it is retained ONLY so the laws below
+    can prove the factored representation denotes the same outcomes on bounded
+    examples.  It is never on the production path.
+    """
+    if not sugars:
+        return finish(done)
+    head, *tail = sugars
+    return head.desugar(ctx).and_then(
+        lambda value: _legacy_collect(tuple(tail), ctx, (*done, value), finish)
+    )
+
+
+def _legacy_spread(elements) -> ExitSet:
+    sugar = SpreadCollectionSugar(
+        kind="list",
+        elements=tuple((None, element) for element in elements),
+        site="spread-site",
+    )
+    # Re-use the production ``finish`` by driving the real desugar body with the
+    # legacy collector substituted in.
+    import sugar_lift_py_tests.sugar.spread_sugar as spread_module
+
+    production = spread_module._collect
+    spread_module._collect = _legacy_collect
+    try:
+        return outcome_to_exitset(sugar.desugar())
+    finally:
+        spread_module._collect = production
+
+
+# --- laws -------------------------------------------------------------------
+
+# Arities are capped so the PRE-fix state REPORTS RED instead of hanging: the
+# materialized product is 3 ** arity, and at arity 8 that is 6561 arms — slow
+# but finite, so the growth curve is readable in both states. Raising this cap
+# does not make the law stronger; it only converts a red into a wall clock.
+_ARITIES = (1, 2, 4, 6, 8)
+_GROWTH_ARITIES = (2, 4, 8)
+
+
+def _assert_at_most_linear(curve: dict, what: str) -> None:
+    """The growth law: multiplying arity by n may not multiply cost by more.
+
+    Stated as a bound, not an equality, because sub-linear is a better answer
+    than linear and must not read as a failure — the fix makes ``normalize``
+    calls flat, for instance. ``1.5`` is slack for constant terms at small
+    arity, and the pre-fix curve exceeds it by orders of magnitude (m ** k
+    against k), so the tolerance is not what decides the verdict.
+    """
+    arities = sorted(curve)
+    low, high = arities[0], arities[-1]
+    arity_ratio = high / low
+    cost_ratio = curve[high] / curve[low]
+    assert cost_ratio <= 1.5 * arity_ratio, (
+        f"{what} grew {cost_ratio:.1f}x while spread arity grew "
+        f"{arity_ratio:.1f}x — the factors are being distributed into their "
+        f"product, not composed. curve={curve}"
+    )
+
+
+def _arm_population(exit_set: ExitSet) -> int:
+    return len(exit_set.exits)
+
+
+def _stored_nodes(exit_set: ExitSet) -> int:
+    """Distinct retained nodes across every arm's guard and value.
+
+    Counted as a DAG, by object identity, because that is what is actually
+    stored: formulas and terms are interned, so element i's prefix guard is
+    ``and_([prefix_{i-1}, g_i])`` — two pointers, with the prefix SHARED, not
+    copied. Expanding those shared nodes into a tree would report O(k**2) for a
+    representation that retains O(k) objects, which would be measuring the
+    traversal rather than the storage.
+    """
+    seen: set[int] = set()
+
+    def visit(node) -> None:
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        if isinstance(node, _Connective):
+            for operand in node.operands:
+                visit(operand)
+        elif isinstance(node, _Ctor):
+            for arg in node.args:
+                visit(arg)
+
+    for exit_ in exit_set.exits:
+        visit(exit_.guard)
+        if isinstance(exit_, Completed):
+            visit(exit_.value.to_term(owner="size"))
+    return len(seen)
+
+
+def test_arm_population_grows_linearly_with_spread_arity() -> None:
+    """The population law: k factors of 3 arms may not cost 3**k arms."""
+    populations = {}
+    for arity in _ARITIES:
+        elements = [_TwoFacedElement(i) for i in range(arity)]
+        populations[arity] = _arm_population(_spread(elements))
+
+    # One completed face plus one halted arm per element: strictly linear.
+    assert populations == {arity: arity + 1 for arity in _ARITIES}, populations
+
+
+def test_stored_representation_grows_linearly_with_spread_arity() -> None:
+    """The storage law: the factored value may not hide an exponential either."""
+    sizes = [
+        (arity, _stored_nodes(_spread([_TwoFacedElement(i) for i in range(arity)])))
+        for arity in _GROWTH_ARITIES
+    ]
+    _assert_at_most_linear(dict(sizes), "retained DAG nodes")
+
+
+def test_work_grows_linearly_with_spread_arity() -> None:
+    """The work law: normalize calls, not just retained arms, stay linear."""
+    import sugar_lift_py_tests.outcome.exit_set as exit_set_module
+
+    counts = {}
+    original = exit_set_module.ExitSet.normalize
+    for arity in _GROWTH_ARITIES:
+        calls = [0]
+
+        def counting(self, _calls=calls):
+            _calls[0] += 1
+            return original(self)
+
+        exit_set_module.ExitSet.normalize = counting
+        try:
+            _spread([_TwoFacedElement(i) for i in range(arity)])
+        finally:
+            exit_set_module.ExitSet.normalize = original
+        counts[arity] = calls[0]
+
+    _assert_at_most_linear(counts, "ExitSet.normalize calls")
+
+
+def test_factored_spread_denotes_the_same_outcomes_as_legacy_expansion() -> None:
+    """Bounded extensional equivalence against the legacy-expansion oracle."""
+    for arity in (1, 2, 3):
+        elements = [_TwoFacedElement(i) for i in range(arity)]
+        factored = _spread(elements)
+        legacy = _legacy_spread(elements)
+        atoms = tuple(
+            sorted(
+                set(_guard_atoms(factored)) | set(_guard_atoms(legacy)),
+                key=lambda a: a.name,
+            )
+        )
+        assert _denotation(factored, atoms) == _denotation(legacy, atoms), arity
+
+
+def test_neither_outcome_face_disappears() -> None:
+    """Completed AND halted both survive factoring, for every element."""
+    elements = [_TwoFacedElement(i) for i in range(4)]
+    exits = _spread(elements)
+    assert any(isinstance(e, Completed) for e in exits.exits)
+    halted_effects = {e.effect for e in exits.exits if isinstance(e, Halted)}
+    assert halted_effects == {element.effect for element in elements}
+
+
+def test_single_arm_elements_keep_the_unfactored_shape() -> None:
+    """No conditional is invented where the element had one completed face."""
+    exits = _spread([_SingleFacedElement(i) for i in range(3)])
+    assert len(exits.exits) == 1
+    exit_ = exits.exits[0]
+    assert isinstance(exit_, Completed)
+    assert exit_.guard == true_guard()
+    term = exit_.value.to_term(owner="single")
+    assert "py.conditional" not in repr(term)
+
+
+def test_distinct_occurrences_stay_distinct_when_content_matches() -> None:
+    """Two elements with identical content are two positions, not one."""
+    twin = _TwoFacedElement(0)
+    exits = _spread([twin, twin])
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    assert completed
+    # Representation-independent: however many arms carry the completed face,
+    # every one of them must show TWO positions. Content equality is not
+    # occurrence identity — merging the twins would silently drop an element.
+    for arm in completed:
+        term = arm.value.to_term(owner="occurrence")
+        assert isinstance(term, _Ctor) and term.name == "python:list", term
+        assert len(term.args) == 2, term

--- a/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import itertools
 
+import pytest
+
 from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.floor import SymbolicValue
 from sugar_lift_py_tests.ir import (
@@ -41,7 +43,11 @@ from sugar_lift_py_tests.outcome.exit_set import (
     outcome_to_exitset,
     true_guard,
 )
-from sugar_lift_py_tests.sugar.spread_sugar import SpreadCollectionSugar
+from sugar_lift_py_tests.sugar.spread_sugar import (
+    SpreadCallSugar,
+    SpreadCollectionSugar,
+    SpreadDictSugar,
+)
 
 # --- the corpus shape: k elements, each with its own completed partition -----
 
@@ -94,13 +100,57 @@ class _SingleFacedElement:
         return Complete(SymbolicValue(ctor(f"only{self.index}", [])))
 
 
-def _spread(elements) -> ExitSet:
-    sugar = SpreadCollectionSugar(
+def _collection_sugar(elements):
+    """``[*a, *b, ...]``."""
+    return SpreadCollectionSugar(
         kind="list",
         elements=tuple((None, element) for element in elements),
         site="spread-site",
     )
-    return outcome_to_exitset(sugar.desugar())
+
+
+def _dict_sugar(elements):
+    """``{**a, **b, ...}`` — every entry is a None-key spread of one operand."""
+    return SpreadDictSugar(
+        entries=tuple((None, element) for element in elements),
+        site="spread-site",
+    )
+
+
+def _call_sugar(elements):
+    """``f(*a, *b, ...)`` — every argument is a starred operand."""
+    return SpreadCallSugar(
+        callee_name="f",
+        callee=None,
+        arguments=tuple(("star", None, element) for element in elements),
+        site="spread-site",
+    )
+
+
+# All three spread sugars route through the SAME ``_collect``, so all three
+# carried the same m ** k defect and all three are pinned here. Naming them
+# individually is the point: ``spread_sugar.py`` had NO tests at all — no file
+# under tests/ mentioned spread — which is how a Cartesian expansion lived in it
+# unnoticed until a 1,421-file corpus walked into it.
+_SUGARS = {
+    "collection": _collection_sugar,
+    "dict": _dict_sugar,
+    "call": _call_sugar,
+}
+_KINDS = tuple(_SUGARS)
+
+# The term each ``finish`` builds, and how many leading term arguments are NOT
+# operand positions, so the occurrence law can say "one position per operand"
+# without restating the production spelling.
+_TERM_SHAPE = {
+    "collection": ("python:list", 0),
+    "dict": ("python:dict", 0),
+    "call": ("python:call", 1),  # callee coordinate first, then one per operand
+}
+
+
+def _spread(elements, kind: str = "collection") -> ExitSet:
+    return outcome_to_exitset(_SUGARS[kind](elements).desugar())
 
 
 # --- the legacy-expansion oracle: denotation, not representation ------------
@@ -209,16 +259,14 @@ def _legacy_collect(sugars, ctx, done, finish):
     )
 
 
-def _legacy_spread(elements) -> ExitSet:
-    sugar = SpreadCollectionSugar(
-        kind="list",
-        elements=tuple((None, element) for element in elements),
-        site="spread-site",
-    )
-    # Re-use the production ``finish`` by driving the real desugar body with the
-    # legacy collector substituted in.
+def _legacy_spread(elements, kind: str = "collection") -> ExitSet:
+    # Re-use each sugar's production ``finish`` by driving the real desugar body
+    # with the legacy collector substituted in. That keeps the oracle honest
+    # about the ONE thing under test — how operands are sequenced — rather than
+    # re-spelling three ``finish`` bodies in the test.
     import sugar_lift_py_tests.sugar.spread_sugar as spread_module
 
+    sugar = _SUGARS[kind](elements)
     production = spread_module._collect
     spread_module._collect = _legacy_collect
     try:
@@ -291,27 +339,32 @@ def _stored_nodes(exit_set: ExitSet) -> int:
     return len(seen)
 
 
-def test_arm_population_grows_linearly_with_spread_arity() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_arm_population_grows_linearly_with_spread_arity(kind: str) -> None:
     """The population law: k factors of 3 arms may not cost 3**k arms."""
     populations = {}
     for arity in _ARITIES:
         elements = [_TwoFacedElement(i) for i in range(arity)]
-        populations[arity] = _arm_population(_spread(elements))
+        populations[arity] = _arm_population(_spread(elements, kind))
 
     # One completed face plus one halted arm per element: strictly linear.
     assert populations == {arity: arity + 1 for arity in _ARITIES}, populations
 
 
-def test_stored_representation_grows_linearly_with_spread_arity() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_stored_representation_grows_linearly_with_spread_arity(kind: str) -> None:
     """The storage law: the factored value may not hide an exponential either."""
-    sizes = [
-        (arity, _stored_nodes(_spread([_TwoFacedElement(i) for i in range(arity)])))
+    sizes = {
+        arity: _stored_nodes(
+            _spread([_TwoFacedElement(i) for i in range(arity)], kind)
+        )
         for arity in _GROWTH_ARITIES
-    ]
-    _assert_at_most_linear(dict(sizes), "retained DAG nodes")
+    }
+    _assert_at_most_linear(sizes, f"{kind}: retained DAG nodes")
 
 
-def test_work_grows_linearly_with_spread_arity() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_work_grows_linearly_with_spread_arity(kind: str) -> None:
     """The work law: normalize calls, not just retained arms, stay linear."""
     import sugar_lift_py_tests.outcome.exit_set as exit_set_module
 
@@ -326,41 +379,46 @@ def test_work_grows_linearly_with_spread_arity() -> None:
 
         exit_set_module.ExitSet.normalize = counting
         try:
-            _spread([_TwoFacedElement(i) for i in range(arity)])
+            _spread([_TwoFacedElement(i) for i in range(arity)], kind)
         finally:
             exit_set_module.ExitSet.normalize = original
         counts[arity] = calls[0]
 
-    _assert_at_most_linear(counts, "ExitSet.normalize calls")
+    _assert_at_most_linear(counts, f"{kind}: ExitSet.normalize calls")
 
 
-def test_factored_spread_denotes_the_same_outcomes_as_legacy_expansion() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_factored_spread_denotes_the_same_outcomes_as_legacy_expansion(
+    kind: str,
+) -> None:
     """Bounded extensional equivalence against the legacy-expansion oracle."""
     for arity in (1, 2, 3):
         elements = [_TwoFacedElement(i) for i in range(arity)]
-        factored = _spread(elements)
-        legacy = _legacy_spread(elements)
+        factored = _spread(elements, kind)
+        legacy = _legacy_spread(elements, kind)
         atoms = tuple(
             sorted(
                 set(_guard_atoms(factored)) | set(_guard_atoms(legacy)),
                 key=lambda a: a.name,
             )
         )
-        assert _denotation(factored, atoms) == _denotation(legacy, atoms), arity
+        assert _denotation(factored, atoms) == _denotation(legacy, atoms), (kind, arity)
 
 
-def test_neither_outcome_face_disappears() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_neither_outcome_face_disappears(kind: str) -> None:
     """Completed AND halted both survive factoring, for every element."""
     elements = [_TwoFacedElement(i) for i in range(4)]
-    exits = _spread(elements)
+    exits = _spread(elements, kind)
     assert any(isinstance(e, Completed) for e in exits.exits)
     halted_effects = {e.effect for e in exits.exits if isinstance(e, Halted)}
     assert halted_effects == {element.effect for element in elements}
 
 
-def test_single_arm_elements_keep_the_unfactored_shape() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_single_arm_elements_keep_the_unfactored_shape(kind: str) -> None:
     """No conditional is invented where the element had one completed face."""
-    exits = _spread([_SingleFacedElement(i) for i in range(3)])
+    exits = _spread([_SingleFacedElement(i) for i in range(3)], kind)
     assert len(exits.exits) == 1
     exit_ = exits.exits[0]
     assert isinstance(exit_, Completed)
@@ -369,16 +427,18 @@ def test_single_arm_elements_keep_the_unfactored_shape() -> None:
     assert "py.conditional" not in repr(term)
 
 
-def test_distinct_occurrences_stay_distinct_when_content_matches() -> None:
+@pytest.mark.parametrize("kind", _KINDS)
+def test_distinct_occurrences_stay_distinct_when_content_matches(kind: str) -> None:
     """Two elements with identical content are two positions, not one."""
     twin = _TwoFacedElement(0)
-    exits = _spread([twin, twin])
+    exits = _spread([twin, twin], kind)
     completed = [e for e in exits.exits if isinstance(e, Completed)]
     assert completed
+    name, leading = _TERM_SHAPE[kind]
     # Representation-independent: however many arms carry the completed face,
-    # every one of them must show TWO positions. Content equality is not
+    # every one of them must show TWO operand positions. Content equality is not
     # occurrence identity — merging the twins would silently drop an element.
     for arm in completed:
         term = arm.value.to_term(owner="occurrence")
-        assert isinstance(term, _Ctor) and term.name == "python:list", term
-        assert len(term.args) == 2, term
+        assert isinstance(term, _Ctor) and term.name == name, term
+        assert len(term.args) - leading == 2, term


### PR DESCRIPTION
Closes #6309.

## The defect

`SpreadCollectionSugar._collect` chained `and_then` once per spread operand, and `ExitSet.sequence` appends every exit of `step(value)` under every completed exit of the prefix. With k operands of m arms each that materializes **m^k** arms.

Measured on `pandas/core/generic.py`: a 1,317-wide arm set, heavy tail (63% of normalize calls at one arm, three above 256), guard nesting depth only 4. The arm **population** was the cost, so #6311's indexed merge could make each level cheaper but could not stop the levels multiplying. That file timed out at both 180s and 300s, which blocked measuring corpus files 122-1420.

## The change

Each operand keeps its complete ExitSet as a **factor**. `ExitSet.factor_completed` collapses a completed **face** of m arms into ONE arm carrying a `GuardedValue` chain: the same partition, moved from the exit level (where sequencing multiplies it) to the value level (where sequencing composes it). Halted arms stay at the exit level under the prefix's completed guard, where they already grow linearly. `finish` runs once, on the factored value tuple.

Both faces retained in full: no pruning, no assumed success, no arm cap, **no materializing fallback**. `factor_completed` refuses loudly (`ExitSetFactoringGap`, naming both guards and the fix) when the completed arms are not provably pairwise exclusive, since a first-match-wins chain can only carry a partition.

## Measured curve (arity 2 -> 8)

| quantity | baseline `e6d688d3c` | head |
| --- | --- | --- |
| arm population | 6 -> 264 | 3 -> 9 (exactly arity + 1) |
| retained DAG nodes | 33 -> 4335 | 35 -> 143 |
| `normalize` calls | 7 -> 511 | 4 -> 4 |

Arm **population** is reported separately from normalization **work**.

## Laws (`tests/test_spread_exit_factoring.py`)

Representation-independent on purpose, because #6309 is licensed to change the arm tuple:

- **bounded extensional equivalence** against a legacy-expansion oracle: the pre-#6309 Cartesian `_collect` kept verbatim, compared by DENOTATION -- every truth assignment mapped to the set of reachable outcomes, guarded values resolved through their conditionals.
- neither outcome face disappears; every element's effect survives.
- distinct occurrences stay distinct when their content matches.
- single-arm operands keep the unfactored shape byte for byte (63% of the corpus's normalize calls).
- at-most-linear growth in retained representation AND in work.

Arities are capped at 8 so the pre-fix state **reports red instead of hanging**.

## On the fingerprint tooth

`test_exit_set_normalize_identity.py` is deliberately **not** rewritten. It pins `ExitSet.normalize` against the pre-repair scan on arms it is *given*, so it constrains the merge, not how spread builds its arms. It does not fossilize the materialized representation and nothing in it went red, so weakening it would delete a live detector for no invariant gained. The new laws are additive.

## Floors preserved

- #6293/#6296 drained Floor rows remain drained; #6298's FOL obligations remain present (`test_both_faces_of_a_partition_survive` still green).
- No detector weakened, no test deleted or skipped, no panic suppressed. #6296 untouched.

## Epsilon R

`R(timeout)`: 1 -> 0 on `pandas/core/generic.py` via the desugar-inclusive reproducer (`DesugarAxis.measure`; a `fn.sugar()`-only sweep reports a false zero here). Corpus files 122-1420 become measurable.

## Retirement path

No shell retirable yet. When the same factoring carries the assertion-With (4,125 sites) and resource-With (811) families, the growth laws here become one parametrized law over every sequencing site, and `_are_exclusive`'s syntactic literal test becomes the honest ceiling to promote: a guard that CARRIES its partition would make `ExitSetFactoringGap` unconstructable.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compose spread operand ExitSets as factors instead of their Cartesian product
> - Replaces recursive `and_then` chaining in spread desugaring with guard-accumulated factoring via a new `ExitSet.factor_completed` method in [exit_set.py](https://github.com/TSavo/sugar/pull/6315/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716).
> - `factor_completed` compresses multiple `Completed` arms into a single `Completed` arm carrying a `GuardedValue` chain, after verifying pairwise guard exclusivity using a new `_are_exclusive` helper.
> - Introduces `ExitSetFactoringGap`, a `ValueError` subclass raised when `Completed` arms cannot be proven exclusive, signaling that factoring is not safe.
> - The rewritten `_collect` in [spread_sugar.py](https://github.com/TSavo/sugar/pull/6315/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945) tracks a conjunctive prefix guard across operands and early-returns a normalized `ExitSet` when an operand has no `Completed` continuation.
> - Risk: factoring raises `ExitSetFactoringGap` for guards that are not provably exclusive, whereas the old `and_then` chaining always succeeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b87a898.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->