### PR TITLE
test: three named zero-expected axes for the desugar residual (timeout, construction_panics, factoring_gaps)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
@@ -78,16 +78,23 @@ def _report(
     }
 
 
+def _open_source_file(path: Path, *, root: Path):
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_source_tree.reporter import CollectingReporter
+
+    return open_source_file_for_construction(
+        path,
+        root=root,
+        reporter=CollectingReporter(),
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--file", required=True)
     parser.add_argument("--corpus", type=Path)
     parser.add_argument("--deadline", type=float, default=180)
     args = parser.parse_args()
-
-    from sugar_lift_python_source.source_oracle import path_source
-    from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
 
     corpus = args.corpus
     if corpus is None:
@@ -99,10 +106,7 @@ def main() -> int:
         parser.error(f"missing file: {path}")
 
     started = time.perf_counter()
-    source_file = SourceFile(
-        path_source(str(path)),
-        reporter=CollectingReporter(),
-    )
+    source_file = _open_source_file(path, root=corpus)
     rows = []
     for index, function in enumerate(source_file.functions()):
         rows.append(

--- a/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Desugar-inclusive, single-file reproducer with an explicit R(timeout) axis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+
+class _FunctionTimeout(BaseException):
+    pass
+
+
+def _timeout(_signum, _frame) -> None:
+    raise _FunctionTimeout()
+
+
+def _desugar_one(
+    function: Any,
+    *,
+    name: str,
+    deadline_seconds: float = 0,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    status = "clean"
+    timed_out = False
+    prior_handler = None
+    try:
+        if deadline_seconds > 0:
+            prior_handler = signal.signal(signal.SIGALRM, _timeout)
+            signal.setitimer(signal.ITIMER_REAL, deadline_seconds)
+        function.sugar().desugar(None)
+    except _FunctionTimeout:
+        status = "timeout"
+        timed_out = True
+    except BaseException as exc:
+        # ConstructionPanic is intentionally BaseException, not Exception.
+        status = type(exc).__name__
+    finally:
+        if deadline_seconds > 0:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            assert prior_handler is not None
+            signal.signal(signal.SIGALRM, prior_handler)
+    span = function.line_col_span()
+    return {
+        "name": name,
+        "line": span.start_line,
+        "status": status,
+        "timedOut": timed_out,
+        "elapsedSeconds": round(time.perf_counter() - started, 6),
+    }
+
+
+def _report(
+    *,
+    file: str,
+    functions: Sequence[dict[str, Any]],
+    elapsed_s: float,
+    deadline_seconds: float,
+) -> dict[str, Any]:
+    discovered = len(functions)
+    completed = len(functions)
+    timeouts = sum(bool(row["timedOut"]) for row in functions)
+    return {
+        "schema": "sugar.desugar-repro.v1",
+        "file": file,
+        "deadlineSeconds": deadline_seconds,
+        "elapsedSeconds": round(elapsed_s, 6),
+        "discovered": discovered,
+        "completed": completed,
+        "R(timeout)": timeouts,
+        "stableZero": discovered > 0 and discovered == completed and timeouts == 0,
+        "functions": list(functions),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", required=True)
+    parser.add_argument("--corpus", type=Path)
+    parser.add_argument("--deadline", type=float, default=180)
+    args = parser.parse_args()
+
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.tree import SourceFile
+
+    corpus = args.corpus
+    if corpus is None:
+        import pandas
+
+        corpus = Path(pandas.__file__).resolve().parent
+    path = (corpus / args.file).resolve()
+    if not path.is_file():
+        parser.error(f"missing file: {path}")
+
+    started = time.perf_counter()
+    source_file = SourceFile(
+        path_source(str(path)),
+        reporter=CollectingReporter(),
+    )
+    rows = []
+    for index, function in enumerate(source_file.functions()):
+        rows.append(
+            _desugar_one(
+                function,
+                name=getattr(function, "name", f"function-{index}"),
+                deadline_seconds=args.deadline,
+            )
+        )
+    report = _report(
+        file=args.file,
+        functions=rows,
+        elapsed_s=time.perf_counter() - started,
+        deadline_seconds=args.deadline,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["stableZero"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
@@ -65,6 +65,12 @@ def _report(
     discovered = len(functions)
     completed = len(functions)
     timeouts = sum(bool(row["timedOut"]) for row in functions)
+    construction_panics = sum(
+        row["status"] == "ConstructionPanic" for row in functions
+    )
+    factoring_gaps = sum(
+        row["status"] == "ExitSetFactoringGap" for row in functions
+    )
     return {
         "schema": "sugar.desugar-repro.v1",
         "file": file,
@@ -73,7 +79,15 @@ def _report(
         "discovered": discovered,
         "completed": completed,
         "R(timeout)": timeouts,
-        "stableZero": discovered > 0 and discovered == completed and timeouts == 0,
+        "R(construction_panics)": construction_panics,
+        "R(factoring_gaps)": factoring_gaps,
+        "stableZero": (
+            discovered > 0
+            and discovered == completed
+            and timeouts == 0
+            and construction_panics == 0
+            and factoring_gaps == 0
+        ),
         "functions": list(functions),
     }
 

--- a/implementations/python/sugar-lift-py-tests/scripts/exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/exit_set_arm_census.py
@@ -1,0 +1,434 @@
+"""Arm census for the four ExitSet composition sites (#6309, halted face).
+
+Method-patching instrument only: it wraps ``ExitSet.sequence``,
+``ExitSet.and_finally``, ``ExitSet.and_exit`` and
+``ExitSet.and_exit_truthiness`` (plus ``ExitSet.normalize``, to capture the
+pre-normalize arm list) and restores every original on exit. **No production
+file changes, so the source stamp does not move.**
+
+Why the row shape is what it is
+-------------------------------
+
+Each site emits arms from a double loop over ``self.exits`` x the other
+operand's exits.  The reviewed question is whether the **halted** face grows
+as a product, so every row records the input cardinalities separately and
+then RECONSTRUCTS the emitted arm counts from them in closed form.  The
+reconstruction is checked against what the site actually appended
+(``reconciles``); a row that does not reconcile is an instrument bug, not a
+finding.
+
+That is deliberately stronger than a remainder bucket.  ``halted_from_exit``
+and ``halted_from_incoming`` are not measured by subtracting one from the
+total -- they are each predicted from the inputs, and their sum is required
+to equal the observed halted count.  A residual can absorb an instrument
+error silently; two independent predictions plus an equality cannot.
+
+Per-site closed forms, read off the source at ``a4eade69a`` (the halted-product
+baseline; ``exit_set.py`` is byte-identical on this branch).  ``S`` is
+``self.exits``, ``O`` the other operand's exits, ``c``/``h`` the completed and
+halted counts of a set.
+
+``sequence`` (:363-376) -- the CONTROL.  The halted bypass at :367-369
+appends one arm per halted incoming and ``continue``s, so halted incomings
+never enter the inner loop::
+
+    halted_from_incoming = h(S)                      # exact, by the bypass
+    iterations           = pre_len - h(S)            # one append per iteration
+
+The inner arm count is driven by ``step()`` and is not a function of the
+inputs, so ``sequence`` reports iterations and faces but claims no product.
+That is the point of a control: it should show the halted face FLAT while the
+other three show it growing.
+
+``and_finally`` (:405-418) -- one append per iteration.  A completed cleanup
+re-emits the incoming only when ``restores(clean.value)`` (:411-416); the
+``else`` at :417-418 is terminal cleanup completion (return-in-finally), which
+CONVERTS a halted incoming into a completion.  So the completed cleanups split
+into restoring (``c_r``) and terminal (``c_t``) and must be counted apart::
+
+    iterations           = |S| * |O|
+    halted_from_exit     = |S| * h(O)
+    halted_from_incoming = h(S) * c_r                # NOT h(S) * c(O)
+    completed_out        = c(S) * c_r + |S| * c_t
+
+With the default predicate (``cleanup_restores=None`` -> always True) ``c_t``
+is 0 and the two spellings coincide, which is exactly why a plain
+``completed(O)`` column would pass unnoticed until someone models
+return-in-finally.
+
+``and_exit`` (:454-487) -- ``exit_disposition_effect(disposition, incoming)``
+reads ``incoming`` ONLY; ``ex`` never reaches it.  So the verdict is a
+function of the incoming exit alone and the completed exit face contributes
+only a multiplicity ``c(O)``.  The halted term is therefore still a product --
+a verdict-weighted left factor times ``c(O)`` -- rather than a per-pair
+unknown, and probing costs ``|S|`` calls, not ``|S| * |O|``.  The
+``RetainedObligation`` branch (:466-483) emits TWO arms per pair, each
+independently completed or halted according to whether ``held`` / ``failed``
+is None, so a single undecidable predicate contributes 0, 1 or 2 halted arms::
+
+    iterations           = |S| * |O|
+    halted_from_exit     = |S| * h(O)
+    halted_from_incoming = c(O) * (n_effect + n_ro_held_halts + n_ro_failed_halts)
+    completed_out        = c(O) * (n_none + 2*n_ro - n_ro_held_halts - n_ro_failed_halts)
+    pre_len              = |S|*h(O) + c(O)*(n_none + n_effect + 2*n_ro)
+
+Note ``n_effect`` counts COMPLETED incomings that halt as well as halted ones
+that stay halted -- an assertion boundary halts a body that never raised, so a
+(completed, completed) pair yields a halted arm.  Neither a
+``|S| x halted(O)`` term nor a ``halted(S) x completed(O)`` term covers that,
+which is why the verdict shapes are first-class row inputs.
+
+``and_exit_truthiness`` (:502-529) -- a completed incoming with a completed
+``ex`` emits one arm and ``continue``s (:508-510); a HALTED incoming with a
+completed ``ex`` emits two (:522-529), one on each truth face.  Here the four
+cardinalities are sufficient::
+
+    iterations           = |S| * |O|
+    halted_from_exit     = |S| * h(O)
+    halted_from_incoming = h(S) * c(O)
+    completed_out        = |S| * c(O)
+    pre_len              = |S|*h(O) + c(S)*c(O) + 2*h(S)*c(O)
+
+Conservation, on every row and at every site::
+
+    completed_out + halted_from_exit + halted_from_incoming == pre_len
+
+with no remainder bucket.  ``post_len`` (after ``normalize``) is recorded
+beside ``pre_len`` but is NOT part of the conservation identity: normalize
+merges arms, so post-normalize length under-reports the work done.  Per the
+same argument, ``iterations`` is the load-bearing column -- an arm born dead
+under ``_and_guards`` returning ``false_guard()`` still cost a loop turn and
+still shows up in ``iterations`` even when it never reaches ``pre_len``'s
+survivors.
+
+Usage::
+
+    from exit_set_arm_census import arm_census
+
+    with arm_census() as rows:
+        ...  # exercise the construction under test
+    for row in rows:
+        print(row.site, row.iterations, row.halted_out)
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class CensusRow:
+    """One call of one composition site."""
+
+    site: str
+
+    # --- inputs, counted separately so the row is reconstructible ---
+    n_incoming: int = 0
+    n_incoming_completed: int = 0
+    n_incoming_halted: int = 0
+    n_other: int = 0
+    n_other_completed: int = 0
+    n_other_halted: int = 0
+
+    # and_finally only: the completed cleanups split by the restores predicate.
+    n_other_completed_restoring: int | None = None
+    n_other_completed_terminal: int | None = None
+
+    # and_exit only: verdict shapes, counted over INCOMINGS (the verdict is a
+    # function of the incoming exit alone), each weighted by n_other_completed.
+    n_verdict_none: int | None = None
+    n_verdict_effect: int | None = None
+    n_verdict_retained: int | None = None
+    n_retained_held_halts: int | None = None
+    n_retained_failed_halts: int | None = None
+    verdict_probe_error: str | None = None
+
+    # --- observed output ---
+    iterations: int = 0
+    pre_len: int = 0
+    post_len: int = 0
+    completed_out: int = 0
+    halted_out: int = 0
+
+    # --- predicted output, reconstructed from the inputs above ---
+    predicted_pre_len: int | None = None
+    predicted_completed_out: int | None = None
+    halted_from_exit: int | None = None
+    halted_from_incoming: int | None = None
+
+    reconciles: bool = False
+    reconcile_detail: str = ""
+
+    def check(self) -> None:
+        """Reconcile prediction against observation; set ``reconciles``."""
+        problems: list[str] = []
+        if self.halted_from_exit is None or self.halted_from_incoming is None:
+            problems.append("no halted prediction")
+        else:
+            predicted_halted = self.halted_from_exit + self.halted_from_incoming
+            if predicted_halted != self.halted_out:
+                problems.append(
+                    f"halted {predicted_halted} predicted != {self.halted_out} observed"
+                )
+        if self.predicted_completed_out is not None:
+            if self.predicted_completed_out != self.completed_out:
+                problems.append(
+                    f"completed {self.predicted_completed_out} predicted "
+                    f"!= {self.completed_out} observed"
+                )
+        if self.predicted_pre_len is not None:
+            if self.predicted_pre_len != self.pre_len:
+                problems.append(
+                    f"pre_len {self.predicted_pre_len} predicted != {self.pre_len} observed"
+                )
+        if self.completed_out + self.halted_out != self.pre_len:
+            problems.append(
+                f"faces {self.completed_out}+{self.halted_out} != pre_len {self.pre_len}"
+            )
+        self.reconcile_detail = "; ".join(problems)
+        self.reconciles = not problems
+
+
+@dataclass
+class _Frame:
+    """One in-flight composition call; collects its own pre-normalize set."""
+
+    row: CensusRow
+    captured: object | None = None
+    _stack: list = field(default_factory=list)
+
+
+def _faces(exits):
+    """(total, completed, halted) for an exit tuple."""
+    from sugar_lift_py_tests.outcome.exit_set import Completed
+
+    completed = sum(1 for e in exits if isinstance(e, Completed))
+    return len(exits), completed, len(exits) - completed
+
+
+@contextmanager
+def arm_census():
+    """Patch the four sites; yield the list of rows collected."""
+    import sugar_lift_py_tests.outcome.exit_set as exit_set_module
+
+    ExitSet = exit_set_module.ExitSet
+    rows: list[CensusRow] = []
+    frames: list[_Frame] = []
+
+    original_normalize = ExitSet.normalize
+    original_sequence = ExitSet.sequence
+    original_and_finally = ExitSet.and_finally
+    original_and_exit = ExitSet.and_exit
+    original_and_exit_truthiness = ExitSet.and_exit_truthiness
+
+    def patched_normalize(self):
+        # Route to the innermost in-flight frame, last write wins: a site's own
+        # ``ExitSet(tuple(exits)).normalize()`` is the last normalize call in
+        # its extent at its own level, and nested composition calls push and
+        # pop their own frames before it runs.
+        if frames:
+            frames[-1].captured = self
+        return original_normalize(self)
+
+    def _observe(frame, result):
+        row = frame.row
+        pre = frame.captured
+        if pre is None:  # pragma: no cover - defensive
+            row.reconcile_detail = "pre-normalize set not captured"
+            return
+        row.pre_len, row.completed_out, row.halted_out = _faces(pre.exits)
+        row.post_len = len(result.exits)
+
+    @contextmanager
+    def _frame(row):
+        frame = _Frame(row)
+        frames.append(frame)
+        try:
+            yield frame
+        finally:
+            frames.pop()
+            rows.append(row)
+
+    def patched_sequence(self, step):
+        row = CensusRow(site="sequence")
+        row.n_incoming, row.n_incoming_completed, row.n_incoming_halted = _faces(
+            self.exits
+        )
+        with _frame(row) as frame:
+            result = original_sequence(self, step)
+            _observe(frame, result)
+        # The bypass at :367-369 is the ONLY source of a halted arm carried
+        # from an incoming, and it fires exactly once per halted incoming.
+        row.halted_from_incoming = row.n_incoming_halted
+        row.halted_from_exit = row.halted_out - row.n_incoming_halted
+        # step() drives the inner loop, so the arm count is not a function of
+        # the inputs; iterations are still exact -- one append per turn.
+        row.iterations = row.pre_len - row.n_incoming_halted
+        row.check()
+        return result
+
+    def patched_and_finally(self, cleanup, *, cleanup_restores=None):
+        row = CensusRow(site="and_finally")
+        row.n_incoming, row.n_incoming_completed, row.n_incoming_halted = _faces(
+            self.exits
+        )
+        seen: list = []
+
+        def recording_cleanup():
+            # Forward the real callable once and keep its result; never invoke
+            # cleanup() a second time.
+            built = cleanup()
+            seen.append(built)
+            return built
+
+        with _frame(row) as frame:
+            result = original_and_finally(
+                self, recording_cleanup, cleanup_restores=cleanup_restores
+            )
+            _observe(frame, result)
+
+        if seen:
+            from sugar_lift_py_tests.outcome.exit_set import Completed
+
+            cleanup_exits = seen[-1].exits
+            row.n_other, row.n_other_completed, row.n_other_halted = _faces(
+                cleanup_exits
+            )
+            restores = cleanup_restores or (lambda _value: True)
+            restoring = sum(
+                1
+                for e in cleanup_exits
+                if isinstance(e, Completed) and restores(e.value)
+            )
+            row.n_other_completed_restoring = restoring
+            row.n_other_completed_terminal = row.n_other_completed - restoring
+            row.iterations = row.n_incoming * row.n_other
+            row.halted_from_exit = row.n_incoming * row.n_other_halted
+            row.halted_from_incoming = row.n_incoming_halted * restoring
+            row.predicted_completed_out = (
+                row.n_incoming_completed * restoring
+                + row.n_incoming * row.n_other_completed_terminal
+            )
+            row.predicted_pre_len = row.iterations
+        row.check()
+        return result
+
+    def patched_and_exit(self, exit_es, *, disposition):
+        row = CensusRow(site="and_exit")
+        row.n_incoming, row.n_incoming_completed, row.n_incoming_halted = _faces(
+            self.exits
+        )
+        row.n_other, row.n_other_completed, row.n_other_halted = _faces(exit_es.exits)
+        with _frame(row) as frame:
+            result = original_and_exit(self, exit_es, disposition=disposition)
+            _observe(frame, result)
+
+        row.iterations = row.n_incoming * row.n_other
+        # Probe AFTER the real call so a contract that refuses raises from the
+        # site under test, not from the instrument.
+        from sugar_lift_py_tests.outcome.exit_disposition import (
+            RetainedObligation,
+            exit_disposition_effect,
+        )
+
+        none_ = effect_ = retained = held_halts = failed_halts = 0
+        try:
+            for incoming in self.exits:
+                verdict = exit_disposition_effect(disposition, incoming)
+                if isinstance(verdict, RetainedObligation):
+                    retained += 1
+                    held_halts += verdict.held is not None
+                    failed_halts += verdict.failed is not None
+                elif verdict is None:
+                    none_ += 1
+                else:
+                    effect_ += 1
+        except BaseException as exc:  # instrument must not mask the real result
+            row.verdict_probe_error = f"{type(exc).__name__}: {exc}"
+            row.check()
+            return result
+
+        c_other = row.n_other_completed
+        row.n_verdict_none = none_
+        row.n_verdict_effect = effect_
+        row.n_verdict_retained = retained
+        row.n_retained_held_halts = held_halts
+        row.n_retained_failed_halts = failed_halts
+        row.halted_from_exit = row.n_incoming * row.n_other_halted
+        row.halted_from_incoming = c_other * (effect_ + held_halts + failed_halts)
+        row.predicted_completed_out = c_other * (
+            none_ + 2 * retained - held_halts - failed_halts
+        )
+        row.predicted_pre_len = row.halted_from_exit + c_other * (
+            none_ + effect_ + 2 * retained
+        )
+        row.check()
+        return result
+
+    def patched_and_exit_truthiness(self, exit_es, *, site):
+        row = CensusRow(site="and_exit_truthiness")
+        row.n_incoming, row.n_incoming_completed, row.n_incoming_halted = _faces(
+            self.exits
+        )
+        row.n_other, row.n_other_completed, row.n_other_halted = _faces(exit_es.exits)
+        with _frame(row) as frame:
+            result = original_and_exit_truthiness(self, exit_es, site=site)
+            _observe(frame, result)
+
+        row.iterations = row.n_incoming * row.n_other
+        row.halted_from_exit = row.n_incoming * row.n_other_halted
+        row.halted_from_incoming = row.n_incoming_halted * row.n_other_completed
+        row.predicted_completed_out = row.n_incoming * row.n_other_completed
+        row.predicted_pre_len = (
+            row.halted_from_exit
+            + row.n_incoming_completed * row.n_other_completed
+            + 2 * row.n_incoming_halted * row.n_other_completed
+        )
+        row.check()
+        return result
+
+    ExitSet.normalize = patched_normalize
+    ExitSet.sequence = patched_sequence
+    ExitSet.and_finally = patched_and_finally
+    ExitSet.and_exit = patched_and_exit
+    ExitSet.and_exit_truthiness = patched_and_exit_truthiness
+    try:
+        yield rows
+    finally:
+        ExitSet.normalize = original_normalize
+        ExitSet.sequence = original_sequence
+        ExitSet.and_finally = original_and_finally
+        ExitSet.and_exit = original_and_exit
+        ExitSet.and_exit_truthiness = original_and_exit_truthiness
+
+
+SITES = ("sequence", "and_finally", "and_exit", "and_exit_truthiness")
+
+
+def totals(rows):
+    """Per-site sums of the load-bearing columns, for a report table."""
+    out = {}
+    for site in SITES:
+        site_rows = [r for r in rows if r.site == site]
+        out[site] = {
+            "calls": len(site_rows),
+            "iterations": sum(r.iterations for r in site_rows),
+            "pre_len": sum(r.pre_len for r in site_rows),
+            "post_len": sum(r.post_len for r in site_rows),
+            "completed_out": sum(r.completed_out for r in site_rows),
+            "halted_out": sum(r.halted_out for r in site_rows),
+            "halted_from_exit": sum(r.halted_from_exit or 0 for r in site_rows),
+            "halted_from_incoming": sum(r.halted_from_incoming or 0 for r in site_rows),
+            "non_reconciling": sum(1 for r in site_rows if not r.reconciles),
+        }
+    return out
+
+
+def dump_rows(rows, path):
+    """Write every row as JSON lines -- the product claim must be recheckable."""
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(asdict(row), sort_keys=True) + "\n")
+    return path

--- a/implementations/python/sugar-lift-py-tests/scripts/run_bisect_point.sh
+++ b/implementations/python/sugar-lift-py-tests/scripts/run_bisect_point.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "6309" ]]; then
+  echo "usage: $0 6309 [deadline-seconds] --only relative/path.py" >&2
+  exit 2
+fi
+deadline="${2:-180}"
+shift 2
+if [[ "${1:-}" != "--only" || -z "${2:-}" ]]; then
+  echo "usage: $0 6309 [deadline-seconds] --only relative/path.py" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${script_dir}/desugar_repro.py" \
+  --file "${2}" \
+  --deadline "${deadline}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
@@ -71,3 +71,12 @@ def test_report_names_timeout_residual_and_requires_nonempty_denominator():
     )
     assert empty["R(timeout)"] == 0
     assert empty["stableZero"] is False
+
+
+def test_open_source_file_binds_construction_context(tmp_path):
+    source = tmp_path / "fixture.py"
+    source.write_text("def f(cm):\n    with cm:\n        pass\n")
+
+    source_file = _MOD._open_source_file(source, root=tmp_path)
+
+    assert source_file.unit.construction_context is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
@@ -73,6 +73,25 @@ def test_report_names_timeout_residual_and_requires_nonempty_denominator():
     assert empty["stableZero"] is False
 
 
+def test_report_splits_nonclean_statuses_into_zero_expected_floor_axes():
+    report = _MOD._report(
+        file="core/generic.py",
+        functions=[
+            {"status": "clean", "timedOut": False},
+            {"status": "ConstructionPanic", "timedOut": False},
+            {"status": "ConstructionPanic", "timedOut": False},
+            {"status": "ExitSetFactoringGap", "timedOut": False},
+        ],
+        elapsed_s=1.25,
+        deadline_seconds=180,
+    )
+
+    assert report["R(timeout)"] == 0
+    assert report["R(construction_panics)"] == 2
+    assert report["R(factoring_gaps)"] == 1
+    assert report["stableZero"] is False
+
+
 def test_open_source_file_binds_construction_context(tmp_path):
     source = tmp_path / "fixture.py"
     source.write_text("def f(cm):\n    with cm:\n        pass\n")

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_SCRIPT = (
+    Path(__file__).parents[1] / "scripts" / "desugar_repro.py"
+)
+_SPEC = importlib.util.spec_from_file_location("desugar_repro", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+
+class _Sugar:
+    def __init__(self, result):
+        self._result = result
+
+    def desugar(self, _ctx=None):
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+
+class _Function:
+    def __init__(self, result):
+        self._result = result
+
+    def sugar(self):
+        return _Sugar(self._result)
+
+    def line_col_span(self):
+        return type("Span", (), {"start_line": 7})()
+
+
+def test_desugar_one_counts_success_and_construction_panic_as_completed_attempts():
+    clean = _MOD._desugar_one(_Function(object()), name="clean")
+    panic = _MOD._desugar_one(
+        _Function(BaseException("construction panic")),
+        name="panic",
+    )
+
+    assert clean["status"] == "clean"
+    assert panic["status"] == "BaseException"
+    assert clean["timedOut"] is False
+    assert panic["timedOut"] is False
+
+
+def test_report_names_timeout_residual_and_requires_nonempty_denominator():
+    report = _MOD._report(
+        file="core/generic.py",
+        functions=[
+            {"status": "clean", "timedOut": False},
+            {"status": "timeout", "timedOut": True},
+        ],
+        elapsed_s=1.25,
+        deadline_seconds=180,
+    )
+
+    assert report["discovered"] == 2
+    assert report["completed"] == 2
+    assert report["R(timeout)"] == 1
+    assert report["stableZero"] is False
+
+    empty = _MOD._report(
+        file="core/generic.py",
+        functions=[],
+        elapsed_s=0.0,
+        deadline_seconds=180,
+    )
+    assert empty["R(timeout)"] == 0
+    assert empty["stableZero"] is False

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
@@ -1,0 +1,387 @@
+"""Teeth for the #6309 halted-face arm census instrument.
+
+The instrument lives in ``scripts/exit_set_arm_census.py`` and only
+method-patches ``ExitSet``; no production file moves, so the source stamp does
+not move either.
+
+Two things are under test here, and they are different:
+
+1. **The instrument reconciles.** Every row's predicted arm counts, rebuilt
+   from the recorded input cardinalities alone, must equal what the site
+   actually appended. A non-reconciling row is an instrument bug, never a
+   finding -- so this is the tooth that has to hold before any number the
+   census prints is worth reading.
+
+2. **The halted face grows as a product at three of the four sites, and is
+   flat at the fourth.** ``sequence`` is the control: its halted bypass means
+   halted arms out stay equal to halted incomings no matter how wide the other
+   operand gets. If the control ever showed growth, the law would be measuring
+   the harness rather than the algebra.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    EffectBoundaryDisposition,
+    EffectMatcher,
+    NeverSuppresses,
+)
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from exit_set_arm_census import SITES, arm_census, totals  # noqa: E402
+
+_WIDTHS = (1, 2, 4, 8)
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def _effect(name: str = "ValueError"):
+    return RaiseEffect(exception_name=name)
+
+
+def _value():
+    """A completed value ``and_exit_truthiness`` can read a truth face from.
+
+    ``exit_set.py:513`` takes the literal fast path for a ``TermValue`` holding
+    a ``bool``; anything else is handed to ``predicate_formula``, which needs a
+    floor value. A bare string would make the fixture, not the algebra, decide
+    whether the site is reachable.
+    """
+    return TermValue(True)
+
+
+def _mixed(width: int, prefix: str) -> ExitSet:
+    """``width`` completed arms and ``width`` halted arms, distinctly guarded."""
+    exits = []
+    for index in range(width):
+        exits.append(Completed(_guard(f"{prefix}_c{index}"), _value()))
+        exits.append(
+            Halted(_guard(f"{prefix}_h{index}"), _effect(), f"{prefix}_s{index}")
+        )
+    return ExitSet(tuple(exits))
+
+
+def _completed_only(width: int, prefix: str) -> ExitSet:
+    return ExitSet(
+        tuple(
+            Completed(_guard(f"{prefix}_c{index}"), _value()) for index in range(width)
+        )
+    )
+
+
+def _rows_for(rows, site):
+    return [row for row in rows if row.site == site]
+
+
+def _assert_all_reconcile(rows):
+    broken = [row for row in rows if not row.reconciles]
+    assert not broken, "\n".join(
+        f"{row.site}: {row.reconcile_detail} :: {row}" for row in broken
+    )
+    assert rows, "census collected no rows; the instrument never fired"
+
+
+# --------------------------------------------------------------------------
+# 1. the instrument reconciles
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("width", _WIDTHS)
+def test_every_row_reconciles_at_and_exit_truthiness(width: int) -> None:
+    body = _mixed(width, "body")
+    exit_es = _mixed(width, "exit")
+
+    with arm_census() as rows:
+        body.and_exit_truthiness(exit_es, site=None)
+
+    _assert_all_reconcile(_rows_for(rows, "and_exit_truthiness"))
+
+
+@pytest.mark.parametrize("width", _WIDTHS)
+def test_every_row_reconciles_at_and_finally(width: int) -> None:
+    body = _mixed(width, "body")
+    cleanup = _mixed(width, "clean")
+
+    with arm_census() as rows:
+        body.and_finally(lambda: cleanup)
+
+    _assert_all_reconcile(_rows_for(rows, "and_finally"))
+
+
+@pytest.mark.parametrize("width", _WIDTHS)
+def test_every_row_reconciles_at_and_exit(width: int) -> None:
+    body = _mixed(width, "body")
+    exit_es = _mixed(width, "exit")
+
+    with arm_census() as rows:
+        body.and_exit(exit_es, disposition=NeverSuppresses())
+
+    _assert_all_reconcile(_rows_for(rows, "and_exit"))
+
+
+@pytest.mark.parametrize("width", _WIDTHS)
+def test_every_row_reconciles_at_sequence(width: int) -> None:
+    body = _mixed(width, "body")
+    tail = _mixed(2, "tail")
+
+    with arm_census() as rows:
+        body.sequence(lambda _value: tail)
+
+    _assert_all_reconcile(_rows_for(rows, "sequence"))
+
+
+def test_conservation_holds_with_no_remainder_bucket() -> None:
+    """completed_out + halted_from_exit + halted_from_incoming == pre_len."""
+    body = _mixed(3, "body")
+    other = _mixed(3, "other")
+
+    with arm_census() as rows:
+        body.and_exit_truthiness(other, site=None)
+        body.and_finally(lambda: other)
+        body.and_exit(other, disposition=NeverSuppresses())
+
+    _assert_all_reconcile(rows)
+    for row in rows:
+        assert (
+            row.completed_out + row.halted_from_exit + row.halted_from_incoming
+            == row.pre_len
+        ), f"{row.site} leaves a remainder: {row}"
+
+
+def test_reconcile_check_can_actually_fail() -> None:
+    """Negative control: a check nothing can fail is not a check.
+
+    Every ``reconciles`` assertion above is only worth reading if a wrong
+    prediction is caught. Perturb each predicted column on a known-good row and
+    require the row to go red.
+    """
+    body = _mixed(2, "body")
+    other = _mixed(2, "other")
+
+    with arm_census() as rows:
+        body.and_exit_truthiness(other, site=None)
+
+    (row,) = _rows_for(rows, "and_exit_truthiness")
+    assert row.reconciles, row.reconcile_detail
+
+    for column in (
+        "halted_from_exit",
+        "halted_from_incoming",
+        "predicted_completed_out",
+        "predicted_pre_len",
+    ):
+        good = getattr(row, column)
+        setattr(row, column, good + 1)
+        row.check()
+        assert not row.reconciles, f"perturbing {column} was not caught"
+        setattr(row, column, good)
+
+    row.check()
+    assert row.reconciles, row.reconcile_detail
+
+
+def test_instrument_restores_every_patched_method() -> None:
+    originals = {
+        name: getattr(ExitSet, name)
+        for name in (
+            "normalize",
+            "sequence",
+            "and_finally",
+            "and_exit",
+            "and_exit_truthiness",
+        )
+    }
+
+    with arm_census():
+        assert getattr(ExitSet, "normalize") is not originals["normalize"]
+
+    for name, original in originals.items():
+        assert getattr(ExitSet, name) is original, f"{name} not restored"
+
+
+# --------------------------------------------------------------------------
+# 2. the growth law, with sequence as the control
+# --------------------------------------------------------------------------
+
+
+def _halted_out_by_width(site: str) -> dict[int, int]:
+    """Halted arms out as the OTHER operand widens; body held fixed."""
+    body = _mixed(2, "body")
+    measured = {}
+    for width in _WIDTHS:
+        other = _mixed(width, "other")
+        with arm_census() as rows:
+            if site == "and_exit_truthiness":
+                body.and_exit_truthiness(other, site=None)
+            elif site == "and_finally":
+                body.and_finally(lambda: other)
+            elif site == "and_exit":
+                body.and_exit(other, disposition=NeverSuppresses())
+            elif site == "sequence":
+                body.sequence(lambda _value: other)
+            else:  # pragma: no cover - guarded by SITES
+                raise AssertionError(site)
+        site_rows = _rows_for(rows, site)
+        _assert_all_reconcile(site_rows)
+        measured[width] = sum(row.halted_out for row in site_rows)
+    return measured
+
+
+@pytest.mark.parametrize("site", ["and_exit", "and_finally", "and_exit_truthiness"])
+def test_halted_arms_grow_with_the_other_operand(site: str) -> None:
+    """The defect: the halted face is a product at all three unbypassed sites."""
+    measured = _halted_out_by_width(site)
+
+    assert measured[8] > measured[1], f"{site}: halted face did not grow: {measured}"
+    # Product, not merely monotone: doubling the operand doubles the halted arms.
+    for small, large in ((1, 2), (2, 4), (4, 8)):
+        assert (
+            measured[large] == 2 * measured[small]
+        ), f"{site}: halted face is not doubling with the operand: {measured}"
+
+
+def test_sequence_is_the_control_and_stays_flat() -> None:
+    """``sequence``'s bypass keeps halted arms carried from incomings linear.
+
+    The tail's own halted arms still scale -- that is the tail's face, not a
+    product with the incoming halts -- so the tooth is on the split column, not
+    on the total.
+    """
+    body = _mixed(2, "body")
+    carried = {}
+    for width in _WIDTHS:
+        tail = _mixed(width, "tail")
+        with arm_census() as rows:
+            body.sequence(lambda _value: tail)
+        site_rows = _rows_for(rows, "sequence")
+        _assert_all_reconcile(site_rows)
+        carried[width] = sum(row.halted_from_incoming for row in site_rows)
+
+    assert len(set(carried.values())) == 1, (
+        f"control moved: halted arms carried from incomings should stay flat "
+        f"at |halted(self)| regardless of tail width, got {carried}"
+    )
+    assert carried[1] == 2, f"expected 2 halted incomings, got {carried}"
+
+
+# --------------------------------------------------------------------------
+# 3. the two splits that a four-cardinality row would get wrong
+# --------------------------------------------------------------------------
+
+
+def test_and_finally_terminal_cleanup_is_not_a_halted_arm() -> None:
+    """Return-in-finally converts a halted incoming into a COMPLETION.
+
+    A row that recorded a plain ``completed(cleanup)`` count would predict
+    ``|halted(self)| x |completed(cleanup)|`` halted arms here. The true
+    number is zero, because every completed cleanup is terminal.
+    """
+    body = _mixed(3, "body")
+    cleanup = _completed_only(2, "clean")
+
+    with arm_census() as rows:
+        body.and_finally(lambda: cleanup, cleanup_restores=lambda _value: False)
+
+    (row,) = _rows_for(rows, "and_finally")
+    assert row.reconciles, row.reconcile_detail
+    assert row.n_other_completed == 2
+    assert row.n_other_completed_restoring == 0
+    assert row.n_other_completed_terminal == 2
+    assert row.halted_from_incoming == 0
+    naive = row.n_incoming_halted * row.n_other_completed
+    assert naive == 6, "the naive four-cardinality prediction should be nonzero here"
+    assert row.halted_out == 0, (
+        "every arm is a terminal completion; a plain completed(cleanup) column "
+        f"would have overstated the halted face by {naive}"
+    )
+
+
+def test_and_finally_restoring_cleanup_does_carry_the_halted_incoming() -> None:
+    """The mirror of the above: with a restoring predicate the product is real."""
+    body = _mixed(3, "body")
+    cleanup = _completed_only(2, "clean")
+
+    with arm_census() as rows:
+        body.and_finally(lambda: cleanup, cleanup_restores=lambda _value: True)
+
+    (row,) = _rows_for(rows, "and_finally")
+    assert row.reconciles, row.reconcile_detail
+    assert row.n_other_completed_restoring == 2
+    assert row.n_other_completed_terminal == 0
+    assert row.halted_from_incoming == 6 == row.n_incoming_halted * 2
+    assert row.halted_out == 6
+
+
+def test_and_exit_halts_a_completed_incoming_against_a_completed_exit() -> None:
+    """An assertion boundary halts a body that never raised.
+
+    That halted arm comes from a (completed incoming, completed ex) pair, which
+    neither ``|self| x halted(exit)`` nor ``halted(self) x completed(exit)``
+    covers. The census reports it through the verdict-shape counts instead.
+    """
+    body = _completed_only(3, "body")
+    exit_es = _completed_only(2, "exit")
+    disposition = EffectBoundaryDisposition(
+        matcher=EffectMatcher(kind="raise", name="ValueError"),
+        unmet=_effect("AssertionError"),
+    )
+
+    with arm_census() as rows:
+        body.and_exit(exit_es, disposition=disposition)
+
+    (row,) = _rows_for(rows, "and_exit")
+    assert row.reconciles, row.reconcile_detail
+    assert row.n_incoming_halted == 0
+    assert row.n_other_halted == 0
+    # Both terms of the four-cardinality formula are zero here...
+    assert row.n_incoming * row.n_other_halted == 0
+    assert row.n_incoming_halted * row.n_other_completed == 0
+    # ...and yet every emitted arm halts.
+    assert row.n_verdict_effect == 3
+    assert row.halted_from_exit == 0
+    assert row.halted_from_incoming == 6
+    assert row.halted_out == 6 == row.pre_len
+    assert row.completed_out == 0
+
+
+def test_iterations_are_recorded_separately_from_surviving_arms() -> None:
+    """``pre_len`` under-reports work wherever a pair emits other than one arm."""
+    body = _mixed(2, "body")
+    exit_es = _completed_only(3, "exit")
+
+    with arm_census() as rows:
+        body.and_exit_truthiness(exit_es, site=None)
+
+    (row,) = _rows_for(rows, "and_exit_truthiness")
+    assert row.reconciles, row.reconcile_detail
+    assert row.iterations == 4 * 3
+    # Halted incomings emit two arms per pair, so arms exceed loop turns.
+    assert row.pre_len == 18 > row.iterations
+    assert row.post_len <= row.pre_len
+
+
+def test_totals_reports_every_site() -> None:
+    body = _mixed(2, "body")
+    other = _mixed(2, "other")
+
+    with arm_census() as rows:
+        body.and_exit_truthiness(other, site=None)
+        body.and_finally(lambda: other)
+        body.and_exit(other, disposition=NeverSuppresses())
+        body.sequence(lambda _value: other)
+
+    summary = totals(rows)
+    assert set(summary) == set(SITES)
+    for site in SITES:
+        assert summary[site]["calls"] >= 1, f"{site} never fired"
+        assert summary[site]["non_reconciling"] == 0, f"{site} has broken rows"


### PR DESCRIPTION
Test-lane only, additive: 5 new files under `implementations/python/sugar-lift-py-tests/`, no production path touched.

## What it does

Splits the desugar-repro failure surface into three independently counted, zero-expected axes instead of one timeout predicate:

```text
R(timeout)
R(construction_panics)
R(factoring_gaps)
```

`stableZero` requires a non-empty completed denominator **and** all three axes at zero. Panic and declared gap are separate columns and both falsify — lumping them was the defect.

This deliberately follows the owner's 2026-07-26 04:01Z ruling shape for the coretests pin: record OBSERVED values in the receipt, hold EXPECTED at zero, let a completed sweep go red **by name**. A red with a separately pinned cause stays legible; a bare red decays into an ignored red.

**This flips the earlier timeout-only headline.** `R(timeout)=0` at `a4eade69a` no longer means the residual is clear — the timeout predicate is strictly weaker than the exit code, and `construction_panics` / `factoring_gaps` are where the remaining signal lives.

## Correctness of the rig

`desugar_repro.py` routes through `open_source_file_for_construction` (scripts/desugar_repro.py:96,99), not a bare `SourceFile(...)` — the earlier revision had the exact defect `lift_rpc.py` names in its own docstring (painting every `With` as RuntimeSelected regardless of resolvability). `ConstructionPanic` derives from `BaseException` and is caught explicitly.

## Receipts

- TDD: the new tooth first failed with `KeyError: R(construction_panics)`; post-commit focused file run `4 passed in 2.67s`.
- Regression fixture is the observed Grok row shape (`timeouts=0, construction_panics=2, factoring_gaps=1`) and returns `stableZero=False`.
- `test_exit_set_arm_census.py`: 28 nodes collected and passing inside a full 1407-node package sweep at the same content (`134 failed, 1256 passed, 12 skipped, 5 errors`, reconciling 1256+134+12+5 = 1407 against `--collect-only`). The 134 failures are unattributed and consistent with trunk-red; **no baseline sweep exists, so no delta is claimed.** None of the 5 errors are in these files.

Base is `a4eade69a`, an ancestor of current main.

Co-authored by Chucky and Honey; branch review and PR by Fizz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add named zero-expected axes (timeout, construction_panics, factoring_gaps) for desugar residual testing
> - Adds [`desugar_repro.py`](https://github.com/TSavo/sugar/pull/6326/files#diff-200f23e22d78a682528fa8008ea2b1c481abee81c8981ff5d932e96bd2fc9161), a CLI tool that runs `sugar().desugar()` on every function in a source file, bounds each call with a POSIX SIGALRM timer, and emits a JSON report with per-function status and aggregate residual counts across three named axes: timeouts, construction panics, and factoring gaps.
> - Adds [`exit_set_arm_census.py`](https://github.com/TSavo/sugar/pull/6326/files#diff-586e4c118b32214ccc1c21d6300160c82ce929723a0c32675192c790ed48c0dc), a context manager that monkey-patches `ExitSet` composition methods to record per-call `CensusRow` data (counts, predictions, reconciliation) without altering return values, plus helpers to aggregate and persist rows.
> - Adds [`run_bisect_point.sh`](https://github.com/TSavo/sugar/pull/6326/files#diff-3f4562dcf968097e711358394be227785c9200bed6d169cd392efa1cc0e76af7) as a thin wrapper around `desugar_repro.py` with fixed usage for bisect workflows.
> - Adds unit tests for both scripts covering status classification, report aggregation, reconciliation logic, conservation laws, and method restoration after instrumentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eee2c2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line tool for desugaring source files with per-function timeout reporting and JSON results.
  - Added instrumentation to census and reconcile `ExitSet` composition outcomes across supported operations.
  - Added a helper script for running targeted desugaring checks with configurable deadlines.

- **Tests**
  - Added coverage for timeout reporting, construction failures, source context handling, census reconciliation, conservation rules, cleanup behavior, and instrumentation restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->