### PR TITLE
The callsite answers the unpack demand: R(DynamicUnpackAssignSugar) 8 -> 0

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -976,6 +976,44 @@ class CallSiteValue(FloorValue):
             operation, ctx, owner_suffix="callsite subscript receiver"
         )
 
+    def project_sequence_with(self, operation, ctx):
+        """`a, b = <call>` -- the same dig-or-symbolic totalizer, live-dispatched.
+
+        This is the whole of the `DynamicUnpackAssignSugar` panic family: of the
+        828 unpack sites measured over 295 installed-pandas modules, 574 reach
+        this receiver (561 `Call` + 13 `Subscript`, since `a, b = d[k]` reduces
+        here too) and every one of them panicked with "no
+        `project_sequence_with` arm". Nothing else was even close.
+
+        Dig the callsite floor when the callee's body projects, and the answer is
+        the dug value's: a literal has authenticated finite members, so the names
+        bind to members already in hand and a genuine arity mismatch stays the
+        loud decidable-`ValueError` gap it is today. When the body is opaque,
+        re-dispatch on the EUF receiver term, which retains
+        `python:unpack.destructure(term, arity)` as a typed effect. Nothing
+        binds on that arm, no count is assumed, and no member is invented.
+
+        NOT routed through `_dig_or_symbolic_redispatch`, though the dig half is
+        identical: that helper's tail calls `perform_operation`, which
+        `b0aadef50` deleted along with the operations layer, so its three callers
+        would raise `ImportError` rather than a typed gap if they were ever
+        reached. Reported separately; this arm dispatches through
+        `operation.submit`, the live door every other receiver already answers.
+        """
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+
+        floor = self._dig_floor_or_none(
+            ctx,
+            owner=f"{operation.owner} callsite unpack right-hand side",
+        )
+        receiver: FloorValue = floor if floor is not None else SymbolicValue(self.term)
+        if receiver is self:
+            # A dig that answers with this same callsite has made no progress;
+            # take the honest uninterpreted receiver rather than re-submitting
+            # into the arm we are standing in.
+            receiver = SymbolicValue(self.term)
+        return operation.submit(receiver, ctx)
+
     def _dig_or_symbolic_redispatch(self, operation, ctx, *, owner_suffix: str):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.operations import perform_operation

--- a/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
+++ b/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
@@ -78,6 +78,37 @@ class _TwinLocus:
     col: int = 0
 
 
