### PR TITLE
Floor: complex field arithmetic, uncapped sequence repetition, term-bearing membership

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_arithmetic.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_arithmetic.py
@@ -1,0 +1,99 @@
+"""The closed arithmetic law for Python's complex field.
+
+``1 + 1j`` was the largest remaining desugar construction panic on the
+installed pandas tree: ``owner=add observed=TermValue``. The left value
+(a number) stands on the addition floor, but no arm named its right operand,
+so the pair fell through to the loud default.
+
+The mechanism is the numeric tower, not a spelling: int, float, bool and
+complex are CLOSED under addition, subtraction and multiplication, and the
+result of mixing any of them with a complex is a complex. That is one law over
+a value category, mirroring ``TermValue``'s own closed int/float arithmetic and
+``SetValue``'s closed-equality membership rather than inventing per-operand
+semantics.
+
+Two things this law deliberately does NOT do:
+
+* It never engages unless one operand is genuinely a ``ComplexValue``, so
+  int-with-int arithmetic keeps folding on the ``TermValue`` floor and no value
+  is silently widened into the complex field.
+* It never invents a result when Python itself would not produce one. An
+  integer too large to enter the float field raises ``OverflowError`` in
+  Python; this law has no arm for that exceptional exit, so the pair stays
+  loud. ``panic = gap``.
+
+The operand's category is read from its own authenticated construction type
+(``ComplexValue`` carries its real/imaginary parts; ``TermValue`` carries its
+Python payload) -- never from a lexical type name at the call site.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+
+def complex_field_coordinate(value) -> Optional[complex]:
+    """This value's coordinate in Python's complex field, or ``None``.
+
+    ``None`` means "not a member of the field as constructed" -- the caller
+    must fall through to its own loud arm, never substitute a default.
+    """
+    from sugar_lift_py_tests.floor.complex_value import ComplexValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+        FalseBoolLiteralSugar,
+    )
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    if type(value) is ComplexValue:
+        return complex(value.real, value.imag)
+    if type(value) is TermValue and type(value.value) in (int, float, bool):
+        try:
+            return complex(value.value)
+        except OverflowError:
+            # Python's own OverflowError boundary. No arm here constructs that
+            # exceptional exit, so the caller's loud gap is the honest answer.
+            return None
+    if type(value) is TrueBoolLiteralSugar:
+        return complex(1)
+    if type(value) is FalseBoolLiteralSugar:
+        return complex(0)
+    return None
+
+
+def closed_complex_operation(
+    left,
+    right,
+    site,
+    *,
+    operate: Callable[[complex, complex], complex],
+):
+    """``operate(left, right)`` in the complex field, or ``None`` to fall through.
+
+    ``None`` is returned -- never a panic -- so that each floor keeps ownership
+    of its own gap testimony and reports its own (owner, pair).
+    """
+    del site
+    from sugar_lift_py_tests.floor.complex_value import ComplexValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    if type(left) is not ComplexValue and type(right) is not ComplexValue:
+        return None
+    left_coordinate = complex_field_coordinate(left)
+    right_coordinate = complex_field_coordinate(right)
+    if left_coordinate is None or right_coordinate is None:
+        return None
+    product = operate(left_coordinate, right_coordinate)
+    return Complete(ComplexValue(product.real, product.imag))
+
+
+def complex_add(left, right, site):
+    return closed_complex_operation(left, right, site, operate=lambda a, b: a + b)
+
+
+def complex_subtract(left, right, site):
+    return closed_complex_operation(left, right, site, operate=lambda a, b: a - b)
+
+
+def complex_multiply(left, right, site):
+    return closed_complex_operation(left, right, site, operate=lambda a, b: a * b)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -53,6 +53,35 @@ class ComplexValue(FloorValue):
             )
         return super().equals(other, site)
 
+    # Python's numeric tower is CLOSED over int/float/bool/complex under these
+    # three operations, so a complex literal stands on each of their floors for
+    # any field member. See floor/complex_arithmetic.py for the one law; a
+    # non-member right operand falls through to this floor's own loud gap.
+
+    def add(self, other, site):
+        from sugar_lift_py_tests.floor.complex_arithmetic import complex_add
+
+        folded = complex_add(self, other, site)
+        if folded is None:
+            return super().add(other, site)
+        return folded
+
+    def subtract(self, other, site):
+        from sugar_lift_py_tests.floor.complex_arithmetic import complex_subtract
+
+        folded = complex_subtract(self, other, site)
+        if folded is None:
+            return super().subtract(other, site)
+        return folded
+
+    def multiply(self, other, site):
+        from sugar_lift_py_tests.floor.complex_arithmetic import complex_multiply
+
+        folded = complex_multiply(self, other, site)
+        if folded is None:
+            return super().multiply(other, site)
+        return folded
+
     def to_term(self, *, owner: str):
         del owner
         from decimal import Decimal

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -807,152 +807,71 @@ class FloorValue:
             )
         )
 
+    def _binary_floor_gap(self, other, site, owner, floor):
+        """The ONE None arm for every binary-operation floor.
+
+        A binary operation stands on a floor only for a NAMED PAIR of operand
+        categories, so the gap names both: the left value's own category
+        (``observed``) and the right operand's, in ``requested``/``fix``.
+        Discarding the right operand made every gap of one owner look alike --
+        34 ``add`` panics on the installed pandas tree said only "TermValue
+        does not stand on the addition floor" and named nothing to implement.
+        The pair IS the dispatch unit; a gap that cannot name its pair cannot
+        be worked.
+
+        The category is read from the operand's own type, which is its
+        authenticated construction coordinate -- never from a lexical name.
+        """
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        observed = type(self).__name__
+        operand = type(other).__name__
+        construction_panic_gap(
+            owner=owner,
+            blame=str(site),
+            observed=observed,
+            requested=f"stand on the {floor} floor for a {operand} right operand",
+            fix=f"write more Floor: implement {observed}.{owner} for {operand}",
+        )
+
     def add(self, other, site):
         # Default: this value does not stand on the addition floor -- it cannot answer
         # what it is to add another value. The None arm: a value that CAN implements
         # add and gives back the sum (or concat); absence here is the honest "no".
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="add",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the addition floor",
-            fix=f"write more Floor: implement {observed}.add",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "add", "addition")
 
     def subtract(self, other, site):
         # Default: this value does not stand on the subtraction floor -- it cannot
         # answer what it is minus another value. The None arm: a value that CAN
         # implements subtract and gives back a term; absence here is the honest "no".
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="subtract",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the subtraction floor",
-            fix=f"write more Floor: implement {observed}.subtract",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "subtract", "subtraction")
 
     def multiply(self, other, site):
         # Default: this value does not stand on the multiplication floor -- it cannot
         # answer what it multiplies by another value to. The None arm: a value that CAN
         # implements multiply and gives back a product; absence here is the honest "no".
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="multiply",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the multiplication floor",
-            fix=f"write more Floor: implement {observed}.multiply",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "multiply", "multiplication")
 
     def power(self, other, site):
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-        observed = type(self).__name__
-        construction_panic_gap(
-            owner="power",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the power floor",
-            fix=f"write more Floor: implement {observed}.power",
-        )
+        self._binary_floor_gap(other, site, "power", "power")
 
     def divide(self, other, site):
         # Default: this value does not stand on the division floor -- it cannot answer
         # what it divides by another value to. The None arm: a value that CAN
         # implements divide and gives back a quotient; absence here is the honest "no".
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="divide",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the division floor",
-            fix=f"write more Floor: implement {observed}.divide",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "divide", "division")
 
     def modulo(self, other, site):
         # Default: this value does not stand on the modulo floor -- it cannot answer
         # what remainder it leaves by another value. The None arm: a value that CAN
         # implements modulo and gives back a remainder; absence here is the honest "no".
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="modulo",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the modulo floor",
-            fix=f"write more Floor: implement {observed}.modulo",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "modulo", "modulo")
 
     def floor_divide(self, other, site):
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="floor_divide",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the floor-division floor",
-            fix=f"write more Floor: implement {observed}.floor_divide",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "floor_divide", "floor-division")
 
     def right_shift(self, other, site):
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-
-        observed = type(self).__name__
-        info = ConstructionGap(
-            owner="right_shift",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the right-shift floor",
-            fix=f"write more Floor: implement {observed}.right_shift",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-        construction_panic(info)
+        self._binary_floor_gap(other, site, "right_shift", "right-shift")
 
     def bitwise_and(self, other, site):
         return self._runtime_bitwise_gap(other, site, "bitwise_and", "and")
@@ -967,30 +886,12 @@ class FloorValue:
         return self._runtime_bitwise_gap(other, site, "left_shift", "left-shift")
 
     def matrix_multiply(self, other, site):
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-        observed = type(self).__name__
-        construction_panic_gap(
-            owner="matrix_multiply",
-            blame=str(site),
-            observed=observed,
-            requested="stand on the matrix-multiplication floor",
-            fix=f"write more Floor: implement {observed}.matrix_multiply",
+        self._binary_floor_gap(
+            other, site, "matrix_multiply", "matrix-multiplication"
         )
 
     def _runtime_bitwise_gap(self, other, site, owner, label):
-        del other
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-        observed = type(self).__name__
-        construction_panic_gap(
-            owner=owner,
-            blame=str(site),
-            observed=observed,
-            requested=f"stand on the runtime bitwise {label} floor",
-            fix=f"write more Floor: implement {observed}.{owner}",
-        )
+        self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 
     def to_term(self, *, owner: str) -> "Term":
         from sugar_lift_py_tests.gap.panic import construction_panic

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -141,47 +141,10 @@ class ListValue(FloorValue):
         return super().add(other, site)
 
     def multiply(self, other, site):
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.floor.term_value import TermValue
+        # Python list repetition, through the one sequence-repetition law.
+        from sugar_lift_py_tests.floor.sequence_repetition import repeat_sequence
 
-        if type(other) is TermValue and type(other.value) in (int, bool):
-            from sugar_lift_py_tests.outcome import Complete
-
-            repeated = len(self.elements) * max(other.value, 0)
-            static_unfold_limit = 128
-
-            if repeated > static_unfold_limit:
-                from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-                construction_panic_gap(
-                    owner="ListValue.multiply",
-                    blame=str(site),
-                    observed=f"list repetition cardinality={repeated}",
-                    requested=f"finite repetition at or below {static_unfold_limit}",
-                    fix="keep exact sequence repetition within the finite unfold budget",
-                )
-            return Complete(ListValue(self.elements * other.value))
-        from sugar_lift_py_tests.floor.sequence_repetition import (
-            is_known_invalid_repetition_count,
-            known_invalid_repetition_type_error,
-        )
-
-        if is_known_invalid_repetition_count(other):
-            return known_invalid_repetition_type_error(self, other, site)
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "python:sequence_repeat",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return repeat_sequence(self, other, site, rebuild=ListValue)
 
     def matrix_multiply(self, other, site):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py
@@ -1,5 +1,58 @@
 from __future__ import annotations
 
+# How large a concrete repetition this floor MATERIALIZES rather than folding to
+# its closed coordinate. Not a cap: see ``repeat_sequence``, which refuses no
+# cardinality and drops no element at any cardinality.
+EAGER_MATERIALIZATION_BUDGET = 128
+
+
+def repeat_sequence(sequence, count, site, *, rebuild):
+    """``sequence * count`` for one concrete sequence, at any cardinality.
+
+    Cardinality does not change WHAT a repetition is. A concrete sequence
+    repeated a concrete number of times has exactly one value, and this law
+    owns two EQUAL representations of it:
+
+        materialized  rebuild(elements * n)
+        folded        python:sequence_repeat(sequence, n)
+
+    The folded form is the same closed coordinate the opaque-count arm emits,
+    so it is exact, not lossy. Which one is built is a representation choice
+    about eager memory -- there is no cardinality at which this law refuses,
+    and none at which it silently drops elements. (List and tuple each carried
+    a private copy of this arm that PANICKED above 128, reporting 19 perfectly
+    ordinary pandas repetitions as construction gaps.)
+
+    ``rebuild`` is the receiver's own constructor over a materialized element
+    tuple, so each sequence category rebuilds itself and no category learns
+    another's shape.
+    """
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    if type(count) is TermValue and type(count.value) in (int, bool):
+        n = count.value
+        if len(sequence.elements) * max(n, 0) <= EAGER_MATERIALIZATION_BUDGET:
+            return Complete(rebuild(sequence.elements * n))
+        return Complete(SymbolicValue(repetition_term(sequence, count, site)))
+    if is_known_invalid_repetition_count(count):
+        return known_invalid_repetition_type_error(sequence, count, site)
+    return Complete(SymbolicValue(repetition_term(sequence, count, site)))
+
+
+def repetition_term(sequence, count, site):
+    """The ONE closed sequence-repetition coordinate, for every count."""
+    from sugar_lift_py_tests.ir import ctor
+
+    return ctor(
+        "python:sequence_repeat",
+        [
+            sequence.to_term(owner=str(site)),
+            count.to_term(owner=str(site)),
+        ],
+    )
+
 
 def is_known_invalid_repetition_count(value) -> bool:
     """Whether construction knows this value cannot satisfy ``__index__``."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -132,30 +132,15 @@ def _closed_member_equal(left, right):
     supported = (TermValue, StringValue, BytesValue, NoneValue, *bool_types)
     if type(left) in supported and type(right) in supported:
         return False
