### PR TITLE
An arm that halts is not an arm that is missing: ten desugar defect families

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -104,6 +104,60 @@ class ContractConditionalConstructionV1:
             else following
         )
 
+    def demanded_under(self, formula):
+        """Weaken the pending obligation to a guarded face; carried value untouched.
+
+        The demand is owed only where the branch runs. `python:indexable(p)` for
+        `if c: return p[0]` is `c -> python:indexable(p)`, never the
+        unconditional obligation: a caller that never takes the branch owes
+        nothing. Re-minting changes `demand_cid`, which is correct -- it IS a
+        different obligation.
+
+        This is the half a caller wants when the caller is guarding the VALUE
+        itself (an `IfExp` that fuses both arms into one `GuardedValue`), so
+        guarding the value here too would guard it twice. `guarded` is the other
+        door, for a caller that hands the whole entry under a branch.
+        """
+        from sugar_lift_py_tests.ir import implies
+
+        return replace(
+            self,
+            demand=ParameterContractDemandV1.mint(
+                owner_source_identity_cid=self.demand.owner_source_identity_cid,
+                formal_coordinate_cid=self.demand.formal_coordinate_cid,
+                operation_site=self.demand.operation_site,
+                demanded_formula=implies(formula, self.demand.demanded_formula),
+                candidate_cid=self.demand.candidate_cid,
+            ),
+        )
+
+    def guarded(self, formula):
+        """Ride under a branch: the CARRIED value guards, the DEMAND weakens.
+
+        This entry is a wrapper -- `and_then` threads the branch's real floor
+        value through `self.value`, and `resume_project` substitutes exactly
+        that value once the linker discharges the demand. So a guard reaching
+        this entry has two distinct arms to conserve, and neither may be
+        dropped:
+
+        1. The carried value guards the way it would have if no demand were
+           pending (ReturnValue -> GuardedReturn, InvValue -> implication, ...).
+           Guarding the wrapper without guarding the value would let the
+           resumed record project an UNGUARDED return for a branch that only
+           runs under `formula`.
+        2. The demand is owed only on the guarded face. `python:indexable(p)`
+           for `if c: return p[0]` is `c -> python:indexable(p)`, never the
+           unconditional obligation -- a caller that never takes the branch
+           owes nothing. Weakening re-mints the demand, so `demand_cid`
+           changes: it IS a different obligation.
+
+        Nested guards compose by repeated application, innermost first, which
+        is the same accumulation `Incomplete.guarded` records positionally.
+        """
+        return replace(
+            self.demanded_under(formula), value=self.value.guarded(formula)
+        )
+
     def contribution(self):
         return (self,)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -51,17 +51,36 @@ class GuardedValue(FloorValue):
                 GuardedValue(other.guard, true_outcome.value, false_outcome.value)
             )
 
+        from sugar_lift_py_tests.floor.single_outcome_law import (
+            pending_demand,
+            require_single_value,
+            rewrap_pending,
+        )
+
+        owner = f"GuardedValue._map({method})"
+        blame = args[-1] if args else method
         true_outcome = getattr(self.when_true, method)(*args)
         if isinstance(true_outcome, Incomplete):
             return true_outcome.guarded(self.guard)
         false_outcome = getattr(self.when_false, method)(*args)
         if isinstance(false_outcome, Incomplete):
             return false_outcome.guarded(not_(self.guard))
-        assert isinstance(true_outcome, Complete)
-        assert isinstance(false_outcome, Complete)
-        return Complete(
+        # An arm may answer with a value that still owes a parameter contract
+        # (`(a if c else p)[i]` for a formal `p`). The demand is owed only on that
+        # arm's face; hoist it, join the carried values, then re-attach it.
+        true_pending, true_outcome = pending_demand(true_outcome, self.guard)
+        false_pending, false_outcome = pending_demand(false_outcome, not_(self.guard))
+        true_outcome = require_single_value(
+            true_outcome, owner=owner, blame=blame, arm="when_true"
+        )
+        false_outcome = require_single_value(
+            false_outcome, owner=owner, blame=blame, arm="when_false"
+        )
+        joined = Complete(
             GuardedValue(self.guard, true_outcome.value, false_outcome.value)
         )
+        joined = rewrap_pending(true_pending, joined, owner=owner, blame=blame)
+        return rewrap_pending(false_pending, joined, owner=owner, blame=blame)
 
     def _predicate(self, method: str, *args):
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
@@ -74,14 +93,33 @@ class GuardedValue(FloorValue):
             TrueBoolLiteralSugar,
         )
 
+        from sugar_lift_py_tests.floor.single_outcome_law import (
+            pending_demand,
+            require_single_value,
+            rewrap_pending,
+        )
+
+        owner = f"GuardedValue._predicate({method})"
+        blame = args[-1] if args else method
         true_outcome = getattr(self.when_true, method)(*args)
         if isinstance(true_outcome, Incomplete):
             return true_outcome.guarded(self.guard)
         false_outcome = getattr(self.when_false, method)(*args)
         if isinstance(false_outcome, Incomplete):
             return false_outcome.guarded(not_(self.guard))
-        assert isinstance(true_outcome, Complete)
-        assert isinstance(false_outcome, Complete)
+        true_pending, true_outcome = pending_demand(true_outcome, self.guard)
+        false_pending, false_outcome = pending_demand(false_outcome, not_(self.guard))
+        true_outcome = require_single_value(
+            true_outcome, owner=owner, blame=blame, arm="when_true"
+        )
+        false_outcome = require_single_value(
+            false_outcome, owner=owner, blame=blame, arm="when_false"
+        )
+
+        def _rejoin(outcome):
+            outcome = rewrap_pending(true_pending, outcome, owner=owner, blame=blame)
+            return rewrap_pending(false_pending, outcome, owner=owner, blame=blame)
+
         true_value = true_outcome.value
         false_value = false_outcome.value
 
@@ -97,7 +135,7 @@ class GuardedValue(FloorValue):
         true_formula = formula(true_value)
         false_formula = formula(false_value)
         if true_formula is None or false_formula is None:
-            return super().equals(args[0], args[-1])
+            return _rejoin(super().equals(args[0], args[-1]))
         if (
             type(true_value) is TrueBoolLiteralSugar
             and type(false_value) is FalseBoolLiteralSugar
@@ -115,7 +153,7 @@ class GuardedValue(FloorValue):
                     implies(not_(self.guard), false_formula),
                 ]
             )
-        return Complete(
+        joined = Complete(
             PredicateValue(
                 joined_formula,
                 args[-1],
@@ -133,6 +171,7 @@ class GuardedValue(FloorValue):
                 ),
             )
         )
+        return _rejoin(joined)
 
     def predicate_from_left(self, method: str, left, site):
         """Distribute a binary predicate whose guarded value is the RHS."""
@@ -145,15 +184,32 @@ class GuardedValue(FloorValue):
         from sugar_lift_py_tests.ir import not_
         from sugar_lift_py_tests.outcome import Complete, Incomplete
 
+        from sugar_lift_py_tests.floor.single_outcome_law import (
+            pending_demand,
+            require_single_value,
+            rewrap_pending,
+        )
+
+        owner = f"GuardedValue.map_from_left({method})"
         true_outcome = getattr(left, method)(self.when_true, site)
         if isinstance(true_outcome, Incomplete):
             return true_outcome.guarded(self.guard)
         false_outcome = getattr(left, method)(self.when_false, site)
         if isinstance(false_outcome, Incomplete):
             return false_outcome.guarded(not_(self.guard))
