### PR TITLE
The delete verb owes the same four arms the read verb answers (+ a silently dropped contract demand)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -95,13 +95,33 @@ class ContractConditionalConstructionV1:
         return cls(source_node, candidate, candidate_cid, demand, value)
 
     def and_then(self, step):
+        """Continue with the carried value; the demand rides on the result.
+
+        A following ``Complete`` takes the demand back and the entry rides on
+        into the block record, where ``link_unit_projection`` enrols it and the
+        linker discharges it.
+
+        Anything else has nowhere to carry it, and this used to ``return
+        following`` -- silently dropping the obligation. A dropped demand is
+        never enrolled and never discharged, so `p[0]` would stand with no
+        `python:indexable(p)` owed by anyone. That is not a smaller answer, it is
+        a wrong one, and it is loud now. Measured on 25 pandas modules / 158
+        functions: 4 such drops before this branch existed, and threading the
+        collection/f-string/bool-op reducers through ``and_then`` exposed 20
+        more that had previously been lost inside an `.value` read instead.
+        """
         from sugar_lift_py_tests.outcome import Complete
 
         following = step(self.value)
-        return (
-            replace(self, value=following.value)
-            if isinstance(following, Complete)
-            else following
+        if isinstance(following, Complete):
+            return replace(self, value=following.value)
+        from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+
+        return rewrap_pending(
+            self,
+            following,
+            owner="ContractConditionalConstructionV1.and_then",
+            blame=self.source_node,
         )
 
     def demanded_under(self, formula):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
@@ -9,9 +9,36 @@ from sugar_lift_py_tests.ir import not_
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Outcome, outcome_to_exitset
 from sugar_lift_py_tests.sugar.binding_projection import (
     GuardedProjection,
+    LoopGuardedProjection,
     UnboundProjection,
 )
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+def _unhandled_projection(state, *, verb: str, name: str, site):
+    """A binding projection constructor with no arm, NAMED.
+
+    `BindingProjection` is a closed union of four constructors, and every verb
+    over it (`read`, `delete`) must answer for all four. A bare
+    `raise TypeError(type(state))` named neither the union nor the missing arm.
+    """
+    from sugar_lift_py_tests.gap.info import GapKind
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner=f"{verb}_binding",
+        blame=site,
+        observed=(
+            f"binding projection {type(state).__name__} has no arm in the "
+            f"`{verb}` verb over BindingProjection (name={name!r})"
+        ),
+        requested=(
+            "every BindingProjection constructor answers every verb over it: "
+            "Sugar, UnboundProjection, GuardedProjection, LoopGuardedProjection"
+        ),
+        fix=f"write the {type(state).__name__} arm of {verb}_binding",
+        gap_kind=GapKind.SUGAR,
+    )
 
 
 def delete_binding(state, *, name: str, site, ctx) -> ExitSet:
@@ -19,8 +46,22 @@ def delete_binding(state, *, name: str, site, ctx) -> ExitSet:
         return ExitSet.completed(BlockValue((), can_fall_through=True))
     if isinstance(state, UnboundProjection):
         return ExitSet.halted(NameErrorEffect(name=name, site=site))
+    if isinstance(state, LoopGuardedProjection):
+        # A name a loop bound on several completed faces is deleted ON EACH FACE,
+        # under that face's guard. `read_binding` already reads the same union;
+        # `del` is the other verb over the SAME projection, and it simply had no
+        # arm for this constructor -- which is what
+        # `TypeError: LoopGuardedProjection` was.
+        exits = ExitSet(())
+        for face in state.completed_faces:
+            exits = exits.union(
+                delete_binding(face.state, name=name, site=site, ctx=ctx).guarded(
+                    face.guard_formula
+                )
+            )
+        return exits.normalize()
     if not isinstance(state, GuardedProjection):
