### PR TITLE
EffectBoundary: derive the exit predicate from guard-level True/False routing (#6298)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -165,11 +165,14 @@ def _derive_effect_boundary(exit_set, protocol, behavior):
             and isinstance(face.value.statements[-1].value, PredicateValue)
         ):
             predicates.append(face.value.statements[-1].value.formula)
-    if not predicates or any(
-        predicate != predicates[0] for predicate in predicates[1:]
+    if predicates and all(
+        predicate == predicates[0] for predicate in predicates[1:]
     ):
+        formula = predicates[0]
+    else:
+        formula = _guarded_literal_suppression_formula(exit_set)
+    if formula is None:
         return None
-    formula = predicates[0]
     actuals = tuple(behavior.formal_actual_values)
     actual_terms = tuple(
         value.to_term(owner=behavior.resolved_object_cid) for value in actuals
@@ -210,6 +213,153 @@ def _derive_effect_boundary(exit_set, protocol, behavior):
         ),
         ExceptionInfoBindingV1(),
     )
+
+
+def _guarded_literal_suppression_formula(exit_set):
+    """The suppression predicate of an exit that routes exact ``True``/``False``.
+
+    A community effect boundary is rarely written as one returned predicate.
+    It is written as a route:
+
+        if <effect absent>:   raise ...
+        if <matched>:         return True
+        return False
+
+    That is the same theorem as ``return <matched>`` with the partition moved
+    from the value level to the GUARD level — the same move
+    ``ExitSet.factor_completed`` makes for sequencing. The predicate is
+    therefore the disjunction of the guards of the exact-``True`` faces.
+
+    It is derived only when the completed face is TOTALLY classified:
+
+    - every completed face is a block ending in ``return`` exact ``True`` or
+      exact ``False`` — one unclassified face and the disjunction would speak
+      for an outcome it does not cover, so the whole derivation refuses;
+    - at least one ``True`` face exists — an empty disjunction is
+      ``never suppresses``, which is a different contract and must not be
+      fabricated here.
+
+    Halted faces are the caller's business: it authenticates them separately
+    and refuses any halt that is not a proven absent-effect halt.
+    """
+    from sugar_lift_py_tests.floor import (
+        BlockValue,
+        BranchResultAuthentication,
+        GuardedReturn,
+    )
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import (
+        _and_guards,
+        _or_guards,
+        false_guard,
+    )
+
+    authenticated = {}
+    for face in exit_set.exits:
+        block = getattr(face, "value", None)
+        if not isinstance(block, BlockValue):
+            continue
+        for statement in block.statements:
+            if isinstance(statement, BranchResultAuthentication):
+                authenticated[statement.slot.slot_id] = statement.observed_guard
+
+    formula = false_guard()
+    saw_true = False
+    for face in exit_set.exits:
+        if not isinstance(face, Completed):
+            continue
+        block = face.value
+        if not isinstance(block, BlockValue) or not block.statements:
+            return None
+        if block.can_fall_through:
+            # An implicit ``None`` result is a third outcome this partition
+            # does not classify. Refuse rather than let the disjunction speak
+            # for it.
+            return None
+        for statement in block.statements:
+            if isinstance(statement, Incomplete):
+                return None
+            if isinstance(statement, GuardedReturn):
+                literal = _exact_bool_literal(statement.value)
+                if literal is None:
+                    return None
+                if literal:
+                    guards = tuple(statement.guards)
+                    guard = guards[0] if len(guards) == 1 else and_(list(guards))
+                    resolved = _resolve_branch_result_guards(
+                        _and_guards(face.guard, guard), authenticated
+                    )
+                    if resolved is None:
+                        return None
+                    saw_true = True
+                    formula = _or_guards(formula, resolved)
+                continue
+            if isinstance(statement, ReturnValue):
+                literal = _exact_bool_literal(statement.value)
+                if literal is None:
+                    return None
+                if literal:
+                    resolved = _resolve_branch_result_guards(
+                        face.guard, authenticated
+                    )
+                    if resolved is None:
+                        return None
+                    saw_true = True
+                    formula = _or_guards(formula, resolved)
+    return formula if saw_true else None
+
+
+def _resolve_branch_result_guards(formula, authenticated):
+    """Replace each branch-result slot literal by its AUTHENTICATED guard.
+
+    A branch guard is spelled ``py.truthy(python:branch_result(<slot>))`` — an
+    opaque coordinate. The block also carries a ``BranchResultAuthentication``
+    proving that slot equivalent to the real observed comparison. Only that
+    testimony may stand in for the slot; an unauthenticated slot returns
+    ``None`` and the whole boundary stays loud rather than being read from a
+    coordinate nobody proved anything about.
+    """
+    from sugar_lift_py_tests.ir import _Atomic, _Connective, _ConstStr, _Ctor
+
+    if isinstance(formula, _Connective):
+        operands = []
+        for operand in formula.operands:
+            resolved = _resolve_branch_result_guards(operand, authenticated)
+            if resolved is None:
+                return None
+            operands.append(resolved)
+        return type(formula)(formula.kind, tuple(operands))
+    if not isinstance(formula, _Atomic) or formula.name != "py.truthy":
+        return formula
+    if len(formula.args) != 1:
+        return formula
+    term = formula.args[0]
+    if not isinstance(term, _Ctor) or term.name != "python:branch_result":
+        return formula
+    if len(term.args) != 1 or not isinstance(term.args[0], _ConstStr):
+        return None
+    return authenticated.get(term.args[0].value)
+
+
+def _exact_bool_literal(value: object) -> bool | None:
+    """``True``/``False`` iff the value is exactly that literal; else ``None``.
+
+    Never truthiness. A symbolic value, a name, or any non-``bool`` constant
+    is unclassified and keeps the boundary loud.
+    """
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+        FalseBoolLiteralSugar,
+    )
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    if isinstance(value, TrueBoolLiteralSugar):
+        return True
+    if isinstance(value, FalseBoolLiteralSugar):
+        return False
+    if isinstance(value, TermValue) and type(value.value) is bool:
+        return value.value
+    return None
 
 
 def _formal_index_for_coordinate(formula, actual_terms, coordinate_name):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1169,3 +1169,150 @@ def test_renamed_source_boundary_routes_type_and_message_by_derived_formals(
         assert type(face.effect).__name__ == expected_effect
     else:
         assert isinstance(face, Completed)
+
+
+# --- Guarded-literal exit predicate (#6298 assertion-With drain) --------------
+#
+# The community shape for an effect boundary does NOT return one predicate
+# expression. It routes to `return True` / `return False` under guards:
+#
+#     if effect_type is None:
+#         raise ...
+#     if not <matched>:
+#         return False
+#     return True
+#
+# That is the SAME theorem as `return effect_type is self.expected`, with the
+# partition moved from the value level to the guard level. Deriving it means
+# reading the disjunction of the guards of the exact-True completed faces —
+# never a manager name, never a spelling.
+
+
+def _guarded_literal_boundary(tmp_path, *, exit_body: str):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n" + exit_body +
+        "def make_guard(expected):\n"
+        "    return ArbitraryBoundary(expected)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="guarded-literal-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+    return derive_manager_summary(protocol, behavior=behavior)
+
+
+def test_guarded_literal_exit_derives_expects_raise_boundary(tmp_path):
+    summary = _guarded_literal_boundary(
+        tmp_path,
+        exit_body=(
+            "        if effect_type is None:\n"
+            "            raise RuntimeError()\n"
+            "        if effect_type is self.expected:\n"
+            "            return True\n"
+            "        return False\n"
+        ),
+    )
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(summary.semantics.mode, ExpectsModeV1)
+    assert isinstance(summary.semantics.effect_kind, RaiseEffectKindV1)
+    assert summary.semantics.expected_type_operand == FormalArgumentProjectionV1(0)
+
+
+def test_guarded_literal_exit_without_absent_effect_halt_derives_suppresses(tmp_path):
+    summary = _guarded_literal_boundary(
+        tmp_path,
+        exit_body=(
+            "        if effect_type is self.expected:\n"
+            "            return True\n"
+            "        return False\n"
+        ),
+    )
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        FormalArgumentProjectionV1,
+        SuppressesModeV1,
+    )
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(summary.semantics.mode, SuppressesModeV1)
+    assert summary.semantics.expected_type_operand == FormalArgumentProjectionV1(0)
+
+
+def test_guarded_literal_exit_with_opaque_completed_face_stays_gap(tmp_path):
+    """Discrimination: one non-literal completed face admits NOTHING.
+
+    `return self.expected` is neither exact True nor exact False, so the
+    guard disjunction would silently speak for a face it does not cover.
+    The whole derivation must stay a typed gap.
+    """
+    summary = _guarded_literal_boundary(
+        tmp_path,
+        exit_body=(
+            "        if effect_type is None:\n"
+            "            raise RuntimeError()\n"
+            "        if effect_type is self.expected:\n"
+            "            return True\n"
+            "        return self.expected\n"
+        ),
+    )
+    assert isinstance(summary, DerivedManagerSummaryGapV1)
+    assert summary.kind == "exit-may-halt"
+
+
+def test_guarded_literal_exit_with_no_true_face_stays_gap(tmp_path):
+    """An all-False exit names no suppression predicate, so nothing is derived.
+
+    Teeth note: perturbing the explicit empty-disjunction refusal in
+    `_guarded_literal_suppression_formula` does NOT turn this red — an empty
+    disjunction is `false_guard()`, which carries no exit-type coordinate, so
+    the operand-resolution arm refuses it anyway. The explicit refusal is
+    defence in depth, not the arm this case exercises. This test pins the
+    CLASS (all-False exit is never a boundary), and its independent teeth are
+    the operand arm's.
+    """
+    summary = _guarded_literal_boundary(
+        tmp_path,
+        exit_body=(
+            "        if effect_type is None:\n"
+            "            raise RuntimeError()\n"
+            "        return False\n"
+        ),
+    )
+    assert isinstance(summary, DerivedManagerSummaryGapV1)
+    assert summary.kind == "exit-may-halt"
+
+
+def test_guarded_literal_exit_without_type_coordinate_stays_gap(tmp_path):
+    """Discrimination: a guard that never tests the exit-type coordinate.
+
+    No formal index is resolvable, so no expected-type operand exists and
+    the boundary must not be constructed from the True face alone.
+    """
+    summary = _guarded_literal_boundary(
+        tmp_path,
+        exit_body=(
+            "        if effect_type is None:\n"
+            "            raise RuntimeError()\n"
+            "        if effect is self.expected:\n"
+            "            return True\n"
+            "        return False\n"
+        ),
+    )
+    assert isinstance(summary, DerivedManagerSummaryGapV1)