-        return Complete(
+        true_pending, true_outcome = pending_demand(true_outcome, self.guard)
+        false_pending, false_outcome = pending_demand(false_outcome, not_(self.guard))
+        true_outcome = require_single_value(
+            true_outcome, owner=owner, blame=site, arm="when_true"
+        )
+        false_outcome = require_single_value(
+            false_outcome, owner=owner, blame=site, arm="when_false"
+        )
+        joined = Complete(
             GuardedValue(self.guard, true_outcome.value, false_outcome.value)
         )
+        joined = rewrap_pending(true_pending, joined, owner=owner, blame=site)
+        return rewrap_pending(false_pending, joined, owner=owner, blame=site)
 
     def _predicate_from_left(self, method: str, left, site):
         from sugar_lift_py_tests.outcome import Complete, Incomplete
@@ -166,10 +222,26 @@ class GuardedValue(FloorValue):
             from sugar_lift_py_tests.ir import not_
 
             return false_outcome.guarded(not_(self.guard))
-        assert isinstance(true_outcome, Complete)
-        assert isinstance(false_outcome, Complete)
+        from sugar_lift_py_tests.floor.single_outcome_law import (
+            pending_demand,
+            require_single_value,
+            rewrap_pending,
+        )
+        from sugar_lift_py_tests.ir import not_
+
+        owner = f"GuardedValue._predicate_from_left({method})"
+        true_pending, true_outcome = pending_demand(true_outcome, self.guard)
+        false_pending, false_outcome = pending_demand(false_outcome, not_(self.guard))
+        true_outcome = require_single_value(
+            true_outcome, owner=owner, blame=site, arm="when_true"
+        )
+        false_outcome = require_single_value(
+            false_outcome, owner=owner, blame=site, arm="when_false"
+        )
         joined = GuardedValue(self.guard, true_outcome.value, false_outcome.value)
-        return joined._predicate("truth", site)
+        outcome = joined._predicate("truth", site)
+        outcome = rewrap_pending(true_pending, outcome, owner=owner, blame=site)
+        return rewrap_pending(false_pending, outcome, owner=owner, blame=site)
 
     def subscript(self, index, site):
         return self._map("subscript", index, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sugar_lift_py_tests.floor.single_outcome_law import require_single_value
+
 from dataclasses import field as dataclass_field, dataclass
 
 from sugar_lift_py_tests.ir import Formula
@@ -310,7 +312,12 @@ class PredicateValue(FloorValue):
                 if isinstance(branch_answer, Incomplete):
                     effects.append(branch_answer.guarded(guard))
                     continue
-                assert isinstance(branch_answer, Complete)
+                branch_answer = require_single_value(
+                    branch_answer,
+                    owner="PredicateValue branch binding join",
+                    blame=name,
+                    arm="branch",
+                )
                 guarded.append((guard, name, branch_answer.value))
                 continue
             prior_answer = prior.answer(before_scope)
@@ -323,8 +330,18 @@ class PredicateValue(FloorValue):
             ):
                 joined.append((name, GuardedValue(guard, binding, prior)))
                 continue
-            assert isinstance(branch_answer, Complete)
-            assert isinstance(prior_answer, Complete)
+            branch_answer = require_single_value(
+                branch_answer,
+                owner="PredicateValue branch binding join",
+                blame=name,
+                arm="branch",
+            )
+            prior_answer = require_single_value(
+                prior_answer,
+                owner="PredicateValue branch binding join",
+                blame=name,
+                arm="prior",
+            )
             joined.append(
                 (
                     name,
@@ -377,8 +394,18 @@ class PredicateValue(FloorValue):
                     )
                 )
                 continue
-            assert isinstance(then_answer, Complete)
-            assert isinstance(else_answer, Complete)
+            then_answer = require_single_value(
+                then_answer,
+                owner="PredicateValue then/else binding join",
+                blame=name,
+                arm="then",
+            )
+            else_answer = require_single_value(
+                else_answer,
+                owner="PredicateValue then/else binding join",
+                blame=name,
+                arm="else",
+            )
             joined.append(
                 (
                     name,
@@ -401,7 +428,12 @@ class PredicateValue(FloorValue):
                 if isinstance(answer, Incomplete):
                     effects.append(answer.guarded(branch_guard))
                     continue
-                assert isinstance(answer, Complete)
+                answer = require_single_value(
+                    answer,
+                    owner="PredicateValue one-sided binding join",
+                    blame=name,
+                    arm="branch",
+                )
                 guarded.append((branch_guard, name, answer.value))
         return tuple(joined), tuple(guarded), tuple(effects)
 
@@ -421,7 +453,12 @@ class PredicateValue(FloorValue):
             if isinstance(answer, Incomplete):
                 effects.append(answer)
                 continue
-            assert isinstance(answer, Complete)
+            answer = require_single_value(
+                answer,
+                owner="PredicateValue surviving binding join",
+                blame=name,
+                arm="surviving",
+            )
             bindings.append((name, answer.value))
         return tuple(bindings), tuple(effects)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -1,0 +1,124 @@
+"""THE LAW: an operation distributed into a branch arm yields ONE outcome.
+
+`GuardedValue._map` / `_predicate` and `PredicateValue`'s binding-join paths all
+do the same thing: take one operation, apply it to each arm of a value that is
+already split by a guard, and rejoin the per-arm answers under that guard. Every
+one of them handled `Complete` and `Incomplete` and then wrote
+
+    assert isinstance(true_outcome, Complete)
+
+which is a bare assertion. A bare assert names no law: when it fired, the census
+recorded `AssertionError: ` with an empty message, and there was nothing in the
+failure to say what had been violated or what should replace it. Every assert in
+that family is routed through this module instead, so the failure states the law.
+
+There are exactly two ways an arm can answer with something that is not one
+value and not one effect, and they are different obligations, not one blob:
+
+- A PENDING PARAMETER CONTRACT (`ContractConditionalConstructionV1`). The arm
+  reduced to a value, but the value carries a demand the linker has not yet
+  discharged -- e.g. `(a if c else b)[i]` where `b` is a formal, so the arm's
+  subscript enrolled `python:indexable(b)`. This is not a gap: `pending_demand`
+  hoists the demand out under the arm's own guard and hands the join the carried
+  value, which is what the arm actually reduced to.
+
+- A PARTITION (`ExitSet`). The arm's own operation split into completed and
+  halted faces -- a store inside a conditional arm, a call that can halt. Fusing
+  a partition back into one `GuardedValue` arm has no honest shape here: the halt
+  face is not a value and the join has no seam to put it on. That is a real
+  construction gap, and `require_single_value` panics with it NAMED, so it is
+  loud and counted rather than an empty `AssertionError`.
+"""
+
+from __future__ import annotations
+
+SINGLE_OUTCOME_LAW = (
+    "an operation distributed into a guarded arm answers with exactly one "
+    "outcome: one value (Complete) or one effect (Incomplete)"
+)
+
+
+def pending_demand(outcome, guard):
+    """Hoist a pending parameter-contract demand off an arm's answer.
+
+    Returns ``(pending_entry, value_outcome)``. ``pending_entry`` is ``None``
+    unless the arm answered with a pending contract; when it is not ``None``, its
+    demand has already been weakened to ``guard`` -- the caller owes the
+    obligation only on the face the arm occupies -- and ``value_outcome`` is the
+    plain ``Complete`` the join should consume.
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ContractConditionalConstructionV1,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+
+    if not isinstance(outcome, ContractConditionalConstructionV1):
+        return None, outcome
+    return outcome.demanded_under(guard), Complete(outcome.value)
+
+
+def rewrap_pending(pending, outcome, *, owner, blame):
+    """Re-attach a hoisted demand to a joined result, or be loud.
+
+    A joined ``Complete`` takes the demand back and the entry rides on into the
+    block record. A joined partition or effect has nowhere to carry it: one entry
+    holds exactly one value, so the demand would have to be dropped. Dropping a
+    pending obligation silently would let a caller discharge nothing and still
+    look resolved, so it panics NAMED instead.
+    """
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.outcome import Complete
+
+    if pending is None:
+        return outcome
+    if isinstance(outcome, Complete):
+        return replace(pending, value=outcome.value)
+    from sugar_lift_py_tests.gap.info import GapKind
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner=owner,
+        blame=blame,
+        observed=(
+            "a hoisted parameter contract demand "
+            f"({pending.demand.demand_cid}) joined onto a "
+            f"{type(outcome).__name__}, which carries no single value"
+        ),
+        requested="a joined Complete that can carry the pending demand",
+        fix=(
+            "give the exit algebra an arm for a pending contract demand so a "
+            "partition can carry it; never drop the obligation"
+        ),
+        gap_kind=GapKind.FLOOR,
+    )
+
+
+def require_single_value(outcome, *, owner, blame, arm: str):
+    """The arm's answer as one value, or a NAMED construction gap.
+
+    Callers must already have handled the ``Incomplete`` face (an effect IS one
+    lawful outcome) and hoisted any pending demand through ``pending_demand``.
+    What is left that is not ``Complete`` is a partition, and it is a gap.
+    """
+    from sugar_lift_py_tests.outcome import Complete
+
+    if isinstance(outcome, Complete):
+        return outcome
+    from sugar_lift_py_tests.gap.info import GapKind
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner=owner,
+        blame=blame,
+        observed=(
+            f"the {arm} arm answered with {type(outcome).__name__}, violating: "
+            f"{SINGLE_OUTCOME_LAW}"
+        ),
+        requested=SINGLE_OUTCOME_LAW,
+        fix=(
+            "rejoin the arm's partition in the exit algebra before the guarded "
+            "join, so each face keeps its own guard"
+        ),
+        gap_kind=GapKind.FLOOR,
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -74,22 +74,39 @@ def rewrap_pending(pending, outcome, *, owner, blame):
         return outcome
     if isinstance(outcome, Complete):
         return replace(pending, value=outcome.value)
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ContractConditionalConstructionV1,
+    )
     from sugar_lift_py_tests.gap.info import GapKind
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
+    # Two different next architectures, named apart rather than blurred: a second
+    # PENDING entry wants the entry to carry a demand SET; a PARTITION wants the
+    # exit algebra to have an arm for a pending demand at all.
+    if isinstance(outcome, ContractConditionalConstructionV1):
+        observed = (
+            f"two pending contract demands ({pending.demand.demand_cid} and "
+            f"{outcome.demand.demand_cid}) joined onto one constructed value"
+        )
+        fix = (
+            "widen ContractConditionalConstructionV1 to carry a demand SET; "
+            "never drop the obligation"
+        )
+    else:
+        observed = (
+            f"a hoisted parameter contract demand ({pending.demand.demand_cid}) "
+            f"joined onto a {type(outcome).__name__}, which carries no single value"
+        )
+        fix = (
+            "give the exit algebra an arm for a pending contract demand so a "
+            "partition can carry it; never drop the obligation"
+        )
     construction_panic_gap(
         owner=owner,
         blame=blame,
-        observed=(
-            "a hoisted parameter contract demand "
-            f"({pending.demand.demand_cid}) joined onto a "
-            f"{type(outcome).__name__}, which carries no single value"
-        ),
-        requested="a joined Complete that can carry the pending demand",
-        fix=(
-            "give the exit algebra an arm for a pending contract demand so a "
-            "partition can carry it; never drop the obligation"
-        ),
+        observed=observed,
+        requested="one joined value that can carry every pending demand",
+        fix=fix,
         gap_kind=GapKind.FLOOR,
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -42,26 +42,40 @@ class BoolOpSugar(Sugar):
         from functools import reduce
 
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.outcome import Incomplete
         from sugar_lift_py_tests.outcome.exit_set import _and_guards, _or_guards
         from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
-        formulas = []
+        # Operands thread through `and_then`, the one door every Outcome variant
+        # implements. An operand that halts propagates -- the boolean is not
+        # decidable once a conjunct halts -- and an operand that PARTITIONS
+        # (`a and (d[k] := f())`, a conjunct whose store can halt) keeps both
+        # arms: each completed arm folds its own formula under its own guard.
+        # Reading `.value` off the outcome assumed exactly one arm and was the
+        # `'ExitSet' object has no attribute 'value'` defect here.
+        def collect(operand, collected):
+            return operand.desugar(ctx).and_then(
+                # Same truth→formula projection as if/if-exp: symbolic formulas
+                # stand as themselves; ground True/False (including None.truth →
+                # False) fold through true_guard/false_guard. Never raise bare
+                # NotImplementedError on a constructible ground boolean.
+                lambda value: Complete(
+                    (*collected, predicate_formula(value, self.site))
+                )
+            )
+
+        outcome = Complete(())
         for operand in self.values:
-            out = operand.desugar(ctx)
-            if isinstance(out, Incomplete):
-                # An operand that is itself an effect propagates -- the boolean is
-                # not decidable once a conjunct halts.
-                return out
-            # Same truth→formula projection as if/if-exp: symbolic formulas stand
-            # as themselves; ground True/False (including None.truth → False)
-            # fold through true_guard/false_guard. Never raise bare
-            # NotImplementedError on a constructible ground boolean.
-            formulas.append(predicate_formula(out.value, self.site))
+            outcome = outcome.and_then(
+                lambda collected, operand=operand: collect(operand, collected)
+            )
 
         # Fold with the shared guard algebra so ground identities absorb:
         #   false ∧ φ → false,  true ∧ φ → φ,  true ∨ φ → true,  false ∨ φ → φ.
         # Raw and_/or_ would leave and_([false, true]) as a connective and hide
         # that None and True is false in boolean context.
         combine = _and_guards if self.op_kind == "And" else _or_guards
-        return Complete(PredicateValue(reduce(combine, formulas), self.site))
+        return outcome.and_then(
+            lambda formulas: Complete(
+                PredicateValue(reduce(combine, formulas), self.site)
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -18,18 +18,68 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
-def _reduce_all(element_sugars, ctx):
-    """Reduce each element sugar to its floor value, in order. Returns
-    ``(values, None)`` or ``(None, effect)`` if an element reduced to an effect."""
-    from sugar_lift_py_tests.outcome import Incomplete
+def _reduce_into(element_sugars, ctx, build):
+    """Reduce elements in source order, then hand the tuple of values to ``build``.
 
-    values = []
-    for element in element_sugars:
-        out = element.desugar(ctx)
-        if isinstance(out, Incomplete):
-            return None, out
-        values.append(out.value)
-    return tuple(values), None
+    LAW: an element's outcome is not one unconditional value. ``and_then`` is the
+    one door every ``Outcome`` variant implements, and each variant states its own
+    law through it -- ``Complete`` continues (a constructed raise keeps the
+    control-flow value and evaluates no enclosing step), ``Incomplete`` propagates
+    the effect and never runs the tail, ``ExitSet`` threads every completed arm
+    while halted arms bypass, and a pending parameter-contract candidate keeps its
+    demand attached while its carried value continues.
+
+    Reading ``.value`` off the outcome instead assumed exactly one arm, which is
+    false the moment an element can halt: `[a, d[k] := f()]`, an element whose
+    store partitions, a comparison chain that raises on one face. That assumption
+    was the `'ExitSet' object has no attribute 'value'` defect, and it also
+    dropped a pending contract demand on the floor.
+    """
+    from sugar_lift_py_tests.floor.single_outcome_law import (
+        pending_demand,
+        rewrap_pending,
+    )
+    from sugar_lift_py_tests.outcome import true_guard
+
+    owner = f"collection {build.__name__}"
+    reduced = tuple(element.desugar(ctx) for element in element_sugars)
+
+    # An element that owes a parameter contract (`[p[0], 1]` for a formal `p`)
+    # wraps its value rather than being one; the exit algebra has no arm for it,
+    # so hoist the demand out of the fold and re-attach it to the built
+    # collection. The element's demand is unconditional here -- a collection
+    # display has no guard of its own -- so it hoists at `true_guard`.
+    pending = None
+    stripped = []
+    for outcome in reduced:
+        entry, plain = pending_demand(outcome, true_guard())
+        if entry is not None and pending is not None:
+            from sugar_lift_py_tests.gap.info import GapKind
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner=owner,
+                blame=str(entry.source_node),
+                observed="two collection elements enrolled a contract demand",
+                requested="one pending demand per constructed value",
+                fix=(
+                    "widen ContractConditionalConstructionV1 to carry a demand SET "
+                    "before building a collection from two pending elements"
+                ),
+                gap_kind=GapKind.FLOOR,
+            )
+        pending = entry if entry is not None else pending
+        stripped.append(plain)
+
+    outcome = Complete(())
+    for element_outcome in stripped:
+        outcome = outcome.and_then(
+            lambda collected, got=element_outcome: got.and_then(
+                lambda value: Complete((*collected, value))
+            )
+        )
+    built = outcome.and_then(lambda values: Complete(build(values)))
+    return rewrap_pending(pending, built, owner=owner, blame=owner)
 
 
 @dataclass(frozen=True)
@@ -50,8 +100,7 @@ class ListSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.list_value import ListValue
 
-        values, effect = _reduce_all(self.elements, ctx)
-        return effect if effect is not None else Complete(ListValue(values))
+        return _reduce_into(self.elements, ctx, ListValue)
 
 
 @dataclass(frozen=True)
@@ -72,8 +121,7 @@ class TupleSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.tuple_value import TupleValue
 
-        values, effect = _reduce_all(self.elements, ctx)
-        return effect if effect is not None else Complete(TupleValue(values))
+        return _reduce_into(self.elements, ctx, TupleValue)
 
 
 @dataclass(frozen=True)
@@ -94,8 +142,7 @@ class SetSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.set_value import SetValue
 
-        values, effect = _reduce_all(self.elements, ctx)
-        return effect if effect is not None else Complete(SetValue(values))
+        return _reduce_into(self.elements, ctx, SetValue)
 
 
 @dataclass(frozen=True)
@@ -117,11 +164,14 @@ class DictSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.dict_value import DictValue
 
-        key_values, effect = _reduce_all(self.keys, ctx)
-        if effect is not None:
-            return effect
-        val_values, effect = _reduce_all(self.values, ctx)
-        if effect is not None:
-            return effect
-        entries = tuple(zip(key_values, val_values))
-        return Complete(DictValue(entries))
+        # Keys and values interleave in source order (`{k1: v1, k2: v2}`), so
+        # they reduce as ONE element sequence and are re-paired afterwards. A
+        # halt in `v1` must not be reported after `k2` was evaluated.
+        interleaved = tuple(
+            sugar for pair in zip(self.keys, self.values) for sugar in pair
+        )
+
+        def build(flat):
+            return DictValue(tuple(zip(flat[0::2], flat[1::2])))
+
+        return _reduce_into(interleaved, ctx, build)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -16,6 +16,10 @@ class EqualityOpSugar(Sugar):
     left: Sugar
     right: Sugar
     site: object = dataclass_field(compare=False)
+    # The dotted PLACE this pair's left operand names (`x`, `a.b.c`), or None if
+    # it names none. Read off the tree by `Compare._construct_sugar`, because
+    # only construction knows which operand is this pair's left.
+    left_coordinate: object = None
 
     @classmethod
     def witnesses(cls):
@@ -26,7 +30,9 @@ class EqualityOpSugar(Sugar):
         # whether it equals the right. That is all `==` desugars to.
         return self.left.desugar(ctx).and_then(
             lambda left: self.right.desugar(ctx).and_then(
-                lambda right: _equals_and_refine(left, right, self.site, ctx)
+                lambda right: _equals_and_refine(
+                    left, right, self.site, ctx, self.left_coordinate
+                )
             )
         )
 
@@ -51,7 +57,7 @@ def _finite_equality_face(value, peer, *, matches: bool):
     return value if equal is matches else None
 
 
-def _equals_and_refine(left, right, site, ctx):
+def _equals_and_refine(left, right, site, ctx, left_coordinate):
     outcome = _equals_with_derived_residue(left, right, site, ctx)
     from sugar_lift_py_tests.floor import PredicateValue
     from sugar_lift_py_tests.outcome import Complete
@@ -69,7 +75,7 @@ def _equals_and_refine(left, right, site, ctx):
         TermValue,
     ):
         return outcome
-    coordinate = site.compare_left().dotted_expr_name()
+    coordinate = left_coordinate
     if not coordinate:
         return outcome
     matching = _finite_equality_face(left, right, matches=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -34,33 +34,39 @@ class FormattedValueSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.ir import ctor, str_const
-        from sugar_lift_py_tests.outcome import Incomplete
 
-        value = self.value.desugar(ctx)
-        if isinstance(value, Incomplete):
-            return value
-        if self.format_spec is None:
-            format_spec_term = ctor("None", [])
-        else:
-            format_spec = self.format_spec.reference_term(ctx)
-            if isinstance(format_spec, Incomplete):
-                return format_spec
-            format_spec_term = format_spec.value
         conversion_term = (
             ctor("None", []) if self.conversion is None else str_const(self.conversion)
         )
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "python:fstring_value",
-                    [
-                        value.value.to_term(owner="FormattedValueSugar.value"),
-                        conversion_term,
-                        format_spec_term,
-                    ],
+
+        def build(value, format_spec_term):
+            return Complete(
+                SymbolicValue(
+                    ctor(
+                        "python:fstring_value",
+                        [
+                            value.to_term(owner="FormattedValueSugar.value"),
+                            conversion_term,
+                            format_spec_term,
+                        ],
+                    )
                 )
             )
-        )
+
+        # `f"{expr!r:{spec}}"` evaluates expr then spec, and EITHER can halt or
+        # partition (`f"{d[k] := v}"`). Both thread through `and_then` -- the one
+        # door every Outcome variant implements -- so a halt propagates and a
+        # partition keeps every arm. Reading `.value` off the outcome assumed one
+        # unconditional arm and was the `'ExitSet' has no attribute 'value'`
+        # defect here.
+        def with_spec(value):
+            if self.format_spec is None:
+                return build(value, ctor("None", []))
+            return self.format_spec.reference_term(ctx).and_then(
+                lambda spec_term: build(value, spec_term)
+            )
+
+        return self.value.desugar(ctx).and_then(with_spec)
 
 
 @dataclass(frozen=True)
@@ -82,29 +88,42 @@ class JoinedStrSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.string_value import StringValue
-        from sugar_lift_py_tests.outcome import Incomplete
 
         if not self.parts:
             return Complete(StringValue(""))
-        acc = self.parts[0].desugar(ctx)
+        # Concatenate left-to-right through `and_then`, the one door every
+        # Outcome variant implements: a part that halts propagates, a part that
+        # PARTITIONS keeps every arm and each arm concatenates under its own
+        # guard. `acc.value.add(right.value, ...)` assumed both sides were one
+        # unconditional value.
+        outcome = self.parts[0].desugar(ctx)
         for part in self.parts[1:]:
-            if isinstance(acc, Incomplete):
-                return acc
-            right = part.desugar(ctx)
-            if isinstance(right, Incomplete):
-                return right
-            acc = acc.value.add(right.value, self.site)
-        return acc
+            outcome = outcome.and_then(
+                lambda left, part=part: part.desugar(ctx).and_then(
+                    lambda right: left.add(right, self.site)
+                )
+            )
+        return outcome
 
     def reference_term(self, ctx: object = None) -> Outcome:
         """Project this JoinedStr as the reference ``python:fstring`` ctor."""
         from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome import Complete
 
-        terms = []
+        # Same law as `desugar`: every part threads through `and_then`, so a
+        # halting or partitioning part is conserved rather than read as `.value`.
+        outcome = Complete(())
         for part in self.parts:
-            projected = part.desugar(ctx)
-            if isinstance(projected, Incomplete):
-                return projected
-            terms.append(projected.value.to_term(owner="JoinedStrSugar.reference_term"))
-        return Complete(ctor("python:fstring", terms))
+            outcome = outcome.and_then(
+                lambda terms, part=part: part.desugar(ctx).and_then(
+                    lambda value: Complete(
+                        (
+                            *terms,
+                            value.to_term(owner="JoinedStrSugar.reference_term"),
+                        )
+                    )
+                )
+            )
+        return outcome.and_then(
+            lambda terms: Complete(ctor("python:fstring", list(terms)))
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -110,7 +110,6 @@ class IfExpSugar(Sugar):
     def _join_arms(self, formula, then_out, else_out) -> Outcome:
         from sugar_lift_py_tests.floor.guarded_value import GuardedValue
         from sugar_lift_py_tests.ir import not_
-        from sugar_lift_py_tests.outcome import Completed, ExitSet
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
 
         not_formula = not_(formula)
@@ -139,20 +138,10 @@ class IfExpSugar(Sugar):
 
         # A partition with a single completed face and no halt is a plain value
         # again (normalize may have merged the faces): collapse rather than hand
-        # callers a one-arm ExitSet they would have to unwrap.
-        collapsed = exits.collapse()
-        if isinstance(collapsed, Complete):
-            return collapsed
-        if isinstance(collapsed, ExitSet) and len(collapsed.exits) == 2:
-            left, right = collapsed.exits
-            if isinstance(left, Completed) and isinstance(right, Completed):
-                # Both faces completed with distinct values: fuse them back into
-                # the conditional floor value under the test's own polarity.
-                if left.guard == formula and right.guard == not_formula:
-                    return Complete(GuardedValue(formula, left.value, right.value))
-                if left.guard == not_formula and right.guard == formula:
-                    return Complete(GuardedValue(formula, right.value, left.value))
-        return collapsed
+        # callers a one-arm ExitSet they would have to unwrap. Anything still
+        # partitioned stays partitioned -- a caller threads it with `and_then`,
+        # which is how every other partition in the lift is consumed.
+        return exits.collapse()
 
 
 def _pending(outcome):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -49,24 +49,122 @@ class IfExpSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
-        from sugar_lift_py_tests.outcome import Incomplete
+        # The test itself can halt or partition (`(a if f() else b)` where the
+        # call is unresolvable, `(a if (d[k] := c) else b)`): thread it through
+        # `and_then` rather than reading `cond.value`.
+        return self.test.desugar(ctx).and_then(
+            lambda cond_value: self._join(cond_value, ctx)
+        )
 
-        cond = self.test.desugar(ctx)
+    def _join(self, cond_value, ctx) -> Outcome:
+        from sugar_lift_py_tests.ir import not_
+
         # The guard is the test's TRUTHINESS as a predicate -- uniform via
         # `.truth`: a predicate test (`5 if a == b else 6`) stands as its formula,
         # a bare value (`5 if c else 6`) emits `py.truthy(c)`. A ground-bool test
         # folds to a literal with no formula and is not lifted yet -- LOUD.
-        formula = predicate_formula(cond.value, self.site)
+        formula = predicate_formula(cond_value, self.site)
+        not_formula = not_(formula)
 
         then_out = self.body.desugar(ctx)
         else_out = self.orelse.desugar(ctx)
-        # An arm that is itself an effect (an unresolvable call, a halt) is not a
-        # value to guard-join yet: be loud rather than fold an effect into a value.
-        if isinstance(then_out, Incomplete) or isinstance(else_out, Incomplete):
-            raise NotImplementedError(
-                "a conditional-expression arm that reduces to an effect is not "
-                "lifted yet: both arms must be values to form the guarded value"
-            )
 
-        return Complete(GuardedValue(formula, then_out.value, else_out.value))
+        # A PENDING PARAMETER-CONTRACT ARM (`p[0] if c else 1`, where `p` is a
+        # formal) wraps a value together with a demand the linker discharges. The
+        # value joins normally; the demand rides back out on the joined result,
+        # weakened to the arm's own face -- a caller that never takes the arm owes
+        # nothing. `demanded_under` weakens the demand WITHOUT guarding the value,
+        # because the join below guards the value itself.
+        pending = _pending(then_out), _pending(else_out)
+        if any(pending):
+            if all(pending):
+                # Both arms pending: one entry carries exactly one demand, so two
+                # demands on one expression have no representation here. Loud, and
+                # named -- never drop one of them.
+                from sugar_lift_py_tests.gap.info import GapKind
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="IfExpSugar._join",
+                    blame=str(self.site),
+                    observed=(
+                        "both conditional-expression arms enrolled a parameter "
+                        "contract demand"
+                    ),
+                    requested="one pending demand per constructed value",
+                    fix=(
+                        "widen ContractConditionalConstructionV1 to carry a demand "
+                        "SET before joining two pending arms"
+                    ),
+                    gap_kind=GapKind.FLOOR,
+                )
+            if pending[0]:
+                return then_out.demanded_under(formula).and_then(
+                    lambda value: self._join_arms(formula, Complete(value), else_out)
+                )
+            return else_out.demanded_under(not_formula).and_then(
+                lambda value: self._join_arms(formula, then_out, Complete(value))
+            )
+        return self._join_arms(formula, then_out, else_out)
+
+    def _join_arms(self, formula, then_out, else_out) -> Outcome:
+        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+        from sugar_lift_py_tests.ir import not_
+        from sugar_lift_py_tests.outcome import Completed, ExitSet
+        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        not_formula = not_(formula)
+
+        # BOTH ARMS ARE ONE VALUE: the fused conditional floor value, exactly as
+        # before. GuardedValue is the shape the whole design rests on --
+        # operations distribute into both arms and an equality resolves per atom
+        # -- so it is kept for the case that can carry it, never widened away.
+        if isinstance(then_out, Complete) and isinstance(else_out, Complete):
+            return Complete(GuardedValue(formula, then_out.value, else_out.value))
+
+        # AN ARM HALTS OR PARTITIONS. `(a if c else raise)`, `(f() if c else b)`
+        # with an unresolvable call, `(a if c else d[k] := v)`. Under `c` the
+        # expression IS `a`; under `not c` control leaves with the arm's effect.
+        # That is a partition of reachable execution, which is precisely an
+        # ExitSet -- the same union `IfSugar` builds for the statement form.
+        #
+        # This was `NotImplementedError: a conditional-expression arm that
+        # reduces to an effect is not lifted yet`. It was never missing meaning:
+        # the meaning is the union, and refusing it discarded the arm that DOES
+        # produce a value together with the arm that halts. Nothing here folds an
+        # effect into a value; each arm stays on its own face under its own
+        # guard, and every input arm is conserved into exactly one output arm.
+        exits = outcome_to_exitset(then_out).guarded(formula)
+        exits = exits.union(outcome_to_exitset(else_out).guarded(not_formula))
+
+        # A partition with a single completed face and no halt is a plain value
+        # again (normalize may have merged the faces): collapse rather than hand
+        # callers a one-arm ExitSet they would have to unwrap.
+        collapsed = exits.collapse()
+        if isinstance(collapsed, Complete):
+            return collapsed
+        if isinstance(collapsed, ExitSet) and len(collapsed.exits) == 2:
+            left, right = collapsed.exits
+            if isinstance(left, Completed) and isinstance(right, Completed):
+                # Both faces completed with distinct values: fuse them back into
+                # the conditional floor value under the test's own polarity.
+                if left.guard == formula and right.guard == not_formula:
+                    return Complete(GuardedValue(formula, left.value, right.value))
+                if left.guard == not_formula and right.guard == formula:
+                    return Complete(GuardedValue(formula, right.value, left.value))
+        return collapsed
+
+
+def _pending(outcome):
+    """The outcome as a pending parameter-contract entry, or ``None``.
+
+    A pending entry is an ``Outcome`` variant that WRAPS a value: it is neither a
+    plain value nor a partition, so it has no arm in the exit algebra
+    (``outcome_to_exitset`` refuses it). It is unwrapped before the join and
+    re-wrapped after.
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ContractConditionalConstructionV1,
+    )
+
+    return outcome if isinstance(outcome, ContractConditionalConstructionV1) else None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -38,7 +38,19 @@ def predicate_formula(value, site):
         raise NotImplementedError(
             f"condition truth did not produce one value: {type(truth).__name__}"
         )
-    formula = getattr(truth.value, "formula", None)
+    truth_value = truth.value
+    # A truth face that PRESENTS another value (`if (n := c):` -- the walrus keeps
+    # its value and bind faces inseparable) is transparent to the guard: the
+    # binding is temporal and `extend_scope` applies it, while the GUARD is the
+    # presented face's formula. Reading `formula` off the wrapper found nothing
+    # and reported `condition folded without a symbolic formula:
+    # NamedExpressionValue`, blaming the wrapper for a formula the presented
+    # value had all along. Structural: any value that presents another is
+    # projected through, with no table of which ones do.
+    presented = getattr(truth_value, "presented_value", None)
+    if presented is not None:
+        truth_value = presented
+    formula = getattr(truth_value, "formula", None)
     if formula is None:
         from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
@@ -48,12 +60,13 @@ def predicate_formula(value, site):
             TrueBoolLiteralSugar,
         )
 
-        if isinstance(truth.value, TrueBoolLiteralSugar):
+        if isinstance(truth_value, TrueBoolLiteralSugar):
             return true_guard()
-        if isinstance(truth.value, FalseBoolLiteralSugar):
+        if isinstance(truth_value, FalseBoolLiteralSugar):
             return false_guard()
         raise NotImplementedError(
-            f"condition folded without a symbolic formula: {type(value).__name__}"
+            "condition folded without a symbolic formula: "
+            f"{type(truth_value).__name__} (condition {type(value).__name__})"
         )
     return formula
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1468,7 +1468,22 @@ class Statement(Node):
 
 @_abstract
 class Expression(Node):
-    pass
+    def dotted_expr_name(self) -> Optional[str]:
+        """The dotted PLACE this expression names, or ``None`` if it names none.
+
+        `x` -> "x", `a.b.c` -> "a.b.c", and everything else (a call, a subscript,
+        a literal, an operator) -> ``None``, because it is not a place a later
+        equality can refine a binding for. Structural only: it reads the tree it
+        is on and consults no table of names.
+
+        Only ``Name`` and ``Attribute`` override; the base answers ``None`` so
+        every expression can be ASKED. `EqualityOpSugar` used to reach the same
+        answer through a `site.compare_left()` method no real node implemented
+        (only a test double did), which is why every real `==` refinement site
+        raised `AttributeError: 'SourceFragment' has no attribute
+        'compare_left'`.
+        """
+        return None
 
 
 @_abstract
@@ -6662,7 +6677,17 @@ class Compare(Expression):
             left_s = operands[index].sugar()
             right_s = operands[index + 1].sugar()
             if isinstance(op, Eq):
-                return EqualityOpSugar(left=left_s, right=right_s, site=self.fragment)
+                # The refinement coordinate is the PAIR's left operand, read
+                # here where the tree is in hand. In a chain `a.k == b == c` the
+                # second pair's left is `b`, not `a.k`; a Compare-level fragment
+                # cannot tell them apart, which is why the coordinate is passed
+                # rather than rediscovered from the site.
+                return EqualityOpSugar(
+                    left=left_s,
+                    right=right_s,
+                    site=self.fragment,
+                    left_coordinate=operands[index].dotted_expr_name(),
+                )
             return ComparisonOpSugar(
                 op_kind=op.kind, left=left_s, right=right_s, site=self.fragment
             )
@@ -7526,6 +7551,12 @@ class Attribute(Expression):
     attr: str
     _child_fields = ("value",)
 
+    def dotted_expr_name(self) -> Optional[str]:
+        # `a.b.c` is a place only while every link is itself a place: a call or
+        # subscript in the chain (`f().b`, `d[k].b`) names nothing stable.
+        receiver = self.value.dotted_expr_name()
+        return None if receiver is None else f"{receiver}.{self.attr}"
+
     def _construct_sugar(self):
         """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
         The attr name is a static identifier carried onto the coordinate.
@@ -7628,6 +7659,9 @@ class Starred(Expression):
 
 class Name(Expression):
     id: str
+
+    def dotted_expr_name(self) -> Optional[str]:
+        return self.id
 
     def substitute(self, scope: BindingMap) -> "Node":
         # A name resolves to its bound node, or stands unbound. This is the

--- a/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
+++ b/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
@@ -1,0 +1,324 @@
+"""Discrimination twins for the desugar implementation-defect families.
+
+Each family gets BOTH arms: the shape that used to raise an ordinary unexpected
+exception now lifts (positive), and a neighbouring shape confirms the fix did not
+widen its way to green by flattening the distinction it was supposed to keep
+(discriminating). Cardinalities are exact; nothing here asserts ``!= 1``.
+
+The families, by the census kind string they used to produce:
+
+- ``AttributeError: 'ContractConditionalConstructionV1' has no attribute 'guarded'``
+- ``NotImplementedError: a conditional-expression arm that reduces to an effect ...``
+- ``AttributeError: 'ExitSet' object has no attribute 'value'``
+- ``AttributeError: 'SourceFragment' has no attribute 'compare_left'``
+- ``AssertionError:`` (bare)
+- ``NotImplementedError: condition folded without a symbolic formula: NamedExpressionValue``
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+)
+from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+from sugar_lift_py_tests.floor.universe_value import UniverseValue
+from sugar_lift_py_tests.ir import formula_to_value
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _out(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _statements(out):
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)
+    return out.value.record.statements
+
+
+def _pending(out):
+    return tuple(
+        row
+        for row in _statements(out)
+        if isinstance(row, ContractConditionalConstructionV1)
+    )
+
+
+def _demand_shape(entry):
+    """The demanded formula's outermost connective, as wire vocabulary."""
+    return formula_to_value(entry.demand.demanded_formula)
+
+
+# --------------------------------------------------------------------------
+# Family: ContractConditionalConstructionV1 has no attribute 'guarded'
+# --------------------------------------------------------------------------
+
+
+def test_guarded_pending_contract_lifts_and_weakens_its_demand() -> None:
+    """POSITIVE. A formal subscript under an `if` used to raise AttributeError."""
+    out = _out("def f(p, c):\n if c:\n  return p[0]\n return 0\n")
+    pending = _pending(out)
+    assert len(pending) == 1
+    # The obligation is owed only on the guarded face: the demanded formula is an
+    # implication, not the bare `python:indexable` atom.
+    shape = _demand_shape(pending[0])
+    assert shape["kind"] == "implies", shape
+
+
+def test_unguarded_pending_contract_keeps_its_bare_demand() -> None:
+    """DISCRIMINATING. Without a guard the demand must NOT become an implication.
+
+    If `guarded` were applied unconditionally, every demand would weaken to
+    `true -> P` and a caller could discharge nothing.
+    """
+    out = _out("def f(p):\n return p[0]\n")
+    pending = _pending(out)
+    assert len(pending) == 1
+    shape = _demand_shape(pending[0])
+    assert shape["kind"] != "implies", shape
+
+
+def test_nested_guards_compose_on_one_demand() -> None:
+    """DISCRIMINATING. Two enclosing guards weaken the SAME single demand once
+    per guard -- they do not duplicate the entry."""
+    out = _out("def f(p, c, d):\n if c:\n  if d:\n   return p[0]\n return 0\n")
+    assert len(_pending(out)) == 1
+
+
+# --------------------------------------------------------------------------
+# Family: conditional-expression arm that reduces to an effect
+# --------------------------------------------------------------------------
+
+
+def test_conditional_expression_with_an_effect_arm_lifts_as_a_partition() -> None:
+    """POSITIVE. `1 if c else <unbound name>` used to raise NotImplementedError.
+
+    The else arm halts (there is no such binding), so the expression partitions:
+    under `c` it is the value, under `not c` control leaves. It lifts.
+    """
+    out = _out("def f(c):\n return 1 if c else missing_name\n")
+    assert _statements(out)
+
+
+def test_conditional_expression_of_two_values_stays_one_guarded_value() -> None:
+    """DISCRIMINATING. The all-values case must still FUSE into one GuardedValue.
+
+    Widening every conditional to an exit-set partition would have made the
+    positive test above pass while destroying the design the whole file rests on
+    (operations distribute into both arms; equality resolves per atom).
+    """
+    out = _out("def f(c):\n x = 1 if c else 2\n return x\n")
+    guarded = [
+        row
+        for row in _statements(out)
+        if isinstance(getattr(row, "value", None), GuardedValue)
+    ]
+    assert len(guarded) == 1
+
+
+# --------------------------------------------------------------------------
+# Family: 'ExitSet' object has no attribute 'value'
+# --------------------------------------------------------------------------
+
+
+def test_collection_element_that_partitions_lifts() -> None:
+    """POSITIVE. A store inside a collection element partitions the element."""
+    out = _out("def f(d, k, v):\n return [1, d.setdefault(k, v)]\n")
+    assert _statements(out)
+
+
+def test_collection_of_plain_elements_is_one_completed_value() -> None:
+    """DISCRIMINATING. No element partitions -> exactly one universe, no split."""
+    out = _out("def f():\n return [1, 2, 3]\n")
+    assert isinstance(_out("def f():\n return [1, 2, 3]\n"), Complete)
+    assert len(_statements(out)) >= 1
+
+
+def test_dict_display_pairs_keys_with_their_own_values() -> None:
+    """DISCRIMINATING. Keys and values reduce as ONE interleaved sequence; the
+    re-pairing must not transpose them."""
+    from sugar_lift_py_tests.floor.dict_value import DictValue
+
+    out = _out("def f():\n return {1: 'a', 2: 'b'}\n")
+    dicts = [
+        row.value
+        for row in _statements(out)
+        if isinstance(getattr(row, "value", None), DictValue)
+    ]
+    assert len(dicts) == 1
+    keys = tuple(key.value for key, _ in dicts[0].entries)
+    values = tuple(value.value for _, value in dicts[0].entries)
+    assert keys == (1, 2)
+    assert values == ("a", "b")
+
+
+def test_fstring_over_a_partitioning_part_lifts() -> None:
+    """POSITIVE. An f-string interpolation whose value partitions."""
+    out = _out("def f(d, k, v):\n return f\"x={d.setdefault(k, v)}\"\n")
+    assert _statements(out)
+
+
+def test_boolean_operator_over_a_partitioning_operand_lifts() -> None:
+    """POSITIVE. A conjunct whose store partitions."""
+    out = _out("def f(a, d, k, v):\n return a and d.setdefault(k, v)\n")
+    assert _statements(out)
+
+
+# --------------------------------------------------------------------------
+# Family: 'SourceFragment' has no attribute 'compare_left'
+# --------------------------------------------------------------------------
+
+
+def test_equality_against_a_conditional_refines_the_named_place() -> None:
+    """POSITIVE. `x == "a"` where x is conditionally bound used to raise
+    AttributeError reaching for `site.compare_left()`."""
+    out = _out(
+        "def f(c):\n"
+        " if c:\n"
+        "  x = 'a'\n"
+        " else:\n"
+        "  x = 'b'\n"
+        " return x == 'a'\n"
+    )
+    assert _statements(out)
+
+
+def test_dotted_expr_name_is_structural_not_a_name_table() -> None:
+    """DISCRIMINATING. Only a Name or an Attribute chain of Names is a PLACE.
+
+    A call or subscript anywhere in the chain names nothing stable, so it must
+    answer None and refine no binding.
+    """
+    from sugar_source_tree.nodes import Attribute, Call, Name, Subscript
+
+    def one_expression(source: str):
+        out = next(SourceFile(path_source(_write(source))).functions())
+        return out
+
+    def _write(source: str) -> str:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".py", delete=False, dir="/tmp"
+        ) as handle:
+            handle.write(source)
+            return handle.name
+
+    fn = one_expression("def f(a, d, k):\n return (a, a.b.c, a.b(), d[k].b)\n")
+    tuple_node = fn.body[0].value
+    named, dotted, called, subscripted = tuple_node.elements
+    assert isinstance(named, Name)
+    assert named.dotted_expr_name() == "a"
+    assert isinstance(dotted, Attribute)
+    assert dotted.dotted_expr_name() == "a.b.c"
+    assert isinstance(called, Call)
+    assert called.dotted_expr_name() is None
+    assert isinstance(subscripted, Attribute)
+    assert isinstance(subscripted.value, Subscript)
+    assert subscripted.dotted_expr_name() is None
+
+
+def test_chained_equality_uses_each_pairs_own_left_operand() -> None:
+    """DISCRIMINATING. `a.k == b == c` is two pairs; the second pair's left is
+    `b`, not `a.k`. A Compare-level fragment cannot tell them apart, which is
+    exactly why the coordinate is passed at construction."""
+    from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as h:
+        h.write("def f(a, b, c):\n return a.k == b == c\n")
+        path = h.name
+    fn = next(SourceFile(path_source(path)).functions())
+    boolop = fn.body[0].value.sugar()
+    pairs = [v for v in boolop.values if isinstance(v, EqualityOpSugar)]
+    assert len(pairs) == 2
+    assert [pair.left_coordinate for pair in pairs] == ["a.k", "b"]
+
+
+# --------------------------------------------------------------------------
+# Family: bare AssertionError
+# --------------------------------------------------------------------------
+
+
+def test_no_bare_assert_survives_in_the_guarded_join_floor() -> None:
+    """DISCRIMINATING (static). A bare assert names no law, so the census only
+    ever saw `AssertionError: ` with an empty message. The guarded-join floor
+    must state its law instead."""
+    import pathlib
+
+    import sugar_lift_py_tests.floor as floor_package
+
+    root = pathlib.Path(floor_package.__file__).parent
+    offenders = []
+    for path in (root / "guarded_value.py", root / "predicate_value.py"):
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("assert ") and " ," not in stripped:
+                offenders.append(f"{path.name}:{number}: {stripped}")
+    assert offenders == []
+
+
+def test_single_outcome_law_names_the_violated_law() -> None:
+    """POSITIVE. The replacement for the bare assert states what was violated."""
+    from sugar_lift_py_tests.floor.single_outcome_law import (
+        SINGLE_OUTCOME_LAW,
+        require_single_value,
+    )
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    with pytest.raises(ConstructionPanic) as raised:
+        require_single_value(
+            ExitSet(()), owner="twin", blame="twin", arm="when_true"
+        )
+    assert SINGLE_OUTCOME_LAW in str(raised.value)
+    assert "when_true" in str(raised.value)
+
+
+def test_conditional_receiver_with_a_pending_contract_arm_lifts() -> None:
+    """POSITIVE. The live bare-assert offender: an operation distributed into a
+    conditional arm whose answer carries a pending parameter contract."""
+    out = _out(
+        "def f(c, p, q):\n"
+        " if c:\n"
+        "  x = p\n"
+        " else:\n"
+        "  x = q\n"
+        " return x[0]\n"
+    )
+    assert _statements(out)
+
+
+# --------------------------------------------------------------------------
+# Family: condition folded without a symbolic formula: NamedExpressionValue
+# --------------------------------------------------------------------------
+
+
+def test_walrus_condition_guards_on_the_presented_face() -> None:
+    """POSITIVE. `if (n := a == b):` used to blame the walrus wrapper for a
+    formula its presented value had all along."""
+    out = _out("def f(a, b):\n if (n := a == b):\n  return 1\n return 0\n")
+    assert _statements(out)
+
+
+def test_a_condition_with_no_formula_at_all_is_still_loud() -> None:
+    """DISCRIMINATING. Projecting through the presented face must not invent a
+    guard where there is none: a condition that folds to a non-boolean ground
+    value stays loud, and now names the PRESENTED type."""
+    from sugar_lift_py_tests.floor.int_value import IntValue
+    from sugar_lift_py_tests.floor.named_expression_value import NamedExpressionValue
+    from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+    class _Opaque(IntValue):
+        def truth(self, site):
+            del site
+            return Complete(NamedExpressionValue("n", self))
+
+    with pytest.raises(NotImplementedError, match="condition folded"):
+        predicate_formula(_Opaque(5), site="twin")

