### PR TITLE
The unpack demand: two more receivers answer, and 98.8% of the family is one blocked arm

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
@@ -32,6 +32,15 @@ class ComprehensionValue(FloorValue):
         del owner
         return self.term
 
+    def project_sequence_with(self, operation, ctx):
+        """`a, b = <comprehension>` -- the comprehension owns the cardinality.
+
+        It answers from `finite_elements` when its owner projected every member
+        of an exact finite iterable, and otherwise retains the arity demand. The
+        operation reads the testimony; this face only routes to it.
+        """
+        return operation.project_comprehension(self, ctx)
+
     def contains(self, item, site):
         # Finite comprehension testimony folds like a list; otherwise membership
         # stays the py.in coordinate over the comprehension term.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -243,6 +243,31 @@ class GuardedValue(FloorValue):
         outcome = rewrap_pending(true_pending, outcome, owner=owner, blame=site)
         return rewrap_pending(false_pending, outcome, owner=owner, blame=site)
 
+    def project_sequence_with(self, operation, ctx):
+        """`a, b = (p if c else q)` -- the unpack distributes into both faces.
+
+        Not `_map`. `_map` re-fuses two ANSWERS into one `GuardedValue`, and the
+        answers here are not values: each face independently either binds a
+        `ScopeRebinds` or halts with its arity obligation, and those two do not
+        fuse into a conditional value. The lawful join is the partition -- each
+        face's answer restricted to its own polarity, then unioned -- which is
+        the same exit algebra `IfSugar` builds and keeps a halt on one face
+        coexisting with a completed exit on the other.
+
+        `collapse()` hands back a plain outcome when the union has one
+        unconditional exit, so an unguarded caller is unaffected.
+        """
+        from sugar_lift_py_tests.ir import not_
+        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        def face(value, guard):
+            return outcome_to_exitset(
+                value.project_sequence_with(operation, ctx)
+            ).guarded(guard)
+
+        exits = face(self.when_true, self.guard)
+        return exits.union(face(self.when_false, not_(self.guard))).collapse()
+
     def subscript(self, index, site):
         return self._map("subscript", index, site)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
@@ -70,6 +70,23 @@ class SequenceProjectionOperation:
         del ctx
         return self._authenticated_members(value, value.items, "array")
 
+    def project_comprehension(self, value: Any, ctx: Any) -> Any:
+        """A comprehension answers from its own finite testimony, or not at all.
+
+        ``ComprehensionValue.finite_elements`` is the authenticated projection of
+        every member of an exact finite iterable, and ``None`` means no such
+        testimony exists. ``None`` is NOT an empty sequence and is not a count:
+        it routes to the runtime arm, where the cardinality stays owed. Reading
+        it as zero members would turn "we do not know" into a decidable arity
+        mismatch, which is the same lie in the opposite direction.
+        """
+        del ctx
+        if value.finite_elements is None:
+            return self._runtime_cardinality(value)
+        return self._authenticated_members(
+            value, value.finite_elements, "comprehension"
+        )
+
     # -- runtime cardinality: the count is not decidable -------------------
 
     def project_symbolic(self, value: Any, ctx: Any) -> Any:

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -170,15 +170,35 @@ def test_arity_mismatch_stays_loud():
         _fn("def A():\n    a, b = (1, 2, 3)\n    return a\n").sugar()
 
 
-def test_non_display_rhs_constructs_but_stays_typed_loud_when_reached():
+def test_non_display_rhs_constructs_and_retains_its_arity_obligation():
     # Construction must be total enough for an unreachable branch to coexist
     # with a closed guard. If execution reaches the dynamic unpack, its unknown
     # iteration/cardinality semantics remain loud rather than fabricating binds.
+    #
+    # "Loud" used to mean SugarNotWritten -- a refusal that banked as measured
+    # while saying nothing about WHAT was owed. #6316 drained it: the demand is
+    # now a typed effect naming the exact obligation
+    # `python:unpack.destructure(term, arity)`. Same law, one rung up, and the
+    # assertion is correspondingly stronger.
+    from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+
     function = _fn("def A(p):\n    a, b = p\n    return a\n")
     sugar = function.sugar()
 
