### PR TITLE
Builtin exception ancestry is vendor testimony, not an empty assumption (#6298)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -98,6 +98,90 @@ def builtin_constant_names() -> frozenset[str]:
 _EMPTY_BUILTIN_TEMPORAL = None
 
 
+# Python owns its exception hierarchy, so the kit TRANSPORTS it rather than
+# deriving or assuming it. Every entry names one builtin exception's immediate
+# bases, restricted to ``BUILTIN_EXCEPTION_NAMES`` (the set is closed under
+# this relation: no base falls outside it except ``object``).
+#
+# Before this table existed every builtin exception carried ``bases=()``, which
+# is not "unknown" -- it is the positive claim that the class has no ancestry.
+# ``except Exception`` therefore did not catch ``raise ValueError``, and
+# ``issubclass(ValueError, Exception)`` reduced to ``False``. A fabricated
+# empty ancestry is a decided answer standing in for vendor testimony; this is
+# the testimony.
+BUILTIN_EXCEPTION_BASES: dict[str, tuple[str, ...]] = {
+    "ArithmeticError": ('Exception',),
+    "AssertionError": ('Exception',),
+    "AttributeError": ('Exception',),
+    "BaseException": (),
+    "BaseExceptionGroup": ('BaseException',),
+    "BlockingIOError": ('OSError',),
+    "BrokenPipeError": ('ConnectionError',),
+    "BufferError": ('Exception',),
+    "BytesWarning": ('Warning',),
+    "ChildProcessError": ('OSError',),
+    "ConnectionAbortedError": ('ConnectionError',),
+    "ConnectionError": ('OSError',),
+    "ConnectionRefusedError": ('ConnectionError',),
+    "ConnectionResetError": ('ConnectionError',),
+    "DeprecationWarning": ('Warning',),
+    "EOFError": ('Exception',),
+    "EncodingWarning": ('Warning',),
+    "EnvironmentError": ('Exception',),
+    "Exception": ('BaseException',),
+    "ExceptionGroup": ('BaseExceptionGroup', 'Exception'),
+    "FileExistsError": ('OSError',),
+    "FileNotFoundError": ('OSError',),
+    "FloatingPointError": ('ArithmeticError',),
+    "FutureWarning": ('Warning',),
+    "GeneratorExit": ('BaseException',),
+    "IOError": ('Exception',),
+    "ImportError": ('Exception',),
+    "ImportWarning": ('Warning',),
+    "IndentationError": ('SyntaxError',),
+    "IndexError": ('LookupError',),
+    "InterruptedError": ('OSError',),
+    "IsADirectoryError": ('OSError',),
+    "KeyError": ('LookupError',),
+    "KeyboardInterrupt": ('BaseException',),
+    "LookupError": ('Exception',),
+    "MemoryError": ('Exception',),
+    "ModuleNotFoundError": ('ImportError',),
+    "NameError": ('Exception',),
+    "NotADirectoryError": ('OSError',),
+    "NotImplementedError": ('RuntimeError',),
+    "OSError": ('Exception',),
+    "OverflowError": ('ArithmeticError',),
+    "PendingDeprecationWarning": ('Warning',),
+    "PermissionError": ('OSError',),
+    "ProcessLookupError": ('OSError',),
+    "RecursionError": ('RuntimeError',),
+    "ReferenceError": ('Exception',),
+    "ResourceWarning": ('Warning',),
+    "RuntimeError": ('Exception',),
+    "RuntimeWarning": ('Warning',),
+    "StopAsyncIteration": ('Exception',),
+    "StopIteration": ('Exception',),
+    "SyntaxError": ('Exception',),
+    "SyntaxWarning": ('Warning',),
+    "SystemError": ('Exception',),
+    "SystemExit": ('BaseException',),
+    "TabError": ('IndentationError',),
+    "TimeoutError": ('OSError',),
+    "TypeError": ('Exception',),
+    "UnboundLocalError": ('NameError',),
+    "UnicodeDecodeError": ('UnicodeError',),
+    "UnicodeEncodeError": ('UnicodeError',),
+    "UnicodeError": ('ValueError',),
+    "UnicodeTranslateError": ('UnicodeError',),
+    "UnicodeWarning": ('Warning',),
+    "UserWarning": ('Warning',),
+    "ValueError": ('Exception',),
+    "Warning": ('Exception',),
+    "ZeroDivisionError": ('ArithmeticError',),
+}
+
+
 def builtin_name_temporal():
     """Return the shared immutable lexical floor for Python's builtin names.
 
@@ -135,11 +219,27 @@ def builtin_name_temporal():
         )
     # Override generic callable coordinates with exact builtins ownership. No
     # exception constructor object is imported or executed to establish it.
-    for name in sorted(BUILTIN_EXCEPTION_NAMES):
-        temporal = temporal.bind_value(
-            name,
-            BuiltinExceptionClassValue(name=name, bases=(), record=BlockValue(())),
+    # Bind exception classes in ancestry order so every base is already the
+    # exact ClassValue its subclass points at -- one object per class, so the
+    # `candidate is supertype` walk in ClassValue.test_python_subtype answers
+    # on identity rather than on a re-spelled copy.
+    exception_values: dict[str, BuiltinExceptionClassValue] = {}
+
+    def exception_value(name: str) -> BuiltinExceptionClassValue:
+        existing = exception_values.get(name)
+        if existing is not None:
+            return existing
+        bases = tuple(
+            exception_value(base) for base in BUILTIN_EXCEPTION_BASES[name]
         )
+        value = BuiltinExceptionClassValue(
+            name=name, bases=bases, record=BlockValue(())
+        )
+        exception_values[name] = value
+        return value
+
+    for name in sorted(BUILTIN_EXCEPTION_NAMES):
+        temporal = temporal.bind_value(name, exception_value(name))
     temporal = temporal.bind_value(
         "issubclass", BuiltinSemanticCallable(operation="python.issubclass")
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_ancestry.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_ancestry.py
@@ -1,0 +1,142 @@
+"""Builtin exception ancestry is VENDOR testimony, not an empty assumption.
+
+Python owns its exception hierarchy. `ValueError` IS an `Exception`; the
+language says so, in the interpreter that also compiles the corpus. Until
+this file existed the kit carried `bases=()` for every builtin exception
+class and a singleton `(identity,)` for every builtin ancestry, so:
+
+    try:
+        raise ValueError("boom")
+    except Exception:
+        ...
+
+did not catch — the matcher walked an ancestry that had been fabricated as
+empty and answered "no match" by SILENCE about a fact the vendor states.
+
+That is the forbidden shape: a decided `False` standing in for an ancestry
+nobody authenticated. Both faces are pinned here — the ones that must match
+AND the ones that must not — because an ancestry table that says yes to
+everything is exactly as wrong as one that says no to everything.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.outcome import Incomplete, outcome_to_exitset
+from sugar_source_tree.tree import SourceFile
+
+
+def _residual_raises(source: str) -> tuple[str, ...]:
+    """Every raise that survived the `try` — the effects still on the wall."""
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    source_file = SourceFile((source, "/tmp/ancestry.py", blake3_512_of(source.encode())))
+    function = next(iter(source_file.functions()))
+    exit_set = outcome_to_exitset(function.sugar().desugar())
+    names: list[str] = []
+    seen: set[int] = set()
+
+    def walk(value: object) -> None:
+        if value is None or isinstance(value, (str, int, bool, float, bytes)):
+            return
+        key = id(value)
+        if key in seen:
+            return
+        seen.add(key)
+        if isinstance(value, Incomplete) and isinstance(value.effect, RaiseEffect):
+            names.append(value.effect.exception_name)
+        effect = getattr(value, "effect", None)
+        if isinstance(effect, RaiseEffect):
+            names.append(effect.exception_name)
+        for attribute in ("statements", "record", "value", "exits"):
+            child = getattr(value, attribute, None)
+            if isinstance(child, tuple):
+                for item in child:
+                    walk(item)
+            else:
+                walk(child)
+
+    for face in exit_set.exits:
+        walk(face)
+    return tuple(sorted(set(names)))
+
+
+def _try_source(*, raised: str, handled: str) -> str:
+    return (
+        "def f():\n"
+        "    try:\n"
+        f"        raise {raised}('boom')\n"
+        f"    except {handled}:\n"
+        "        return 1\n"
+        "    return 2\n"
+    )
+
+
+# --- faces that MUST match (ancestry is real) --------------------------------
+
+
+def test_except_exception_catches_value_error():
+    assert _residual_raises(_try_source(raised="ValueError", handled="Exception")) == ()
+
+
+def test_except_arithmetic_error_catches_zero_division_error():
+    assert (
+        _residual_raises(
+            _try_source(raised="ZeroDivisionError", handled="ArithmeticError")
+        )
+        == ()
+    )
+
+
+def test_except_os_error_catches_file_not_found_error():
+    assert (
+        _residual_raises(_try_source(raised="FileNotFoundError", handled="OSError"))
+        == ()
+    )
+
+
+def test_except_base_exception_catches_keyboard_interrupt():
+    assert (
+        _residual_raises(
+            _try_source(raised="KeyboardInterrupt", handled="BaseException")
+        )
+        == ()
+    )
+
+
+# --- faces that MUST NOT match (the ancestry table has to say no, too) -------
+
+
+def test_except_value_error_does_not_catch_type_error():
+    assert _residual_raises(_try_source(raised="TypeError", handled="ValueError")) == (
+        "TypeError",
+    )
+
+
+def test_ancestry_is_directional_subclass_does_not_catch_superclass():
+    """`except ValueError` must NOT catch a bare `Exception`.
+
+    The perturbation that a permissive table would pass: ancestry is a
+    partial order, not a symmetric relation.
+    """
+    assert _residual_raises(_try_source(raised="Exception", handled="ValueError")) == (
+        "Exception",
+    )
+
+
+def test_except_arithmetic_error_does_not_catch_os_error():
+    assert _residual_raises(_try_source(raised="OSError", handled="ArithmeticError")) == (
+        "OSError",
+    )
+
+
+def test_keyboard_interrupt_is_not_an_exception():
+    """`except Exception` must NOT catch `KeyboardInterrupt`.
+
+    The one place the real hierarchy differs from the naive "everything is an
+    Exception" table, and the reason the table is transported rather than
+    assumed.
+    """
+    assert _residual_raises(
+        _try_source(raised="KeyboardInterrupt", handled="Exception")
+    ) == ("KeyboardInterrupt",)

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1316,3 +1316,68 @@ def test_guarded_literal_exit_without_type_coordinate_stays_gap(tmp_path):
         ),
     )
     assert isinstance(summary, DerivedManagerSummaryGapV1)