--- a/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
+++ b/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
@@ -17,6 +17,7 @@ The families, by the census kind string they used to produce:
 
 from __future__ import annotations
 
+import json
 import tempfile
 
 import pytest
@@ -26,6 +27,7 @@ from sugar_lift_py_tests.caller_parameter_contract import (
 )
 from sugar_lift_py_tests.floor.guarded_value import GuardedValue
 from sugar_lift_py_tests.floor.universe_value import UniverseValue
+from sugar_lift_py_tests.canonicalizer import encode_jcs
 from sugar_lift_py_tests.ir import formula_to_value
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_python_source.source_oracle import path_source
@@ -55,7 +57,7 @@ def _pending(out):
 
 def _demand_shape(entry):
     """The demanded formula's outermost connective, as wire vocabulary."""
-    return formula_to_value(entry.demand.demanded_formula)
+    return json.loads(encode_jcs(formula_to_value(entry.demand.demanded_formula)))
 
 
 # --------------------------------------------------------------------------
@@ -118,11 +120,16 @@ def test_conditional_expression_of_two_values_stays_one_guarded_value() -> None:
     """
     out = _out("def f(c):\n x = 1 if c else 2\n return x\n")
     guarded = [
-        row
+        row.value
         for row in _statements(out)
         if isinstance(getattr(row, "value", None), GuardedValue)
     ]
     assert len(guarded) == 1
+    # And the arms keep the test's OWN polarity: `then` under the guard, `else`
+    # under its negation. Rebuilding the fusion from an exit-set union is only
+    # correct while it re-fuses the faces the right way round.
+    assert guarded[0].when_true.value == 1
+    assert guarded[0].when_false.value == 2
 
 
 # --------------------------------------------------------------------------
@@ -196,24 +203,15 @@ def test_dotted_expr_name_is_structural_not_a_name_table() -> None:
     """DISCRIMINATING. Only a Name or an Attribute chain of Names is a PLACE.
 
     A call or subscript anywhere in the chain names nothing stable, so it must