-    if stands_on_the_term_floor(left) and stands_on_the_term_floor(right):
-        # Neither side is a closed ground value, but BOTH state a coordinate in
-        # the theory, so equality is UNDECIDED here -- not unrepresentable.
-        # Undecided is what ``None`` means to every membership owner above: it
-        # emits the typed ``python.*.contains`` obligation over the operands'
-        # own terms. Falling to NotImplemented instead reported an ordinary
-        # `call() in [...]` as a construction gap even though the obligation was
-        # exactly constructible (the residual CallSiteValue membership panics
-        # left after #6293).
-        return None
+    # A residual pair measured on the installed pandas tree lands here:
+    # `{List,Tuple}Value.contains x CallSiteValue`. A call's result IS a value of
+    # undecided identity, so the honest answer is ``None`` (emit the typed
+    # python.*.contains obligation), not NotImplemented (a gap). What it is NOT
+    # is "any value carrying a term": FunctionCallable carries one and is a
+    # callable, never a member -- two tests pin that refusal deliberately. The
+    # discriminator has to be the value's own testimony about whether it DENOTES
+    # a value, which no floor states yet. Left loud until it does.
     return NotImplemented
-
-
-def stands_on_the_term_floor(value) -> bool:
-    """Whether this value states its OWN coordinate in the theory.
-
-    Read from the value's construction -- it overrides ``to_term`` -- never from
-    a table of category names. ``FloorValue.to_term`` is the loud default: a
-    value that has not overridden it cannot testify about itself, so membership
-    against it stays a named gap.
-    """
-    from sugar_lift_py_tests.floor.floor_value import FloorValue
-
-    return type(value).to_term is not FloorValue.to_term
 
 
 def _finite_union(left, right):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -132,7 +132,30 @@ def _closed_member_equal(left, right):
     supported = (TermValue, StringValue, BytesValue, NoneValue, *bool_types)
     if type(left) in supported and type(right) in supported:
         return False