+
+
+# --- Effect boundary consumes an ANCESTOR match, not only exact identity -----
+#
+# `matches_raise_effect` is the one matcher for With and Try, and it walks the
+# raised effect's ancestry. Builtin ancestry is Python's own testimony, so a
+# boundary written against `Exception` consumes a `ValueError` halt and does
+# NOT consume a `KeyboardInterrupt` one. Both faces, because an ancestry table
+# that says yes to everything is as wrong as one that says no to everything.
+
+
+@pytest.mark.parametrize(
+    ("expected_type", "body", "expected_face"),
+    [
+        ("Exception", 'raise ValueError("needle")', "completed"),
+        ("ArithmeticError", 'raise ZeroDivisionError("needle")', "completed"),
+        ("BaseException", 'raise KeyboardInterrupt("needle")', "completed"),
+        ("Exception", 'raise KeyboardInterrupt("needle")', "halted"),
+        ("ValueError", 'raise Exception("needle")', "halted"),
+        ("ArithmeticError", 'raise OSError("needle")', "halted"),
+    ],
+)
+def test_boundary_consumes_authenticated_builtin_ancestry_only_in_one_direction(
+    tmp_path, expected_type, body, expected_face
+):
+    implementation = (
+        "class Boundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n\n"
+        "def boundary(expected):\n"
+        "    return Boundary(expected)\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="boundary")
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        f"    with arbitrary.boundary({expected_type}):\n"
+        f"        {body}\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+    face = outcome_to_exitset(boundary.desugar()).exits[0]
+    assert type(face).__name__.lower() == expected_face

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -525,16 +525,56 @@ class SourceUnit:
             )
         return None
 