### PR DESCRIPTION
## What

`_derive_effect_boundary` could only read a boundary whose `__exit__` returns **one predicate expression** (`return effect_type is self.expected`). The community shape does not do that. It routes exact literals under guards:

```python
def __exit__(self, exc_type, exc_val, exc_tb):
    if exc_type is None:
        fail(...)              # absent-effect halt
    if not <matched>:
        return False
    return True
```

Same theorem, partition moved from the **value level** to the **guard level** — the same move `ExitSet.factor_completed` (#6315) makes for sequencing. Derivation now reads the disjunction of the guards of the exact-`True` results.

Because a branch guard is spelled `py.truthy(python:branch_result(<slot>))` — an opaque coordinate — each slot is resolved through the block's own `BranchResultAuthentication`. **Only that testimony may stand in for a slot.** An unauthenticated slot refuses.

No name table, no manager spelling, no truthiness. The admission boundary is unchanged: production still obtains an authenticated contract or stays loud.

## Total-or-refuse

The disjunction is derived only when the completed face is totally classified. Any of these keeps the whole boundary a typed `DerivedManagerSummaryGapV1`:

- a completed result that is not exact `True`/`False`
- a block that can fall through (implicit `None` is a third outcome this partition does not classify)
- an unauthenticated branch-result slot
- no `True` face at all
- no exit-type coordinate resolvable from the derived formula

## Which R component

`R_construction`, assertion/effect-boundary bucket (4125 sites). This lands **one structural blocker**, not the mass — see Measured below.

## Shell deleted

None yet. This does not retire an instrument; it removes a shape restriction inside the acquisition path. The retirement path for the assertion-With census is unchanged: it hatches when the four heads acquire authenticated contracts, and it cannot hatch on this arm alone.

## Tests

`implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py`, five renamed non-vendor fixtures (real shape, no vendor named):

| test | face |
| --- | --- |
| `..._derives_expects_raise_boundary` | positive, Expects (absent-effect halt present) |
| `..._without_absent_effect_halt_derives_suppresses` | positive, Suppresses |
| `..._with_opaque_completed_face_stays_gap` | discrimination: one unclassified result admits nothing |
| `..._with_no_true_face_stays_gap` | discrimination: all-False exit |
| `..._without_type_coordinate_stays_gap` | discrimination: guard never tests the exit-type coordinate |

**Perturbation results** (each run after green, in production, not in the test):

- drop the exact-bool refusal → `..._opaque_completed_face_stays_gap` **RED**. Has teeth.
- drop the empty-disjunction refusal → all five still green. **Reported, not hidden**: an empty disjunction is `false_guard()`, which carries no exit-type coordinate, so the operand arm refuses it anyway. That explicit refusal is defence in depth; the test pins the class, and its independent teeth are the operand arm's. Noted in the test's docstring.
- the two positive twins were **RED before the change** and green after — that is their perturbation.
- `..._without_type_coordinate_stays_gap` is the paired complement of the first positive twin: identical fixture, only the compared coordinate changed (`effect_type` → `effect`); one derives, one gaps.

## Arm population

Unchanged. The completed exit face is already ONE factored arm carrying a `GuardedReturn` chain; this reads that chain and composes guards with `_or_guards`. No Cartesian materialization is reintroduced and `ExitSetFactoringGap` is untouched.

## Measured

**ΔR on the corpus construction axis: 0, and stated as such.** No corpus site moves yet. Measured on the focused discrimination corpus: 2 manager shapes move gap → derived `EffectBoundarySemanticsV1`; 3 stay typed gaps.

Why the corpus does not move, measured structurally rather than guessed — a static read of the four heads at `/usr/local/lib/python3.14/site-packages`:

```
pytest.raises              RaisesExc.__exit__  returns={True:1, False:1}
                           remaining blockers (calls in __exit__):
                           fail, self.matches, cast, len,
                           self.excinfo.fill_unfilled, AssertionError
tm.assert_produces_warning no class __exit__ — @contextmanager generator
tm.external_error_raised   no class __exit__ — @contextmanager generator
```

So for the 3555-site `pytest.raises` head this shot removes the **return-shape** blocker and leaves the **opaque-call-target** blockers, which are a different axis and a different owner. The 499 + 32 generator heads are the `GeneratorWithSugar` path and are not touched by this at all.

Claiming any part of the 4125 from this PR would be a stale-measurement claim. It is not claimed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive `EffectBoundary` suppression predicate from guard-level True/False exit routing
> - `_derive_effect_boundary` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6325/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) now falls back to a new `_guarded_literal_suppression_formula` helper when exit faces return mixed predicates instead of a single shared one.
> - `_guarded_literal_suppression_formula` inspects completed exit faces, requires all returns to be exact boolean literals, authenticates branch-result guards via `BranchResultAuthentication`, and builds the disjunction of guards for True-returning faces as the suppression predicate.
> - `_resolve_branch_result_guards` replaces `py.truthy(python:branch_result(<slot>))` atomics with authenticated observed guards, refusing derivation for unauthenticated or malformed references.
> - Cases that previously produced a `DerivedManagerSummaryGapV1` (exit-may-halt) may now yield a `DerivedManagerSummaryV1` with `EffectBoundarySemanticsV1` when all faces return guarded exact True/False and a True face exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 974b0b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->