+    out = sugar.desugar()
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
+    assert "exactly 2 members" in out.effect.reason
+    assert "(a, b)" in out.effect.reason
+
+
+def test_display_rhs_arity_mismatch_is_still_a_refusal_not_an_effect():
+    # DISCRIMINATING against the change above: a DISPLAY right-hand side has
+    # lift-time cardinality, so `a, b = (1, 2, 3)` is decidably wrong and must
+    # NOT be softened into the runtime-cardinality effect. Only the undecidable
+    # count becomes an obligation.
     with pytest.raises(SugarNotWritten):
-        sugar.desugar()
+        _fn("def A():\n    a, b = (1, 2, 3)\n    return a\n").sugar()
 
 
 def test_mixed_chained_targets_stay_loud():

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -33,6 +33,32 @@ def _substituted(source: str):
     return next(SourceFile(path_source(path)).functions()).substitute({})
 
 
+def _assert_unpack_effect(effect, *, arity: int, names: tuple[str, ...]):
+    """The typed arity obligation itself: the effect names the count it demands
+    and the targets it demands it for, and it binds nothing."""
+    from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+    from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+
+    assert isinstance(effect, SequenceUnpackRuntimeEffect)
+    reason = effect.reason
+    assert f"exactly {arity} members" in reason, reason
+    assert ", ".join(names) in reason, reason
+    assert not isinstance(getattr(effect, "value", None), ScopeRebinds)
+    return effect
+
+
+def _assert_unpack_arity_obligation(out, *, arity: int, names: tuple[str, ...]):
+    """The typed arity obligation a non-display unpack retains, and NO binding.
+
+    `a, b = <name>` has no lift-time cardinality: the count belongs to Python's
+    `__iter__` at runtime. The lift keeps the demand as one typed effect rather
+    than refusing to have a meaning (#6316) and rather than assuming the count
+    matched (which would be the one forbidden move). CPython binds nothing when
+    `UNPACK_SEQUENCE` raises, so this asserts nothing bound too.
+    """
+    assert isinstance(out, Incomplete), type(out).__name__
+    return _assert_unpack_effect(out.effect, arity=arity, names=names)
+
 def _return(exit_):
     assert isinstance(exit_, Completed)
     assert isinstance(exit_.value, UniverseValue)
@@ -129,8 +155,17 @@ def test_pandas_blocks_nested_if_augassign_reads_unbound_binding_as_a_node() -> 
     function = _substituted(source)
     reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
     assert any(isinstance(read.state, UnboundBinding) for read in reads)
-    with pytest.raises(SugarNotWritten):
-        _out(source)
+    # #6316 drained this refusal too. Here the unpack sits INSIDE an `if`, so the
+    # arity obligation is one HALTED face of the partition and the complementary
+    # face still completes -- the guard and the obligation coexist, which is the
+    # whole point of retaining the demand instead of refusing the statement.
+    out = _out(source)
+    assert isinstance(out, ExitSet)
+    halted = [exit_ for exit_ in out.exits if isinstance(exit_, Halted)]
+    completed = [exit_ for exit_ in out.exits if isinstance(exit_, Completed)]
+    assert len(halted) == 1
+    assert len(completed) == 1
+    _assert_unpack_effect(halted[0].effect, arity=2, names=("col", "loc"))
 
 
 def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
@@ -182,8 +217,12 @@ def test_pandas_converter_if_augassign_reads_unbound_binding_as_a_node() -> None
     reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
     names = {read.name for read in reads if isinstance(read.state, UnboundBinding)}
     assert {"vmin", "vmax"} <= names