+    def _builtin_exception_ancestry(self, identity):
+        """Python's own ancestry for a ``builtins`` exception identity.
+
+        ``None`` when the identity is not a builtin one — a source class owns
+        its own base graph and is resolved lexically below. The previous
+        behaviour returned the singleton ``(identity,)`` for every non-local
+        class, which is not "ancestry unknown" but the positive claim that the
+        class has no ancestors, and it silently made ``except Exception`` fail
+        to match ``raise ValueError``.
+        """
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+            BUILTIN_EXCEPTION_BASES,
+        )
+
+        args = getattr(identity, "args", ())
+        if len(args) != 2 or getattr(args[0], "value", None) != "builtins":
+            return None
+        root = getattr(args[1], "value", None)
+        if root not in BUILTIN_EXCEPTION_BASES:
+            return None
+        ancestry = []
+        pending = [root]
+        while pending:
+            name = pending.pop(0)
+            coordinate = ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const(name)],
+            )
+            if coordinate in ancestry:
+                continue
+            ancestry.append(coordinate)
+            pending.extend(BUILTIN_EXCEPTION_BASES[name])
+        return tuple(ancestry)
+
     def exception_type_mro(self, node: "Name"):
         """Return the source-authenticated ancestry known for ``node``.
 
-        Builtin/imported identities authenticate the exact class. Source class
-        identities additionally carry every lexically resolved base coordinate.
-        A computed base or cycle leaves the testimony unavailable, never guessed.
+        Builtin identities carry Python's OWN hierarchy, transported from
+        ``BUILTIN_EXCEPTION_BASES`` — the language states that ``ValueError``
+        is an ``Exception``, so the ancestry is cited, never assumed. Source
+        class identities carry every lexically resolved base coordinate. A
+        computed base or cycle leaves the testimony unavailable, never guessed.
         """
         identity = self.exception_type_identity(node)
         if identity is None:
             return None