-        raise TypeError(type(state))
+        _unhandled_projection(state, verb="delete", name=name, site=site)
     guard = branch_result_guard(state.slot, site)
     return (
         delete_binding(state.when_true, name=name, site=site, ctx=ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -32,7 +32,9 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
             )
         return exits.normalize()
     if not isinstance(state, GuardedProjection):
-        raise TypeError(type(state))
+        from sugar_lift_py_tests.sugar.delete_name_sugar import _unhandled_projection
+
+        _unhandled_projection(state, verb="read", name=read_name, site=read_site)
 
     guard = branch_result_guard(state.slot, read_site)
     return (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -90,9 +90,33 @@ class LoopRecurrenceSugar(Sugar):
             elif isinstance(outcome, Incomplete):
                 exits.append(Halted(face.guard, outcome.effect, recurrence))
             else:
-                from sugar_source_tree.binding_state import BindingStateWireGap
-
-                raise BindingStateWireGap(
-                    "loop outward face did not construct return or raise testimony"
+                # The face reduced to something richer than one return value or
+                # one effect: a return whose expression PARTITIONS (`return
+                # d.setdefault(k, v)`), a guarded return, or a return that owes a
+                # parameter contract (`return p[0]`). None of those is a missing
+                # wire -- each is a partition the face contributes under its own
+                # guard, which is what `BindingStateWireGap: loop outward face did
+                # not construct return or raise testimony` was refusing to state.
+                from sugar_lift_py_tests.floor.single_outcome_law import (
+                    pending_demand,
                 )
+                from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+                # A pending demand's home is a block entry, and this face builds
+                # exactly one: it rides beside the return in the same record.
+                pending, plain = pending_demand(outcome, face.guard)
+                for exit_ in outcome_to_exitset(plain).guarded(face.guard).exits:
+                    if isinstance(exit_, Halted):
+                        exits.append(Halted(exit_.guard, exit_.effect, recurrence))
+                    else:
+                        entries = (exit_.value,) if pending is None else (
+                            pending,
+                            exit_.value,
+                        )
+                        exits.append(
+                            Completed(
+                                exit_.guard,
+                                BlockValue(entries, can_fall_through=False),
+                            )
+                        )
         return ExitSet(tuple(exits)).normalize()

--- a/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
+++ b/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from dataclasses import dataclass
 
 import pytest
 
@@ -31,6 +32,7 @@ from sugar_lift_py_tests.canonicalizer import encode_jcs
 from sugar_lift_py_tests.ir import formula_to_value
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_source_tree.tree import SourceFile
 
 
@@ -42,6 +44,22 @@ def _out(source: str):
 
 
 def _statements(out):
+    """Every body statement the lift produced, across whatever shape it produced.
+
+    A function whose body partitions reduces to an ExitSet of universes rather
+    than to one `Complete`; both are lawful, and a twin about "does this lift"
+    must not be blind to the partitioned shape.
+    """
+    from sugar_lift_py_tests.outcome import Completed, ExitSet
+
+    if isinstance(out, ExitSet):
+        rows = []
+        for exit_ in out.exits:
+            if isinstance(exit_, Completed):
+                assert isinstance(exit_.value, UniverseValue)
+                rows.extend(exit_.value.record.statements)
+        assert rows
+        return tuple(rows)
     assert isinstance(out, Complete)
     assert isinstance(out.value, UniverseValue)
     return out.value.record.statements
@@ -53,6 +71,26 @@ def _pending(out):
         for row in _statements(out)
         if isinstance(row, ContractConditionalConstructionV1)
     )
+
+
+@dataclass(frozen=True)
+class _Site:
+    """A minimal site: the effect vocabulary asks a locus for filename/line/col."""
+
+    filename: str = "twin.py"
+    line: int = 1
+    col: int = 0
+
+
+class _BoundState(Sugar):
+    """A stand-in for a bound face: `delete_binding` treats any Sugar as bound."""
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):  # pragma: no cover - never reduced by delete
+        raise AssertionError("delete_binding must not reduce a bound face")
 
 
 def _demand_shape(entry):
@@ -345,3 +383,116 @@ def test_a_condition_with_no_formula_at_all_is_still_loud() -> None:
 
     with pytest.raises(NotImplementedError, match="TermValue"):
         predicate_formula(_Walrus(), site="twin")
+
+
+# --------------------------------------------------------------------------
+# Family: TypeError: LoopGuardedProjection
+# --------------------------------------------------------------------------
+
+
+def test_delete_over_a_loop_guarded_projection_unions_its_faces() -> None:
+    """POSITIVE. `del` over a loop-guarded projection had no arm at all, so it
+    raised `TypeError: LoopGuardedProjection` -- while `read` over the SAME
+    projection had had one all along. It now deletes ON EACH completed face,
+    under that face's own guard, exactly as the read verb reads them."""
+    from sugar_lift_py_tests.ir import atomic
+    from sugar_lift_py_tests.outcome import Completed, Halted
+    from sugar_lift_py_tests.sugar.binding_projection import (
+        LoopGuardedCompletedFace,
+        LoopGuardedProjection,
+        UnboundProjection,
+    )
+    from sugar_lift_py_tests.sugar.delete_name_sugar import delete_binding
+
+    entered = atomic("entered", [])
+    empty = atomic("empty", [])
+    projection = LoopGuardedProjection(
+        (
+            # The loop ran: `y` is bound, so deleting it completes.
+            LoopGuardedCompletedFace("normal", entered, _BoundState()),
+            # The loop never ran: `y` was never bound, so deleting it halts.
+            LoopGuardedCompletedFace(
+                "normal", empty, UnboundProjection("y", _Site())
+            ),
+        )
+    )
+    exits = delete_binding(projection, name="y", site=_Site(), ctx=None)
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    assert len(completed) == 1
+    assert len(halted) == 1
+    # Each face keeps its OWN guard -- the union must not flatten them together.
+    assert completed[0].guard == entered
+    assert halted[0].guard == empty
+
+
+def test_read_and_delete_answer_the_same_projection_union() -> None:
+    """DISCRIMINATING. Both verbs over `BindingProjection` must cover the same
+    four constructors, and an uncovered one must be NAMED, not a bare TypeError.
+    """
+    import inspect
+
+    from sugar_lift_py_tests.sugar import delete_name_sugar, guarded_binding_read_sugar
+
+    constructors = (
+        "Sugar",
+        "UnboundProjection",
+        "GuardedProjection",
+        "LoopGuardedProjection",
+    )
+    for module, verb in (
+        (guarded_binding_read_sugar, "read_binding"),
+        (delete_name_sugar, "delete_binding"),
+    ):
+        source = inspect.getsource(getattr(module, verb))
+        missing = [name for name in constructors if name not in source]
+        assert missing == [], f"{verb} has no arm for {missing}"
+        assert "raise TypeError(" not in source, verb
+
+
+def test_unhandled_projection_names_the_union_and_the_verb() -> None:
+    """POSITIVE. The replacement for the bare TypeError states the closed union
+    it is answering for and which verb is missing an arm."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.sugar.delete_name_sugar import _unhandled_projection
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _unhandled_projection(object(), verb="delete", name="y", site=_Site())
+    message = str(raised.value)
+    assert "BindingProjection" in message
+    assert "LoopGuardedProjection" in message
+    assert "delete" in message
+
+
+# --------------------------------------------------------------------------
+# Family: BindingStateWireGap
+# --------------------------------------------------------------------------
+
+
+def test_loop_outward_face_returning_a_partition_lifts() -> None:
+    """POSITIVE. A loop's outward face whose `return` expression PARTITIONS used
+    to raise `BindingStateWireGap: loop outward face did not construct return or
+    raise testimony`. It was never a missing wire -- the face contributes its
+    partition under its own guard."""
+    out = _out(
+        "def f(xs, d, k, v):\n"
+        " for x in xs:\n"
+        "  if x:\n"
+        "   return d.setdefault(k, v)\n"
+        " return 0\n"
+    )
+    assert _statements(out)
+
+
+def test_loop_outward_face_with_a_plain_return_stays_one_completed_face() -> None:
+    """DISCRIMINATING. The simple face must NOT be routed through the partition
+    path: a plain `return` is still one completed exit carrying one return."""
+    from sugar_lift_py_tests.floor import ReturnValue
+
+    out = _out("def f(xs):\n for x in xs:\n  if x:\n   return 1\n return 0\n")
+    returns = [
+        row
+        for row in _statements(out)
+        if isinstance(row, ReturnValue) or isinstance(getattr(row, "value", None), ReturnValue)
+    ]
+    assert len(returns) >= 1


### PR DESCRIPTION
Follow-up to #6319, which was merged mid-run and captured only its first two
commits. This carries the remaining two, cherry-picked cleanly onto current
`main` (post-#6309 / `8563b0dd0`).

## Two more defect families

**`TypeError: LoopGuardedProjection` (1 row).** `read_binding` and
`delete_binding` are two verbs over the SAME closed four-constructor
`BindingProjection` union, and `delete_binding` simply had no
`LoopGuardedProjection` arm. It now deletes on each completed face under that
face's own guard — exactly what the read verb already did. Both bare
`raise TypeError(type(state))` sites are replaced by a gap that names the union,
the verb, and the missing constructor.

The twin is written at construction level, against a `LoopGuardedProjection`
built directly: the census row proves the constructor reaches this verb on real
source, but no minimal source shape drove it, and a twin that does not exercise
the arm it names is not a twin.

**`BindingStateWireGap: loop outward face did not construct return or raise
testimony` (1 row).** Never a missing wire. A face whose `return` reduces to
something richer than one value or one effect — here a return that owes a
parameter contract — is a partition the face contributes under its own guard. A
pending demand's home is a block entry, and the face builds exactly one: it
rides beside the return in the same record.

## And a silent unsoundness found on the way

`ContractConditionalConstructionV1.and_then` returned the following outcome
unchanged whenever it was not `Complete`, **silently discarding the pending
demand**. A demand that never reaches the block record is never enrolled by
`link_unit_projection` and never discharged by the linker, so `p[0]` stood with
`python:indexable(p)` owed by nobody. That is not a smaller answer, it is a
wrong one.

Measured on 25 pandas modules / 158 functions: **4 silent drops at
`origin/main`**, and 24 once #6319's reducers thread through `and_then` instead
of reading `.value` — the same losses, previously hidden inside the crash they
caused. They are loud and NAMED now, and the panic states which of two
architectures the case wants.

This raises the typed-loud construction floor by 9 on the 611-function subset.
That is the correct direction — silence here is unsound — and every one of them
points at #6321.

## Measurement

Paired, same manifest, 60 pandas modules / 611 functions:

| | baseline | head | Δ |
|---|---:|---:|---:|
| R_defects (category 4) | 20 | **0** | −20 |
| R_construction_panics (category 3) | 9 | 31 | +22 |

`sugar-source-tree`: 613 passed / 1 failed, the same inherited red
(`test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`) that fails
at `origin/main`. 24 twins, both arms each, every one perturbed after green and
confirmed to fail.

## Blocked

#6321 — `outcome_to_exitset` still has no arm for
`ContractConditionalConstructionV1`, a declared member of the `Outcome` union it
exists to lift. #6309 landed without touching that function. Every call site
outside `outcome/exit_set.py` hoists the demand instead, which is why the defect
count is zero; the missing arm is still missing.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `LoopGuardedProjection` support to `delete_binding` and align its arms with `read_binding`
> - `delete_binding` in [delete_name_sugar.py](https://github.com/TSavo/sugar/pull/6322/files#diff-93a5ffbb2b078a311327a1d0598ffa094308c47fc2f9e2b741e3b64a944096f4) now handles `LoopGuardedProjection` by unioning deletions across completed faces under their guards, matching the arms already supported by `read_binding`.
> - Both `delete_binding` and `read_binding` now raise a structured `ConstructionPanic` (via the new `_unhandled_projection` helper) instead of a generic `TypeError` for unknown `BindingProjection` variants.
> - `LoopRecurrenceSugar.desugar` now handles loop outward faces that return partitioned values or carry pending demands, producing guarded `Completed`/`Halted` exits instead of raising `BindingStateWireGap`.
> - `ContractConditionalConstructionV1.and_then` now wraps non-`Complete` follow-on outcomes with `rewrap_pending` (owner/blame context) instead of passing them through unchanged.
> - Tests in [test_desugar_defect_family_twins.py](https://github.com/TSavo/sugar/pull/6322/files#diff-cd024db81bb220534c47790ad3814c4dabdf7fc6e43b3e22d9c2d8e0597de824) assert parity between `read` and `delete` arms and validate the new loop and pending-demand handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4267c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->