+def _answers_when_dig_yields(dug, source: str):
+    """Every `(receiver, answer)` the unpack demand produced, with the callsite
+    dig forced to `dug`.
+
+    A callsite whose callee body projects a finite display is not reachable from
+    a two-function fixture here -- the callee universe is not available to the
+    dig at this seam -- so the dig is driven directly. That keeps the twin about
+    THIS arm's routing rather than about the availability of a callee universe.
+    """
+    import sugar_lift_py_tests.operations.sequence_projection_operation as spo
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+
+    answers: list[tuple[str, object]] = []
+    original_dig = CallSiteValue._dig_floor_or_none
+    original_submit = spo.SequenceProjectionOperation.submit
+
+    def recording(self, value, ctx):
+        answer = original_submit(self, value, ctx)
+        answers.append((type(value).__name__, answer))
+        return answer
+
+    CallSiteValue._dig_floor_or_none = lambda self, ctx, **kwargs: dug
+    spo.SequenceProjectionOperation.submit = recording
+    try:
+        _out(source)
+    finally:
+        CallSiteValue._dig_floor_or_none = original_dig
+        spo.SequenceProjectionOperation.submit = original_submit
+    return answers
+
+
 def _operation(*names: str):
     """One unpack demand, addressed by a genuine runtime locus.
 
@@ -231,77 +262,79 @@ def test_a_display_right_hand_side_never_reaches_this_operation() -> None:
 # ==========================================================================
 
 
-def test_callsite_receiver_is_the_whole_remaining_panic_family() -> None:
-    """FRONTIER. `a, b = <call>` is the entire measured residual on this axis.
-
-    Bounded re-measure at `a4eade69a` over the first 40 installed-pandas modules
-    (371 functions): 8 submits reached `CallSiteValue` and all 8 panicked, 6
-    reached `SymbolicValue` and none did. Every panic was "no
-    `project_sequence_with` arm", none was an arity mismatch.
-
-    This is NOT a design question. `floor/call_site_value.py` already carries the
-    pattern, named and in use for two sibling operations::
-
-        def subscript_with(self, operation, ctx):
-            return self._dig_or_symbolic_redispatch(
-                operation, ctx, owner_suffix="callsite subscript receiver")
-
-    `_dig_or_symbolic_redispatch` digs the callsite floor when the body projects
-    and otherwise re-dispatches on `SymbolicValue(self.term)`, which lands
-    exactly on the two lawful arms above with nothing invented. The arm is ~4
-    lines and the file is held by another owner, so this test pins the loud gap
-    and names its retirement rather than working around it.
-
-    When that arm lands, this test is replaced by the positive/discriminating
-    pair immediately below it, which is written and skipped, not deleted.
-    """
-    for source in (
-        "def A(o):\n a, b = o.split()\n return a\n",
-        "def A(d, k):\n a, b = d[k]\n return a\n",
-    ):
-        seen, raised = _receivers(source)
-        assert seen == ["CallSiteValue"], seen
-        assert isinstance(raised, ConstructionPanic)
-        assert "project_sequence_with" in str(raised)
-
-
-@pytest.mark.skip(
-    reason=(
-        "needs the project_sequence_with arm in floor/call_site_value.py, held "
-        "by another owner; enable together with that arm"
-    )
-)
 def test_callsite_receiver_answers_like_its_dug_floor() -> None:
-    """The pair that retires the frontier test above, written ahead of the arm.
+    """POSITIVE. `a, b = <call>` was the entire measured residual on this axis.
 
-    An opaque call body carries no cardinality, so it must land on the SAME
-    answer a symbolic receiver gets -- the retained arity obligation, nothing
-    bound. That it goes through a callsite rather than a name must make no
-    difference to the answer, only to how the answer is reached.
+    574 of the 828 unpack sites over 295 installed-pandas modules reach this
+    receiver -- 561 `Call` plus 13 `Subscript`, because `a, b = d[k]` reduces
+    here too -- and every one panicked with "no `project_sequence_with` arm".
+
+    An opaque call body carries no cardinality, so it must land on exactly the
+    answer a symbolic receiver gets: the arity obligation retained, nothing
+    bound. That it arrives through a callsite changes how the answer is reached,
+    never what the answer is.
     """
     seen, out = _receivers("def A(o):\n a, b = o.split()\n return a\n")
-    assert seen == ["CallSiteValue"]
+    # Dug to the opaque residual, then re-dispatched on the EUF receiver term.
+    assert seen == ["CallSiteValue", "SymbolicValue"], seen
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
     assert "exactly 2 members" in out.effect.reason
+    assert "(a, b)" in out.effect.reason
     assert not isinstance(getattr(out.effect, "value", None), ScopeRebinds)
 
 
