### PR TITLE
DynamicUnpackAssign: submit the unpack demand to the RHS value

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .sequence_projection_operation import SequenceProjectionOperation
+
+__all__ = ["SequenceProjectionOperation"]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
@@ -1,0 +1,146 @@
+"""The sequence-projection operation: what ``a, b = <rhs>`` demands of one
+reduced RHS value.
+
+Python's unpacking assignment is ITERABLE unpacking, not subscription, and it
+is not a sequence of independent stores.  ``UNPACK_SEQUENCE`` materializes the
+right-hand side and demands EXACTLY the arity the target spells; only then does
+it bind, left to right.  So the whole statement has exactly two outcomes:
+
+    Unpack(value, arity)
+        the value yields exactly `arity` members -> Completed(names bound to
+                                                             those members)
+        it yields any other count, or is not iterable
+                                             -> Halted(unpack effect, nothing
+                                                       bound)
+
+Which one happens is decided by the RHS.  That decision is the whole content of
+the operation, and it splits on ONE question: does the reduced value carry
+authenticated finite members?
+
+- It does (a tuple/array literal floor value): the count is lift-time
+  decidable.  Matching arity binds each name to the member ALREADY IN HAND --
+  never a fabricated element.  A mismatch is a decidable ``ValueError`` whose
+  exact exceptional exit has no floor value yet, so it stays a loud
+  construction gap rather than a guessed exit.
+
+- It does not (a symbolic term, an object, an opaque call coordinate): the
+  cardinality is known only at runtime.  There is no lift-time evidence naming
+  either the count or the exception type, so the arity demand is retained as
+  the typed ``SequenceUnpackRuntimeEffect`` carrying the exact
+  ``python:unpack.destructure(term, arity)`` obligation -- the same coordinate
+  family the comprehension destructure already states
+  (``sugar/comprehension_sugar.py::_guard_destructure``).  Assuming the count
+  matched would be the one forbidden move.
+
+Anything else reaches ``FloorValue.project_sequence_with`` and stays a loud
+floor construction gap: an unwritten floor is never a silent success.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+
+@dataclass(frozen=True)
+class SequenceProjectionOperation:
+    """One unpack demand: ``target_names`` positions against one reduced RHS."""
+
+    method_name: ClassVar[str] = "project_sequence_with"
+
+    target_names: tuple[str, ...]
+    owner: str
+    blame: object
+
+    @property
+    def arity(self) -> int:
+        return len(self.target_names)
+
+    def submit(self, value: Any, ctx: Any) -> Any:
+        """Ask the value what it unpacks to. The value owns the answer."""
+        return value.project_sequence_with(self, ctx)
+
+    # -- authenticated finite members: the count is decidable ---------------
+
+    def project_tuple(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._authenticated_members(value, value.items, "tuple")
+
+    def project_array(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._authenticated_members(value, value.items, "array")
+
+    # -- runtime cardinality: the count is not decidable -------------------
+
+    def project_symbolic(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._runtime_cardinality(value)
+
+    def project_object(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._runtime_cardinality(value)
+
+    # -- the two answers ---------------------------------------------------
+
+    def _authenticated_members(self, value: Any, members: tuple, display: str) -> Any:
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+        from sugar_lift_py_tests.outcome import Complete
+
+        if len(members) != self.arity:
+            self._arity_mismatch_gap(value, len(members), display)
+        return Complete(
+            ScopeRebinds(tuple(zip(self.target_names, members, strict=True)))
+        )
+
+    def _runtime_cardinality(self, value: Any) -> Any:
+        from sugar_lift_py_tests.effect import (
+            SequenceUnpackRuntimeEffect,
+            runtime_effect_evidence_from_terms,
+        )
+        from sugar_lift_py_tests.ir import ctor, num
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        term = value.to_term(owner=f"{self.owner}.value")
+        operation = ctor(
+            "python:unpack.destructure",
+            [term, num(self.arity)],
+            symbol_kind="coordinate",
+        )
+        return Incomplete(
+            SequenceUnpackRuntimeEffect(
+                "sequence unpack runtime boundary: unpack demands exactly "
+                f"{self.arity} members for targets "
+                f"({', '.join(self.target_names)}) but the right-hand side "
+                "carries no authenticated cardinality -- iteration count "
+                "belongs to Python's runtime __iter__; "
+                f"arity={self.arity} site={self.blame}",
+                **runtime_effect_evidence_from_terms(operation, operation, self.blame),
+            )
+        )
+
+    def _arity_mismatch_gap(self, value: Any, members: int, display: str) -> None:
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic
+
+        relation = "not enough" if members < self.arity else "too many"
+        construction_panic(
+            ConstructionGap(
+                owner=self.owner,
+                blame=str(self.blame),
+                observed=(
+                    f"{type(value).__name__} of {members} members unpacked into "
+                    f"{self.arity} targets ({relation} values)"
+                ),
+                requested=(
+                    "ground ValueError exceptional exit for a decidable "
+                    f"{display} unpack arity mismatch"
+                ),
+                fix=(
+                    "write more Floor: a ground ValueError exit value so this "
+                    "decidable mismatch states its exception instead of "
+                    "panicking"
+                ),
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dynamic_unpack_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dynamic_unpack_assign_sugar.py
@@ -3,12 +3,38 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 
+from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
 
 
 @dataclass(frozen=True)
 class DynamicUnpackAssignSugar(Sugar):
-    """Construct a valid unpack shape while keeping unknown iteration loud."""
+    """``<name>, <name>, ... = <rhs>`` where the RHS is NOT a display.
+
+    The tree cannot pair targets with members here (``Assign._destructured_binding``
+    zips displays only), so ``substitution_binding`` threads nothing and the
+    names are still unbound when this statement reduces. That is exactly what
+    the desugar owes: evaluate the RHS ONCE, then ask the reduced value what it
+    unpacks to.
+
+    The answer is the value's, not this sugar's -- ``SequenceProjectionOperation``
+    is submitted through the floor's ``project_sequence_with`` port, and the
+    value decides:
+
+    - authenticated finite members (tuple/array literal): the arity is
+      lift-time decidable, so each name binds to the member ALREADY IN HAND and
+      rides forward as a ``ScopeRebinds`` support entry -- the same scope
+      threading a mutation uses, no second door;
+    - runtime cardinality (symbolic / object / opaque coordinate): the count
+      belongs to ``__iter__`` at runtime, so the arity demand is retained as a
+      typed ``SequenceUnpackRuntimeEffect``. Nothing binds on that arm, exactly
+      as CPython binds nothing when ``UNPACK_SEQUENCE`` raises;
+    - anything else: a loud floor construction gap.
+
+    No arm assumes the count matched, and no arm invents a member. The RHS's own
+    arms are conserved because it is reduced through ``and_then`` first.
+    """
 
     target_names: tuple[str, ...]
     value: Sugar
@@ -16,21 +42,25 @@ class DynamicUnpackAssignSugar(Sugar):
 
     @classmethod
     def witnesses(cls):
-        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
-
-        return NotVerdictBearing(
-            sugar_name=cls.__name__,
-            floor_name="typed dynamic unpack obligation",
-            reason="unknown iterable cardinality and members cannot fabricate bindings",
+        return typed_red_effect_witness(
+            name="sequence_unpack_runtime_effect",
+            owner_sugar="DynamicUnpackAssignSugar",
+            source="def A(o, v):\n    a, b = o\n    return v\n",
+            effect_class="SequenceUnpackRuntimeEffect",
+            reason_needle="sequence unpack",
+            blame_needle="arity=2",
+            wrong_reason_needle="unpack demands exactly 3 members",
         )
 
-    def desugar(self, ctx=None):
-        del ctx
-        from sugar_source_tree.panic import SugarNotWritten
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.operations import SequenceProjectionOperation
 
-        raise SugarNotWritten(
-            owner="DynamicUnpackAssignSugar.desugar",
-            observed="runtime-selected unpack members",
-            requested="authenticated finite iterable members and cardinality",
-            fix="construct the iterable members or keep the unpack obligation loud",
+        operation = SequenceProjectionOperation(
+            target_names=self.target_names,
+            owner=type(self).__name__,
+            blame=self.site,
+        )
+        # Python evaluates the right-hand side before it unpacks anything.
+        return self.value.desugar(ctx).and_then(
+            lambda value: operation.submit(value, ctx)
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
@@ -1,0 +1,267 @@
+"""``a, b = <non-display rhs>``: the unpack demand submitted to the RHS value.
+
+Python's unpacking assignment materializes the right-hand side and demands
+EXACTLY the arity the target spells, binding only after that demand is met.
+These twins name that law and assert the constructed artifact carrying it, each
+paired with a discriminating arm that fails when the law is violated:
+
+1. The arity submitted IS the target count -- two targets and three targets
+   construct different obligations.
+2. The RHS is REDUCED before the unpack; its reduced term is what the
+   obligation names. Two different RHS expressions project differently.
+3. Unauthenticated cardinality retains the typed
+   ``SequenceUnpackRuntimeEffect``; it never completes with invented members.
+4. Nothing binds on that arm -- a later read of a target is not satisfied by a
+   fabricated value. The discriminating arm is a display unpack, which DOES
+   bind, so this is not "everything is red".
+5. Authenticated finite members bind POSITIONALLY, member-by-member, to the
+   values already in hand (asserted at the layer that owns the members: the
+   projection operation and the ``ScopeRebinds`` it constructs).
+6. A DECIDABLE arity mismatch stays loud -- the exact ``ValueError`` exit is
+   unwritten, so it panics rather than guessing an exit or a member.
+7. A floor value with no ``project_sequence_with`` stays loud, naming the
+   frontier (``TupleValue`` / ``ListValue`` / ``CallSiteValue``) instead of
+   silently succeeding.
+
+Arm/outcome structure is read through ``outcome_to_exitset``; this module reads
+arms, it does not claim how many exits the control algebra has.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+from sugar_lift_py_tests.floor.array_literal import ArrayLiteral
+from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+from sugar_lift_py_tests.operations import SequenceProjectionOperation
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
+    DynamicUnpackAssignSugar,
+)
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_source_tree.tree import SourceFile
+
+
+def _function_sugar(tmp_path: Path, source: str, stem: str):
+    path = tmp_path / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    functions = list(SourceFile(path_source(str(path))).functions())
+    return functions[-1].sugar()
+
+
+def _statement(tmp_path: Path, source: str, stem: str):
+    sugar = _function_sugar(tmp_path, source, stem)
+    return next(
+        statement
+        for statement in sugar.statements
+        if isinstance(statement, DynamicUnpackAssignSugar)
+    )
+
+
+def _outcome(tmp_path: Path, source: str, stem: str):
+    return _function_sugar(tmp_path, source, stem).desugar(None)
+
+
+def _unpack_effect(tmp_path: Path, source: str, stem: str):
+    outcome = _outcome(tmp_path, source, stem)
+    assert isinstance(outcome, Incomplete), outcome
+    effect = outcome.effect
+    assert isinstance(effect, SequenceUnpackRuntimeEffect), effect
+    return effect
+
+
+def _obligation(tmp_path: Path, source: str, stem: str) -> tuple[str, str, str]:
+    """Site-free projection of the retained unpack obligation.
+
+    (effect class, reason without site, the constructed operation term). Any
+    change of arity, of RHS coordinate, or of target roster must move this.
+    """
+    effect = _unpack_effect(tmp_path, source, stem)
+    return (
+        type(effect).__name__,
+        re.sub(r" site=.*$", "", effect.reason),
+        str(effect.witness.operation),
+    )
+
+
+TWO_TARGETS = "def A(o, v):\n    a, b = o\n    return v\n"
+THREE_TARGETS = "def A(o, v):\n    a, b, c = o\n    return v\n"
+OTHER_RHS = "def A(o, v):\n    a, b = v\n    return v\n"
+ATTRIBUTE_RHS = "def A(o, v):\n    a, b = o.shape\n    return v\n"
+OTHER_ATTRIBUTE_RHS = "def A(o, v):\n    a, b = o.size\n    return v\n"
+
+
+# ---------------------------------------------------------------------------
+# Law 1 -- the arity submitted is the target count.
+# ---------------------------------------------------------------------------
+
+
+def test_target_count_is_the_submitted_arity(tmp_path: Path) -> None:
+    two = _statement(tmp_path, TWO_TARGETS, "two")
+    three = _statement(tmp_path, THREE_TARGETS, "three")
+    assert two.target_names == ("a", "b")
+    assert three.target_names == ("a", "b", "c")
+
+    two_obligation = _obligation(tmp_path, TWO_TARGETS, "two")
+    three_obligation = _obligation(tmp_path, THREE_TARGETS, "three")
+    assert "exactly 2 members" in two_obligation[1]
+    assert "exactly 3 members" in three_obligation[1]
+    # Discrimination: a different arity is a different obligation term, not the
+    # same term with different prose.
+    assert two_obligation[2] != three_obligation[2]
+    assert two_obligation[2].count("ConstInt") == 1
+
+
+def test_target_roster_is_retained(tmp_path: Path) -> None:
+    """The names the unpack must satisfy are named, in order."""
+    reason = _obligation(tmp_path, TWO_TARGETS, "two")[1]
+    assert "targets (a, b)" in reason
+    assert "targets (b, a)" not in reason
+
+
+# ---------------------------------------------------------------------------
+# Law 2 -- the RHS is reduced first, and IS what the obligation names.
+# ---------------------------------------------------------------------------
+
+
+def test_reduced_rhs_is_the_unpacked_term(tmp_path: Path) -> None:
+    same_arity_other_rhs = _obligation(tmp_path, OTHER_RHS, "other_rhs")
+    two = _obligation(tmp_path, TWO_TARGETS, "two")
+    # Same arity, same targets, different RHS coordinate: the obligation term
+    # must differ, or the unpack is not naming what it unpacks.
+    assert two[1] == same_arity_other_rhs[1]
+    assert two[2] != same_arity_other_rhs[2]
+
+
+def test_rhs_expression_is_reduced_not_quoted(tmp_path: Path) -> None:
+    attribute = _obligation(tmp_path, ATTRIBUTE_RHS, "attr_rhs")
+    other = _obligation(tmp_path, OTHER_ATTRIBUTE_RHS, "attr_rhs_other")
+    # The reduced attribute coordinate rides in the obligation ...
+    assert "shape" in attribute[2]
+    # ... and a different attribute is a different obligation.
+    assert attribute[2] != other[2]
+    assert "shape" not in other[2]
+
+
+# ---------------------------------------------------------------------------
+# Law 3/4 -- runtime cardinality stays typed red, and binds nothing.
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_cardinality_retains_the_typed_unpack_effect(tmp_path: Path) -> None:
+    effect = _unpack_effect(tmp_path, TWO_TARGETS, "two")
+    assert "no authenticated cardinality" in effect.reason
+    assert "name='python:unpack.destructure'" in str(effect.witness.operation)
+
+
+def test_nothing_binds_on_the_runtime_arm(tmp_path: Path) -> None:
+    """A later read of a target is NOT satisfied by an invented member."""
+    read_target = "def A(o):\n    a, b = o\n    return a\n"
+    outcome = _outcome(tmp_path, read_target, "read_target")
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, SequenceUnpackRuntimeEffect)
+
+    # Discrimination: a display unpack DOES bind, and returns the paired
+    # member -- so the assertion above is about this shape, not about
+    # everything being red.
+    display = "def A(p, q):\n    a, b = p, q\n    return a\n"
+    display_outcome = _outcome(tmp_path, display, "display")
+    assert isinstance(display_outcome, Complete), display_outcome
+    assert "p" in str(display_outcome.value.record)
+    assert "q" not in str(display_outcome.value.record)
+
+
+# ---------------------------------------------------------------------------
+# Law 5 -- authenticated finite members bind positionally.
+# ---------------------------------------------------------------------------
+
+
+def _operation(*names: str) -> SequenceProjectionOperation:
+    return SequenceProjectionOperation(
+        target_names=names, owner="twin", blame="twin-site"
+    )
+
+
+def test_authenticated_tuple_members_bind_positionally() -> None:
+    members = (TermValue(1), TermValue(2))
+    outcome = _operation("a", "b").submit(TupleLiteralValue(members), None)
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == ScopeRebinds((("a", TermValue(1)), ("b", TermValue(2))))
+    # Discrimination: the pairing is positional, not the reversed one, and not
+    # the same member twice.
+    assert outcome.value != ScopeRebinds((("a", TermValue(2)), ("b", TermValue(1))))
+    assert outcome.value != ScopeRebinds((("a", TermValue(1)), ("b", TermValue(1))))
+
+
+def test_authenticated_array_members_bind_positionally() -> None:
+    members = (TermValue(7), TermValue(8), TermValue(9))
+    outcome = _operation("a", "b", "c").submit(ArrayLiteral(members), None)
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == ScopeRebinds(
+        (("a", TermValue(7)), ("b", TermValue(8)), ("c", TermValue(9)))
+    )
+
+
+def test_bound_members_thread_to_the_rest_of_the_block() -> None:
+    """The rebind is scope: later statements resolve the names it bound."""
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
+
+    outcome = _operation("a", "b").submit(
+        TupleLiteralValue((TermValue(1), TermValue(2))), None
+    )
+    ctx = outcome.value.extend_scope(ReduceContext(TemporalContext.empty()))
+    assert ctx.temporal.value_if_bound("a") == TermValue(1)
+    assert ctx.temporal.value_if_bound("b") == TermValue(2)
+    # Discrimination: a name the unpack did not bind stays unbound.
+    assert ctx.temporal.value_if_bound("c") is None
+
+
+# ---------------------------------------------------------------------------
+# Law 6 -- a decidable mismatch stays loud.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("members", "names", "relation"),
+    [
+        ((TermValue(1), TermValue(2)), ("a", "b", "c"), "not enough"),
+        ((TermValue(1), TermValue(2), TermValue(3)), ("a", "b"), "too many"),
+    ],
+)
+def test_decidable_arity_mismatch_stays_loud(members, names, relation) -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        _operation(*names).submit(TupleLiteralValue(members), None)
+    info = raised.value.info
+    assert relation in info.observed
+    assert "ValueError" in info.requested
+    assert str(len(members)) in info.observed
+    assert str(len(names)) in info.observed
+
+
+# ---------------------------------------------------------------------------
+# Law 7 -- an unwritten floor stays loud, and names the frontier.
+# ---------------------------------------------------------------------------
+
+
+def test_unwritten_projection_floor_stays_loud(tmp_path: Path) -> None:
+    """``a, b = xs[0]`` over a list display: ``ListValue`` has no unpack port.
+
+    The members ARE authenticated here, so this is not an undecidable shape --
+    it is an unwritten floor, and it says so. Next owner: the floor value's
+    ``project_sequence_with``.
+    """
+    source = "def A(p, q, r, s):\n    xs = [[p, q], [r, s]]\n    a, b = xs[0]\n    return a\n"
+    with pytest.raises(ConstructionPanic) as raised:
+        _outcome(tmp_path, source, "list_floor")
+    info = raised.value.info
+    assert info.requested == "project_sequence_with"
+    assert info.observed == "ListValue"
+    assert info.owner == "DynamicUnpackAssignSugar"