-    with pytest.raises(SugarNotWritten):
-        _out(source)
+    # #6316 drained this refusal. The unpack no longer declines to have a
+    # meaning: the RHS is a plain name with no authenticated cardinality, so the
+    # arity demand is RETAINED as a typed effect carrying the exact obligation.
+    # Pinning the replacement is strictly stronger than pinning the refusal --
+    # it names the effect, the arity, and that nothing bound.
+    _assert_unpack_arity_obligation(_out(source), arity=2, names=("vmin", "vmax"))
 
 
 def test_augassign_over_explicitly_unbound_local_builds_guarded_read() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
+++ b/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
@@ -22,6 +22,7 @@ Every twin states its arity exactly. None asserts `!= 1`.
 from __future__ import annotations
 
 import tempfile
+from dataclasses import dataclass
 
 import pytest
 
@@ -66,11 +67,28 @@ def _receivers(source: str) -> tuple[list[str], object]:
         spo.SequenceProjectionOperation.submit = original
 
 
+@dataclass(frozen=True)
+class _TwinLocus:
+    """A genuine runtime locus. `RuntimeEffectSite` is a runtime-checkable
+    Protocol, so structure is the whole requirement -- and a locus STRING is
+    correctly refused, which is why this is a real object and not prose."""
+
+    filename: str = "twin.py"
+    line: int = 1
+    col: int = 0
+
+
 def _operation(*names: str):
+    """One unpack demand, addressed by a genuine runtime locus.
+
+    The blame must be a real `RuntimeEffectSite`: the runtime arm refuses to
+    mint evidence from a locus string, so a twin that passed prose would be
+    testing a path production cannot reach.
+    """
     from sugar_lift_py_tests.operations import SequenceProjectionOperation
 
     return SequenceProjectionOperation(
-        target_names=names, owner="twin", blame="twin.py:1:0"
+        target_names=names, owner="twin", blame=_TwinLocus()
     )
 
 
@@ -284,3 +302,110 @@ def test_a_callsite_that_digs_to_a_display_binds_its_members() -> None:
     )
     assert seen == ["CallSiteValue"]
     assert isinstance(out, Complete)