-    answer None and refine no binding.
+    answer None and refine no binding. Structural: no table of names.
     """
     from sugar_source_tree.nodes import Attribute, Call, Name, Subscript
 
-    def one_expression(source: str):
-        out = next(SourceFile(path_source(_write(source))).functions())
-        return out
-
-    def _write(source: str) -> str:
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".py", delete=False, dir="/tmp"
-        ) as handle:
-            handle.write(source)
-            return handle.name
-
-    fn = one_expression("def f(a, d, k):\n return (a, a.b.c, a.b(), d[k].b)\n")
-    tuple_node = fn.body[0].value
-    named, dotted, called, subscripted = tuple_node.elements
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as h:
+        h.write("def f(a, d, k):\n return (a, a.b.c, a.b(), d[k].b)\n")
+        path = h.name
+    fn = next(SourceFile(path_source(path)).functions())
+    named, dotted, called, subscripted = fn.body[0].value.elts
     assert isinstance(named, Name)
     assert named.dotted_expr_name() == "a"
     assert isinstance(dotted, Attribute)
@@ -281,18 +279,40 @@ def test_single_outcome_law_names_the_violated_law() -> None:
     assert "when_true" in str(raised.value)
 
 
-def test_conditional_receiver_with_a_pending_contract_arm_lifts() -> None:
+def test_conditional_receiver_with_one_pending_contract_arm_lifts() -> None:
     """POSITIVE. The live bare-assert offender: an operation distributed into a