### PR DESCRIPTION
## The refusal named what was missing

`a, b = <non-display rhs>` constructed, then refused at desugar:

```
SugarNotWritten(owner="DynamicUnpackAssignSugar.desugar",
                observed="runtime-selected unpack members",
                requested="authenticated finite iterable members and cardinality")
```

That refusal was accurate. The sugar had no way to **ask** the reduced RHS what it unpacks to. `FloorValue.project_sequence_with` — the port for exactly that question — was declared on the dispatch surface and routed by `TupleLiteralValue`, `ArrayLiteral`, `ObjectValue`, `SymbolicValue` and `OpaqueOpCallsite`, but `SequenceProjectionOperation` (the operation it dispatches on) did not exist, so nothing could ever be submitted through it. `SequenceUnpackRuntimeEffect` was likewise declared, exported, and never constructed.

This writes the operation and submits it. It is not a bypass: it is the missing half of an already-wired port.

## The mechanism

`SequenceProjectionOperation(target_names, owner, blame)` carries the arity the source spells and splits on the ONE question that decides an unpack — does the reduced RHS carry authenticated finite members?

| RHS floor value | decision | outcome |
|---|---|---|
| `TupleLiteralValue` / `ArrayLiteral`, count == arity | lift-time decidable | `Complete(ScopeRebinds(...))` — each name bound to the member already in hand, threaded to the rest of the block |
| same, count != arity | decidable `ValueError` | loud construction gap requesting the unwritten ground `ValueError` exit |
| `SymbolicValue` / `ObjectValue` / `OpaqueOpCallsite` | undecidable count | `Incomplete(SequenceUnpackRuntimeEffect)` retaining `python:unpack.destructure(term, arity)` |
| anything else | unwritten floor | `FloorValue.project_sequence_with` construction gap |