+
+
+# ==========================================================================
+# Category: comprehension coordinate -- its own iteration owns the count
+# ==========================================================================
+
+
+def test_comprehension_receiver_retains_the_arity_demand() -> None:
+    """POSITIVE. `a, b = (x for x in xs)` used to panic with no arm at all.
+
+    A comprehension over an unknown iterable has no authenticated member
+    testimony, so the count is its own iteration's and the demand is retained.
+    """
+    for source in (
+        "def A(xs):\n a, b = (x for x in xs)\n return a\n",
+        "def A(xs):\n a, b = [x for x in xs]\n return a\n",
+    ):
+        seen, out = _receivers(source)
+        assert seen == ["ComprehensionValue"], seen
+        assert isinstance(out, Incomplete)
+        assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
+        assert "exactly 2 members" in out.effect.reason
+
+
+def test_absent_finite_testimony_is_not_read_as_zero_members() -> None:
+    """DISCRIMINATING, and the sharp edge of this category.
+
+    `finite_elements is None` means "no member testimony exists". Reading it as
+    an empty tuple would make every unknown comprehension a DECIDABLE arity
+    mismatch -- "0 members unpacked into 2 targets" -- turning "we do not know"
+    into a confident wrong answer. It must route to the runtime arm instead.
+    """
+    from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+    from sugar_lift_py_tests.ir import make_var
+
+    absent = ComprehensionValue(make_var("xs"), finite_elements=None)
+    out = _operation("a", "b").submit(absent, None)
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
+
+
+def test_present_finite_testimony_binds_and_a_wrong_count_stays_loud() -> None:
+    """DISCRIMINATING partner. When the comprehension DID project every member,
+    the count is decidable, so it must bind on a match and stay loud on a
+    mismatch -- the same two answers a tuple literal gets, never the runtime
+    obligation."""
+    from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.ir import make_var
+
+    members = (TermValue(1), TermValue(2))
+    present = ComprehensionValue(make_var("xs"), finite_elements=members)
+
+    out = _operation("a", "b").submit(present, None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, ScopeRebinds)
+    assert tuple(name for name, _ in out.value.bindings) == ("a", "b")
+
+    with pytest.raises(ConstructionPanic):
+        _operation("a", "b", "c").submit(present, None)
+
+
+# ==========================================================================
+# Category: conditional value -- the unpack distributes into both faces
+# ==========================================================================
+
+
+def test_conditional_receiver_partitions_into_one_face_per_arm() -> None:
+    """POSITIVE. `a, b = (p if c else q)` used to panic with no arm at all.
+
+    Each face answers for itself under its own polarity. They are NOT fused
+    back into a conditional value: an answer here is a binding or a halt, and
+    those do not fuse.
+    """
+    seen, out = _receivers("def A(c, p, q):\n a, b = p if c else q\n return a\n")
+    assert seen == ["GuardedValue"]
+    assert isinstance(out, ExitSet)
+    assert len(out.exits) == 2
+    for exit_ in out.exits:
+        assert isinstance(exit_, Halted)
+        assert isinstance(exit_.effect, SequenceUnpackRuntimeEffect)
+
+
+def test_each_conditional_face_owes_its_own_operand_not_a_shared_one() -> None:
+    """DISCRIMINATING. The two faces carry DIFFERENT obligations: under `c` the
+    unpack is owed of `p`, under `not c` of `q`. Distributing but reporting one
+    shared operand would look identical in arity and be wrong about what the
+    caller must satisfy."""
+    _, out = _receivers("def A(c, p, q):\n a, b = p if c else q\n return a\n")
+    operands = {
+        str(exit_.effect.runtime_operand.term.args[0]) for exit_ in out.exits
+    }
+    assert len(operands) == 2, operands
+    assert any("p" in operand for operand in operands)
+    assert any("q" in operand for operand in operands)
+
+
+def test_the_two_conditional_faces_carry_complementary_guards() -> None:
+    """DISCRIMINATING. One face rides under the test, the other under its
+    negation -- never both under the same guard, which would claim the unpack
+    is owed of two different values on the same execution."""
+    _, out = _receivers("def A(c, p, q):\n a, b = p if c else q\n return a\n")
+    guards = [exit_.guard for exit_ in out.exits]
+    assert len(guards) == 2
+    negated = [guard for guard in guards if getattr(guard, "kind", None) == "not"]
+    assert len(negated) == 1
+    assert negated[0].operands[0] in guards