+    if stands_on_the_term_floor(left) and stands_on_the_term_floor(right):
+        # Neither side is a closed ground value, but BOTH state a coordinate in
+        # the theory, so equality is UNDECIDED here -- not unrepresentable.
+        # Undecided is what ``None`` means to every membership owner above: it
+        # emits the typed ``python.*.contains`` obligation over the operands'
+        # own terms. Falling to NotImplemented instead reported an ordinary
+        # `call() in [...]` as a construction gap even though the obligation was
+        # exactly constructible (the residual CallSiteValue membership panics
+        # left after #6293).
+        return None
     return NotImplemented
+
+
+def stands_on_the_term_floor(value) -> bool:
+    """Whether this value states its OWN coordinate in the theory.
+
+    Read from the value's construction -- it overrides ``to_term`` -- never from
+    a table of category names. ``FloorValue.to_term`` is the loud default: a
+    value that has not overridden it cannot testify about itself, so membership
+    against it stays a named gap.
+    """
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    return type(value).to_term is not FloorValue.to_term
 
 
 def _finite_union(left, right):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -204,6 +204,14 @@ class TermValue(FloorValue):
             SymbolicValue,
         ):
             return SymbolicValue(self.to_term(owner=str(site))).add(other, site)
+        # A number plus a complex literal is a complex: the numeric tower's own
+        # closed law, not a per-operand special case. `1 + 1j` was the largest
+        # remaining pandas add panic.
+        from sugar_lift_py_tests.floor.complex_arithmetic import complex_add
+
+        folded = complex_add(self, other, site)
+        if folded is not None:
+            return folded
         return super().add(other, site)
 
     def subtract(self, other, site):
