### PR TITLE
ExitSet: rejoin complementary completed faces as GuardedValue factors (#6309)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -263,6 +263,48 @@ class ExitSet(Generic[T]):
                     exits.append(Halted(guard, following.effect, following.state))
         return ExitSet(tuple(exits)).normalize()
 
+    def try_rejoin_as_guarded_value(self):
+        """Rejoin a pure complementary completed pair into one ``GuardedValue``.
+
+        ``sequence`` is a Cartesian product: a spread (or any value collect)
+        over *k* elements each yielding *m* arms materialises *m^k* concrete
+        exits. When the arms are exactly the two faces of one partition —
+        ``Completed(g, v_t)`` and ``Completed(complement(g), v_f)``, no
+        halted face — both faces are already represented by one
+        ``GuardedValue(g, v_t, v_f)``. Rejoining keeps the factor form so a
+        later ``and_then`` multiplies by one, not by two (#6309 / residual
+        R(timeout) arm population after #6311).
+
+        Returns ``Complete(GuardedValue(...))`` when the shape matches, else
+        ``None``. Never drops a face, never invents a halt, never rejoins
+        when any arm is halted (control exits stay multi-arm ExitSets).
+        """
+        if len(self.exits) != 2:
+            return None
+        left, right = self.exits
+        if not isinstance(left, Completed) or not isinstance(right, Completed):
+            return None
+        if _is_negation(left.guard, right.guard):
+            # left.guard is not_(right.guard)  →  right is the positive face
+            if getattr(left.guard, "kind", None) == "not":
+                guard, when_true, when_false = right.guard, right.value, left.value
+            else:
+                guard, when_true, when_false = left.guard, left.value, right.value
+        elif left.guard == complement_guard(right.guard):
+            guard, when_true, when_false = right.guard, right.value, left.value
+        elif right.guard == complement_guard(left.guard):
+            guard, when_true, when_false = left.guard, left.value, right.value
+        else:
+            return None
+        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+        from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+        if not isinstance(when_true, FloorValue) or not isinstance(
+            when_false, FloorValue
+        ):
+            return None
+        return Complete(GuardedValue(guard, when_true, when_false))
+
     def and_then(self, step):
         return self.sequence(lambda value: outcome_to_exitset(step(value)))
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -5,15 +5,33 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.outcome.exit_set import ExitSet
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+def _factor_value_outcome(outcome):
+    """Keep complementary completed faces as one GuardedValue factor (#6309).
+
+    Spread collect chains ``and_then`` once per element. ``ExitSet.sequence`` is
+    a Cartesian product, so *k* elements each yielding *m* arms produce *m^k*
+    concrete exits. When an element's outcome is exactly the two faces of one
+    partition, rejoin them into ``GuardedValue`` before sequencing so the next
+    element multiplies by one factor, not by two. Both faces stay represented;
+    halted arms are never rejoined (see ``ExitSet.try_rejoin_as_guarded_value``).
+    """
+    if isinstance(outcome, ExitSet):
+        rejoined = outcome.try_rejoin_as_guarded_value()
+        if rejoined is not None:
+            return rejoined
+    return outcome
 
 
 def _collect(sugars: tuple, ctx, done: tuple, finish):
     if not sugars:
         return finish(done)
     head, *tail = sugars
-    return head.desugar(ctx).and_then(
+    return _factor_value_outcome(head.desugar(ctx)).and_then(
         lambda value: _collect(tuple(tail), ctx, (*done, value), finish)
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_population_rejoin.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_population_rejoin.py
@@ -1,0 +1,127 @@
+"""Arm population: complementary completed faces rejoin as GuardedValue (#6309).
+
+After #6311, normalize work is near-linear in arm count. What remains of
+R(timeout) is arm POPULATION: ``ExitSet.sequence`` is a Cartesian product, and
+a spread-shaped collect over *k* two-face elements materialises 2^k concrete
+exits when destinations accumulate along the path.
+
+This twin pins the factor disposition: a pure complementary completed pair
+rejoins into one ``GuardedValue`` so collect multiplies by one factor per
+element, not by two. Both faces stay represented. Halted arms never rejoin.
+
+R(arm_cartesian) on the synthetic k=10 collect is 0 only when rejoin holds;
+the planted 2^k baseline stays as the red witness that the product is real.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.floor import CallSiteValue, GuardedValue, SymbolicValue
+from sugar_lift_py_tests.ir import atomic, ctor, not_, str_const
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+from sugar_lift_py_tests.effect import RaiseEffect
+
+
+def _guard(name: str):
+    return atomic(name, [])
+
+
+def _callsite(tag: str) -> CallSiteValue:
+    return CallSiteValue(
+        target_name=tag,
+        arg_values=(),
+        parameters=(),
+        term=ctor("python:call", [str_const(tag)]),
+        body=None,
+        site=f"site:{tag}",
+    )
+
+
+def _two_face(i: int) -> ExitSet:
+    g = _guard(f"g{i}")
+    return ExitSet(
+        (
+            Completed(g, _callsite(f"e{i}_t")),
+            Completed(not_(g), _callsite(f"e{i}_f")),
+        )
+    ).normalize()
+
+
+def test_try_rejoin_complementary_completed_becomes_guarded_value() -> None:
+    g = _guard("p")
+    es = ExitSet(
+        (Completed(g, _callsite("t")), Completed(not_(g), _callsite("f")))
+    ).normalize()
+
+    rejoined = es.try_rejoin_as_guarded_value()
+
+    assert isinstance(rejoined, Complete)
+    assert isinstance(rejoined.value, GuardedValue)
+    assert rejoined.value.guard == g
+    assert rejoined.value.when_true == _callsite("t")
+    assert rejoined.value.when_false == _callsite("f")
+
+
+def test_try_rejoin_refuses_halted_face() -> None:
+    g = _guard("p")
+    effect = RaiseEffect(exception_name="ValueError")
+    es = ExitSet(
+        (Halted(g, effect, _callsite("s")), Completed(not_(g), _callsite("c")))
+    ).normalize()
+
+    assert es.try_rejoin_as_guarded_value() is None
+
+
+def test_try_rejoin_refuses_non_complementary_guards() -> None:
+    es = ExitSet(
+        (
+            Completed(_guard("a"), _callsite("t")),
+            Completed(_guard("b"), _callsite("f")),
+        )
+    ).normalize()
+
+    assert es.try_rejoin_as_guarded_value() is None
+
+
+def test_spread_shaped_collect_stays_linear_in_element_count() -> None:
+    """k two-face factors compose to one GuardedValue path, not 2^k ExitSet arms.
+
+    The planted Cartesian baseline (sequence without rejoin) is 2^k — that is
+    the residual #6309 owns. With rejoin at each factor, collect finishes with
+    a single completed outcome whose values carry nested faces.
+    """
+    k = 10
+
+    def chain_cartesian(idx: int, done: tuple):
+        if idx == k:
+            terms = [v.to_term(owner="o") for v in done]
+            return Complete(SymbolicValue(ctor("python:list", terms)))
+        return _two_face(idx).and_then(
+            lambda v, idx=idx, done=done: chain_cartesian(idx + 1, (*done, v))
+        )
+
+    cartesian = chain_cartesian(0, ())
+    assert hasattr(cartesian, "exits"), "cartesian path must stay multi-arm ExitSet"
+    assert len(cartesian.exits) == 2**k, (
+        f"planted residual: without rejoin, k={k} must produce {2**k} arms; "
+        f"got {len(cartesian.exits)}"
+    )
+
+    def chain_factored(idx: int, done: tuple):
+        if idx == k:
+            terms = [v.to_term(owner="o") for v in done]
+            return Complete(SymbolicValue(ctor("python:list", terms)))
+        outcome = _two_face(idx)
+        rejoined = outcome.try_rejoin_as_guarded_value()
+        assert rejoined is not None, f"element {idx} must rejoin"
+        return rejoined.and_then(
+            lambda v, idx=idx, done=done: chain_factored(idx + 1, (*done, v))
+        )
+
+    factored = chain_factored(0, ())
+    assert isinstance(
+        factored, Complete
+    ), f"factored collect must finish as one Complete, got {type(factored).__name__}"
+    assert isinstance(factored.value, SymbolicValue)
+    # R(arm_cartesian)=0 for this twin: one completed outcome, not 2^k ExitSet arms.
+    assert not isinstance(factored, ExitSet)


### PR DESCRIPTION
## R(timeout) status

**No claim that `pandas/core/generic.py` clears.** This PR is the next #6309 disposition after #6311: arm *population*, not normalize cost.

| measurement (main tip `e6d688d3c` + this) | result |
|---|---|
| SourceFile door + DesugarAxis.measure on `pandas/core/generic.py` | CLEARED ~53–120s wall-clock (load-sensitive); `arms_max` observed 8 mid-file, **689** at end |
| `open_source_file_for_construction(populate_derived=True)` single-file | **TIMEOUT in open phase @300s** (package demand/context), normalize never entered |
| Synthetic spread collect k=10 two-face elements | planted Cartesian **2^10 arms**; factored rejoin → **1 Complete** |

#6311 left R(timeout)=1 with arm growth remaining. Identity auth + bucketed normalize are on main. This PR does not restore the timeout floor and must not be read as doing so.

## What this does

`ExitSet.sequence` is a Cartesian product. Spread `_collect` chains `and_then` per element → *m^k* concrete exits when each element yields *m* arms and destinations accumulate.

When an ExitSet is exactly:

```
Completed(g, v_t) | Completed(complement(g), v_f)   # no halted arm
```

both faces are already one `GuardedValue(g, v_t, v_f)`. Rejoin before sequencing so the next element multiplies by **one factor**, not two.

- `ExitSet.try_rejoin_as_guarded_value()` — returns `Complete(GuardedValue)` or `None`
- `spread_sugar._collect` — factors element outcomes before `and_then`
- Halted faces **never** rejoin (control ExitSets stay multi-arm)

## Twin (stays red if rejoin regresses)

`test_exit_set_arm_population_rejoin.py`:

1. Planted residual: k=10 collect **without** rejoin → `len(exits) == 2**10`
2. Factored path: rejoin each element → single `Complete` (not ExitSet)
3. Halts / non-complementary guards refuse rejoin

## Validation

```
pytest --noconftest \
  tests/test_exit_set_arm_population_rejoin.py \
  tests/test_exit_set.py \
  tests/test_exit_set_normalize_identity.py \
  tests/test_exit_set_normalize_complexity.py \
  # + test_starred_spread.py
# 86 + spread tests: all green
```

## ΔR / ΕR

| axis | before | after | notes |
|---|---|---|---|
| R(arm_cartesian) synthetic k=10 | 1024 | **0** | factored twin |
| R(timeout) generic.py | 1 (per #6311 @300s) | **not claimed 0** | still load/door sensitive; open door 300s red |

Part of #6309. Supersedes nothing of #6311.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExitSet.try_rejoin_as_guarded_value` to collapse complementary completed faces into a `GuardedValue`
> - Adds `try_rejoin_as_guarded_value()` to `ExitSet` in [exit_set.py](https://github.com/TSavo/sugar/pull/6318/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716): when the set holds exactly two complementary `Completed` exits whose values are `FloorValue`, it returns a `Complete(GuardedValue(...))` rejoining the two faces; otherwise returns `None`.
> - Introduces `_factor_value_outcome` in [spread_sugar.py](https://github.com/TSavo/sugar/pull/6318/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945) and calls it inside `_collect` before chaining with `and_then`, so complementary completed faces are rejoined early rather than proliferating into exponentially large `ExitSet` arms.
> - Adds tests in [test_exit_set_arm_population_rejoin.py](https://github.com/TSavo/sugar/pull/6318/files#diff-96863b164516a833d579fb3f1c3d138b94dc1f05bf7942641cb2341242850d3c) covering successful rejoin, rejection of halted faces, rejection of non-complementary guards, and a linearity test showing the factored chain stays O(k) arms instead of O(2^k).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 079fcc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->