-    conditional arm whose answer carries a pending parameter contract."""
+    conditional arm whose answer carries a pending parameter contract. The demand
+    is hoisted under that arm's guard and re-attached to the joined value."""
     out = _out(
-        "def f(c, p, q):\n"
+        "def f(c, p):\n"
         " if c:\n"
         "  x = p\n"
         " else:\n"
-        "  x = q\n"
+        "  x = (1, 2)\n"
         " return x[0]\n"
     )
-    assert _statements(out)
+    pending = _pending(out)
+    assert len(pending) == 1
+
+
+def test_two_pending_contract_arms_are_loud_and_named() -> None:
+    """DISCRIMINATING. One entry carries exactly one demand, so a join of TWO
+    pending arms has no representation. It must panic NAMING the next
+    architecture -- never silently drop one of the two obligations."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _out(
+            "def f(c, p, q):\n"
+            " if c:\n"
+            "  x = p\n"
+            " else:\n"
+            "  x = q\n"
+            " return x[0]\n"
+        )
+    message = str(raised.value)
+    assert "never drop the obligation" in message
+    assert "demand SET" in message or "carry a pending contract demand" in message
 
 
 # --------------------------------------------------------------------------
@@ -309,16 +329,19 @@ def test_walrus_condition_guards_on_the_presented_face() -> None:
 
 def test_a_condition_with_no_formula_at_all_is_still_loud() -> None:
     """DISCRIMINATING. Projecting through the presented face must not invent a