@@ -221,6 +229,11 @@ class TermValue(FloorValue):
             from sugar_lift_py_tests.effect import runtime_subtract
 
             return runtime_subtract(self, other, site)
+        from sugar_lift_py_tests.floor.complex_arithmetic import complex_subtract
+
+        folded = complex_subtract(self, other, site)
+        if folded is not None:
+            return folded
         return super().subtract(other, site)
 
     def multiply(self, other, site):
@@ -248,6 +261,11 @@ class TermValue(FloorValue):
         if type(other) in (ListValue, StringValue, TupleValue):
             if type(self.value) is int:
                 return other.multiply(self, site)
+        from sugar_lift_py_tests.floor.complex_arithmetic import complex_multiply
+
+        folded = complex_multiply(self, other, site)
+        if folded is not None:
+            return folded
         return super().multiply(other, site)
 
     def power(self, other, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -243,47 +243,10 @@ class TupleValue(FloorValue):
         )
 
     def multiply(self, other, site):
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.floor.term_value import TermValue
+        # Python tuple repetition, through the one sequence-repetition law.
+        from sugar_lift_py_tests.floor.sequence_repetition import repeat_sequence
 
-        if type(other) is TermValue and type(other.value) in (int, bool):
-            from sugar_lift_py_tests.outcome import Complete
-
-            repeated = len(self.elements) * max(other.value, 0)
-            static_unfold_limit = 128
-
-            if repeated > static_unfold_limit:
-                from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-                construction_panic_gap(
-                    owner="TupleValue.multiply",
-                    blame=str(site),
-                    observed=f"tuple repetition cardinality={repeated}",
-                    requested=f"finite repetition at or below {static_unfold_limit}",
-                    fix="keep exact sequence repetition within the finite unfold budget",
-                )
-            return Complete(TupleValue(self.elements * other.value))
-        from sugar_lift_py_tests.floor.sequence_repetition import (
-            is_known_invalid_repetition_count,
-            known_invalid_repetition_type_error,
-        )
-
-        if is_known_invalid_repetition_count(other):
-            return known_invalid_repetition_type_error(self, other, site)
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "python:sequence_repeat",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return repeat_sequence(self, other, site, rebuild=TupleValue)
 
     def subscript(self, index, site):
         # Concrete tuple + in-range TermValue int folds to the element; out of

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
@@ -1,0 +1,196 @@
+"""A complex literal stands on the arithmetic floor for the whole numeric tower.
+
+``1 + 1j`` was the largest remaining desugar construction panic on the installed
+pandas tree (``owner=add observed=TermValue``). The mechanism is the closed
+numeric tower -- int/float/bool/complex are closed under +, -, * -- not a
+per-operand spelling.
+
+Python is the reference: every folded result is asserted against Python's own
+evaluation of the same expression, so the floor is a faithful mirror rather than
+a re-derivation.
+
+Each positive arm carries a discriminating arm: a shape that must NOT enter the
+complex field.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    ComplexValue,
+    ListValue,
+    StringValue,
+    SymbolicValue,
+    TermValue,
+)
+from sugar_lift_py_tests.floor.complex_arithmetic import complex_field_coordinate
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+SITE = "complex-site"
+
+
+def _folded(outcome) -> complex:
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is ComplexValue
+    return complex(outcome.value.real, outcome.value.imag)
+
+
+# -- positive arm: the mixed-operand pairs the census actually found ----------
+
+
+def test_int_plus_complex_literal_is_pythons_own_sum() -> None:
+    """The exact pandas shape: `1 + 1j`."""
+    assert _folded(TermValue(1).add(ComplexValue(0.0, 1.0), SITE)) == 1 + 1j
+
+
+def test_complex_literal_plus_int_is_pythons_own_sum() -> None:
+    assert _folded(ComplexValue(0.0, 1.0).add(TermValue(1), SITE)) == 1j + 1
+
+
+def test_float_plus_complex_literal_is_pythons_own_sum() -> None:
+    """The exact pandas shape: `1.0 + 1.0j`."""
+    assert _folded(TermValue(1.0).add(ComplexValue(0.0, 1.0), SITE)) == 1.0 + 1.0j
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    (
+        (TermValue(1), ComplexValue(0.0, 2.0), 1 + 2j),
+        (ComplexValue(3.0, 4.0), ComplexValue(1.0, 2.0), (3 + 4j) + (1 + 2j)),
+        (ComplexValue(3.0, 4.0), TermValue(2.5), (3 + 4j) + 2.5),
+        (TermValue(True), ComplexValue(0.0, 1.0), True + 1j),
+        (TrueBoolLiteralSugar(site=SITE), ComplexValue(0.0, 1.0), 1 + 1j),
+        (FalseBoolLiteralSugar(site=SITE), ComplexValue(0.0, 1.0), 0 + 1j),
+    ),
+)
+def test_addition_mirrors_python_for_every_field_member(left, right, expected) -> None:
+    assert _folded(left.add(right, SITE)) == expected
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    (
+        (TermValue(1), ComplexValue(0.0, 1.0), 1 - 1j),
+        (ComplexValue(0.0, 1.0), TermValue(1), 1j - 1),
+        (ComplexValue(3.0, 4.0), ComplexValue(1.0, 2.0), (3 + 4j) - (1 + 2j)),
+    ),
+)
+def test_subtraction_mirrors_python(left, right, expected) -> None:
+    assert _folded(left.subtract(right, SITE)) == expected
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    (
+        (TermValue(2), ComplexValue(0.0, 1.0), 2 * 1j),
+        (ComplexValue(0.0, 1.0), ComplexValue(0.0, 1.0), 1j * 1j),
+        (ComplexValue(1.0, 2.0), ComplexValue(3.0, 4.0), (1 + 2j) * (3 + 4j)),
+        (ComplexValue(1.0, 2.0), TermValue(3.0), (1 + 2j) * 3.0),
+    ),
+)
+def test_multiplication_mirrors_python(left, right, expected) -> None:
+    assert _folded(left.multiply(right, SITE)) == expected
+
+
+def test_i_squared_is_exactly_negative_one() -> None:
+    """The identity that makes the field a field, asserted exactly."""
+    product = ComplexValue(0.0, 1.0).multiply(ComplexValue(0.0, 1.0), SITE).value
+
+    assert product.real == -1.0
+    assert product.imag == 0.0
+
+
+# -- discriminating arm: nothing else is widened into the field ---------------
+
+
+def test_two_integers_still_fold_on_the_number_floor() -> None:
+    """No operand was silently widened: int + int is still an int TermValue."""
+    outcome = TermValue(3).add(TermValue(4), SITE)
+
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is TermValue
+    assert outcome.value.value == 7
+    assert type(outcome.value.value) is int
+
+
+def test_two_floats_still_fold_on_the_number_floor() -> None:
+    outcome = TermValue(1.5).add(TermValue(2.5), SITE)
+
+    assert type(outcome.value) is TermValue
+    assert outcome.value.value == 4.0
+
+
+@pytest.mark.parametrize(
+    "off_field",
+    (
+        TermValue("1"),
+        TermValue(None),
+        TermValue(b"1"),
+        ListValue((TermValue(1),)),
+        StringValue("1"),
+    ),
+)
+def test_a_non_member_operand_keeps_the_complex_floor_loud(off_field) -> None:
+    """`panic = gap`: the field law admits members, and refuses to invent for
+    anything else -- including values Python itself would reject."""
+    with pytest.raises(ConstructionPanic) as raised:
+        ComplexValue(0.0, 1.0).add(off_field, SITE)
+
+    info = raised.value.info
+    assert info.owner == "add"
+    assert info.observed == "ComplexValue"
+    assert type(off_field).__name__ in info.fix
+
+
+def test_an_integer_too_large_for_the_float_field_stays_loud() -> None:
+    """Python raises OverflowError here. No arm constructs that exit, so the
+    pair stays a named gap rather than a fabricated value."""
+    assert complex_field_coordinate(TermValue(10**400)) is None
+
+    with pytest.raises(ConstructionPanic) as raised:
+        TermValue(10**400).add(ComplexValue(0.0, 1.0), SITE)
+
+    info = raised.value.info
+    assert info.owner == "add"
+    assert info.observed == "TermValue"
+    assert "ComplexValue" in info.fix
+
+
+def test_a_symbolic_operand_keeps_its_own_symbolic_door() -> None:
+    """A complex plus an opaque callsite is not a field member; the complex
+    floor must not swallow it into a fabricated concrete complex."""
+    opaque = CallSiteValue("vendor.op", (), (), ctor("call:vendor.op", []), None)
+
+    assert complex_field_coordinate(opaque) is None
+    with pytest.raises(ConstructionPanic) as raised:
+        ComplexValue(0.0, 1.0).add(opaque, SITE)
+
+    assert raised.value.info.owner == "add"
+    assert "CallSiteValue" in raised.value.info.fix
+
+
+def test_an_integer_plus_a_symbolic_operand_is_still_symbolic() -> None:
+    """The complex arm sits AFTER the symbolic arms and stole none of them."""
+    symbolic = SymbolicValue(TermValue(2).to_term(owner=SITE))
+
+    outcome = TermValue(1).add(symbolic, SITE)
+
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is SymbolicValue
+
+
+# -- the field coordinate is read from the value, not from a name -------------
+
+
+def test_the_field_coordinate_comes_from_the_constructed_value() -> None:
+    assert complex_field_coordinate(ComplexValue(1.0, 2.0)) == 1 + 2j
+    assert complex_field_coordinate(TermValue(7)) == 7 + 0j
+    assert complex_field_coordinate(TermValue(7.5)) == 7.5 + 0j
+    assert complex_field_coordinate(TrueBoolLiteralSugar(site=SITE)) == 1 + 0j
+    assert complex_field_coordinate(FalseBoolLiteralSugar(site=SITE)) == 0j

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_repetition_has_no_cardinality_cap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_repetition_has_no_cardinality_cap.py
@@ -1,0 +1,204 @@
+"""Sequence repetition refuses no cardinality and drops no element.
+
+List and tuple each carried a private ``multiply`` arm that PANICKED once a
+concrete repetition exceeded 128 elements, reporting perfectly ordinary
+repetitions on the installed pandas tree as construction gaps. One law now
+owns both categories: above the eager-materialization budget the repetition is
+FOLDED to the same closed ``python:sequence_repeat`` coordinate the opaque-count
+arm already emits -- the same value, not an approximation of it.
+
+Each positive arm is paired with a discriminating arm: a shape that must NOT
+take the same door. Cardinalities are asserted exactly, because a repetition
+law that merely produced "not 1" element would be satisfied by 0 and by 2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    ListValue,
+    SymbolicValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.floor.sequence_repetition import (
+    EAGER_MATERIALIZATION_BUDGET,
+    repetition_term,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import _Ctor
+from sugar_lift_py_tests.outcome import Complete
+
+SEQUENCES = (ListValue, TupleValue)
+SITE = "repetition-site"
+
+
+# -- positive arm: at or below the budget, the repetition is materialized -----
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_repetition_at_the_budget_materializes_every_element(sequence_type) -> None:
+    element = TermValue(7)
+
+    outcome = sequence_type((element,)).multiply(
+        TermValue(EAGER_MATERIALIZATION_BUDGET), SITE
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, sequence_type)
+    # Exact cardinality: 128 elements, every one the repeated element.
+    assert len(outcome.value.elements) == EAGER_MATERIALIZATION_BUDGET
+    assert outcome.value.elements == (element,) * EAGER_MATERIALIZATION_BUDGET
+
+
+# -- positive arm: one element past the budget no longer panics ---------------
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_one_element_past_the_budget_folds_instead_of_panicking(
+    sequence_type,
+) -> None:
+    sequence = sequence_type((TermValue(7),))
+    count = TermValue(EAGER_MATERIALIZATION_BUDGET + 1)
+
+    outcome = sequence.multiply(count, SITE)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+    assert outcome.value.term == repetition_term(sequence, count, SITE)
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_a_cardinality_no_machine_could_materialize_still_constructs(
+    sequence_type,
+) -> None:
+    """The old arm panicked here; nothing about the VALUE is unknown."""
+    sequence = sequence_type((TermValue(7),))
+    count = TermValue(10**12)
+
+    outcome = sequence.multiply(count, SITE)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+    term = outcome.value.term
+    assert isinstance(term, _Ctor)
+    assert term.name == "python:sequence_repeat"
+    assert term.args[1] == count.to_term(owner=SITE)
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_no_cardinality_makes_repetition_panic(sequence_type) -> None:
+    """The discrimination that names the law: NO count is a construction gap."""
+    sequence = sequence_type((TermValue(1), TermValue(2)))
+
+    for count in (0, 1, 63, 64, 65, 128, 129, 10**6, 10**15):
+        outcome = sequence.multiply(TermValue(count), SITE)
+        assert isinstance(outcome, Complete), count
+
+
+# -- discriminating arm: the folded form is the OPAQUE-count coordinate -------
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_folded_concrete_count_is_the_same_construction_as_an_opaque_count(
+    sequence_type,
+) -> None:
+    """One coordinate, not a second parallel spelling for large concretes."""
+    sequence = sequence_type((TermValue(7),))
+    opaque = SymbolicValue(TermValue(3).to_term(owner=SITE))
+
+    folded = sequence.multiply(TermValue(10**9), SITE).value.term
+    opaque_folded = sequence.multiply(opaque, SITE).value.term
+
+    assert isinstance(folded, _Ctor) and isinstance(opaque_folded, _Ctor)
+    assert folded.name == opaque_folded.name == "python:sequence_repeat"
+    # Same receiver term on both; only the count operand differs.
+    assert folded.args[0] == opaque_folded.args[0]
+    assert folded.args[1] != opaque_folded.args[1]
+
+
+# -- discriminating arm: a known-invalid count is still a typed TypeError -----
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_a_known_invalid_count_does_not_reach_either_repetition_arm(
+    sequence_type, tmp_path
+) -> None:
+    """Removing the cap must not have widened the door to non-index counts.
+
+    The typed TypeError exit carries a genuine runtime locus, so this arm needs
+    a real fragment -- not the prose site the folding arms accept.
+    """
+    from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    source = tmp_path / "sequence_repeat.py"
+    source.write_text("def witness():\n    return [1] * 1.5\n", encoding="utf-8")
+    fragment = next(SourceFile(path_source(str(source))).functions()).fragment
+
+    outcome = sequence_type((TermValue(1),)).multiply(TermValue(1.5), fragment)
+
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, TypeErrorRuntimeEffect)
+
+
+# -- discriminating arm: each category rebuilds ITSELF ------------------------
+
+
+def test_each_sequence_category_rebuilds_its_own_shape() -> None:
+    """One shared law, but a list never materializes as a tuple."""
+    element = TermValue(7)
+
+    from_list = ListValue((element,)).multiply(TermValue(3), SITE).value
+    from_tuple = TupleValue((element,)).multiply(TermValue(3), SITE).value
+
+    assert type(from_list) is ListValue
+    assert type(from_tuple) is TupleValue
+    assert len(from_list.elements) == 3
+    assert len(from_tuple.elements) == 3
+
+
+# -- the value with no elements ----------------------------------------------
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_an_empty_sequence_repeats_to_empty_at_any_count(sequence_type) -> None:
+    """len 0 * huge n is 0, materializable -- never folded, never a panic."""
+    outcome = sequence_type(()).multiply(TermValue(10**12), SITE)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, sequence_type)
+    assert len(outcome.value.elements) == 0
+
+
+@pytest.mark.parametrize("sequence_type", SEQUENCES)
+def test_a_negative_count_repeats_to_empty(sequence_type) -> None:
+    outcome = sequence_type((TermValue(7),)).multiply(TermValue(-4), SITE)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, sequence_type)
+    assert len(outcome.value.elements) == 0
+
+
+# -- the gap that remains: no sequence category invented a repetition ---------
+
+
+def test_a_value_off_the_sequence_floor_still_panics_and_names_its_pair() -> None:
+    """`panic = gap`: closing the cardinality gap closed no OTHER gap."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    class OffFloor(FloorValue):
+        pass
+
+    with pytest.raises(ConstructionPanic) as raised:
+        OffFloor().multiply(TermValue(3), SITE)
+
+    info = raised.value.info
+    assert info.owner == "multiply"
+    assert info.observed == "OffFloor"
+    # The pair, not just the left operand -- the dispatch unit is (owner, pair).
+    assert "TermValue" in info.requested
+    assert "OffFloor.multiply for TermValue" in info.fix


### PR DESCRIPTION
## What this closes

A fresh panic census at `origin/main` (`e6d688d3c`) over a **1/6 deterministic stride sample of the installed pandas tree (236 of 1411 files)** measured **20 desugar construction panics** — not the 1074 of the `d94f67a31` board. #6293 and #6296 landed the bulk. This PR closes the residual pairs that measurement actually found, and reports the ones that stay loud.

### `add × TermValue` (6 of 20) — the pair was misnamed

Every occurrence is a **complex literal**: `1 + 1j` (`pandas/tests/dtypes/test_common.py`, `tests/groupby/test_groupby.py` ×3), `1.0 + 1.0j` (`tests/io/pytables/test_complex.py` ×2). The left operand is an ordinary number; the right is a `ComplexValue`, and no arm named it.

`int`/`float`/`bool`/`complex` are **closed** under `+`, `-`, `*`. `floor/complex_arithmetic.py` owns that one law: `ComplexValue` stands on those three floors for any field member, and `TermValue` carries the reflected arms. The field coordinate is read from the value's own construction (`ComplexValue` carries real/imag; `TermValue` carries its Python payload), never from a lexical type name.

Stays loud: a non-member operand, and an integer too large to enter the float field — Python raises `OverflowError` there and no arm constructs that exceptional exit. `panic = gap`.

### `ListValue.multiply` / `TupleValue.multiply` (3 of 20) — a size cap, deleted

Both floors carried a private arm that **panicked** once a concrete repetition exceeded 128 elements. Measured shapes: `[2] * 10001`, `["a"] * num`.

Cardinality does not change *what* a repetition is. `floor/sequence_repetition.py` now owns one law with two **equal** representations: materialize within an eager-memory budget, otherwise **fold** to the same closed `python:sequence_repeat` coordinate the opaque-count arm already emits. There is no cardinality at which it refuses and none at which it drops an element. `array_literal.py` keeps its own `STATIC_UNFOLD_LIMIT` arm — a different owner (loop-unroll budget), left alone.

### `{List,Tuple}Value.contains × CallSiteValue` (2 of 20) — attempted, then reverted

Worth recording because the near-miss is the interesting part. These fall to `NotImplemented` because neither operand is closed ground, and a call's *result* genuinely is a value of undecided identity — so `None` (emit the typed `python.*.contains` obligation) is the honest answer, not a gap.

The tempting implementation is "any operand carrying a term is undecided". **That is wrong**: `FunctionCallable` also carries a term, and `test_opaque_list_member_stays_loud` / `test_opaque_member_stays_loud` deliberately pin that a callable is never a membership member. Widening on `to_term` would have turned two pinned refusals into obligations to make a count look better.

The real discriminator is whether a value **denotes a value**, which no floor states about itself yet. Reverted (`751142009`) and reported open rather than guessed.

### The instrument fix that made this dispatchable

Ten binary-operation gap arms did `del other`. Every one of the 34 board `add` panics therefore said only *"TermValue does not stand on the addition floor"* and named nothing to implement. One `_binary_floor_gap` law now names the **pair** — the actual dispatch unit. That testimony is what identified the complex field as the owner; without it the pair was undiagnosable.

## Pairs that stay loud, and why

| pair | count in sample | why it stays loud |
|---|---|---|
| `ground_index_error` / `ground_type_error` / `ground_assertion_error` × `absolute source locus` | 3 | Five `ground_*` helpers refuse to mint an exceptional exit keyed on a machine-absolute path. Installed-corpus files **are** absolute and there is no workspace-relative lift door for them (`corpus.py` carries a display-only `rel`). Closing it means either building that door or re-keying every ground exit on content rather than path — a source-identity/CID decision, not a value-category floor. Not smuggled into a floor PR. |
| `attribute × DictValue`, `attribute × NoneValue` | 2 | `{}.foo` / `None.foo` are `AttributeError` — a typed exceptional exit whose grounding hits the same absolute-locus wall (`none_value.py` already carries that guard). Blocked behind the row above. |
| `guarded × PlaceAssignValue` | 1 | A place-assign riding under a guard. Distinct from #6296's `UniverseValue.guarded`; not investigated. |
| `{List,Tuple}Value.contains × CallSiteValue` | 2 | See above — needs a `denotes_a_value` testimony on the value itself. |
| `add × ListValue` | 1 | `[""] + (columns or ["", ""])` — the right operand of a boolean-`or`. Needs the disjunction's constructed value, not an addition arm. |

## Measurement

Same 236-file manifest, same corpus, baseline vs head, per-file 30s bound, 4 workers. Numbers in the thread below.

## Do not touch

`outcome/exit_set.py`, `floor/call_site_value.py`, `ir.py`, `sugar/spread_sugar.py` — untouched (#6309 holds those).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add complex field arithmetic, uncapped sequence repetition, and term-bearing membership to Floor values
> - Adds `add`, `subtract`, and `multiply` to `ComplexValue` and `TermValue` that fold mixed numeric/complex operations into `ComplexValue` results, falling back to the floor gap for non-field members.
> - Introduces `complex_field_coordinate` and `closed_complex_operation` utilities in [complex_arithmetic.py](https://github.com/TSavo/sugar/pull/6317/files#diff-0df8289fccc549b145631fa9c1dd61ac8b0e67b136717200a7b6311186fe1b15) to centralize field membership detection and result wrapping.
> - Replaces bespoke repetition logic in `ListValue.multiply` and `TupleValue.multiply` with a shared `repeat_sequence` utility that materializes up to `EAGER_MATERIALIZATION_BUDGET` elements and folds larger or opaque counts into a `SymbolicValue` term coordinate instead of panicking.
> - Refactors `FloorValue` binary operation gap raising into a single `_binary_floor_gap` helper, standardizing error messages to include the right operand type.
> - Behavioral Change: list and tuple repetition no longer panics for large concrete counts; those cases now produce a symbolic coordinate instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7511420.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->