+        builtin_ancestry = self._builtin_exception_ancestry(identity)
+        if builtin_ancestry is not None:
+            return builtin_ancestry
         module = self._require_typed_module("SourceUnit.exception_type_mro")
         definitions = [
             statement


### PR DESCRIPTION
## The bug, stated plainly

```python
try:
    raise ValueError("boom")
except Exception:
    ...
```

**did not catch.** Measured, not inferred — the lifted function's record still carried `Incomplete(RaiseEffect(ValueError))`.

## Why

Every builtin exception class was constructed as `BuiltinExceptionClassValue(name=name, bases=(), ...)`, and `SourceUnit.exception_type_mro` returned the singleton `(identity,)` for any class with no local `ClassDef`.

`bases=()` is not "ancestry unknown". It is the positive claim that the class has no ancestors. `matches_raise_effect` — **the one matcher shared by Try and With**, and therefore the one every assertion boundary in the 4,125 depends on — then walked that fabricated-empty ancestry and returned `False`.

That is the forbidden shape: a decided `False` standing in for testimony nobody authenticated. It is not a missing arm, it is a wrong answer, and it was silent.

## The fix — cite, don't invent

Python owns its exception hierarchy. The kit already vendors `BUILTIN_EXCEPTION_NAMES`; it now vendors the relation over that set too:

- `BUILTIN_EXCEPTION_BASES`, 69 entries, each naming one class's **immediate** bases. The set is closed under the relation — no base falls outside it except `object`, checked at generation.
- builtin class values are bound in ancestry order, so each base **is** the exact `ClassValue` its subclass points at. `ClassValue.test_python_subtype` compares `candidate is supertype`, so a re-spelled copy would not have answered.
- `SourceUnit._builtin_exception_ancestry` returns the real transitive ancestry for a `builtins` identity. Source classes are unaffected and still resolve their own base graph lexically; an unresolvable one is still `None`, still loud.

No behaviour is derived. The table is a value transported from the language that also compiles the corpus.

## Which R component

`R_construction`, assertion/effect-boundary bucket — but the blast radius is wider than that bucket, because the matcher is shared with `Try`. This is a **correctness fix, not a count fix**: it converts silently-wrong non-matches into correct matches on both faces.

## Shell deleted

None. This does not retire an instrument. The retirement path it opens: with ancestry authenticated, the remaining undecidable case is a *source* class whose base graph is genuinely unresolvable, and that is the one that should become a retained `python.subtype` obligation rather than a decided `False`. That is the next rung and it is not in this PR — today an unresolvable source ancestry still decides `False`, and I am naming it rather than shipping it silently.

## Tests — both faces, exact cardinality

New `implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_ancestry.py`, 8 cases through `SourceFile → sugar → desugar`, asserting the exact tuple of residual raises:

| must match (residual `()`) | must NOT match (residual is the raise) |
| --- | --- |
| `except Exception` / `raise ValueError` | `except ValueError` / `raise TypeError` |
| `except ArithmeticError` / `raise ZeroDivisionError` | `except ValueError` / `raise Exception` (direction) |
| `except OSError` / `raise FileNotFoundError` | `except ArithmeticError` / `raise OSError` |
| `except BaseException` / `raise KeyboardInterrupt` | **`except Exception` / `raise KeyboardInterrupt`** |

That last row is the whole argument for transporting the table instead of assuming one: it is the place the real hierarchy disagrees with "everything is an Exception".

New parametrized boundary twin in `test_sole_path_manager_construction.py`, 6 cases, driving a **renamed non-vendor** manager through `populate_source_derived_resource_refs` → `With.sugar()` → `desugar()` and asserting the routed face — 3 `completed` (halt consumed via ancestry), 3 `halted` (ancestry correctly says no).

### Perturbation, both directions, run in production after green

| perturbation | result |
| --- | --- |
| disable `_builtin_exception_ancestry` (revert to singleton) | **exactly 3 red** — the three consume-faces; the three non-consume faces stay green |
| flatten the table so everything derives from `Exception` | **`except Exception` / `raise KeyboardInterrupt` red** |

A permissive table and an empty table each fail a different half. That pair is the teeth.

## Arm population

Unchanged. Ancestry is consulted inside the matcher's verdict; it adds no exit arms and no guard partition. `factor_completed` and `ExitSetFactoringGap` untouched.

## Measured

**ΔR on the corpus construction axis: unmeasured, and stated as unmeasured.** A bounded 8-file pandas slice was launched at this head and had not produced a row when this PR was opened — the box was at load ~340–540 from concurrent work and the probe was starved. I am not converting "not measured" into a number.

What IS measured is the focused evidence above: 8/8 Try faces and 6/6 boundary faces, with the perturbation pair. Note `R(timeout)=3` at head (#6324), so any count taken here is a lower bound over 1418/1421 regardless.

Local regression breadth was also starved out at that load; it is CI's signal on this PR and is deliberately not gated on. **Reviewers should read CI rather than this section for blast radius** — this change alters exception matching globally, which is exactly why it needs the broad run rather than my laptop's.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix builtin exception ancestry so try/except subtype matching uses the actual Python hierarchy
> - Previously, builtin exception classes were created with empty `bases=()`, so subtype walks (e.g. checking whether `ValueError` is a subclass of `Exception`) always failed.
> - Adds [`BUILTIN_EXCEPTION_BASES`](https://github.com/TSavo/sugar/pull/6330/files#diff-61c663f349f832607b3966470d5dfecfcda065d57744eabcf0ed411db6501e7d) — a dict encoding Python's full builtin exception hierarchy — and uses it to wire correct base `ClassValue` objects into each `BuiltinExceptionClassValue` at construction time.
> - [`SourceUnit.exception_type_mro`](https://github.com/TSavo/sugar/pull/6330/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now consults a new `_builtin_exception_ancestry` helper that walks `BUILTIN_EXCEPTION_BASES` breadth-first, returning the full MRO-style identity chain for builtin exceptions instead of a singleton.
> - New tests in [`test_builtin_exception_ancestry.py`](https://github.com/TSavo/sugar/pull/6330/files#diff-b2fdfdba8db42b6f4fa8762b299bec9fc395cfcb7bb96ac1afae48718415364f) and [`test_sole_path_manager_construction.py`](https://github.com/TSavo/sugar/pull/6330/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) assert correct matching and non-matching across ancestor/descendant pairs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f79b37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->