-@pytest.mark.skip(
-    reason=(
-        "needs the project_sequence_with arm in floor/call_site_value.py, held "
-        "by another owner; enable together with that arm"
+def test_a_callsite_digs_before_it_falls_back_to_the_symbolic_term() -> None:
+    """DISCRIMINATING. The arm must CONSULT the dig, not skip to the term.
+
+    An arm that always answered with `SymbolicValue(self.term)` would pass the
+    test above -- opaque bodies are the common case -- while throwing away every
+    decidable count a projecting callee body hands over. This drives the dig half
+    directly: when the floor digs to authenticated finite members, the names bind
+    to the members ALREADY IN HAND and no runtime obligation is minted.
+
+    Asserted on the operation's own answer rather than the function outcome,
+    because the TREE froze `return a` as an unbound read at substitution time --
+    it cannot pair targets with members for a non-display right-hand side, which
+    is the whole reason this sugar exists. So the rebinds are correct and the
+    tail still reads unbound. That is a separate, pre-existing seam (the one
+    `test_binding_state_unbound` documents), not this arm's answer, and this twin
+    is careful not to claim otherwise.
+    """
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+
+    members = (TermValue(4), TermValue(5))
+    answers = _answers_when_dig_yields(
+        TupleLiteralValue(members), "def A(o):\n a, b = o.split()\n return a\n"
     )
-)
-def test_a_callsite_that_digs_to_a_display_binds_its_members() -> None:
-    """DISCRIMINATING partner. When the callee's body DOES project a finite
-    display, the count is decidable after the dig and the names bind -- so the
-    arm must not answer every callsite with the runtime obligation."""
-    seen, out = _receivers(
-        "def pair():\n return (1, 2)\n\ndef A():\n a, b = pair()\n return a\n"
-    )
-    assert seen == ["CallSiteValue"]
-    assert isinstance(out, Complete)
+
+    # The callsite consulted the dig -- the dug display received the demand --
+    # and the callsite's own answer is that display's answer.
+    assert [name for name, _ in answers] == ["TupleLiteralValue", "CallSiteValue"]
+    for _, answer in answers:
+        assert isinstance(answer, Complete)
+        assert isinstance(answer.value, ScopeRebinds)
+        assert tuple(n for n, _ in answer.value.bindings) == ("a", "b")
+        # The SAME member objects the dug display was holding.
+        assert tuple(v for _, v in answer.value.bindings) == members
+    del CallSiteValue
+
+
+def test_a_dug_display_of_the_wrong_size_stays_the_decidable_gap() -> None:
+    """DISCRIMINATING. Digging must not launder a decidable mismatch into the
+    runtime obligation: once the count IS known, getting it wrong is a gap."""
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _answers_when_dig_yields(
+            TupleLiteralValue((TermValue(1), TermValue(2), TermValue(3))),
+            "def A(o):\n a, b = o.split()\n return a\n",
+        )
+    assert "too many values" in str(raised.value)
+    assert "ground ValueError" in str(raised.value)
 
 
 # ==========================================================================


### PR DESCRIPTION
## `R(DynamicUnpackAssignSugar) 8 → 0` on the measured slice

Cleared to own `project_sequence_with` in `floor/call_site_value.py`. One arm,
and the family is gone.

### Measured ΔR, paired, same manifest

First 40 installed-pandas modules, 371 functions. Instrument wraps
`SequenceProjectionOperation.submit` and buckets by the receiver that could not
answer.

| | base (`06fefd9aa`) | head | Δ |
|---|---:|---:|---:|
| **unpack panics** | **8** | **0** | **−8** |
| &nbsp;&nbsp;`CallSiteValue` | 8 | 0 | −8 |
| other panic owners | 22 | 23 | +1 |
| &nbsp;&nbsp;`CCC.and_then` | 9 | 10 | +1 |
| &nbsp;&nbsp;`guarded` / `IfExpSugar._join` / `TupleValue.contains` / `collection build` | 13 | 13 | 0 |
| **net across the panic axis** | | | **−7** |

The +1 is the familiar shape and I am not hiding it: a function that used to
stop at the unpack now gets further and meets the `and_time` hole already filed
as #6321. It is newly *reached*, not newly caused.

Submits rose 14 → 24, which is the arm working: every `CallSiteValue` now
re-submits to its dug or symbolic receiver, and more functions survive far
enough to reach an unpack at all (`CallSiteValue` submits 8 → 9).

**Neither slice contains any of the three `R(timeout)` files from #6324**
(`core/arrays/arrow/array.py`, `core/reshape/pivot.py`,
`tests/extension/test_arrow.py`) — checked, zero matches — so these counts are
not absorbing a timeout row. Any count taken at a commit that does include them
is a lower bound; these are not.

### The arm

Dig the callsite floor when the callee's body projects; the answer is the dug
value's. A display has authenticated finite members, so the names bind to the
members **already in hand**, and a genuine arity mismatch stays the loud
decidable-`ValueError` gap it already was. When the body is opaque, re-dispatch
on the EUF receiver term, retaining `python:unpack.destructure(term, arity)` as
a typed effect. Nothing binds on that arm, no count assumed, no cap, no
sentinel, no vendor arm.

### One deviation from the instruction, and why

I was told to mirror `_dig_or_symbolic_redispatch` verbatim. **I mirrored its
dig half and not its tail**, because its tail calls `perform_operation` — which
`b0aadef50` deleted along with the operations layer:

```
$ python -c "from sugar_lift_py_tests.operations import perform_operation"
ImportError: cannot import name 'perform_operation'
```

`subscript_with`, `binary_operator_with`, and `unary_operator_with` all end in
that call. Reaching any of them raises `ImportError` — not a typed gap, not a
panic, an ordinary crash escape. Mirroring verbatim would have shipped a fourth
dead arm that measured as fixed. This one dispatches through
`operation.submit`, the live door every other receiver already answers.

Filed separately as a crash-escape report; **the identity path (`__eq__`,
`__hash__`, `_term_cycle_key`, the weak coordinate memo) is untouched**, and so
are `exit_set.py` / `spread_sugar.py`.

### The dig twin asserts the operation's answer, not the function's

When the dig yields a display, the rebinds are correct — `('a', TermValue(4)),
('b', TermValue(5))`, the same objects — but `return a` still reads unbound,
because the **tree** froze it as an `UnboundBinding` at substitution time. It
cannot pair targets with members for a non-display right-hand side, which is the
entire reason `DynamicUnpackAssignSugar` exists. That is a separate pre-existing
seam (the one `test_binding_state_unbound` documents) and the twin is careful
not to claim this arm fixed it.

### Tests

17 twins, one pair per receiver category, exact arities, no vendor spellings.
Twelve perturbations run after green, **all twelve fail** — the nine from #6327
plus three for this arm:

```
callsite-skips-the-dig · callsite-binds-on-opaque · callsite-arm-removed
```

The two twins that #6327 left skipped are now **live, not skipped**: the opaque
path and the dig path each have a positive and a discriminating partner.

`sugar-source-tree`: **631 passed / 1 failed** — the one inherited red
(`test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`), red at
`origin/main` too.

### What remains on this axis

Nothing measured. `SymbolicValue`, `ComprehensionValue`, `GuardedValue`,
`TupleLiteralValue`, `ArrayLiteral`, `ObjectValue`, `OpaqueOpCallsite` and now
`CallSiteValue` all answer. A receiver category that still cannot answer soundly
would reach `FloorValue.project_sequence_with` and stay loud, which is the
frontier working as designed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle dynamic unpack assignment on `CallSiteValue` by digging before falling back to symbolic dispatch
> - Adds `CallSiteValue.project_sequence_with` in [call_site_value.py](https://github.com/TSavo/sugar/pull/6328/files#diff-8c40ae10c3e0722cf284a5e0bb43d2d29524ce10b6eb590893ccfcab4785689a) to handle sequence projection (destructuring) on callsite receivers.
> - The method calls `_dig_floor_or_none` with an unpack-specific owner message; if a floor value is found it delegates to that value, otherwise it falls back to dispatching on a `SymbolicValue` of the callsite's term to avoid resubmission loops.
> - Removes the test asserting that unpacking a callsite raises a missing-arm panic, and replaces it with tests covering the dig-then-delegate path, the symbolic fallback path, a size-mismatch case (3-tuple into 2 targets raises `ConstructionPanic`), and correct `ScopeRebinds` on success.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f703c6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->