--- a/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
+++ b/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
@@ -1,0 +1,286 @@
+"""Discrimination twins for `a, b = <rhs>`, one pair per RECEIVER CATEGORY.
+
+`DynamicUnpackAssignSugar` submits ONE demand -- `SequenceProjectionOperation`,
+arity N against one reduced RHS -- and the receiving floor value decides the
+answer. So the axis that matters is the receiver's category, never the RHS's
+spelling: a call is a call whether it is `o.split()`, `np.shape(x)`, or
+`self._get()`, and nothing here names a vendor.
+
+The categories, and what each one owes:
+
+- **authenticated finite members** (tuple / array literal). The count is
+  lift-time decidable, so each name binds to the member ALREADY IN HAND.
+- **runtime cardinality** (symbolic term, object). `__iter__` owns the count, so
+  the arity demand is RETAINED as a typed effect and nothing binds -- exactly
+  as CPython binds nothing when `UNPACK_SEQUENCE` raises.
+- **undug callsite coordinate**. Currently loud; see the frontier test at the
+  bottom, which names the arm that retires it.
+
+Every twin states its arity exactly. None asserts `!= 1`.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _out(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _receivers(source: str) -> tuple[list[str], object]:
+    """Reduce `source`, recording the category of every submitted receiver.
+
+    The receiver, not the source text, is what the operation dispatches on --
+    so it is what the twins assert.
+    """
+    import sugar_lift_py_tests.operations.sequence_projection_operation as spo
+
+    seen: list[str] = []
+    original = spo.SequenceProjectionOperation.submit
+
+    def recording(self, value, ctx):
+        seen.append(type(value).__name__)
+        return original(self, value, ctx)
+
+    spo.SequenceProjectionOperation.submit = recording
+    try:
+        try:
+            return seen, _out(source)
+        except BaseException as raised:  # the raise IS the answer for some arms
+            return seen, raised
+    finally:
+        spo.SequenceProjectionOperation.submit = original
+
+
+def _operation(*names: str):
+    from sugar_lift_py_tests.operations import SequenceProjectionOperation
+
+    return SequenceProjectionOperation(
+        target_names=names, owner="twin", blame="twin.py:1:0"
+    )
+
+
+# ==========================================================================
+# Category: runtime cardinality -- the count belongs to __iter__
+# ==========================================================================
+
+
+def test_symbolic_receiver_retains_the_arity_demand_and_binds_nothing() -> None:
+    """POSITIVE. A plain-name RHS has no lift-time cardinality."""
+    seen, out = _receivers("def A(p):\n a, b = p\n return a\n")
+    assert seen == ["SymbolicValue"]
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
+    assert "exactly 2 members" in out.effect.reason
+    assert "(a, b)" in out.effect.reason
+    # CPython binds nothing when UNPACK_SEQUENCE raises. Neither does this.
+    assert not isinstance(getattr(out.effect, "value", None), ScopeRebinds)
+
+
+def test_the_retained_arity_is_the_targets_own_count_not_a_constant() -> None:
+    """DISCRIMINATING. The demand must carry the arity the source spells.
+
+    An obligation that always said "2" would satisfy the test above while
+    stating a count the program never demanded.
+    """
+    _, two = _receivers("def A(p):\n a, b = p\n return a\n")
+    _, three = _receivers("def A(p):\n a, b, c = p\n return a\n")
+    assert "exactly 2 members" in two.effect.reason
+    assert "exactly 3 members" in three.effect.reason
+    assert "(a, b, c)" in three.effect.reason
+
+
+def test_an_attribute_receiver_is_the_same_category_as_a_name() -> None:
+    """DISCRIMINATING (category, not spelling). `o.pair` and `p` reduce to the
+    same symbolic category, so they must get the same answer -- the dispatch
+    must not be reading the source shape."""
+    seen, out = _receivers("def A(o):\n a, b = o.pair\n return a\n")
+    assert seen == ["SymbolicValue"]
+    assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
+    assert "exactly 2 members" in out.effect.reason
+
+
+def test_the_obligation_survives_a_guard_as_one_halted_face() -> None:
+    """DISCRIMINATING. Under an `if`, the demand is one HALTED face and the
+    complementary face still completes. A refusal could not coexist with the
+    guard; a retained obligation can, which is the whole point of the rung."""
+    _, out = _receivers(
+        "def A(i, values):\n"
+        " if isinstance(i, tuple):\n"
+        "  col, loc = i\n"
+        "  return loc\n"
+    )
+    assert isinstance(out, ExitSet)
+    halted = [exit_ for exit_ in out.exits if isinstance(exit_, Halted)]
+    completed = [exit_ for exit_ in out.exits if isinstance(exit_, Completed)]
+    assert len(halted) == 1
+    assert len(completed) == 1
+    assert isinstance(halted[0].effect, SequenceUnpackRuntimeEffect)
+    assert "(col, loc)" in halted[0].effect.reason
+
+
+# ==========================================================================
+# Category: authenticated finite members -- the count is decidable
+# ==========================================================================
+
+
+def test_matching_arity_binds_each_name_to_the_member_already_in_hand() -> None:
+    """POSITIVE. Members are handed over, never re-derived or fabricated."""
+    from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+
+    members = (TermValue(7), TermValue(9))
+    out = _operation("a", "b").submit(TupleLiteralValue(members), None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, ScopeRebinds)
+    assert len(out.value.bindings) == 2
+    names = tuple(name for name, _ in out.value.bindings)
+    bound = tuple(value for _, value in out.value.bindings)
+    assert names == ("a", "b")
+    # The SAME objects, not equal reconstructions.
+    assert bound[0] is members[0]
+    assert bound[1] is members[1]
+
+
+def test_a_decidable_arity_mismatch_stays_loud_and_is_not_softened() -> None:
+    """DISCRIMINATING. This is the one that keeps the runtime-cardinality arm
+    honest: a count the lift CAN decide, and got wrong, must NOT be routed to
+    the "belongs to __iter__" effect. Only an undecidable count is an
+    obligation; a decided-and-wrong one is a gap."""
+    from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _operation("a", "b").submit(
+            TupleLiteralValue((TermValue(1), TermValue(2), TermValue(3))), None
+        )
+    message = str(raised.value)
+    assert "too many values" in message
+    assert "ground ValueError" in message
+
+
+def test_too_few_members_reports_the_other_direction() -> None:
+    """DISCRIMINATING. The gap names WHICH way the count is wrong; a single
+    "mismatch" message would lose the half that tells you what to write."""
+    from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _operation("a", "b", "c").submit(
+            TupleLiteralValue((TermValue(1), TermValue(2))), None
+        )
+    assert "not enough values" in str(raised.value)
+
+
+def test_a_display_right_hand_side_never_reaches_this_operation() -> None:
+    """DISCRIMINATING, and the reason the two tests above are unit-level.
+
+    `a, b = (1, 2)` is paired by the TREE (`Assign._destructured_binding` zips
+    displays), so no dynamic unpack is ever constructed and the operation is not
+    submitted. If a display ever did start arriving here, these twins would be
+    asserting a path the source cannot reach, and this test would say so.
+    """
+    seen, out = _receivers("def A():\n a, b = (1, 2)\n return a\n")
+    assert seen == []
+    assert isinstance(out, Complete)
+
+    seen, out = _receivers("def A():\n a, b = [1, 2]\n return a\n")
+    assert seen == []
+    assert isinstance(out, Complete)
+
+    # And the tree owns the display mismatch, ahead of any floor question.
+    seen, raised = _receivers("def A():\n a, b = (1, 2, 3)\n return a\n")
+    assert seen == []
+    assert isinstance(raised, SugarNotWritten)
+
+
+# ==========================================================================
+# Category: undug callsite coordinate -- THE LIVE FRONTIER
+# ==========================================================================
+
+
+def test_callsite_receiver_is_the_whole_remaining_panic_family() -> None:
+    """FRONTIER. `a, b = <call>` is the entire measured residual on this axis.
+
+    Bounded re-measure at `a4eade69a` over the first 40 installed-pandas modules
+    (371 functions): 8 submits reached `CallSiteValue` and all 8 panicked, 6
+    reached `SymbolicValue` and none did. Every panic was "no
+    `project_sequence_with` arm", none was an arity mismatch.
+
+    This is NOT a design question. `floor/call_site_value.py` already carries the
+    pattern, named and in use for two sibling operations::
+
+        def subscript_with(self, operation, ctx):
+            return self._dig_or_symbolic_redispatch(
+                operation, ctx, owner_suffix="callsite subscript receiver")
+
+    `_dig_or_symbolic_redispatch` digs the callsite floor when the body projects
+    and otherwise re-dispatches on `SymbolicValue(self.term)`, which lands
+    exactly on the two lawful arms above with nothing invented. The arm is ~4
+    lines and the file is held by another owner, so this test pins the loud gap
+    and names its retirement rather than working around it.
+
+    When that arm lands, this test is replaced by the positive/discriminating
+    pair immediately below it, which is written and skipped, not deleted.
+    """
+    for source in (
+        "def A(o):\n a, b = o.split()\n return a\n",
+        "def A(d, k):\n a, b = d[k]\n return a\n",
+    ):
+        seen, raised = _receivers(source)
+        assert seen == ["CallSiteValue"], seen
+        assert isinstance(raised, ConstructionPanic)
+        assert "project_sequence_with" in str(raised)
+
+
+@pytest.mark.skip(
+    reason=(
+        "needs the project_sequence_with arm in floor/call_site_value.py, held "
+        "by another owner; enable together with that arm"
+    )
+)
+def test_callsite_receiver_answers_like_its_dug_floor() -> None:
+    """The pair that retires the frontier test above, written ahead of the arm.
+
+    An opaque call body carries no cardinality, so it must land on the SAME
+    answer a symbolic receiver gets -- the retained arity obligation, nothing
+    bound. That it goes through a callsite rather than a name must make no
+    difference to the answer, only to how the answer is reached.
+    """
+    seen, out = _receivers("def A(o):\n a, b = o.split()\n return a\n")
+    assert seen == ["CallSiteValue"]
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
+    assert "exactly 2 members" in out.effect.reason
+    assert not isinstance(getattr(out.effect, "value", None), ScopeRebinds)
+
+
+@pytest.mark.skip(
+    reason=(
+        "needs the project_sequence_with arm in floor/call_site_value.py, held "
+        "by another owner; enable together with that arm"
+    )
+)
+def test_a_callsite_that_digs_to_a_display_binds_its_members() -> None:
+    """DISCRIMINATING partner. When the callee's body DOES project a finite
+    display, the count is decidable after the dig and the names bind -- so the
+    arm must not answer every callsite with the runtime obligation."""
+    seen, out = _receivers(
+        "def pair():\n return (1, 2)\n\ndef A():\n a, b = pair()\n return a\n"
+    )
+    assert seen == ["CallSiteValue"]
+    assert isinstance(out, Complete)


### PR DESCRIPTION
## Lead with the number that matters: **98.8% of this family is blocked, and I did not touch it**

I was asked to drain the 822 `DynamicUnpackAssignSugar` panics. Re-measured
first, as instructed. The answer arrived immediately and it is not the one the
board implies:

**The 822 is essentially one receiver category, and it lives in a file on my
do-not-touch list.**

### Re-measure — bounded, at `0c64014d1`

Instrument wraps `SequenceProjectionOperation.submit` and buckets by the
receiver that could not answer. Ranged over the **first 40 installed-pandas
modules, 371 functions** (no lease, no sweep, no census — Mac was loaded):

```
submits by receiver:   CallSiteValue 8 · SymbolicValue 6
panics  by receiver:   CallSiteValue 8   (100%)
panic kind:            "no project_sequence_with arm"  8/8
                       arity mismatch                  0/8
```

`SymbolicValue` submits and never panics — it answers with the runtime
obligation, as #6316 designed.

### Static shape ranking — 295 modules, 828 unpack sites

Cheap tree walk, no body reduction, so it covers breadth the reduction run
cannot afford:

| RHS category | sites | reaches | status |
|---|---:|---|---|
| `Call` | 561 | `CallSiteValue` | **BLOCKED** |
| `Subscript` | 13 | `CallSiteValue` | **BLOCKED** |
| `display:Tuple` | 164 | *nothing* | tree pairs displays; never submitted |
| `Attribute` | 45 | `SymbolicValue` | already answers |
| `Name` | 38 | `SymbolicValue` | already answers |
| `GeneratorExp` | 4 | `ComprehensionValue` | **drained here** |
| `IfExp` | 3 | `GuardedValue` | **drained here** |

**574 of the 581 sites that reach the operation and panic are `CallSiteValue`.
That is 98.8%.** `floor/call_site_value.py` is on my do-not-touch list, so I
stopped and reported rather than working around it. Details and the exact arm
in the message to the lead and in the frontier test in this PR.

### What this PR does drain: 7 sites, two receiver categories, honestly small

- **`ComprehensionValue`** (`a, b = (x for x in xs)`) answers from its own
  testimony. `finite_elements` is the authenticated projection of every member
  of an exact finite iterable; `None` means no such testimony exists, so it
  routes to the runtime arm and is **never read as zero members**. Reading it as
  empty would turn "we do not know" into a decidable arity mismatch — a
  confident wrong answer, the same lie as assuming the count matched, pointing
  the other way. There is a twin for exactly that.

- **`GuardedValue`** (`a, b = p if c else q`) **distributes into both faces**.
  Deliberately not through `_map`: `_map` re-fuses two answers into one
  conditional value, and an answer here is a binding or a halt, which do not
  fuse. The lawful join is the partition — each face under its own polarity,
  then unioned — so under `c` the unpack is owed of `p` and under `not c` of
  `q`. Two different obligations that a shared operand would have silently
  merged; there is a twin asserting the operands differ and a twin asserting the
  guards are complementary.

Neither invents a preimage, caps a size, or emits a sentinel. Neither converts a
panic into a refusal.

### Also: I was wrong about #6316, and said so

I filed #6323 yesterday reporting that #6316 turned the dynamic-unpack refusal
into a plain effect. That was my misread of exactly this trade — the typed
`SequenceUnpackRuntimeEffect` names the count, the targets, and the term the
obligation is owed of, where `SugarNotWritten` named nothing and banked as
measured. #6323 is closed with the correction.

The three tests that looked like regressions were stale assertions pinned to the
drained refusal. They are **re-pinned, not deleted**, and strictly stronger:
effect type, exact arity, exact target names, and that **nothing bound** —
CPython binds nothing when `UNPACK_SEQUENCE` raises. The nested-`if` case now
asserts the obligation is one **halted face** with the complementary face still
completing, which a refusal could not express at all.

Plus a discriminating twin that a **display** RHS is still a refusal, not an
effect: `a, b = (1, 2, 3)` has lift-time cardinality, so it is decidably wrong
and must not be softened into "the count belongs to `__iter__`". Only an
undecidable count becomes an obligation.

### Tests

17 twins in `test_sequence_projection_receivers.py`, one pair per receiver
category, exact arities, no vendor spellings. Nine perturbations run after
green, **all nine fail**:

```
arity-hardcoded · mismatch-softened-to-effect · direction-unnamed
members-reconstructed · runtime-arm-binds-anyway
comprehension-none-as-empty · comprehension-always-runtime
conditional-shared-guard · conditional-drops-else-face
```

Two twins for the `CallSiteValue` arm are written and **skipped, not deleted**,
so the blocked category is one line plus one un-skip away.

`sugar-source-tree`: 629 passed / 1 failed — the one inherited red
(`test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`) that fails
at `origin/main` too.

### Measured ΔR

**On the 40-module reduction slice: ΔR = 0.** Stated plainly because it is the
honest number — the two categories I drained do not occur in those 40 modules at
all, and the 8 panics there are all `CallSiteValue`. The drain is measured over
the five modules that do contain the shapes (in the thread).

Scale, stated as measurement rather than projection: **7 of 581** reachable
panic sites drain here; **574 stay loud on `CallSiteValue`**, blocked on a file
I did not touch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `project_sequence_with` to `ComprehensionValue` and `GuardedValue` for sequence unpack projection
> - Adds `ComprehensionValue.project_sequence_with`, delegating to `SequenceProjectionOperation.project_comprehension`, which routes to a runtime-cardinality effect when `finite_elements` is absent or binds authenticated members when finite elements are present.
> - Adds `GuardedValue.project_sequence_with`, which projects each arm independently and returns an `ExitSet` with two faces, each carrying the arm's guard and projection outcome.
> - Updates `SequenceProjectionOperation.project_comprehension` to handle the `finite_elements=None` case without treating it as a zero-member decidable mismatch.
> - Replaces prior `SugarNotWritten` expectations in tests for non-display RHS unpack to assert `Incomplete` carrying a `SequenceUnpackRuntimeEffect` instead; display RHS arity mismatch still raises `SugarNotWritten`.
> - Behavioral Change: unpack against symbolic, attribute, comprehension, and guarded RHS values now produces a deferred runtime effect rather than an immediate refusal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a71e327.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->