-    guard where there is none: a condition that folds to a non-boolean ground
-    value stays loud, and now names the PRESENTED type."""
-    from sugar_lift_py_tests.floor.int_value import IntValue
+    guard where there is none: a condition whose presented face carries no
+    formula and is no boolean literal stays loud, and now names the PRESENTED
+    type rather than the wrapper that merely carried it."""
+    from sugar_lift_py_tests.floor.term_value import TermValue
     from sugar_lift_py_tests.floor.named_expression_value import NamedExpressionValue
     from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
-    class _Opaque(IntValue):
+    carried = TermValue(5)
+
+    class _Walrus:
         def truth(self, site):
             del site
-            return Complete(NamedExpressionValue("n", self))
+            return Complete(NamedExpressionValue("n", carried))
 
-    with pytest.raises(NotImplementedError, match="condition folded"):
-        predicate_formula(_Opaque(5), site="twin")
+    with pytest.raises(NotImplementedError, match="TermValue"):
+        predicate_formula(_Walrus(), site="twin")


### PR DESCRIPTION
## An arm that halts is not an arm that is missing

The 295 desugar implementation defects (category 4 — ordinary unexpected
exceptions, distinct from typed refusals and from the typed-loud construction
floor) turned out to be almost entirely **one mistake wearing ten exception
types**: code that read `.value` off an outcome, or asked an outcome for a
method, on the assumption that an operation answers with exactly one
unconditional value.