- **No arm assumes the count matched, no arm invents a member.** Nothing binds on the runtime arm, exactly as CPython binds nothing when `UNPACK_SEQUENCE` raises.
- The obligation coordinate is the same family `comprehension_sugar::_guard_destructure` already states — no new algebra.
- The RHS is reduced through `and_then` first, so its own arms are conserved and the obligation term names what it actually unpacks.

## Fences respected

`TupleValue`, `ListValue` and `CallSiteValue` are the live frontier: their members ARE authenticated, so `a, b = xs[0]` and `a, b = source_visible_call()` are **unwritten floor, not undecidable source**. Adding `project_sequence_with` to those value categories belongs to the Floor owner (#6309 territory); `test_unwritten_projection_floor_stays_loud` pins it as a loud gap that names the next owner. `outcome/exit_set.py`, `floor/call_site_value.py`, `ir.py` and `sugar/spread_sugar.py` are untouched.

## Twins

`tests/test_dynamic_unpack_projection.py` — seven laws, each with a discriminating arm, exact cardinality, renamed fixtures. All 12 green. Then perturbed, one at a time, confirming each law's twin fails:

| perturbation | caught by |
|---|---|
| reverse the member pairing | 3 positional twins |
| drop the arity check | both mismatch twins |
| hard-code arity 2 | arity + mismatch twins |
| fabricate the unpacked term instead of reducing the RHS | both RHS twins |
| assume success on runtime cardinality | 6 twins |
| swallow the unwritten-floor panic | frontier twin |

## Measurement

Measured ΔR on the owed-obligation axis (census category 2) over a 23-file pandas subset (669 raw occurrences of the shape), baseline `origin/main` vs head, same subset, same instrument. Numbers posted as a follow-up comment when the run lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `DynamicUnpackAssignSugar.desugar` to submit unpack demand to RHS value
> - Introduces [`SequenceProjectionOperation`](https://github.com/TSavo/sugar/pull/6316/files#diff-9be349b5e190d0d25eea1243b590d33cad0994bfaf442e9c32851518f50a31a4), a frozen dataclass that encapsulates sequence-unpack projection logic via `value.project_sequence_with`.
> - For tuple/array values with matching arity, returns `Complete` with positional `ScopeRebinds`; for values without authenticated cardinality (symbolic, object), returns `Incomplete` with a `SequenceUnpackRuntimeEffect`; raises `ConstructionPanic` on decidable arity mismatches.
> - Implements [`DynamicUnpackAssignSugar.desugar`](https://github.com/TSavo/sugar/pull/6316/files#diff-0239e2a0c5deaf6ecae660949c22ae620f22544371321f9b9053ac912e714934) to desugar the RHS first, then submit the reduced value to the operation via `and_then`.
> - Updates `witnesses()` to declare a typed red-effect witness for `SequenceUnpackRuntimeEffect` instead of a generic non-verdict-bearing witness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4730cbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->