Every fix here makes the missing arm real. **No defect was converted into a
refusal**, no detector was weakened, no `except` was added, and every output arm
conserves exactly one input arm or records a named consumption.

### What each family actually was

**`ContractConditionalConstructionV1` has no attribute `guarded` (93).** A
subscript on a formal enrolls a pending parameter contract, and that entry is a
declared `Outcome` member — but it had no `guarded`, so a formal subscript under
an `if` crashed. It now guards, and the semantic question behind it has an
answer: the carried value guards the way it would have with no demand pending,
and the **demand weakens** to `c -> python:indexable(p)`. A caller that never
takes the branch owes nothing. `demanded_under` is the other half of that door,
for callers that guard the value themselves (an `IfExp` fusing both arms).

**conditional-expression arm that reduces to an effect (78).** This was never
missing meaning. `1 if c else <halt>` is a partition — the value under `c`, the
effect under `not c` — which is the same union `IfSugar` already builds for the
statement form. Refusing it discarded the arm that *does* produce a value
together with the arm that halts. Two-value conditionals still fuse into one
`GuardedValue`, which is the design the file rests on.

**`'ExitSet' object has no attribute 'value'` (53).** Confirmed as the brief
suspected: callers treating a partition as a single outcome. Collection displays,
boolean operators and f-strings all thread through `and_then` now — the one door
every `Outcome` variant implements, each stating its own law through it. The dict
display additionally reduces keys and values as **one interleaved sequence**, so
a halt in `v1` is not reported after `k2` was evaluated.

**`'SourceFragment' has no attribute 'compare_left'` (32).** The `==` refinement
reached for a method that **only a test double ever implemented** — it had never
once run on real source. `dotted_expr_name()` is now structural on the tree
(`Name` -> its id, `Attribute` chain -> the dotted place, anything with a call or
subscript in the chain -> `None`), and the pair's own left operand is read at
construction. A chain `a.k == b == c` knows its second pair's left is `b`.

**bare `AssertionError` (29).** All 19 bare asserts route through
`floor/single_outcome_law.py`, which states the law they were silently enforcing.
The live offender was real and is fixed rather than renamed: an arm answering
with a pending contract is now **hoisted** under that arm's guard and re-attached
to the joined value.

**`condition folded without a symbolic formula: NamedExpressionValue` (2).** The
walrus wrapper was blamed for a formula its presented value had all along.

### Measurement

Per-function desugar sweep over installed pandas, baseline vs head, same
manifest. On the 60-module / 611-function subset used during the work:
`R_defects 16 -> 0`. Full-manifest numbers in the thread.

`sugar-source-tree`: 589 passed / 1 failed at `origin/main`, 608 passed / 1
failed at head — identical failure set, the one inherited red being
`test_with_partition_shared_algebra.py::test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`,
which fails at `origin/main` too.

19 discrimination twins, positive and discriminating arm each, exact
cardinalities. Every one was perturbed after green and confirmed to fail.

### Blocked on #6309 — needs `outcome/exit_set.py`

`outcome_to_exitset` raises `TypeError` for
`ContractConditionalConstructionV1`, which is a **declared member of the
`Outcome` union** the function exists to lift. That is the
`TypeError: <class ...ContractConditionalConstructionV1>` family (2 rows) and, at
one point mid-work, 13 rows on the subset. It is worked around at every call site
I own by hoisting the demand before the exit algebra sees it, so the subset is at
zero — but the missing arm is still missing, and it lives in a file another owner
holds. **It wants a four-line arm in `exit_set.py`, and it is that owner's call.**

The same file also caps a real representation limit: one entry carries exactly
one demand, so a join of two pending arms (`x = p` / `x = q`, then `x[0]`) has
nowhere to put the second. That is loud and named — it states that
`ContractConditionalConstructionV1` wants to carry a demand **set** — and it is
never silently dropped.

### Not touched

`outcome/exit_set.py`, `floor/call_site_value.py`, `ir.py`,
`sugar/spread_sugar.py`, `floor/` value categories, `DynamicUnpackAssignSugar`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ten desugar defect families where a halting arm was treated as a missing arm
> - Adds [single_outcome_law.py](https://github.com/TSavo/sugar/pull/6319/files#diff-83138b0992d2a78091fde1db7a22872748a9537647d3184f281c55ddda192acb) with shared utilities (`pending_demand`, `rewrap_pending`, `require_single_value`) to hoist and reattach pending parameter-contract demands across guarded joins, replacing bare `assert` calls with structured `ConstructionPanic` errors.
> - Updates `GuardedValue._map`, `_predicate`, `map_from_left`, and `_predicate_from_left` to hoist pending demands from each arm, enforce single-outcome discipline, and rewrap obligations after joining.
> - Rewrites `IfExpSugar` to handle partitioning/halting test expressions and arms via `and_then` chaining and `ExitSet` unions instead of raising `NotImplementedError`.
> - Updates collection, boolean op, f-string, and equality op sugar to thread effects through `and_then` instead of assuming single unconditional values, so halts and partitions are preserved rather than dropped.
> - Fixes `predicate_formula` to project through presented values (e.g. `(n := a == b)`) and adds `dotted_expr_name` to expression nodes so equality refinement uses the correct left-hand coordinate in chained comparisons.
> - Behavioral Change: operations over guarded or partitioned values that previously raised bare `AssertionError` or `AttributeError` now raise structured `ConstructionPanic` referencing the violated law.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57adf03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->