### PR TITLE
One board, one denominator: pin the corpus, pin the root, split site prevalence from R

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -758,6 +758,27 @@ execution. `bcargo`, `brun`, and `bpytest` are compatibility adapters. A binary
 cache hit may skip compilation, never command or test execution. See
 `docs/build-execution.md` for task, capability, artifact, and recovery details.
 
+**Never pipe a measurement command and then read `$?`.** After a pipeline the
+shell reports the *last stage's* status, so `bpytest ... | tail -20` gives you
+`tail`'s exit code and **a red run reads green**. This is not a quirk of `tail`;
+`| head`, `| grep`, and `| tee` discard the verdict identically. Three test runs
+were banked as passing this way before anyone noticed. Capture the status before
+piping, or set `-o pipefail`:
+
+```bash
+bin/bpytest -q tests/... > /tmp/out.log 2>&1; echo "EXIT=$?"; tail -20 /tmp/out.log
+```
+
+The adapters propagate correctly — `bpytest` returns 2 on a failing run. The
+channel carrying the red is what replaces it, which is the same shape as every
+other false green: the signal is fine, the wire is not.
+
+Two more that cost real time. Python tests need `PYTHONPATH` set explicitly —
+`implementations/python/pytest.ini` sets only `--import-mode=importlib`, so every
+runner supplies the path itself. And an import error at **collection** makes a
+whole file vanish rather than fail: the suite does not go red, it goes
+*smaller*. Check the collected count, not just the colour.
+
 - `make help`: list supported build and test targets.
 - `make build-rust`: build the Rust workspace in release mode.
 - `make test-rust`: run Rust workspace and Rust-driven RPC tests.

--- a/docs/audits/2026-07-05-pandas-wall-baseline.md
+++ b/docs/audits/2026-07-05-pandas-wall-baseline.md
@@ -1,5 +1,15 @@
 # Pandas Wall Baseline, July 5 2026
 
+> **NON-AUTHORITATIVE BOARD.** The numbers below were measured before the
+> Python corpus board had a pinned denominator. The file *count* (1421) happens
+> to match the current pin, but a count is not an identity: nothing here records
+> which pandas bytes were walked, so these figures cannot be differenced against
+> a current measurement to yield a delta. The sole authority is
+> `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`,
+> pinned to `docs/ledgers/pins/pandas-3.0.3.pin.json`
+> (aggregate `bbb70a76…`, content-only `a1155ae2…`, path-bound `04b67544…`).
+> Quote those. Kept here as testimony of what was observed and when.
+
 Part of #3503.
 
 This is the August-seat scouting baseline for full pandas source plus its test

--- a/docs/audits/pandas-gap-census.md
+++ b/docs/audits/pandas-gap-census.md
@@ -1,5 +1,15 @@
 # Pandas Gap Census
 
+> **NON-AUTHORITATIVE BOARD.** The numbers below were measured before the
+> Python corpus board had a pinned denominator. The file *count* (1421) happens
+> to match the current pin, but a count is not an identity: nothing here records
+> which pandas bytes were walked, so these figures cannot be differenced against
+> a current measurement to yield a delta. The sole authority is
+> `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`,
+> pinned to `docs/ledgers/pins/pandas-3.0.3.pin.json`
+> (aggregate `bbb70a76…`, content-only `a1155ae2…`, path-bound `04b67544…`).
+> Quote those. Kept here as testimony of what was observed and when.
+
 Part of #3503. This is the shared pandas wall payload for sibling drain lanes; it is a census and work-list, not a recognizer change.
 
 ## Gate Handoff

--- a/docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json
+++ b/docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json
@@ -1,0 +1,10008 @@
+{
+  "kind": "control-effect-construction-recensus",
+  "authority": "sole authoritative Python corpus scoreboard; every other census output is non-authoritative",
+  "commit": "9a78828ee6a9fb09b083d397a367994722cb1639",
+  "corpus": "/home/tsavo/pandas303-audit/pandas",
+  "corpusRoot": "/home/tsavo/pandas303-audit/pandas",
+  "corpusPin": {
+    "kind": "sugar-corpus-pin/v1",
+    "distribution": "pandas",
+    "version": "3.0.3",
+    "fileCount": 1421,
+    "aggregateHash": "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c",
+    "aggregateHashConvention": "sha256 over: pin kind, distribution, version, then one '<relpath> <sha256> <sizeBytes>' line per file, sorted by relpath. Root path excluded so the same corpus pins identically on every box.",
+    "interoperableDigests": {
+      "contentOnly": "a1155ae27c10a1828ac6a02b890a8b1ee23881a5f78c3d6265f02a63065ca77d",
+      "pathBound": "04b67544e3628d25d1b20653558fb2c702a870ae3f97bc8492a9f70f854a9c31",
+      "enumerator": "SourceTree(root).paths()"
+    },
+    "root": "/home/tsavo/pandas303-audit/pandas"
+  },
+  "door": "enum:path_source\u2192SourceFile\u2192functions\u2192sugar\u2192desugar",
+  "isolation": "in-process",
+  "paths": {
+    "engineLog": "/home/tsavo/scoreboard-tree/baseline-9a78828ee/engine.jsonl",
+    "progress": "/home/tsavo/scoreboard-tree/baseline-9a78828ee/progress.log",
+    "checkpoint": "/home/tsavo/scoreboard-tree/baseline-9a78828ee/checkpoint.jsonl",
+    "result": "/home/tsavo/scoreboard-tree/baseline-9a78828ee/recensus.json"
+  },
+  "denominator": {
+    "enrolled": 1421,
+    "terminalRows": 1421,
+    "completed": 1416,
+    "corpusManifestCid": "sha256:c267d971bb2d1a3dd65769bb76ce6efec080803fea51df3964353e8c9f073c03",
+    "missingFiles": [],
+    "duplicateFiles": [],
+    "malformedRows": [],
+    "complete": true,
+    "enrolledFilesOmitted": "1421 identities; see corpus pin docs/ledgers/pins/pandas-3.0.3.pin.json"
+  },
+  "filesTotal": 1421,
+  "filesCompleted": 1416,
+  "defects": [
+    {
+      "file": "tests/io/excel/test_writers.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 55069 outside 0..27637\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    },
+    {
+      "file": "tests/io/pytables/test_store.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 30014 outside 0..27637\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    },
+    {
+      "file": "tests/io/test_compression.py",
+      "type": "SourceCallBindingGap",
+      "message": "unconsumed call actual"
+    },
+    {
+      "file": "tests/io/test_sql.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 83389 outside 0..27637\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    },
+    {
+      "file": "tests/io/test_stata.py",
+      "type": "SourceCallBindingGap",
+      "message": "unconsumed call actual"
+    }
+  ],
+  "constructionPanics": [],
+  "R_construction_panics": 0,
+  "functionsTotal": 27451,
+  "functionsConstructClean": 22550,
+  "R": 4,
+  "R_construction": 4,
+  "families": {
+    "ConstructedValueTestimonyNotWritten": 1,
+    "ContextManagerResolutionConstructionGap": 1,
+    "SugarNotWritten": 1,
+    "UnsupportedWithBindingTarget": 1
+  },
+  "R_desugar": 9694,
+  "desugarFamilies": {
+    "SubscriptStoreRuntimeEffect": 3118,
+    "AttributeStoreRuntimeEffect": 2226,
+    "RaiseEffect": 1740,
+    "NameErrorEffect": 1378,
+    "SequenceUnpackRuntimeEffect": 1070,
+    "SubscriptDeleteRuntimeEffect": 35,
+    "PowerRuntimeEffect": 31,
+    "YieldSuspensionSugar.desugar": 29,
+    "YieldFromSugar.desugar": 17,
+    "BitwiseXorRuntimeEffect": 14,
+    "matches_raise_effect": 11,
+    "SubtractRuntimeEffect": 9,
+    "UnaryPlusRuntimeEffect": 9,
+    "SubscriptResultRuntimeEffect": 3,
+    "TypeErrorRuntimeEffect": 2,
+    "ClassDefinitionSugar.desugar": 1,
+    "MatrixMultiplyRuntimeEffect": 1
+  },
+  "R_backend_defects": 5,
+  "backendDefects": {
+    "BackendDefect:unclassified": 5
+  },
+  "cmResolutions": {
+    "gap:unrecognized:opaque-call-target:func": 5737,
+    "gap:dynamic-export": 715,
+    "gap:unrecognized:opaque-call-target:cast": 709,
+    "gap:unrecognized:target-outside-binding": 24,
+    "derived-contract": 17,
+    "gap:unrecognized:non-manager-result:BlockValue": 17,
+    "gap:unrecognized:artifact-module-absent": 14,
+    "gap:unrecognized:opaque-call-target:setTZ": 9,
+    "gap:unrecognized:opaque-call-target:get_handle": 8,
+    "gap:no-derived-contract": 7,
+    "gap:unrecognized:opaque-call-target:nullcontext": 5,
+    "gap:unrecognized:force-floor:attribute:ObjectValue": 1,
+    "gap:unrecognized:opaque-call-target:available_protocols": 1
+  },
+  "R_cm_derived_contract": 17,
+  "astSitePrevalence": {
+    "site:function-def": 27777,
+    "site:with-item": 7673,
+    "site:with-statement": 7663,
+    "site:try-statement": 688
+  },
+  "desugarConstructionPanics": [
+    {
+      "where": "_testing/asserters.py:413:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=TrueBoolLiteralSugar observed=TrueBoolLiteralSugar requested=ride under a guard fix=write more Floor: implement TrueBoolLiteralSugar.guarded"
+    },
+    {
+      "where": "_testing/asserters.py:452:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "_testing/asserters.py:703:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f917eb1d43a5cd6c7079640bdcfa6bef39d4996f0281fef374f8105a8db2604195024fd0e10e8598bb71fb703215b6ea3f20bc0421ab73477cfc4b4a2e8cde6b', start_line=839, start_col=17, end_line=839, end_col=31) observed=two distinct pending contract demands (blake3-512:84d77a01fe901c4f7516936012036f3e4e65137bf640b2b9ed0a71264f51af48106d559006b357dd39d40fc30e414035d556c6e47af31ba82effd19c1aae0aae and blake3-512:67e5fc3fc1031a70429d0c48346a8e7fb6f0c97224ce7f5195ac68ba0281d81df0ba2ea59e404af112854cd915069e5c76f4a4c1b3e509fd4ea6315bc2bc7de9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_testing/asserters.py:1478:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "_version.py:179:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/_version.py' [7416, 8082) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "_version.py:396:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=409, start_col=27, end_line=409, end_col=45) observed=two distinct pending contract demands (blake3-512:9add4a8c22ca93aaa08dbb651e26a4ae16724fc1596c1be27caf39c3866b9aef9fa41eeacbce5bea1cd88e9a0dc83f08ab421c208908456c3f46e87b01ead73e and blake3-512:4cee671db79975e0bfe3baa45b8c42414fde0b76c420dc0a5500720ab529746598bfa6d5a687e8f66035030616827e593d72f12f4711afcdd028d61056d66444) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_version.py:420:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/_version.py' [15743, 15811) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "_version.py:459:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=476, start_col=23, end_line=476, end_col=44) observed=a hoisted parameter contract demand (blake3-512:d81770f41f283d603bde9f2a0d4b0a7de5ff57e6f259e123ea47f5d773e9b8399632594004021c1ffe32daba8d613f5b643b69bbaa181257529fd2482a35ead3) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "_version.py:483:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=494, start_col=19, end_line=494, end_col=40) observed=two distinct pending contract demands (blake3-512:84636c1af9b4b9f5f0bf935b38dedbe6edac7695e0dde98050f1c60d3e3a4f67d87d34f2e74dd3d20af9d3539f1be6b449bdd71b2f6dc8c9fd5c5b8dc66a5d78 and blake3-512:7555c00c70d7707dc801b48750508ab1a6bdd8f71d44545e245a3186983c1faa1c1ddc3158816987c83d66505438e4866d0babde9def49d77753d0d372dbcc71) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_version.py:510:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=519, start_col=19, end_line=519, end_col=40) observed=two distinct pending contract demands (blake3-512:2b1969904d29d5d1e916b25b8d38c7c2b1295c61b27db7bd526cbb996ae3dfaf7535dcc12982af72dbb34aa40f8002c39fff592e5b1ba8199da88816369556f9 and blake3-512:79c3c5665fa32080661ed0ae9fa805e2988caf9308858d0d02acc75a6825a1a3a563d98f9f12d155aeb20da510ceada9b3d5b01660bebf177cfb4e49f277357b) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_version.py:539:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=548, start_col=19, end_line=548, end_col=40) observed=two distinct pending contract demands (blake3-512:9e21544cdd61a58ee142b783299f3dfaa0fa63fce2230fed30ddd4ad6f5632c67bf984e44e5b287bfd023b5f5bb626acb5a611fe27184d31ac6c25e28d3af5f3 and blake3-512:725aa99eab4e0431f6f76fafeb4558d5329159e9a11f4bdc8f0be59af0bba5e79cf8a803f29d36ab36537f26297162d671ddfe59f23996a5997d9d418c5b51a0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_version.py:561:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=572, start_col=28, end_line=572, end_col=46) observed=two distinct pending contract demands (blake3-512:9e13f6e744ed94ae3362272993a511d9d5a2d6027ec933f1ba1139dc3da36332549c90b57a1e7b4e7453745d72e88d3d29f5bfd53d833e328e0ec7e7f05af592 and blake3-512:ef7d3be71bc61c6c0b88ebfaaf54fbd1a0e64348da24ba71a4a059640c21fc030add160249673c28dd206ece642d0e8db1c1f9ffe67ac71082044813a812d4f9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_version.py:581:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=592, start_col=24, end_line=592, end_col=42) observed=two distinct pending contract demands (blake3-512:af9b8edb157f5ab05ae4cae6e2bb0ea23b8dd0491d1e9d443e8938347dbfb2a29139a9b8798a836cd62e801498ec95f40b918c33ce2b96b6e57f8960a4b9d053 and blake3-512:8daa5fbbcc468bb40686fcdda10a4993a8a2e219e95b4ab0ac36736ad9ead50a220ff1d83503110ae827c9b4858de4c5d19ae23526b06f415ca4cffe6f674e3a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "_version.py:601:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=637, start_col=17, end_line=637, end_col=32) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:0ce98e8e8a9de45c85ee58a3ec38c8aca498467c157d2396d396dddee99d728728ac41aa592f72b2fb53d6f483ed83a0da6578ab54e7bce57e439b4bbb0b20fb and blake3-512:819cc2f1de3a4ed36a6d260dbf74b4b62090aa7901c5d8f1bb8d9cdc901614771f2fa91b31bbdd5bf46497e57081240afbb135c3a1dfac754fb6193d3ba7c000) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/_numba/executor.py:21:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/_numba/executor.py' [783, 953) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/_numba/executor.py:29:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/_numba/executor.py' [783, 953) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/_numba/executor.py:165:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e43d759ac1025de3f79cbf9f50edf339ec255822f8730ee2251cb7367b4062d58b1351bd1c06db5ea0a50f83cda0c2d86f64c517739e159ebab8a6a2d5c58f0a', start_line=217, start_col=23, end_line=217, end_col=50) observed=a hoisted parameter contract demand (blake3-512:a68c982da33e19d206e494d1290839f1defc411d0fe878836de6210a0827abbb7ce644b6d5c709efefdfeb81a3c23f2c8dc764e90f5c5d0cccfa17bc04a9c5f7) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/algorithms.py:1560:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4153ab68f8130f8455a205fe67ef63b620355d57191e6919a1e09bdc86ebe0f992e934de9885179e88dcab2274e328c4d5c7b4971e968a3e7e7c863c0f61f204', start_line=1565, start_col=29, end_line=1565, end_col=44) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:325da48251ecc19822937e92ba9e09cf5fec6e7846d679734f5a7ea1f47283000c57a623c0b1766fb569271e9d85415d136e97976b0fa21552b04e773d19d201 and blake3-512:d8441440161c17c4525c5db30d013416b94ad4c85cee85d02adb7ebfb0d819abd1ed43fa6ac6ff47e416bd1eeff71a075ac2856125f89d5ebe258f8f3fb8d6f7) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/algorithms.py:1637:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/algorithms.py' [54289, 54301) node=Attribute> observed=LambdaCallable requested=stand on the attribute floor fix=write more Floor: implement LambdaCallable.attribute"
+    },
+    {
+      "where": "core/array_algos/masked_reductions.py:111:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/array_algos/replace.py:46:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=StringValue observed=StringValue requested=ride under a guard fix=write more Floor: implement StringValue.guarded"
+    },
+    {
+      "where": "core/arrays/_arrow_string_mixins.py:403:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/_arrow_string_mixins.py' [14249, 14409) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/arrays/_mixins.py:345:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/_mixins.py' [11721, 12177) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/arrays/_ranges.py:31:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/arrays/arrow/array.py:1829:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ab7c939b8a80fcbee94adbbe4795ce68f6da84166557e9443fe5a799eb2cca1056330ce1648b25a73b1ad145c00dbcb50c93718f95b489a90270d990fb1adfba', start_line=1848, start_col=15, end_line=1848, end_col=27) observed=two distinct pending contract demands (blake3-512:0b17409d8ffde352ff7e779f9dbe31e1516147a911e4b87c67e5f08dd490d7aeeb3104380019e46bc7cc8ab76d9903bfa443f8fa991876ffb62b2923eff837f4 and blake3-512:dd527454b56c8e1299e13ec5794935616e16c6cbb83b408a33290635a455d54f9c3968937a15a78f81b2e264a4e8703cee6851f5eec8d6c0c2e57e6039705bf8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/arrow/array.py:2208:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/arrow/array.py' [84179, 84215) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/arrays/arrow/extension_types.py:138:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=ClassDefinitionValue observed=ClassDefinitionValue requested=ride under a guard fix=write more Floor: implement ClassDefinitionValue.guarded"
+    },
+    {
+      "where": "core/arrays/base.py:1284:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/base.py' [43826, 44135) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/arrays/base.py:1419:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:18f642bc599956065c2e8d77e83385e8a07a8e6aa5274dfd95a7069eff58bbabc9300686f45966a3f8a2a2050f380af83a30fd3dac798771dce4fac6fa4a2db0', start_line=1480, start_col=16, end_line=1480, end_col=31) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:43dfe2c44e7bb08cdd14b12da6175f9e936953317272a38380bfd6a7e21d1a2453490b25e423d273945b2d59da2caf596a7694ae2d0cce117ee7e074e8fcca88 and blake3-512:6ecd58688320e0c143e7cac2187e19174b82fdb1b36460ea95ec56b82716cea5da0681c7e09a47f468f02ca00efca0ec86858857ede714a80dc52a3e6e5a4b78) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/arrays/base.py:2517:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:18f642bc599956065c2e8d77e83385e8a07a8e6aa5274dfd95a7069eff58bbabc9300686f45966a3f8a2a2050f380af83a30fd3dac798771dce4fac6fa4a2db0', start_line=2558, start_col=67, end_line=2558, end_col=77) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:10927b7e266f03337ef33a8378226f856ad290467788afc01f75deedfb9fa5361f002b62de74434653ae43d4c4da721e91ad1326f5ac7b1267d3b6c4ec9c30ab and blake3-512:ee9dbcb5f8d9a2414ec688b7b2d6d4faf968e55d180818904d1421d68a13947367eb9e39100eaecbe13e9bda40668c52137be3b1e97901099a6ae29cefbf8f31) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/arrays/boolean.py:178:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/boolean.py' [7418, 7428) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "core/arrays/categorical.py:2353:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0e1da309ed4b27d98b571c175ece063b54028055503f561796003516278f828222cacc454e113e70ef49f484aa1ed35f571f108bd3551bd822ea820caefea84d', start_line=2364, start_col=19, end_line=2364, end_col=29) observed=two distinct pending contract demands (blake3-512:f23e9605a903c4eae4837119bd9f119cb067d1170ada302bce6c04aead64e23f2cd599eeca29941a32223316fb40085c9b34fb747bdd3663736ab6c3f1db3024 and blake3-512:a858bf52e6e3204d56a6dcda4c576ba407ba23c3fd8784959e8ec331ad945487f7b2690e3bb5f22f524f1d0436613c92dc24841e19563886936879480f1b6ba8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/datetimes.py:2936:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/core/arrays/datetimes.py:3004:27 observed=py.lt operand=NoneValue() requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='None', args=()) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "core/arrays/interval.py:755:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0fd0c7fac5ede4d863a44cbcb62cc48818c5a9a1c26e8a0575ee222ac465fbe4b9c8c9037b21d74b194b182c7b20785a04c8487826cb2a74a5ac56630ab56b9c', start_line=780, start_col=16, end_line=780, end_col=31) observed=two distinct pending contract demands (blake3-512:369645f42bb5e1d4fee5fb4cff3386bfced425b4b00156a611722f73d8dd571989f1e5e95e756923cb044732b49bc53c53d80666b219f93c6b9c222d2b243fd2 and blake3-512:8a37dd3745381294eb34c4d4402479c49cc0b7c71d52f78f6e8d32f8936b1efee875295269a652ea4ddbc8af238a73ff5228bcb4aa374b41437aba1ee11df63e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/interval.py:986:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0fd0c7fac5ede4d863a44cbcb62cc48818c5a9a1c26e8a0575ee222ac465fbe4b9c8c9037b21d74b194b182c7b20785a04c8487826cb2a74a5ac56630ab56b9c', start_line=996, start_col=18, end_line=996, end_col=29) observed=two distinct pending contract demands (blake3-512:e8b1e4b462b79867bb3eb45fbbaba83d77fbcdc699883f0f9c4f3753ffb9287df7b792e35fe9da7b0e36d6803bd2003be8a9047c98a5ad012dee2cf79d22d0bd and blake3-512:271684d2828b9cd27d91cc23d1dc0e57e27ad6f2948b7af7aee43ecfcfc2525197881ddc89aa6aa8d297520b59fff2d00101eee39c6fce2e6976505f27155293) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/interval.py:1003:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0fd0c7fac5ede4d863a44cbcb62cc48818c5a9a1c26e8a0575ee222ac465fbe4b9c8c9037b21d74b194b182c7b20785a04c8487826cb2a74a5ac56630ab56b9c', start_line=1013, start_col=18, end_line=1013, end_col=29) observed=two distinct pending contract demands (blake3-512:c7ddae93c2e87fa6184b137c5461a9deb4028cae667ce2a26430463605147384363c41b233c97c5c0ba911a2da8859129ac8e93eeedef02b0aecedfcac208187 and blake3-512:970e33ffaba758358ec8479920bf6cd35ef95207e899c5211595987c958960c0ec36e5d400167cb942908116ce072ca53201793d1a1437fdc9075e6150ba1814) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/interval.py:1167:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0fd0c7fac5ede4d863a44cbcb62cc48818c5a9a1c26e8a0575ee222ac465fbe4b9c8c9037b21d74b194b182c7b20785a04c8487826cb2a74a5ac56630ab56b9c', start_line=1193, start_col=16, end_line=1193, end_col=36) observed=a hoisted parameter contract demand (blake3-512:51837fa5d74f4d861cedfddd85a4274478496a08c6e121df47dc6e9d8d9cb4de0a025eb14813525163e5340342e636adbce418679dfc3c2422899e1b04438593) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/interval.py:2055:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/interval.py' [69321, 69475) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for GuardedValue"
+    },
+    {
+      "where": "core/arrays/masked.py:272:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/masked.py' [9509, 9810) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/arrays/numeric.py:137:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/numeric.py' [6605, 6614) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "core/arrays/sparse/array.py:841:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:60b43c9f8ecd1b902c28609633d023cfcd8065dec3d536bacffe19075f2a00973385ffea6c461575c2a516082921885357cb28ce26fd92f2a0084875a72b51d7', start_line=862, start_col=16, end_line=862, end_col=30) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:308f5c0efbca9d614b75a6efe2248a78a4e0be15299eacd0b72c63777db99af9ce164a7020974bd207be03842559ddf52e7b96e0f61ced51405329ab985324ef and blake3-512:a8bdb8b19e2196b7cdcf476c7f78840c455600f9fc958b84a607905d38d25ad6ec485dbbaa842fe155544c8cffe0bd3fa27bbfec5d75d7cde69fbb0602610e68) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/arrays/sparse/array.py:1890:0",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/core/arrays/sparse/array.py:1942:24 observed=two distinct pending contract demands (blake3-512:291b85e5a2d4e0fd921e9dd2bb9b7d1b5ec553a97570929aca01e1d52472ed3638cb466f2d23d5a3dc41bc663c1fd446ba8578d30e023a3c96e7e2d97f337827 and blake3-512:b2fab706679b56262804e5ae9ffc4e38781f14af29218a767b9a8586953656545e4f45f3a501917a9942d64a77a27164baced6d35833334cd4150183d878b722) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/sparse/scipy_sparse.py:40:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:908d182f0826b24d95583419afa0bd9d1a180e4499a47f26c22a829ad9b5d1a85d753e4762898d9cc626f9955143232c7b556d755731cbfa45c24d7a59924f61', start_line=71, start_col=35, end_line=71, end_col=44) observed=a hoisted parameter contract demand (blake3-512:98d2d559e2611db34a1bdafc9fa0510771dec7ffa329df09901b04f9a75cfe0dfd7f29b6270eac3a64ae3019bf616526fb83b7310cd378ccb2ff8af352557c2e) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/string_arrow.py:383:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/string_arrow.py' [14263, 14282) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a SymbolicValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for SymbolicValue"
+    },
+    {
+      "where": "core/dtypes/concat.py:134:0",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/dtypes/concat.py' [5280, 5303) node=BinOp> observed=ComprehensionValue requested=stand on the subtraction floor for a SetValue right operand fix=write more Floor: implement ComprehensionValue.subtract for SetValue"
+    },
+    {
+      "where": "core/dtypes/dtypes.py:563:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/dtypes/dtypes.py:681:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0dabfedd4a3b4301d5e845a1a8dcd0768668fdca92a0cc9031090ee1db8663055808dd936bd151182815d41a14d4a5e20fa222dbb27e086282c91e286dc22ea5', start_line=685, start_col=47, end_line=685, end_col=57) observed=two distinct pending contract demands (blake3-512:2489ae2f95a6f8e42c39d1da7fda5d9cc0305e377d03f16fa2c859df43fef3526dd7bd26d20568a3faa11a0d29c2005052a47965395131170653a5e94f507ec8 and blake3-512:cea05d31a8024532a8b8a1e6780e5899bcd8751ebda728e5f000d49750a6130e76040ac0469483e69f9f91d648f6037d2c92b5729aea5ce8e410b53036c1e1ae) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/dtypes/dtypes.py:965:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0dabfedd4a3b4301d5e845a1a8dcd0768668fdca92a0cc9031090ee1db8663055808dd936bd151182815d41a14d4a5e20fa222dbb27e086282c91e286dc22ea5', start_line=969, start_col=19, end_line=969, end_col=30) observed=a hoisted parameter contract demand (blake3-512:6ed0197b92f1ac0cb2d43c3775c1faec26ea3b1bf18d85479f6626355df91ab726cf91e112104b8746360f1e9bd50391434f82a84a44028203bfef2c78dfea03) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/dtypes/dtypes.py:1151:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0dabfedd4a3b4301d5e845a1a8dcd0768668fdca92a0cc9031090ee1db8663055808dd936bd151182815d41a14d4a5e20fa222dbb27e086282c91e286dc22ea5', start_line=1153, start_col=19, end_line=1153, end_col=28) observed=two distinct pending contract demands (blake3-512:359701cdb838ed95d63a33cfe8a09b04bb7d40ab6f3de88e7b4dabf94b9bb5a9759adba9c810df5bf36c2a04a86923acfbefb0356b904aec9647bfdd3cffc069 and blake3-512:a1b7868e9214f13c5d6adb246caa4609502b00508a8000d0ad52f0592324f7a1390fdd69eab93fbcea0a6c0c257dc3497311e1fbef1a2422b29260ee8845b0da) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/dtypes/dtypes.py:1429:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0dabfedd4a3b4301d5e845a1a8dcd0768668fdca92a0cc9031090ee1db8663055808dd936bd151182815d41a14d4a5e20fa222dbb27e086282c91e286dc22ea5', start_line=1433, start_col=24, end_line=1433, end_col=40) observed=a hoisted parameter contract demand (blake3-512:bc67eff64951367e26a3ad85f6048a0c7714959671fc1b0709659537785555bdf16846d184453bc5c34c1a36aafebfe67234022edab6ededa6b1a12b5ad6ef5b) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/dtypes/missing.py:491:0",
+      "owner": "bitwise_invert",
+      "message": "write more Floor for this Construction: owner=bitwise_invert blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/dtypes/missing.py' [13763, 13768) node=UnaryOp> observed=NoneValue requested=stand on the bitwise-invert floor fix=write more Floor: implement NoneValue.bitwise_invert"
+    },
+    {
+      "where": "core/frame.py:702:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:831:32 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/frame.py:1895:4",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:2006:23 observed=two distinct pending contract demands (blake3-512:c5c6b15f1ad0c1fdf81c4803f57a3d1b7deb562a1d22629445d7a7bc67d5d58322f0945f443c5ea4f21b3d0bd40ea3bf696e02293d30fa43597baf5975af8acb and blake3-512:be97f3c0fc691801b86ffc7306386b9515b9dd8ae2e526ea2b62e00305dfd8f4186ba1fb7f6724bd15d56a7da83619374d01d4e53c14e7b076c709770657d5af) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:2239:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=2345, start_col=29, end_line=2345, end_col=38) observed=a hoisted parameter contract demand (blake3-512:fd849705184189ac104dfbc88757323ae5e23e34424de687782522e4e849880e4f2b7c8d72f3a75970b37c78f25a0d5e3ca8ece7b3c16996022551bade957132) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:2337:8",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=2345, start_col=29, end_line=2345, end_col=38) observed=a hoisted parameter contract demand (blake3-512:fd849705184189ac104dfbc88757323ae5e23e34424de687782522e4e849880e4f2b7c8d72f3a75970b37c78f25a0d5e3ca8ece7b3c16996022551bade957132) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:2458:4",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:2593:36 observed=two distinct pending contract demands (blake3-512:ee8ed5ffec27855981f1167cf96ba44702b719584ab86cc7ebff0f55f282e8484c7700d83ec2336a85f1e718ae4bd01d4c024895596a0c909727a5be5bbf7dd5 and blake3-512:78525bcab37ddbc4db96e281c321b3b913f35c8c5e96b208d562d74ab2f6237abd3027898e773701b0f3cd8e4b609fbdbcf7204db199d86a0ade6a91d17eaf71) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:5764:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=5769, start_col=52, end_line=5769, end_col=65) observed=a hoisted parameter contract demand (blake3-512:0b0a5c29db9dbeb47adf3d17bbeaf2f6fcc4693d90bf2f4421193ad6338ad257d19086f0c0c63f66c664e0ea9662fad299c7f2223b4f5246f877dccd49d947bd) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:6821:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:7041:52 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/frame.py:7859:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=7953, start_col=17, end_line=7953, end_col=58) observed=a hoisted parameter contract demand (blake3-512:8e072bdec9e943e46b3b78dc805783357d59b7d4d40efb812740cf9e3911b83b7c7602bd953dde753736badf7f43a3bb6f4c8c48cbb5c0ac610af5affb46b762) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:8128:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=8359, start_col=48, end_line=8359, end_col=53) observed=two distinct pending contract demands (blake3-512:227df01be4e0582e21788cf4eda60bd1a3659985d8a704342c2e661cddef0374efd1fa44329e8ebfc8ff3407976416b306cfb9aa18fd6fbeb468a2f89e76e52b and blake3-512:e39009e92bf4266b7a1a39aa458541acaf1886dc65d27905cc9b8a945be55a2c7c78ef444ae7743fd1708a83eb85fabf7d880432067d6bd26d23b752962753a0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:9340:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=9439, start_col=53, end_line=9439, end_col=61) observed=a hoisted parameter contract demand (blake3-512:f7e9423616f135157cc440dfbe939cca26943d38561dd0921de5fe7068df034eda1ea29850ffd82b3449244db571b4ac2206336bc353ee58af31a82c369f007f) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:11852:4",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:11875:15 observed=two distinct pending contract demands (blake3-512:88b5ea27943da1c26bfb5d0edde8475ec444b5c66c6775423d8a712a1aae0163c0f3f22ec55c3e7d65c237f4152686298d513b66dac0e97a15c6cc982938c6c8 and blake3-512:85dae2f989374bc267d6cf9e1d541acc45ea8363595a1a915d114b7b4e1f88ffc88ec0ab7a3e2974bca59b5cce3b0dc4c1d66c9e9b8274c7e4649ad6ddb06d8e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:13423:12",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=13424, start_col=38, end_line=13424, end_col=42) observed=two distinct pending contract demands (blake3-512:29469256d9789ff8e93bebf58d0d87620f2bf34f02f1d9b1c00480724e536b9d6ee2d892c8dd3b4fc5f8d937d07323ff1063ed0db9ea256d77a450d81a008013 and blake3-512:78ebba991bab81eb1d3106a3bc4ff1cbd9f77cdf7a294448da83f151eaa8bb5488028cdeed9bb4f0ef695e5034228c32e597090a2f99a48ac6c800e2c29343da) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/generic.py:7388:4",
+      "owner": "collection TupleValue",
+      "message": "write more Floor for this Construction: owner=collection TupleValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=7779, start_col=47, end_line=7779, end_col=57) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:044f5e517e831751c96161ee27c15d3e9a284797925adb1d71a9f2b66fafbfa07d0d7622d0dc0fbd9ac81f80ef79028f0a86fd53bd080ac3534bfe837c3409a8 and blake3-512:2acc4d3c82076e6fb8138ced9750cd2ffd962eaa4a3d2b00b97f59942b4a9336631600d60fef1c1422117cd0a420bafc22046a4e41f5a8ba509b76b3772b083b) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/generic.py:8088:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=8238, start_col=46, end_line=8238, end_col=58) observed=a hoisted parameter contract demand (blake3-512:4029920b5fbbe2317e3223b8f679766bee11ad0da4989db6b69cfd4ee68c41e449ed464ffc3eacabdb62411d8465426910a453d8a324080a903ba76cb09538ef) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/generic.py:9596:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=9652, start_col=23, end_line=9652, end_col=33) observed=two distinct pending contract demands (blake3-512:95773201fd81e85e0ae33d86bf8b2b8bffe42b337f41ee065423369ea55d2fff654a4f657b7d2d0fbfbb67fc018310e608f94c2b7fcabf60e1a7c939b68be1ac and blake3-512:934ecd428608ed248848bfcf60a255b47169553f316b49a448801ff9b18fe0868a2c6c0bff57bcea8ffa4c03b0ca23d910eae9dbdc4d48116d51c1d3b3342d42) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/groupby/generic.py:314:4",
+      "owner": "ground_assertion_error",
+      "message": "write more Floor for this Construction: owner=ground_assertion_error blame=/home/tsavo/pandas303-audit/pandas/core/groupby/generic.py:467:16 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/groupby/groupby.py:5506:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/groupby/groupby.py:5645:12 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/groupby/grouper.py:321:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/groupby/grouper.py' [12036, 12446) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/groupby/indexing.py:158:4",
+      "owner": "bitwise_or",
+      "message": "write more Floor for this Construction: owner=bitwise_or blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/groupby/indexing.py' [5072, 5120) node=BinOp> observed=FalseBoolLiteralSugar requested=stand on the runtime bitwise or floor for a CallSiteValue right operand fix=write more Floor: implement FalseBoolLiteralSugar.bitwise_or for CallSiteValue"
+    },
+    {
+      "where": "core/groupby/indexing.py:187:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/groupby/indexing.py' [6814, 6850) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a PredicateValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for PredicateValue"
+    },
+    {
+      "where": "core/groupby/ops.py:880:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9e9f9f30bd21ca8d22516dc3569c714ba1bdfad1de36b81bba839fe0e399973a1d571fced75cc95a20610655be6a06f1dab59e2fd2fb46370406d4312be693f6', start_line=887, start_col=62, end_line=887, end_col=71) observed=two distinct pending contract demands (blake3-512:f26f6d0e86ca56ec3f56459a403b591ee5816d7331ca1174cf4fba0bb585392ff42dbc2408ad882b5c3629a3a5b61aa8b937d515df563f091561fc29d10081e6 and blake3-512:03e373f77b2858dbbb89cd618798195c2782a5a40ea6bd8227c5df6bf84605eb6fd80f5f06732c3c06cd1e068eca3a5a7b5d4bd88bdcdd69b03df742d22a905f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexers/utils.py:398:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexers/utils.py' [11081, 11196) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/accessors.py:666:4",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/accessors.py' [19559, 19569) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "core/indexes/api.py:185:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/api.py' [5263, 5405) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/api.py:284:0",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/api.py' [8831, 8846) node=BinOp> observed=ComprehensionValue requested=stand on the subtraction floor for a SetValue right operand fix=write more Floor: implement ComprehensionValue.subtract for SetValue"
+    },
+    {
+      "where": "core/indexes/base.py:1592:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/base.py' [52110, 52278) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/base.py:1919:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=1944, start_col=21, end_line=1944, end_col=30) observed=a hoisted parameter contract demand (blake3-512:c62b77bd92ded883651ab705d6afed5790fce9af8f4736f142a1f8eb54ed38040eb53ee68f656d8cd7349bf3a7a516d6a4dcda5e4af358b0f51cff273cf2f189) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/base.py:3472:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/base.py' [111690, 111739) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/base.py:4703:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=4744, start_col=31, end_line=4744, end_col=41) observed=a hoisted parameter contract demand (blake3-512:4c4e5506e42023e3647a376bcdfa5630ba1e5046a67dd7e571d652afd9dd575171ca3ac7396258555c4ee69b1e43a1a5821a62d112ae6e4158573959bbec2b11) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/base.py:4717:8",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=4744, start_col=31, end_line=4744, end_col=41) observed=a hoisted parameter contract demand (blake3-512:4c4e5506e42023e3647a376bcdfa5630ba1e5046a67dd7e571d652afd9dd575171ca3ac7396258555c4ee69b1e43a1a5821a62d112ae6e4158573959bbec2b11) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/base.py:6580:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/base.py' [227086, 227226) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/base.py:7222:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=7268, start_col=34, end_line=7268, end_col=46) observed=a hoisted parameter contract demand (blake3-512:7d3daf4db0b0b4ee5d44a7457d9d3ec59529f7e01696ba41b86c4f07ec5c0aec63deec22bbb75cf51fa0957949fb102270f4068f26f205368212616c69c8e882) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/base.py:7421:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=7424, start_col=22, end_line=7424, end_col=31) observed=two distinct pending contract demands (blake3-512:b5cd88ec1863b6a1c1d807e826d016f0a5b50dd58ad9e60162a8256e760f24d001fafa956ef86bd6cfc9b98bd45bf867e529dce77afa81cdd31b7a2cbf4d2473 and blake3-512:8b53e65f2df9b48abb4e2187a691a11c27d2fe968ba563eb739c3163c1e675b7d2acd997f578491f63a335c94c56ec6f783336f171dfb60d7f7b55114f4f2fae) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/base.py:7875:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=7913, start_col=45, end_line=7913, end_col=57) observed=two distinct pending contract demands (blake3-512:52e22711796df22fbda6ff0799494a04bcbae07994a69c2c9adfc83347e572d2fb58724427936aaac9232a4f6e718b6798d9863966c5595b7488cd45a3c46b9e and blake3-512:9e0da036f1d3e9547576ec34b5db75a6804dcba54838713a33d6633ea06a56976c11f52f0048236040000c05dd6a21fb2ee5a84ac9a5221f1fb4f304ecf9f154) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/datetimelike.py:629:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3f31565bab842fc2fa82d3cbd266b2d177c432fc9f43f4d49331ba679c2e0e20de910c175935d6c1ff18d3ed537ebb0a448722a0ab1494f502ec5ebb599b9d37', start_line=668, start_col=16, end_line=668, end_col=23) observed=two distinct pending contract demands (blake3-512:cc7dac2c4bf0c85b1bce4510904c1ef7c717af53e785928ad10b885d5c9fce3dd0df6bbe66b7c239c7466e4bd16926719a4b0712c056a83b16a6b2e0d8708217 and blake3-512:5be80381d335551cfe1560299ac1e59746405d9e7b70a0002900e9fb0bc77f630122765f3ef11e7273e4bc6052137f473ddf216ba091d99c7e111c29ed1f157b) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/datetimelike.py:718:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3f31565bab842fc2fa82d3cbd266b2d177c432fc9f43f4d49331ba679c2e0e20de910c175935d6c1ff18d3ed537ebb0a448722a0ab1494f502ec5ebb599b9d37', start_line=723, start_col=20, end_line=723, end_col=27) observed=two distinct pending contract demands (blake3-512:263d7adce0da0ee60e1fa71c0d975e75d089bb8346cf1f6c8be0235bdaa274f03599180b59bdff02fb342f50b9af281fd4bd5fb67c31c94235e0c4cdee111d69 and blake3-512:e8c089a009f8f51c9d88d661a9ea46295bd668fde2f90f850b27ce6d188fcc975670e62f73995ca6b50a727fc3de288ce1d8cca31dc885ca1bccb4b281971695) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/datetimelike.py:792:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3f31565bab842fc2fa82d3cbd266b2d177c432fc9f43f4d49331ba679c2e0e20de910c175935d6c1ff18d3ed537ebb0a448722a0ab1494f502ec5ebb599b9d37', start_line=794, start_col=11, end_line=794, end_col=18) observed=two distinct pending contract demands (blake3-512:8d04c2d3edadaa4eaf7ee8959268f1adf8f07676f3aac8c6a357635c7a57a6adea4c64b752e51b5e58cbf43592cc51d1703f0e06f083498b33d6231c9742a945 and blake3-512:9e5b72b55bddd3cebea037aa40aeee5e67f129d29887ce663924bfc667da733f81475545b93f7b6ab4635a9e5be7973642dba305f6e6436e1efb070d30045cd3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/datetimelike.py:830:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3f31565bab842fc2fa82d3cbd266b2d177c432fc9f43f4d49331ba679c2e0e20de910c175935d6c1ff18d3ed537ebb0a448722a0ab1494f502ec5ebb599b9d37', start_line=849, start_col=11, end_line=849, end_col=18) observed=two distinct pending contract demands (blake3-512:02f759d7fba60775aeed9ff3fe097eff95fe044ae6a5383227b38f3706021cc8ad4a8c71b5d9ae0e12f4b9ccde15393fae973b4ae36a3abd3a48b57aa71653ff and blake3-512:8a8496968e830db0f78079d8aa25a2202492744b705dec1ee6a9c92f53b58b5a28516655074f18be38dace59ab174ea05cff3fe7c0b44b066a46e0c1bd21d791) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/datetimelike.py:860:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3f31565bab842fc2fa82d3cbd266b2d177c432fc9f43f4d49331ba679c2e0e20de910c175935d6c1ff18d3ed537ebb0a448722a0ab1494f502ec5ebb599b9d37', start_line=864, start_col=11, end_line=864, end_col=18) observed=two distinct pending contract demands (blake3-512:661d6336d6eeafc14b2858a868c88e1bda4d65fc4940a71c5d2e88fb465c9b9578e08d57fffb9303b8545184ac44aa50cf5769b05820bc7d0627841fd545078c and blake3-512:ffe23128199f555aa645b15b92501c5b41cad0b042e8a874b872c130d4f91d8885ee643b02940e3f4a37b767e8c9f6008c5b99a05bcceadea8a28cc252e97304) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/interval.py:1287:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/interval.py' [49357, 49367) node=BinOp> observed=StringValue requested=stand on the multiplication floor for a TermValue right operand fix=write more Floor: implement StringValue.multiply for TermValue"
+    },
+    {
+      "where": "core/indexes/multi.py:1555:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/indexes/multi.py:1580:16 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/indexes/multi.py:3802:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/multi.py' [132044, 132274) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/multi.py:3813:8",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/multi.py' [132044, 132274) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/range.py:805:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/range.py' [24799, 25048) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/indexes/range.py:1180:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/indexes/range.py:1256:19 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/interchange/from_dataframe.py:139:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/interchange/from_dataframe.py:167:20 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/internals/blocks.py:1989:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f5d95fb36a12e8adbf32a37e43224e397add4bafddb442b027da2fee93b8c637692a99d6ec882988bd49ccae12e88d7aab428b8f4ad50bebb7bf195fdd39c8ae', start_line=2014, start_col=32, end_line=2014, end_col=42) observed=two distinct pending contract demands (blake3-512:afe391e81da7574a5c362f587d20983e0ee03598f365be403b51c5071bafec705eac35a250bbf946967b2b2f98d0fdfd75ab97e141098992b588db15d6f07177 and blake3-512:3085b1e7da70db5a44a006c4a8f0c2608dbecfaab85eb344bed50f51dae46580e65673cb3b7894d27d357a240666b25b4cf38fb5c27985c3fe3ac29efa8af8fe) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/internals/construction.py:193:0",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/core/internals/construction.py:224:16 observed=two distinct pending contract demands (blake3-512:c1f65479cacf29a412cb27736574ff7e3bfac8fb5060ceef7791f0049b987214da845aa9030e4d19848aa1a34990d30ef88a930fd896393756eb5722f110aa37 and blake3-512:9644a34469ad9bd583ca468e920be96524b88ef78334b8e290e818736a1a004af44915d5a27d0eab7a1f9b1be2bedfbce18fff9edddc28ebdb787fe972b2d3ea) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/internals/construction.py:375:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/internals/construction.py' [13516, 14069) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/internals/construction.py:463:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6e6041efdd1dabef956bb73df07b601c76d6ac819a457daa606408e98b33505304c7e72463d66809884fdedb697f57cd4b6965e91eac606cfab62739f4ae8f35', start_line=475, start_col=31, end_line=475, end_col=38) observed=a hoisted parameter contract demand (blake3-512:241a73983aba8381e6759dc5663d6f4665bbfc30dc819c1c83939615727cfe1af82e4c6d9421cdb6d586c4413be265fcf0f6b76d875520d692c38a4b271d7c31) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/internals/construction.py:489:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6e6041efdd1dabef956bb73df07b601c76d6ac819a457daa606408e98b33505304c7e72463d66809884fdedb697f57cd4b6965e91eac606cfab62739f4ae8f35', start_line=495, start_col=25, end_line=495, end_col=32) observed=two distinct pending contract demands (blake3-512:424f3942ad83446646d59f50a774886cd00871ccf0ef0701f4961141f176ab6eec79ff39775dfea2727ec3859b42e2728fe654620399d9599b8eb9a6120eadee and blake3-512:15bad14989c3486ce28f535ac5826569a80ce841a34d3bf2ce2b4d6e0cbfe3a8b6c827547d710360edf53b38979d3154eb6cba6c7d3c1225adeefba411c466b9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/internals/construction.py:605:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/internals/managers.py:552:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/internals/managers.py' [16307, 16435) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/internals/managers.py:2028:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0db048ffa9e524845e3e148a6750ac31f76e2a7825a77aee78619381d52539cc824005ce0d94729ed7b54dea5c3a3dde0aab000e4ede169133f0af7623709859', start_line=2038, start_col=19, end_line=2038, end_col=28) observed=two distinct pending contract demands (blake3-512:fe43d0769676bf64f93703ad1cf20495484ba84202e4bdf5593f0509cb8a94753f2281ed23c73156c59911a62e47e72555cdf711c3caa61318d197e69db44ba3 and blake3-512:f8387ddf56b69c2b7f5cdd743d16082116efcbbfdaee4bf1843008f15935a3145791ae906088fd293e12cde4d51b4f33ce528f2fd3cd1692202e43beab2f9537) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/internals/managers.py:2375:0",
+      "owner": "collection TupleValue",
+      "message": "write more Floor for this Construction: owner=collection TupleValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0db048ffa9e524845e3e148a6750ac31f76e2a7825a77aee78619381d52539cc824005ce0d94729ed7b54dea5c3a3dde0aab000e4ede169133f0af7623709859', start_line=2376, start_col=12, end_line=2376, end_col=18) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:d578324340664f0db1804234e20bb9833106de7b844746350c3f500ec0c4451bda3e2825ceba33d42fa32e00bab84e666fa3359e8bcb0150bdbcb534a4e46987 and blake3-512:9964b2113a90cdd92ebbeafe912d8f3c4cb659c0cd6a7bf6956bc7fb9e086ebd1f7d13139327b75baa7f7a3cdf3da4e9cbf821712098ab2ce713cd0cccdc7b60) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/methods/selectn.py:106:4",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/methods/selectn.py' [3990, 4000) node=BinOp> observed=TermValue requested=stand on the subtraction floor for a GuardedValue right operand fix=write more Floor: implement TermValue.subtract for GuardedValue"
+    },
+    {
+      "where": "core/nanops.py:1536:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:47bb2c4a1a8ab30fa369145aeddbbb60c321818bde36962ed244e8202a0b129a1beebe7ac3c0c3806da32e3eaaf7830dd345b9d1ccddb5c007b866e5d699e1d4', start_line=1560, start_col=24, end_line=1560, end_col=36) observed=two distinct pending contract demands (blake3-512:0472a7d4043acd79c2ed63ecb665d6fadc4f3bfc85a124032171b2af95b80346bb921a28302d166e9fb4cc910911b9c6bc9883745133e3be14b98dfeecbca3ff and blake3-512:41d8aebbbb8d08166ba8c4d5bf37c47ee08c59b8d03e86dd6c035ea6fdfe0a35f4b3249a745823595ce9fec1a3764da2497f0fb9ecffcc470e909203ac893c90) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/nanops.py:1628:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:47bb2c4a1a8ab30fa369145aeddbbb60c321818bde36962ed244e8202a0b129a1beebe7ac3c0c3806da32e3eaaf7830dd345b9d1ccddb5c007b866e5d699e1d4', start_line=1646, start_col=12, end_line=1646, end_col=20) observed=two distinct pending contract demands (blake3-512:4442648f74d1dd7f446fb1bfd5a5089c7b95f75851ac302cc4ac59356ddf06a7e930c339d1c7af78f4d5049e919ad31a98cd826a74aad0363284ad169777454e and blake3-512:4cd5f961aa5817f913bc40e10624c30a3721cf908444fbdab63417c2ea0ed1c738d6c7cd68932a2c223995bc05f71385d085f1de12c8ea3676d43e360e07c524) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/nanops.py:1692:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:47bb2c4a1a8ab30fa369145aeddbbb60c321818bde36962ed244e8202a0b129a1beebe7ac3c0c3806da32e3eaaf7830dd345b9d1ccddb5c007b866e5d699e1d4', start_line=1707, start_col=12, end_line=1707, end_col=20) observed=two distinct pending contract demands (blake3-512:e4bd0cf54d8f906e03bce266cb44c7754a4ae0999692d603e760dd7b5edc6fc4aad174a8aa23bb014527575ea0eac36ebc174a7378435926239eb09161ccf2e6 and blake3-512:def13f9985702c34b5453c5bb7d284e56c241ad9ee88aae3baa047617e5d8727ad0315eec65086c2c5b8e8b231915c74fb610e24f2db6f7abc5f6a9dcab56cb0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/ops/missing.py:71:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/ops/missing.py' [2914, 2935) node=BinOp> observed=PredicateValue requested=stand on the runtime bitwise and floor for a CallSiteValue right operand fix=write more Floor: implement PredicateValue.bitwise_and for CallSiteValue"
+    },
+    {
+      "where": "core/ops/missing.py:131:0",
+      "owner": "collection TupleValue",
+      "message": "write more Floor for this Construction: owner=collection TupleValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d1065f69885e80142a77f9c3886df2ce94ebb25eabaedec8806debeaaacfc3e65fb2d8c03205f13319e04f98d8462d982548f1a6ffc56aaac6ca5101455bbcea', start_line=157, start_col=24, end_line=157, end_col=33) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:6ba31796b08e459cc67c9f1f124b6c3073b3acfbc6676dccbfd0484ca67b438b1e6008656d6192413eb2640018391e68a36c3a22904ef5f0264651b0f5e87655 and blake3-512:66e03e95b3759a2f5e08c04fa091ddfeaf2d4a084ab2ae3d3b764118877f7de730abfc9d388b26f9ba175ef886cdc8fa57c4e371d8677e8ba2acc0bc310ccabf) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/resample.py:2105:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/resample.py' [65228, 65333) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "core/resample.py:2710:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e32173c6e520a3a728758b03dde8a4c195cdf30c1435cef73b2fb5c1e4c9020e204f18f00da26610d2a91615613b5ed1932327d68e038c78de74126f93004725', start_line=2725, start_col=45, end_line=2725, end_col=50) observed=two distinct pending contract demands (blake3-512:6e6976fb9ea4cac4eb53e711c5ab9651520290db2fb6fa824feccfe16ca23503fba979bae86ac4810c7db2210304d2cb70600eafb5424b1d6a58aa27c9b41d21 and blake3-512:e01bb138f5fdeae0eb384c724e79667671b0963da2aeddaa2e73eb3f32256bf1fc42a07b63db537e4da605801004edc9f98df3852a2dd0012b7132f9471f848e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/concat.py:667:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5b04fa85580c2e32e286dd766dac63457620f9676816a78c4e9c80dc84e92f9d9757543c0cb98d609efbd4270f8e15d365883834263b52b6eebc554002ecf10d', start_line=693, start_col=17, end_line=693, end_col=24) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:e79d61c8ac1a283f75d144f9ec374bbe5b80861970c82c8864b17599b73060b4777e00edba699deddfdaa2321fc9e27b5cfc4aae4e900c4da9d1ec9b8c30cdcd and blake3-512:804bbe40b4da18069d19c32731814764b3f8346624a1d49cfb9e23cd1ae9a42737ea3723522cc4c34642f96ce7996469f2ac4c368421be881b2c323baefeb6d5) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/reshape/concat.py:701:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/reshape/concat.py:877:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5b04fa85580c2e32e286dd766dac63457620f9676816a78c4e9c80dc84e92f9d9757543c0cb98d609efbd4270f8e15d365883834263b52b6eebc554002ecf10d', start_line=878, start_col=11, end_line=878, end_col=21) observed=two distinct pending contract demands (blake3-512:f86e174bd136951149810a9622fb6c6051d449ee4147447d369951634e71fd4a0eb6418d0415bcbe1b71c80b27837c86eef55f8120650b85e7061ef68a49da99 and blake3-512:9303b9184d1f1689046598d6ab43222b932c9d961d3030efce17bad3ed8ddc23d3819055385e8157be898432287b5657587ad4711e27d7bd327ba1089476f016) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/concat.py:887:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/reshape/melt.py:282:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/reshape/melt.py:359:33 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/reshape/merge.py:2043:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:50a78e9497b11c8e5b4a60d99c529d6eb2b812dabb425eed300c0b34ca3be1515b3934ccc217e4304ec0bc1120ea487c1be82f9f023d6e669997a80e2f612c88', start_line=2088, start_col=28, end_line=2088, end_col=40) observed=two distinct pending contract demands (blake3-512:12cb0376243c8f46a0bfd805a84a9329741073372ad2398f378b761e0d29f9f3ba1199925fd8b3ab6d16692346f148b3c9b4ba4c7fc742cbd23243aac043b639 and blake3-512:91005be63190fdf7489349677df0594580b4139133e34b1bf8a0758bfe41f77f8ead38612d5c6f22e99f971bc00040e85b10c1cc9a11361942c2b99e05afee11) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/pivot.py:284:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c463d3c1a1e885ac94c4d904c3d1286ba452d2a1d329b6411254165bec6c76d12bafe54b3a6b73b7084437360cf4507ecc304efb5bb9f5c47a0100de28c4303e', start_line=327, start_col=19, end_line=327, end_col=34) observed=a hoisted parameter contract demand (blake3-512:d981648d2d10499da5ff11f6f6b9b06d28d5466ccb259d65d6c455c44ee1ca5c923db7d0daaf5b6f62a028e8d16287f15d0cdc7079ba6d68b6027debfd85eb7b) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/pivot.py:536:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c463d3c1a1e885ac94c4d904c3d1286ba452d2a1d329b6411254165bec6c76d12bafe54b3a6b73b7084437360cf4507ecc304efb5bb9f5c47a0100de28c4303e', start_line=616, start_col=12, end_line=616, end_col=31) observed=a hoisted parameter contract demand (blake3-512:2f33f76c3c25ca4bc4f263b9cbd922d6fb11244b133cecd8d7996f18b1bd0d91d3660f44a8a1acc41e8b5e85d243fd775f271f5972e39d846867f3853ee63ad4) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/pivot.py:700:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c463d3c1a1e885ac94c4d904c3d1286ba452d2a1d329b6411254165bec6c76d12bafe54b3a6b73b7084437360cf4507ecc304efb5bb9f5c47a0100de28c4303e', start_line=891, start_col=26, end_line=891, end_col=35) observed=two distinct pending contract demands (blake3-512:5969b3323433a1f2d56f8e1da8347aca2f8b6d4b9b171adc0cf2d1dc86e607b55249da02f792b6c4108453722b92cd41a41be95a4be01bd94bfed965b5bcc24e and blake3-512:af63f1ae4f036f8b0272d2371d5fcdbd9dc5fcd02210c85cc32c186ede13220a631d1ca5b5f2246ef98caf3e7bf621894ed59c2c41a23b738dd16a62c99d89b0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/series.py:6813:4",
+      "owner": "collection TupleValue",
+      "message": "write more Floor for this Construction: owner=collection TupleValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:97526e51483023253082395415f94013ebba184410b80485928cb4ed758732a41531c938c51c840e4f675b3db2a4c636e16f3bd5d74979832ca27c04e51c8f04', start_line=6837, start_col=42, end_line=6837, end_col=51) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:5ec19686ba242fd455caf166d26603b59810d8b72b3d099ee2a9b1418f76be6db4fcf836b8f95a53f55d9f518afab754c95c6991ea02598dd10cd098dc56f520 and blake3-512:61fc08528abdc7fa8e921d48ab7ff69de70cccb6c73c5fc8ca2736b1c643cc72468705f0d58ff1d212b4b7e37f28b513e502f25961b25675908e742e83155add) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "core/sorting.py:372:0",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/core/sorting.py:435:15 observed=two distinct pending contract demands (blake3-512:7d56cf3716caaa00f9bed4e74e2e079a0f329d02bdd07be3c8e0f02b9fd2675759d8c407f2dbc884e24e9e609d43885bade05414434ca571f102804527c868a3 and blake3-512:0f8a1a16cc3e2a799097a6e4225b32525e4bfb3dd2df4a67f434cf855361bc73588b0596e192ade0ee0f5f0efb985da25e4c240ad043dc5e3674edf9be3118ed) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/sorting.py:599:0",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/sorting.py' [18443, 18487) node=BinOp> observed=PredicateValue requested=stand on the addition floor for a TermValue right operand fix=write more Floor: implement PredicateValue.add for TermValue"
+    },
+    {
+      "where": "core/sorting.py:675:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:58e844b0a5e547db5b60d088916ace4fb45806bca9373467d90857c01227f7e2c913f29abdde9b582b13ea48aeeeaca0fcb640a7d2a4558e446e8d18efa96f30', start_line=683, start_col=35, end_line=683, end_col=50) observed=two distinct pending contract demands (blake3-512:770164e6bca1879f8209a3fd11480e7a9b2efb2d0a3fae17aac2638bed03185f368dd4605ad7360382644ff51803f64b8b221192519ea6d05de7e52c1df2089a and blake3-512:90a625ca58fab9c34e1053aea81d356cb080167f571939bfc96e0dd12ca005740b57765690c69fbe9c5c516b990f0bf62f252909f50dddb9658e6286f499a21e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "core/strings/accessor.py:81:0",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/strings/accessor.py' [3463, 3548) node=BinOp> observed=SetValue requested=stand on the subtraction floor for a CallSiteValue right operand fix=write more Floor: implement SetValue.subtract for CallSiteValue"
+    },
+    {
+      "where": "core/strings/accessor.py:1500:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/strings/accessor.py' [55050, 55075) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a SymbolicValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for SymbolicValue"
+    },
+    {
+      "where": "core/strings/object_array.py:339:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/strings/object_array.py:343:8",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/tools/numeric.py:51:0",
+      "owner": "bitwise_invert",
+      "message": "write more Floor for this Construction: owner=bitwise_invert blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/tools/numeric.py' [7871, 7880) node=UnaryOp> observed=NoneValue requested=stand on the bitwise-invert floor fix=write more Floor: implement NoneValue.bitwise_invert"
+    },
+    {
+      "where": "core/util/hashing.py:299:0",
+      "owner": "bitwise_xor",
+      "message": "write more Floor for this Construction: owner=bitwise_xor blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/util/hashing.py' [10101, 10119) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise xor floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_xor for GuardedValue"
+    },
+    {
+      "where": "core/window/rolling.py:444:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/window/rolling.py:480:23 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/excel/_util.py:270:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:77fa23ab05294cc4bb059e535c3e5b2466f45fa2552aee83ad4406ac33cacf35b8003aa139e23928348a63d3ed40e67da286de4e0e701a8f0ba7c393fcbf34bf', start_line=298, start_col=18, end_line=298, end_col=24) observed=two distinct pending contract demands (blake3-512:15bbcefcd8c0a6952c7dc9eedbc5708d4a2334e17af1b4e29d2a4e7d1ad605bc3322ed0f5a6fb115857bfae98dc2764281bfddf8da2e00ef7ee8f147fff59d7e and blake3-512:9c6bd797466eaeba3b29488c17c098c0d92481f9ee8b929af4a000a0d19e02335cfbb5a8843a6d1475c60306af6164e1d5b58a0a4d49bbe7e01c3794e6cf05e6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/formats/excel.py:690:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/excel.py' [22836, 22950) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/formats/format.py:1484:4",
+      "owner": "truth",
+      "message": "write more Floor for this Construction: owner=truth blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/format.py' [50178, 50209) node=BoolOp> observed=LambdaCallable requested=stand as a condition fix=write more Floor: implement LambdaCallable.truth"
+    },
+    {
+      "where": "io/formats/format.py:1620:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3a0d67b5f29ecb800108e210a523d45920cbc26aad3b198dc4d636ab2f528215e088f02c68b2ef15a688ebf3effd3dcdc55082453ea3e41b3f01c9cd00eb0849', start_line=1621, start_col=27, end_line=1621, end_col=35) observed=two distinct pending contract demands (blake3-512:d37f42f3af2a671ed832abd502478d830291147ab6f36b610329452a13c47c5de5bb4cab681da8cc7902b32d1328fa1675f5d6054f05b11661aaec032371e0ba and blake3-512:e744b90fa79f26ea519f432e7e74d502f98e484b422b3174d577df0d296045a5eb367535cc669e96ce0e3defd3e35903323db5ef796f546ac4afa7eb57b9be5d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/formats/html.py:147:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/html.py' [5127, 5169) node=BinOp> observed=PredicateValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement PredicateValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/formats/html.py:400:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/html.py' [14405, 14551) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/formats/printing.py:35:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d84a4a1d7783cbd692187c730c778b7cc3e21f909ffec3d990a5d7a3a7d6f39a3297942a300dc57e8d7eb890d18b352fa16a92a6e791113c9867ac783b5d65b0', start_line=55, start_col=52, end_line=55, end_col=62) observed=two distinct pending contract demands (blake3-512:0d120565b8b5a544d5aaeb9578ad3a92ba3eb40d59ea8cd34c4161367cde0aaaeacfa3cd074791abacc607a8e4f1fcef434d3e099a95aa5d072b2326513f0a7c and blake3-512:3d1ccd7e55befe5a90b5358715d4c6650e2febdaf3f41e16523ec47284f75490747b3e0dd469d5bcf1f50f0432be0a13a39fcc7baa442b47929f21eb2267121f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/formats/style.py:2412:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [98512, 98534) node=BinOp> observed=PredicateValue requested=stand on the addition floor for a StringValue right operand fix=write more Floor: implement PredicateValue.add for StringValue"
+    },
+    {
+      "where": "io/formats/style.py:2526:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670', start_line=2561, start_col=34, end_line=2561, end_col=44) observed=two distinct pending contract demands (blake3-512:c14327dc6e67ec04553c8ae11bc8f3e073afdfb3efde2250e3b5e627271188e1a42057c20a2b5a313b3bd451f97d0a265228c440a6e88506534721ba3012bd99 and blake3-512:0f1a2fed83f732ef1e23bfe1c014428b6670e9ab6742b5be733fe671c676ed300be529d50be815e9af83b005d27678b2fa948519d88f5f36ef502e91639f7b06) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/formats/style.py:4183:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670', start_line=4234, start_col=21, end_line=4234, end_col=29) observed=a hoisted parameter contract demand (blake3-512:9465e094ce76e0a5c548bc68aea0a8df4f29f26a569764d5d5174ede7bbd44f3f5ceaeeb794a423d713c0fae89f959b60c29e9b218f835ee165f2c6b5aac469a) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "io/formats/style.py:4216:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670', start_line=4234, start_col=21, end_line=4234, end_col=29) observed=a hoisted parameter contract demand (blake3-512:9465e094ce76e0a5c548bc68aea0a8df4f29f26a569764d5d5174ede7bbd44f3f5ceaeeb794a423d713c0fae89f959b60c29e9b218f835ee165f2c6b5aac469a) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "io/formats/style.py:4327:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [173218, 173249) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "io/formats/style.py:4395:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [173218, 173249) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "io/formats/style_render.py:2239:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "io/formats/style_render.py:2403:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ace7715a54b17df1feb200a485d4ad9cf077550b9d834322b59e2dabc93d2512fa1176dc8e4f7fcab8ac591cdc8a9112e81401edeace1ffe0291579fbc7d9acb', start_line=2430, start_col=8, end_line=2430, end_col=25) observed=two distinct pending contract demands (blake3-512:284d8701940a0375297d609ddc13e7a6bb23558a8fe844d9b00625415f9687b917fd228210a702e883b1a81da6c0d72b625d9081c881b6cc75de4b94205405f2 and blake3-512:a8fa57d91fa908643fc86f04e9188ce38f3d98f9332ad45c5ced892ea25494f53d4de383822681abc9a4f3df7441fe39b245c21b7b36dfe23940f7f199d6aff0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/formats/style_render.py:2648:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/formats/style_render.py:2676:9 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/formats/xml.py:226:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/xml.py' [7507, 7531) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/json/_normalize.py:39:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:15085b92c3e402a374b0279603c56ca6fd4c91a06636939bf7accbd3bf565926eb3d7e96698f4e3bb1166c661261a3e854d0aeb69593d42adf92bced21bf34b7', start_line=45, start_col=11, end_line=45, end_col=15) observed=two distinct pending contract demands (blake3-512:6e1cf35b905bf29d51117be4e23d3b4525a7f30e21081668b95136d4b8f8a5da141def53018b83203696808f0be2f8ac023075d6d7e7a6385ff963856e948bcc and blake3-512:acb16638a50d38a17c482ab0408820ff05edcb5bda7139a5f951db7464dc946825cfb928c7feb8e78c5e161e6d7f2153006f7785acd00db8a8c6084ffbacb243) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/json/_normalize.py:72:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/json/_normalize.py:149:15 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/json/_table_schema.py:157:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f71c43347a5666d1bce1a9b6b912a9ed7b5a03f962a0a4e8ccb6a18f3bf644e8f83e26c9ffb46b929107ee99a9110083660441fe5fee1245d9e97241241d1de4', start_line=198, start_col=10, end_line=198, end_col=23) observed=a hoisted parameter contract demand (blake3-512:cd734028f8bf206006965b572d93a1fcdcebf1a28da9b6230a62041c7ab1f32eb282add58ae1c4d6f9dae2989adb645382ab7b4acc4f68ed484fcda7a0a14c0a) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "io/parsers/arrow_parser_wrapper.py:172:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/parsers/arrow_parser_wrapper.py' [6668, 6695) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/parsers/base_parser.py:306:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "io/parsers/base_parser.py:324:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/base_parser.py:386:19 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/base_parser.py:391:4",
+      "owner": "ground_type_error",
+      "message": "write more Floor for this Construction: owner=ground_type_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/base_parser.py:427:20 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/base_parser.py:449:4",
+      "owner": "GuardedValue._map(subscript)",
+      "message": "write more Floor for this Construction: owner=GuardedValue._map(subscript) blame=/home/tsavo/pandas303-audit/pandas/io/parsers/base_parser.py:527:52 observed=two distinct pending contract demands (blake3-512:228b3b8433afa08c9cf5be7dd7ef453c99cf5a54512729f1a389d37d2d60708168adacc84199152fb9fa2dc88ed1984d05748a184fe5ea98ebfc1539a0de10f6 and blake3-512:7061ea59268f973b2f13b510fc3c326106b9317171b806e838db02b1c7c132c5f6f4e46182880aed3e0a9b8b3c8794fade48b36767175866cffb9ee3f03cfe22) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/parsers/base_parser.py:608:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c22b67191f3f02fec81206ff8136ff998d6d9f6fefc0d6d39b530c92716c03c976930ef63b0b8c5b0372f013b606cdc8804dce670951a2a610175e6676ae24c2', start_line=624, start_col=40, end_line=624, end_col=48) observed=two distinct pending contract demands (blake3-512:92053e4167c478c9953cbb96f30a115ed688c85578359a115275b11fe41384b187826e3a1f9d7d082626ccdc962f50c9e7bf05cfa85ebd04adb2bfbad5aa4e88 and blake3-512:2358a488a575d5abdbb1be72a1b2bc05940c9425f3f82c181ab3936140b2fc7c6bea14237c39aa5285ccbaa13a56db2044f94fffdede6fc78d8b50e6f7784d01) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/parsers/base_parser.py:836:0",
+      "owner": "collection TupleValue",
+      "message": "write more Floor for this Construction: owner=collection TupleValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c22b67191f3f02fec81206ff8136ff998d6d9f6fefc0d6d39b530c92716c03c976930ef63b0b8c5b0372f013b606cdc8804dce670951a2a610175e6676ae24c2', start_line=861, start_col=35, end_line=861, end_col=50) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:a1a46d9a4e1c81a7fa60fe6555d533015567f71bc350ada35aff8dd9ef6caf3092709e0f3aca7e61148da80a14ae2df5deb31ccd1fc00d9cc564589a2e0016b1 and blake3-512:aad9dba9f5d21dffbbe02eb19aa56e36dd57fd7e06b6dc9d0ec5a485156c9101578a884b09cad9c9674192afc6f9cfe4f97b2bac5a192cbf241285a39774158d) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "io/parsers/python_parser.py:569:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/python_parser.py:706:36 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/python_parser.py:824:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/parsers/python_parser.py' [30963, 31047) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "io/parsers/python_parser.py:1266:4",
+      "owner": "ground_type_error",
+      "message": "write more Floor for this Construction: owner=ground_type_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/python_parser.py:1336:20 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/readers.py:1719:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:353b1ad55e8bed6a7b4551def06bfc6730c199249f6e39a10ad60992cf2314ced91e11945996f0cf6996d1ae012ca0fdf9d3640a3f933bdc2ab91e445be9c1c2', start_line=1808, start_col=20, end_line=1808, end_col=40) observed=two distinct pending contract demands (blake3-512:3c0a27545fd76eb45899dc84317c4b24a622ab6f8046cc585dcf29c5c8388f14ffbe3a9ee660493278d4970c368fb902430c2a8f10f4a005a6461d4888beeba0 and blake3-512:815d5109e742fef8beed6e934caab246e8789e51f6c7771569d8113a9b280810565bc61e9509b1ed841a6e01bbe8dbc525dc7299fd43774b0b8b9b9f5b91d3b9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "io/parsers/readers.py:2269:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/parsers/readers.py' [89699, 90039) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "io/sas/sas_xport.py:138:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/io/sas/sas_xport.py:156:8 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='python:dict', args=()), _ConstStr(value='_', sort=PrimitiveSort(name='String')))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='python:dict', args=()), _ConstStr(value='_', sort=PrimitiveSort(name='String')))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "io/stata.py:441:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e357752723c313ce44ee035a98d4e78f5578b175881f1c2108e7fb218a9385a9cd9552c45bf65a073bb4efa206ff5ba02c3570cf7b3c4f6a7dd0cad1a60f0db2', start_line=545, start_col=20, end_line=545, end_col=29) observed=a hoisted parameter contract demand (blake3-512:b4377a476b326767e4e6b8509c42b3f47222672a95b5cc832a39efa3091a8edc71ff74c70e4b96ecd66d442643b561c8435e79aadc652df38a04c3e5247f9054) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "io/stata.py:1338:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e357752723c313ce44ee035a98d4e78f5578b175881f1c2108e7fb218a9385a9cd9552c45bf65a073bb4efa206ff5ba02c3570cf7b3c4f6a7dd0cad1a60f0db2', start_line=1339, start_col=35, end_line=1339, end_col=48) observed=a hoisted parameter contract demand (blake3-512:1e72a48f1fb35a717efcdada26ffcadf0b0cd78f0fc09718099c57940d19ac9d8fa6d003ce022280c6fb03fdf6211a3452af306aa5879ad0df18640c90d5e0a3) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "io/stata.py:1601:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "io/stata.py:2248:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [81635, 81665) node=BinOp> observed=BytesValue requested=stand on the multiplication floor for a SymbolicValue right operand fix=write more Floor: implement BytesValue.multiply for SymbolicValue"
+    },
+    {
+      "where": "io/stata.py:2961:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "io/stata.py:3165:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [116005, 116035) node=BinOp> observed=BytesValue requested=stand on the multiplication floor for a SymbolicValue right operand fix=write more Floor: implement BytesValue.multiply for SymbolicValue"
+    },
+    {
+      "where": "io/stata.py:3203:4",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [118170, 118180) node=BinOp> observed=TermValue requested=stand on the subtraction floor for a GuardedValue right operand fix=write more Floor: implement TermValue.subtract for GuardedValue"
+    },
+    {
+      "where": "io/stata.py:3504:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [129665, 129693) node=BinOp> observed=BytesValue requested=stand on the addition floor for a CallSiteValue right operand fix=write more Floor: implement BytesValue.add for CallSiteValue"
+    },
+    {
+      "where": "io/stata.py:3610:4",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [131820, 131839) node=BinOp> observed=BytesValue requested=stand on the multiplication floor for a GuardedValue right operand fix=write more Floor: implement BytesValue.multiply for GuardedValue"
+    },
+    {
+      "where": "plotting/_matplotlib/boxplot.py:274:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e4d84c95db3aa59677ca268907605e5de98d2b8f7b63b12f47ad8d4e2c9b98268dba688b7fa585278eeaf9ac8b80e56c33dd026f3c2ab8806cd795c36b2d57af', start_line=278, start_col=24, end_line=278, end_col=35) observed=two distinct pending contract demands (blake3-512:51a5b2eb84c68139eaca5b5bc2cd9c3241baf7f63677bc187007e912c1a1a43b16acf1aa875b0474cceec3fdf2d687a049160b219b63dec10545fe76ac7cd715 and blake3-512:b3b7317b90c27be85a28bc14a97b13d0ebe709a4d11dfe8dc94899b98ac439c837b98e6752755328341e2ae1ab33f604b7e9416f94861e5e0b475417af5f010a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:139:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d559deffd7175659afa5c03fed29ae46f40c745ed4b9a6a6454c3f0d7888d4857d8e503e0557e1458b0861ee4ebce4bee8057e9d0f4b12fa2da18e6788853537', start_line=192, start_col=68, end_line=192, end_col=77) observed=a hoisted parameter contract demand (blake3-512:f1395aab975e9bbfaeb0d39f7510e105e4a6d0ac76faecd0c4061384008bf7f08b90d2037b762366045218206288ca342bd3af2e490aeef9082f54b6e90e35db) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:582:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=ComprehensionValue observed=ComprehensionValue requested=ride under a guard fix=write more Floor: implement ComprehensionValue.guarded"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:1119:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d559deffd7175659afa5c03fed29ae46f40c745ed4b9a6a6454c3f0d7888d4857d8e503e0557e1458b0861ee4ebce4bee8057e9d0f4b12fa2da18e6788853537', start_line=1163, start_col=22, end_line=1163, end_col=31) observed=a hoisted parameter contract demand (blake3-512:b9c470961e632a91e6c22c943f1fc8cd4ffe4a9c2a9a98710b0510a48cfbae3e37c0f51c24e2e5acdee914533e7a935be3e60f3a48042465ce9b7e0a2fa02860) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:1315:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d559deffd7175659afa5c03fed29ae46f40c745ed4b9a6a6454c3f0d7888d4857d8e503e0557e1458b0861ee4ebce4bee8057e9d0f4b12fa2da18e6788853537', start_line=1332, start_col=16, end_line=1332, end_col=23) observed=a hoisted parameter contract demand (blake3-512:21c05fbe9061330bf35e54c8c4429ba4ce0b4240e9537d209ec0d6a1a4bfd01346f37b5a26ff9ffa31e2c1239bc7f59892b5cb1d7ef9309c7a868250bccbbfb1) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:1462:4",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/plotting/_matplotlib/core.py' [50749, 50755) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "plotting/_matplotlib/hist.py:493:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:92bd3094197fa9d0eceaf882f440f2535ebe231879f294f57c0d2a4ecbd5777730331dac81a587a214c0471995aaa2cac966ebae1d56dbbdbecf14f354444a04', start_line=537, start_col=15, end_line=537, end_col=27) observed=a hoisted parameter contract demand (blake3-512:647c873815d9c7f46e3d01dd1ce745813316ecd1755569afab913b8420a6d787c69899df0fd9b7ac4ad00049a7beee2df6af0fcf0b949b9b06b93ebc9b593743) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "plotting/_matplotlib/misc.py:345:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/plotting/_matplotlib/misc.py' [10421, 10903) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "plotting/_matplotlib/timeseries.py:227:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:595036af5873c5512667ee163f7fe06fb018683a3f28dd150c1755f282a63f78751323e003556071241ea872330abbac779c4a511e0dbdbcfd181feef2a0bf73', start_line=252, start_col=24, end_line=252, end_col=32) observed=two distinct pending contract demands (blake3-512:f8a9a0aaa960ba6170f341e0b453ed6139358c893583221b1159851d03c99cd7cbdefd8ed418b8a458654a1288367e84a10d42282a184b676bae2cf4ec9cab3c and blake3-512:b9626334642d5ac92be0c95de5e08db1ce07f9fc98d26637419b78020e3dd638887c475ae2ae7f96adb2389207f9e12ce8b25ae76d890fd315112d050c9db6a5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:683:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ef8d292c92cf672a5bdaeacafa0d68c4da034b6091b0f3614626e8ab42279cf3ed90c698ca525801048d8b804e460c93a190774162c487369e4ce71c3eb7ff4e', start_line=686, start_col=34, end_line=686, end_col=42) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:2c99b90606f2fc024393f8c75db10af0b38c79468d5985069b1541fb91bf9287eb93a878eda5570ef060971a864082a57766fbe63a54a238fbb3daf8e3d121f9 and blake3-512:35a5a0be1b9f6630b818dfdae94af74dd5cf553dcc9bd6f25df389abfcce90096f93710ab7130c9df8ed9694e634e98fd692f4f3d2785cd4a94106f705bf2be3) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:685:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ef8d292c92cf672a5bdaeacafa0d68c4da034b6091b0f3614626e8ab42279cf3ed90c698ca525801048d8b804e460c93a190774162c487369e4ce71c3eb7ff4e', start_line=686, start_col=34, end_line=686, end_col=42) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:2c99b90606f2fc024393f8c75db10af0b38c79468d5985069b1541fb91bf9287eb93a878eda5570ef060971a864082a57766fbe63a54a238fbb3daf8e3d121f9 and blake3-512:35a5a0be1b9f6630b818dfdae94af74dd5cf553dcc9bd6f25df389abfcce90096f93710ab7130c9df8ed9694e634e98fd692f4f3d2785cd4a94106f705bf2be3) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:707:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/apply/test_frame_apply.py:721:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:727:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/apply/test_frame_apply.py:743:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:1102:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ef8d292c92cf672a5bdaeacafa0d68c4da034b6091b0f3614626e8ab42279cf3ed90c698ca525801048d8b804e460c93a190774162c487369e4ce71c3eb7ff4e', start_line=1107, start_col=15, end_line=1107, end_col=29) observed=a hoisted parameter contract demand (blake3-512:38329f733f96088be757cce0367863c774916c3765a8b0184c99ffd2c34ec78774598109547e640547def25a5ae94f589e54866dbc0c8552af211d6f3b3333fe) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/apply/test_invalid_arg.py:202:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1a2b00ed9faeb66823b5bf57d534f5ec309cdf5201045bf43b199fabd931e597ff0d207c885c936577ec06e599da93a29f8497c97c1e03b94f3224923e997889', start_line=203, start_col=11, end_line=203, end_col=19) observed=two distinct pending contract demands (blake3-512:17f8b64f176c6611a5eb73ba289421660f91bcd5f19ee7b275ef1273a0562112b986ed9b1ef15fe57bd9955e25f41281a9c2b1a311621a052add6772f86dd20f and blake3-512:7ef36643181c72a324dfd31639f1d24711e34b63cf0303f04c9bf71b07269b80b482fcf5d5db521b8a881af927efdb50c2d979b709a2a1f4f75d84997169e8af) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arithmetic/test_datetime64.py:2349:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f90275ed88819ecede1bf68a5d30d41d0426d135c84e06ab0d183424fa16fb8c1d88345c147ca769acb675b8e2e662aa049d081b8434f3d6c47bac7f936b1905', start_line=2353, start_col=66, end_line=2353, end_col=74) observed=two distinct pending contract demands (blake3-512:9dbe9964096b93dd6e3e2d53d6527f226bf5eeb3b86167b1bf33d960253b35f2a8c7785eac5144e8a6a473c30ea4ce8346c5f3718790053c8f645d1c2e6ccba0 and blake3-512:8afada7698b4157f81ef2d43b1d241afc7ec6803229d9758ab86d24c2827277e643d58d7aa015144bf4504e3cbba92c1cee86f57c426ca5c96be1787211b78bd) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arithmetic/test_numeric.py:821:4",
+      "owner": "divide",
+      "message": "write more Floor for this Construction: owner=divide blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arithmetic/test_numeric.py' [29643, 29663) node=BinOp> observed=BlockValue requested=stand on the division floor for a CallSiteValue right operand fix=write more Floor: implement BlockValue.divide for CallSiteValue"
+    },
+    {
+      "where": "tests/arithmetic/test_string.py:247:0",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arithmetic/test_string.py' [8140, 8152) node=BinOp> observed=NoneValue requested=stand on the addition floor for a CallSiteValue right operand fix=write more Floor: implement NoneValue.add for CallSiteValue"
+    },
+    {
+      "where": "tests/arithmetic/test_timedelta64.py:47:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arithmetic/test_timedelta64.py' [1181, 1279) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/arithmetic/test_timedelta64.py:1257:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arithmetic/test_timedelta64.py' [45890, 45946) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/arithmetic/test_timedelta64.py:2225:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f1795139f36189f3a45bdda66760ae63c131255eb6cbf619ef22cd554bb75bbe9b33f851a5f8d5541555438a3ed48111183a7741e6c7766839fca0032df71383', start_line=2234, start_col=59, end_line=2234, end_col=67) observed=two distinct pending contract demands (blake3-512:2f5aff5828be8bc6bf588cfac87a07605f428471861e97305dcfce1871e7b8877098c9ff2c11aa442ac85551f9262844a12470f9f436ed05c05f943ed341f8d8 and blake3-512:e29cca8a41c1c622aaa30befca5c4d23e3c89e89edead9b087914571ea57a20a62953a03bd661bc40855e874f808ef8bc519a07c8a63e37d13765ccd90a2202a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arithmetic/test_timedelta64.py:2254:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f1795139f36189f3a45bdda66760ae63c131255eb6cbf619ef22cd554bb75bbe9b33f851a5f8d5541555438a3ed48111183a7741e6c7766839fca0032df71383', start_line=2260, start_col=67, end_line=2260, end_col=75) observed=two distinct pending contract demands (blake3-512:5d71a3d13a00954027602375b6d9d9acc61ec1a189f62096b58e4f603a657ae42afd8449df30aa1df19ab8d40dc6ec21ec4f557dabf6b36b6dada3b4a2db5645 and blake3-512:51d528e1850b24f54509b4eac5a3c2f71e64aa4253f6297d1656b307f21cdfb7d1cb15eb40818546bf2786b47d717a94d746c737f9f76cc27b813c34b55ec057) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arrays/categorical/test_analytics.py:101:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arrays/categorical/test_analytics.py' [3439, 3492) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/arrays/integer/test_concat.py:56:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:032c93ad7be85d08ba1a05c5ad2e9d327a4f9007c14d6dbb91c8cd39938fe7af33603c2278e07ff27b3329d791e4f46b09592f6bc85cb6adef8717c2fcf3702a', start_line=61, start_col=42, end_line=61, end_col=61) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:e80d47a8afb85e879892d7fc23ee7031502edeecfad23dff9f934834b6be95068c68a0c82d0df3ecffaabcf8a131ea550112906cb7f0457fd9f6e9813925502f and blake3-512:3c3c0f94bf061fe55f4a913dd40b81d0178ae2f9f19a1500974de73280401e369891ee1af9a9c3d13b52731b371141b81e7d0d5edff66384f1f390bfc25cd934) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/arrays/integer/test_dtypes.py:62:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arrays/integer/test_dtypes.py' [1678, 1776) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/arrays/integer/test_dtypes.py:78:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arrays/integer/test_dtypes.py' [2119, 2207) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/arrays/masked/test_arrow_compat.py:70:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cc8033fb8ad5bd580f394a4f7401680edf8a047dbbdb1fb7f0efd06b53eb4c9626dded7113578cb2b3109408e4120831558f8a9cdb76a2947d982c41c547ef68', start_line=73, start_col=28, end_line=73, end_col=37) observed=two distinct pending contract demands (blake3-512:ef3d892f414a7dbc9b2660f6ac1e693772d8c0a35f8250f7a080e123823ca9e246a149dfeecaa2c5f54da82ddb4fb2e9839d850da8988f87ea255040f23e3264 and blake3-512:411012abdc96c93f881e9a03c29cdeb0354eecd45a458b299c2b96d504561142ecd92c0e8ffdf0a8fb0e729db6a236e330e9f419f42673cef97f8090972daa31) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arrays/test_datetimelike.py:217:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f393002003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00', start_line=223, start_col=50, end_line=223, end_col=57) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:ac5cfb8b25582454feae02ce22d4a368bf64e09dfbc7575a79b212285b84e49b7d99c8adf2783ef6e668ec4ad318580350f83f2fab62cb485a75a22bd71115c2 and blake3-512:baead57a9e72967ee0b02f264f4ed52597f6cd3f8c322269de0ab42248f3a2fd49e244bbf1863ab87436be366c79c9fe1f501e90fabdecbbabd05bb96da590ac) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/arrays/test_datetimelike.py:246:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f393002003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00', start_line=247, start_col=47, end_line=247, end_col=55) observed=two distinct pending contract demands (blake3-512:a8de9f9ddb0b6625630003b2e130858d15b11e5b2b4cb3b03a7c0a34d1e2bcb503681f7539b87d887b599407c0cf548a0e7e700db72e6ee87bd984796c6be68d and blake3-512:85cd8bb4b407c9cf4a749c346c74e6aa33b78362dbc3e27910704df7da437a6086c817bca3aafc2056bbeae645b507133469b6e0c4c7adaf5781042e918933fa) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arrays/test_datetimelike.py:394:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f393002003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00', start_line=404, start_col=21, end_line=404, end_col=29) observed=two distinct pending contract demands (blake3-512:005021e65e8be532462c5d7debf8ed551cc84fe9f9d6c92a116968fa3b061af9f52253ad7d4695b2ac9bfc03b1bb1c0431291a7e5cae4f374f5539b5378a9d7e and blake3-512:8563d1f78d78041bf83d32e0e876de1721a696e58cb1eb50a2884ff29af554da6cdd5d6e8e5d726063c86571740dd93b135a8db1076d054315426637a81107c7) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/arrays/test_datetimelike.py:563:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f393002003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00', start_line=567, start_col=18, end_line=567, end_col=26) observed=two distinct pending contract demands (blake3-512:b53add227a91ae6827f6c7dad9fc17ed4a7bc010b1e0c85303959c244c85049833ffd9f28423ada336aaaeeaf5c6b4b80286d56d33ecae27cd8db847a07fe292 and blake3-512:366c603b4f323a3669c8107474006e942287792f66064069f91dde4f985e3910e8b44ee3f228cde596b2f56f9d43457cce184bb981aaba2db6628ea21f813f7e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/computation/test_eval.py:599:4",
+      "owner": "unary_plus",
+      "message": "write more Floor for this Construction: owner=unary_plus blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/computation/test_eval.py' [21911, 21916) node=UnaryOp> observed=TrueBoolLiteralSugar requested=stand on the unary-plus floor fix=write more Floor: implement TrueBoolLiteralSugar.unary_plus"
+    },
+    {
+      "where": "tests/computation/test_eval.py:846:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c7a53c52998eacd64f8634930528d3e9bccbfc9d18957e998556bfd6f718e3a80cb053c0f9534169fdeb4e136c41c38a919b5feda7a15cb0a5b607c0662ee99c', start_line=851, start_col=18, end_line=851, end_col=43) observed=two distinct pending contract demands (blake3-512:d5a81f6553578f5d01a0c3c05a30f8240ea480fc1a067fde3d4bce65435558394992069dc21262f1d14f76585cd423d27f35a08e8f19cbdaf612ee66e1ede63c and blake3-512:b1120a657744709c4c40d919ccb62cc61a09a0be46e4abfd91a2a6d3b5a0163574c15752abb60462adf4744a7db969ad8840632041fd7791262d8ebb7a31a65b) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/casting.py:46:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:44e3d72778de58b4c77dec07fb49da77c0f30dac99af096368fbbbea23b13ecd6a1470c3427ab21dc02876879581a8f7ce023874d647ce22f604049b517a68b7', start_line=47, start_col=27, end_line=47, end_col=35) observed=two distinct pending contract demands (blake3-512:2e451a3f3b2c237b7be70ad78c4112ffaa71a594f9ca475a16818a589dc62ebd1a558628d2c441414da16e6b9f9996c14755d585e680b962954684b20211b62b and blake3-512:bb43b9d348b53d52564d5d43d8e0e093194f0cec59f3b7ecdf037d49f33dd16cbe71b9fe9717d0c48bb9c04f40a5e1e9662fc7e2c7afef586d2a592bdc503e9f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/casting.py:58:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:44e3d72778de58b4c77dec07fb49da77c0f30dac99af096368fbbbea23b13ecd6a1470c3427ab21dc02876879581a8f7ce023874d647ce22f604049b517a68b7', start_line=70, start_col=32, end_line=70, end_col=40) observed=a hoisted parameter contract demand (blake3-512:dde758a668a298163979a9cd9dc6e2e79c8d9f257bff614c5c3f111f4310cefa706a10442722b8e6b19ca419012e97601c56b14a54a2748233b79c35329098a0) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/constructors.py:19:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1306392a279cdc82982b0c6705f29fd2f4f3af713d6b9ee905ff31771f4e1ca43adb885f6523fe29981872049326e0ab558991e47be57c837744693d110a1377', start_line=20, start_col=28, end_line=20, end_col=35) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:27fcd1ec7926da15c408a3c41e4dc7084061132080c31dbc7ff7e5d71116130195ac9dfd687e227dfb74a9585bbb725555ab9e16e22441f8af8e167a2a6d85cd and blake3-512:160ecd845e46d564495d014647f853d7488b93787d986bbdc9e4a04da845a2b53a84c75c20ba9574c08e8edaa2e026b00d2e3d5ef6f51f6faf10a7a7c1885dee) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/constructors.py:53:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1306392a279cdc82982b0c6705f29fd2f4f3af713d6b9ee905ff31771f4e1ca43adb885f6523fe29981872049326e0ab558991e47be57c837744693d110a1377', start_line=54, start_col=17, end_line=54, end_col=24) observed=two distinct pending contract demands (blake3-512:dd4a055ce5bf85a90135a08d034ef714efe91456acd8489928cb3c43945b53c6960818be20b89624411656c6690d70d323c37812ff3666bfc4bb7ccd96a745db and blake3-512:baf5db4eaf46163aa298b19e86609a6433d494416fb04319818acdb5d06c54dcd0e4122754927ffeb3aa95b8c44e8a9241b738674484044f5e83a9965ff4bea5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/getitem.py:155:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:598aa6d222052a972d7e2fc564c1a67619057c9b50be2138c46b12f87ecb5c605189274559d3a4112cf9b3cd3924af6705657c37bcc8c3c9c29efe7199be72c2', start_line=157, start_col=17, end_line=157, end_col=25) observed=two distinct pending contract demands (blake3-512:e71e3504851dbe15d7c8535ace3e5665d3fbd52c852f724864b2eba939b575eced70ea2710696a053c63c2bde9f91f1ca134034dc3a9afc083f8c5a6383a6511 and blake3-512:ac0af9bf16fa8499c38fcf3eb4ab045f840789b385af314dc4d67e8edb8fe9faff692fa13ad1752f4506e70a1a10e6e8aabb5f54d7c91d344f56312641066f81) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/getitem.py:217:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:598aa6d222052a972d7e2fc564c1a67619057c9b50be2138c46b12f87ecb5c605189274559d3a4112cf9b3cd3924af6705657c37bcc8c3c9c29efe7199be72c2', start_line=223, start_col=17, end_line=223, end_col=27) observed=two distinct pending contract demands (blake3-512:c0d487b563473cc318dc39843f07410986e33ad2e4481abc57c6a449448eb4167ac2ab6547b3a02d8511d6333d9320e88e17a8ecd0ea02172b2ba0b89c42365c and blake3-512:93be97ea16c734eec6edeb1dda18b48e575a0ef6d1d48809eca15ac0a1e93efe8a24e5628b21489308af7fed7107a402483f31f92e7db67a836e9b1a82e61cd6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/getitem.py:286:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:598aa6d222052a972d7e2fc564c1a67619057c9b50be2138c46b12f87ecb5c605189274559d3a4112cf9b3cd3924af6705657c37bcc8c3c9c29efe7199be72c2', start_line=294, start_col=17, end_line=294, end_col=30) observed=two distinct pending contract demands (blake3-512:83e8cec3346414d72e5b1a91fc0079e7f4f9186513bab4580cffc3122edc6c5d881754924e47b9a21c83b647e59183bd21011bf0648fc0b443161e1b51f12560 and blake3-512:9a6b388941695be1272a6e134a65c6f21f78519a736d4f7f8e3cf041e1f6fac63f0a46040b07bc3cf70eb5be46e88d37bd212ebf9495e92d34da33194ba6d9cd) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/getitem.py:384:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:598aa6d222052a972d7e2fc564c1a67619057c9b50be2138c46b12f87ecb5c605189274559d3a4112cf9b3cd3924af6705657c37bcc8c3c9c29efe7199be72c2', start_line=385, start_col=21, end_line=385, end_col=36) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:9a6a738a98366f5ee898038961d84569beacd5ec6bcf07f8d8b8913bd8c3e482256e25a6e3772ecf20d1422b5451b24ea8946f66da4a4bbf2d0799fcd98f4f9d and blake3-512:88b7fa5dc22ba823cf8f71acf3216fcd798ab4c00cf7b55ffec144e3eeab3a50762c179a507da93d3d64b36fc942d52ab8e8ef83eae7b26f842c02a50f275302) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/getitem.py:406:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:598aa6d222052a972d7e2fc564c1a67619057c9b50be2138c46b12f87ecb5c605189274559d3a4112cf9b3cd3924af6705657c37bcc8c3c9c29efe7199be72c2', start_line=410, start_col=42, end_line=410, end_col=61) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:0fe5c018667c7d479e6f278c7bb5a75e8d9c67511554a689198675ba6e2e1e554ac8280d24a9996189366fe6a99e8d9b80fba2782779b33bba4d92ec7142eb3f and blake3-512:56bbc8aea94ebb7355a2a6e220b4372e8d48bf5b6c76a1a2da74b40e97bfb57b70dcd606724213bbd01b51b5b96328731dc8ff684cbbc9704749eea8c5277054) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/getitem.py:436:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:598aa6d222052a972d7e2fc564c1a67619057c9b50be2138c46b12f87ecb5c605189274559d3a4112cf9b3cd3924af6705657c37bcc8c3c9c29efe7199be72c2', start_line=437, start_col=16, end_line=437, end_col=31) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:a4ec963acf313bf7e91557fac6ffff7c5df78e42f6455a0ce48770f8d6e97da738bcb4b6f99a53a316805285fd6fcac0b6556e22d08823af03cdcd8bd0cad734 and blake3-512:b8103ba4ad3a8bf3c839f0edf0b3c8295dc515fbbf37e7fe309c36b24419ac833af630ab7f9c2427e06c66bbad770f47e45ae79c22cd693029e271bf4cb56558) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/groupby.py:96:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/groupby.py' [3515, 3670) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/interface.py:139:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:72b2cef4d9c766faadb8f24c29abf6a338ac53cbb6a6fa43b299d7fff7cc5ebae8b512e76259b79ca715ee7a20761738f74d66f007599d903ff222c67548e017', start_line=141, start_col=15, end_line=141, end_col=22) observed=two distinct pending contract demands (blake3-512:c08caa02b7c288a97690b0c0474ce642316f69a0b513957a4bfb5d237a7ba5b95d26cf0a9332c561e7f244865fa1474367cde508509df36482628be90f4705e1 and blake3-512:0e72964e3f930f04ad0d93f1186a0c9fac606dd78e1b25d86886608c74e4f7fa6d787a7916521446fcdd83918438e94d4eb89f6aca15851f9a83f86eed730b65) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/interface.py:150:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:72b2cef4d9c766faadb8f24c29abf6a338ac53cbb6a6fa43b299d7fff7cc5ebae8b512e76259b79ca715ee7a20761738f74d66f007599d903ff222c67548e017', start_line=153, start_col=15, end_line=153, end_col=22) observed=two distinct pending contract demands (blake3-512:ddea2f5d4b6afbe0f63cd0d863a8f4219db3936d1d8cad4091f2a6ca3899f8354dda2aebc385ced8b2ee7600d8861b61addcbd801cb56bc78c373bec998f3445 and blake3-512:ad23d8a5b70ae1629b91715dd261f4c74ac265a52e35c9d10096dedb77f803a8b31bac2b3db3d7a94113d2813ed5f035b5858867749bdaa9ad8e3a1f0455ead8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/methods.py:306:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=307, start_col=55, end_line=307, end_col=62) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:59c9b70f30457f1bdda49ea494784ea2d31a9072bafd265566ad4e264b4c47961dec7578422475514934922531b55f25cbbc88c54336d0071d25622d93a293dd and blake3-512:ab74c4c29c6e12b9b758bdfb1aa6276054ae384cbe6e94c967a60bf949d3ffb55c47924d386895464416cad9140a0ba513c3ace66cf3aa4c4dbed923d76bd0ab) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/methods.py:339:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=340, start_col=38, end_line=340, end_col=46) observed=a hoisted parameter contract demand (blake3-512:5501ded705b704c39b4f25f4996bba9e513b3aeaad11dea4f8432ab0fd7ffdb1d4885c3194583f9b6ea069e1388ef6bc67b63cef5a51b9316f6919104b896231) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/methods.py:460:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=462, start_col=22, end_line=462, end_col=30) observed=two distinct pending contract demands (blake3-512:b6f3f3efb13ee6c5ed00219e014e04272422d3b214766ada6059795dc2f5e2ece52ec9a71036ff28ecfaa2c5d448fce28e24e5bd48a520dd85cd8f90d6d77dff and blake3-512:b364ebaa3fb20ef74b0b84cd697bc78e087de58bf9e05f51f3f6f297324be58bd6c9964b7b335f671369a5f9279ea788a7fe4c7995a4d3428441aaefa3a177c9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/methods.py:473:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/methods.py' [18537, 18890) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/methods.py:491:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=494, start_col=15, end_line=494, end_col=22) observed=two distinct pending contract demands (blake3-512:9450f2e4407271250c42038c5953e1d5b47c7e12844e9918e164d9697110d191126195b9442e289045d8cec33ca071adac5f74d180a8f7c7ad9de3aff05bf13d and blake3-512:0aef2670727a26303096adc2ac7ce9ed3ba77637c0189f3c498164732c6f736285a0e1f6fa9cabe7bc430eb0463d9bc5fcb0e19e4cb259f026f19fa3c658cfe1) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/methods.py:551:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=552, start_col=14, end_line=552, end_col=22) observed=two distinct pending contract demands (blake3-512:cfd21bc558587d0c1df81c29285dff6d23c71f940f57fbeb4b96a6a50580a3810a7ee1971b62ad0820c63fff65601dffbdafc7dbfed176344c0dc39b520578e2 and blake3-512:461d8e8970e8407295d8f99b311bf35c7b6e552849455513b020dee2f23a03bf97b0c11ef5f45f7d6968710802a664bbdc27e142966fd4ac529796227cb4704a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/methods.py:629:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=630, start_col=15, end_line=630, end_col=22) observed=two distinct pending contract demands (blake3-512:0c1feec4b923cc46511fddf3e12f4629fce481924ac085f574c9b03dc00c37f0f1b8cb4e2487ec19963f87c898b65d8e61c0af09ba0a559e8da1cd000cfced4d and blake3-512:8a959e876e38ee75ee8c7e73ce64b6c6b51a044d470fd389c5e34941e679f3359b8ed948ad276bfbfbd89e80c693e4d93801cb6e9e2aaeecbc0e387241df73cb) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/methods.py:673:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/methods.py' [25520, 25566) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/methods.py:704:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=710, start_col=54, end_line=710, end_col=63) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:97a58d78a409feaed6b6c049d5c6df9d35095ebcd3f514538cd7cda8da680a281e476688027b981df251494422bf0fea2e8ab9917ec0737a306cd556e9dfde38 and blake3-512:c2a4b4691d75801a6826b5db825e5f46c2531a1fe83ce8b90e2240fbd6112e5df2151a3fd3fafb0e20de88c6d1936b98d2346023f71b035ce00d77310e371dc5) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/methods.py:713:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f7cddd8d497419736fc6ebb707da07eb360cf6aa65b34f653b7bbdef5d220568568975f848c922ee4b5b708a5461c974519e7eee8403c2d9b66a4cd386cfd1a', start_line=715, start_col=17, end_line=715, end_col=25) observed=two distinct pending contract demands (blake3-512:3813c211800386b1ccc035ad37733b67dc86d0cb24e75b3b2bf7b11c0495ef6d2bc222fc10185e3d04739f3b15adcab8c71252ada1388f51bb37f541e30c2e26 and blake3-512:51ba711ff07050e87665e6519e1ea27c74dd0f1d045fafdd9338dd71b6d6bad85640c5cdeed9eca25636f484a8c632b6ac7a6237721f9c776b935670d50622e3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/missing.py:139:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e51f60aa852ebde5b6b268af65a8dc5cb84fcb2ad053ba7dfe824b222a038af0453169a8a56bc45dafa80073901410878f852b84e7223d6f8d3262d562a2ec76', start_line=140, start_col=21, end_line=140, end_col=36) observed=two distinct pending contract demands (blake3-512:dba3f5405323869820b630860160f60921e8f9faa3df4abecbe5f7c2cff26f2737aec090a5058f8bb51e1c0b7a6cdd375f151372caecd5445402ebc2acf93933 and blake3-512:d7a2253d6052451966dab58a4bd30555bf4711664bc18728cdc7c12fd85d303aa45c47675db20981ea052a00a57cd517c7072a82c4c4cde58293b2dcf44818d3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/missing.py:159:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e51f60aa852ebde5b6b268af65a8dc5cb84fcb2ad053ba7dfe824b222a038af0453169a8a56bc45dafa80073901410878f852b84e7223d6f8d3262d562a2ec76', start_line=160, start_col=21, end_line=160, end_col=36) observed=two distinct pending contract demands (blake3-512:e3d0c8d2cea912e10939fcbc5f142e5f6a5e3a6787c24ae69754adadfe6283dedd88d070c8102db2a5400f40c148fa440a44a2343588fbda103e7048f905a76b and blake3-512:01ed754431c84dee407a5bb0793beeb7c90789cb1e80d8239b0d7c92e863387d21851f55c39f37b9b781b174eb206fd392998c1752a044a82e14d170733b43f8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/missing.py:174:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e51f60aa852ebde5b6b268af65a8dc5cb84fcb2ad053ba7dfe824b222a038af0453169a8a56bc45dafa80073901410878f852b84e7223d6f8d3262d562a2ec76', start_line=175, start_col=21, end_line=175, end_col=36) observed=two distinct pending contract demands (blake3-512:dfef649d3da563a39e7a44a8bb3b4524ecffb7606163a4893ec4818958e61878e67a362faa11b43282219ba9112297e7c14869950feabc92d9b3430e2ff1e06a and blake3-512:774c0ad91590a89ce64ed61199f16205fdf7f2b98b473ac79fdf64be5de1979785f1c9c315fa222c1dd0d22685de6bb130263d12ee716ab22e5fe21c2531562b) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:77:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=78, start_col=33, end_line=78, end_col=41) observed=two distinct pending contract demands (blake3-512:2f88690ba6c745d06cf44ad0540cd41c0588d3e35c35668537800aecfa2f7f36ea6fb6c0177f3174faeab6e772a03c29ea9b558a429e6ea0b15f3faa49aa957a and blake3-512:56ae7fd84b9746f5be6bee40294000a06ce56c79ba26f3bbf67e136d4689391b53205f9741166af975cb3d1061bd6773e9a3c32b3c5999801f65e1c4ea2d2dd6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:101:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=104, start_col=33, end_line=104, end_col=42) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:ec5063c0a0ed9e28b9b8eb567d77632e5dc59c160df681817254f0b35c2a1933ec2f78ec0e19d265485c86ad2d493eafb4f927b4a15100f2ffb7b34f6fa7fa2c and blake3-512:4c812ff37664dd63d2001b6483ee3fe0d50a58b52cd861f873afd44df6c9f889461fc041f75c8a5167ae87a8eb5e36507177ae30eeadcfc5035dc76b4ccc6ea0) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:114:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=117, start_col=31, end_line=117, end_col=39) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:88462a505c9ace9f3999e2993f04963cf1afe914c9a10d847c325c7d7fbdae3b4e2378222c3c0156e66e9733cf064817628fc6312c9438af04d4e80a54fb6a92 and blake3-512:82c9b7107c386d49b1a54732f9845548190532ac755e266b4bac8fbc5c134cc59c0d82ad1024085ef726a8bb066b18ccc6fb289f890b5def1fcdf1e33078f73e) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:127:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=128, start_col=12, end_line=128, end_col=20) observed=two distinct pending contract demands (blake3-512:1368d6c12722c8ba1819a2ba9a2640c9e5e31038189998b57dc35897ec737bc9ce1fed9c12013675fdd9d112349ebf40b7edee444836b245370f9216976066d7 and blake3-512:2a6849dcc98e7427d9260d7508bbe25dafbeb02d284c6dbc01b003a2b5cd2ffdb5b89ce465cb2fb4156f93c6148ea2a39c5520decf78fb4f84f0538bef79829d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:138:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=139, start_col=12, end_line=139, end_col=20) observed=two distinct pending contract demands (blake3-512:67f268d61590aa7c7e8f376449e4f6b9397f48809b1fe3f0dca93741d81f9cb50caef2ec45e0788c4da3dffb7ec86b323ffca521169a9957b21c8243423837bb and blake3-512:f57e28bcddbd0ee63f80373418e121fd582502eec80d7041b79365cc397d304d2c7ae10acbbf03932cf04f17f6f8cecf23ea90cce915d5501bb0f6a97611c972) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:185:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=197, start_col=30, end_line=197, end_col=37) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:efa3ce8b767998570dfd26a816a400f66051ff3c76a10a9a7ce99845a6ab212a22adc0beccc85fe0fd60274efd6f3e36d545919cf940e7e466311498aae71269 and blake3-512:add932c84e947e48cd5dcec16c4b8521df7d0f9eaa5f926cb723de903c486b613cbe8a53cf4d634fbe7d3efbe28bbca7c50b178a62d1955d0786614c77ff2b66) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:216:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=218, start_col=15, end_line=218, end_col=23) observed=a hoisted parameter contract demand (blake3-512:39a7ce2149139acbce10fd7f0a2823767c9cd7ee73603bbc2932658fbd63e4788e25c60abc1f1f6f13dad65be3f59a98a46705eac5f593cdd5aaf2f05d15a075) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:231:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=233, start_col=15, end_line=233, end_col=23) observed=a hoisted parameter contract demand (blake3-512:77d920be4dec6ff55f1ebcfdc899f5c2774904f346a3d9f29d7b363a7286ff4c4c0f5f78613606aa27f1478a33b312ab306d76ee675b041b996692f5956b948e) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:261:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=262, start_col=47, end_line=262, end_col=55) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:93f98418fa7d6137c627de19244b28aef63cda36b4f47b054c839a5f9b6c85eae20891eded07f69e1a2836e3aededb10212b410958e0ef9897544d5488f66b68 and blake3-512:50f03250fcd845b3f097dea67048dfb099ac3ede99de45b254a4d4ba6b68e8a96b88794c2a82b5b70aeed518adc22a404645fd707334a1c29067cd8b6c3347cf) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:344:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=354, start_col=15, end_line=354, end_col=22) observed=two distinct pending contract demands (blake3-512:bec3293dfd8660bd792cfde890f14b195306fed92e86eb9eb115cdee60c067c25b2ddfe8f847a68dcc71fd57b554ecc7fae28d3a7f50cefbb31d32521015e314 and blake3-512:a2e4f9fa337b0bf6ed6a797319481cad3c9e463b00538e4257109f5bdf87c7a03c2bbb0dee8d8ad3f46aeae94b051218b97303a61148a2717293ec818aed57ff) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:356:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=373, start_col=15, end_line=373, end_col=22) observed=two distinct pending contract demands (blake3-512:25eb822af99e9ee2ba0f03b6f777f3946d48cedbffdb0e4fd4384e3eb830524ef5a2e8f3fd1d71298b650625b010ad639774ed5e428d641b6d2a997b080a0469 and blake3-512:bfb78f943a40afab45b35b74df556bcb3f801a3eba06adcc78c6f7dbbdbc150c7ee51c0afd14a5dbbae77835f10e87488388957a91c5ebacd5c46894b8bf9272) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/reshaping.py:375:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba1ec4a2396582193fd71197f902a09feac7fe2baa802d6031f30bbe8f0679a6509fbc070bb424b6520dec58d09febf919a09e9f477240bad8e65bdcffe8cb42', start_line=376, start_col=47, end_line=376, end_col=55) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:82d2fc8c16771565ba4b7753072334f4760dfede35837f16f2d60ea1be3245fd336fd4b255c58b4178db3dd1a35aa91d89e25c556441d37e907a36ddb82d143a and blake3-512:46cc7e61d6f42e67677e72d9063d7df00aa73c53a395323311a8a3867c716836d641fd762a3f9901e5268c2d48765e4313df6e124fd60b744290ae0df1833b17) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:64:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4352f390a78f08056230616b39430b701e56061bb9835ec0085004817db68b8bd0936b7d37320e74af2283881d5178283ea25a0faa41ade240082550be1a4e57', start_line=68, start_col=15, end_line=68, end_col=22) observed=two distinct pending contract demands (blake3-512:433f4adc5bd69f1d9d58ed0f3565be396f607e37d4a3c3ef851e02803e451d7d8f581789c5d01d8d91f4e686cb615d2e1a0253bcc7f4ea6adf9f7e77fe03436c and blake3-512:e3598844ac9a358514e6e989d457186ba0652023f2652eba8718d86b2492ded0916c732cc93493426d616521996ec670474e1ba7a41b743390b9f70c5ab671b3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:103:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4352f390a78f08056230616b39430b701e56061bb9835ec0085004817db68b8bd0936b7d37320e74af2283881d5178283ea25a0faa41ade240082550be1a4e57', start_line=107, start_col=15, end_line=107, end_col=22) observed=two distinct pending contract demands (blake3-512:ff3f4e39a288bb970db8ba4aaf49860d884270617c2f9109f6472545ebf607cd5094151ea76ea8dd81880af803699393687bcf5034428d5041fcf593793a2dae and blake3-512:c51cb90e124b10f83570c1e0fdcc25e527067ea5b1c78d999c38e7bd1a7c2ea555533b5014ac4742030c8019ec9326876c09ee54b5aaee8df4165871f04babf2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:156:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/setitem.py' [5321, 5414) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:179:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4352f390a78f08056230616b39430b701e56061bb9835ec0085004817db68b8bd0936b7d37320e74af2283881d5178283ea25a0faa41ade240082550be1a4e57', start_line=189, start_col=16, end_line=189, end_col=24) observed=two distinct pending contract demands (blake3-512:e588298238eae4540e152e4ff2e1485bb2da91a013906430528bb62d7e3f9d32cba60857a35dd8a9b3c2e96e1b61a6b34b5c6e42322fd58a436f1281da9d9fdb and blake3-512:8c6d2271821d898b7c1e62fdd5afaa8fc17024b8a9dfbaa2069b504089d0425786fcd043714ebca3c214b84b57440ba42117da9c5c959f3d5d98a8a11adc41a3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:196:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/setitem.py' [6584, 6677) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:212:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/setitem.py' [7094, 7187) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:346:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/base/setitem.py' [11405, 11498) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:374:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4352f390a78f08056230616b39430b701e56061bb9835ec0085004817db68b8bd0936b7d37320e74af2283881d5178283ea25a0faa41ade240082550be1a4e57', start_line=375, start_col=14, end_line=375, end_col=22) observed=two distinct pending contract demands (blake3-512:33e463a31df61ab2be1d7cc7285a6f241df24bd644ed9968ddf6cfb9570ba7733dfe73068dc9db3efdedd4c9ac7795875da1a9774c43cf2ffe273a697040b5ee and blake3-512:0180501636adc04dbed6a3da337a8f1dba4af5207211334f3629559497b09845033a82086b007ed7d75250191a8709a77540290811a6c8019f3bf86b08ec1505) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:384:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4352f390a78f08056230616b39430b701e56061bb9835ec0085004817db68b8bd0936b7d37320e74af2283881d5178283ea25a0faa41ade240082550be1a4e57', start_line=387, start_col=16, end_line=387, end_col=23) observed=two distinct pending contract demands (blake3-512:816beb0d6274de0f458a26f9b9467912fa64eb322ca28d825b0430a68eb15a5b7522da7e404f44381ed207da441f2a39b5f76c587f7b928a26f6dee6588e8b44 and blake3-512:3866a17a4e69bc2e6a9003caa814dc95f776992912a259425d2d089f9d5b3c6eed43a7fb2e1e72738b7599eac28509dd6d13b780757316dbafafc5caf3e95d77) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/base/setitem.py:403:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4352f390a78f08056230616b39430b701e56061bb9835ec0085004817db68b8bd0936b7d37320e74af2283881d5178283ea25a0faa41ade240082550be1a4e57', start_line=404, start_col=35, end_line=404, end_col=43) observed=two distinct pending contract demands (blake3-512:389a432273b98f273297d2d70aac3d7fdd2acfb3c256966fc89a3dc2fc5b6f1a5df8bb52c3c7d7db41cc83729340f821f6f92c8329ba40a40fc64e0471148597 and blake3-512:fff9ee088900e3cfe19d697c5afc1f3f55d632c2c3b7e3d4746fcc05b933be3276cf28bba5206773687ddc62e7788fb0d1da743adae39808ad6914f735721419) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/decimal/array.py:257:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:da81ebdfc5ee57c41adee81f7f8e00f065893e2ea5343ea369da25263c98dea18b75ba0b9b5e56d6d1c1b2354d530926ea75faf8cc70957bf27a0efff37de751', start_line=262, start_col=20, end_line=262, end_col=38) observed=a hoisted parameter contract demand (blake3-512:fa2210033ce55acc11e9113e6810c4e55bf2dabc9e30a77779c72f1b7d19ad8a12be46b6299ad8118059a4e26f21de780f9cfc0f3c7f829e2b0c5c83166fe16f) joined onto a ExitSet, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/test_arrow.py:231:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb', start_line=239, start_col=31, end_line=239, end_col=51) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:97d32ba3a90b3cc60d6aee4829622175d711d6d7f1b22a130dc04e86970ac42491f4c5ba4385eca3fffb6160b1bfa4825518f47eb67b6ffd81a6429681614019 and blake3-512:98bb7fadcca9d0990ca12af0a2af4ffb9ce6558e827d7baf2e90891a5ffd1a370d8baf5069f22c356e88b1dcfb9d8a168647334e92b865330a10d0d1408d1989) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/test_arrow.py:245:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb', start_line=253, start_col=31, end_line=253, end_col=51) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:2c104c4b794df628f9affeb9a8680151b9644a81ec6b94a318e6636a5d36a54d05d2b87e49b835445f3119b6ed7d1c8309f5c1411c5848fbdd7a19ef0311177f and blake3-512:fbb4711431b05de0ca6e4c9b6956109a7c10b8fc8fe875bec3d881c8b7b73f416ee15bf0739c437cd88b2a1b3ad63c69631968a412147a69259fa00bb0bf96ed) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/extension/test_arrow.py:689:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb', start_line=694, start_col=29, end_line=694, end_col=44) observed=two distinct pending contract demands (blake3-512:b6726d9330dd20777c3a02c244a1876898f209117bce05a921be712e12729b343319fa636912b6155a20e7678de35e0f0465473158b403cf603a9cd0700af1cf and blake3-512:e70e6531473b0d8f86a4438179b3110e8ff2d18c0a2f0c07ad2c9d9d5fd848016242604659fb67e69de94bc2a60057bfb06ff142eb83416d7ed3354e631347c6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/test_masked.py:184:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/extension/test_masked.py' [5182, 5423) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/extension/test_sparse.py:245:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ad3d4b0ef00ad9253e6f2f0a4ea6ca69b77562b8b24bd52d4704326ed0a76f7c6bd955c05333cbe122b429edc85018d21802330d1152945cfb80d4fa4f575ba2', start_line=251, start_col=29, end_line=251, end_col=44) observed=two distinct pending contract demands (blake3-512:baa6fd3188c062018a4fe693acad661fce4ef614a2177e5ea8e8d724e8e7351fa3236a90e1d90bdba0b13d044c14d20085f598df136f1075d53067fac6d3a9df and blake3-512:5364f032ddaafa444b3a4ec304eb3eb3e8ef772160e52ebba392ce4bc116ad22fa2af348e07ca8e1237e8954f51b4bb5d67cd54e8d2be652d6a79cbf3899529d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/test_sparse.py:267:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ad3d4b0ef00ad9253e6f2f0a4ea6ca69b77562b8b24bd52d4704326ed0a76f7c6bd955c05333cbe122b429edc85018d21802330d1152945cfb80d4fa4f575ba2', start_line=269, start_col=21, end_line=269, end_col=36) observed=two distinct pending contract demands (blake3-512:3a0008adf64b4aa8580ab242a9219ce7b157b36b583c76d92774fe85c017a573945cb0c08526cb68b9119514dadedf0dc3858ffd65a14057f917f93d73343f43 and blake3-512:f94559b98cda26b20f84c531c5e8061016b4ef71abbb3bf5539cd421073330a072980394746e1dd2a177db75ff1ccc04f8d02a6efd051d3bc7451609881aa8c4) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/extension/test_sparse.py:324:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ad3d4b0ef00ad9253e6f2f0a4ea6ca69b77562b8b24bd52d4704326ed0a76f7c6bd955c05333cbe122b429edc85018d21802330d1152945cfb80d4fa4f575ba2', start_line=325, start_col=15, end_line=325, end_col=22) observed=two distinct pending contract demands (blake3-512:8e69a23a569b2590536a0507c6efd0702f320e0281102ff6664fe6d3417626be5f7916ea869e191f7fcf050901273b3c53178119be0896e6ff22e3e0ec6fed60 and blake3-512:24a32f5b6521e6ce5cebb9e1706e76f48d8111c4ec7ec49abf22c4f88fae0f5ceebaacd565d3d821aa6c809089dcdf935100e230f748ca556e4d0eda24aae3b5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_get.py:8:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1f931c8ae11a360c051f870f6ed032150eb0b117384b26f65340b805c0178d01036115cce31f701bed4865a591285561089ebd2791f8c07d7da0645fe267904c', start_line=14, start_col=35, end_line=14, end_col=51) observed=two distinct pending contract demands (blake3-512:df030d337e8b07b4813396914c398f155fb037924fef11d47d9c4c3c82175be81216f9eb50670cdc43bc4a60da5ccbeafa7b300ce2cb6ecff7e5b290947dc41c and blake3-512:666ddafed765e0705bb808c2a9e068f495d21a152fd4d9045ff146db2f98fa2a84ea4e14a04683b850468ff159e9094dbd43fd417c873242a7f331fe9ace72e6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_indexing.py:285:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9236a6a7f3e2a8f8653f81dfce392f36716f2f60489b83efa03e22845cde08d1ee06a8d66c554a30968289595b5d56cb3fac56c8d9ad4e2d840fa5dfdf4f5967', start_line=296, start_col=31, end_line=296, end_col=50) observed=two distinct pending contract demands (blake3-512:8e5937855367230a47f3de7f5ad50107fd5d5641a1ea0fb4063c9e8ed8bbbf2b6f79989cbdffde3c7560bb78be9db3b394e6256c95c260d7a378255e7a6257a1 and blake3-512:2ac14e19afe2eb9f3cd9d5f37f291d3ed31420c37277755a011e94eb93d8159bc34ffc93b332bdf99b8233efd6ade808e3c1e7ab0eb1638ae59a98509a4330d8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_indexing.py:504:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9236a6a7f3e2a8f8653f81dfce392f36716f2f60489b83efa03e22845cde08d1ee06a8d66c554a30968289595b5d56cb3fac56c8d9ad4e2d840fa5dfdf4f5967', start_line=513, start_col=31, end_line=513, end_col=48) observed=two distinct pending contract demands (blake3-512:3954e32602c62458e261d4e2b7b568f70dceddc740a362e7a584f40a91e17202ce33bfe3a062babd91bfcee13592dd0bce4ae344a57adf9e35415f59052a3be0 and blake3-512:d806b00a4bc2e4095a1f29ed22055d9e389c1b09ae94b6e3ebeca36b603940e25ad1e79fe2ab39c39257c16e65a82d65344ad47da6b0663973eb74b05021c145) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_indexing.py:697:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9236a6a7f3e2a8f8653f81dfce392f36716f2f60489b83efa03e22845cde08d1ee06a8d66c554a30968289595b5d56cb3fac56c8d9ad4e2d840fa5dfdf4f5967', start_line=699, start_col=15, end_line=699, end_col=31) observed=a hoisted parameter contract demand (blake3-512:79030f52c123c124208ea7e8d0825518775d232e8befadc4864abd3df06976876284e0984f671a0096c31c9d792b90436f03af82d0629606a1e8d3834899d46f) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_setitem.py:345:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:09877ae8cbc6eca519af6382a6ab383c4048f5f187f6e28e0d29b1581e52f694ad353968e427fb25ab04e665a82478fd45a998bfd0f453c06f9f6b73dd3bc5bc', start_line=351, start_col=31, end_line=351, end_col=38) observed=two distinct pending contract demands (blake3-512:929c19d999133fb721d6ac635988634735507ff06a10cbb202c85f343250ee6285bae1eac69e2cf113a345552ba8c20330c1f501b4bb058dd9ef9e8315ac214b and blake3-512:2252bb3fdd285e046a366732a636339acc433750c5f0b0ec9584e5a01db154e524cb68d7abdec5268bad41137fcc61cb1ab0e68300aa1d3ac79d2bb80a2e40d9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_setitem.py:665:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:09877ae8cbc6eca519af6382a6ab383c4048f5f187f6e28e0d29b1581e52f694ad353968e427fb25ab04e665a82478fd45a998bfd0f453c06f9f6b73dd3bc5bc', start_line=666, start_col=26, end_line=666, end_col=42) observed=two distinct pending contract demands (blake3-512:bb2d971829ef63bf26c166ed2a5b043f0d6785afb455740ab959f879f954f5a037a03d7e6198ca4226741612e37c2f3f6af352b81faa928cc904efd3e8c2a70f and blake3-512:0954dfbfcaea302363fcb79e9dd785fff929d95b57be86bbf1fde8a9a269e7933876681db5111033b07d0e004fbcbe1d7e60f0d4fe5bd429fdec70c5b5f41b9d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_setitem.py:948:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:09877ae8cbc6eca519af6382a6ab383c4048f5f187f6e28e0d29b1581e52f694ad353968e427fb25ab04e665a82478fd45a998bfd0f453c06f9f6b73dd3bc5bc', start_line=956, start_col=17, end_line=956, end_col=38) observed=two distinct pending contract demands (blake3-512:93d21f8783021abdbbc48c08b7f209710c933d507350c4e301966409445b6d2cf6812aee6cdaf6e765fb9729d5bbe2ab557f554af02d71ca90d44db8fcff4011 and blake3-512:29c747b7de2348d266f35071aed9ecad813f0eebd3281774232d350aa7c8d524c311b131f1733ec6c4c3cbb926b85c6a266034cba459e45abb700cfd4ad5a93c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/indexing/test_xs.py:169:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d8a95e69b89a9d8bc734890dcb069a5200d562e2de303c8f352be0154e8e52f2887f20f37ee82a7d65cf3a46b5ca84342969e0bfdde8bd5e5d420356e45b0754', start_line=172, start_col=19, end_line=172, end_col=60) observed=a hoisted parameter contract demand (blake3-512:bb8e06c32cc08f209dc9660746d1408de80730c9026d2036ebbe9a03498822c6f5eddc4dd051e2d4bc696d9a8f5bd257fa5c311e4cff5bc395bfd7bb596838dd) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_combine_first.py:33:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ed5286810bae691313dca97aedd45f49be8c1a8a643b9427bb30c5a201dcbb82b6d1e831022b61fae13bb7af51fb115f65dbb801c7241d4e30c4517516be9792', start_line=34, start_col=21, end_line=34, end_col=36) observed=two distinct pending contract demands (blake3-512:5ece9bbf30c89c25e00c45a40b8bc921cdd6841865817efd4367439bdc07c6ff5e969bc0b1396bcf7054e404298fae3cb7a8858e401854149e64952b42b47c19 and blake3-512:e7317cd4c96b01a486e2a04945b3ea2b7e5529b421906b3696e63ef00b986d96e6ae58b68bbec71fc81abec062898415ae4f311d280a47003593b0d747175176) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_combine_first.py:61:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ed5286810bae691313dca97aedd45f49be8c1a8a643b9427bb30c5a201dcbb82b6d1e831022b61fae13bb7af51fb115f65dbb801c7241d4e30c4517516be9792', start_line=62, start_col=19, end_line=62, end_col=34) observed=two distinct pending contract demands (blake3-512:c059ea669d59ed8826c5481e5edaccc0df4afea0b457e1acc2ff3d93cf3eb675b6662c318f1009462478a5b23f5943f4250bfc9752cb6677a135b539b6db7fa8 and blake3-512:2ad7568c282cd85e3ba8a1359ea5a61634f34cfbc81a4cbe0af711d55f9492aab0be30f6fbc1f0a27bbc1c14169d218452e61572df6f1a1d3a8f280c9bcd190c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_combine_first.py:69:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ed5286810bae691313dca97aedd45f49be8c1a8a643b9427bb30c5a201dcbb82b6d1e831022b61fae13bb7af51fb115f65dbb801c7241d4e30c4517516be9792', start_line=70, start_col=19, end_line=70, end_col=34) observed=two distinct pending contract demands (blake3-512:5f596dda9321767823d60055787d3df772adb588ec92f65ca29dc155c28701b439de87a74f9dcd54fdee1c5c23cefe2245a6d905bbfccb88b3e125a47256df6f and blake3-512:8960c84350d4b0846c72823b94cde635bfce7b63b6e5b4658f4ce39fc9a3b51afcf7dfd458ff199360a4863d81fd951a56408e305a82faf780c776a507121da9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_cov_corr.py:107:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ff49d8efaa661bda2d89f3e2199248eb2ba80f64179d7844d6313a53f20e7c42a84f7a27cbb43ebbad4e8c103c01bf3e38752282804b35ea4fcc34cea28530df', start_line=114, start_col=19, end_line=114, end_col=35) observed=two distinct pending contract demands (blake3-512:3d22b24453c4ae88695e0871954fc901ff2953a7e4f24e912973005aaea0ea7b68121d87ef78d19af74a49a52f7b0881cbb049568ee12ce3e06be8b3468fe695 and blake3-512:49046454adb8fdf1f66996040443cb49e9edea4814bbab10df6d32de13e9a0556310e309f84735ac04e4d245983138582033ba7bd4f67fbe9c551ae8f41efed5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_cov_corr.py:336:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ff49d8efaa661bda2d89f3e2199248eb2ba80f64179d7844d6313a53f20e7c42a84f7a27cbb43ebbad4e8c103c01bf3e38752282804b35ea4fcc34cea28530df', start_line=337, start_col=41, end_line=337, end_col=60) observed=two distinct pending contract demands (blake3-512:89bfdc98466cece9a6a654fcb2f9b19a307ff02af3aa31733c1a9e213fbb62e20984715ff73194095afadc0488bc9a9af99c4cbc9549ecd119fff20c4878f070 and blake3-512:86f4a0ac06dd44f1240fa7c079142fc7b6dd670ee06a4c2f335de23b7348bdd68a378d955b64e83a2a433fdd62437c205656333b0c3a21a706d0ace32db5631c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_diff.py:22:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:b35daa05ecc721a59ada723d80dbd31bb3ce0c6345ec498991faa5cee8082401a0ee5ba599f14d2008b9cfc262787fbdb91637014e42de66e88e1e2e526dd992', start_line=26, start_col=19, end_line=26, end_col=26) observed=two distinct pending contract demands (blake3-512:5a75cacb91a49606f321cf89065f598dc51e48ba7a319e2a79a947c7ce817ef165892124dff3767d067b11c0981d801a92263eb37c509d0217e58860bdd68dbf and blake3-512:b0f8b6f1aeaaab2218787b12a41ff21e53e69ed59cf65ca2dc1453ef0747a1b0e1ff89002077c39da852bad6b01f1ff8c0dda92d01ae6ce55d1fbea137e386ee) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_dot.py:56:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:644742c93cf1ba49ea10556a8bf537863a61a0b624ea1236e8a3e865859f67a8fe649af67d24edd45e06071e343b8eba675d14ce0061b290c16b807b5671543f', start_line=58, start_col=25, end_line=58, end_col=35) observed=two distinct pending contract demands (blake3-512:62ade1a3ef104e7f4ba355ba2780292c03790004259e9859759b4a7513e393c4b5355df2d512728c0d4ffcd351ee7619cb0d9d4ae1c221e517c6946aeb04a941 and blake3-512:0aa588280f0821fe981c6cee36a88322d69c2e38050c7916306fb567f4466618cfc5ebf6a7fcb7e03e4428c678f566523f6ee474bb236ca99ea96e0b2a557241) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_map.py:172:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/frame/methods/test_map.py:184:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/frame/methods/test_quantile.py:775:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f56341df92fb89d9dfdaff735cc615569132068546f498b314506a78547eda37306a3b655592d25c668bc271bd8caa6abdb9ed88036bbfc326cff6fd19556b0a', start_line=791, start_col=23, end_line=791, end_col=31) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:4a601fbf63ba0905f0415119518070c5fdeab988159342e6adf895c9cf01bcbf12460c9202618c2a0ee82a7c3e739e02e44dba75c4d8b697d60828413db26746 and blake3-512:78ea6d0234a7e0e5412c1bec4dd68ee12240c8b0e63952da46fe6310680fa4ee651e499d4da9544f98ef51aa6468f84b645ff8d9412fa18a189134b2f7aee93b) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_quantile.py:797:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f56341df92fb89d9dfdaff735cc615569132068546f498b314506a78547eda37306a3b655592d25c668bc271bd8caa6abdb9ed88036bbfc326cff6fd19556b0a', start_line=811, start_col=23, end_line=811, end_col=31) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:c6b1bfaa53732bf173990d741360805351b12a72832824342ec8fcf57604588dd19d9db8318d51235ff336712eb56ec0a19fc8fc2fafc1fc26cafc9cdfbf049d and blake3-512:962338c71cb1151ebe17acb7a193212fdff5113c151d37981f03854bd64f1ed7ff5f6a3208513f5183e658a67a6e5a950d77ab76bff69996d90aeb0430d25218) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_quantile.py:834:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/frame/methods/test_replace.py:194:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d79d9a22446b446d430ab340e3cba8ef3a8f66a1c42a6815937973fc17e5ef970ed7e11d6bb579a522ca08c2916cd9a51d6dc691d3d31808964ab0d5273cdfb6', start_line=210, start_col=70, end_line=210, end_col=82) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:2ff8f3c677e3c1ba5cd7ec858da324e0d9a896e5f7c467f3a2c330a4b2cd3072f0678d52a61947b78fab54a3b78b04ff9a87b91013c1f4ff42e6427d3f24f607 and blake3-512:53877dbc8ffa4f8c4b2d6a30fbb7dd4aaa243d36816fadc76f4e395515f3fe6f7f4032a15948ebdcdbcc11ffd49405fcd1e9de32a55a8c25e8526a2b8410bcae) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_replace.py:263:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d79d9a22446b446d430ab340e3cba8ef3a8f66a1c42a6815937973fc17e5ef970ed7e11d6bb579a522ca08c2916cd9a51d6dc691d3d31808964ab0d5273cdfb6', start_line=275, start_col=70, end_line=275, end_col=82) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:3226845def09775492be1a271d4e48ab06eb034d8a0cd2c8fee0c8116952e35b429d152203982d73a3054e676d66b2513c70824476ebc3fcabe30566c3f774e5 and blake3-512:fab00cf3c8bb6f90632e1e4c8081d5f04b7a6f8acbbf2615641d158fb27765a57e36f49f13d2a2f4895833221c2f8cca2f72fecd892bf0075dbf9e2b781e81ef) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_replace.py:321:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d79d9a22446b446d430ab340e3cba8ef3a8f66a1c42a6815937973fc17e5ef970ed7e11d6bb579a522ca08c2916cd9a51d6dc691d3d31808964ab0d5273cdfb6', start_line=331, start_col=74, end_line=331, end_col=86) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:f7e8822bb43e674457d38869444cc4e6458ce22723d4c98078ca0a1a0413612a977a935e2c54e977d4877d5a5642e2a3ab03dea98faa48c8d34cda1900392e9b and blake3-512:95fdcca042136d6ed888196afacbe21be69e02b713f41556186cce06d429009393e4671c62855ef36c62aac54652b53bddddddb512b23c16bd0bebb3de0979be) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_replace.py:353:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d79d9a22446b446d430ab340e3cba8ef3a8f66a1c42a6815937973fc17e5ef970ed7e11d6bb579a522ca08c2916cd9a51d6dc691d3d31808964ab0d5273cdfb6', start_line=365, start_col=70, end_line=365, end_col=82) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:243a2521419eafa8fb9ac32bf24d921adc3ee37c2921cb9fbdc8432c4e7ddc8c904194141d3098f13991590bfe28858f68375d416a50f7058828e958c67c75d9 and blake3-512:41017ec0398428aeb69c93dfbc8455236801e1620cd7405a0e51c6e319e8b14fa94ba152b54c56a3d38a8991b4057c2b0f752b425e052f2740eaa8500ef5d105) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_replace.py:371:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d79d9a22446b446d430ab340e3cba8ef3a8f66a1c42a6815937973fc17e5ef970ed7e11d6bb579a522ca08c2916cd9a51d6dc691d3d31808964ab0d5273cdfb6', start_line=373, start_col=72, end_line=373, end_col=84) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:866987dfd3184b71c5d373f1dc7858876ac946dbf8511322339781d4153a996031c1287b04f84d50c82b5cbd6bd189bbf440d3685543e576e42eb28300227193 and blake3-512:6070ac5c2631eca0d2633a3c8a54065ed7a883fe8b35cc55b83971ed8b1863e9326dd3d30f9a3abb239949c93c1e1ca5ddda5f8fe053f9a8549046900fbbe5d7) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_reset_index.py:622:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0060c21832f1b77ea4bdeb23ce86d3c8be324257aa2bec258c9e01f7d072fea493dc27ed660d3bf5f95948c25d8b92443519f08fca8a83f42cd2fff8ab223db8', start_line=634, start_col=50, end_line=634, end_col=58) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:a20981d4cb590d4776ad5c5c32a703a117f7c8d220811bc3da74b997d536469e0eb47518367b6a3b3cc1fdfe00a5bd21df61b67446b057c081a961d5386fd092 and blake3-512:f8c41b26b73f999cc3b95d5ac8625957718b7e1654a83ba4202cb786162962b9449ed8287032e9a981f62f4546345c71d85adb56bd4622982706d6faac086b16) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_set_index.py:198:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/frame/methods/test_set_index.py' [6522, 6683) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/frame/methods/test_set_index.py:220:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:2a11919e247ceb210e2e40ebaa7a1df58968dea51befb305e90f9017f331add133f3bd39c7d01e450058a2553dabc4ff745dc1cd18da1d0c0aa585fa42266568', start_line=225, start_col=26, end_line=225, end_col=31) observed=a hoisted parameter contract demand (blake3-512:939d18e15106676f597dd5c8106c414b4eea0979faf0257086b74ee41df48644950125ae3f56c9c4c4f1ffac83889fcc3812168a83dec0abc0de4a9070c19b03) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_set_index.py:362:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:2a11919e247ceb210e2e40ebaa7a1df58968dea51befb305e90f9017f331add133f3bd39c7d01e450058a2553dabc4ff745dc1cd18da1d0c0aa585fa42266568', start_line=368, start_col=36, end_line=368, end_col=43) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:d6d9be4d08cb96cd5141f01de201f69742714993e864aedee37ff93913f36835dde640289232031d884092f8c4c861f6a421fc0214c96c4a36d0bf1180a2ba45 and blake3-512:10e80e7190ee95c3438f74e7ee00bb32b3557ab150d96af0ff04559af896b698c029a1c0ad8fecfeb83f129fd44afc7291ac68303c5070f7179c151ecab1f0bb) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_set_index.py:396:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:2a11919e247ceb210e2e40ebaa7a1df58968dea51befb305e90f9017f331add133f3bd39c7d01e450058a2553dabc4ff745dc1cd18da1d0c0aa585fa42266568', start_line=398, start_col=48, end_line=398, end_col=55) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:f9c782a20c3c355a6ffeb6b7454d46320208ace8f693918a06e0902bad6795a5541f137a290694535e950be8d665f9f70f1a8d4bb8594ccee57b8c6498347800 and blake3-512:574554d9ac8d3eda8e7ecab6bac8977fc2312ce7361c1c358d063963b3d72a9e075388be705144ea649b9399da667147c3272684d729eee2b7dc76b9a6613f0c) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/methods/test_shift.py:405:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/tests/frame/methods/test_shift.py:420:16 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "tests/frame/methods/test_sort_index.py:741:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eae03036cc5145f079a72caf07f38c75c4d4128a721201bbb872999e5e2f71aad468ed0b4956791d317d199f9968fee83fbc503576c0de421b054111bb3aa89a', start_line=754, start_col=21, end_line=754, end_col=37) observed=two distinct pending contract demands (blake3-512:bfa27e0169215ee158590571ae4deafcb9d10ba0c90dcdb105bc1c34f8fdb8176476b5043e2a5970044ec028cf1aab5a98f1b7023bfb6ac180efc09c1c18dc23 and blake3-512:ea400e224ffa7e585921bb0241ea4cc116cfd7e6c9c9fdc6ecedb8d362914a570c7370d0df4964e508c2770190108236c549155e7982c262ef84bc1c1eb18e02) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_to_csv.py:472:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:b883131ba3c733863825e3ccbff49f401907034741cefdbb4dee4cdffe7fceed9f928fa4e09ee4459293198e753fbe9b4e01ea334c5bf26922c7e1c743ecfec1', start_line=476, start_col=31, end_line=476, end_col=57) observed=two distinct pending contract demands (blake3-512:303ff2a7bd6076b6dec38473b304302e6c834aaf299f01982829912465f37ac36a10c8565d6572fe2befc2e85ed3c90f722d7f1792b3fdb5af998b1ea4567580 and blake3-512:99650f5c88d667b1f1ff56442397fe17cd06b1fb2558897fd39b40de4be76343a9648ded5240497f92c231c4c063eb37f06a90cac624771bff95cc6f65828322) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/methods/test_value_counts.py:162:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:32d34b3b2d42f5c810df59db20196155ea1448ed1ea28f0be7d0928af6d51a2c40f90db585aeece7a613d1c7135d4d9c5eddfc044040c1f84a632aac2a71bf28', start_line=167, start_col=12, end_line=167, end_col=22) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:f3f67bc2afc558f40347a8569fea641322ea08f371ddfe5844eebd835a14e4acf34a796531805f18bb3a5140d40523de2167dcccd6a0a87e3727ca19f35feada and blake3-512:2a48372b8aad0b66585be6775e118136e21da90196a25e32a2376f63f02d9ed614b126b6957da08534e436bfbf1d2102e50b4eda19ab7b5dbdf33c1dc7a741a0) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/frame/test_arithmetic.py:1503:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:99e72897b98223584a172214eb7a580a3dde9257a187d587159fe7716826edb568d360b58342ab5bde1be4354aefb135e3e6b95686e013aa4ec8e44daaa8c4c3', start_line=1521, start_col=24, end_line=1521, end_col=43) observed=two distinct pending contract demands (blake3-512:a32646c3da380cdf36059e8d83d8527296cd2870bb9dd1559d08fe6e70e7fe59fe6a56e9631de4fb89ca1d3ba174b0f9e3388e249fa481c097273d5a8bd91620 and blake3-512:57dd3006c60c1def01b9f23e17ceeb28a5df246ca05beae6ddf030778bae529062b15bd8388315d93bcfe66b027c58d54f8589b1d6e53fdb4f3a267b27033912) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_constructors.py:865:4",
+      "owner": "dict.subscript",
+      "message": "write more Floor for this Construction: owner=dict.subscript blame=/home/tsavo/pandas303-audit/pandas/tests/frame/test_constructors.py:883:27 observed=missing concrete key StringValue(value='z') requested=exact dictionary post-state or exceptional exit fix=carry exact dictionary provenance and intervening mutation testimony before deciding KeyError; otherwise keep the missing post-state construction loud"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1261:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1263, start_col=24, end_line=1263, end_col=33) observed=two distinct pending contract demands (blake3-512:741d014aae6107b44100877c25b802a6c0faefdda33a5499d54a33eec064e5b0bdd70011ffa1bd0b31b8146eb46a520493e92d6f929857eb4d3f90220152d978 and blake3-512:70ca11d6a1a312350b8613fcb29d3c12d57bc8d68a9e30510e6f616e53e0c9cfb99464d31b84ff8b36d3fde2b5c685b7fe99d773673255bb59157952020efc93) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1266:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1268, start_col=25, end_line=1268, end_col=34) observed=two distinct pending contract demands (blake3-512:80f4fdbbdcf2212b3f9e1c72296d390252318a2408e5021e54687c35842b2aa9454ec4c9469a4a915071725694cb36b766c5c9fb4505aa548ad9bb975d5f85d6 and blake3-512:0c845a76e90feedfda31cffaeebecdd5f6d5239844d10e80b50534a20099956a77ba4ae2eacd61e0f2af0de7fe131c60e983bd8feca3725502e87d1481088f7e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1271:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1273, start_col=17, end_line=1273, end_col=24) observed=two distinct pending contract demands (blake3-512:e89a5e9801648baaf04952ad0ce88019f03f2b34ad916ae0a085fc12c3642086523b6adbb71426f06685c6f0515995a8dae7e03b743ea85c5bd50f93ddc3ef63 and blake3-512:d3d29e79af72b898e14ee67196e959f6beea4835d2b62ba1d90cd87412b09692f6dccd896a3c1155c2e506536ab17e6d4657115fbb994d04b6629d2774d6bbe6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1276:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1278, start_col=17, end_line=1278, end_col=26) observed=two distinct pending contract demands (blake3-512:d71524bbbf3bb69099afac0a8ca9640f70be91cd871174b0c54407f20ca5e684be4125ab194611af1abeedde52fe706588421c3d805d518a98beedaf5595cce3 and blake3-512:64763520a5a2fa53b0b5cd962ab07fa394e4a41717f965d940bf18a4e0e537ef799e7e2b420dc4ef620e35037cf8d5d184ad0736cbb11c2af1ea340039958630) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1281:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1283, start_col=17, end_line=1283, end_col=26) observed=two distinct pending contract demands (blake3-512:a30573449ee1ff1b2e758661885c7736d1142dbc7133d5416e03912faa45965517719650a048a91574c9b56d5ef2efb5f9d3fed244eee85b1d09b61a549b7f49 and blake3-512:61c7b2af76fbd20fc2db272256b8325cfd003e9a2cde70101356bcd218150e8a3cb9e030736f32e3156d72974b2c33293c879c124e28d63aac6f207d44198db9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1286:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1288, start_col=17, end_line=1288, end_col=26) observed=two distinct pending contract demands (blake3-512:63dce9e34680e0d81f863eac0f1fa419467d97ed26c3f2970e838753d79c6af67a2cb61f21a6f806f5afe018371f8b98d6d6b080862de2b29f2c580b6f893bfc and blake3-512:087ea5151a2bb673319f9b99284a6952b11142ef2d9283a18bfe85f5baf95ce7194a6ce89eb5bad928b23d8e09b1f326eeb7c6b49c06440b9433b61c8219c7e0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1291:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1293, start_col=17, end_line=1293, end_col=24) observed=two distinct pending contract demands (blake3-512:d4eaae370c1bb12f284fe57d2f6642efc5b5ca2e457bd0b053d594fd07170159a6e4217ae726bab73ffd92d6659f029fc5f9382e048d0d47478f812c816b0616 and blake3-512:50f0f799607a277825f7d45af00c216957d02027362b1382d73a71402c7f9064ea5f688244695a7afe738f7583fe1a805ae66a685fdf3cd5c32457074af63e8c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1296:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1298, start_col=17, end_line=1298, end_col=24) observed=two distinct pending contract demands (blake3-512:61be4c3cf4fb5a6a238715c954c6c00d1b3d8837b21757edb0bd1fa0cb53308fdbeb55007d6e82e785824db28b9aeee7a685f4abe7c9d0c2ccda92c3c7d3fc97 and blake3-512:52e7c54192fb977a36eda247662ecfb4bac62c5bd817c288b693c34c1cf830ef78df8736862243f0deb119639c1535e3b62967037da726a21f92dbac8fbc7578) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1301:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1303, start_col=17, end_line=1303, end_col=26) observed=two distinct pending contract demands (blake3-512:b0a4b119c3bd0299140d2c2112f96d019068f298ee3594ff924b0ebb02a3fe522a84bb02e3b4dabd0beddd2abd2ca4353dd6448c2b69805043ba47985b3b83e7 and blake3-512:e8639bbfc6f546212ee9d4bb3541af0805eda2c0abc3cd1b0373382aff354fbec2b336d0b7f885799f3fa8ebcdab5ccf72846769459999e99add820404719caa) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1306:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1308, start_col=17, end_line=1308, end_col=24) observed=two distinct pending contract demands (blake3-512:21dae4b72a375cf2e04f1365d1b4c2810be28dc9127ac9c679519f2ca222ca736435988c240b4887bbc8cd1adade3da48c337e54706afb462b5ae78dd9b2645c and blake3-512:a9a24c6468d1ea5434f4145532d2d3ac8486125bded6c783ccc02007db83d1d6ddf76e71d640faafcd344f90ab08c96631e0b7a91738bfaf288ae5530e15a563) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1311:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1313, start_col=17, end_line=1313, end_col=24) observed=two distinct pending contract demands (blake3-512:f0c3e7d77ba2801364d7acf0a4396362ddf6cfc43943d6fb4954ca79114e57b23299866d0f12510040e0620a13404e3f609ccd143c4af59129e47fb867fd066f and blake3-512:c06417ab8380e47f635a48572c9eac0cfaf7e2a244772ca053246955616228892b8261df97d0ee524500f4ce46c4215d0e41888377eca65c10e4cfae46cf5609) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1316:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1318, start_col=20, end_line=1318, end_col=27) observed=two distinct pending contract demands (blake3-512:7c8eec149faa3a78108a49594d699d98a487b55c33851dbdf932878c83a7d9f024973aa3df9819f14038b66190760bd7ccf02f4aea87de8d53a676c3c3293583 and blake3-512:228bd6ef9641972aeabd7c47d2cb6fff2dc3da9183434a98c1f3ec2a25bacf1baf982e72b853e4ee6b801705f4fd1a9bd895b17ac3578e7959197a8981b54a3a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1321:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1323, start_col=20, end_line=1323, end_col=31) observed=two distinct pending contract demands (blake3-512:767a05ec80bb951007045194186a342b00e8dbf86c72a44b3e38a1112809c289bb60a4bacfa1fb513bec94f09e2205ac829a876153088331fe91997f2b5555cd and blake3-512:a5b2371279469f32ddd84f82fc33fcd6b34bd157f8d79511b8a52dc000131e6b85ea36e217be6c3f552e6d7c06275887fa67093758fa43aa787b74018133f6dc) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1326:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1328, start_col=20, end_line=1328, end_col=26) observed=two distinct pending contract demands (blake3-512:8da6d702ea5ae279bfb0765bd92c811bde5f8896bcc51b4d9887ef49d5ad1def7fce08f4cbd93b44357c2f183d31d49e338c4ee5ddb6485c25d7a13c00068e67 and blake3-512:46e924b9a14abf0865c0f6ce9cbefb1c29eb363b5b5f564673eb5987f1ca42433704ce7ef94f975a06ac3f180b65250dc3738cce3c38eab95c98368c16388b26) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1331:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1333, start_col=20, end_line=1333, end_col=30) observed=two distinct pending contract demands (blake3-512:86d3203fba59c1ff6a84b91b78aff2f0b1656d9fc7b97101af3cec520c39bd6d6704952dd87dfdc39dfebea02f7c3ad7706fe9b194d76767c9f0ed92d7ac651e and blake3-512:b6fa2cfb73ae75f855fc2ce2c9e1bbb68f717bb79f8f8321d7584b6203039b16f8c5f170b13b6ee117389142d614d2d2cc5f0d6864ed1b5af671dced68384690) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1336:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1338, start_col=17, end_line=1338, end_col=25) observed=two distinct pending contract demands (blake3-512:424cc64f6be617e3d1c3a9240114e396d47a3aa870d014e7614f5060f08a2fd434a5f778e35afacbc44574036a31d550060e3b3c85b302f446d3bed6e10d9d31 and blake3-512:92bd44a936c9400ae17564d2a58e30afeca1ffb91a5852605bff300e06a0166f01fb26d2b26da43a1060d97727fa1fa2eed798e7ae47d706ffc78ecfb3538ebe) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1341:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1343, start_col=20, end_line=1343, end_col=25) observed=two distinct pending contract demands (blake3-512:fab78aa639c60f98e9b9fcc39d62e2071af2fa9d53c648b191602f5a54ad5eec2fc893f80839cf8207f2a624c58063d036654c816547094f1d73cd83916e8215 and blake3-512:704315f5c701814ea15b98e5f9b7f10b157d2d1368c8f0ed05d5178e991e477e31bd940da483307355ad78be57e5c00eba76e82a54bdfa95b30964488d48af57) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1346:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1348, start_col=20, end_line=1348, end_col=52) observed=two distinct pending contract demands (blake3-512:046ee4f7929e69432bf9cb38d8d41abd29af0b5e3b352676feef168356feccfcad8420fd680812a04b518c7e976b5bb8292dd6246f01e19a0d41a199fbff0ada and blake3-512:d4fab5b80b06ddd5285f7dfb61428a4ddc9e0f871a2ecfa2873143442d783cecd0465d5c28bd7f77e0bd61dd4cbb96f5bf0c3eb000a3795dc9f0d45cc5c50753) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1356:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1358, start_col=20, end_line=1358, end_col=30) observed=two distinct pending contract demands (blake3-512:0a92a4b89aa6357416457706715806a4e8a3450271a192683911c4ccf1182c44b98bc97e5828f7e8a1550db377ee4c5e82a0b78de4ad1540e0e6fef8daade106 and blake3-512:aaa8a29df3240217384865ffdb2920f16554e1f92a0a2af5dc5258333c6d4069f01762c871db48f7c488ba4693d69d4e6e072e4458310010df9e5986257873af) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1361:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1363, start_col=20, end_line=1363, end_col=27) observed=two distinct pending contract demands (blake3-512:45acea393bb8102a25310d7790264622a15c79737ea9f4bb979650e36458e9a742a09a08aed24e6c74fd52622d0824bf95b798864aec2fd4d80a0e99e07ece58 and blake3-512:eabe5b557fa60eb7e091af196dc26bd229c83a6f99d1796525dfee6b2d4899d0a42c537fdbd1ca012054eba9fb0a0562bd7b7373c9959741f40e43a8bd1eb200) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1366:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1369, start_col=20, end_line=1369, end_col=32) observed=two distinct pending contract demands (blake3-512:c7d300e2913251107d1d4a9de007ff001a67f38000a25aa5455e31a63f22fd174f843e65f5ae070943e6ffc6fa4634bedb36bc5fd6aa7d746b1a29c25d648897 and blake3-512:5e32130b33828f69b8a23a876e0528eb5021b6a1d132c016513ed2fe00b792ad8a66701a6e0698732a1af6cf72fcdf67e143b5af1b18654475f8052dea87601a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1372:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1375, start_col=20, end_line=1375, end_col=43) observed=two distinct pending contract demands (blake3-512:fd7a596921ebcc5d0c1212d572b363238a482bf275237afe49651b2dfae8340e4749b81087504dfced51ee3e69ad3ca70641e8c5035bcb04c760556f631f794f and blake3-512:ac2b1de522e8cb1b6f583061e375bcfc117ba551605af9d2ae1a5f7262eafc0502c8ea35c7389932dd383eb11efd2fe635f9d0d92df303757b7f0abc82175522) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_query_eval.py:1378:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:972b8778cb98f54960e516972f7767a0bfbccffbb1f5c629615a9da17bdb0773bfa721386ab1e7bf6737863d3a3e5864dff58b381914e5fa6e5fc1ff818c6b45', start_line=1380, start_col=20, end_line=1380, end_col=33) observed=two distinct pending contract demands (blake3-512:779516bbeaeea33cd682f854e969a5d994188b126ba9fe13d4c9e6c4bd0ce8033aa042ff49efb6696d6f13f8a9e172e369b30b1de966a7a3962f0362213e5d4a and blake3-512:6a251b56c379b4a281bfa1702c32496aff34207b94f21bfe43b42e2915f0dd3454b43293daa0f3baa547ec3e37339a2b93604a840fc42f5908fa3ba65ebe905c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/frame/test_subclass.py:749:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fc059a034b5b47681b111cea2ba6fe12fe75a3fb6bb51cc0f38d07a073219110ff16230181caaf4cbcf5a668442bc1e426f99c607eaf5f9ac24035a1e45b9636', start_line=754, start_col=26, end_line=754, end_col=33) observed=a hoisted parameter contract demand (blake3-512:5bfd5c2729c0579a5ea9c266d4bf2c419ddf0a2a646dcc909d25cc8d9e4c3691f7534bdbd0b6693670abab671130c013063f2ac388370f7e02737e9b705851b5) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/generic/test_to_xarray.py:38:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:55d7ea3e3178ef4bbc1a6368f2ff434345b8f7bb8d7c5b695eff5a554830803090115f1b64b500f8bf10774ea8dc73beb6b928031caec03be0532951b93dbe0c', start_line=46, start_col=19, end_line=46, end_col=28) observed=a hoisted parameter contract demand (blake3-512:40515f111df566715b8de0917316a2b51456da7f1c7adb90d0562ba9f2441d9d80820d375389069dc7f59fcd59e2d02b6260061a2ccdb43b1c57e8a8298e4f64) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/aggregate/test_aggregate.py:1342:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1ae467b73fe1740bf3700faf97cfcb16fbacbf1cfe414144017e769d6bd51b709d82f1ac3ae9b82116d5bb504e6c8dc02f49d5dba2d00cd4686528cb51795bee', start_line=1351, start_col=11, end_line=1351, end_col=44) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:2fce33e046f72ae50f5e40a89ada8318c49f794699c26ca39adf088a30f513f4f2fc5e68fac3cfa5c1412cb8928b20d0539b16f0c7566262ac5a9d991cc7ca0a and blake3-512:caf7aed124d4f23936ce8c950e05ff1d7ef10537f304b65393dd25cb431833c5967b78b4eedfcd05ef62b167d6c1ea5ba68b6090e2161b2ceb585385c321d956) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/methods/test_rank.py:467:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:470caa6c6480dee43db1d2a14abb1c04a4033086bd62913e36f73231b6ac22300123f2b57d8e2536455129cd14cbdb85130e4a9b9bdb2b56c1cd70829c2cd6c1', start_line=470, start_col=16, end_line=470, end_col=24) observed=two distinct pending contract demands (blake3-512:87109d40e84169b3e6562fdfff4bc8a2a5aea68d77c51021523e345ce9ee9ae1ee0b49d6bb6aee79057496c947d223749171fdfd164bf726b2ce3b95c993d72d and blake3-512:7b9b93c34b7987843ef7c0bac88aa252d7d2eaaf6903439d9a6d28fc9e411ed2a1e6b7cda1dcc6cc1c80e7cbca83846290502bf7d776ac4df2da7684474e1ea8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/methods/test_value_counts.py:149:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c7d7618f868a0fca48ad31f2689c494565f0005e9bb2e40ee50613a76cdc4ac63867d8489a574800d84e28ed0556d8dd4ba7dfcedb83ab6cde4e1a095131315c', start_line=152, start_col=21, end_line=152, end_col=33) observed=two distinct pending contract demands (blake3-512:44bf1c630c0dc14bddc9f997045b01aa3a64c0d159ea14776782a2049a06e71e9496fff2a4c77bee908c325cd6caeceeb93b81c6380d07217615ab4dd1fa5c8f and blake3-512:6bfdfe1c206d2f6d7864bc4cba3a1827b48d754378dcd4ce018b210c777c6c0d0714a49fc94c703bd1029bf104360f0b09e640f0d06cbdba8fa486bfdb2d94ba) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/methods/test_value_counts.py:162:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c7d7618f868a0fca48ad31f2689c494565f0005e9bb2e40ee50613a76cdc4ac63867d8489a574800d84e28ed0556d8dd4ba7dfcedb83ab6cde4e1a095131315c', start_line=165, start_col=21, end_line=165, end_col=33) observed=two distinct pending contract demands (blake3-512:ed6334cfdce12e0f8690bd51f765e7dacf71d3ae258e910d6abe1422eb1cd5be8e3438245a71b42cbe0880e3405eb24973d4598c8a02a617121c04f62ac18f01 and blake3-512:d6f96cbe4aca076229ca5d008646ca771ad74872b7d4d6557b4685f480c41a0458450cc2185c5bfbbe27441225679fa38f44da78885f762db6780a30ff443db0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/methods/test_value_counts.py:283:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/methods/test_value_counts.py:868:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c7d7618f868a0fca48ad31f2689c494565f0005e9bb2e40ee50613a76cdc4ac63867d8489a574800d84e28ed0556d8dd4ba7dfcedb83ab6cde4e1a095131315c', start_line=884, start_col=13, end_line=884, end_col=47) observed=a hoisted parameter contract demand (blake3-512:f4e74f7468a07b3fbca33b054674fbafd61e7992731d1a5b184082dede467ad3be5aba1215617eb422ee3abb5770fda6165fd12493a4a77da6dfd47794b227ff) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_api.py:148:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/groupby/test_api.py' [5861, 5888) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for GuardedValue"
+    },
+    {
+      "where": "tests/groupby/test_api.py:210:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/groupby/test_api.py' [8413, 8440) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for GuardedValue"
+    },
+    {
+      "where": "tests/groupby/test_apply.py:147:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/groupby/test_apply.py:185:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/groupby/test_categorical.py:1270:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f', start_line=1274, start_col=56, end_line=1274, end_col=67) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:65f231cc2f5b383ec48e1489e603bc570b32a65099158409e7fd03fb318fafe4c1c70fb3f5ba2c406fca3c268d742d68d5eded11743b2830fa58065aeb420afd and blake3-512:77e5ef6849edbafd71e02d9d5c1fbc1511a2b6746e254f23337300be95135c062f2b49c4c1219dbd60b982895180a52640c978becbfde3f7f2c9f5204bea9465) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:194:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=195, start_col=12, end_line=195, end_col=29) observed=a hoisted parameter contract demand (blake3-512:49e66febd5bff56b22e1cdb64d1fa1bed36ccc588469617120bd120b39e7c39e7ed0379025d98e299b82e7c8aeb1396e8d96dcbec14a03ff40678f92c84b3d21) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:204:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=205, start_col=12, end_line=205, end_col=29) observed=a hoisted parameter contract demand (blake3-512:5abef137d65bd72a7ac5552f995095b56b24361d6ea88a015e215395055ccbdfe96536e657ca063074392397b1c0ee47391287cda19407d1b2068bb0fa35d2f5) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:212:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=213, start_col=12, end_line=213, end_col=29) observed=a hoisted parameter contract demand (blake3-512:3058a3490ece6c0914a3e140cd890a075288735db095db68aaab9231418275f36621fc9368b7fc8a6380cbe72fdd6571a9d87ea190666764df641c04419a4dc2) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:337:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=339, start_col=11, end_line=339, end_col=18) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:ec68a98efc0cdaea866abc35f99f5c6c9771cd0bf5c52297715974b4af347ba9c45839fa0809b031c3dcc72909cee2ba0ac95762f9ba158bcbc25abd4c19bfba and blake3-512:b6bbd680f0995312ba23928b155d937ffcba46dc0d514a9bccbe0efe78ac190fe83e63f16d6be70950126725599d76617ad2ad4f0fc3caadde5e922b0555d678) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:479:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=505, start_col=43, end_line=505, end_col=52) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:a66fb1841bf27d829e37fac9ee271df423fd0e20fe5dd3fceed15edcc4a43c82c1f9cfd99c40539fe67c8e64beb7d1201232d56499e340edae63c5e9297fbcc1 and blake3-512:37a5aac5a42df47b8030cdc34cb496cd3a4e2e5f6e91dfab2b14686e1789815a5c2405d9591ee2b4b5fb8efce2e77fbaacdcbb0fb77b680953e1a31640ab608e) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:974:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=975, start_col=25, end_line=975, end_col=32) observed=two distinct pending contract demands (blake3-512:9c01c15675335b924c081c663b45a8970ec884845716850bb98125bbd619daaa0292a025b2a5d65f672ca30fe5b17a48ff77f0a8e35305c6cf05107794e55708 and blake3-512:d352c21045c007d87aeef0c0923b2efe0bc22378c525669aff11d6d88ca94a28b366e468d8445c04e554b42c3e0f2afe400e3ed40f91c2e3c38ef115ac1d7458) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1003:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=1009, start_col=34, end_line=1009, end_col=41) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:1d6874dfd587ece7bd2419beab5c0f8403b8d4756e3307858af0ebf366d202dc65271eca442b2d6564864c798a5333e8dd5315454493d9773c94c625f22ef9c6 and blake3-512:c84d91dc7b69b54ee05b010fc0d14d7ed62aae63e6cab5a0e27f364695fdd6636222ee81b0e5b5ae23309be1404bdd7773486109f857cedab522d775693ce700) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1382:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=1384, start_col=8, end_line=1384, end_col=24) observed=a hoisted parameter contract demand (blake3-512:eedbfb9671562ac40a6dd4908c931cffa96d497f187a3a8d027e9d751476bd79b0b66b9bae759cac862194e5950f02fdf76163126ec856762895ee1d418ce234) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1458:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=1463, start_col=42, end_line=1463, end_col=49) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:7adf99d208330b4e5cf39ed7ec4c25c144b533316bd2f878b054c5c0ff45a86373035a66cc771dcfe598add501ce55d8795c9fb4f6ee803fa93e32793a46882a and blake3-512:78cfe2ad255298ac029fe74a002762495b57d98859318b3d0d24f5adf75cb52cc4d7dd25730faaabd024db842e25ed859381292079b60209855f4c3ccb36c11a) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1488:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1493:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1498:8",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:2793:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=2799, start_col=12, end_line=2799, end_col=21) observed=two distinct pending contract demands (blake3-512:2dc1d1282106577fd5d09bc0bbc10facd45f504a3e43649d577d0875bd4cd9eb663d1a4fee347dc58f6927ed3707f870f15014bf3eca5f12743bcb3929a6167e and blake3-512:24b2a6fe41db8479cdacac099365b6883c1af2273629f0e01382bf0d09371d590a9c9379843581d6e6304d8c5be36f00b00c8a27841aee096d459d88bf2a2038) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:2809:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5e41cf36a53ecc9380c419d2b8bd1ed866ed2ecd4ab8b4e86959cd4a3a8770a38555d341d77d23989923e415b4301f99f66e7d6448d94e728c5159c2f4af8a9f', start_line=2816, start_col=12, end_line=2816, end_col=21) observed=two distinct pending contract demands (blake3-512:49a8d9f256fb2a271bfcef1c07b6dcda2d9462aa7df1e85492675a0db7b804d4299ccdf75c80c29bc654e5c5d21f58cb43b7a5690ffad44cc7ec6cc732a6bd23 and blake3-512:46306de74cd3dc0e666ad9764e5833da4d8930bb6e48384e8bacfde0df1d5d73c7394fcbd31b3f9785aefbf118eb04f98881063798a5f125404e9ce0220dd3c9) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_groupby_dropna.py:322:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9961631f59071685bfe76e19df54598939fc573b636277943add0f96a9d76b6c165ddbc018985644222c56d687e4eea981367195b59491d2ce0f85dba7aea647', start_line=329, start_col=26, end_line=329, end_col=40) observed=two distinct pending contract demands (blake3-512:199322ce08f1813e4a877f6a2be763e3c5c7a6a21bc839458ae5f99d3851598fda16be4e248ff9bc5a5a8ca1c67ca0020073ad6343a3e16345ec703013825b60 and blake3-512:60903749afbba8b2f89a3afebfd6a9d6d291c7858bb024967e06cf05a18832035aa8ce87d6b881b04492bdda3d092d518ba87af6a208fc8ea0a48b02bc6e0e6a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_grouping.py:1124:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9053d983dc89db0d3396179a6a9b3bbaad85d0e77a6bd481c8d1efcbc31aac611f8e764a6fd8204b132601a2247fea66c710ae0aa6d22ee8feac180c97f10abd', start_line=1127, start_col=18, end_line=1127, end_col=25) observed=two distinct pending contract demands (blake3-512:f84860eae21a313ac9c397512891653f9d4c4cb3541184fccf7ea46a467463bd90d232be65994b82a4a062db964d21c65ceffbabd3ca765bef9a2c980b49594f and blake3-512:b6219741d4d918ad261e48f28ac4784fd9c163c4780160ef367d9cbb4ec2bb80b96bc8bc5d23139b532c3737bc596a6b81d5ac22a8108cdfabe66499a6b56ce2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/test_libgroupby.py:121:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:517a1ddeeb474a6eddfedb67e3bc461f2297ae6888a3ca0b769e93a74f27ab003ffc9eab4602028d843a71b5079edc481dfd35ccc57386a9ab48248a7e9d27a4', start_line=135, start_col=52, end_line=135, end_col=61) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:06f7d9efed1264f3a7496cd18199c82a02af5bc6e8e6ed0367d26ba1f6a8fb4302eef2c275126d0f58030ad8a8d284ee5cfd6a83788bd7ea5aaed8edae404674 and blake3-512:22c2f57ec2fde034f77aea577b06e16edeaf197e761c0b6c2c56d518386ed6dc0a0f727ffa070207d55b3983f7155f81e093a6798df3c6628d343e25f1a1c734) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_libgroupby.py:132:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:517a1ddeeb474a6eddfedb67e3bc461f2297ae6888a3ca0b769e93a74f27ab003ffc9eab4602028d843a71b5079edc481dfd35ccc57386a9ab48248a7e9d27a4', start_line=135, start_col=52, end_line=135, end_col=61) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:06f7d9efed1264f3a7496cd18199c82a02af5bc6e8e6ed0367d26ba1f6a8fb4302eef2c275126d0f58030ad8a8d284ee5cfd6a83788bd7ea5aaed8edae404674 and blake3-512:22c2f57ec2fde034f77aea577b06e16edeaf197e761c0b6c2c56d518386ed6dc0a0f727ffa070207d55b3983f7155f81e093a6798df3c6628d343e25f1a1c734) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/groupby/test_reductions.py:357:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/groupby/test_reductions.py' [11450, 11628) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/groupby/test_timegrouper.py:941:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:155ea7fe58e03921df1b8090dab1ed971eb9938a3430de9aac27e9d7724a4c4ea88ab76cdd7eb8e09485cc72fb729ad9a1028b7d319609478e5b95692e989329', start_line=949, start_col=17, end_line=949, end_col=31) observed=two distinct pending contract demands (blake3-512:1ebba5c52de5edc723192a3c9410a5fdba3cbc124763aa18220b0ada812f1346c7b34bc6023a1dd16d949bef0e506b233a88a943c7d91642d1c77c58f3082870 and blake3-512:4c4fd29a72807a20b8dd348ff1a030b171f2ceafc32c9792f18d500ebd299de3159a78ccff57e960e088f66ff102a5cc8ce655a984ddb04252af52230b51d901) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/groupby/transform/test_transform.py:361:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d2c9f650ba45f5ca5126386df1b1acc041df14a9e3650f05ee7c85fcd342256fccf8ef9c640d41b55bc8eae08a27f1345beb40fce73b8a9297897a03958340ea', start_line=365, start_col=16, end_line=365, end_col=30) observed=two distinct pending contract demands (blake3-512:8d4ab1c37ea924ca070e4d96c384eaa915575917021d7e2bc7795da0d04fb737c706605330c32e8ed8746bc811b6dda84c5fc0ce0335682b7cc270d7781f8cdc and blake3-512:4488418a1c43030f967eca151def1cc8783f44272cf8fa4f594f533ebd2e57d6c3e885fef433e330c204f49273c37c42da2eb84d1d10d206ece4789a5881579e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/categorical/test_append.py:16:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:2579ab03f8351d655907bd7cf394a478691d77e310d142772631582fdf76a27624d9e13096f2195787ee11659cf811cc151ba3368ba07dce7323febc10d3d329', start_line=18, start_col=17, end_line=18, end_col=23) observed=two distinct pending contract demands (blake3-512:7ff634f948768b0386dda5e5819bad5b1b2a2825f4425cd8d1fba199a9caa2abec4699e3899b2b83d6eb9df530ab578129c517b060c06e52c7b25e6e8f12d6e1 and blake3-512:3a4e83dcc5f374bbd28bc8253878d4648767a0453416f4f03d0ce1dc5fa891ffdbcc833fbb9d58b0216175c4355f116b7f1e3d816e13e568066df0f0a7f884d3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/categorical/test_category.py:89:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c51f9d28bf5d5f5ff933ab3501e5e50fb0d33e1035250fd8e76ef6a8c51f9bb2af18dd05ffc07f876ee499203ed4673785682302f2e4ae04669bcdc8a015b97b', start_line=107, start_col=35, end_line=107, end_col=42) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:e99d778bddb172a1f4aac242e0f06bd7c0389f3d0e10439410e61ca86f46aef87735c7ee0b885bc207129b6d2210e67af8ff3dcee21c31d9ce8edf8616168253 and blake3-512:353a9aa46727f460fc93f2721121d9a113ff0a717280946933087dcf56142ffda45fdae533d21fccea4a551683255034a520157b0f41eae745d545a104bef132) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/indexes/datetimelike_/test_value_counts.py:32:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/indexes/datetimelike_/test_value_counts.py' [1109, 1196) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/indexes/datetimes/test_date_range.py:52:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/indexes/datetimes/test_date_range.py' [1744, 1867) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/indexes/datetimes/test_ops.py:30:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f782dc99979a30f7f7e5454f5b35c2df78790885cd6e7472e23aaacfd55259a85d85f886c2ee6e238d52d9db6d2ce50c1b68dc08b87be376c711fd051b0bc00a', start_line=31, start_col=12, end_line=31, end_col=19) observed=a hoisted parameter contract demand (blake3-512:922db38901ef5a858705141b3ed3ce614cfd0e64a22b7321de71f3cd1d77f07fbc1edea1eadee5b14a9e24917ff1a42f0bc02dd2dece4d109cbcea39c098d1a0) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/interval/test_constructors.py:215:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:226bb6bb767ca9e4ad3bd5af3749c2c3b5f0c8fe4a6dcd30893097dfa4a8fcf7d9f71b40f19bf06f8dce520f63d8eb36f60640ea29fd3e09b9ae68afbb017f3b', start_line=220, start_col=46, end_line=220, end_col=56) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:1f96ce1cdae5bdc70facb6a4ce01931899fae2ed44e285e3b232d586d206e6a421c8f7f41a257076cacc70dd8c253b136939fa7cde0f529468a2e0fde7d9b4b4 and blake3-512:4bd22ede7d82ee956bd19e9ef1671bfa73106683a6808df01b27be14e52d0a23b4ef9dc393db28729e9e844a86a631812f7201342465b357b672b96998008892) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/indexes/interval/test_constructors.py:325:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:226bb6bb767ca9e4ad3bd5af3749c2c3b5f0c8fe4a6dcd30893097dfa4a8fcf7d9f71b40f19bf06f8dce520f63d8eb36f60640ea29fd3e09b9ae68afbb017f3b', start_line=336, start_col=26, end_line=336, end_col=37) observed=two distinct pending contract demands (blake3-512:bb7ac65fbb60ad739b53920401ba9b98b4b3ecbe2e5be6df272413c9dcd504326957faf8d420c4eccc57844b8df14581e5a52b8f2bcd535f0262ea74c9d68988 and blake3-512:c18897ad9041cd810205b7184255047458dec751f32495fe7e88d4bb76766953be4649c991824ba0fffff2d313c215b5d208e58e299f4a0a1c2f719a61e02ddd) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/interval/test_constructors.py:376:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:226bb6bb767ca9e4ad3bd5af3749c2c3b5f0c8fe4a6dcd30893097dfa4a8fcf7d9f71b40f19bf06f8dce520f63d8eb36f60640ea29fd3e09b9ae68afbb017f3b', start_line=389, start_col=35, end_line=389, end_col=46) observed=two distinct pending contract demands (blake3-512:e101a9fd5ad9221fb985aefc9061d985f864930946dcd27cc888d19a3a153925ec6bc930fc1823ab3da027e095d6b6b59f526088b65b444ea3157a6fa352e041 and blake3-512:5f2448358f9126b4f024b7d79ff5582279193615fb0cac9e7cc26e00f15600c8f7cca71825a1e1b14f57a0501dbf9cfe2cd4c34e9edce398d4eac8631d65dd78) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/interval/test_indexing.py:224:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:241912033cb937167f88fb4b4ebbd7173b08edb01812dcc05e7c6ab394b337de2e0348acf45068f4159c76e21d7a53f5c2d41112a7fd20d891fe2e39166cdfca', start_line=226, start_col=42, end_line=226, end_col=52) observed=two distinct pending contract demands (blake3-512:b5db35449d3c5202a5fb19739caf855b35f08f21db104af448c40417377172a59dc893fd51066c4b0f432c858270fd040af117087214ee4a5364e3da89a6d83e and blake3-512:0e3741023df315bd466426117c3e0f8593b4011790a45a8f6ec16c1f8ceec8d58436d223a5959e8cd9feee0d97adcb74d51275fe6520d8e8f543c695fe791923) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/interval/test_interval.py:345:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fab008f8c71b085ed0d2743bf6ebbe9e1c27e81520d1b93a9d883d35f0a66304ea177efdb576d6b3d285cb5fcf6aa7e0e7d3eef16e2c2372e1931018b7c13061', start_line=355, start_col=28, end_line=355, end_col=37) observed=two distinct pending contract demands (blake3-512:d92cb1656ce74e90d70a9c2e933cd5355e693b160a4fe3a679be50a4827200894c303ed22089847a5659440341112b65f959937e0030ed074462b313577c3baa and blake3-512:679c9f84115645eb9d98766fb3ddfa4a3c435ac220d6e349a8299fca13a63ad1f371f8bdfec298d6e14988ff3a5e991b2601e0234206bf92eb4c43cf7a42ab7a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/interval/test_interval.py:382:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fab008f8c71b085ed0d2743bf6ebbe9e1c27e81520d1b93a9d883d35f0a66304ea177efdb576d6b3d285cb5fcf6aa7e0e7d3eef16e2c2372e1931018b7c13061', start_line=391, start_col=42, end_line=391, end_col=51) observed=two distinct pending contract demands (blake3-512:e853407291fa638a78af310e57b8f8adbed27f5c4df1f2869ba347fc5c16de0abad0bd6e5af742dff207420fef381c654fae881461130c3c3d35bae702c5dcd3 and blake3-512:c8b2b172be94bc162f6fdb3e9638c214af491a849df43e9bf141f5c8308771bbb0d8f2c2e5a50404aa63e416257a3cc8c4df03e8a3308820e632d0ea156fc6d2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/interval/test_interval_tree.py:151:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:16098667ac824e7c6cf7572645f9fd53179f67b8ca57f0d57b3fabe393584c240bab2299d24df62328b2cc5c742af381d6ffd8883c089f75fbd6cbdcf26fb0eb', start_line=153, start_col=28, end_line=153, end_col=39) observed=two distinct pending contract demands (blake3-512:cea4166d7f80190c78682cab8e240d325a2d3c3e8b3cac719b60303a5554dde44b0df64d6dea32d479d158fc92380c2251051ed4a5b07b4c7de862e83eb498b4 and blake3-512:0a34a7db688f1f4e68af82cecb4c826b49ffdb8111d308472ed26bb3a769747f143c3dba7855fa74da5300be8e7e7557c72eae63877c5e090da857eb0ec58c10) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/multi/test_duplicates.py:116:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:288309b7eff3af13867f5dd4788106f905040fe57166cc1ef85e81dddb10b48c5ff955f078383d8c72deb47d303b3231330e8e0cd72824fba91e05237680ef27', start_line=128, start_col=30, end_line=128, end_col=38) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:b88bbcdf04b4104f98f57fc7aa360305953d8890cfed9e908e41d3192d3e1f5bc347f8ae34b86cd3494c3cb9cbb78c95717216296e6815365353c0dbee7633dd and blake3-512:f7eb93432298a183cd75608297c12f183e466c5d89833aedfd576c23ba8bb1dffdc297afa7582aa886e3d022689ec96d5307fb0bf60216c54eb5bfb4ae4eb798) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/indexes/multi/test_indexing.py:537:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:753884a472a19662c4df7b67361b017f8725eba0a1761124d51c9965b1aff2fa45ec94246d17323675d9470d0b28a21ad3e7e3ef2e3b2cc8e700d3d18053c606', start_line=542, start_col=13, end_line=542, end_col=21) observed=two distinct pending contract demands (blake3-512:b78ca680144321510403c937c9d58f551dc06f52e0ac01a62f727df735c4a2e0f1d56a8df04aa72eb84d31aaeddb2c2adbaace1db079dda4833d588fedefb8bf and blake3-512:ab7f34f8a0e707a96a91015a6a4519ebb41c8bdef8537a3ab87b622c68722db2e210cb21329139c984e4f890e2eced44a5f78f872f870748cfeedcec04df8c06) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/multi/test_integrity.py:268:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/multi/test_reindex.py:12:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c81f17f32bfd900a6a31b8c8668bd0b9d1b146883a31b0db3dc0aa55f33e4ad723032e0a3c6283ff14dba7a6170f1d67bee9f7a0ee8a56c27e33b6619630a970', start_line=13, start_col=39, end_line=13, end_col=46) observed=a hoisted parameter contract demand (blake3-512:62eaea2dcb99508ed702ae132ed651de73587a4e477f61f065e30eb34d971c2e2358fc6d45b01f949d3c35993fa39d8a390dc7c580e3afb0b023a50d2a768ef8) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/multi/test_reshape.py:93:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0e5e5621a8cba8a46e88cd2237e37c3aa8689d23a62731b2def0aed3d2e3850538fa02333f788076ec6e604517e9d55d503212d51b3b9d3919e3e46f25c1cbe9', start_line=94, start_col=13, end_line=94, end_col=20) observed=two distinct pending contract demands (blake3-512:c0edd722832f2e64581676725ca69de126b30118a9e435ca6c4528004d7b9a597e5a1cdf114c4a7ae8fbd61d1de8f26a6fabf86ae03c080a6d4250d78389da76 and blake3-512:079b532ff0977083340ba8637199655d3833b1e393b1fa33208cba5af0463495995c6b276eae6fc71df583ebb3a96a1d588151bb11f6ca38db37ae1696134c8a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/multi/test_reshape.py:204:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0e5e5621a8cba8a46e88cd2237e37c3aa8689d23a62731b2def0aed3d2e3850538fa02333f788076ec6e604517e9d55d503212d51b3b9d3919e3e46f25c1cbe9', start_line=205, start_col=13, end_line=205, end_col=21) observed=two distinct pending contract demands (blake3-512:93c4db2360bb49a749c778ccf13871ff0cb3aa4688ea84cffd698fb55ee11d5f421522bb4946f2835b09a6ad70782776c9c62e10a05c13d8ec85a0243fffe344 and blake3-512:c45466849f56d84f26ead3fe0a9ecc00cad26670ea394992c5e2960b7de0013547b2e642a7c1bb05f83149e03c4aa4634e9eb90c29e77e56e23430566af2372e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/multi/test_setops.py:240:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5dfc550564649eb5cf149c6eba73f10a397bf5c8bcc1b303c77f473b58f6d87942aa11947cdd7d0e36612b54fef88104ae95bab0dadf56b119cc6b7c499edd2d', start_line=241, start_col=13, end_line=241, end_col=20) observed=two distinct pending contract demands (blake3-512:bea66c6318ea962af53d9c5247c8558033833efb6ef08e200dd63d773eb9bca1b9fad396b55a27f0c15680649ae565c10e2b711ac6d504d3ecbded321830a73d and blake3-512:1da009bd767f65011683c5f2b4b757a4ed07f21388063e575676df8e0f9f007535d706e67fc58bb59612dc39083615910ddaa2c56e3803503b94914789de8144) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/multi/test_setops.py:285:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5dfc550564649eb5cf149c6eba73f10a397bf5c8bcc1b303c77f473b58f6d87942aa11947cdd7d0e36612b54fef88104ae95bab0dadf56b119cc6b7c499edd2d', start_line=286, start_col=13, end_line=286, end_col=20) observed=two distinct pending contract demands (blake3-512:875a25dd496f41858f1b20c45fba4a6a85a655eb8478f2d48a77636ad20d09e072da28ded618672cfa0ba0f5a7d0899ecb17f180521b17821a4156d90aff9624 and blake3-512:38cee22933acd634a61cdec53f319f729719c64f4047cc571bfd80066fb6acb0d3514fb70dfebe7a28fe2812f8e0a20d4ede85b18d455a759fd91e234f87e5ff) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/period/test_period.py:116:4",
+      "owner": "BlockValue.to_term",
+      "message": "write more Floor for this Projection: owner=BlockValue.to_term blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/indexes/period/test_period.py' [3823, 3839) node=Call> observed=BlockValue requested=project this floor value to a term fix=write more Floor: implement BlockValue.to_term"
+    },
+    {
+      "where": "tests/indexes/ranges/test_range.py:535:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:2156173cf57cb6ba681c1340ccef35a54859c193c0cc5c9e92eb3294b9575f7b902ca3caa38652a282527ca349c1131d86f7b6704c4df0e50fa268ffffd6f830', start_line=537, start_col=17, end_line=537, end_col=27) observed=two distinct pending contract demands (blake3-512:2a57b5ce69b0bc3ae4714e9d71df37a30a00df9b05cfe808690b903afde922a62879469330315613f0965de4b10b9e8ec73c3088ef5c2f59f1201bac0f73d49e and blake3-512:ffbbc444bd4f94603a9ebc69aa1c6e45283ac0cc6997e408c8905f4aab55429e05a8d9370b22646e6bafe347a7380407787aa537772795f33ef9cf55fac7f6e5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/ranges/test_setops.py:51:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:da7c5ac97b25a28d891a0689f8dd8ae59b78c047d9a311b212b0554164c0a0467b4e23052e2627cabe517679782d770b6e3f8c9a95d26c761d58cc095a02bde3', start_line=53, start_col=58, end_line=53, end_col=66) observed=two distinct pending contract demands (blake3-512:68eb2da9430114f1cf0c2d748870e3eddb90fcaa87347d72bcfee0f895080b8b68670c8922ca215c096cdbc286298ede1990726deb1fdfeb6f7b8b144ba58baf and blake3-512:1d02ad3138eb0df161b2cb0a0042e83dc54d2f6abe4e26ab7ce31b6c3048af08e571640a3a39f9d868f1d011d56e72b87e66bb665c0e1f1d80179dae05e255d2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/ranges/test_setops.py:126:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:da7c5ac97b25a28d891a0689f8dd8ae59b78c047d9a311b212b0554164c0a0467b4e23052e2627cabe517679782d770b6e3f8c9a95d26c761d58cc095a02bde3', start_line=128, start_col=42, end_line=128, end_col=50) observed=two distinct pending contract demands (blake3-512:7f291ca4f79423392b10105e6f9854384e32d9a1ee13591f3985cbbb4ca268a0934d6775fc4fc2d4859d496f17773cc681640a608e7111e4cbba466a6d755502 and blake3-512:75956291127a508225de9ce84ae5ce588ab32b3dd9fafebeaa29ee350950c73ce232181e4b620d7da6c7565bfbe878ce163ac4a1727431a8cc1e9772754f3837) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/ranges/test_setops.py:452:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:da7c5ac97b25a28d891a0689f8dd8ae59b78c047d9a311b212b0554164c0a0467b4e23052e2627cabe517679782d770b6e3f8c9a95d26c761d58cc095a02bde3', start_line=458, start_col=15, end_line=458, end_col=25) observed=two distinct pending contract demands (blake3-512:3b18a5b4faeae0807e92fcdd4717bf3dbd9e49d0d1dbfcc99c9990f99063e68641385830e07b95b4f4aadecfd8c5fda108133d84a9b58ffe86206105352d63b2 and blake3-512:4c954c5189d354825be2d7e3f269794f6bac35889774d0676b36e36b4671fa91701135f94a41df0f80454af27d5a7557a84d98cd9a3dee6b8bc632186ab50363) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_any_index.py:120:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:690fcf2267e84b28c93d73248f693c5214d73163116176f0e3e977a59a8345171d4d0de02ab2cc04a7b0aac1f16f9cb694114dff6e77c2ad4c0dd017f7c579cf', start_line=125, start_col=17, end_line=125, end_col=27) observed=two distinct pending contract demands (blake3-512:0ce5ff82633a53e6ca467506a1708470c36d6842253c36f6fd8016f4ee747aff02c9c6b4cb5fc2fa68ec8900cd4c1609db0439af3318dd577d6607fe8f4cc7bb and blake3-512:64bac322e06f8a7389b9b44c02212cb3aa6c16d6d9ddcc71ca67699fa27162a00e493c2c5a295117c632c0b378a65c9b9c20ad3533dd36b9aac24b158c5eaba4) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_base.py:705:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:691ad8238240597640b09c34f459a2fd2fdea2f89ab7a5bb1dddea0aeb4443c0aff868bc045d47d798b99aaae3a9eeb53383c0bba20d802de781b0a77bf31cd6', start_line=707, start_col=15, end_line=707, end_col=40) observed=two distinct pending contract demands (blake3-512:e5c025b3e6ce0900c70750a3e37a8f856a869ab18daeec02ec8540e5c8affb1523e988266b39eb26aa41eb8d2c13bcc6dfa94fcc35efb78b9c276b0371d879d0 and blake3-512:d284c9c02089c92ceefe8d4218bf6e5963a8638a287ae3347f5a4fec97c3a047710aba26ade725903ba6e5b6f00117f8cfa933f6069d0375bf388e50523d7d2e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_common.py:208:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:28f0b236932bcfec8589e447fe9f57ac24d31bec8b870b17b5b302dd5a66b9d7eab2d7dc0e2929683fcbeb95d240aef64dceaadbc2d9235524bcdb67d2b83bd6', start_line=214, start_col=14, end_line=214, end_col=28) observed=two distinct pending contract demands (blake3-512:67ae971b847c6a476f2355708710ed1f59a5059c2bf25ad6dfc2e0079e27a9acb42ac9f5d068dc47b48dbf32b29ca683b50f6ba12d0605adefefc1c60e058d5c and blake3-512:6772336bd6b7847ab3ecbf13e581540c8d894c802748c5b9b7505408f99003028ca755d9d6f898a758d71c761e409259ec0f4f07ebe6f2a0c9970a1805f78ba3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_common.py:447:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/indexes/test_common.py' [16113, 16309) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/indexes/test_datetimelike.py:35:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:657802e76cea31e9dffd6509052dc1013770c91b9f47233c28cc91f7e3549a6ea5f9b069e90ca0dd3a39fd2db4fa0188948c2a25ed5bb2a02d6fa0310a4a8de8', start_line=36, start_col=16, end_line=36, end_col=32) observed=two distinct pending contract demands (blake3-512:1773bf339a9f38f777400a66efb3826bced369c3b6bed02e090a77c1daf822316b53e973ea40b863ad5aee58abf055049f4d0f5d4de9f4f27994d8fd5657ac35 and blake3-512:7626607b6df00ac2ede3403e565fa2ffe3b2f55f3c98114db81724342e1b760328ef8f7d8492b8c38e66bfdb413b88238499f7e8fb37122679ce3897c1a0f028) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_datetimelike.py:145:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:657802e76cea31e9dffd6509052dc1013770c91b9f47233c28cc91f7e3549a6ea5f9b069e90ca0dd3a39fd2db4fa0188948c2a25ed5bb2a02d6fa0310a4a8de8', start_line=151, start_col=39, end_line=151, end_col=47) observed=two distinct pending contract demands (blake3-512:c7235cbfa430e494e81a9f6aa54dee0e5f65be557a71b88a33c5be79e7530d4b8cdb7846b72766ff82bcdcf6b44845b765e2bc982f8d845957c0dbda2d44774d and blake3-512:265fffdd32d0152364223f77c63191029b21a4cee022810a4f89a5ac0afe9398d58fa037be5512a2082f5a6ab10fb482a0328f81e77cdb248a46255d27a5b8b2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_frozen.py:58:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ed4dec3f28e8529683b3aaddc905a7cece87befe763878093a4c2832a905993e0aa933b5034dfeb896bdf3ee509568680be36879b3b2b764a5a0076d3f715f49', start_line=59, start_col=17, end_line=59, end_col=31) observed=two distinct pending contract demands (blake3-512:6f07d90d8e2adc52d5d86b2a86d11be3e1edfeb87e729b3e14c8a75fc59048e7bb2d419f25ced38fc0a4cfdd1c915eb933fd820c529ed594253d0e11f16fefde and blake3-512:184d7f4ecdaf1102d6abaf2bea52cb86cfc0aa38a8458099e194a2bb07f42b7b0ade132a1d426568f39c86b679d7ba335bb21c3d0fa7a538017a05ea0cb501e2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_old_base.py:310:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/test_old_base.py:435:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4a2dd872b1dcb1190e1ab8bde234f3c2296a6bf2f6e3eafdf825c48f2cbb956743706364c4918b953d70d6de0f4bcf61baa35de05c21bab340afee763ba6035d', start_line=437, start_col=18, end_line=437, end_col=28) observed=two distinct pending contract demands (blake3-512:ec390a8244d6131b3249b464810835ea0146f202d81395d92143c40f7b57a38140e92263b7ec10dcc81a09c313c2fdc83d8b2b0981d15e7469ab4596c6b569a7 and blake3-512:8b2ebf9d5e049fedb34893679edaf9e18fe03ea6b0fe3749beae83dcfb9772825bb091b19a1a2fa063adc07796923f179f29c7a9988b286cde9136705c5f385f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_old_base.py:808:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:4a2dd872b1dcb1190e1ab8bde234f3c2296a6bf2f6e3eafdf825c48f2cbb956743706364c4918b953d70d6de0f4bcf61baa35de05c21bab340afee763ba6035d', start_line=809, start_col=14, end_line=809, end_col=30) observed=two distinct pending contract demands (blake3-512:165a0e0cd5baee89b9f1070f9681ffb27c60e82b72466a902dc965032e621071e8dcb0bd4fc27ecdaa6bc4162c0a72024f7e6dee29d21ab78efb87897db0bf56 and blake3-512:2718269dd8dba31640dcde7b7387230387d07b518358a87d3c4530cd54d26988df7388dcbd593e1015aec04976ca63362e012082f00afdeee9fdd4f63d0a8a70) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:187:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=190, start_col=35, end_line=190, end_col=43) observed=two distinct pending contract demands (blake3-512:8129526be57c0f35f161953c592b7c7507064bbf7bd1d93c643659b2cd7c3e0280ba80b4734edc81d20287d6da1bfebd782c620df76bc8fed49720d5b7e214b0 and blake3-512:8cb0843c205163f35d63112397aba8f8e8047720bcdff0233952738581d8eb5f122de13289d514a85f7c805fd3592d7699de88c574a2187648d07d7be2c088f5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:462:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=470, start_col=17, end_line=470, end_col=26) observed=two distinct pending contract demands (blake3-512:8e19ee6b458d031ac40a23b29ed93bcefc103dc4af70486c04aa50f9aa342319fa1da455862eac726da177fc96356bf34b627d4d622dc79064dac36dfafca235 and blake3-512:e2c8c5f1c28292612c2c2c4d61f5af5be284ec2b2cd9b64b504a1d5aa405f16d600c52157cbec2d06faf091aea6f61393b426ecef23730b0fe7d5325fae7b2da) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:505:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=508, start_col=29, end_line=508, end_col=37) observed=two distinct pending contract demands (blake3-512:dfd3f982b08058e23d7c20b66f277f25dc4be3f31145cd188fdd72f05c546a2f8baad09a4ea9e31f5bfd30ba0222ab6397a5c0f970228fb822858845a9240925 and blake3-512:f99a5810d5188c212c0fa9e735d7a5cbe6723f94513795a979358babc77433ab69904f9addb5134dbe95b118bf8ed7ad1e79d36fad357fc8ae859392962d259d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:534:0",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/indexes/test_setops.py' [19190, 19355) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:719:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=720, start_col=16, end_line=720, end_col=26) observed=two distinct pending contract demands (blake3-512:9aeec839838b9eb7a9a40d7c7d48d8fb7ee57abd533b1f28c4b2526a5283f01b1ad496c197cfe2a6c317703890439a8e1d494b1bd6332567222227622600c3e8 and blake3-512:e06c034cf5bead1da4266780397181acefaad5f341664c428f062618db9f78ecd6864564c7933dcb0166fc9fa38bc6f117a6042f84f5ce60779c6d8e7e77fb63) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:757:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=760, start_col=16, end_line=760, end_col=27) observed=a hoisted parameter contract demand (blake3-512:2dc25377942866ea232f2451531890f38cc07f28e95c43f0ab0842060d65255386d6b96d3c4f59f4a6dd6ecd827417f5d2629a34098f207ac4999a572ce45580) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:784:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=785, start_col=16, end_line=785, end_col=27) observed=two distinct pending contract demands (blake3-512:6c262d611f2b71a88b987c479dca9b02b1725cf603354c245ae5d42a34c8fb12cde251ab9898137876ae4e90f5e2e8018ef12cf43fe4d9a96217136a6140fd25 and blake3-512:84f737fdbb4c1db262f9eafe9cc89b7a9b1474dc8da720e4b6b935a1303db9f696b11f82c02ec28ca4ca5d21165c9492eb77b085830e5d097e0976287a7a241e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:797:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=799, start_col=16, end_line=799, end_col=27) observed=two distinct pending contract demands (blake3-512:fbc566722cfbf311e302f5ecb1ba27ed502fed7bcc0ebb873f3299e97bc1368727836f2a926d04e8a0a0267feef146513d7baaf543112f665b26234931b331c2 and blake3-512:d08ea581e45cf232c5788e110e5d7eb86bec9bdd1e163cdf517065906dcdea7453cca6824170ad38a05b0a3dbca1901d87367f3eec399d9f49a822e03a168d7d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:828:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=829, start_col=16, end_line=829, end_col=27) observed=a hoisted parameter contract demand (blake3-512:be5ad877c143219075c34e6f4df671be8076c5c5cbc9bb60130bbc1a87ea25cc111e376a1905a0e569ffc5a343ceb856428b7d8109d7510ddeea44daab5d2d91) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:848:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=853, start_col=19, end_line=853, end_col=30) observed=a hoisted parameter contract demand (blake3-512:e37198ae66bd71d3c9641365fe2d0f9024996f3b2b87ad6f3cb710446f3368fd9697f951671952cb9d6cce0b2e497b3cdcf5d872ba6d48742cbbfa7e56691612) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:866:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=867, start_col=16, end_line=867, end_col=27) observed=a hoisted parameter contract demand (blake3-512:775cca8da0945cb924db16adde9e977a8c05e254904ee20abd54047b8ce75f6073f1957fb02f85328d2ffe7cb7ac03a0de48336f4218aace189150c1a99dcec2) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:875:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:cef262c39665e863a15d71c8e61f82a80674c43e882ba490f72c82cc2b6e934972005f2fca1ba6279db255c48f54c3b2e1b3a3f518da00fb195fcc89ddb7e506', start_line=876, start_col=16, end_line=876, end_col=27) observed=two distinct pending contract demands (blake3-512:a15417013c959b8cefd6daf9b52e34f6263e236eaad30b7d0e9c9d3cdbd6451f0685d028f759c0a9972feeca01dee184c9dab569dceae2649e4c750f8b35a78a and blake3-512:3cc811bcdca8ea53f49afbd4d1b6fae32544511056cac9f328ed1bc98f3479fd368b004048cd9357ca2f7a1f77716538c228409675bb8e93e56d5ade6fe75984) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/multiindex/test_getitem.py:66:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:590d4a20d5bc0933e0adbf171ff8844fcaeb705c2a64deaa237df0044949c8200fba315d6ccfae78ded6e783cdc2a426277b6686d682c571cdfa846ff6c03874', start_line=67, start_col=8, end_line=67, end_col=60) observed=a hoisted parameter contract demand (blake3-512:74c21ef14277a1bb55bf6a5b2bbecdfd089feb6cdb4a2fdbcb434449e603c29b317c1194c9cc5eb2ebc6e1a116f6692498558ae49e202cc9e3c922aa21bf2b91) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/multiindex/test_indexing_slow.py:78:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0e129e1ef0ca55f392d6422ce53911d75b038707cd30479f44efe86b7c0ef665883ed64ec64d8fd9c08f587d36fe64d8627a3ecb4f87d8355e9e30500492ec23', start_line=85, start_col=34, end_line=85, end_col=54) observed=two distinct pending contract demands (blake3-512:fffb1783d27c9c0225a140daf3aa515a701418bb5a10e94a0778b562df81c87e8bad91ffe05211d5126ade386b0f91e0e12d82551ea94113a82a76b76242cc7e and blake3-512:0710918c196059e83fef9ac01bc73ce1c6efe88b82a5e73e6efaef5bf2b2f10934572f4ce9aa2b30379c1dd9459ad36e41dc449e294bc22ae64c55ede43e7170) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/multiindex/test_loc.py:538:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f8ed8fc588405e4f4226f15bd2a6f93fc7f05d427bb573e31f1b7f14109e7e8a8315ca998290b237138378e3d559aaed4cf1b70930137299d572a869046116f1', start_line=541, start_col=15, end_line=541, end_col=22) observed=a hoisted parameter contract demand (blake3-512:9de0c96224d8c1e261e24670d357af44b4167132b9b55f40c79c227315129f20b844ba30b26443e8cab8e8525e5c1c16e1bed68e22d800f03f3033b7417eaf1e) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/multiindex/test_partial.py:171:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:9a5f8113c3a54a1526f533aaa1a7debe24bfc35096e3ca2c2063dfe6c9e625de65b6d78fcbb441c420666b5af8460690b04fbba1a89b54b50732bb2663ea9bfd', start_line=188, start_col=17, end_line=188, end_col=27) observed=two distinct pending contract demands (blake3-512:ac10ade4b5e670cc4a8b1c08f8bcc43bf65b039eff7c1f4d774a1432a6bf85689dcab3dd5d00814a248cc4ed9fc170e09f586abbec96fb97b64297e56206d083 and blake3-512:2a622d2a994762a469438c2f79032ab6764f80c1dd2c046cb55232e77998b7797618156ebaa8ab52361e7c2055becab8a63683d9e7d972f60905410167ee0bd0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/multiindex/test_slice.py:737:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d3df7323da8536ef2b219ef46cb72ff25823b1e0c871caf7c4660b16170a352c002de518ffb8f2a7f4c6346c046c2a52273f579330b52d3c8a8fea8c1374d128', start_line=744, start_col=12, end_line=744, end_col=20) observed=two distinct pending contract demands (blake3-512:597624fdb77e74b8ffc4ee4067e8d875499ec22eae1a6aefa03b4e3b65895b4265e8ab7c248308d14f6c4ca61d1d6bbe62ed760e9ff1fe5bcbc1c056675edbcd and blake3-512:e5b094696c25b0e10d6c1013a07afb9f2cb9771a78bbc5135bf2fb870fb2237575cfd731502ce64a0d1e44533d1c6bf10c76948c93495a74ec7f04bd63c87991) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/test_categorical.py:523:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6276a32425062c21351d29914fc50c66c2c9e35b6ff3a7e2f73fcdb75a841f6e9ab6c0f803c4f9e03e05a01cf33bc79c0d09f3b9124e08eaec6409454838a78c', start_line=530, start_col=24, end_line=530, end_col=37) observed=two distinct pending contract demands (blake3-512:3d2bcb2a5953c4b5f9dd3e61b24ae2d39a8891ebf100307e9bd78856faa13d98db2383974d06b0904d3b2835597dbd8ac55cf96434a206eef9f05c911427e3ce and blake3-512:bb5ef7a1cbf42c038b9d1c64ddffae82630ef5e9d2231a5d67fd243ca0d9522340cc831264c4e9d7d32167bf6dca19f1dcda6f07e06f05c8a86943b6b2c151d7) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/indexing/test_coercion.py:353:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:8d0e8896c9ca9bfe00a7bef691dd94fba0bb5e71eed0a4429195323ea7de0b06318e4947eaa2968b596e546c34bd98e25f611b4be107ed5d96950a03d85b42bb', start_line=361, start_col=40, end_line=361, end_col=46) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:8457b1f6bf6984fe0896599a659bcb22bbd3bbb6c9871f372790392213ff02b95f4b9989af196fca05530b035262c5ddf212f430e0c449e7f9e90d77b1de1449 and blake3-512:60750bef6192d5a33eb9f82299ffcab84f674824964d4ae7b70f46d8e89ad46d8d2c08dd22c8002e7726ba01026b8f126b4955d20ee637c729f31928673f40d8) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/indexing/test_coercion.py:364:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:8d0e8896c9ca9bfe00a7bef691dd94fba0bb5e71eed0a4429195323ea7de0b06318e4947eaa2968b596e546c34bd98e25f611b4be107ed5d96950a03d85b42bb', start_line=367, start_col=39, end_line=367, end_col=45) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:5b249694bcd6a54eb29047cba24e3dfafcf9d240e11ba4cd2cb1a46badb79c0022ccc40758f38b0a8c8051cf9ed294f55fe46c8bff9c841857b45e6033acc5ab and blake3-512:157da4cfa4409828a68c7360ee11db5d960f508b76cb86dae15b6ab0124b7660ac367180886c76c9eb1e291e66ec8fa28d64e636c76a5a7c666bdec860cf0754) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/internals/test_internals.py:73:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:efe7175e4aefd04d36507adaeb7049c5d3b9d7b6641485f80014fce4a820e28fd60fdcd3961f964164f8215491808420df38d6dd153fc9af55f45456daafe5ca', start_line=74, start_col=20, end_line=74, end_col=28) observed=two distinct pending contract demands (blake3-512:6319fb15ece60dd252a4f7a485fb22bf33cc93ea8e2380da2f14183e8bb0261a7413bb6629ed43560cead7ed6a101a6a22b8efb4319460ba65f9f62e92f400a8 and blake3-512:8708bf23a1fd69ad35f783420fba3e52c92f99ce7d455e73e596374ecc71030f5763dce8ee0c070ce359233380da92644db9f8864f310961cbc88b4222d8bd59) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/internals/test_internals.py:83:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/internals/test_internals.py' [2824, 2865) node=BinOp> observed=ComplexValue requested=stand on the multiplication floor for a SymbolicValue right operand fix=write more Floor: implement ComplexValue.multiply for SymbolicValue"
+    },
+    {
+      "where": "tests/io/excel/test_openpyxl.py:160:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/excel/test_openpyxl.py' [5453, 5464) node=Attribute> observed=EffectCoordinate requested=stand on the attribute floor fix=write more Floor: implement EffectCoordinate.attribute"
+    },
+    {
+      "where": "tests/io/excel/test_readers.py:354:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:00182a103634bd0b7e6f881e8481ffc2a15a02bff82bb3e412a7ef6c7afb948de013a84747a82059fcb7fc7a82ed0b81ba527b670e92569f7daaac1ab4500ba1', start_line=355, start_col=19, end_line=355, end_col=37) observed=a hoisted parameter contract demand (blake3-512:640d0b99f06b05a4ff183e47328d3eb7ca9db8d48b8cc741818795d1e9308892e764c266035a491b0d07b3c5297480879db2ba6cf0467b918e4e29f4b4e448ad) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/io/formats/style/test_bar.py:73:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c8c8ffe84b87fcef55038c83bc23fc3891c44c191e52aff1cff388e630efafd859a18f745878b74047ebe6d1d5de26efd529334097c8e609b7a6e429ac798f10', start_line=76, start_col=40, end_line=76, end_col=46) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:ab5e5c652582d1008e0e20af3cdfaeef2f6aef1246745268558c9f54a7ecf62e6d964b0ae24213b74f62b6d26a5e3916c662c8b5fdb7c73794e4835c49310186 and blake3-512:5aad4f0ca370c04b771cf6b6e4778a2adb79bf3dfecbbc5017e618a602237c60c42ac2516a9e80e96963f8f598ec4a24704cd5cf2455cc6b7cf97eeda9d87844) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/io/formats/style/test_bar.py:92:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c8c8ffe84b87fcef55038c83bc23fc3891c44c191e52aff1cff388e630efafd859a18f745878b74047ebe6d1d5de26efd529334097c8e609b7a6e429ac798f10', start_line=95, start_col=40, end_line=95, end_col=46) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:9235e83060eb0cf924591c03497076f026e850cc581a957500f0cd7b7fdd9a0c60393c9f551b99cfddf13415e9e2b101a4fe7952a4d42f3bb0bbc2f977eb42a1 and blake3-512:f431548cccaad3be7206f80cdd912825a6ee061c9c0f485b692ff3d371d887b78ed51e6e4ed10c870256e4f14b697fbf03417e4a9fddd5672d4d92357622c34d) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/io/formats/style/test_bar.py:112:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c8c8ffe84b87fcef55038c83bc23fc3891c44c191e52aff1cff388e630efafd859a18f745878b74047ebe6d1d5de26efd529334097c8e609b7a6e429ac798f10', start_line=115, start_col=40, end_line=115, end_col=46) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:9c72a0031da06f8d7f67b035c408e351b77c7fe8fe8fb8b2248a3c820c550a8d1eb6108d2558ae9a9f6af3d42a496fd981f75e3863fce6131ec3dc43ac403067 and blake3-512:6e1c9b0f73690f8ca00f48236fc5d89e0bc7427ea9bbbfab43761a317404a7a98e83304124435afdb0b7c8d146451604d738a97725ec95510fdad5e717e675e7) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/io/formats/style/test_bar.py:179:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c8c8ffe84b87fcef55038c83bc23fc3891c44c191e52aff1cff388e630efafd859a18f745878b74047ebe6d1d5de26efd529334097c8e609b7a6e429ac798f10', start_line=189, start_col=16, end_line=189, end_col=25) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:06d524467b8a52445d9cba4439ddd20b6f3052a54fb148a5bfb191bd3b98a7e99b1e2f2fbd2d14626f61f6cb96238a6953ff44faf9e77dd7d01e9e6b23220e15 and blake3-512:e654079b1b65c43c7af28a3eb6c9c69368752cbb9bfde36638a1636ae1709a8644d7de3fb9b714efd9506b7d82fef79e831ccafa8cbb2f177ce947bc3e117c14) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/io/formats/style/test_bar.py:279:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c8c8ffe84b87fcef55038c83bc23fc3891c44c191e52aff1cff388e630efafd859a18f745878b74047ebe6d1d5de26efd529334097c8e609b7a6e429ac798f10', start_line=282, start_col=46, end_line=282, end_col=52) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:158293dad6df0fefc8ed6260c8fe51ea184e41b10f003ca7686838d69c2e28d1607002a6d940b737290a20dd3e3e152a8622578e295edb951f955380c5b2ed3b and blake3-512:051370a129ebd038cf9d199ffb4e3285aa9cbcf98db3dc0786c4fdfdf5c457c456f929133b7b0c905c58f63d4e8e5360c7e87870e6d09264b2d465184247e188) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/io/formats/style/test_to_latex.py:145:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1e824492937914023ba9ed612918b0c821f4829dca55845d7d2ff22dd5b9a05658822b85cbe1776555c48ee15dbc530b957ef75f9aa6a043fd416a592f50a30a', start_line=152, start_col=22, end_line=152, end_col=38) observed=two distinct pending contract demands (blake3-512:115cf59f0214774f574e25a1bfd39905400b714b5f50ddf97385ecd5452386031ea1122d566f83e18df825099716392a9ff5b8d1d335d9940722c746e1945268 and blake3-512:aeecbc142a6e03e1f5a71bace3c7cb72f6dff48f5cc98f85c2336c2fa6f07ddddfa6457b451973a1c95a649841c994eb6345f46b779b4c4e3fdc417674754a89) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/io/formats/style/test_to_latex.py:715:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1e824492937914023ba9ed612918b0c821f4829dca55845d7d2ff22dd5b9a05658822b85cbe1776555c48ee15dbc530b957ef75f9aa6a043fd416a592f50a30a', start_line=716, start_col=27, end_line=716, end_col=37) observed=two distinct pending contract demands (blake3-512:bb899d2904834f0989c5746bd65442eb6bc550a2cd173b935f75d0b2cc8d2147d20d07da1258453c2e628cade2b730c6504e8ef22377a20c150018967c6983ec and blake3-512:2df6ab94b3ccbbe5f665bd030baed3f15d8154153587c0c305da34a3743fb057547c964207418f90bfe43829032dcd205bccc206dc027fd4d2c62e30016b6326) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/io/json/test_normalize.py:126:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6e2cb797db057e192385cef75c427071ef965925f27a119d2ddd16fccb077621fae6dcbf9807549fa84dfc14ea6380e11b79c3c4dbac379115c26232ec786c93', start_line=127, start_col=32, end_line=127, end_col=45) observed=two distinct pending contract demands (blake3-512:cefcf559fc8b4ddc081479dea3e1f1628b329363d56d2ce967c18a2ca0969789e29b8d92550116359b4133709fc8da966b8b1d78dc16b5b093d4fb43d373abbb and blake3-512:49e05062d7a6e7d18a48283c7a9d3f1bf3659f97340ea226ae27c507365a8a33bb47579c1f96dd5f3e1d47d709ef7739b01b7b1fd1f26427b55d3f4bfad666a3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/io/json/test_normalize.py:365:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6e2cb797db057e192385cef75c427071ef965925f27a119d2ddd16fccb077621fae6dcbf9807549fa84dfc14ea6380e11b79c3c4dbac379115c26232ec786c93', start_line=366, start_col=32, end_line=366, end_col=45) observed=two distinct pending contract demands (blake3-512:8a16902948cd41b4584930bb36f3fb65032c9b13dafe7c4170efa1260849c1c025d4f3158080281215b4ae106062997e6e8189c986b8376d2582c0bed3724cbb and blake3-512:4d2ac5501b67bb3887408ea0dc06a3edbc4349578dd3983ab15343020686751383242b9bc98e575d6a650365171163200c7f555cb2b965bb1c6e10b051dceb6e) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/io/json/test_ujson.py:566:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/json/test_ujson.py' [19944, 19976) node=BinOp> observed=BytesValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement BytesValue.add for SymbolicValue"
+    },
+    {
+      "where": "tests/io/parser/dtypes/test_dtypes_basic.py:242:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:2ca31233ff882a874e317163123d29c504f3dc9c6cdae6ee938fdb142b2526ae49a0dabd425324711bd8003e7bcc9673bc0284e645959e3bca2c75817b806368', start_line=244, start_col=12, end_line=244, end_col=30) observed=two distinct pending contract demands (blake3-512:ca9aa133b34336a61b375b1ae577912d2d415248b630b876defbafa48a979ac56fd8e2f41431450f4f94581b80c48c2a59c695bb9fa1c81d558f39c7b729dd6c and blake3-512:25228b84b38c41ada5b6228408825279bebc6da898dcdd6101295356e44d260298b922b0d1164b2d6059e44202013a9d96eb70c07879bf1eab490638a308d4a2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/io/parser/test_converters.py:111:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/tests/io/parser/test_converters.py:186:30 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "tests/io/parser/test_header.py:546:0",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/parser/test_header.py' [15855, 15883) node=BinOp> observed=ListValue requested=stand on the addition floor for a PredicateValue right operand fix=write more Floor: implement ListValue.add for PredicateValue"
+    },
+    {
+      "where": "tests/io/pytables/test_select.py:294:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/pytables/test_select.py' [10358, 10425) node=BinOp> observed=PredicateValue requested=stand on the runtime bitwise and floor for a CallSiteValue right operand fix=write more Floor: implement PredicateValue.bitwise_and for CallSiteValue"
+    },
+    {
+      "where": "tests/io/sas/test_sas7bdat.py:303:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/tests/io/sas/test_sas7bdat.py:344:26 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "tests/plotting/frame/test_frame_color.py:22:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:25968a8d22ec30ce10950805e96a3316de4029c2d0c72a52ee397f7acc2eb2c53f3c31a9873239853a5b62171bb4c3b6d026856102bc7c1ff9ae5b45c34ebcef', start_line=25, start_col=18, end_line=25, end_col=29) observed=two distinct pending contract demands (blake3-512:02f786ee5afe7eb7435e730bb59889cfeefa301138d40fb0c51bd067c8c8f602e2432ac906fa3ed26728b6752a89e5a61a7f6a2790276fbd746cbb9dc5fb30e8 and blake3-512:c1124bd2efca8897527a47b5eb8ff80baf05d71db156d216f7bb84dfa032e681614e3674bffa149a23e2d951c98f182c7620caad2a54a20ce352ab2b86432db8) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/plotting/test_converter.py:217:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0efbc4b49710c61eefecb0e830570e9b45dc2fc7194255ff4901ed98f2f64a4d611dcef5eb35d6c71c67fedd481663e1d530e046f96b03e2de2a207d4b743145', start_line=222, start_col=25, end_line=222, end_col=34) observed=two distinct pending contract demands (blake3-512:45ff06c76338f35e724e3b42baaf53480e6245ee01affbb1085f7c2f3563d09e0b1b7bab9a86f773cc6d4f7b3ca049f8b628d0442d0194936f425682e44e3423 and blake3-512:9728efec9e50613b58da0fb2057e82504e9cfdf54e7a36768162e09b6105b3325fb81a436dccc81c20053640f39a089cc08801a8ff57cc4fd310cfd78a9fdbb0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/plotting/test_hist_method.py:389:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e899686a38f691a4cc82dcc217f364228aa4afbbe2b3682bc79ccf0ac6bb97f17dfdc46d16b3aa3f437cef6736f839626b968719561275428de9865d124320e3', start_line=399, start_col=30, end_line=399, end_col=51) observed=two distinct pending contract demands (blake3-512:47dd23238ae079cf9a56aff6069059eadf0713ab12832fe3549c6d3f7fe2ec16f759c868bfdc90e0ab32b07f673b15ca95a2f2a2133e35d4f4b5aa2bc21b9b18 and blake3-512:7a189ced2282b218604edd95fe4509d6aadd7036d67466836e07f191fd3fcd5064f0b30b8358a57bc0a4f7f5ef7dbc312e39e224102e833ca1a2742fbe817c6f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/plotting/test_misc.py:251:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6a44cce2e225f19d21b6519e1e49be201d8b6d869b20f7b07cfd7fa431b84c145f9cf9ef8ef8dc7a43cc4b65a6972b9a7ca91faf37520e9659ae4d8824540250', start_line=254, start_col=54, end_line=254, end_col=64) observed=two distinct pending contract demands (blake3-512:6427f6b69d7d42bce8312a7717aeb0257c65a8d455a91d4a34191ae6cc13f8eb93689ef2c406d3db82cdbe70a8eb94af8569ceeafc989a1ba161ab26a0d9aef3 and blake3-512:29e05b72b5ed0c962bdf15913ec7070ac2094139d3658cb2a4b227098a9d98f623c5cf950f466be9db42b50d0647b21c658179395bce7c76e74e47ff1556d723) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/plotting/test_misc.py:282:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6a44cce2e225f19d21b6519e1e49be201d8b6d869b20f7b07cfd7fa431b84c145f9cf9ef8ef8dc7a43cc4b65a6972b9a7ca91faf37520e9659ae4d8824540250', start_line=291, start_col=58, end_line=291, end_col=68) observed=two distinct pending contract demands (blake3-512:5a6e128a2fb712aa24796c18e7161d081297cc358950f09dd54511fdc9a1ee1c06e51d6e65767c1575af75a9fbd422cb553ea6d51e7f7db0e6250b1b38a12b4f and blake3-512:76c83d9214a5474c26fe0b6065017718d754d2dcf1ac8fcac870f8e5256ec8eecd33ecac9570652f43c50af46f284e8755a35b2221a2d4d22d7f85462d171f2f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/plotting/test_misc.py:363:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6a44cce2e225f19d21b6519e1e49be201d8b6d869b20f7b07cfd7fa431b84c145f9cf9ef8ef8dc7a43cc4b65a6972b9a7ca91faf37520e9659ae4d8824540250', start_line=368, start_col=58, end_line=368, end_col=68) observed=two distinct pending contract demands (blake3-512:199e77ef51b63606f53db2e656e0a9af4b612edc89d82435af1ce71f723c37d91f82cb77e747b5ec978719ff825d6828a966205dee5eb7d209a2befcf725d094 and blake3-512:8877dbaa33cacd5a05c31cec8efa65f61a3c05a26168284b6e33e4383d555d96a8e520d7c689f997b0b6ac79d88723c54f5833fda7fb953731a9062ed7b74256) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/plotting/test_misc.py:696:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6a44cce2e225f19d21b6519e1e49be201d8b6d869b20f7b07cfd7fa431b84c145f9cf9ef8ef8dc7a43cc4b65a6972b9a7ca91faf37520e9659ae4d8824540250', start_line=701, start_col=17, end_line=701, end_col=31) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:2842c05306e31364f95f3adabc81e2a3e0f18b51b24a5781120d4e85cc7262836a3f6e664ab0c8dfc42720f337046a70af2712f7dc042ade07ba4ecf587b701c and blake3-512:9784b6e3590c98246b240eccbdc9115e576e6e974f6a913266e69247bca4ee5e813f067d8d95731f58b569bff6fff81f7341e9fa95380f218a6e05da9a60e9be) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/reductions/test_reductions.py:1383:4",
+      "owner": "IfExpSugar._join",
+      "message": "write more Floor for this Construction: owner=IfExpSugar._join blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/reductions/test_reductions.py' [46826, 46879) node=IfExp> observed=both conditional-expression arms enrolled a parameter contract demand requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before joining two pending arms"
+    },
+    {
+      "where": "tests/resample/test_resample_api.py:442:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c6135fb0f30fbb485a13ceadbbc4af601dcaa8c024b2891018709c1abd514c9c6b42378fda4640cfb86800af8cdec087133063dae75f55dbe274f3ed385595b2', start_line=448, start_col=19, end_line=448, end_col=32) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:9587d41a343afb1a39b76e01ed6abbe996edb4a7ac48baf07347b61687c8b2cec79e88cc18a816a0d9cb10ccd48582fdfe43c41c17e37815c09338af58c5ade7 and blake3-512:61a53e61b4f5727ce38977fbc6ff48670f3f04c9977827a4db3a097820911d2e09f1280cda340c612eff51ae2bd00a2332ec06d99031deffb80cd0c38f79be62) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/resample/test_resample_api.py:521:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c6135fb0f30fbb485a13ceadbbc4af601dcaa8c024b2891018709c1abd514c9c6b42378fda4640cfb86800af8cdec087133063dae75f55dbe274f3ed385595b2', start_line=523, start_col=14, end_line=523, end_col=24) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:6fbc5d629e8af52589885899c4e8c6614546a3e4fb5a7ddfb76a03939501048fca0153c6b4994a4cf9e6e06d8efb68bb4402969e301f8c55342370685889db64 and blake3-512:5c29cc72a7b8d453d7ec3a7f3c460a1f36f432a744b0500087370bb173c27541a5f8c75a9ba68b022ff61509bcad1f631a698ccd86257c469eacdef1f65b03c4) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/resample/test_resampler_grouper.py:447:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:a26b3ae79004f17b07406fa2a0f1e121d548292873d6845f42530dda00ae904ac84abab2a1f7149c0705b02c4f94a5592c35a7fd9dbc76a76ded54a4be45f0b7', start_line=458, start_col=30, end_line=458, end_col=37) observed=a hoisted parameter contract demand (blake3-512:34573f8a05c4b4001ccef4a5a7676553a8cb12dad22166b1ef605a443d65144964a00ca59990d9fe204fb35f9f74f5bdf6041b26f3d921f194758e20bdacd926) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/resample/test_resampler_grouper.py:538:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:a26b3ae79004f17b07406fa2a0f1e121d548292873d6845f42530dda00ae904ac84abab2a1f7149c0705b02c4f94a5592c35a7fd9dbc76a76ded54a4be45f0b7', start_line=549, start_col=30, end_line=549, end_col=37) observed=a hoisted parameter contract demand (blake3-512:c35cabcff90de2bcf9dfc66f487cbc9b44e620b2fe9f33e1b5314e7b704c94200d5e9fb5b9c6f7cfc4cb444140877b173fee7501318a2bb291f9f7b4976ce454) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/resample/test_time_grouper.py:77:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c9320f310b28e42a609aeb27fb4fb80f2e851144df81ea33c7978ae7d098b11f2cde5c204beaed7ddd31c3eebd4ad71c5e385a8558d4ffed8ef8b84bf347d927', start_line=78, start_col=15, end_line=78, end_col=26) observed=two distinct pending contract demands (blake3-512:183ed0c132a3a92436bef9b7ccddc0328b702493665430920b7aae69c8b6cb9008f808a618045e9818e81febb89d28a1fcd004ba56d2d3e082ec88e070fbf648 and blake3-512:9a60c17cdbbf9b9a54b98cb744634ce42bd152b575f3e0077093bbb346ea97d5c2482da522435b4a17c785bc008bd192e73f27ceea0174b493f29ba95ba598bb) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/concat/test_append.py:21:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1f7dfac2dc1e443dc1799df3ef2ae7f18febe1d94683276b530522aabb02d15ddc9812285e7f3dcdf7eaf6bb56bcd8998330a7be6bfb21dc8e109949790e72a5', start_line=46, start_col=50, end_line=46, end_col=65) observed=two distinct pending contract demands (blake3-512:1b4aac96cfec40c105bf817cbfe436b1258b0d54eaf654e889e3006b1a3a668297c5124a00d4f674d9e6eeab2293a8547ac889bc46075a711488b7dd4c77ce6e and blake3-512:09d2e9c11e7dcf02423d718ad8db944c6977eddef803a2c86760ce7a47812825c2d15b58f770e53d82503146373632991474c9ee1a78f30acf0f1e55cfc263e0) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/concat/test_concat.py:612:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:79724a5b763f0e5af9c98ecc02cfbcd2ef333c91be32b8b9843e96b85007597bc3b2fa0b412eb40213e0a23270285752ce9c75b88489878a50df72e2a68828b5', start_line=620, start_col=26, end_line=620, end_col=33) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:a2373add93387980b78ca450b51099d495df24300375b966510309aa674c984f11b03fe240dd0f5e4e18db610d5609f08f87c1a713c5d4dba0b0183f0ded6517 and blake3-512:20760d74f3a82e54b4c21b9cc20eff39ba874c4a772fd0a350caa06cbc2188240895d79b6ee29f5a91396d2849afedfaf5a49de02ff03bf6f48302ebb5818053) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/reshape/merge/test_join.py:992:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:991579e8c5068b7495334eede1be29e7f7574afa151fa245f1aa40b1c68be508d461d367e4d67f8c4fab92bd57d7510ca25b0c6420ca8ed9a3106a2e47bfd0de', start_line=997, start_col=56, end_line=997, end_col=70) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:57fbddffcadba4f73770d8530b182e14da57c69c721c7c7ba9e08ed4ba5bc4f3d0d62111aadaede3cb6f50f0793bc2f99eb491b35489b21ee75324920490d28a and blake3-512:d52ab2231a67d6cf3633dc6f5595496e7cb1beea836d324c3fbbf8ee2a377ec602135ba8c0b3ad33ca75cabcd6839dbbb585c783f1119632a306d4134eddbf24) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/reshape/merge/test_merge.py:234:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:04f6b63e5e4f59d20ce760b87ae6ef9e137e424bfe3b909c95443b2da28acddeb7acd25f3c6ad80ac8bce3baa4687c32a1f58cfac5edccd47200788b6f57be98', start_line=236, start_col=19, end_line=236, end_col=30) observed=a hoisted parameter contract demand (blake3-512:6924578d585ccd845e91f31907450f659cb9a8c669ad71260e25c98b4478ad4cd177c9508b1b2954023bb6477d2b86ab3dc42f4e8ada508fa66293570608462d) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/merge/test_merge_cross.py:17:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:aa5ef6a5c54f4f6d35e084b32e9866baffbf096d7b4a9a936c9d99a295235a684fa87b50c0052ac8648397569e203d547f7c1af62e906a07c2d1b9cab12e17df', start_line=24, start_col=56, end_line=24, end_col=70) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:e6416231f09b23b94004d19ec93278ba7322fcb5a5e038db3ca2edcff4fa8e1950e77ebae69ad86ca39927e0a7c804d54d4db92744709a9655253c8eaf47e56a and blake3-512:e29a4ca78e21325f16ea6a3ccdac22957ba0349cb41384f69eb298444fbeeb9f428b81fa150811cb75b0744310278267783a45449a0cfe65cb8e7ce09a3d7f2b) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/reshape/merge/test_multi.py:101:12",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/reshape/merge/test_multi.py' [3248, 3266) node=BinOp> observed=BlockValue requested=stand on the multiplication floor for a TermValue right operand fix=write more Floor: implement BlockValue.multiply for TermValue"
+    },
+    {
+      "where": "tests/reshape/test_crosstab.py:70:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:33cb8e69482452a5a235cf6d494b27bbfb2d1087b1ec0162bd58c9cbf016ab484c31ba2ab9418f79a8b1bf046ea0d37cf542b0f3d81295ad2bb1d3b6779cb248', start_line=71, start_col=26, end_line=71, end_col=33) observed=two distinct pending contract demands (blake3-512:965553910eb46080d2a6fc069efa64ea01deef41c353e446348859333f948e3b1c15a8362a6c954d3ba03452dd6c4cca5f2cf99fa1ece83f75feb61decf554bf and blake3-512:707c97753edb600074e66c33812d707eb446a226100304af0fe423eb7094edac0adc32236a232c722bd21897253bb3cc0eed6faba94a26be255f8c0e4289b7ee) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_crosstab.py:75:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:33cb8e69482452a5a235cf6d494b27bbfb2d1087b1ec0162bd58c9cbf016ab484c31ba2ab9418f79a8b1bf046ea0d37cf542b0f3d81295ad2bb1d3b6779cb248', start_line=76, start_col=45, end_line=76, end_col=52) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:f9e278984299088a585a15b49ab5003767b64bb6f207e5836d318f3a373054d2cfaa1fa394d363d1a1933f2beb3bc5086474d2bc9dda4cce0893f14f738b782a and blake3-512:a48239811bfbcdbeee6d2f8d3efc312caadad6e3f0ee9c5a6c7fa5cb68c764a941ee86309592a8e3c8b6b1464e6a46e154a36c0a1096411c1098f890ed697e69) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/reshape/test_crosstab.py:611:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:33cb8e69482452a5a235cf6d494b27bbfb2d1087b1ec0162bd58c9cbf016ab484c31ba2ab9418f79a8b1bf046ea0d37cf542b0f3d81295ad2bb1d3b6779cb248', start_line=612, start_col=35, end_line=612, end_col=43) observed=two distinct pending contract demands (blake3-512:c9ff17af217a7b2f3a2b8ae9556e5efebd2deaa66025e6341d0cc23da8e2ebfe66ea75e7839af441232961b4d01e8994419b3e70bc0fa0b51fddd4d5c23b7f6e and blake3-512:09d5990a96571fa10a42e4e74150fc2fbc186305f4c4bf4e7fb5a6781fb14c16b08ae71a398f7d460175f0765008e8b9d32d782687e7cfc5ff3afa924096472c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_melt.py:84:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f730e9b7176dfc2d877a37a77fb21ce461fd94f4635afcfae56dd532e3cd9dc0bdd852e44833f09a2afe8b5ee2810a4019c31d15dc23e673b07be984d0f4fad', start_line=94, start_col=26, end_line=94, end_col=33) observed=two distinct pending contract demands (blake3-512:d427a25eedf5bd223beb0f675694981ccb87fcfdc36894c032c936a9c3cd7e18724603e92ae904f17b305784f6c6bfaa0cd6f364bd0873051ac017f0dace0044 and blake3-512:d620c7a2b27c692ce9edd9f679ae9532b6b34ce5d065b3b412da2a0c0166b33a30db4545d45fc813116a3230189747338800110266fed0d41380d1131d243a2c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_melt.py:101:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f730e9b7176dfc2d877a37a77fb21ce461fd94f4635afcfae56dd532e3cd9dc0bdd852e44833f09a2afe8b5ee2810a4019c31d15dc23e673b07be984d0f4fad', start_line=108, start_col=26, end_line=108, end_col=33) observed=two distinct pending contract demands (blake3-512:bbb299413fb3204cedc5913dbfbac110b2e3f06d411eaf42664a2f164c08559fbad180c426fe6ab5b818926db30d65eccbee89e799ad03fab37374fcd9b7e1ca and blake3-512:52eb91f4c48d0374751cb5d9eaee9a568d105c8bc359b82cf40c6b8f49ca4b07d81b9b12c1f690f857b5440527e7049b8ce083140d843cda98645c524323997c) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_melt.py:115:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f730e9b7176dfc2d877a37a77fb21ce461fd94f4635afcfae56dd532e3cd9dc0bdd852e44833f09a2afe8b5ee2810a4019c31d15dc23e673b07be984d0f4fad', start_line=121, start_col=25, end_line=121, end_col=40) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:43f7c803b95fa80fedb4b0052206ace8032911506cc982eec803ee865d86658767d84e84bbdd1020407fa8e4d2fe6b995ffb119b38a6d98fd561982b5c105012 and blake3-512:24ee9ffa29fba2967d65ed0adfb1ff8a36fee69afb5a9407023b0f862ae12d13e8ffcab267062aaa851cab77be0d0fbad0476b64fe894e38f98ebc5994aca441) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/reshape/test_melt.py:177:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f730e9b7176dfc2d877a37a77fb21ce461fd94f4635afcfae56dd532e3cd9dc0bdd852e44833f09a2afe8b5ee2810a4019c31d15dc23e673b07be984d0f4fad', start_line=198, start_col=26, end_line=198, end_col=33) observed=two distinct pending contract demands (blake3-512:6588b473236aaa6b4c849501884c2119a0218ec3f0d769c9d916c633bf7fe06fa5de96081eb5c2530f2ae1eaaed55c6f895daa0f55a750cfde266f739d3496eb and blake3-512:56bc985a7e16963b70b5a749880353d4fecb2afeab1d78c978ef604f6c9fc954b078e3013380b1115698ab4ec0f004e16fa972a3b7014d9376e545a55ad21bd5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_melt.py:204:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f730e9b7176dfc2d877a37a77fb21ce461fd94f4635afcfae56dd532e3cd9dc0bdd852e44833f09a2afe8b5ee2810a4019c31d15dc23e673b07be984d0f4fad', start_line=227, start_col=29, end_line=227, end_col=36) observed=two distinct pending contract demands (blake3-512:0374284c27f60d36c90e38bce361e021128d20f1717c80507701ac1397f61c6ee0efee5fd174946019e8de08f9db1bceca7781041067086bb9d8e96e423f4234 and blake3-512:aff0218daba4391d6bb29fa5c4313576b380ec5347b251542a1773ada53744d679541d2140389ef72e2a3793e14116aa704aa6100a3f58a12f4fdf7e6fd61c50) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_melt.py:233:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0f730e9b7176dfc2d877a37a77fb21ce461fd94f4635afcfae56dd532e3cd9dc0bdd852e44833f09a2afe8b5ee2810a4019c31d15dc23e673b07be984d0f4fad', start_line=264, start_col=29, end_line=264, end_col=36) observed=two distinct pending contract demands (blake3-512:f3f3618b050496630da14d9f589d4587e20906eb6ea64053f11dba8004dfb91a1766decdae1ddb8e0a054889f05f8059de43ac6de31f1e805ed375e2ba8e1d08 and blake3-512:e434c253412d5522cb74acac5fca57c64e5f115721c68b8de7af32f6cfa61d2d64e0f3138b5656a84b9a77de52ac47e4da5f47811c7a3e4ae56bc12d65952e1b) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/reshape/test_pivot.py:1075:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c297edf4bc459d298d1c7e6ffa341a7c732d50bdad9dd742167c1a7f88fb1b5bfcdba34ed57512aea367dd455c64b34833981384951f815229a37f6dcef4c71d', start_line=1077, start_col=45, end_line=1077, end_col=52) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:96109db794b4058b7e164c69bb29a8312870306cdbf1d93f6aad1b14f21329ad299d321325c648346ee832c53e53a1c369d2826737be04563ca270936bcf4655 and blake3-512:5a8183d308114f4984666094cc875ce07ede102048f0bacd56336e7021905b6b56d5653ebf1c1cd93f06164baad277ac47fb5c9d0f7365c3487f51ebfd1c505a) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/series/indexing/test_getitem.py:420:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:bdceeccd8c749695ff2059f75ad309dc5de92370f893d9a377dd22ed6e73b45ee16daa544304a714e404c4594c59e99a31bc461b5fe5bb7d659e9999039415f7', start_line=425, start_col=17, end_line=425, end_col=32) observed=two distinct pending contract demands (blake3-512:54e676cacc4526f1ccc7bce56ddccdb3e615ab13acb37981c92f831077d9600081ff2a168035fae512c5067ad62bec4527cb8a584f9aa09a39bc761e533c4354 and blake3-512:188fdbdb6b05b75105e8dcae495302470992db880ca61463e9cc9538eab01587bbbf6f34d09b3902a3ef2e3aa4c23c5528ad69739b1e39866bfafb2ae6fb8c96) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/indexing/test_getitem.py:512:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:bdceeccd8c749695ff2059f75ad309dc5de92370f893d9a377dd22ed6e73b45ee16daa544304a714e404c4594c59e99a31bc461b5fe5bb7d659e9999039415f7', start_line=515, start_col=14, end_line=515, end_col=40) observed=two distinct pending contract demands (blake3-512:e597c29f18818e6abf09ef715cfbca47060577cf12da32c8983b408a74218b49d3c608de45d24283777b7c337fb9c8f295044052867e8f9dc0cc0cafc4c84d1d and blake3-512:e796323b1f17beec07a53230cfc5209fa0306a29c7a4aa46b967188d937540eae5e57ab011f2307564f0e3e06e0f24ccdec0e1f4d228a91d46a0c4504316631a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/indexing/test_getitem.py:551:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:bdceeccd8c749695ff2059f75ad309dc5de92370f893d9a377dd22ed6e73b45ee16daa544304a714e404c4594c59e99a31bc461b5fe5bb7d659e9999039415f7', start_line=553, start_col=13, end_line=553, end_col=31) observed=two distinct pending contract demands (blake3-512:ef8b27171812fff7bf8ab182bede31c4bf539c7bde837bc3bf76eb61c25c9466c19843d71bb7a0e41ceaca0b984084cad23858a7ac0f54e5088b1eb7ced8daf6 and blake3-512:29c61182c2114bd5fa66aae1df2bd88f8cb5531db723cec727608715e4c929ca76ff45fd2fd07a5b3c070060fc2a7b69b74407ea100d761bea5530721abb9a07) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/indexing/test_indexing.py:229:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d525116d6bb3b78cc1eb0ac8ba86a24824f48f24910d21fec450d62a345192c588084fc3d613d80c8ef8f394585f1e9c88b679ca4f7d11dcda451c1d6b51af6d', start_line=231, start_col=15, end_line=231, end_col=35) observed=two distinct pending contract demands (blake3-512:0a22659bf2f620f0151dbfc6ca897dae8270a24f6139ba65b10faba0e639757de7010b13d55086e22d398eee0a18e49d31955e6df8c215e702dac0823a2df0e8 and blake3-512:afb3186cca4322a5107b2c353cbea7d01cfea1a33f995976cfcca2d4a2fc4182a2aaccf4e8e89786593a27a17844f5196ff3cacdf3a9ab4b648410d501daa715) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_align.py:25:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:93a760729049f27b1181f4db153a6524ebbbbaa725d61277a86522055e2b677efe3a94b15e57111c8cb1fa741e924390360af29c864363f8be598b703e425568', start_line=26, start_col=8, end_line=26, end_col=44) observed=two distinct pending contract demands (blake3-512:f9c38dba15505f719e5f406145a36966ba83c5bd012fb9bbbda6e5d7a79aa4714a93e3f287642645f2f271bc1578c326857da39662efad43be685328be194f0e and blake3-512:d00ccbc0568a0a54eef14d0945043d605ea3282935ae2ae01318b5f93c0f713e3db1dcb5e14dbc9d4364b943040c85083d9c2739e460e0bba053b44357746d49) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_align.py:55:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:93a760729049f27b1181f4db153a6524ebbbbaa725d61277a86522055e2b677efe3a94b15e57111c8cb1fa741e924390360af29c864363f8be598b703e425568', start_line=56, start_col=8, end_line=56, end_col=27) observed=a hoisted parameter contract demand (blake3-512:b000684449bb4e8bf4e9fb63e8abca4da6571b473b2268082c457cb2a1ed7e865e860b6af0640792a44fb0328642da1015b1130ef20ab0b83a9e51c70ee0cb53) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_case_when.py:82:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:936f7e995b6fb45f9691b07df877c94c94c4a8ef79234564e5fa9bfffcdc559f72351d0b671ade37780ef7b2d1bc7124eb199ec42a83a12bbe0f851f1b8d4f92', start_line=87, start_col=37, end_line=87, end_col=44) observed=two distinct pending contract demands (blake3-512:7351e7c9eb2c0e2b99c48855d1a2a037cbbc1f4aafe754be9e4195be53d52d310c82d1034b64053f44e1dc4f2b68bccdbb3128e5e17a85576ad9cbcf334661e6 and blake3-512:5c673f09d58155c9a0efd3ba256ca19257fa2ec18e6002449790800859be0010da73f3b6ba7edccb38a3ad4e4b8e7c940d65f56851a97e31b8d28a71106305e5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_case_when.py:93:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:936f7e995b6fb45f9691b07df877c94c94c4a8ef79234564e5fa9bfffcdc559f72351d0b671ade37780ef7b2d1bc7124eb199ec42a83a12bbe0f851f1b8d4f92', start_line=100, start_col=13, end_line=100, end_col=20) observed=two distinct pending contract demands (blake3-512:740eb4f9cf583306604865967a6dc039764a53004126a609b813494d34ab2a68245d440e592b2305a7575d93f09e2284f8ed787db7e1d21c571568a4c3f6a86b and blake3-512:1e74fe5d051ab6619a0ba452f880a927b1475bb332455da3b0b73e182eb041ceac9f0f92ff9ae863065b2ad5940ff29cbbeae16deac6fd0eac9a800dde72ff0b) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_case_when.py:107:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:936f7e995b6fb45f9691b07df877c94c94c4a8ef79234564e5fa9bfffcdc559f72351d0b671ade37780ef7b2d1bc7124eb199ec42a83a12bbe0f851f1b8d4f92', start_line=114, start_col=13, end_line=114, end_col=20) observed=two distinct pending contract demands (blake3-512:b4582d7046e9c52d6dd93fcf5d5d462fb80aec65e63d524034e13ef15cdacdc158c633b29d5a7f378265af678e12e2b3a3510d4f8cdcd3f49bfe1e59bffb321c and blake3-512:6dca40c68bad338cec47a686f4fdc6c31571294f7e8372ab2cc53bdd4bd915bedb6e530cd2d9de4950061171a73727f5ca95df5802625c77a4bc2fa88729fd3a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_case_when.py:159:0",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:936f7e995b6fb45f9691b07df877c94c94c4a8ef79234564e5fa9bfffcdc559f72351d0b671ade37780ef7b2d1bc7124eb199ec42a83a12bbe0f851f1b8d4f92', start_line=163, start_col=45, end_line=163, end_col=52) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:9349aa938b1bc9c05bb906784c6677149bf0c312ffefd1365896ddf2cc4745c42bf5f6fee344675252847898171d4b53571569d0339613b1732c0d51b6a2df8f and blake3-512:5851e901751b7b772477ede7f789761b2ebc0f833eedc1a6fc0b8d06874ba1ccda30cd7018d0ee5112478249461a6e6ff5aa505e122d85c31e61badb0f785159) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/series/methods/test_cov_corr.py:157:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fb666e6debbf9d495550062b46de4f003e86746274315e66a69dbc90a63572bad724344b3ab4a6ada69dc05d2825c53e7b948253a105a516f679c9a3194a6960', start_line=175, start_col=12, end_line=175, end_col=32) observed=two distinct pending contract demands (blake3-512:223ab620892fd7a8a1eeed21facc0da9940f42e0ceb54d993ec48cea0f60a156e09305c6e3bf6b623c747c30869282430caaa927b243062ebf04dcd839ff44b3 and blake3-512:8c16e1c659c6839fcce5ce5c3eb80c0dbb5d9c782d8ab086506a0a7dbb6d7f9ae165b4c39eaacde394e455b0f2ea8ff79991f8329b1506d3bb947c3f8685ac4a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/methods/test_reindex.py:395:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:73c3645c81c326c401b002e08e66ccb7f5393d6256933e84cfe9f8b7611bf498259e3a37e65951a58f1d47868a2ead1c39db8d038b2f4a4be21649d797143007', start_line=398, start_col=18, end_line=398, end_col=27) observed=two distinct pending contract demands (blake3-512:17dbfe8319eb86625a06547ccc15b4fea8a0457f44f6ec86abe2de6e32492ed57d62e5bf86db083c8de400f885256b841f17403a20bd91e38414977b6ee96942 and blake3-512:e756eb4ae66689305d4633b90be0c4f4f00e2339985b648d47cdeefca15334fb25be64676c738d45f6dca19ebe193133f45d60deb91bbfce52c39d1faeac3b6f) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/test_arithmetic.py:62:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:409c0a6fc11fce462048910ec02114d37e899c702f4aa5c096405f0aa333b1dd8ea31b7cc71b93b65193098c1af14868afe8e0e6b3ccf8e50cc5c0aa32c74c0c', start_line=70, start_col=17, end_line=70, end_col=22) observed=two distinct pending contract demands (blake3-512:373f481beb0b002692758c1eaa4156bc655611fa42c8c3db92c9b40f389db77ce8d2b64e5ce09248b7fd563078e78e7e2540409693fc8a199d7cc819ac4c6111 and blake3-512:152c17972ab942de13e6fd2c7e9085fce2acb1d2876101f54fd43a2769f912324b1e53d660f344c9b4e4b858f57c1dd31fc1fccf6cbcc360fa2b609d6ca68977) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/series/test_arithmetic.py:568:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:409c0a6fc11fce462048910ec02114d37e899c702f4aa5c096405f0aa333b1dd8ea31b7cc71b93b65193098c1af14868afe8e0e6b3ccf8e50cc5c0aa32c74c0c', start_line=571, start_col=74, end_line=571, end_col=82) observed=two distinct pending contract demands (blake3-512:93dcc2304d1bc16e5dfbe7a0aec37ab746b4a06281f31a94d001b0bb53c80c6762fbb22cd39bf553f9df0aaa405db3b8fab06692762e6739fb37acccc5f7949a and blake3-512:1dfe403116c4bb2009b8b1fee234f3d96c5aa1912f94489ef373dba04d4f02b52ee55b80f438c2764f692c02404509a4e1f91f3cd5d7154b7dcf28b853c73b76) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/test_expressions.py:35:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:8e923d4c723cd8e291468ffe3ac3ca137ce9e1ced61421c8d7f08d0895d2288d4974ed119478020f5d3dd4c43272cb375bebbff17099bd7e64bac3f116d86a3f', start_line=39, start_col=17, end_line=39, end_col=28) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:d62842412f3f3b307db6387df9a409c31c4ec75b680cc1a7328fcbe23e2002ae9571dd3e3a33e1d9d00348b74c74ec9dbd29c4eb0890482a9c81603ecb6a67b7 and blake3-512:b831ac34cee52a40bdaba7a4aa9a4826f0889399623cfa3ac9c9fcedd579cf806ebcc9d6119d7337d3dc73d7d87b8469a636797f55d0322ccc17be2c711934f0) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/test_expressions.py:47:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:8e923d4c723cd8e291468ffe3ac3ca137ce9e1ced61421c8d7f08d0895d2288d4974ed119478020f5d3dd4c43272cb375bebbff17099bd7e64bac3f116d86a3f', start_line=51, start_col=17, end_line=51, end_col=29) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:ba1d55a4427856771fb4043f9a3021e69aef29827030928f806b9b26ce935a0b66415f570a375607e27d95d65e5a12d441ead087db8c91c278f444fa40f5ffb7 and blake3-512:d6509ad1b5b2f0abeff551e757b9abf21bbc8a3351eeb5e281c59878fd9fc9c89778d28ff8a42f284a1691cd6420bd4446a63edbce65800f302ed40a29385c1b) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/tools/test_to_datetime.py:670:4",
+      "owner": "collection ListValue",
+      "message": "write more Floor for this Construction: owner=collection ListValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f3daafe21f74b8cefa91aae1f468642bf65c8ce1be40055f989a5a1c687ddf379240448b2ccd0916925132ee4e857fd5054f436f8c992fe455691b88b430579b', start_line=678, start_col=14, end_line=678, end_col=21) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:664efae0dbebaabe1dc50e685950eb58f79c33e2bc23e416c866119963ea91092b463791c851e36932b91f3413de7947faa39658f5e5779ec953b139629316ef and blake3-512:272d69bb8e37426b627b3e2b2191699bfb0e7335fa74d2d0fb2e956715368cd55fbb5eaf869d93d2872f7b800173087ac30b62134026a96a237d5723625f3b7e) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/tools/test_to_datetime.py:2069:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f3daafe21f74b8cefa91aae1f468642bf65c8ce1be40055f989a5a1c687ddf379240448b2ccd0916925132ee4e857fd5054f436f8c992fe455691b88b430579b', start_line=2071, start_col=42, end_line=2071, end_col=53) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:e7212e17508a27eb18dec126e399789f036190b7f64ed11b80ee95bd40e4c01d9441367ac7b39890238e8193d8efc9e496e1ff14409234e6f597490286b00904 and blake3-512:9f3cc9579fdb2c2c07b53caccf7a705c9814196bba3e80ad343604f795d4d12616ce1c65bf4edc6805a343b1ef03e41af929a39a791cb523254168b065b62afe) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/tseries/frequencies/test_freq_code.py:34:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:67ec7f69a74e07e3ad3e912d4fbcb5dbcdff83d4f15ae25fcc3d42b592c4c2de4f6137d382ae02ec696047fb5c76fca3ecb88da4c82ef998b42744d241b5f548', start_line=36, start_col=24, end_line=36, end_col=31) observed=two distinct pending contract demands (blake3-512:e55b72165e7c1067623b98dd6635ea365e8e65a42ee24b93d47c758ec23ddc8648ab9d774b1fb36fab04ff3ab3fa9c0d7a410ca67090aea0a5647d1209f490a8 and blake3-512:147cc1ae01b329ce81a9ea718f17836117504fefea815c6462e5c4155be9576f5ccc75b75acdf393c495cc0a8c99a2c264ca4309dae6ecb50b35a5eabb9218f1) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/tseries/frequencies/test_inference.py:248:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ba341b6de0a4fefa402e9ffce65d52705409948f1a096ee35981bf81a3c232106cea4b7a5cc649f548a0fac71586e7abee77aa60f3b945f9488e24705559d729', start_line=251, start_col=21, end_line=251, end_col=33) observed=two distinct pending contract demands (blake3-512:3f13baf3c6a8e296ec30e4e6b463a05ef07b6c117dcfc02e24dbf6ad5491b471cf0ece6b140386dca07ac35e091c29eb41975550e897ddd604aafaa85c3bc524 and blake3-512:b8a3199975157917533ba6da127c84ad0f40bccf004452556f5af0fe322cd6c6ff80365a6a50476e10418c091a7dfa9bfbba03bec534360c3047228c89a954ed) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/util/test_assert_frame_equal.py:302:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:e02d4a933722292467d6a9209628663d0022827fffbfdde72f00faef89fbfcd96b41cafe28c2696fe3eec948345117f9a10a55a9cde3ca4c6154525205115d0e', start_line=304, start_col=48, end_line=304, end_col=58) observed=two distinct pending contract demands (blake3-512:850e250d6590762eca0b4b6269d7ab984efbbc8165fdaa467153a60c30520da70eb2220f9a79bbdc7645757aa890de2d8ecd9b09624089328f39d3a9edc67844 and blake3-512:f5d0908413685d30cbb24514f00482aebf58e60c4c8f907a5eff7228e63a641b0f458980c25ed423f1ac135a7c37e5ca8bbe27c66d19a6c163d7cd508c8291a3) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_apply.py:243:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c50e1469da4e0b18327d05f0c66e195a5640decafd840b54ef659e2a85b8c5935c2d83bae1f60aa574a08649eeefea0644744c6054a2771bd485cdfa74a81310', start_line=251, start_col=19, end_line=251, end_col=30) observed=two distinct pending contract demands (blake3-512:31c521cd922c73c0468c6c41aa313aefd98d69db9a5c87d9e9cf0d58a64cc06dd910c54efea1edb8ca3684360f83939187071722aad05eb3cce2de03429eaece and blake3-512:e494af986969cd831d047a72a678eb255608a772dbb542cfb1b3eece6f450938c7bbb0ff4d7db2e0cda53d23365eb49685a59ae7088674b7be4739e8d8c120b2) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_apply.py:255:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c50e1469da4e0b18327d05f0c66e195a5640decafd840b54ef659e2a85b8c5935c2d83bae1f60aa574a08649eeefea0644744c6054a2771bd485cdfa74a81310', start_line=263, start_col=18, end_line=263, end_col=28) observed=two distinct pending contract demands (blake3-512:c049cebfc4b659e8b5cef3a297ff8ddf0cc5cce83b7bb88783bccc9b1991a1fe04938c14e1f9ab0606c72663bfde611c37dfdbe18b6fa5b81fb9bcea4d33ec13 and blake3-512:7c01da7d6a0eaa90b0b8d010adc68800156b269efc47503f3099c08bab3ecd190f1f0ab7155c9a5c3a232ddf9e3b85d53f3e02fd65b59fe7b7021163aae9e00d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_ewm.py:649:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:8774da66e33e42cab5bc4c9c975d9be55c11d219ea4b84350f310908da5c2c486191ded2d85b1f1643dd8c6934f2053ae2870fff0d945a3ea7d773d7487daa15', start_line=653, start_col=23, end_line=653, end_col=31) observed=two distinct pending contract demands (blake3-512:7987eb36174b9b2141fef09fb4528abfdb4ae86c30a0d5868a5c0df47dfa0da3bcea07a4e3a46f6804903ce2663180d1f1d122b620223c4b5808d87a731cf83b and blake3-512:b4a4e79e861a22bbf08fc2b3a84a1ccdd0e63a529cabcdf76d8af21a9e49ecf23816e8a0ded513da4392b4d7c63d16ab6a51dc49caa411c9766a155692e54550) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:104:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=111, start_col=49, end_line=111, end_col=64) observed=a hoisted parameter contract demand (blake3-512:d753a845b855fa4ea3039af034ced4ad7d100cd08d7c52caddf9cf0e3e3defc28bd83a998fd86f4baa2f4edd40790f4b9a73b49a5817478dc51c97cc1f3f5e39) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:116:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=123, start_col=49, end_line=123, end_col=64) observed=a hoisted parameter contract demand (blake3-512:73a1e558b8dd688372cd3bbd4c5bad186c450cde2ba07ec228b301cc677ac845bd773146f5487b35c7cc862def2a5f555030e68cb083286b13eeef41c81236a5) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:130:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=139, start_col=49, end_line=139, end_col=64) observed=a hoisted parameter contract demand (blake3-512:9c1e2ff6192db11c6be38834d88d9890707ba9042c2af31568ae95c8987abc08f545bd89e3ba77e1330a7cf21a9e920e5a5845778a47a68369ae4fd9bdedfe69) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:201:4",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=215, start_col=36, end_line=215, end_col=54) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:92499d878de435f9e81d4b714ce2bfe8cff8771aff984d5c38d4b66c7513c2cf1d5a561422c4fabef081e7c1ad270c7ce3a3a356c280bb2d72935e5ffac3cccc and blake3-512:e74d9fb0e768c816a5146a76d5126bf97347e0738d16ed9d4faba8f9178bfa31a8fb8359bfb9c209ba1942713e0719b5f04f12188771cffb66e11614924adcde) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements"
+    },
+    {
+      "where": "tests/window/test_groupby.py:233:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=241, start_col=49, end_line=241, end_col=64) observed=a hoisted parameter contract demand (blake3-512:6f7499190cfebfd0c6b00128d4a8bcddb574db3fc8f04c735a2dc20842b141b7236a1adb425778f1c8166ef65348cefc97ec0d4f4429bd0d3e73c83af28f3794) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:1061:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=1068, start_col=49, end_line=1068, end_col=59) observed=a hoisted parameter contract demand (blake3-512:49aa2afb0b0e8ef9f5df1ca53283a6a20379089198816a29b3f9dcd370fb78799dfb81418a69c71f9dbf6d1d09952dc4930861c2a686da3869dd41aac2050c09) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:1073:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=1080, start_col=49, end_line=1080, end_col=59) observed=a hoisted parameter contract demand (blake3-512:badb50b6edd5eaee647327d18b40f387985abe3525e23fd7459241f4f9835347020dbd9805803c28565db7636e29cbf7c3878879b393fec41138af280773e732) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:1087:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=1096, start_col=49, end_line=1096, end_col=59) observed=a hoisted parameter contract demand (blake3-512:13daba2b38557097251f148996fd2c97f9de15ab27a9d49d98942866a28e404698cd44c277ceb06d9e2c21ebfee3911036a91350b9c5e22d7415b8ba8bf5aeb3) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_groupby.py:1128:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:382f81d21d35c28f95675b7748459f3126c8b7e88ab138d72b35f0344b72ea5d8752dc2cbebe448698f0b60e5f4ddabdf77c36c3d186281d1abf297243b0a4d2', start_line=1136, start_col=49, end_line=1136, end_col=59) observed=a hoisted parameter contract demand (blake3-512:6fefd399c8e4ff3e56846718b5e969dac00e9e97496237faaab0161f78c5e14d01b824b8090011538ff80f1df25c4d3a94b1e00f72c7734d84d8ed752895eee1) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_numba.py:473:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1927ffd0adaa5f16f7a1294c951283498e1234c7117727f29f2a4bc597072f4839e23f3468737d692c02c87922a882a812898e70fff368fe37d39c7142c2dd93', start_line=476, start_col=30, end_line=476, end_col=37) observed=two distinct pending contract demands (blake3-512:2bc07bfd1feb5cddd24233452874acc5288f719bcec5dffa7a7a708bed529db869528de462f01bbee9472163f4265e6fbd2d0501281be4f293351d51b5a758c6 and blake3-512:517b286624811cffa877b968bef0f7d29b60bcd2bfc3fcada846e147d111d6e4b8d88d9eed218375ea2e076f7685d97f8b51561aa5c1e6cb16b0bb7b2e356ab5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_numba.py:475:8",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:1927ffd0adaa5f16f7a1294c951283498e1234c7117727f29f2a4bc597072f4839e23f3468737d692c02c87922a882a812898e70fff368fe37d39c7142c2dd93', start_line=476, start_col=30, end_line=476, end_col=37) observed=two distinct pending contract demands (blake3-512:2bc07bfd1feb5cddd24233452874acc5288f719bcec5dffa7a7a708bed529db869528de462f01bbee9472163f4265e6fbd2d0501281be4f293351d51b5a758c6 and blake3-512:517b286624811cffa877b968bef0f7d29b60bcd2bfc3fcada846e147d111d6e4b8d88d9eed218375ea2e076f7685d97f8b51561aa5c1e6cb16b0bb7b2e356ab5) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_pairwise.py:80:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0caeb54308227afe6a4e9ba686797477dc457f6924976f0cb67d1826d37db47fbf8887d8f28da8ab6852555fc92b67348356040153e29c98af939bcd07822939', start_line=84, start_col=23, end_line=84, end_col=31) observed=two distinct pending contract demands (blake3-512:886e7b0426c5e85edf843e6a67bc3c36e610b2cb346516dd9d6b10cbcce4c25af82ce7a8213b79ec94519a3bc6ef82ba8d9afc906d7d16b09698505074bcc3ff and blake3-512:26aaff59ef17b8b981cc74a7ac8c41da863de2a3844b0509b3481724e29e6f22f5c2d798cfb1371cf93ae082ad92092e6c50abc03fc3b063857566d160a6bc2a) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_rolling_functions.py:92:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:34487e040d5a4c697a44d1dea8c9eedb5e70be018ec0c34551c8a164b4332ebd0dd18580424f7c532b249401a970c18f6764e6e4d4148a196247bc7f35ed9648', start_line=101, start_col=19, end_line=101, end_col=30) observed=two distinct pending contract demands (blake3-512:ed5dd07f4df6137e62cae0a9e2821add398428f6cb91f9f5cf2fea156cde1e24a19c1c54da900ecaa932aa70480e799e9f03a5c691ba0f3b6c3d57cdad80baf5 and blake3-512:94d1c11025ae2dc0476e8133b28c1802e1067a7aa11585959eda35cf4d9a7815d6c5eceb1e4033c85693a6e0930a34df0dc760e1f1e6a7ab1b23682d943cdda6) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_rolling_functions.py:120:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:34487e040d5a4c697a44d1dea8c9eedb5e70be018ec0c34551c8a164b4332ebd0dd18580424f7c532b249401a970c18f6764e6e4d4148a196247bc7f35ed9648', start_line=129, start_col=18, end_line=129, end_col=28) observed=two distinct pending contract demands (blake3-512:78faed4562e0073011d53573238e55e5eef1f16c47be8ba0932af0eb34b1159c176d0ac8044228610c82a7bfb3dae1fa5a67768d3af8e43d169c46628c93e8f4 and blake3-512:96f827d7984eff5fedb6dbc23962d7ae95e4cd8b0484a2d30b502298ef519a72875efa53a2aaa2aca20606a0243a6f72b11838106b9c50ac85bd4001502d3b9d) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_rolling_quantile.py:59:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ea65c9fb4b3c369210e1279c9d1ca48f2f27115a9c073c0837b7b3adc3946861265885f40967091da050aa3e8b1e6627fff118050b7b68b601549a8bd4aad017', start_line=67, start_col=19, end_line=67, end_col=30) observed=two distinct pending contract demands (blake3-512:975ca86e15d8ec4cd314cfccdebfef32b5cf45a01c6f67a22a64a68665d9aef4f8cf6be89407c8c97427f5b76b381cde1af72864627910c364f8c046f1282111 and blake3-512:2fdb950a2ff105ee346226450e48cdda01a9b1c1633e6833fbaa75104df93d2ad86adc91b199714609f686d8ae9429f0e7419e087559a6b1f84a1f8b8ab12440) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_rolling_quantile.py:72:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ea65c9fb4b3c369210e1279c9d1ca48f2f27115a9c073c0837b7b3adc3946861265885f40967091da050aa3e8b1e6627fff118050b7b68b601549a8bd4aad017', start_line=80, start_col=18, end_line=80, end_col=28) observed=two distinct pending contract demands (blake3-512:8743fb2790cab61d917ebf198e80ada7a50b7c48190bdc555ccc1e5f8faa68fe0a9bf2ebce91c456e97ea4b6b904a830f2c859b078f37e69cda5735a3990dcc8 and blake3-512:6e13e0fc656d1fb1a936ba3e178dd71bca8b81a8db9a1e69af6842e5af686ff04430459b83ec7d028bff3bf4c46519b9db064c4f95ccd648caeec8298ed0a660) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_rolling_skew_kurt.py:43:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:12c7b6aa21b0cfcf69aba2d9f402311853d15395f3dc1ab400797692988bf3cf97c22dc7842aa0d304aed9c39fa1bfa1ad73b1a427f5f3bab188c4f9f78dff17', start_line=53, start_col=19, end_line=53, end_col=30) observed=two distinct pending contract demands (blake3-512:b5b369424592d2aefc0ef26f52e0bce11f7627cbd2746d2445e12fb9d6c43fcc800573621b95c969a2d5df87e129e192aacc9102a9f0d0be32ba81169cb297fc and blake3-512:c01df81d2f3cd323ab1b1086222de4964df7281634d1435166f6226f0b9d7aaba8ecbcd7d961d2a15f871b6b6c91ab7c2be072782ed19ca86cb32604bb29abc7) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "tests/window/test_rolling_skew_kurt.py:58:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:12c7b6aa21b0cfcf69aba2d9f402311853d15395f3dc1ab400797692988bf3cf97c22dc7842aa0d304aed9c39fa1bfa1ad73b1a427f5f3bab188c4f9f78dff17', start_line=68, start_col=18, end_line=68, end_col=28) observed=two distinct pending contract demands (blake3-512:3b8b09e7df585c52f661b0eefbc5ab26594fdb02a718a4b26932df63e814138717b352059fadb0bb62de9a61b784bd191202d0adeb90a95b0ffed38d244353d4 and blake3-512:0d43c27000a9ee87c0f54dfe81fe7106c706713353773507d4c3ac9d9be360c0ba5dcfdeea35d6f64349607b01db4928430b132d888540f4e0e3e3956803fead) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    },
+    {
+      "where": "util/_decorators.py:227:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:5a370fa5143a4251ba7b3a4b1398e853f3b54736ee9e03d97c798fc94f008ae7f0c4d98760c845232a849063a90162fd951365805a203041853edc39c8de4dda', start_line=261, start_col=49, end_line=261, end_col=64) observed=two distinct pending contract demands (blake3-512:f9dac584aa0682a8e65229ccf7709e7529ab5dead11761201fc93cc2b90efe790c3cf41eaa260b93428d756a1459d30f4c0176e92ee5544ec5050278a2e18a8a and blake3-512:427dc184ab3930ba3a6f737e55123e3b52b1c6c6b3088dfce34e44349d41374a13d84fbe9d9ba6734374dc030148266f672fcf2d3b41e5d2b090cfa129402775) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation"
+    }
+  ],
+  "R_desugar_construction_panics": 502,
+  "desugarDefects": [
+    {
+      "kind": "desugar-exception",
+      "where": "core/arrays/datetimelike.py:1397:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47510:47522#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47611:47663#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47737:47797#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47963:47992#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48092:48136#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48209:48271#blake3-512:db5e087706ef5b82be770d95310e52f5e77761a221ed24bcf9f1d079f5a9fe908c285a0838859242952999c39fb445d09b34350f1406bdcb36386a60e3152d9c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48331:48352#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48331:48352#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48759:48792#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48916:48944#blake3-512:93dec2e44389e5faa573b077dad22653b6fb8ad424a1fe0d9e3b465d17c86f1e648aeed35ba0acab88e5a0c2e779be0cb268e10932e131daaa4599eeb9b4c92e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@49080:49179#blake3-512:09f0c132de3e6ef493ff0b7d738720598f1af09d4c461856674ea38646c500fc96e2e89f451f3b55f74cded37e48602efeb1d20a57fcc83b22279f292d697e99', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@49298:49327#blake3-512:05110f4925fab4a851d128a6a943c61e23b1cbade1a2fe8653ecabb2a6ab15cc01485e6c490667bccb5ea67d7322b174b9b6cec38a681d77ff119ff54a533d83', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47510:47522#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47611:47663#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47737:47797#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47963:47992#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48092:48136#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48209:48271#blake3-512:db5e087706ef5b82be770d95310e52f5e77761a221ed24bcf9f1d079f5a9fe908c285a0838859242952999c39fb445d09b34350f1406bdcb36386a60e3152d9c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48331:48352#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48759:48792#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/arrays/datetimelike.py:1461:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50522:50534#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50623:50675#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50750:50810#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50977:51006#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51107:51151#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51224:51245#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51224:51245#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51624:51649#blake3-512:5f91653d24cc9e95fb6d47941aae54fd9d3654e2d93153abfe6ffafc78c96a5ae794325d0868755a5e9c53df581c38844c4bad9486717fb604765d1e1095fc37', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51742:51775#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51900:51928#blake3-512:93dec2e44389e5faa573b077dad22653b6fb8ad424a1fe0d9e3b465d17c86f1e648aeed35ba0acab88e5a0c2e779be0cb268e10932e131daaa4599eeb9b4c92e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52064:52163#blake3-512:09f0c132de3e6ef493ff0b7d738720598f1af09d4c461856674ea38646c500fc96e2e89f451f3b55f74cded37e48602efeb1d20a57fcc83b22279f292d697e99', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52284:52320#blake3-512:3ea6c30605e53e3c155dbca7f63de0e075eb731694fa491d8ae0e741cc2e82ebebd7aa0cc3ef20eac4bbbbf909d9f510d02e6ad44e5c808e74eb6ece4522c4a7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52410:52439#blake3-512:05110f4925fab4a851d128a6a943c61e23b1cbade1a2fe8653ecabb2a6ab15cc01485e6c490667bccb5ea67d7322b174b9b6cec38a681d77ff119ff54a533d83', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50522:50534#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50623:50675#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50750:50810#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50977:51006#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51107:51151#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51224:51245#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51624:51649#blake3-512:5f91653d24cc9e95fb6d47941aae54fd9d3654e2d93153abfe6ffafc78c96a5ae794325d0868755a5e9c53df581c38844c4bad9486717fb604765d1e1095fc37', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51624:51649#blake3-512:5f91653d24cc9e95fb6d47941aae54fd9d3654e2d93153abfe6ffafc78c96a5ae794325d0868755a5e9c53df581c38844c4bad9486717fb604765d1e1095fc37', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51742:51775#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51900:51928#blake3-512:93dec2e44389e5faa573b077dad22653b6fb8ad424a1fe0d9e3b465d17c86f1e648aeed35ba0acab88e5a0c2e779be0cb268e10932e131daaa4599eeb9b4c92e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52064:52163#blake3-512:09f0c132de3e6ef493ff0b7d738720598f1af09d4c461856674ea38646c500fc96e2e89f451f3b55f74cded37e48602efeb1d20a57fcc83b22279f292d697e99', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52284:52320#blake3-512:3ea6c30605e53e3c155dbca7f63de0e075eb731694fa491d8ae0e741cc2e82ebebd7aa0cc3ef20eac4bbbbf909d9f510d02e6ad44e5c808e74eb6ece4522c4a7', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/arrays/datetimelike.py:1927:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/arrays/sparse/array.py:1209:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/frame.py:11380:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/generic.py:13403:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / StringValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457334:457347#blake3-512:5b32feb0e3630b4d6204e6ffed269ece2581008fc37b12a4390aac94e85fd9155d8260315e9c190bdaec8715100bbd286c890864894ec58c02be3189cc993ce9', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457745:457758#blake3-512:5b603297f0e13ffd4e7ffcde2d896f06b13295b32a24239867e9dfc07c587eb8705d174e6c8a82e7f95b7ae09a26c8f04b5ee0b04699125c00bb3de765c0d4b8', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@459055:459069#blake3-512:edf862325999580225168d4ddba09e14894a34b33abbf14bd2b933186427c005f08a5bfd936619145fe81b45f7ca8396f6fe25e33aeb6ff91e251e8689411923', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462613:462629#blake3-512:a3ae6b2e60ba425f091734cb9f68162e83e9128e362fcbb869c63999032a930a92737fde7da749e002fde8637cabe58ea6094b9fb5b2203b440171adc2e59c49', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))))))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/groupby/groupby.py:4829:8",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / GuardedValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@155833:155899#blake3-512:2dbf2bbbe2b15293fe852f0f1dbb5cd9bb5187bedf861f44bcb0019796438e42f98bfe368e150476ce4fb7f4eff66216d87a1905d31bcdd026be36ba6d476776', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@155833:155899#blake3-512:2dbf2bbbe2b15293fe852f0f1dbb5cd9bb5187bedf861f44bcb0019796438e42f98bfe368e150476ce4fb7f4eff66216d87a1905d31bcdd026be36ba6d476776', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@156023:156051#blake3-512:c7a34f63e65fe32cf3a770a985febd3ce20336b652985c636d7c88940ac1427d3becf25b78035fe520497a5609a087bece642e3b0c3ca35bd0e6634475a69c8f', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@156293:156355#blake3-512:aa034839cd487177b95b1e22ab7e1a59b053466281ab54c5f84c86957c9109599991a7c3c4a7d9273878fe32eb486887ca197a145e899bd7bc766907e8ff88c7', sort=PrimitiveSort(name='String')),)),))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@155833:155899#blake3-512:2dbf2bbbe2b15293fe852f0f1dbb5cd9bb5187bedf861f44bcb0019796438e42f98bfe368e150476ce4fb7f4eff66216d87a1905d31bcdd026be36ba6d476776', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@156023:156051#blake3-512:c7a34f63e65fe32cf3a770a985febd3ce20336b652985c636d7c88940ac1427d3becf25b78035fe520497a5609a087bece642e3b0c3ca35bd0e6634475a69c8f', sort=PrimitiveSort(name='String')),)),))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/groupby/ops.py:312:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/indexes/base.py:4147:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/methods/selectn.py:224:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / SymbolicValue\n  arm A guard: _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:efa16f7745ca9e27dd2fd887511ed151272290d13bf49e0cd7d93f6bf63ee405ec8fb910405e929cfcc1ede8b4895ec6c9e2ea6f045db5d94dce9a34b7279331@7521:7559#blake3-512:ac796d6da6a5621d5243e380f3852f7997bd44c4a32f87e90131472362f96cad692ad87190c29326bf887a41fe437abbc6c3435bdc35b9d4d88d86b41dc70521', sort=PrimitiveSort(name='String')),)),))\n  arm B guard: _Atomic(name='python.loop.exhausted', args=(_ConstStr(value='blake3-512:524374dbac522550b29c9009f26ac3d271f23ded5ebab0602749cad7f0d780d46c551ac740b44ff30b1d98449a6bf4ca9748109d0493139ff0720c77dce4faa6', sort=PrimitiveSort(name='String')),))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/missing.py:239:0",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/reshape/encoding.py:43:0",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/reshape/merge.py:2654:0",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/reshape/merge.py:2724:0",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/excel/_openpyxl.py:445:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13152:13212#blake3-512:b0005402b4ee2ed1cc0a6a188b922fe467f624b2b535734ead9166f1ba5fe6179bd7ddbe9154f3df9c6cfee5c6337f8dc1b48633f5d0e9b9ccb48282e31a3464', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13229:13247#blake3-512:35e2015e13c75b1a04d0dedf55999b8e1568f4e19161564364fddf60d1b717cad1a8bcefac772d71a41c58e653899e48a90e582e16d086eabac5e8e07f469700', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13268:13302#blake3-512:8a9d5093a013bbd36270d46c1e1317288e714e2a49eda68aca921c44e942525f3e23223a2f051154b66d9089a409c8d742e4f244cd14982ede3bee6fba48f72d', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13152:13212#blake3-512:b0005402b4ee2ed1cc0a6a188b922fe467f624b2b535734ead9166f1ba5fe6179bd7ddbe9154f3df9c6cfee5c6337f8dc1b48633f5d0e9b9ccb48282e31a3464', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='or', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13229:13247#blake3-512:35e2015e13c75b1a04d0dedf55999b8e1568f4e19161564364fddf60d1b717cad1a8bcefac772d71a41c58e653899e48a90e582e16d086eabac5e8e07f469700', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13229:13247#blake3-512:35e2015e13c75b1a04d0dedf55999b8e1568f4e19161564364fddf60d1b717cad1a8bcefac772d71a41c58e653899e48a90e582e16d086eabac5e8e07f469700', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13268:13302#blake3-512:8a9d5093a013bbd36270d46c1e1317288e714e2a49eda68aca921c44e942525f3e23223a2f051154b66d9089a409c8d742e4f244cd14982ede3bee6fba48f72d', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13560:13592#blake3-512:8bc4b8b9494b5419ffbb3faf47137eb13eb179eb30fb2dccb26202bb2cd04a81ab495301edb69a531dba0b42fb6e6efa5afc25a3957223d7621281d38589aa8b', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13805:13839#blake3-512:551e1dba02f569823f4e680f0b9fe826f28ee03caba16d22d05b4e84995cb983187230d6882323309efb8ab2d894e3e7893a00c1bfae1d173d6d080c3cce4e86', sort=PrimitiveSort(name='String')),)),))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/excel/_openpyxl.py:614:4",
+      "detail": "AttributeError: 'ExitSet' object has no attribute 'value'"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/formats/excel.py:85:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/formats/style.py:4259:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167797:167819#blake3-512:1239200891b25516c66e12b7641cb2926725e32a2b2cb19606d9acc2d4297502a090c7949eb1adb16e163083a7f82f482667a7efd3fca5f658e6cf77f5d73d06', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167871:167890#blake3-512:c5cc2922f13ebfdad0ef103088246e72fb7c4b3fab7de01148679f943d4382f994aeb70b8ec34169c10d22a9ee852c8daeacc76da505f2e1bae5513234548808', sort=PrimitiveSort(name='String')),)),))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)), _Connective(kind='or', operands=(_Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167797:167819#blake3-512:1239200891b25516c66e12b7641cb2926725e32a2b2cb19606d9acc2d4297502a090c7949eb1adb16e163083a7f82f482667a7efd3fca5f658e6cf77f5d73d06', sort=PrimitiveSort(name='String')),)),)))), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167797:167819#blake3-512:1239200891b25516c66e12b7641cb2926725e32a2b2cb19606d9acc2d4297502a090c7949eb1adb16e163083a7f82f482667a7efd3fca5f658e6cf77f5d73d06', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167871:167890#blake3-512:c5cc2922f13ebfdad0ef103088246e72fb7c4b3fab7de01148679f943d4382f994aeb70b8ec34169c10d22a9ee852c8daeacc76da505f2e1bae5513234548808', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167942:167962#blake3-512:9db9101ff0f908c96ecc00a5492d43edf4117122870779d0bc9670071a534df483542d5f97d336fb0385a6e4cec3613995aeecd36053c15e99f8c241c1f9521a', sort=PrimitiveSort(name='String')),)),))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: [\"PartitionFace(partition=('sugar.exit_set.partition', ('IfExpSugar', <SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [168497, 168620) node=IfExp>, _Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)))), side=True)\"]\n  arm B faces: [\"PartitionFace(partition=('sugar.exit_set.partition', ('IfExpSugar', <SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [168497, 168620) node=IfExp>, _Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)))), side=True)\"]"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/formats/style_render.py:2579:0",
+      "detail": "AttributeError: 'ExitSet' object has no attribute 'value'"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "plotting/_matplotlib/core.py:1617:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "plotting/_matplotlib/core.py:1777:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "plotting/_matplotlib/hist.py:107:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/dtypes/cast/test_box_unbox.py:50:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: TermValue / ComplexValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1242:1257#blake3-512:efc583ae5dfeb50fa2439b74389240f61f551c7d0e2c294ff942d490122d6869e54a68cf97578a77229bfe51369c91a617e73b7edacdbf49422cb3e8a810a89c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1315:1343#blake3-512:2685c9f9a075ca577a725aabfb387149b48635579f34871cc4aefa7441fdac7b9fed313555930d1b836b2e6c768e40b0a889bf7a95db0e05e0d077839a2cab8f', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1315:1343#blake3-512:2685c9f9a075ca577a725aabfb387149b48635579f34871cc4aefa7441fdac7b9fed313555930d1b836b2e6c768e40b0a889bf7a95db0e05e0d077839a2cab8f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1396:1414#blake3-512:a04187ee9d749c146fac73de63d40494019c8ed921dbf501738cb4a0f991060ac9d09c067c00057c98ecbb8b0a07ecce5db0bcefeefa99146e83a52fe8f094c0', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1396:1414#blake3-512:a04187ee9d749c146fac73de63d40494019c8ed921dbf501738cb4a0f991060ac9d09c067c00057c98ecbb8b0a07ecce5db0bcefeefa99146e83a52fe8f094c0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1471:1488#blake3-512:6c689285fc8445cc8062fdfc6fedee2351844799f84ad60f042fd46e316d2cc506cfff4fff3b97c530462f28639034b75193029ac6b4d266e16d4f8ef7299124', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1554:1570#blake3-512:fafd1d66b5b5ff4189a0d0d64c5f588b292d9cabab1417423ecbeecaa48635d4078251bc5b8ee4d9507e0b94201d15e80d0d83c5c2b32e464ad26cae50892245', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1627:1642#blake3-512:0d36a46b43b620b8d4d692bcaf7e64c1963051d3d0842728f7c47801946047e68f70f76bcc66eea1be5cd941c939d643bf8cc68b4a7bf1169bb7095d57252b08', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1696:1711#blake3-512:da7ff919837e44dd8af59b74e42ebe80b3dd92f0fb1ea8e84880514b8042232e77f76ea284a2f30cb403cb57ab224c3d77c26f7cad24d090bf8388bdf4f99cc5', sort=PrimitiveSort(name='String')),)),))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1242:1257#blake3-512:efc583ae5dfeb50fa2439b74389240f61f551c7d0e2c294ff942d490122d6869e54a68cf97578a77229bfe51369c91a617e73b7edacdbf49422cb3e8a810a89c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1315:1343#blake3-512:2685c9f9a075ca577a725aabfb387149b48635579f34871cc4aefa7441fdac7b9fed313555930d1b836b2e6c768e40b0a889bf7a95db0e05e0d077839a2cab8f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1396:1414#blake3-512:a04187ee9d749c146fac73de63d40494019c8ed921dbf501738cb4a0f991060ac9d09c067c00057c98ecbb8b0a07ecce5db0bcefeefa99146e83a52fe8f094c0', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1471:1488#blake3-512:6c689285fc8445cc8062fdfc6fedee2351844799f84ad60f042fd46e316d2cc506cfff4fff3b97c530462f28639034b75193029ac6b4d266e16d4f8ef7299124', sort=PrimitiveSort(name='String')),)),))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/extension/test_arrow.py:172:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: TermValue / TermValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5398:5427#blake3-512:eccb2f0c8d7cd3c2ae1f5e65d81dfa95cfe20584c1f668a80905d416292c333ab2c5d73a05832ee47247c11518a25a240831df3114ef30c8a337764117e6770e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5490:5520#blake3-512:267ce1b51ee4f295387bcf48e52658563ba279dc00a752dd2531024100146d4da62e1c2ac73f015386546af3d7ed648b7f74a0afa6282bf0f27f899ca572cb62', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5490:5520#blake3-512:267ce1b51ee4f295387bcf48e52658563ba279dc00a752dd2531024100146d4da62e1c2ac73f015386546af3d7ed648b7f74a0afa6282bf0f27f899ca572cb62', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5580:5616#blake3-512:5d4aa384a4bc682ef124f56c06530629eecf3b6b3d4492796414446d47aca4687c60093e6ec397d92428de7f077ab48e023834412f7c112194a9f00ee4d4e6ac', sort=PrimitiveSort(name='String')),)),))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5398:5427#blake3-512:eccb2f0c8d7cd3c2ae1f5e65d81dfa95cfe20584c1f668a80905d416292c333ab2c5d73a05832ee47247c11518a25a240831df3114ef30c8a337764117e6770e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5490:5520#blake3-512:267ce1b51ee4f295387bcf48e52658563ba279dc00a752dd2531024100146d4da62e1c2ac73f015386546af3d7ed648b7f74a0afa6282bf0f27f899ca572cb62', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5580:5616#blake3-512:5d4aa384a4bc682ef124f56c06530629eecf3b6b3d4492796414446d47aca4687c60093e6ec397d92428de7f077ab48e023834412f7c112194a9f00ee4d4e6ac', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5670:5708#blake3-512:0cb8f0c236f68703bdaaf6afcffa702ec236435f98edef04ef0ffcef1c18d839b209334498387ae9e13e4ed33a5b3747dacd070ad5a614310b9e4c7c3d3b1300', sort=PrimitiveSort(name='String')),)),))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/extension/test_masked.py:312:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / SymbolicValue\n  arm A guard: _Connective(kind='or', operands=(_Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),)))), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11586:11617#blake3-512:ad1b7fc9743c000da1c3158d274866625acd8acf30219abb1a24a221316e7288c76a24f14ac6ed530c926a7ba1f729f51bd89500c3ffe4856ba40f7d70b5f15c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),))))))))\n  arm B guard: _Connective(kind='or', operands=(_Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10734:10764#blake3-512:12dda3b3ab06d68648ccd07c667c8e179742dcc7e8aa9df44cec951d7b43e4f6fb93ee15ebd94e377bf8026aafdc18c16aa6549449d550a6fd17ab0430d9d5b7', sort=PrimitiveSort(name='String')),)),)))))), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11586:11617#blake3-512:ad1b7fc9743c000da1c3158d274866625acd8acf30219abb1a24a221316e7288c76a24f14ac6ed530c926a7ba1f729f51bd89500c3ffe4856ba40f7d70b5f15c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10734:10764#blake3-512:12dda3b3ab06d68648ccd07c667c8e179742dcc7e8aa9df44cec951d7b43e4f6fb93ee15ebd94e377bf8026aafdc18c16aa6549449d550a6fd17ab0430d9d5b7', sort=PrimitiveSort(name='String')),)),))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_categorical.py:2000:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: ListValue / ListValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67090:67111#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67090:67111#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67143:67165#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67090:67111#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67143:67165#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67229:67250#blake3-512:dabbcf5355560bad7c44688eeafdd31219a1e12111d4a288c72a6008c967c3ff8592d449f17b268c6b7b467c099232582ff25bdc9ec068aed44ed58a7f617d1b', sort=PrimitiveSort(name='String')),)),))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_categorical.py:2036:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: ListValue / ListValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68464:68485#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68464:68485#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68517:68539#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68464:68485#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68517:68539#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68603:68624#blake3-512:dabbcf5355560bad7c44688eeafdd31219a1e12111d4a288c72a6008c967c3ff8592d449f17b268c6b7b467c099232582ff25bdc9ec068aed44ed58a7f617d1b', sort=PrimitiveSort(name='String')),)),))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_categorical.py:2072:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: ListValue / ListValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69777:69798#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69777:69798#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69830:69852#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69777:69798#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69830:69852#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69916:69937#blake3-512:dabbcf5355560bad7c44688eeafdd31219a1e12111d4a288c72a6008c967c3ff8592d449f17b268c6b7b467c099232582ff25bdc9ec068aed44ed58a7f617d1b', sort=PrimitiveSort(name='String')),)),))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_reductions.py:1344:0",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/numeric/test_indexing.py:437:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/test_base.py:728:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/test_datetimelike.py:98:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/test_datetimelike.py:117:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/test_old_base.py:413:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/test_old_base.py:921:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/indexes/test_old_base.py:931:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/io/parser/test_read_fwf.py:643:0",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/series/indexing/test_setitem.py:1087:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/series/indexing/test_setitem.py:1197:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/test_nanops.py:370:4",
+      "detail": "TypeError: <class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>"
+    }
+  ],
+  "R_desugar_defects": 40,
+  "unresolvableDispatchTargets": [],
+  "R_unresolvable_dispatch_targets": 0,
+  "elapsedSeconds": 3267.223010778427,
+  "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+  "sourceStamp": {
+    "commit": "9a78828ee6a9fb09b083d397a367994722cb1639",
+    "repo": "/home/tsavo/scoreboard-checkout",
+    "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+    "platform": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
+    "host": "Battleaxe",
+    "loadAverage": [
+      15.1748046875,
+      16.44384765625,
+      18.10546875
+    ],
+    "measuredAtUnix": 1785088448.3900185
+  },
+  "floorSummary": {
+    "kind": "pandas-floor-summary-v1",
+    "floor": "control-effect",
+    "measurement": "measured",
+    "unmeasurableReasons": [],
+    "corpus": {
+      "files": [
+        "pandas/__init__.py",
+        "pandas/_config/__init__.py",
+        "pandas/_config/config.py",
+        "pandas/_config/dates.py",
+        "pandas/_config/display.py",
+        "pandas/_config/localization.py",
+        "pandas/_libs/__init__.py",
+        "pandas/_libs/tslibs/__init__.py",
+        "pandas/_libs/window/__init__.py",
+        "pandas/_testing/__init__.py",
+        "pandas/_testing/_hypothesis.py",
+        "pandas/_testing/_io.py",
+        "pandas/_testing/_warnings.py",
+        "pandas/_testing/asserters.py",
+        "pandas/_testing/compat.py",
+        "pandas/_testing/contexts.py",
+        "pandas/_typing.py",
+        "pandas/_version.py",
+        "pandas/_version_meson.py",
+        "pandas/api/__init__.py",
+        "pandas/api/executors/__init__.py",
+        "pandas/api/extensions/__init__.py",
+        "pandas/api/indexers/__init__.py",
+        "pandas/api/interchange/__init__.py",
+        "pandas/api/internals.py",
+        "pandas/api/types/__init__.py",
+        "pandas/api/typing/__init__.py",
+        "pandas/api/typing/aliases.py",
+        "pandas/arrays/__init__.py",
+        "pandas/compat/__init__.py",
+        "pandas/compat/_constants.py",
+        "pandas/compat/_optional.py",
+        "pandas/compat/numpy/__init__.py",
+        "pandas/compat/numpy/function.py",
+        "pandas/compat/pickle_compat.py",
+        "pandas/compat/pyarrow.py",
+        "pandas/conftest.py",
+        "pandas/core/__init__.py",
+        "pandas/core/_numba/__init__.py",
+        "pandas/core/_numba/executor.py",
+        "pandas/core/_numba/extensions.py",
+        "pandas/core/_numba/kernels/__init__.py",
+        "pandas/core/_numba/kernels/mean_.py",
+        "pandas/core/_numba/kernels/min_max_.py",
+        "pandas/core/_numba/kernels/shared.py",
+        "pandas/core/_numba/kernels/sum_.py",
+        "pandas/core/_numba/kernels/var_.py",
+        "pandas/core/accessor.py",
+        "pandas/core/algorithms.py",
+        "pandas/core/api.py",
+        "pandas/core/apply.py",
+        "pandas/core/array_algos/__init__.py",
+        "pandas/core/array_algos/datetimelike_accumulations.py",
+        "pandas/core/array_algos/masked_accumulations.py",
+        "pandas/core/array_algos/masked_reductions.py",
+        "pandas/core/array_algos/putmask.py",
+        "pandas/core/array_algos/quantile.py",
+        "pandas/core/array_algos/replace.py",
+        "pandas/core/array_algos/take.py",
+        "pandas/core/array_algos/transforms.py",
+        "pandas/core/arraylike.py",
+        "pandas/core/arrays/__init__.py",
+        "pandas/core/arrays/_arrow_string_mixins.py",
+        "pandas/core/arrays/_mixins.py",
+        "pandas/core/arrays/_ranges.py",
+        "pandas/core/arrays/_utils.py",
+        "pandas/core/arrays/arrow/__init__.py",
+        "pandas/core/arrays/arrow/_arrow_utils.py",
+        "pandas/core/arrays/arrow/accessors.py",
+        "pandas/core/arrays/arrow/array.py",
+        "pandas/core/arrays/arrow/extension_types.py",
+        "pandas/core/arrays/base.py",
+        "pandas/core/arrays/boolean.py",
+        "pandas/core/arrays/categorical.py",
+        "pandas/core/arrays/datetimelike.py",
+        "pandas/core/arrays/datetimes.py",
+        "pandas/core/arrays/floating.py",
+        "pandas/core/arrays/integer.py",
+        "pandas/core/arrays/interval.py",
+        "pandas/core/arrays/masked.py",
+        "pandas/core/arrays/numeric.py",
+        "pandas/core/arrays/numpy_.py",
+        "pandas/core/arrays/period.py",
+        "pandas/core/arrays/sparse/__init__.py",
+        "pandas/core/arrays/sparse/accessor.py",
+        "pandas/core/arrays/sparse/array.py",
+        "pandas/core/arrays/sparse/scipy_sparse.py",
+        "pandas/core/arrays/string_.py",
+        "pandas/core/arrays/string_arrow.py",
+        "pandas/core/arrays/timedeltas.py",
+        "pandas/core/base.py",
+        "pandas/core/col.py",
+        "pandas/core/common.py",
+        "pandas/core/computation/__init__.py",
+        "pandas/core/computation/align.py",
+        "pandas/core/computation/api.py",
+        "pandas/core/computation/check.py",
+        "pandas/core/computation/common.py",
+        "pandas/core/computation/engines.py",
+        "pandas/core/computation/eval.py",
+        "pandas/core/computation/expr.py",
+        "pandas/core/computation/expressions.py",
+        "pandas/core/computation/ops.py",
+        "pandas/core/computation/parsing.py",
+        "pandas/core/computation/pytables.py",
+        "pandas/core/computation/scope.py",
+        "pandas/core/config_init.py",
+        "pandas/core/construction.py",
+        "pandas/core/dtypes/__init__.py",
+        "pandas/core/dtypes/api.py",
+        "pandas/core/dtypes/astype.py",
+        "pandas/core/dtypes/base.py",
+        "pandas/core/dtypes/cast.py",
+        "pandas/core/dtypes/common.py",
+        "pandas/core/dtypes/concat.py",
+        "pandas/core/dtypes/dtypes.py",
+        "pandas/core/dtypes/generic.py",
+        "pandas/core/dtypes/inference.py",
+        "pandas/core/dtypes/missing.py",
+        "pandas/core/flags.py",
+        "pandas/core/frame.py",
+        "pandas/core/generic.py",
+        "pandas/core/groupby/__init__.py",
+        "pandas/core/groupby/base.py",
+        "pandas/core/groupby/categorical.py",
+        "pandas/core/groupby/generic.py",
+        "pandas/core/groupby/groupby.py",
+        "pandas/core/groupby/grouper.py",
+        "pandas/core/groupby/indexing.py",
+        "pandas/core/groupby/numba_.py",
+        "pandas/core/groupby/ops.py",
+        "pandas/core/indexers/__init__.py",
+        "pandas/core/indexers/objects.py",
+        "pandas/core/indexers/utils.py",
+        "pandas/core/indexes/__init__.py",
+        "pandas/core/indexes/accessors.py",
+        "pandas/core/indexes/api.py",
+        "pandas/core/indexes/base.py",
+        "pandas/core/indexes/category.py",
+        "pandas/core/indexes/datetimelike.py",
+        "pandas/core/indexes/datetimes.py",
+        "pandas/core/indexes/extension.py",
+        "pandas/core/indexes/frozen.py",
+        "pandas/core/indexes/interval.py",
+        "pandas/core/indexes/multi.py",
+        "pandas/core/indexes/period.py",
+        "pandas/core/indexes/range.py",
+        "pandas/core/indexes/timedeltas.py",
+        "pandas/core/indexing.py",
+        "pandas/core/interchange/__init__.py",
+        "pandas/core/interchange/buffer.py",
+        "pandas/core/interchange/column.py",
+        "pandas/core/interchange/dataframe.py",
+        "pandas/core/interchange/dataframe_protocol.py",
+        "pandas/core/interchange/from_dataframe.py",
+        "pandas/core/interchange/utils.py",
+        "pandas/core/internals/__init__.py",
+        "pandas/core/internals/api.py",
+        "pandas/core/internals/blocks.py",
+        "pandas/core/internals/concat.py",
+        "pandas/core/internals/construction.py",
+        "pandas/core/internals/managers.py",
+        "pandas/core/internals/ops.py",
+        "pandas/core/methods/__init__.py",
+        "pandas/core/methods/describe.py",
+        "pandas/core/methods/selectn.py",
+        "pandas/core/methods/to_dict.py",
+        "pandas/core/missing.py",
+        "pandas/core/nanops.py",
+        "pandas/core/ops/__init__.py",
+        "pandas/core/ops/array_ops.py",
+        "pandas/core/ops/common.py",
+        "pandas/core/ops/dispatch.py",
+        "pandas/core/ops/docstrings.py",
+        "pandas/core/ops/invalid.py",
+        "pandas/core/ops/mask_ops.py",
+        "pandas/core/ops/missing.py",
+        "pandas/core/resample.py",
+        "pandas/core/reshape/__init__.py",
+        "pandas/core/reshape/api.py",
+        "pandas/core/reshape/concat.py",
+        "pandas/core/reshape/encoding.py",
+        "pandas/core/reshape/melt.py",
+        "pandas/core/reshape/merge.py",
+        "pandas/core/reshape/pivot.py",
+        "pandas/core/reshape/reshape.py",
+        "pandas/core/reshape/tile.py",
+        "pandas/core/roperator.py",
+        "pandas/core/sample.py",
+        "pandas/core/series.py",
+        "pandas/core/shared_docs.py",
+        "pandas/core/sorting.py",
+        "pandas/core/sparse/__init__.py",
+        "pandas/core/sparse/api.py",
+        "pandas/core/strings/__init__.py",
+        "pandas/core/strings/accessor.py",
+        "pandas/core/strings/object_array.py",
+        "pandas/core/tools/__init__.py",
+        "pandas/core/tools/datetimes.py",
+        "pandas/core/tools/numeric.py",
+        "pandas/core/tools/timedeltas.py",
+        "pandas/core/tools/times.py",
+        "pandas/core/util/__init__.py",
+        "pandas/core/util/hashing.py",
+        "pandas/core/util/numba_.py",
+        "pandas/core/window/__init__.py",
+        "pandas/core/window/common.py",
+        "pandas/core/window/doc.py",
+        "pandas/core/window/ewm.py",
+        "pandas/core/window/expanding.py",
+        "pandas/core/window/numba_.py",
+        "pandas/core/window/online.py",
+        "pandas/core/window/rolling.py",
+        "pandas/errors/__init__.py",
+        "pandas/errors/cow.py",
+        "pandas/io/__init__.py",
+        "pandas/io/_util.py",
+        "pandas/io/api.py",
+        "pandas/io/clipboard/__init__.py",
+        "pandas/io/clipboards.py",
+        "pandas/io/common.py",
+        "pandas/io/excel/__init__.py",
+        "pandas/io/excel/_base.py",
+        "pandas/io/excel/_calamine.py",
+        "pandas/io/excel/_odfreader.py",
+        "pandas/io/excel/_odswriter.py",
+        "pandas/io/excel/_openpyxl.py",
+        "pandas/io/excel/_pyxlsb.py",
+        "pandas/io/excel/_util.py",
+        "pandas/io/excel/_xlrd.py",
+        "pandas/io/excel/_xlsxwriter.py",
+        "pandas/io/feather_format.py",
+        "pandas/io/formats/__init__.py",
+        "pandas/io/formats/_color_data.py",
+        "pandas/io/formats/console.py",
+        "pandas/io/formats/css.py",
+        "pandas/io/formats/csvs.py",
+        "pandas/io/formats/excel.py",
+        "pandas/io/formats/format.py",
+        "pandas/io/formats/html.py",
+        "pandas/io/formats/info.py",
+        "pandas/io/formats/printing.py",
+        "pandas/io/formats/string.py",
+        "pandas/io/formats/style.py",
+        "pandas/io/formats/style_render.py",
+        "pandas/io/formats/xml.py",
+        "pandas/io/html.py",
+        "pandas/io/iceberg.py",
+        "pandas/io/json/__init__.py",
+        "pandas/io/json/_json.py",
+        "pandas/io/json/_normalize.py",
+        "pandas/io/json/_table_schema.py",
+        "pandas/io/orc.py",
+        "pandas/io/parquet.py",
+        "pandas/io/parsers/__init__.py",
+        "pandas/io/parsers/arrow_parser_wrapper.py",
+        "pandas/io/parsers/base_parser.py",
+        "pandas/io/parsers/c_parser_wrapper.py",
+        "pandas/io/parsers/python_parser.py",
+        "pandas/io/parsers/readers.py",
+        "pandas/io/pickle.py",
+        "pandas/io/pytables.py",
+        "pandas/io/sas/__init__.py",
+        "pandas/io/sas/sas7bdat.py",
+        "pandas/io/sas/sas_constants.py",
+        "pandas/io/sas/sas_xport.py",
+        "pandas/io/sas/sasreader.py",
+        "pandas/io/spss.py",
+        "pandas/io/sql.py",
+        "pandas/io/stata.py",
+        "pandas/io/xml.py",
+        "pandas/plotting/__init__.py",
+        "pandas/plotting/_core.py",
+        "pandas/plotting/_matplotlib/__init__.py",
+        "pandas/plotting/_matplotlib/boxplot.py",
+        "pandas/plotting/_matplotlib/converter.py",
+        "pandas/plotting/_matplotlib/core.py",
+        "pandas/plotting/_matplotlib/groupby.py",
+        "pandas/plotting/_matplotlib/hist.py",
+        "pandas/plotting/_matplotlib/misc.py",
+        "pandas/plotting/_matplotlib/style.py",
+        "pandas/plotting/_matplotlib/timeseries.py",
+        "pandas/plotting/_matplotlib/tools.py",
+        "pandas/plotting/_misc.py",
+        "pandas/testing.py",
+        "pandas/tests/__init__.py",
+        "pandas/tests/api/__init__.py",
+        "pandas/tests/api/test_api.py",
+        "pandas/tests/api/test_types.py",
+        "pandas/tests/apply/__init__.py",
+        "pandas/tests/apply/common.py",
+        "pandas/tests/apply/conftest.py",
+        "pandas/tests/apply/test_frame_apply.py",
+        "pandas/tests/apply/test_frame_apply_relabeling.py",
+        "pandas/tests/apply/test_frame_transform.py",
+        "pandas/tests/apply/test_invalid_arg.py",
+        "pandas/tests/apply/test_numba.py",
+        "pandas/tests/apply/test_series_apply.py",
+        "pandas/tests/apply/test_series_apply_relabeling.py",
+        "pandas/tests/apply/test_series_transform.py",
+        "pandas/tests/apply/test_str.py",
+        "pandas/tests/arithmetic/__init__.py",
+        "pandas/tests/arithmetic/common.py",
+        "pandas/tests/arithmetic/conftest.py",
+        "pandas/tests/arithmetic/test_array_ops.py",
+        "pandas/tests/arithmetic/test_bool.py",
+        "pandas/tests/arithmetic/test_categorical.py",
+        "pandas/tests/arithmetic/test_datetime64.py",
+        "pandas/tests/arithmetic/test_interval.py",
+        "pandas/tests/arithmetic/test_numeric.py",
+        "pandas/tests/arithmetic/test_object.py",
+        "pandas/tests/arithmetic/test_period.py",
+        "pandas/tests/arithmetic/test_string.py",
+        "pandas/tests/arithmetic/test_timedelta64.py",
+        "pandas/tests/arrays/__init__.py",
+        "pandas/tests/arrays/boolean/__init__.py",
+        "pandas/tests/arrays/boolean/test_arithmetic.py",
+        "pandas/tests/arrays/boolean/test_astype.py",
+        "pandas/tests/arrays/boolean/test_comparison.py",
+        "pandas/tests/arrays/boolean/test_construction.py",
+        "pandas/tests/arrays/boolean/test_function.py",
+        "pandas/tests/arrays/boolean/test_indexing.py",
+        "pandas/tests/arrays/boolean/test_logical.py",
+        "pandas/tests/arrays/boolean/test_ops.py",
+        "pandas/tests/arrays/boolean/test_reduction.py",
+        "pandas/tests/arrays/boolean/test_repr.py",
+        "pandas/tests/arrays/categorical/__init__.py",
+        "pandas/tests/arrays/categorical/test_algos.py",
+        "pandas/tests/arrays/categorical/test_analytics.py",
+        "pandas/tests/arrays/categorical/test_api.py",
+        "pandas/tests/arrays/categorical/test_astype.py",
+        "pandas/tests/arrays/categorical/test_constructors.py",
+        "pandas/tests/arrays/categorical/test_dtypes.py",
+        "pandas/tests/arrays/categorical/test_indexing.py",
+        "pandas/tests/arrays/categorical/test_map.py",
+        "pandas/tests/arrays/categorical/test_missing.py",
+        "pandas/tests/arrays/categorical/test_operators.py",
+        "pandas/tests/arrays/categorical/test_replace.py",
+        "pandas/tests/arrays/categorical/test_repr.py",
+        "pandas/tests/arrays/categorical/test_sorting.py",
+        "pandas/tests/arrays/categorical/test_subclass.py",
+        "pandas/tests/arrays/categorical/test_take.py",
+        "pandas/tests/arrays/categorical/test_warnings.py",
+        "pandas/tests/arrays/datetimes/__init__.py",
+        "pandas/tests/arrays/datetimes/test_constructors.py",
+        "pandas/tests/arrays/datetimes/test_cumulative.py",
+        "pandas/tests/arrays/datetimes/test_reductions.py",
+        "pandas/tests/arrays/floating/__init__.py",
+        "pandas/tests/arrays/floating/conftest.py",
+        "pandas/tests/arrays/floating/test_arithmetic.py",
+        "pandas/tests/arrays/floating/test_astype.py",
+        "pandas/tests/arrays/floating/test_comparison.py",
+        "pandas/tests/arrays/floating/test_concat.py",
+        "pandas/tests/arrays/floating/test_construction.py",
+        "pandas/tests/arrays/floating/test_contains.py",
+        "pandas/tests/arrays/floating/test_function.py",
+        "pandas/tests/arrays/floating/test_repr.py",
+        "pandas/tests/arrays/floating/test_to_numpy.py",
+        "pandas/tests/arrays/integer/__init__.py",
+        "pandas/tests/arrays/integer/conftest.py",
+        "pandas/tests/arrays/integer/test_arithmetic.py",
+        "pandas/tests/arrays/integer/test_comparison.py",
+        "pandas/tests/arrays/integer/test_concat.py",
+        "pandas/tests/arrays/integer/test_construction.py",
+        "pandas/tests/arrays/integer/test_dtypes.py",
+        "pandas/tests/arrays/integer/test_function.py",
+        "pandas/tests/arrays/integer/test_indexing.py",
+        "pandas/tests/arrays/integer/test_reduction.py",
+        "pandas/tests/arrays/integer/test_repr.py",
+        "pandas/tests/arrays/interval/__init__.py",
+        "pandas/tests/arrays/interval/test_astype.py",
+        "pandas/tests/arrays/interval/test_formats.py",
+        "pandas/tests/arrays/interval/test_interval.py",
+        "pandas/tests/arrays/interval/test_interval_pyarrow.py",
+        "pandas/tests/arrays/interval/test_overlaps.py",
+        "pandas/tests/arrays/masked/__init__.py",
+        "pandas/tests/arrays/masked/test_arithmetic.py",
+        "pandas/tests/arrays/masked/test_arrow_compat.py",
+        "pandas/tests/arrays/masked/test_function.py",
+        "pandas/tests/arrays/masked/test_indexing.py",
+        "pandas/tests/arrays/masked_shared.py",
+        "pandas/tests/arrays/numpy_/__init__.py",
+        "pandas/tests/arrays/numpy_/test_indexing.py",
+        "pandas/tests/arrays/numpy_/test_numpy.py",
+        "pandas/tests/arrays/period/__init__.py",
+        "pandas/tests/arrays/period/test_arrow_compat.py",
+        "pandas/tests/arrays/period/test_astype.py",
+        "pandas/tests/arrays/period/test_constructors.py",
+        "pandas/tests/arrays/period/test_reductions.py",
+        "pandas/tests/arrays/sparse/__init__.py",
+        "pandas/tests/arrays/sparse/test_accessor.py",
+        "pandas/tests/arrays/sparse/test_arithmetics.py",
+        "pandas/tests/arrays/sparse/test_array.py",
+        "pandas/tests/arrays/sparse/test_astype.py",
+        "pandas/tests/arrays/sparse/test_combine_concat.py",
+        "pandas/tests/arrays/sparse/test_constructors.py",
+        "pandas/tests/arrays/sparse/test_dtype.py",
+        "pandas/tests/arrays/sparse/test_indexing.py",
+        "pandas/tests/arrays/sparse/test_libsparse.py",
+        "pandas/tests/arrays/sparse/test_reductions.py",
+        "pandas/tests/arrays/sparse/test_unary.py",
+        "pandas/tests/arrays/string_/__init__.py",
+        "pandas/tests/arrays/string_/test_concat.py",
+        "pandas/tests/arrays/string_/test_string.py",
+        "pandas/tests/arrays/string_/test_string_arrow.py",
+        "pandas/tests/arrays/test_array.py",
+        "pandas/tests/arrays/test_datetimelike.py",
+        "pandas/tests/arrays/test_datetimes.py",
+        "pandas/tests/arrays/test_ndarray_backed.py",
+        "pandas/tests/arrays/test_period.py",
+        "pandas/tests/arrays/test_timedeltas.py",
+        "pandas/tests/arrays/timedeltas/__init__.py",
+        "pandas/tests/arrays/timedeltas/test_constructors.py",
+        "pandas/tests/arrays/timedeltas/test_cumulative.py",
+        "pandas/tests/arrays/timedeltas/test_reductions.py",
+        "pandas/tests/base/__init__.py",
+        "pandas/tests/base/common.py",
+        "pandas/tests/base/test_constructors.py",
+        "pandas/tests/base/test_conversion.py",
+        "pandas/tests/base/test_fillna.py",
+        "pandas/tests/base/test_misc.py",
+        "pandas/tests/base/test_transpose.py",
+        "pandas/tests/base/test_unique.py",
+        "pandas/tests/base/test_value_counts.py",
+        "pandas/tests/computation/__init__.py",
+        "pandas/tests/computation/test_compat.py",
+        "pandas/tests/computation/test_eval.py",
+        "pandas/tests/config/__init__.py",
+        "pandas/tests/config/test_config.py",
+        "pandas/tests/config/test_localization.py",
+        "pandas/tests/construction/__init__.py",
+        "pandas/tests/construction/test_extract_array.py",
+        "pandas/tests/copy_view/__init__.py",
+        "pandas/tests/copy_view/index/__init__.py",
+        "pandas/tests/copy_view/index/test_datetimeindex.py",
+        "pandas/tests/copy_view/index/test_index.py",
+        "pandas/tests/copy_view/index/test_intervalindex.py",
+        "pandas/tests/copy_view/index/test_periodindex.py",
+        "pandas/tests/copy_view/index/test_timedeltaindex.py",
+        "pandas/tests/copy_view/test_array.py",
+        "pandas/tests/copy_view/test_astype.py",
+        "pandas/tests/copy_view/test_chained_assignment_deprecation.py",
+        "pandas/tests/copy_view/test_clip.py",
+        "pandas/tests/copy_view/test_constructors.py",
+        "pandas/tests/copy_view/test_copy_deprecation.py",
+        "pandas/tests/copy_view/test_core_functionalities.py",
+        "pandas/tests/copy_view/test_functions.py",
+        "pandas/tests/copy_view/test_indexing.py",
+        "pandas/tests/copy_view/test_internals.py",
+        "pandas/tests/copy_view/test_interp_fillna.py",
+        "pandas/tests/copy_view/test_methods.py",
+        "pandas/tests/copy_view/test_replace.py",
+        "pandas/tests/copy_view/test_setitem.py",
+        "pandas/tests/copy_view/test_util.py",
+        "pandas/tests/copy_view/util.py",
+        "pandas/tests/dtypes/__init__.py",
+        "pandas/tests/dtypes/cast/__init__.py",
+        "pandas/tests/dtypes/cast/test_box_unbox.py",
+        "pandas/tests/dtypes/cast/test_can_hold_element.py",
+        "pandas/tests/dtypes/cast/test_construct_from_scalar.py",
+        "pandas/tests/dtypes/cast/test_construct_ndarray.py",
+        "pandas/tests/dtypes/cast/test_construct_object_arr.py",
+        "pandas/tests/dtypes/cast/test_dict_compat.py",
+        "pandas/tests/dtypes/cast/test_downcast.py",
+        "pandas/tests/dtypes/cast/test_find_common_type.py",
+        "pandas/tests/dtypes/cast/test_infer_datetimelike.py",
+        "pandas/tests/dtypes/cast/test_infer_dtype.py",
+        "pandas/tests/dtypes/cast/test_promote.py",
+        "pandas/tests/dtypes/test_common.py",
+        "pandas/tests/dtypes/test_concat.py",
+        "pandas/tests/dtypes/test_dtypes.py",
+        "pandas/tests/dtypes/test_generic.py",
+        "pandas/tests/dtypes/test_inference.py",
+        "pandas/tests/dtypes/test_missing.py",
+        "pandas/tests/extension/__init__.py",
+        "pandas/tests/extension/array_with_attr/__init__.py",
+        "pandas/tests/extension/array_with_attr/array.py",
+        "pandas/tests/extension/array_with_attr/test_array_with_attr.py",
+        "pandas/tests/extension/base/__init__.py",
+        "pandas/tests/extension/base/accumulate.py",
+        "pandas/tests/extension/base/base.py",
+        "pandas/tests/extension/base/casting.py",
+        "pandas/tests/extension/base/constructors.py",
+        "pandas/tests/extension/base/dim2.py",
+        "pandas/tests/extension/base/dtype.py",
+        "pandas/tests/extension/base/getitem.py",
+        "pandas/tests/extension/base/groupby.py",
+        "pandas/tests/extension/base/index.py",
+        "pandas/tests/extension/base/interface.py",
+        "pandas/tests/extension/base/io.py",
+        "pandas/tests/extension/base/methods.py",
+        "pandas/tests/extension/base/missing.py",
+        "pandas/tests/extension/base/ops.py",
+        "pandas/tests/extension/base/printing.py",
+        "pandas/tests/extension/base/reduce.py",
+        "pandas/tests/extension/base/reshaping.py",
+        "pandas/tests/extension/base/setitem.py",
+        "pandas/tests/extension/conftest.py",
+        "pandas/tests/extension/date/__init__.py",
+        "pandas/tests/extension/date/array.py",
+        "pandas/tests/extension/decimal/__init__.py",
+        "pandas/tests/extension/decimal/array.py",
+        "pandas/tests/extension/decimal/test_decimal.py",
+        "pandas/tests/extension/json/__init__.py",
+        "pandas/tests/extension/json/array.py",
+        "pandas/tests/extension/json/test_json.py",
+        "pandas/tests/extension/list/__init__.py",
+        "pandas/tests/extension/list/array.py",
+        "pandas/tests/extension/list/test_list.py",
+        "pandas/tests/extension/test_arrow.py",
+        "pandas/tests/extension/test_categorical.py",
+        "pandas/tests/extension/test_common.py",
+        "pandas/tests/extension/test_datetime.py",
+        "pandas/tests/extension/test_extension.py",
+        "pandas/tests/extension/test_interval.py",
+        "pandas/tests/extension/test_masked.py",
+        "pandas/tests/extension/test_numpy.py",
+        "pandas/tests/extension/test_period.py",
+        "pandas/tests/extension/test_sparse.py",
+        "pandas/tests/extension/test_string.py",
+        "pandas/tests/extension/uuid/__init__.py",
+        "pandas/tests/extension/uuid/test_uuid.py",
+        "pandas/tests/frame/__init__.py",
+        "pandas/tests/frame/common.py",
+        "pandas/tests/frame/conftest.py",
+        "pandas/tests/frame/constructors/__init__.py",
+        "pandas/tests/frame/constructors/test_from_dict.py",
+        "pandas/tests/frame/constructors/test_from_records.py",
+        "pandas/tests/frame/indexing/__init__.py",
+        "pandas/tests/frame/indexing/test_coercion.py",
+        "pandas/tests/frame/indexing/test_delitem.py",
+        "pandas/tests/frame/indexing/test_get.py",
+        "pandas/tests/frame/indexing/test_get_value.py",
+        "pandas/tests/frame/indexing/test_getitem.py",
+        "pandas/tests/frame/indexing/test_indexing.py",
+        "pandas/tests/frame/indexing/test_insert.py",
+        "pandas/tests/frame/indexing/test_mask.py",
+        "pandas/tests/frame/indexing/test_set_value.py",
+        "pandas/tests/frame/indexing/test_setitem.py",
+        "pandas/tests/frame/indexing/test_take.py",
+        "pandas/tests/frame/indexing/test_where.py",
+        "pandas/tests/frame/indexing/test_xs.py",
+        "pandas/tests/frame/methods/__init__.py",
+        "pandas/tests/frame/methods/test_add_prefix_suffix.py",
+        "pandas/tests/frame/methods/test_align.py",
+        "pandas/tests/frame/methods/test_asfreq.py",
+        "pandas/tests/frame/methods/test_asof.py",
+        "pandas/tests/frame/methods/test_assign.py",
+        "pandas/tests/frame/methods/test_astype.py",
+        "pandas/tests/frame/methods/test_at_time.py",
+        "pandas/tests/frame/methods/test_between_time.py",
+        "pandas/tests/frame/methods/test_clip.py",
+        "pandas/tests/frame/methods/test_combine.py",
+        "pandas/tests/frame/methods/test_combine_first.py",
+        "pandas/tests/frame/methods/test_compare.py",
+        "pandas/tests/frame/methods/test_convert_dtypes.py",
+        "pandas/tests/frame/methods/test_copy.py",
+        "pandas/tests/frame/methods/test_count.py",
+        "pandas/tests/frame/methods/test_cov_corr.py",
+        "pandas/tests/frame/methods/test_describe.py",
+        "pandas/tests/frame/methods/test_diff.py",
+        "pandas/tests/frame/methods/test_dot.py",
+        "pandas/tests/frame/methods/test_drop.py",
+        "pandas/tests/frame/methods/test_drop_duplicates.py",
+        "pandas/tests/frame/methods/test_droplevel.py",
+        "pandas/tests/frame/methods/test_dropna.py",
+        "pandas/tests/frame/methods/test_dtypes.py",
+        "pandas/tests/frame/methods/test_duplicated.py",
+        "pandas/tests/frame/methods/test_equals.py",
+        "pandas/tests/frame/methods/test_explode.py",
+        "pandas/tests/frame/methods/test_fillna.py",
+        "pandas/tests/frame/methods/test_filter.py",
+        "pandas/tests/frame/methods/test_first_valid_index.py",
+        "pandas/tests/frame/methods/test_get_numeric_data.py",
+        "pandas/tests/frame/methods/test_head_tail.py",
+        "pandas/tests/frame/methods/test_infer_objects.py",
+        "pandas/tests/frame/methods/test_info.py",
+        "pandas/tests/frame/methods/test_interpolate.py",
+        "pandas/tests/frame/methods/test_is_homogeneous_dtype.py",
+        "pandas/tests/frame/methods/test_isetitem.py",
+        "pandas/tests/frame/methods/test_isin.py",
+        "pandas/tests/frame/methods/test_iterrows.py",
+        "pandas/tests/frame/methods/test_join.py",
+        "pandas/tests/frame/methods/test_map.py",
+        "pandas/tests/frame/methods/test_matmul.py",
+        "pandas/tests/frame/methods/test_nlargest.py",
+        "pandas/tests/frame/methods/test_pct_change.py",
+        "pandas/tests/frame/methods/test_pipe.py",
+        "pandas/tests/frame/methods/test_pop.py",
+        "pandas/tests/frame/methods/test_quantile.py",
+        "pandas/tests/frame/methods/test_rank.py",
+        "pandas/tests/frame/methods/test_reindex.py",
+        "pandas/tests/frame/methods/test_reindex_like.py",
+        "pandas/tests/frame/methods/test_rename.py",
+        "pandas/tests/frame/methods/test_rename_axis.py",
+        "pandas/tests/frame/methods/test_reorder_levels.py",
+        "pandas/tests/frame/methods/test_replace.py",
+        "pandas/tests/frame/methods/test_reset_index.py",
+        "pandas/tests/frame/methods/test_round.py",
+        "pandas/tests/frame/methods/test_sample.py",
+        "pandas/tests/frame/methods/test_select_dtypes.py",
+        "pandas/tests/frame/methods/test_set_axis.py",
+        "pandas/tests/frame/methods/test_set_index.py",
+        "pandas/tests/frame/methods/test_shift.py",
+        "pandas/tests/frame/methods/test_size.py",
+        "pandas/tests/frame/methods/test_sort_index.py",
+        "pandas/tests/frame/methods/test_sort_values.py",
+        "pandas/tests/frame/methods/test_swaplevel.py",
+        "pandas/tests/frame/methods/test_to_csv.py",
+        "pandas/tests/frame/methods/test_to_dict.py",
+        "pandas/tests/frame/methods/test_to_dict_of_blocks.py",
+        "pandas/tests/frame/methods/test_to_numpy.py",
+        "pandas/tests/frame/methods/test_to_period.py",
+        "pandas/tests/frame/methods/test_to_records.py",
+        "pandas/tests/frame/methods/test_to_timestamp.py",
+        "pandas/tests/frame/methods/test_transpose.py",
+        "pandas/tests/frame/methods/test_truncate.py",
+        "pandas/tests/frame/methods/test_tz_convert.py",
+        "pandas/tests/frame/methods/test_tz_localize.py",
+        "pandas/tests/frame/methods/test_update.py",
+        "pandas/tests/frame/methods/test_value_counts.py",
+        "pandas/tests/frame/methods/test_values.py",
+        "pandas/tests/frame/test_alter_axes.py",
+        "pandas/tests/frame/test_api.py",
+        "pandas/tests/frame/test_arithmetic.py",
+        "pandas/tests/frame/test_arrow_interface.py",
+        "pandas/tests/frame/test_block_internals.py",
+        "pandas/tests/frame/test_constructors.py",
+        "pandas/tests/frame/test_cumulative.py",
+        "pandas/tests/frame/test_iteration.py",
+        "pandas/tests/frame/test_logical_ops.py",
+        "pandas/tests/frame/test_nonunique_indexes.py",
+        "pandas/tests/frame/test_npfuncs.py",
+        "pandas/tests/frame/test_query_eval.py",
+        "pandas/tests/frame/test_reductions.py",
+        "pandas/tests/frame/test_repr.py",
+        "pandas/tests/frame/test_stack_unstack.py",
+        "pandas/tests/frame/test_subclass.py",
+        "pandas/tests/frame/test_ufunc.py",
+        "pandas/tests/frame/test_unary.py",
+        "pandas/tests/frame/test_validate.py",
+        "pandas/tests/generic/__init__.py",
+        "pandas/tests/generic/test_duplicate_labels.py",
+        "pandas/tests/generic/test_finalize.py",
+        "pandas/tests/generic/test_frame.py",
+        "pandas/tests/generic/test_generic.py",
+        "pandas/tests/generic/test_label_or_level_utils.py",
+        "pandas/tests/generic/test_series.py",
+        "pandas/tests/generic/test_to_xarray.py",
+        "pandas/tests/groupby/__init__.py",
+        "pandas/tests/groupby/aggregate/__init__.py",
+        "pandas/tests/groupby/aggregate/test_aggregate.py",
+        "pandas/tests/groupby/aggregate/test_cython.py",
+        "pandas/tests/groupby/aggregate/test_numba.py",
+        "pandas/tests/groupby/aggregate/test_other.py",
+        "pandas/tests/groupby/conftest.py",
+        "pandas/tests/groupby/methods/__init__.py",
+        "pandas/tests/groupby/methods/test_describe.py",
+        "pandas/tests/groupby/methods/test_groupby_shift_diff.py",
+        "pandas/tests/groupby/methods/test_is_monotonic.py",
+        "pandas/tests/groupby/methods/test_kurt.py",
+        "pandas/tests/groupby/methods/test_nlargest_nsmallest.py",
+        "pandas/tests/groupby/methods/test_nth.py",
+        "pandas/tests/groupby/methods/test_quantile.py",
+        "pandas/tests/groupby/methods/test_rank.py",
+        "pandas/tests/groupby/methods/test_sample.py",
+        "pandas/tests/groupby/methods/test_size.py",
+        "pandas/tests/groupby/methods/test_skew.py",
+        "pandas/tests/groupby/methods/test_value_counts.py",
+        "pandas/tests/groupby/test_all_methods.py",
+        "pandas/tests/groupby/test_api.py",
+        "pandas/tests/groupby/test_apply.py",
+        "pandas/tests/groupby/test_bin_groupby.py",
+        "pandas/tests/groupby/test_categorical.py",
+        "pandas/tests/groupby/test_counting.py",
+        "pandas/tests/groupby/test_cumulative.py",
+        "pandas/tests/groupby/test_filters.py",
+        "pandas/tests/groupby/test_groupby.py",
+        "pandas/tests/groupby/test_groupby_dropna.py",
+        "pandas/tests/groupby/test_groupby_subclass.py",
+        "pandas/tests/groupby/test_grouping.py",
+        "pandas/tests/groupby/test_index_as_string.py",
+        "pandas/tests/groupby/test_indexing.py",
+        "pandas/tests/groupby/test_libgroupby.py",
+        "pandas/tests/groupby/test_missing.py",
+        "pandas/tests/groupby/test_numba.py",
+        "pandas/tests/groupby/test_numeric_only.py",
+        "pandas/tests/groupby/test_pipe.py",
+        "pandas/tests/groupby/test_raises.py",
+        "pandas/tests/groupby/test_reductions.py",
+        "pandas/tests/groupby/test_timegrouper.py",
+        "pandas/tests/groupby/transform/__init__.py",
+        "pandas/tests/groupby/transform/test_numba.py",
+        "pandas/tests/groupby/transform/test_transform.py",
+        "pandas/tests/indexes/__init__.py",
+        "pandas/tests/indexes/base_class/__init__.py",
+        "pandas/tests/indexes/base_class/test_constructors.py",
+        "pandas/tests/indexes/base_class/test_formats.py",
+        "pandas/tests/indexes/base_class/test_indexing.py",
+        "pandas/tests/indexes/base_class/test_pickle.py",
+        "pandas/tests/indexes/base_class/test_reshape.py",
+        "pandas/tests/indexes/base_class/test_setops.py",
+        "pandas/tests/indexes/base_class/test_where.py",
+        "pandas/tests/indexes/categorical/__init__.py",
+        "pandas/tests/indexes/categorical/test_append.py",
+        "pandas/tests/indexes/categorical/test_astype.py",
+        "pandas/tests/indexes/categorical/test_category.py",
+        "pandas/tests/indexes/categorical/test_constructors.py",
+        "pandas/tests/indexes/categorical/test_equals.py",
+        "pandas/tests/indexes/categorical/test_fillna.py",
+        "pandas/tests/indexes/categorical/test_formats.py",
+        "pandas/tests/indexes/categorical/test_indexing.py",
+        "pandas/tests/indexes/categorical/test_map.py",
+        "pandas/tests/indexes/categorical/test_reindex.py",
+        "pandas/tests/indexes/categorical/test_setops.py",
+        "pandas/tests/indexes/conftest.py",
+        "pandas/tests/indexes/datetimelike_/__init__.py",
+        "pandas/tests/indexes/datetimelike_/test_drop_duplicates.py",
+        "pandas/tests/indexes/datetimelike_/test_equals.py",
+        "pandas/tests/indexes/datetimelike_/test_indexing.py",
+        "pandas/tests/indexes/datetimelike_/test_is_monotonic.py",
+        "pandas/tests/indexes/datetimelike_/test_nat.py",
+        "pandas/tests/indexes/datetimelike_/test_sort_values.py",
+        "pandas/tests/indexes/datetimelike_/test_value_counts.py",
+        "pandas/tests/indexes/datetimes/__init__.py",
+        "pandas/tests/indexes/datetimes/methods/__init__.py",
+        "pandas/tests/indexes/datetimes/methods/test_asof.py",
+        "pandas/tests/indexes/datetimes/methods/test_astype.py",
+        "pandas/tests/indexes/datetimes/methods/test_delete.py",
+        "pandas/tests/indexes/datetimes/methods/test_factorize.py",
+        "pandas/tests/indexes/datetimes/methods/test_fillna.py",
+        "pandas/tests/indexes/datetimes/methods/test_insert.py",
+        "pandas/tests/indexes/datetimes/methods/test_isocalendar.py",
+        "pandas/tests/indexes/datetimes/methods/test_map.py",
+        "pandas/tests/indexes/datetimes/methods/test_normalize.py",
+        "pandas/tests/indexes/datetimes/methods/test_repeat.py",
+        "pandas/tests/indexes/datetimes/methods/test_resolution.py",
+        "pandas/tests/indexes/datetimes/methods/test_round.py",
+        "pandas/tests/indexes/datetimes/methods/test_shift.py",
+        "pandas/tests/indexes/datetimes/methods/test_snap.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_frame.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_julian_date.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_period.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_pydatetime.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_series.py",
+        "pandas/tests/indexes/datetimes/methods/test_tz_convert.py",
+        "pandas/tests/indexes/datetimes/methods/test_tz_localize.py",
+        "pandas/tests/indexes/datetimes/methods/test_unique.py",
+        "pandas/tests/indexes/datetimes/test_arithmetic.py",
+        "pandas/tests/indexes/datetimes/test_constructors.py",
+        "pandas/tests/indexes/datetimes/test_date_range.py",
+        "pandas/tests/indexes/datetimes/test_datetime.py",
+        "pandas/tests/indexes/datetimes/test_formats.py",
+        "pandas/tests/indexes/datetimes/test_freq_attr.py",
+        "pandas/tests/indexes/datetimes/test_indexing.py",
+        "pandas/tests/indexes/datetimes/test_iter.py",
+        "pandas/tests/indexes/datetimes/test_join.py",
+        "pandas/tests/indexes/datetimes/test_npfuncs.py",
+        "pandas/tests/indexes/datetimes/test_ops.py",
+        "pandas/tests/indexes/datetimes/test_partial_slicing.py",
+        "pandas/tests/indexes/datetimes/test_pickle.py",
+        "pandas/tests/indexes/datetimes/test_reindex.py",
+        "pandas/tests/indexes/datetimes/test_scalar_compat.py",
+        "pandas/tests/indexes/datetimes/test_setops.py",
+        "pandas/tests/indexes/datetimes/test_timezones.py",
+        "pandas/tests/indexes/interval/__init__.py",
+        "pandas/tests/indexes/interval/test_astype.py",
+        "pandas/tests/indexes/interval/test_constructors.py",
+        "pandas/tests/indexes/interval/test_equals.py",
+        "pandas/tests/indexes/interval/test_formats.py",
+        "pandas/tests/indexes/interval/test_indexing.py",
+        "pandas/tests/indexes/interval/test_interval.py",
+        "pandas/tests/indexes/interval/test_interval_range.py",
+        "pandas/tests/indexes/interval/test_interval_tree.py",
+        "pandas/tests/indexes/interval/test_join.py",
+        "pandas/tests/indexes/interval/test_pickle.py",
+        "pandas/tests/indexes/interval/test_setops.py",
+        "pandas/tests/indexes/multi/__init__.py",
+        "pandas/tests/indexes/multi/conftest.py",
+        "pandas/tests/indexes/multi/test_analytics.py",
+        "pandas/tests/indexes/multi/test_astype.py",
+        "pandas/tests/indexes/multi/test_compat.py",
+        "pandas/tests/indexes/multi/test_constructors.py",
+        "pandas/tests/indexes/multi/test_conversion.py",
+        "pandas/tests/indexes/multi/test_copy.py",
+        "pandas/tests/indexes/multi/test_drop.py",
+        "pandas/tests/indexes/multi/test_duplicates.py",
+        "pandas/tests/indexes/multi/test_equivalence.py",
+        "pandas/tests/indexes/multi/test_formats.py",
+        "pandas/tests/indexes/multi/test_get_level_values.py",
+        "pandas/tests/indexes/multi/test_get_set.py",
+        "pandas/tests/indexes/multi/test_indexing.py",
+        "pandas/tests/indexes/multi/test_integrity.py",
+        "pandas/tests/indexes/multi/test_isin.py",
+        "pandas/tests/indexes/multi/test_join.py",
+        "pandas/tests/indexes/multi/test_lexsort.py",
+        "pandas/tests/indexes/multi/test_missing.py",
+        "pandas/tests/indexes/multi/test_monotonic.py",
+        "pandas/tests/indexes/multi/test_names.py",
+        "pandas/tests/indexes/multi/test_partial_indexing.py",
+        "pandas/tests/indexes/multi/test_pickle.py",
+        "pandas/tests/indexes/multi/test_reindex.py",
+        "pandas/tests/indexes/multi/test_reshape.py",
+        "pandas/tests/indexes/multi/test_setops.py",
+        "pandas/tests/indexes/multi/test_sorting.py",
+        "pandas/tests/indexes/multi/test_take.py",
+        "pandas/tests/indexes/multi/test_util.py",
+        "pandas/tests/indexes/numeric/__init__.py",
+        "pandas/tests/indexes/numeric/test_astype.py",
+        "pandas/tests/indexes/numeric/test_indexing.py",
+        "pandas/tests/indexes/numeric/test_join.py",
+        "pandas/tests/indexes/numeric/test_numeric.py",
+        "pandas/tests/indexes/numeric/test_setops.py",
+        "pandas/tests/indexes/object/__init__.py",
+        "pandas/tests/indexes/object/test_astype.py",
+        "pandas/tests/indexes/object/test_indexing.py",
+        "pandas/tests/indexes/period/__init__.py",
+        "pandas/tests/indexes/period/methods/__init__.py",
+        "pandas/tests/indexes/period/methods/test_asfreq.py",
+        "pandas/tests/indexes/period/methods/test_astype.py",
+        "pandas/tests/indexes/period/methods/test_factorize.py",
+        "pandas/tests/indexes/period/methods/test_fillna.py",
+        "pandas/tests/indexes/period/methods/test_insert.py",
+        "pandas/tests/indexes/period/methods/test_is_full.py",
+        "pandas/tests/indexes/period/methods/test_repeat.py",
+        "pandas/tests/indexes/period/methods/test_shift.py",
+        "pandas/tests/indexes/period/methods/test_to_timestamp.py",
+        "pandas/tests/indexes/period/test_constructors.py",
+        "pandas/tests/indexes/period/test_formats.py",
+        "pandas/tests/indexes/period/test_freq_attr.py",
+        "pandas/tests/indexes/period/test_indexing.py",
+        "pandas/tests/indexes/period/test_join.py",
+        "pandas/tests/indexes/period/test_monotonic.py",
+        "pandas/tests/indexes/period/test_partial_slicing.py",
+        "pandas/tests/indexes/period/test_period.py",
+        "pandas/tests/indexes/period/test_period_range.py",
+        "pandas/tests/indexes/period/test_pickle.py",
+        "pandas/tests/indexes/period/test_resolution.py",
+        "pandas/tests/indexes/period/test_scalar_compat.py",
+        "pandas/tests/indexes/period/test_searchsorted.py",
+        "pandas/tests/indexes/period/test_setops.py",
+        "pandas/tests/indexes/period/test_tools.py",
+        "pandas/tests/indexes/ranges/__init__.py",
+        "pandas/tests/indexes/ranges/test_constructors.py",
+        "pandas/tests/indexes/ranges/test_indexing.py",
+        "pandas/tests/indexes/ranges/test_join.py",
+        "pandas/tests/indexes/ranges/test_range.py",
+        "pandas/tests/indexes/ranges/test_setops.py",
+        "pandas/tests/indexes/string/__init__.py",
+        "pandas/tests/indexes/string/test_astype.py",
+        "pandas/tests/indexes/string/test_indexing.py",
+        "pandas/tests/indexes/test_any_index.py",
+        "pandas/tests/indexes/test_base.py",
+        "pandas/tests/indexes/test_common.py",
+        "pandas/tests/indexes/test_datetimelike.py",
+        "pandas/tests/indexes/test_engines.py",
+        "pandas/tests/indexes/test_frozen.py",
+        "pandas/tests/indexes/test_index_new.py",
+        "pandas/tests/indexes/test_indexing.py",
+        "pandas/tests/indexes/test_numpy_compat.py",
+        "pandas/tests/indexes/test_old_base.py",
+        "pandas/tests/indexes/test_setops.py",
+        "pandas/tests/indexes/test_subclass.py",
+        "pandas/tests/indexes/timedeltas/__init__.py",
+        "pandas/tests/indexes/timedeltas/methods/__init__.py",
+        "pandas/tests/indexes/timedeltas/methods/test_astype.py",
+        "pandas/tests/indexes/timedeltas/methods/test_factorize.py",
+        "pandas/tests/indexes/timedeltas/methods/test_fillna.py",
+        "pandas/tests/indexes/timedeltas/methods/test_insert.py",
+        "pandas/tests/indexes/timedeltas/methods/test_repeat.py",
+        "pandas/tests/indexes/timedeltas/methods/test_shift.py",
+        "pandas/tests/indexes/timedeltas/test_arithmetic.py",
+        "pandas/tests/indexes/timedeltas/test_constructors.py",
+        "pandas/tests/indexes/timedeltas/test_delete.py",
+        "pandas/tests/indexes/timedeltas/test_formats.py",
+        "pandas/tests/indexes/timedeltas/test_freq_attr.py",
+        "pandas/tests/indexes/timedeltas/test_indexing.py",
+        "pandas/tests/indexes/timedeltas/test_join.py",
+        "pandas/tests/indexes/timedeltas/test_ops.py",
+        "pandas/tests/indexes/timedeltas/test_pickle.py",
+        "pandas/tests/indexes/timedeltas/test_scalar_compat.py",
+        "pandas/tests/indexes/timedeltas/test_searchsorted.py",
+        "pandas/tests/indexes/timedeltas/test_setops.py",
+        "pandas/tests/indexes/timedeltas/test_timedelta.py",
+        "pandas/tests/indexes/timedeltas/test_timedelta_range.py",
+        "pandas/tests/indexing/__init__.py",
+        "pandas/tests/indexing/common.py",
+        "pandas/tests/indexing/interval/__init__.py",
+        "pandas/tests/indexing/interval/test_interval.py",
+        "pandas/tests/indexing/interval/test_interval_new.py",
+        "pandas/tests/indexing/multiindex/__init__.py",
+        "pandas/tests/indexing/multiindex/test_chaining_and_caching.py",
+        "pandas/tests/indexing/multiindex/test_datetime.py",
+        "pandas/tests/indexing/multiindex/test_getitem.py",
+        "pandas/tests/indexing/multiindex/test_iloc.py",
+        "pandas/tests/indexing/multiindex/test_indexing_slow.py",
+        "pandas/tests/indexing/multiindex/test_loc.py",
+        "pandas/tests/indexing/multiindex/test_multiindex.py",
+        "pandas/tests/indexing/multiindex/test_partial.py",
+        "pandas/tests/indexing/multiindex/test_setitem.py",
+        "pandas/tests/indexing/multiindex/test_slice.py",
+        "pandas/tests/indexing/multiindex/test_sorted.py",
+        "pandas/tests/indexing/test_at.py",
+        "pandas/tests/indexing/test_categorical.py",
+        "pandas/tests/indexing/test_chaining_and_caching.py",
+        "pandas/tests/indexing/test_check_indexer.py",
+        "pandas/tests/indexing/test_coercion.py",
+        "pandas/tests/indexing/test_datetime.py",
+        "pandas/tests/indexing/test_floats.py",
+        "pandas/tests/indexing/test_iat.py",
+        "pandas/tests/indexing/test_iloc.py",
+        "pandas/tests/indexing/test_indexers.py",
+        "pandas/tests/indexing/test_indexing.py",
+        "pandas/tests/indexing/test_loc.py",
+        "pandas/tests/indexing/test_na_indexing.py",
+        "pandas/tests/indexing/test_partial.py",
+        "pandas/tests/indexing/test_scalar.py",
+        "pandas/tests/interchange/__init__.py",
+        "pandas/tests/interchange/test_impl.py",
+        "pandas/tests/interchange/test_spec_conformance.py",
+        "pandas/tests/interchange/test_utils.py",
+        "pandas/tests/internals/__init__.py",
+        "pandas/tests/internals/test_api.py",
+        "pandas/tests/internals/test_internals.py",
+        "pandas/tests/io/__init__.py",
+        "pandas/tests/io/conftest.py",
+        "pandas/tests/io/excel/__init__.py",
+        "pandas/tests/io/excel/test_odf.py",
+        "pandas/tests/io/excel/test_odswriter.py",
+        "pandas/tests/io/excel/test_openpyxl.py",
+        "pandas/tests/io/excel/test_readers.py",
+        "pandas/tests/io/excel/test_style.py",
+        "pandas/tests/io/excel/test_writers.py",
+        "pandas/tests/io/excel/test_xlrd.py",
+        "pandas/tests/io/excel/test_xlsxwriter.py",
+        "pandas/tests/io/formats/__init__.py",
+        "pandas/tests/io/formats/style/__init__.py",
+        "pandas/tests/io/formats/style/test_bar.py",
+        "pandas/tests/io/formats/style/test_exceptions.py",
+        "pandas/tests/io/formats/style/test_format.py",
+        "pandas/tests/io/formats/style/test_highlight.py",
+        "pandas/tests/io/formats/style/test_html.py",
+        "pandas/tests/io/formats/style/test_matplotlib.py",
+        "pandas/tests/io/formats/style/test_non_unique.py",
+        "pandas/tests/io/formats/style/test_style.py",
+        "pandas/tests/io/formats/style/test_to_latex.py",
+        "pandas/tests/io/formats/style/test_to_string.py",
+        "pandas/tests/io/formats/style/test_to_typst.py",
+        "pandas/tests/io/formats/style/test_tooltip.py",
+        "pandas/tests/io/formats/test_console.py",
+        "pandas/tests/io/formats/test_css.py",
+        "pandas/tests/io/formats/test_eng_formatting.py",
+        "pandas/tests/io/formats/test_format.py",
+        "pandas/tests/io/formats/test_ipython_compat.py",
+        "pandas/tests/io/formats/test_printing.py",
+        "pandas/tests/io/formats/test_to_csv.py",
+        "pandas/tests/io/formats/test_to_excel.py",
+        "pandas/tests/io/formats/test_to_html.py",
+        "pandas/tests/io/formats/test_to_latex.py",
+        "pandas/tests/io/formats/test_to_markdown.py",
+        "pandas/tests/io/formats/test_to_string.py",
+        "pandas/tests/io/generate_legacy_storage_files.py",
+        "pandas/tests/io/json/__init__.py",
+        "pandas/tests/io/json/conftest.py",
+        "pandas/tests/io/json/test_compression.py",
+        "pandas/tests/io/json/test_deprecated_kwargs.py",
+        "pandas/tests/io/json/test_json_table_schema.py",
+        "pandas/tests/io/json/test_json_table_schema_ext_dtype.py",
+        "pandas/tests/io/json/test_normalize.py",
+        "pandas/tests/io/json/test_pandas.py",
+        "pandas/tests/io/json/test_readlines.py",
+        "pandas/tests/io/json/test_ujson.py",
+        "pandas/tests/io/parser/__init__.py",
+        "pandas/tests/io/parser/common/__init__.py",
+        "pandas/tests/io/parser/common/test_chunksize.py",
+        "pandas/tests/io/parser/common/test_common_basic.py",
+        "pandas/tests/io/parser/common/test_data_list.py",
+        "pandas/tests/io/parser/common/test_decimal.py",
+        "pandas/tests/io/parser/common/test_file_buffer_url.py",
+        "pandas/tests/io/parser/common/test_float.py",
+        "pandas/tests/io/parser/common/test_index.py",
+        "pandas/tests/io/parser/common/test_inf.py",
+        "pandas/tests/io/parser/common/test_ints.py",
+        "pandas/tests/io/parser/common/test_iterator.py",
+        "pandas/tests/io/parser/common/test_read_errors.py",
+        "pandas/tests/io/parser/conftest.py",
+        "pandas/tests/io/parser/dtypes/__init__.py",
+        "pandas/tests/io/parser/dtypes/test_categorical.py",
+        "pandas/tests/io/parser/dtypes/test_dtypes_basic.py",
+        "pandas/tests/io/parser/dtypes/test_empty.py",
+        "pandas/tests/io/parser/test_c_parser_only.py",
+        "pandas/tests/io/parser/test_comment.py",
+        "pandas/tests/io/parser/test_compression.py",
+        "pandas/tests/io/parser/test_concatenate_chunks.py",
+        "pandas/tests/io/parser/test_converters.py",
+        "pandas/tests/io/parser/test_dialect.py",
+        "pandas/tests/io/parser/test_encoding.py",
+        "pandas/tests/io/parser/test_header.py",
+        "pandas/tests/io/parser/test_index_col.py",
+        "pandas/tests/io/parser/test_mangle_dupes.py",
+        "pandas/tests/io/parser/test_multi_thread.py",
+        "pandas/tests/io/parser/test_na_values.py",
+        "pandas/tests/io/parser/test_network.py",
+        "pandas/tests/io/parser/test_parse_dates.py",
+        "pandas/tests/io/parser/test_python_parser_only.py",
+        "pandas/tests/io/parser/test_quoting.py",
+        "pandas/tests/io/parser/test_read_fwf.py",
+        "pandas/tests/io/parser/test_skiprows.py",
+        "pandas/tests/io/parser/test_textreader.py",
+        "pandas/tests/io/parser/test_unsupported.py",
+        "pandas/tests/io/parser/test_upcast.py",
+        "pandas/tests/io/parser/usecols/__init__.py",
+        "pandas/tests/io/parser/usecols/test_parse_dates.py",
+        "pandas/tests/io/parser/usecols/test_strings.py",
+        "pandas/tests/io/parser/usecols/test_usecols_basic.py",
+        "pandas/tests/io/pytables/__init__.py",
+        "pandas/tests/io/pytables/common.py",
+        "pandas/tests/io/pytables/conftest.py",
+        "pandas/tests/io/pytables/test_append.py",
+        "pandas/tests/io/pytables/test_categorical.py",
+        "pandas/tests/io/pytables/test_compat.py",
+        "pandas/tests/io/pytables/test_complex.py",
+        "pandas/tests/io/pytables/test_errors.py",
+        "pandas/tests/io/pytables/test_file_handling.py",
+        "pandas/tests/io/pytables/test_keys.py",
+        "pandas/tests/io/pytables/test_put.py",
+        "pandas/tests/io/pytables/test_pytables_missing.py",
+        "pandas/tests/io/pytables/test_read.py",
+        "pandas/tests/io/pytables/test_retain_attributes.py",
+        "pandas/tests/io/pytables/test_round_trip.py",
+        "pandas/tests/io/pytables/test_select.py",
+        "pandas/tests/io/pytables/test_store.py",
+        "pandas/tests/io/pytables/test_subclass.py",
+        "pandas/tests/io/pytables/test_time_series.py",
+        "pandas/tests/io/pytables/test_timezones.py",
+        "pandas/tests/io/sas/__init__.py",
+        "pandas/tests/io/sas/test_byteswap.py",
+        "pandas/tests/io/sas/test_sas.py",
+        "pandas/tests/io/sas/test_sas7bdat.py",
+        "pandas/tests/io/sas/test_xport.py",
+        "pandas/tests/io/test_clipboard.py",
+        "pandas/tests/io/test_common.py",
+        "pandas/tests/io/test_compression.py",
+        "pandas/tests/io/test_feather.py",
+        "pandas/tests/io/test_fsspec.py",
+        "pandas/tests/io/test_gcs.py",
+        "pandas/tests/io/test_html.py",
+        "pandas/tests/io/test_http_headers.py",
+        "pandas/tests/io/test_iceberg.py",
+        "pandas/tests/io/test_orc.py",
+        "pandas/tests/io/test_parquet.py",
+        "pandas/tests/io/test_pickle.py",
+        "pandas/tests/io/test_s3.py",
+        "pandas/tests/io/test_spss.py",
+        "pandas/tests/io/test_sql.py",
+        "pandas/tests/io/test_stata.py",
+        "pandas/tests/io/test_util.py",
+        "pandas/tests/io/xml/__init__.py",
+        "pandas/tests/io/xml/conftest.py",
+        "pandas/tests/io/xml/test_to_xml.py",
+        "pandas/tests/io/xml/test_xml.py",
+        "pandas/tests/io/xml/test_xml_dtypes.py",
+        "pandas/tests/libs/__init__.py",
+        "pandas/tests/libs/test_hashtable.py",
+        "pandas/tests/libs/test_join.py",
+        "pandas/tests/libs/test_lib.py",
+        "pandas/tests/libs/test_libalgos.py",
+        "pandas/tests/plotting/__init__.py",
+        "pandas/tests/plotting/common.py",
+        "pandas/tests/plotting/conftest.py",
+        "pandas/tests/plotting/frame/__init__.py",
+        "pandas/tests/plotting/frame/test_frame.py",
+        "pandas/tests/plotting/frame/test_frame_color.py",
+        "pandas/tests/plotting/frame/test_frame_groupby.py",
+        "pandas/tests/plotting/frame/test_frame_legend.py",
+        "pandas/tests/plotting/frame/test_frame_subplots.py",
+        "pandas/tests/plotting/frame/test_hist_box_by.py",
+        "pandas/tests/plotting/test_backend.py",
+        "pandas/tests/plotting/test_boxplot_method.py",
+        "pandas/tests/plotting/test_common.py",
+        "pandas/tests/plotting/test_converter.py",
+        "pandas/tests/plotting/test_datetimelike.py",
+        "pandas/tests/plotting/test_groupby.py",
+        "pandas/tests/plotting/test_hist_method.py",
+        "pandas/tests/plotting/test_misc.py",
+        "pandas/tests/plotting/test_series.py",
+        "pandas/tests/plotting/test_style.py",
+        "pandas/tests/reductions/__init__.py",
+        "pandas/tests/reductions/test_reductions.py",
+        "pandas/tests/reductions/test_stat_reductions.py",
+        "pandas/tests/resample/__init__.py",
+        "pandas/tests/resample/conftest.py",
+        "pandas/tests/resample/test_base.py",
+        "pandas/tests/resample/test_datetime_index.py",
+        "pandas/tests/resample/test_period_index.py",
+        "pandas/tests/resample/test_resample_api.py",
+        "pandas/tests/resample/test_resampler_grouper.py",
+        "pandas/tests/resample/test_time_grouper.py",
+        "pandas/tests/resample/test_timedelta.py",
+        "pandas/tests/reshape/__init__.py",
+        "pandas/tests/reshape/concat/__init__.py",
+        "pandas/tests/reshape/concat/test_append.py",
+        "pandas/tests/reshape/concat/test_append_common.py",
+        "pandas/tests/reshape/concat/test_categorical.py",
+        "pandas/tests/reshape/concat/test_concat.py",
+        "pandas/tests/reshape/concat/test_dataframe.py",
+        "pandas/tests/reshape/concat/test_datetimes.py",
+        "pandas/tests/reshape/concat/test_empty.py",
+        "pandas/tests/reshape/concat/test_index.py",
+        "pandas/tests/reshape/concat/test_invalid.py",
+        "pandas/tests/reshape/concat/test_series.py",
+        "pandas/tests/reshape/concat/test_sort.py",
+        "pandas/tests/reshape/merge/__init__.py",
+        "pandas/tests/reshape/merge/test_join.py",
+        "pandas/tests/reshape/merge/test_merge.py",
+        "pandas/tests/reshape/merge/test_merge_antijoin.py",
+        "pandas/tests/reshape/merge/test_merge_asof.py",
+        "pandas/tests/reshape/merge/test_merge_cross.py",
+        "pandas/tests/reshape/merge/test_merge_index_as_string.py",
+        "pandas/tests/reshape/merge/test_merge_ordered.py",
+        "pandas/tests/reshape/merge/test_multi.py",
+        "pandas/tests/reshape/test_crosstab.py",
+        "pandas/tests/reshape/test_cut.py",
+        "pandas/tests/reshape/test_from_dummies.py",
+        "pandas/tests/reshape/test_get_dummies.py",
+        "pandas/tests/reshape/test_melt.py",
+        "pandas/tests/reshape/test_pivot.py",
+        "pandas/tests/reshape/test_pivot_multilevel.py",
+        "pandas/tests/reshape/test_qcut.py",
+        "pandas/tests/reshape/test_union_categoricals.py",
+        "pandas/tests/scalar/__init__.py",
+        "pandas/tests/scalar/interval/__init__.py",
+        "pandas/tests/scalar/interval/test_arithmetic.py",
+        "pandas/tests/scalar/interval/test_constructors.py",
+        "pandas/tests/scalar/interval/test_contains.py",
+        "pandas/tests/scalar/interval/test_formats.py",
+        "pandas/tests/scalar/interval/test_interval.py",
+        "pandas/tests/scalar/interval/test_overlaps.py",
+        "pandas/tests/scalar/period/__init__.py",
+        "pandas/tests/scalar/period/test_arithmetic.py",
+        "pandas/tests/scalar/period/test_asfreq.py",
+        "pandas/tests/scalar/period/test_period.py",
+        "pandas/tests/scalar/test_na_scalar.py",
+        "pandas/tests/scalar/test_nat.py",
+        "pandas/tests/scalar/timedelta/__init__.py",
+        "pandas/tests/scalar/timedelta/methods/__init__.py",
+        "pandas/tests/scalar/timedelta/methods/test_as_unit.py",
+        "pandas/tests/scalar/timedelta/methods/test_round.py",
+        "pandas/tests/scalar/timedelta/test_arithmetic.py",
+        "pandas/tests/scalar/timedelta/test_constructors.py",
+        "pandas/tests/scalar/timedelta/test_formats.py",
+        "pandas/tests/scalar/timedelta/test_timedelta.py",
+        "pandas/tests/scalar/timestamp/__init__.py",
+        "pandas/tests/scalar/timestamp/methods/__init__.py",
+        "pandas/tests/scalar/timestamp/methods/test_as_unit.py",
+        "pandas/tests/scalar/timestamp/methods/test_normalize.py",
+        "pandas/tests/scalar/timestamp/methods/test_replace.py",
+        "pandas/tests/scalar/timestamp/methods/test_round.py",
+        "pandas/tests/scalar/timestamp/methods/test_timestamp_method.py",
+        "pandas/tests/scalar/timestamp/methods/test_to_julian_date.py",
+        "pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py",
+        "pandas/tests/scalar/timestamp/methods/test_tz_convert.py",
+        "pandas/tests/scalar/timestamp/methods/test_tz_localize.py",
+        "pandas/tests/scalar/timestamp/test_arithmetic.py",
+        "pandas/tests/scalar/timestamp/test_comparisons.py",
+        "pandas/tests/scalar/timestamp/test_constructors.py",
+        "pandas/tests/scalar/timestamp/test_formats.py",
+        "pandas/tests/scalar/timestamp/test_timestamp.py",
+        "pandas/tests/scalar/timestamp/test_timezones.py",
+        "pandas/tests/series/__init__.py",
+        "pandas/tests/series/accessors/__init__.py",
+        "pandas/tests/series/accessors/test_cat_accessor.py",
+        "pandas/tests/series/accessors/test_dt_accessor.py",
+        "pandas/tests/series/accessors/test_list_accessor.py",
+        "pandas/tests/series/accessors/test_sparse_accessor.py",
+        "pandas/tests/series/accessors/test_str_accessor.py",
+        "pandas/tests/series/accessors/test_struct_accessor.py",
+        "pandas/tests/series/indexing/__init__.py",
+        "pandas/tests/series/indexing/test_datetime.py",
+        "pandas/tests/series/indexing/test_delitem.py",
+        "pandas/tests/series/indexing/test_get.py",
+        "pandas/tests/series/indexing/test_getitem.py",
+        "pandas/tests/series/indexing/test_indexing.py",
+        "pandas/tests/series/indexing/test_mask.py",
+        "pandas/tests/series/indexing/test_set_value.py",
+        "pandas/tests/series/indexing/test_setitem.py",
+        "pandas/tests/series/indexing/test_take.py",
+        "pandas/tests/series/indexing/test_where.py",
+        "pandas/tests/series/indexing/test_xs.py",
+        "pandas/tests/series/methods/__init__.py",
+        "pandas/tests/series/methods/test_add_prefix_suffix.py",
+        "pandas/tests/series/methods/test_align.py",
+        "pandas/tests/series/methods/test_argsort.py",
+        "pandas/tests/series/methods/test_asof.py",
+        "pandas/tests/series/methods/test_astype.py",
+        "pandas/tests/series/methods/test_autocorr.py",
+        "pandas/tests/series/methods/test_between.py",
+        "pandas/tests/series/methods/test_case_when.py",
+        "pandas/tests/series/methods/test_clip.py",
+        "pandas/tests/series/methods/test_combine.py",
+        "pandas/tests/series/methods/test_combine_first.py",
+        "pandas/tests/series/methods/test_compare.py",
+        "pandas/tests/series/methods/test_convert_dtypes.py",
+        "pandas/tests/series/methods/test_copy.py",
+        "pandas/tests/series/methods/test_count.py",
+        "pandas/tests/series/methods/test_cov_corr.py",
+        "pandas/tests/series/methods/test_describe.py",
+        "pandas/tests/series/methods/test_diff.py",
+        "pandas/tests/series/methods/test_drop.py",
+        "pandas/tests/series/methods/test_drop_duplicates.py",
+        "pandas/tests/series/methods/test_dropna.py",
+        "pandas/tests/series/methods/test_dtypes.py",
+        "pandas/tests/series/methods/test_duplicated.py",
+        "pandas/tests/series/methods/test_equals.py",
+        "pandas/tests/series/methods/test_explode.py",
+        "pandas/tests/series/methods/test_fillna.py",
+        "pandas/tests/series/methods/test_get_numeric_data.py",
+        "pandas/tests/series/methods/test_head_tail.py",
+        "pandas/tests/series/methods/test_infer_objects.py",
+        "pandas/tests/series/methods/test_info.py",
+        "pandas/tests/series/methods/test_interpolate.py",
+        "pandas/tests/series/methods/test_is_monotonic.py",
+        "pandas/tests/series/methods/test_is_unique.py",
+        "pandas/tests/series/methods/test_isin.py",
+        "pandas/tests/series/methods/test_isna.py",
+        "pandas/tests/series/methods/test_item.py",
+        "pandas/tests/series/methods/test_map.py",
+        "pandas/tests/series/methods/test_matmul.py",
+        "pandas/tests/series/methods/test_nlargest.py",
+        "pandas/tests/series/methods/test_nunique.py",
+        "pandas/tests/series/methods/test_pct_change.py",
+        "pandas/tests/series/methods/test_pop.py",
+        "pandas/tests/series/methods/test_quantile.py",
+        "pandas/tests/series/methods/test_rank.py",
+        "pandas/tests/series/methods/test_reindex.py",
+        "pandas/tests/series/methods/test_reindex_like.py",
+        "pandas/tests/series/methods/test_rename.py",
+        "pandas/tests/series/methods/test_rename_axis.py",
+        "pandas/tests/series/methods/test_repeat.py",
+        "pandas/tests/series/methods/test_replace.py",
+        "pandas/tests/series/methods/test_reset_index.py",
+        "pandas/tests/series/methods/test_round.py",
+        "pandas/tests/series/methods/test_searchsorted.py",
+        "pandas/tests/series/methods/test_set_name.py",
+        "pandas/tests/series/methods/test_size.py",
+        "pandas/tests/series/methods/test_sort_index.py",
+        "pandas/tests/series/methods/test_sort_values.py",
+        "pandas/tests/series/methods/test_to_csv.py",
+        "pandas/tests/series/methods/test_to_dict.py",
+        "pandas/tests/series/methods/test_to_frame.py",
+        "pandas/tests/series/methods/test_to_numpy.py",
+        "pandas/tests/series/methods/test_tolist.py",
+        "pandas/tests/series/methods/test_truncate.py",
+        "pandas/tests/series/methods/test_tz_localize.py",
+        "pandas/tests/series/methods/test_unique.py",
+        "pandas/tests/series/methods/test_unstack.py",
+        "pandas/tests/series/methods/test_update.py",
+        "pandas/tests/series/methods/test_value_counts.py",
+        "pandas/tests/series/methods/test_values.py",
+        "pandas/tests/series/test_api.py",
+        "pandas/tests/series/test_arithmetic.py",
+        "pandas/tests/series/test_arrow_interface.py",
+        "pandas/tests/series/test_constructors.py",
+        "pandas/tests/series/test_cumulative.py",
+        "pandas/tests/series/test_formats.py",
+        "pandas/tests/series/test_iteration.py",
+        "pandas/tests/series/test_logical_ops.py",
+        "pandas/tests/series/test_missing.py",
+        "pandas/tests/series/test_npfuncs.py",
+        "pandas/tests/series/test_reductions.py",
+        "pandas/tests/series/test_subclass.py",
+        "pandas/tests/series/test_ufunc.py",
+        "pandas/tests/series/test_unary.py",
+        "pandas/tests/series/test_validate.py",
+        "pandas/tests/strings/__init__.py",
+        "pandas/tests/strings/conftest.py",
+        "pandas/tests/strings/test_api.py",
+        "pandas/tests/strings/test_case_justify.py",
+        "pandas/tests/strings/test_cat.py",
+        "pandas/tests/strings/test_extract.py",
+        "pandas/tests/strings/test_find_replace.py",
+        "pandas/tests/strings/test_get_dummies.py",
+        "pandas/tests/strings/test_split_partition.py",
+        "pandas/tests/strings/test_string_array.py",
+        "pandas/tests/strings/test_strings.py",
+        "pandas/tests/test_aggregation.py",
+        "pandas/tests/test_algos.py",
+        "pandas/tests/test_col.py",
+        "pandas/tests/test_common.py",
+        "pandas/tests/test_downstream.py",
+        "pandas/tests/test_errors.py",
+        "pandas/tests/test_expressions.py",
+        "pandas/tests/test_flags.py",
+        "pandas/tests/test_multilevel.py",
+        "pandas/tests/test_nanops.py",
+        "pandas/tests/test_optional_dependency.py",
+        "pandas/tests/test_register_accessor.py",
+        "pandas/tests/test_sorting.py",
+        "pandas/tests/test_take.py",
+        "pandas/tests/tools/__init__.py",
+        "pandas/tests/tools/test_to_datetime.py",
+        "pandas/tests/tools/test_to_numeric.py",
+        "pandas/tests/tools/test_to_time.py",
+        "pandas/tests/tools/test_to_timedelta.py",
+        "pandas/tests/tseries/__init__.py",
+        "pandas/tests/tseries/frequencies/__init__.py",
+        "pandas/tests/tseries/frequencies/test_freq_code.py",
+        "pandas/tests/tseries/frequencies/test_frequencies.py",
+        "pandas/tests/tseries/frequencies/test_inference.py",
+        "pandas/tests/tseries/holiday/__init__.py",
+        "pandas/tests/tseries/holiday/test_calendar.py",
+        "pandas/tests/tseries/holiday/test_federal.py",
+        "pandas/tests/tseries/holiday/test_holiday.py",
+        "pandas/tests/tseries/holiday/test_observance.py",
+        "pandas/tests/tseries/offsets/__init__.py",
+        "pandas/tests/tseries/offsets/common.py",
+        "pandas/tests/tseries/offsets/test_business_day.py",
+        "pandas/tests/tseries/offsets/test_business_halfyear.py",
+        "pandas/tests/tseries/offsets/test_business_hour.py",
+        "pandas/tests/tseries/offsets/test_business_month.py",
+        "pandas/tests/tseries/offsets/test_business_quarter.py",
+        "pandas/tests/tseries/offsets/test_business_year.py",
+        "pandas/tests/tseries/offsets/test_common.py",
+        "pandas/tests/tseries/offsets/test_custom_business_day.py",
+        "pandas/tests/tseries/offsets/test_custom_business_hour.py",
+        "pandas/tests/tseries/offsets/test_custom_business_month.py",
+        "pandas/tests/tseries/offsets/test_dst.py",
+        "pandas/tests/tseries/offsets/test_easter.py",
+        "pandas/tests/tseries/offsets/test_fiscal.py",
+        "pandas/tests/tseries/offsets/test_halfyear.py",
+        "pandas/tests/tseries/offsets/test_index.py",
+        "pandas/tests/tseries/offsets/test_month.py",
+        "pandas/tests/tseries/offsets/test_offsets.py",
+        "pandas/tests/tseries/offsets/test_offsets_properties.py",
+        "pandas/tests/tseries/offsets/test_quarter.py",
+        "pandas/tests/tseries/offsets/test_ticks.py",
+        "pandas/tests/tseries/offsets/test_week.py",
+        "pandas/tests/tseries/offsets/test_year.py",
+        "pandas/tests/tslibs/__init__.py",
+        "pandas/tests/tslibs/test_api.py",
+        "pandas/tests/tslibs/test_array_to_datetime.py",
+        "pandas/tests/tslibs/test_ccalendar.py",
+        "pandas/tests/tslibs/test_conversion.py",
+        "pandas/tests/tslibs/test_fields.py",
+        "pandas/tests/tslibs/test_libfrequencies.py",
+        "pandas/tests/tslibs/test_liboffsets.py",
+        "pandas/tests/tslibs/test_np_datetime.py",
+        "pandas/tests/tslibs/test_npy_units.py",
+        "pandas/tests/tslibs/test_parse_iso8601.py",
+        "pandas/tests/tslibs/test_parsing.py",
+        "pandas/tests/tslibs/test_period.py",
+        "pandas/tests/tslibs/test_resolution.py",
+        "pandas/tests/tslibs/test_strptime.py",
+        "pandas/tests/tslibs/test_timedeltas.py",
+        "pandas/tests/tslibs/test_timezones.py",
+        "pandas/tests/tslibs/test_to_offset.py",
+        "pandas/tests/tslibs/test_tzconversion.py",
+        "pandas/tests/util/__init__.py",
+        "pandas/tests/util/conftest.py",
+        "pandas/tests/util/test_assert_almost_equal.py",
+        "pandas/tests/util/test_assert_attr_equal.py",
+        "pandas/tests/util/test_assert_categorical_equal.py",
+        "pandas/tests/util/test_assert_extension_array_equal.py",
+        "pandas/tests/util/test_assert_frame_equal.py",
+        "pandas/tests/util/test_assert_index_equal.py",
+        "pandas/tests/util/test_assert_interval_array_equal.py",
+        "pandas/tests/util/test_assert_numpy_array_equal.py",
+        "pandas/tests/util/test_assert_produces_warning.py",
+        "pandas/tests/util/test_assert_series_equal.py",
+        "pandas/tests/util/test_deprecate.py",
+        "pandas/tests/util/test_deprecate_kwarg.py",
+        "pandas/tests/util/test_deprecate_nonkeyword_arguments.py",
+        "pandas/tests/util/test_doc.py",
+        "pandas/tests/util/test_hashing.py",
+        "pandas/tests/util/test_numba.py",
+        "pandas/tests/util/test_rewrite_warning.py",
+        "pandas/tests/util/test_shares_memory.py",
+        "pandas/tests/util/test_show_versions.py",
+        "pandas/tests/util/test_util.py",
+        "pandas/tests/util/test_validate_args.py",
+        "pandas/tests/util/test_validate_args_and_kwargs.py",
+        "pandas/tests/util/test_validate_inclusive.py",
+        "pandas/tests/util/test_validate_kwargs.py",
+        "pandas/tests/window/__init__.py",
+        "pandas/tests/window/conftest.py",
+        "pandas/tests/window/moments/__init__.py",
+        "pandas/tests/window/moments/conftest.py",
+        "pandas/tests/window/moments/test_moments_consistency_ewm.py",
+        "pandas/tests/window/moments/test_moments_consistency_expanding.py",
+        "pandas/tests/window/moments/test_moments_consistency_rolling.py",
+        "pandas/tests/window/test_api.py",
+        "pandas/tests/window/test_apply.py",
+        "pandas/tests/window/test_base_indexer.py",
+        "pandas/tests/window/test_cython_aggregations.py",
+        "pandas/tests/window/test_dtypes.py",
+        "pandas/tests/window/test_ewm.py",
+        "pandas/tests/window/test_expanding.py",
+        "pandas/tests/window/test_groupby.py",
+        "pandas/tests/window/test_numba.py",
+        "pandas/tests/window/test_online.py",
+        "pandas/tests/window/test_pairwise.py",
+        "pandas/tests/window/test_rolling.py",
+        "pandas/tests/window/test_rolling_functions.py",
+        "pandas/tests/window/test_rolling_quantile.py",
+        "pandas/tests/window/test_rolling_skew_kurt.py",
+        "pandas/tests/window/test_timeseries_window.py",
+        "pandas/tests/window/test_win_type.py",
+        "pandas/tseries/__init__.py",
+        "pandas/tseries/api.py",
+        "pandas/tseries/frequencies.py",
+        "pandas/tseries/holiday.py",
+        "pandas/tseries/offsets.py",
+        "pandas/util/__init__.py",
+        "pandas/util/_decorators.py",
+        "pandas/util/_doctools.py",
+        "pandas/util/_exceptions.py",
+        "pandas/util/_print_versions.py",
+        "pandas/util/_test_decorators.py",
+        "pandas/util/_tester.py",
+        "pandas/util/_validators.py",
+        "pandas/util/version/__init__.py"
+      ],
+      "filesTotal": 1421,
+      "manifestCid": "sha256:c267d971bb2d1a3dd65769bb76ce6efec080803fea51df3964353e8c9f073c03"
+    },
+    "rows": [
+      {
+        "file": "pandas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/config.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/dates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/display.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/localization.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_libs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_libs/tslibs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_libs/window/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/_hypothesis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/_io.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/_warnings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/asserters.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/contexts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_typing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_version.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_version_meson.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/executors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/extensions/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/indexers/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/interchange/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/types/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/typing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/typing/aliases.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/arrays/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/_constants.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/_optional.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/numpy/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/numpy/function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/pickle_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/pyarrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/executor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/extensions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/mean_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/min_max_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/shared.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/sum_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/var_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/algorithms.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/datetimelike_accumulations.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/masked_accumulations.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/masked_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/putmask.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/transforms.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arraylike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_arrow_string_mixins.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_mixins.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_ranges.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/_arrow_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/accessors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/extension_types.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/boolean.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/floating.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/integer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/masked.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/numpy_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/scipy_sparse.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/string_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/string_arrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/col.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/align.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/check.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/engines.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/eval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/expr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/expressions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/parsing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/pytables.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/scope.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/config_init.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/cast.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/inference.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/flags.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/grouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/numba_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexers/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexers/objects.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexers/utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/accessors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/category.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/extension.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/frozen.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/multi.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/buffer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/column.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/dataframe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/dataframe_protocol.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/from_dataframe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/blocks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/managers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/selectn.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/to_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/nanops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/array_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/dispatch.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/docstrings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/invalid.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/mask_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/resample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/encoding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/melt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/merge.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/pivot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/reshape.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/tile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/roperator.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/shared_docs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sparse/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sparse/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/strings/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/strings/accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/strings/object_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/times.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/util/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/util/hashing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/util/numba_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/doc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/ewm.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/expanding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/numba_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/online.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/rolling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/errors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/errors/cow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/clipboard/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/clipboards.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_calamine.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_odfreader.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_odswriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_openpyxl.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_pyxlsb.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_xlrd.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_xlsxwriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/feather_format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/_color_data.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/console.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/css.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/csvs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/excel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/info.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/printing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/style_render.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/iceberg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/_json.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/_table_schema.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/orc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parquet.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/arrow_parser_wrapper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/base_parser.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/c_parser_wrapper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/python_parser.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/readers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/pytables.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sas7bdat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sas_constants.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sas_xport.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sasreader.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/spss.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sql.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/stata.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_core.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/boxplot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/converter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/core.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/hist.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/timeseries.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/tools.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/testing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/api/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/api/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/api/test_types.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_frame_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_frame_apply_relabeling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_frame_transform.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_invalid_arg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_series_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_series_apply_relabeling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_series_transform.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_str.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_array_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_bool.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_datetime64.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_object.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_timedelta64.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_comparison.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_logical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_reduction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_algos.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_analytics.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_operators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_warnings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_comparison.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_contains.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_to_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_comparison.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_reduction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_interval_pyarrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_overlaps.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_arrow_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked_shared.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/numpy_/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/numpy_/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/numpy_/test_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_arrow_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_arithmetics.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_combine_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_libsparse.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_unary.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/test_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/test_string_arrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_ndarray_backed.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_conversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_transpose.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/computation/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/computation/test_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/computation/test_eval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/config/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/config/test_config.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/config/test_localization.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/construction/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/construction/test_extract_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_datetimeindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_intervalindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_periodindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_timedeltaindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_chained_assignment_deprecation.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_clip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_copy_deprecation.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_core_functionalities.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_functions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_interp_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_methods.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_box_unbox.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_can_hold_element.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_construct_from_scalar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_construct_ndarray.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_construct_object_arr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_dict_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_downcast.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_find_common_type.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_infer_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_infer_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_promote.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_inference.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/array_with_attr/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/array_with_attr/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/array_with_attr/test_array_with_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/accumulate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/casting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/dim2.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/interface.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/io.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/methods.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/printing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/reduce.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/reshaping.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/date/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/date/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/decimal/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/decimal/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/decimal/test_decimal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/json/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/json/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/json/test_json.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/list/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/list/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/list/test_list.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_arrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_extension.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_masked.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_sparse.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/uuid/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/uuid/test_uuid.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/constructors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/constructors/test_from_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/constructors/test_from_records.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_coercion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_delitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_get.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_get_value.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_mask.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_set_value.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_where.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_xs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_add_prefix_suffix.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_align.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_asfreq.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_assign.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_at_time.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_between_time.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_clip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_combine.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_combine_first.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_compare.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_convert_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_copy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_count.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_cov_corr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_diff.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_dot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_drop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_drop_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_droplevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_dropna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_duplicated.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_explode.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_filter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_first_valid_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_get_numeric_data.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_head_tail.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_infer_objects.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_info.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_interpolate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_is_homogeneous_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_isetitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_isin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_iterrows.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_matmul.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_nlargest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_pct_change.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_pipe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_pop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_rank.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reindex_like.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_rename.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_rename_axis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reorder_levels.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reset_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_sample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_select_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_set_axis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_set_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_size.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_sort_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_sort_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_swaplevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_csv.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_dict_of_blocks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_records.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_timestamp.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_transpose.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_truncate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_tz_convert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_update.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_alter_axes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_arrow_interface.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_block_internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_iteration.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_logical_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_nonunique_indexes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_npfuncs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_query_eval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_stack_unstack.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_ufunc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_unary.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_validate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_duplicate_labels.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_finalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_label_or_level_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_to_xarray.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_aggregate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_cython.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_other.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_groupby_shift_diff.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_is_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_kurt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_nlargest_nsmallest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_nth.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_rank.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_sample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_size.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_skew.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_all_methods.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_bin_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_counting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_filters.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_groupby_dropna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_groupby_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_grouping.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_index_as_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_libgroupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_numeric_only.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_pipe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_raises.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_timegrouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/transform/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/transform/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/transform/test_transform.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_reshape.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_where.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_append.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_category.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_drop_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_is_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_nat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_sort_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_delete.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_factorize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_isocalendar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_resolution.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_snap.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_julian_date.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_pydatetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_tz_convert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_date_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_freq_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_iter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_npfuncs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_partial_slicing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_scalar_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_interval_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_interval_tree.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_analytics.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_conversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_copy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_drop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_equivalence.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_get_level_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_get_set.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_integrity.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_isin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_lexsort.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_names.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_partial_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_reshape.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/object/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/object/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/object/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_asfreq.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_factorize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_is_full.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_to_timestamp.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_freq_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_partial_slicing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_period_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_resolution.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_scalar_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_searchsorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_tools.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/string/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/string/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/string/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_any_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_engines.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_frozen.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_index_new.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_numpy_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_old_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_factorize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_delete.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_freq_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_scalar_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_searchsorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_timedelta_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/interval/test_interval_new.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_chaining_and_caching.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_iloc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_indexing_slow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_loc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_multiindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_partial.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_slice.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_sorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_at.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_chaining_and_caching.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_check_indexer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_coercion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_floats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_iat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_iloc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_indexers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_loc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_na_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_partial.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_scalar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/test_impl.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/test_spec_conformance.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/test_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/internals/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/internals/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/internals/test_internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_odf.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_odswriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_openpyxl.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_readers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_writers.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_xlrd.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_xlsxwriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_bar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_exceptions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_highlight.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_matplotlib.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_non_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_to_latex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_to_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_to_typst.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_tooltip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_console.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_css.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_eng_formatting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_ipython_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_printing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_csv.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_excel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_latex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_markdown.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/generate_legacy_storage_files.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_compression.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_deprecated_kwargs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_json_table_schema.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_json_table_schema_ext_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_pandas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_readlines.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_ujson.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_chunksize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_common_basic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_data_list.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_decimal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_file_buffer_url.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_float.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_inf.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_ints.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_iterator.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_read_errors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/test_dtypes_basic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/test_empty.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_c_parser_only.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_comment.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_compression.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_concatenate_chunks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_converters.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_dialect.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_encoding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_header.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_index_col.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_mangle_dupes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_multi_thread.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_na_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_network.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_parse_dates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_python_parser_only.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_quoting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_read_fwf.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_skiprows.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_textreader.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_unsupported.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_upcast.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/test_parse_dates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/test_strings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/test_usecols_basic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_append.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_complex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_errors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_file_handling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_keys.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_put.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_pytables_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_read.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_retain_attributes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_round_trip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_select.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_store.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_time_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_byteswap.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_sas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_sas7bdat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_xport.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_clipboard.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_compression.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/test_feather.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_fsspec.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_gcs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_http_headers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_iceberg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_orc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_parquet.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_s3.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_spss.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_sql.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/test_stata.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/test_to_xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/test_xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/test_xml_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_hashtable.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_lib.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_libalgos.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_color.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_legend.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_subplots.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_hist_box_by.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_backend.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_boxplot_method.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_converter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_hist_method.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reductions/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reductions/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reductions/test_stat_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_datetime_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_period_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_resample_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_resampler_grouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_time_grouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_append.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_append_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_dataframe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_empty.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_invalid.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_sort.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_antijoin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_cross.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_index_as_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_ordered.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_multi.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_crosstab.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_cut.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_from_dummies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_get_dummies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_melt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_pivot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_pivot_multilevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_qcut.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_union_categoricals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_contains.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_overlaps.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/test_asfreq.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/test_na_scalar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/test_nat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/methods/test_as_unit.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_as_unit.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_timestamp_method.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_to_julian_date.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_tz_convert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_comparisons.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_timestamp.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_cat_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_dt_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_list_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_sparse_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_str_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_struct_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_delitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_get.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_mask.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_set_value.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_where.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_xs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_add_prefix_suffix.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_align.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_argsort.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_autocorr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_between.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_case_when.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_clip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_combine.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_combine_first.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_compare.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_convert_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_copy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_count.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_cov_corr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_diff.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_drop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_drop_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_dropna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_duplicated.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_explode.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_get_numeric_data.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_head_tail.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_infer_objects.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_info.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_interpolate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_is_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_is_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_isin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_isna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_item.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_matmul.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_nlargest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_nunique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_pct_change.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_pop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_rank.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_reindex_like.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_rename.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_rename_axis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_reset_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_searchsorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_set_name.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_size.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_sort_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_sort_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_csv.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_tolist.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_truncate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_unstack.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_update.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_arrow_interface.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_iteration.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_logical_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_npfuncs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_ufunc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_unary.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_validate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_case_justify.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_cat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_extract.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_find_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_get_dummies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_split_partition.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_string_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_strings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_aggregation.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_algos.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_col.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_downstream.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_errors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_expressions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_flags.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_multilevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_nanops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_optional_dependency.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_register_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_time.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/test_freq_code.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/test_frequencies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/test_inference.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_calendar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_federal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_holiday.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_observance.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_day.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_halfyear.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_hour.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_month.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_quarter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_year.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_custom_business_day.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_custom_business_hour.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_custom_business_month.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_dst.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_easter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_fiscal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_halfyear.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_month.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_offsets.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_offsets_properties.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_quarter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_ticks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_week.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_year.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_array_to_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_ccalendar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_conversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_fields.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_libfrequencies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_liboffsets.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_np_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_npy_units.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_parse_iso8601.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_parsing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_resolution.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_strptime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_to_offset.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_tzconversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_almost_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_attr_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_categorical_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_extension_array_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_frame_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_index_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_interval_array_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_numpy_array_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_produces_warning.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_series_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_deprecate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_deprecate_kwarg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_deprecate_nonkeyword_arguments.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_doc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_hashing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_rewrite_warning.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_shares_memory.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_show_versions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_args.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_args_and_kwargs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_inclusive.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_kwargs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/test_moments_consistency_ewm.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/test_moments_consistency_expanding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/test_moments_consistency_rolling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_base_indexer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_cython_aggregations.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_ewm.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_expanding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_online.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_pairwise.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling_functions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling_skew_kurt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_timeseries_window.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_win_type.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/frequencies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/holiday.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/offsets.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_decorators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_doctools.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_exceptions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_print_versions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_test_decorators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_tester.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_validators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/version/__init__.py",
+        "category": "completed"
+      }
+    ],
+    "totals": {
+      "R_backend_defects": 5,
+      "R_cm_derived_contract": 17,
+      "R_control_effect": 9,
+      "R_desugar": 9694,
+      "backendDefectsOrProcessTerminals": 5,
+      "constructionPanics": 0,
+      "desugarConstructionPanics": 502,
+      "desugarDefects": 40
+    }
+  },
+  "controlEffectStableZeroTerms": {
+    "completedDenominatorPositive": true,
+    "denominatorComplete": true,
+    "timeouts": 0,
+    "constructionPanics": 0,
+    "factoringGaps": 13,
+    "unresolvableDispatchTargets": 0,
+    "backendDefectFiles": 3,
+    "desugarConstructionPanics": 502,
+    "desugarDefects": 40
+  },
+  "red": true,
+  "redReasons": [
+    "5 per-file terminal defect rows",
+    "502 desugar construction panics (construction-law None arms -- red, and never semantic R)",
+    "40 desugar defects",
+    "denominator incomplete: 1416/1421 completed"
+  ],
+  "controlEffectStableZero": false
+}

--- a/docs/ledgers/pass3-pandas-control-effect-d94f67a31.md
+++ b/docs/ledgers/pass3-pandas-control-effect-d94f67a31.md
@@ -1,6 +1,26 @@
 # Pass 3 board — pandas control-effect census @ `d94f67a31`
 
-**Authority:** provisional checkpoint reconstruction  
+> ## ARCHIVED — NOT COMPARABLE TO THE CURRENT BOARD
+>
+> **Do not quote any number in this file against a current measurement, and in
+> particular do not quote its With-R.** Two things make it non-comparable, and
+> either alone would be enough:
+>
+> 1. **Different corpus.** This ran over a 1,415-file pandas. The current board
+>    is pinned to pandas 3.0.3, 1,421 files, identified by an aggregate content
+>    hash (`sugar_lift_py_tests.corpus_pin`). A delta between the two is a
+>    different pandas, not motion.
+> 2. **Understated by construction.** 780 of its 1,415 files aborted at
+>    `ValueError: 'dynamic-export' is not a valid WithConstructionGapKind`
+>    before their gaps could be tallied. Its construction With mass is a floor
+>    over 635 files, not a measurement over 1,415. That decode defect is fixed
+>    (`WithConstructionGapKind.parse`), which is exactly why the numbers below
+>    cannot be differenced against anything measured after it.
+>
+> Kept as testimony of what was observed and when. The authority is
+> `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`.
+
+**Authority:** ARCHIVED — superseded, non-comparable. Was: provisional checkpoint reconstruction  
 **Source:** `.sugar/pandas-four-axis-census-d94f67a31/control-effect/checkpoint.jsonl`  
 **Rows:** 1415 / 1415 (full manifest)  
 **Lease:** completed/findings; `measuredCommit=d94f67a3149ea2aceee4f9a8cff0397b6f6d374a`  

--- a/docs/ledgers/pins/pandas-3.0.3.pin.json
+++ b/docs/ledgers/pins/pandas-3.0.3.pin.json
@@ -4,6 +4,8 @@
   "version": "3.0.3",
   "fileCount": 1421,
   "aggregateHash": "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c",
+  "contentOnlyHash": "a1155ae27c10a1828ac6a02b890a8b1ee23881a5f78c3d6265f02a63065ca77d",
+  "pathBoundHash": "04b67544e3628d25d1b20653558fb2c702a870ae3f97bc8492a9f70f854a9c31",
   "root": "/home/tsavo/pandas303-audit/pandas",
   "files": [
     {

--- a/docs/ledgers/pins/pandas-3.0.3.pin.json
+++ b/docs/ledgers/pins/pandas-3.0.3.pin.json
@@ -1,0 +1,7115 @@
+{
+  "kind": "sugar-corpus-pin/v1",
+  "distribution": "pandas",
+  "version": "3.0.3",
+  "fileCount": 1421,
+  "aggregateHash": "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c",
+  "root": "/home/tsavo/pandas303-audit/pandas",
+  "files": [
+    {
+      "path": "__init__.py",
+      "sha256": "742f85c135ee654bff1203efcee7664bf82fc7305ac3912ff304a063f5f7ea3c",
+      "sizeBytes": 8223
+    },
+    {
+      "path": "_config/__init__.py",
+      "sha256": "3bef6f14a689af91c4e63bb3d103b015e69c32a7022775855923bb657926d67b",
+      "sizeBytes": 1105
+    },
+    {
+      "path": "_config/config.py",
+      "sha256": "038563ba34f9af6e61494cc20721bcf2d61e837e6d44c18055bc213ce67ed794",
+      "sizeBytes": 27125
+    },
+    {
+      "path": "_config/dates.py",
+      "sha256": "3e4c134692445fec83fc6b8db30798aca5c7e05d948e4688c575e36adb3582a0",
+      "sizeBytes": 669
+    },
+    {
+      "path": "_config/display.py",
+      "sha256": "c6ffd37ad594845955a68836dd0cf284c62c49ca29b3f38eb162001a798a749f",
+      "sizeBytes": 1804
+    },
+    {
+      "path": "_config/localization.py",
+      "sha256": "32be9d6c8a3f00d525b98c3c4ba6cb45d0437df79a5855d8b587eee18a524423",
+      "sizeBytes": 5210
+    },
+    {
+      "path": "_libs/__init__.py",
+      "sha256": "b160c0fc3733cd3fb5c04044e177f9c112f6b41eddd912ad6db1ebc02359c9e3",
+      "sizeBytes": 673
+    },
+    {
+      "path": "_libs/tslibs/__init__.py",
+      "sha256": "d1d6bb192e6baeecaf4e61223fa2e4205b6cf2c6d3f534b41d30376a34dc933f",
+      "sizeBytes": 2114
+    },
+    {
+      "path": "_libs/window/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "_testing/__init__.py",
+      "sha256": "bdf0346241c793054a29ae87c51ee480f4ddbe48c075e7a5b3c1fbcd7fcfea64",
+      "sizeBytes": 17843
+    },
+    {
+      "path": "_testing/_hypothesis.py",
+      "sha256": "06d33f515de25e686d6b2c88aa063faa18798f5d62e02cd9ed2f8f4241da747a",
+      "sizeBytes": 2325
+    },
+    {
+      "path": "_testing/_io.py",
+      "sha256": "589fca5148d5ebb53ce701e145b1549162e73df7e09d52674b4dafa3fbd26ce2",
+      "sizeBytes": 3468
+    },
+    {
+      "path": "_testing/_warnings.py",
+      "sha256": "9a2e43ea6d0393c954e6008c38a9582f1b44a6e563775559b39b2becabfe8f35",
+      "sizeBytes": 10121
+    },
+    {
+      "path": "_testing/asserters.py",
+      "sha256": "0f81ba27297d2ed3ab1e6801c6efb19a04505014bb9548c4d6f625220dc06981",
+      "sizeBytes": 50070
+    },
+    {
+      "path": "_testing/compat.py",
+      "sha256": "3c7a34a5a01165f39151c5192aa8d48dd1fcdfb113aed895f9f11e76671412b1",
+      "sizeBytes": 659
+    },
+    {
+      "path": "_testing/contexts.py",
+      "sha256": "3f0751a7a2d12044f5195d220736be558d4f856efdf0f40c33839babb70b7198",
+      "sizeBytes": 3616
+    },
+    {
+      "path": "_typing.py",
+      "sha256": "8f86578f9de29d505fcebfbec55920dd94a3a0841fdfd39bcbccc873aaccf5ab",
+      "sizeBytes": 16692
+    },
+    {
+      "path": "_version.py",
+      "sha256": "5c5d86698d44ff2c8dffe899ef1328085da2205283e0f0a02e688c96512f19cd",
+      "sizeBytes": 23695
+    },
+    {
+      "path": "_version_meson.py",
+      "sha256": "eaaac9719bded0c390f569cd96ab47943eb84693535c5d2202a365886411f47c",
+      "sizeBytes": 79
+    },
+    {
+      "path": "api/__init__.py",
+      "sha256": "ae92ca947433123b835b5d3daf21162c0870d2f92b4881d6fc7f43185ce1ec4e",
+      "sizeBytes": 250
+    },
+    {
+      "path": "api/executors/__init__.py",
+      "sha256": "5850bc40020935a6b50d7cdffb5ba59eb66f3b3a002302f1d4f7e53e83711ac8",
+      "sizeBytes": 174
+    },
+    {
+      "path": "api/extensions/__init__.py",
+      "sha256": "3c16f026c152508cf4b6c2bdd6a09155bfdf24b917e9707652335fc8a3efa074",
+      "sizeBytes": 685
+    },
+    {
+      "path": "api/indexers/__init__.py",
+      "sha256": "a09fe4b3988dc9f130b0e1ec4b59f43d03319a4a417bdaf52ea26fcd6a4f6f5c",
+      "sizeBytes": 357
+    },
+    {
+      "path": "api/interchange/__init__.py",
+      "sha256": "e9bb6fa80f8713be7d545eec4cab77d4163e9975045952b2a9d889e9d6f2b415",
+      "sizeBytes": 230
+    },
+    {
+      "path": "api/internals.py",
+      "sha256": "250a258d0f24e03ba9bd65910b7960365caf36e541e0c68a3b0c9b0ae41b7ba4",
+      "sizeBytes": 2386
+    },
+    {
+      "path": "api/types/__init__.py",
+      "sha256": "30fd156e177d32c654ffcc3f2fc57372b260085a79225279f966a472c8c1df94",
+      "sizeBytes": 447
+    },
+    {
+      "path": "api/typing/__init__.py",
+      "sha256": "7f10eb4cca5763eff7cea6ec40add9a6c7c4319a5f806d418635532bff3ce151",
+      "sizeBytes": 1451
+    },
+    {
+      "path": "api/typing/aliases.py",
+      "sha256": "82634873f6c981d8653618ec22e4ec546e9de4009e080d57bbd955abed014ecd",
+      "sizeBytes": 2808
+    },
+    {
+      "path": "arrays/__init__.py",
+      "sha256": "1218ebf418b219b65c9dc56bac4ee6c2ca6582768571b7ef9e311029e637307a",
+      "sizeBytes": 671
+    },
+    {
+      "path": "compat/__init__.py",
+      "sha256": "2140de57cfa8171f35722cfbd03ca1e346e9ae0b08be2eb3fd0fd3bbc9056c8b",
+      "sizeBytes": 3603
+    },
+    {
+      "path": "compat/_constants.py",
+      "sha256": "a972d7a64e642535920ca80dd2bd23a6906d7b7b764dac4517ec47ae34719223",
+      "sizeBytes": 751
+    },
+    {
+      "path": "compat/_optional.py",
+      "sha256": "2147fb6c50c00220cc8bf6929305ab40b3fc82cd2f72313ed6d728fc34a35300",
+      "sizeBytes": 5638
+    },
+    {
+      "path": "compat/numpy/__init__.py",
+      "sha256": "2704f42b16175ffdb674b1f999f6dc6c0a050ee087776709e32a6bda0456b3e1",
+      "sizeBytes": 1120
+    },
+    {
+      "path": "compat/numpy/function.py",
+      "sha256": "b7d8e1b229583f5370eb375468ceacb22838f23c272862a002290f7ff9556b15",
+      "sizeBytes": 11752
+    },
+    {
+      "path": "compat/pickle_compat.py",
+      "sha256": "f25b535ac3aa3860e8e6a7b98e586ab1b92356789439671298d3b812bf2a743f",
+      "sizeBytes": 4184
+    },
+    {
+      "path": "compat/pyarrow.py",
+      "sha256": "b95b7127d6c6a8c1ea90950b6ac546415979fa5dd3a2211ad0511a47494d49c7",
+      "sizeBytes": 3291
+    },
+    {
+      "path": "conftest.py",
+      "sha256": "f23a71865d42770b0def6e4b4b5d4f95a1e11f305cc4d8c248332e5fdb3f2f2a",
+      "sizeBytes": 53450
+    },
+    {
+      "path": "core/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/_numba/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/_numba/executor.py",
+      "sha256": "9cad9dd00567396759f1efeaa81a52184a6aecf027fb368b451f750c8187f180",
+      "sizeBytes": 8028
+    },
+    {
+      "path": "core/_numba/extensions.py",
+      "sha256": "dabcac87b17db531031f45ec623dede223e4166de58e63ffc48120b780dcd66b",
+      "sizeBytes": 18509
+    },
+    {
+      "path": "core/_numba/kernels/__init__.py",
+      "sha256": "d2a0ea17947cca4612f0202c2e06f7fc9b2be1743ba60710465b46c72a56f209",
+      "sizeBytes": 520
+    },
+    {
+      "path": "core/_numba/kernels/mean_.py",
+      "sha256": "75ceef7f8d2c402939bf5a9874366e2c37291b5c0255362d6918d3e7bffc0d2f",
+      "sizeBytes": 5663
+    },
+    {
+      "path": "core/_numba/kernels/min_max_.py",
+      "sha256": "e71323d2aec37843846539c1883530d43e9c4fe25caa6c7c471788098e86da6a",
+      "sizeBytes": 5206
+    },
+    {
+      "path": "core/_numba/kernels/shared.py",
+      "sha256": "25405af7a2d7e0d9978605cdca8f39f48c0c5c4976f44ca199174ca10a359fbf",
+      "sizeBytes": 611
+    },
+    {
+      "path": "core/_numba/kernels/sum_.py",
+      "sha256": "7269ae8c9226e34f83e4704fc6051d2621d311147a0bd9bd92b3b11e07e60b11",
+      "sizeBytes": 6796
+    },
+    {
+      "path": "core/_numba/kernels/var_.py",
+      "sha256": "077fe7138f9b739bc4c5b3922b2d7fca035cc081f4f35559a6abbc7246eb82e6",
+      "sizeBytes": 7120
+    },
+    {
+      "path": "core/accessor.py",
+      "sha256": "1a8ceb8112db574473bdf95f3b71e2fc87c5265b5bd6308c69dd83ae8d3a5ee2",
+      "sizeBytes": 17375
+    },
+    {
+      "path": "core/algorithms.py",
+      "sha256": "60f34f55044afb2902a5fed776dbd51ffdef823f096a7faa3ae709bcf6edcbed",
+      "sizeBytes": 54861
+    },
+    {
+      "path": "core/api.py",
+      "sha256": "e4e40fb879e409593b40200ce0c98c9b3c62b17c3f27985373ad70f8a2a9275c",
+      "sizeBytes": 2889
+    },
+    {
+      "path": "core/apply.py",
+      "sha256": "62f5f2592cf2f34b34021f96e96717a991ca3fecfc70e94f6020778852c80186",
+      "sizeBytes": 70029
+    },
+    {
+      "path": "core/array_algos/__init__.py",
+      "sha256": "f182e53ba4f2b043f196d7db34a746f4c9555de0cb7d3206368da7511f99c25d",
+      "sizeBytes": 408
+    },
+    {
+      "path": "core/array_algos/datetimelike_accumulations.py",
+      "sha256": "e7e574a1ff2976774008fe1f3f34a328663f8df523d8823a5bb53d748f371d6c",
+      "sizeBytes": 1854
+    },
+    {
+      "path": "core/array_algos/masked_accumulations.py",
+      "sha256": "30ca9704080598c9bff68a2d8aab48166131801a6a26f3d2ebe640c68f5b44d1",
+      "sizeBytes": 2897
+    },
+    {
+      "path": "core/array_algos/masked_reductions.py",
+      "sha256": "5589b55fd4973f159058a000c883ee529d683357be1b8124108f0985906eafc4",
+      "sizeBytes": 5331
+    },
+    {
+      "path": "core/array_algos/putmask.py",
+      "sha256": "a3d59eb040854b98d06692f3ad4069d59fbcf88a7fe8a52d68b711173f756cae",
+      "sizeBytes": 4594
+    },
+    {
+      "path": "core/array_algos/quantile.py",
+      "sha256": "3535764720c4b83a8cf4530fee64aa399f97a14af94e15986b135dcfc168bac4",
+      "sizeBytes": 6531
+    },
+    {
+      "path": "core/array_algos/replace.py",
+      "sha256": "4f2d90ae84c7febc62d5ec2e62285661570a52d8a1867306e78deae55b17cef9",
+      "sizeBytes": 4139
+    },
+    {
+      "path": "core/array_algos/take.py",
+      "sha256": "8244d8b0041e956eb3b0e2239007c7d2d992d6cd34181e22acf75b48ed136bb0",
+      "sizeBytes": 19529
+    },
+    {
+      "path": "core/array_algos/transforms.py",
+      "sha256": "4cfa523d7e4289e3d5193154c278a6a5c0b961e04eb6300f2b6d3042f1bdd902",
+      "sizeBytes": 1104
+    },
+    {
+      "path": "core/arraylike.py",
+      "sha256": "6f9c0613571bef06fc74c4290367d823d7cfb4ed9057dd6ab3b9bb92e6cdb90f",
+      "sizeBytes": 17836
+    },
+    {
+      "path": "core/arrays/__init__.py",
+      "sha256": "7f4d0dd5574419d384b8b503a70da8d6f2c89e551e47eae37ae5152f987d1f09",
+      "sizeBytes": 1314
+    },
+    {
+      "path": "core/arrays/_arrow_string_mixins.py",
+      "sha256": "747eaadc8fb4fba0ae8952c1afea22b9eae3816fc5c0f8c9273ba024f43d9c65",
+      "sizeBytes": 16151
+    },
+    {
+      "path": "core/arrays/_mixins.py",
+      "sha256": "5cd6335c1de5b7fbe756bf5313643a37619115251785bc45a1dc9291441e13f7",
+      "sizeBytes": 17243
+    },
+    {
+      "path": "core/arrays/_ranges.py",
+      "sha256": "5951bad44d1a1980c141ede2674182e8b039551f54a2ad0c1aeb557dd2bf346a",
+      "sizeBytes": 6919
+    },
+    {
+      "path": "core/arrays/_utils.py",
+      "sha256": "e6adef4ec799b6923574ef9ebaed34d5d53f6d299be7a1daaa11119fe8461fe2",
+      "sizeBytes": 2485
+    },
+    {
+      "path": "core/arrays/arrow/__init__.py",
+      "sha256": "38af4f6481622751ab2e9a6528727a815e597e17b1db43ff6afbdd3b9657cdce",
+      "sizeBytes": 221
+    },
+    {
+      "path": "core/arrays/arrow/_arrow_utils.py",
+      "sha256": "46e9518f25b3527f6054555eca99dd5300cb7b3a51d92580083ebf0589b12838",
+      "sizeBytes": 1586
+    },
+    {
+      "path": "core/arrays/arrow/accessors.py",
+      "sha256": "7295ebfec55796c05a490cac2e271275e985416d04b81fbac221128aa4e7c0d8",
+      "sizeBytes": 14748
+    },
+    {
+      "path": "core/arrays/arrow/array.py",
+      "sha256": "5a1c4bea8b2df5fc08cd7ae8c2f7f7627fb2813cef9c5cc2c719f1212153424f",
+      "sizeBytes": 119936
+    },
+    {
+      "path": "core/arrays/arrow/extension_types.py",
+      "sha256": "99aca6b818509f631a6abd034bdf291fecc370257383cae862368481ea3d9ea7",
+      "sizeBytes": 5476
+    },
+    {
+      "path": "core/arrays/base.py",
+      "sha256": "dc237a818bcf6003fb11f44a9334355be8447c12f4a5a8b7883c1947b4f67749",
+      "sizeBytes": 101659
+    },
+    {
+      "path": "core/arrays/boolean.py",
+      "sha256": "25cb2766fc2eea983521dcac3cf7a31d1941c15c6b2c3fe1058182fcd759d1e9",
+      "sizeBytes": 13414
+    },
+    {
+      "path": "core/arrays/categorical.py",
+      "sha256": "ece7b28d2aaa631eb38af1d489be2d7f59f85c8a9344f937eecdc2e117e9a111",
+      "sizeBytes": 103012
+    },
+    {
+      "path": "core/arrays/datetimelike.py",
+      "sha256": "31221821ae57b14a040af039b8293333757cc3173227b258d381ef83cf31c911",
+      "sizeBytes": 97469
+    },
+    {
+      "path": "core/arrays/datetimes.py",
+      "sha256": "9f6da2c1960e86feec6c729d1e8de862b1120c7e85ff02167f8f62561b54c01c",
+      "sizeBytes": 100672
+    },
+    {
+      "path": "core/arrays/floating.py",
+      "sha256": "178c9ba2ac9a9ade394596aeac874a53141139223fb9d3418abacd184dcedd2b",
+      "sizeBytes": 4765
+    },
+    {
+      "path": "core/arrays/integer.py",
+      "sha256": "27df25c3a466d0a17bf316cab4d855e8306c07dfac632cad6b64206c12675464",
+      "sizeBytes": 6965
+    },
+    {
+      "path": "core/arrays/interval.py",
+      "sha256": "5bd647ac42f5fd9af9d706fa081323152374edd52391aba4a46a763215afdd6c",
+      "sizeBytes": 73770
+    },
+    {
+      "path": "core/arrays/masked.py",
+      "sha256": "287907e823c1bcb5bbe1209dd0b814afe42f4e3d8764ed55556099b3ded6bbaf",
+      "sizeBytes": 67620
+    },
+    {
+      "path": "core/arrays/numeric.py",
+      "sha256": "e60a706cfd7eb75b08ac525ecec928443da93e72e5d465e9cb6637c48364442c",
+      "sizeBytes": 9896
+    },
+    {
+      "path": "core/arrays/numpy_.py",
+      "sha256": "0c02758c88eb4fada4ef27bfcd03c7e0fea1c7b9693752e8be5d1d5a46b8b8cc",
+      "sizeBytes": 20247
+    },
+    {
+      "path": "core/arrays/period.py",
+      "sha256": "78201bfd26bf1d41447bff775611aa637057f5e2c3263a834e899f21b5cf0977",
+      "sizeBytes": 47767
+    },
+    {
+      "path": "core/arrays/sparse/__init__.py",
+      "sha256": "33db4cbf035f8fd01322718fa38e74823befaf39ca8827c9b578d3687d0289d3",
+      "sizeBytes": 356
+    },
+    {
+      "path": "core/arrays/sparse/accessor.py",
+      "sha256": "a6161d8b11c7544fa51e8b2a34633780f4ac1ad08e4c510fde5f48d1291a26c3",
+      "sizeBytes": 15178
+    },
+    {
+      "path": "core/arrays/sparse/array.py",
+      "sha256": "21a1cbd170d8d8561232607a785556f6e0628b137961a2d8354a4c6751d0f823",
+      "sizeBytes": 65955
+    },
+    {
+      "path": "core/arrays/sparse/scipy_sparse.py",
+      "sha256": "a9b140361776055e6573055d8c596e64307fdf34782040af65594009c38c94e1",
+      "sizeBytes": 6508
+    },
+    {
+      "path": "core/arrays/string_.py",
+      "sha256": "e7292ba16cd5fd4962f04ef7f5055bbe60b60726a39935f62573011a4e2970ef",
+      "sizeBytes": 41818
+    },
+    {
+      "path": "core/arrays/string_arrow.py",
+      "sha256": "362b1f086d33517a9153aef15e565af8c23590d36da090a126117fdced8989bf",
+      "sizeBytes": 21464
+    },
+    {
+      "path": "core/arrays/timedeltas.py",
+      "sha256": "1caee6c541ee15452069abf10894483c0dba191f8bb381d0a39dc404582faeb1",
+      "sizeBytes": 42201
+    },
+    {
+      "path": "core/base.py",
+      "sha256": "b429d4df3e8b31db7c27cdac6a683af582a67c202854313dcc1e6f24f0f34163",
+      "sizeBytes": 50102
+    },
+    {
+      "path": "core/col.py",
+      "sha256": "59642ad98aa2af81a3d92eeee91ae86d76c2996a77560b658f0ad307e42fa6ef",
+      "sizeBytes": 15221
+    },
+    {
+      "path": "core/common.py",
+      "sha256": "b2d177f0673d8a449b8ef146c6a35444480bdbb7b8339b313875bd03e2df63b5",
+      "sizeBytes": 18014
+    },
+    {
+      "path": "core/computation/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/computation/align.py",
+      "sha256": "983c92ce8f81a27137f72269733e17e6787521819b36c0cd9561f2ea48b840d4",
+      "sizeBytes": 6762
+    },
+    {
+      "path": "core/computation/api.py",
+      "sha256": "090d80174870c9d7204c7c9c302162c99200539ed17194fe4d589dd7b488b15e",
+      "sizeBytes": 65
+    },
+    {
+      "path": "core/computation/check.py",
+      "sha256": "55bd58a8bab7f35fa7529f158e483ac9c24ec4fddd57668ef578f2335ba17b64",
+      "sizeBytes": 226
+    },
+    {
+      "path": "core/computation/common.py",
+      "sha256": "b9af6f5dbbbd42093a182d3e8cc95323619d38597c5b706cee83ffcf13effe9c",
+      "sizeBytes": 1442
+    },
+    {
+      "path": "core/computation/engines.py",
+      "sha256": "218c7af03d4428ac8cb31ab1573f54bd9bccfda89df8b10e28f43e7cb122bf95",
+      "sizeBytes": 3462
+    },
+    {
+      "path": "core/computation/eval.py",
+      "sha256": "b8d807077cf5cb3e0e1623945a85b48be6a8669c2119c6ed066d33da446a4644",
+      "sizeBytes": 15403
+    },
+    {
+      "path": "core/computation/expr.py",
+      "sha256": "64221b97f9333bcc3c4c8ef2fceddabc12b41ab9acb9a3f863c04f87afb0fc5a",
+      "sizeBytes": 25611
+    },
+    {
+      "path": "core/computation/expressions.py",
+      "sha256": "560b25ba67f47680a69c25c0fd599851bd02f6c3919d850d887345a8c1057de4",
+      "sizeBytes": 8368
+    },
+    {
+      "path": "core/computation/ops.py",
+      "sha256": "a8c4b325c3152fa244ab75d3acc82198dfe7b3ac5326e69f04845b20d5c27164",
+      "sizeBytes": 14487
+    },
+    {
+      "path": "core/computation/parsing.py",
+      "sha256": "54f1f6567efdf55e554114f0b98eb195931aa14b28efe69db534e0c5ac5c8230",
+      "sizeBytes": 7711
+    },
+    {
+      "path": "core/computation/pytables.py",
+      "sha256": "7f1455348703e35d49e23ac5ebe2409a8697e203624a0ccd88c885f5f39d5312",
+      "sizeBytes": 21556
+    },
+    {
+      "path": "core/computation/scope.py",
+      "sha256": "9b3376980e45b576a2dbde05a040ec89c8b3000742488d9a227821b23288398f",
+      "sizeBytes": 10204
+    },
+    {
+      "path": "core/config_init.py",
+      "sha256": "4fb740c90e2cac7d5792a9d1a00c6c44783262595cd389c43380d2a83906dfb4",
+      "sizeBytes": 26657
+    },
+    {
+      "path": "core/construction.py",
+      "sha256": "e8dffab196fceffcfddd111b7c03625ed37c603c235f2c42e291c9a02dcb0cce",
+      "sizeBytes": 28016
+    },
+    {
+      "path": "core/dtypes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/dtypes/api.py",
+      "sha256": "964120c72e6429a036ad4ed7a567d281de2fb1071552bdcd76e75dbddfd24e9e",
+      "sizeBytes": 1783
+    },
+    {
+      "path": "core/dtypes/astype.py",
+      "sha256": "44c42c1135a01cc52f910c2410e0dd03656e43d16ee97579c4a1d3dcf5885793",
+      "sizeBytes": 10217
+    },
+    {
+      "path": "core/dtypes/base.py",
+      "sha256": "1baba591c1556e9f1bb1dcec307b60e92ca6fc7af5d173576c1c94dad3112b9e",
+      "sizeBytes": 17700
+    },
+    {
+      "path": "core/dtypes/cast.py",
+      "sha256": "a2b8f643dc4c7f59981b5033d08888b462b43de01cd0bfb23d5e32137d04dcd9",
+      "sizeBytes": 60017
+    },
+    {
+      "path": "core/dtypes/common.py",
+      "sha256": "f90784e80e52331f5ebb6901a296e32711e90e30b0a13ab2b6ff320c85226c94",
+      "sizeBytes": 56234
+    },
+    {
+      "path": "core/dtypes/concat.py",
+      "sha256": "6fd2fddac8db23835e7c3d6351702b8cebca4054975dc80a652bd505b6eb593c",
+      "sizeBytes": 12224
+    },
+    {
+      "path": "core/dtypes/dtypes.py",
+      "sha256": "5db7bf389018e443d05a497d27a452e649a210f6d835a691400f973ac1ff37f7",
+      "sizeBytes": 80669
+    },
+    {
+      "path": "core/dtypes/generic.py",
+      "sha256": "823cdf0798e600e8d6d6cbad9d2a4f274c156885ecb948c6c65fd4daabcfa3e2",
+      "sizeBytes": 4129
+    },
+    {
+      "path": "core/dtypes/inference.py",
+      "sha256": "a2731d57e67f220d64d9fc1bbe506415d15f8ebc3ed71d46f7429257e127709d",
+      "sizeBytes": 12641
+    },
+    {
+      "path": "core/dtypes/missing.py",
+      "sha256": "bd4139b36941a2c611ad5243fb2e1634effd6aa584c7c3c448e3e0d7ee265331",
+      "sizeBytes": 21406
+    },
+    {
+      "path": "core/flags.py",
+      "sha256": "884bcc4f870c128f493d34879bea1d6866ca51e9b8c5ecd991b496f2cfab0f2b",
+      "sizeBytes": 4219
+    },
+    {
+      "path": "core/frame.py",
+      "sha256": "a586223dd3d657ce514e6979ed514b8ff9edfb2c4a7d78bae0fba0e69c6e52be",
+      "sizeBytes": 574516
+    },
+    {
+      "path": "core/generic.py",
+      "sha256": "7108a1ea15ca0483e6d95205cc4a8d9435caf6d6aff371880c7c3dbb06585ac5",
+      "sizeBytes": 463158
+    },
+    {
+      "path": "core/groupby/__init__.py",
+      "sha256": "9f266c8f2545f9b171e761d86cae1240c7c336eb2f619d40346255c4478091f4",
+      "sizeBytes": 301
+    },
+    {
+      "path": "core/groupby/base.py",
+      "sha256": "1372765f44f3ff18d4873b07e33839680eaa057f3327fd8036c0e0374d3481a3",
+      "sizeBytes": 2721
+    },
+    {
+      "path": "core/groupby/categorical.py",
+      "sha256": "924f081402a60812bad8accf6a7dd955e7fd30fe2203a8a1696a28f96a78fab5",
+      "sizeBytes": 2853
+    },
+    {
+      "path": "core/groupby/generic.py",
+      "sha256": "4973999fc2e383b31d4584b201ba0da7b2808297949bc4ff413906a269f2eb53",
+      "sizeBytes": 139394
+    },
+    {
+      "path": "core/groupby/groupby.py",
+      "sha256": "e9efe5b591f88e5e1e6f1f6305e1c87a37d48047e6208309aed6673e229a64c8",
+      "sizeBytes": 202185
+    },
+    {
+      "path": "core/groupby/grouper.py",
+      "sha256": "ebc98acccb774a278e2a05f00068d4c70704cfcc5c34807219ad9240f9f51ca6",
+      "sizeBytes": 32642
+    },
+    {
+      "path": "core/groupby/indexing.py",
+      "sha256": "1063ec99ba8632ea327d25e5817bc99f8dddae5a564d48098558552be0e8b2ae",
+      "sizeBytes": 9453
+    },
+    {
+      "path": "core/groupby/numba_.py",
+      "sha256": "dc3953e4354b442d29ca7917bbafa7953e461a2f200ecee3304a8bb190713ba7",
+      "sizeBytes": 4923
+    },
+    {
+      "path": "core/groupby/ops.py",
+      "sha256": "01b1d4ecee85b7b76d437473b124cb7e92e6fc02ced02ca070d3c3658d3329a7",
+      "sizeBytes": 42144
+    },
+    {
+      "path": "core/indexers/__init__.py",
+      "sha256": "a6069ad83502ef8229a1840dd046d6cc59238fedc6b1d7ef4314439572826179",
+      "sizeBytes": 790
+    },
+    {
+      "path": "core/indexers/objects.py",
+      "sha256": "3b12dee7e9a5685a30d0c49d61eb77f21476b9db464b39ce5e5c3e70beb9707c",
+      "sizeBytes": 23382
+    },
+    {
+      "path": "core/indexers/utils.py",
+      "sha256": "9c3259cb8d0eb58228c3540551e67859c97e014013e244f6f864211b5ae22bf9",
+      "sizeBytes": 17035
+    },
+    {
+      "path": "core/indexes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/indexes/accessors.py",
+      "sha256": "666837a7c1d1811cfaecca901e30c4163242ff7e9a4cc5261ceadb794897e09a",
+      "sizeBytes": 20342
+    },
+    {
+      "path": "core/indexes/api.py",
+      "sha256": "2c68c8f003f0fffbaf6af0885678dc2beb7f1f9d2e40fef7f92a7971528255ea",
+      "sizeBytes": 9519
+    },
+    {
+      "path": "core/indexes/base.py",
+      "sha256": "4d48200c8523162b278b6b662f8db1e6e36a4f62b26c76910c6e9d5bb84a9925",
+      "sizeBytes": 277653
+    },
+    {
+      "path": "core/indexes/category.py",
+      "sha256": "254e38dd3a27173946b816f83f72393f51f8325300a6c1b6a3977f4a31fc6786",
+      "sizeBytes": 17079
+    },
+    {
+      "path": "core/indexes/datetimelike.py",
+      "sha256": "8a2b5311001b3088884ac5d998e333befc2fa325666b0599687879b4a866ffb2",
+      "sizeBytes": 38256
+    },
+    {
+      "path": "core/indexes/datetimes.py",
+      "sha256": "682e989267eb2fe87d563a1c653111652621e245a92e659f3d1b69674a4ea728",
+      "sizeBytes": 57595
+    },
+    {
+      "path": "core/indexes/extension.py",
+      "sha256": "3b28c47ce69ee7770bc129564517e9d3b57cb10c4f380c6ad750f3aeea01ee44",
+      "sizeBytes": 5389
+    },
+    {
+      "path": "core/indexes/frozen.py",
+      "sha256": "675d02e35214aa258d387af6735be7e6b2767900852acdbfd0f3e1bd6921e41a",
+      "sizeBytes": 3342
+    },
+    {
+      "path": "core/indexes/interval.py",
+      "sha256": "d01337db94fc827356122853b59786b206d1dbf4f6efcf3aab81352d08504bdf",
+      "sizeBytes": 50445
+    },
+    {
+      "path": "core/indexes/multi.py",
+      "sha256": "09c7894aff541dcb15567fd49b6cef2fb3cd4670f8a3d0d491ad9a21d56c76e2",
+      "sizeBytes": 166907
+    },
+    {
+      "path": "core/indexes/period.py",
+      "sha256": "2f2be59ffe062e65c6ee0c22281b35cd18d465d84c99ddd90667ef285ac77901",
+      "sizeBytes": 19368
+    },
+    {
+      "path": "core/indexes/range.py",
+      "sha256": "34ff74c9e83a282d4df1f56e168edb154362e8e2380d2028c0ceed75fcb0b89c",
+      "sizeBytes": 53786
+    },
+    {
+      "path": "core/indexes/timedeltas.py",
+      "sha256": "53828d4eab5f647af2a52f6550d01a70d2cf5018b786f276343f012295cb8a99",
+      "sizeBytes": 13219
+    },
+    {
+      "path": "core/indexing.py",
+      "sha256": "930006ac3352621fe3d31bcde97acd62be7c0a2a5fc174db68bab925800633c5",
+      "sizeBytes": 96287
+    },
+    {
+      "path": "core/interchange/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/interchange/buffer.py",
+      "sha256": "7938917834a1beb4c764bae76ccb87dd2516a0c3bfbe2d6382648eb6acd42a6a",
+      "sizeBytes": 3428
+    },
+    {
+      "path": "core/interchange/column.py",
+      "sha256": "c13cb222ea6ea95081f06940cab79f46506885e7d0b22eb2211ad77ae5836a60",
+      "sizeBytes": 18062
+    },
+    {
+      "path": "core/interchange/dataframe.py",
+      "sha256": "d7e0cbe4a459a37a6c038f6d976484fabcc01cf617b3ff3e78448be70007e2e7",
+      "sizeBytes": 3867
+    },
+    {
+      "path": "core/interchange/dataframe_protocol.py",
+      "sha256": "826e774749b31debcfadb180241ec174ebb91ee4d7137942668d9546fd2145ee",
+      "sizeBytes": 16263
+    },
+    {
+      "path": "core/interchange/from_dataframe.py",
+      "sha256": "e97d3f194d7ac0bd1aeea45cdfbf5710708991933bae80bca3881f4a9410d465",
+      "sizeBytes": 19788
+    },
+    {
+      "path": "core/interchange/utils.py",
+      "sha256": "4cdc91fae5e6ec9ffec14d022e921ff6287f6eaf29e5a06e52fe8eff8d7028af",
+      "sizeBytes": 5051
+    },
+    {
+      "path": "core/internals/__init__.py",
+      "sha256": "6e52bfe965f81acf52cc6c8b79c610971440896ffd845257f68b4f6d0ed7d817",
+      "sizeBytes": 2116
+    },
+    {
+      "path": "core/internals/api.py",
+      "sha256": "68fc2c74b76a1aec433df9aef12d2c60089c9561a9c9307c91d919c0eb6e06a2",
+      "sizeBytes": 5615
+    },
+    {
+      "path": "core/internals/blocks.py",
+      "sha256": "f7269b866ac3b39c5734c3c2e6f4ffd6280867ec1fd2e4f92ec336c4d22789a6",
+      "sizeBytes": 80959
+    },
+    {
+      "path": "core/internals/concat.py",
+      "sha256": "94f4b6181a1799746f5e81d7f08f6f4fa258600069f97db5a2ded2c0dfbd55dc",
+      "sizeBytes": 15180
+    },
+    {
+      "path": "core/internals/construction.py",
+      "sha256": "33727bc29d0b41bfec3b60d76bb5783441497f2a690a5a9ad87ae0f200e7741d",
+      "sizeBytes": 33744
+    },
+    {
+      "path": "core/internals/managers.py",
+      "sha256": "216049aaaf8045d373f2fbeaf7823677ac4c28f95f3ee2a93e68e441c63b8de7",
+      "sizeBytes": 88265
+    },
+    {
+      "path": "core/internals/ops.py",
+      "sha256": "1c3e920547da363e38ea55bd32e4dacf4fabecb85d6dbff51ed3cd61191542e4",
+      "sizeBytes": 5175
+    },
+    {
+      "path": "core/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/methods/describe.py",
+      "sha256": "d96e3f7ae683a207446b9676e373fa86a9f06d762b1cfc990cc76693303d4462",
+      "sizeBytes": 10554
+    },
+    {
+      "path": "core/methods/selectn.py",
+      "sha256": "4ec91895090b705b119a63347878539c2f11a7dfdcdd8f564d99526a98c6ad9f",
+      "sizeBytes": 8712
+    },
+    {
+      "path": "core/methods/to_dict.py",
+      "sha256": "579c2762988be356929cfcc068465543561352677826dc88073130e0c26093a7",
+      "sizeBytes": 9417
+    },
+    {
+      "path": "core/missing.py",
+      "sha256": "1bf263b9ed3d028f408de6b2931612cef8dfef0fe8e2a92856394cd8782e4969",
+      "sizeBytes": 33972
+    },
+    {
+      "path": "core/nanops.py",
+      "sha256": "eef65af2c7e73c3fbf7f80f904429c8ff7f438e59f7996a506e4496d5185b796",
+      "sizeBytes": 53534
+    },
+    {
+      "path": "core/ops/__init__.py",
+      "sha256": "5e7e986f0fab1f4e23f244ec6150b2051f10a3a4d1b639bfc96a9f89aaf953b0",
+      "sizeBytes": 1621
+    },
+    {
+      "path": "core/ops/array_ops.py",
+      "sha256": "02fdab9e8abf59d38db82fbad1d73571840eae93087f5c6ea6b27d7a966a202a",
+      "sizeBytes": 19686
+    },
+    {
+      "path": "core/ops/common.py",
+      "sha256": "d2456a9c366f468b6abc3279bf19295c808d1a74a942223e688d81c6555c31fd",
+      "sizeBytes": 3802
+    },
+    {
+      "path": "core/ops/dispatch.py",
+      "sha256": "60f86733c73b0bdae292b52e8efd14b76edf67bd32001069fe97428a4180380f",
+      "sizeBytes": 636
+    },
+    {
+      "path": "core/ops/docstrings.py",
+      "sha256": "77560ceb0a772e6b15ba327969a37432fda38f9b77e09a91ccd057e0f02fe963",
+      "sizeBytes": 18779
+    },
+    {
+      "path": "core/ops/invalid.py",
+      "sha256": "8a1d7a598d486474f7a029ea3d5ba1de6a9c6f9427d95fd5a5e20b18a632b714",
+      "sizeBytes": 1706
+    },
+    {
+      "path": "core/ops/mask_ops.py",
+      "sha256": "055278fa7e9ac3c9a93a4db36aee8736b4569b74be92c7c72af3f4155d310e34",
+      "sizeBytes": 5638
+    },
+    {
+      "path": "core/ops/missing.py",
+      "sha256": "c6daafa06f91611d085db8c2dedc624aec28da2ad510bdbb7f1387dae18e9b8b",
+      "sizeBytes": 5069
+    },
+    {
+      "path": "core/resample.py",
+      "sha256": "680965bea4846f1e10dfd5c9e47a118b670bc56e08430346309a5716358ae290",
+      "sizeBytes": 101425
+    },
+    {
+      "path": "core/reshape/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/reshape/api.py",
+      "sha256": "424e72f83e7e39d4582a40a073e92d7312863464823ed788484b01c9715623d3",
+      "sizeBytes": 680
+    },
+    {
+      "path": "core/reshape/concat.py",
+      "sha256": "2f30af4fac16848bfe1ca43519ae52a30db53fb9cd03ef8d8cabe9a4148dd4ee",
+      "sizeBytes": 31009
+    },
+    {
+      "path": "core/reshape/encoding.py",
+      "sha256": "9c8846e7b3ff04e55b3f60e2bf53df1b460ff6d7a3c0c110f17debd8c548018b",
+      "sizeBytes": 19750
+    },
+    {
+      "path": "core/reshape/melt.py",
+      "sha256": "d294f6e1ec0f94343aa938b51c8ed9f6924c974a631e7009f9fc52f191e3915f",
+      "sizeBytes": 22076
+    },
+    {
+      "path": "core/reshape/merge.py",
+      "sha256": "af66f4a95da5bd65049f3d31797f9c49600ebc61c437060e1c2fefb5e97df037",
+      "sizeBytes": 114541
+    },
+    {
+      "path": "core/reshape/pivot.py",
+      "sha256": "af4d2e4c032acfc4a1342ce9f68330b855c76e37f4882f359d400071ffb6b3a5",
+      "sizeBytes": 39698
+    },
+    {
+      "path": "core/reshape/reshape.py",
+      "sha256": "4f140cb8cbae568442d5681b84631efbe578100984b26b004d3c0b77c65ed7cb",
+      "sizeBytes": 40378
+    },
+    {
+      "path": "core/reshape/tile.py",
+      "sha256": "620e1ad4f2643d8a4212d5acc6500cc77e437300c539381614a18641f50b414d",
+      "sizeBytes": 23408
+    },
+    {
+      "path": "core/roperator.py",
+      "sha256": "3f68c99174fa92508c09f25e5367cd59fce1604d542c53292fb100cbc45392dd",
+      "sizeBytes": 1115
+    },
+    {
+      "path": "core/sample.py",
+      "sha256": "21419fd0ec18abef28a0cb657d57777b35f77db86e131f1b120f12580e125354",
+      "sizeBytes": 4975
+    },
+    {
+      "path": "core/series.py",
+      "sha256": "fffc9ba5667e75d5415306d28a980ed6ee5ce2c8215c46cba7a3b4b549fca244",
+      "sizeBytes": 280462
+    },
+    {
+      "path": "core/shared_docs.py",
+      "sha256": "0e4fa59b5287c33962b29a62fe86878a71f7824700cfd2fe1133b9d52e567d6e",
+      "sizeBytes": 21933
+    },
+    {
+      "path": "core/sorting.py",
+      "sha256": "04326e71eb29649ee053cfbb08f0e96301c7240a300711745d170420fec15d6e",
+      "sizeBytes": 22507
+    },
+    {
+      "path": "core/sparse/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/sparse/api.py",
+      "sha256": "cb4a270a904a0a3ff921ac9bc397be83193ccc06bd775a7966ee7c44bccf4f59",
+      "sizeBytes": 143
+    },
+    {
+      "path": "core/strings/__init__.py",
+      "sha256": "4d1c3e1f4b3aa826d7a1028cd35fd28b180f382466ada8582a99630f21f05a42",
+      "sizeBytes": 807
+    },
+    {
+      "path": "core/strings/accessor.py",
+      "sha256": "650a537041e5faf7da01397a52450c65b2e5f0c4101ee9250c94e1d192dc8b14",
+      "sizeBytes": 163190
+    },
+    {
+      "path": "core/strings/object_array.py",
+      "sha256": "4e5c9ec8a423016cff05abeb2962ed183d4c33057d80f8525f8dcdc575e58930",
+      "sizeBytes": 16499
+    },
+    {
+      "path": "core/tools/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/tools/datetimes.py",
+      "sha256": "85ce936697df744e9008a716085f4879b69e5304827055ba45705759b8c73517",
+      "sizeBytes": 41948
+    },
+    {
+      "path": "core/tools/numeric.py",
+      "sha256": "570b4ac39571744cfb8033c04259c98907e747b16625c24b8f5ebca91609edbd",
+      "sizeBytes": 10859
+    },
+    {
+      "path": "core/tools/timedeltas.py",
+      "sha256": "6808c599708a761443fb6963b82e70042a74ecd4e6dc963ad1097b0130fdf000",
+      "sizeBytes": 7296
+    },
+    {
+      "path": "core/tools/times.py",
+      "sha256": "cae2b9c249062a2993e13fea201eb9c93b676502d837f19984cf2172b8a33135",
+      "sizeBytes": 4825
+    },
+    {
+      "path": "core/util/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "core/util/hashing.py",
+      "sha256": "9dfe1a5466f4813f63edb798315fc26cb08e558a505822c04de60772a037ce09",
+      "sizeBytes": 10487
+    },
+    {
+      "path": "core/util/numba_.py",
+      "sha256": "261519c6441e7372f07421613f4536da37cb4846a74ab4fc8f2ac834a5091183",
+      "sizeBytes": 4251
+    },
+    {
+      "path": "core/window/__init__.py",
+      "sha256": "0dec01f175e42c610382d42a20260f9a7919677638b4deb33e84d8be936e2461",
+      "sizeBytes": 450
+    },
+    {
+      "path": "core/window/common.py",
+      "sha256": "daf243d3fa6eb09c35ac3660511ac26a2d18c03fbfdca98e9e467c783314cbe6",
+      "sizeBytes": 6785
+    },
+    {
+      "path": "core/window/doc.py",
+      "sha256": "f2c37974feb898656f006f3c5352f6891058ccdda4c9ecbac8e39423913be039",
+      "sizeBytes": 5764
+    },
+    {
+      "path": "core/window/ewm.py",
+      "sha256": "031c9ea93cc758775e9373f4537c9d4333136b365abd596a399a3b5b47f44b08",
+      "sizeBytes": 39714
+    },
+    {
+      "path": "core/window/expanding.py",
+      "sha256": "5445a9b45ed2b2f87484473e4caf66a93d576939c0d2972a0966c7d052584b8a",
+      "sizeBytes": 44917
+    },
+    {
+      "path": "core/window/numba_.py",
+      "sha256": "e9da82b657e2462b05da8e3864e35afd27db75e4300c194ec6b44491bfb4cc2c",
+      "sizeBytes": 10935
+    },
+    {
+      "path": "core/window/online.py",
+      "sha256": "55d3cb81f2d55f984bd1fa46c53ed943c2c2866e98dd16621f93eb9b5ac68acf",
+      "sizeBytes": 3682
+    },
+    {
+      "path": "core/window/rolling.py",
+      "sha256": "fdc42ff68b1cc023e3598ecf62fdc3f60f2a56bb8557fd5aa492dbfd5e729f4a",
+      "sizeBytes": 115918
+    },
+    {
+      "path": "errors/__init__.py",
+      "sha256": "ffb0baea2c2fdfeccdf903b376f437799e88e891788f8945c60031e9e130331d",
+      "sizeBytes": 34630
+    },
+    {
+      "path": "errors/cow.py",
+      "sha256": "9093e56ed3ece0e4de05e6675da10c0787fcbe6c80936956c455674a7e40b074",
+      "sizeBytes": 2153
+    },
+    {
+      "path": "io/__init__.py",
+      "sha256": "435802a173029db507671168ef16d49906c1e20d724a4ad79029b6e897f8c703",
+      "sizeBytes": 292
+    },
+    {
+      "path": "io/_util.py",
+      "sha256": "72572f93b4f3253906ab206919bce2b78524e86f1db40d3e35c698c90477b44d",
+      "sizeBytes": 10227
+    },
+    {
+      "path": "io/api.py",
+      "sha256": "8a734643b88a93e7672de1065993b6ffcabdafd55b5000f1d792b4b9163c8f6f",
+      "sizeBytes": 1277
+    },
+    {
+      "path": "io/clipboard/__init__.py",
+      "sha256": "dda173768a9b69b13c5ccf8562375821cb53a6cfec4c024324cae111b0effd45",
+      "sizeBytes": 24235
+    },
+    {
+      "path": "io/clipboards.py",
+      "sha256": "c7fe26309155076c7f7bab2068007f6f03916202cdaef59493941b713e1d5af1",
+      "sizeBytes": 6391
+    },
+    {
+      "path": "io/common.py",
+      "sha256": "784116d34728e7d28734ead974d60253e98f940a1e09002ac7afc6e234fdffb4",
+      "sizeBytes": 44681
+    },
+    {
+      "path": "io/excel/__init__.py",
+      "sha256": "5c4af594dc67c5d7f432df5e8960a64adc6a6f0a9a68fac10da573350adf2dd5",
+      "sizeBytes": 486
+    },
+    {
+      "path": "io/excel/_base.py",
+      "sha256": "536344624d85a159206565d518e71ca322029446e5b8a22c1d0e41bfcd042d04",
+      "sizeBytes": 70410
+    },
+    {
+      "path": "io/excel/_calamine.py",
+      "sha256": "4af3532fefe1b0bae27b07783dc34180bf216c53b93c953b0b5f65c83093a9bc",
+      "sizeBytes": 4180
+    },
+    {
+      "path": "io/excel/_odfreader.py",
+      "sha256": "1beb2f2e7fe3a05fa1362995e1ccb6a28da7d2318327c11cda90cf46b405279b",
+      "sizeBytes": 8232
+    },
+    {
+      "path": "io/excel/_odswriter.py",
+      "sha256": "85f49786fd6e5f496d51b788e920cce8d78790e96d2830ecef39e3273b7d41ef",
+      "sizeBytes": 11519
+    },
+    {
+      "path": "io/excel/_openpyxl.py",
+      "sha256": "ea884d8a38646a86cc52f2565ae89937dbc8128cadd3dc8de361e2f3497c0e86",
+      "sizeBytes": 20115
+    },
+    {
+      "path": "io/excel/_pyxlsb.py",
+      "sha256": "9441f74d4100c1d688d4c38a77bca5fae8c37ccef8ca4f7d6da60dcf78deaacb",
+      "sizeBytes": 4861
+    },
+    {
+      "path": "io/excel/_util.py",
+      "sha256": "7b37b35d25b64ab851282a7473d2aad32ab25791b99fbd9f621ac765ccd733fb",
+      "sizeBytes": 8081
+    },
+    {
+      "path": "io/excel/_xlrd.py",
+      "sha256": "c88d6acef1b7bd68f8e85f5692980b13b7f34fc1ca298eb371b3eb827c5f3543",
+      "sizeBytes": 5093
+    },
+    {
+      "path": "io/excel/_xlsxwriter.py",
+      "sha256": "4bd2b2bfc13b432069f25f997cee107ccc3d641f304b16ebf76b4697cc6e07c7",
+      "sizeBytes": 9380
+    },
+    {
+      "path": "io/feather_format.py",
+      "sha256": "2cc9d405df9f3e4f08e412cc7ac30be00d87314bc2b9cdd2f5eff7f42500366d",
+      "sizeBytes": 6817
+    },
+    {
+      "path": "io/formats/__init__.py",
+      "sha256": "721508df388bfc8c6499255325aa7da267b7a5d2e0374dfcc5e782009ec72d57",
+      "sizeBytes": 237
+    },
+    {
+      "path": "io/formats/_color_data.py",
+      "sha256": "7d9fd096ebcc15434a504e3e4f7db1ecf9f49ee9508319ac10c1c1f5445c04e6",
+      "sizeBytes": 4332
+    },
+    {
+      "path": "io/formats/console.py",
+      "sha256": "afedf18b0d93e2963ec261aef0f934a5aa0aae371ab30670f6b29f196d470b55",
+      "sizeBytes": 2757
+    },
+    {
+      "path": "io/formats/css.py",
+      "sha256": "026f6fef755cbb810610dd3ea53ffd81b60beb8eace4185740ecd53974ee8e26",
+      "sizeBytes": 12891
+    },
+    {
+      "path": "io/formats/csvs.py",
+      "sha256": "f988b2d8bb2a4c3453efd5e3231679df242f0359306b8fd5ed6d807c53739aca",
+      "sizeBytes": 10809
+    },
+    {
+      "path": "io/formats/excel.py",
+      "sha256": "a358b7c014b7db688a9ab391110a793ff1180a93bb5246dd55e3de9a9d269ada",
+      "sizeBytes": 35621
+    },
+    {
+      "path": "io/formats/format.py",
+      "sha256": "0980accd350a42bb76ba39470f044e030814ee2920edbfc1d2182b018ce4eab4",
+      "sizeBytes": 66886
+    },
+    {
+      "path": "io/formats/html.py",
+      "sha256": "b489a60ab42dd2b041f3d18e72bf9509f793b4edb8df16990db402db8046c755",
+      "sizeBytes": 24553
+    },
+    {
+      "path": "io/formats/info.py",
+      "sha256": "3f98505e425aada7897d45d0f34b271ad0257fc3df22c061201d407ddf9806fd",
+      "sizeBytes": 27360
+    },
+    {
+      "path": "io/formats/printing.py",
+      "sha256": "8592d9bf4353b6030cb2709d5e788155b966b51281a766b6cb6131ad35879c0a",
+      "sizeBytes": 18768
+    },
+    {
+      "path": "io/formats/string.py",
+      "sha256": "5d6a08ce4631b911014f2cba6d722f0167b7e2b95bcff72337ed207920e9bb23",
+      "sizeBytes": 6708
+    },
+    {
+      "path": "io/formats/style.py",
+      "sha256": "939b16a917da571869b9ba174850ef668f0d40b373dbb997f35f5bd0588be1a2",
+      "sizeBytes": 177431
+    },
+    {
+      "path": "io/formats/style_render.py",
+      "sha256": "6a95bef5a1928acffbfd8889a5e5cec20abaf9772c436f5202f1fc749fdabe7f",
+      "sizeBytes": 98616
+    },
+    {
+      "path": "io/formats/xml.py",
+      "sha256": "c1ce7878403d93abaed856ba635dd9452914bb88fd5f334483f0c00d76d204d1",
+      "sizeBytes": 17159
+    },
+    {
+      "path": "io/html.py",
+      "sha256": "2c4cd6857d70abf3bcde8251143b5773fd50a3282a8f53f2e98681069cc49f89",
+      "sizeBytes": 39806
+    },
+    {
+      "path": "io/iceberg.py",
+      "sha256": "4563c8bcd16ca2ad62cbe60e9955eb4f3aa0a9c7f5b0cdb9ee2c6456e1b6f734",
+      "sizeBytes": 5157
+    },
+    {
+      "path": "io/json/__init__.py",
+      "sha256": "455756b801158a83873f20b81abf585c703751603828928a958a27f29649213a",
+      "sizeBytes": 270
+    },
+    {
+      "path": "io/json/_json.py",
+      "sha256": "4665ad2cbcbd3ecd871a56933f7b462ab7f884c4a55741f621771cb1cacdce4d",
+      "sizeBytes": 49807
+    },
+    {
+      "path": "io/json/_normalize.py",
+      "sha256": "4ba39dc0f15c8050a1c8861805e97c8256b24298d83e0e23778237bd1c6433d3",
+      "sizeBytes": 20797
+    },
+    {
+      "path": "io/json/_table_schema.py",
+      "sha256": "c0468c9b19f321c1f8bced3be4f12a18539278e058437be9f0a7717273414d10",
+      "sizeBytes": 12100
+    },
+    {
+      "path": "io/orc.py",
+      "sha256": "2557cb3763a0413117a46304de3dc0dd64ed10541e588a5d7c107fcb6657e23a",
+      "sizeBytes": 8635
+    },
+    {
+      "path": "io/parquet.py",
+      "sha256": "fe2991ff93fd8cb8bd13f75d7bed1cfe63e42c9a0779e58f426ed8f74f2a56e9",
+      "sizeBytes": 24453
+    },
+    {
+      "path": "io/parsers/__init__.py",
+      "sha256": "ec12f1e249fdcb98a981f654599e32fcc2c450d817e8c4390f20f0b21849c553",
+      "sizeBytes": 204
+    },
+    {
+      "path": "io/parsers/arrow_parser_wrapper.py",
+      "sha256": "b9b446383ccc51bd36734a75d3f5ba78dc455fe4a7dbfe190eb4ae377379eeeb",
+      "sizeBytes": 11952
+    },
+    {
+      "path": "io/parsers/base_parser.py",
+      "sha256": "3e387c8699701d21c372d1954a7933b26cc328ee2751dbadff6748fd24c071ea",
+      "sizeBytes": 32912
+    },
+    {
+      "path": "io/parsers/c_parser_wrapper.py",
+      "sha256": "4e9ce2074fc73a3315c5427244ae682913d37fee18d1762acf9cde9b6dfee693",
+      "sizeBytes": 12915
+    },
+    {
+      "path": "io/parsers/python_parser.py",
+      "sha256": "b9694acd858de51c619f73893909a3ddb5c886cce0948ffb2fdb85e853cda788",
+      "sizeBytes": 55162
+    },
+    {
+      "path": "io/parsers/readers.py",
+      "sha256": "eb1445c5eeeb10546bd13bb1fbf022dd31d56ae0599d7287515c84c38d5e59f3",
+      "sizeBytes": 92966
+    },
+    {
+      "path": "io/pickle.py",
+      "sha256": "a1cc4f4f4ae1803f2400f307480b783cfabe5f57aee7a4d2fc9a1d47d69a6757",
+      "sizeBytes": 9145
+    },
+    {
+      "path": "io/pytables.py",
+      "sha256": "f018daa4df563086510d45250695dc1313cbf87fa6662a641b4fc56f47cd75ac",
+      "sizeBytes": 185357
+    },
+    {
+      "path": "io/sas/__init__.py",
+      "sha256": "00802e742f5fefce24704cee868f0689753adef8f64e1462b4ace797b22692ae",
+      "sizeBytes": 69
+    },
+    {
+      "path": "io/sas/sas7bdat.py",
+      "sha256": "d7f72ccc3a519d095eb939c1bac8b393f14be0fbe722d968b2fd1b4c28a25800",
+      "sizeBytes": 27023
+    },
+    {
+      "path": "io/sas/sas_constants.py",
+      "sha256": "a823e0007116819659bea5dbd043385ae843f5bf03c2175423126e88c209d2ea",
+      "sizeBytes": 8719
+    },
+    {
+      "path": "io/sas/sas_xport.py",
+      "sha256": "1dba412c99ce5533800f687a11ccdaba893e3a4ed775b63236efbfb4c5f664ce",
+      "sizeBytes": 15064
+    },
+    {
+      "path": "io/sas/sasreader.py",
+      "sha256": "89f5075eb0a8011621f9f516a32e2edeb89bdea9a8fd9dcc4074054eb64939dc",
+      "sizeBytes": 6190
+    },
+    {
+      "path": "io/spss.py",
+      "sha256": "0340f754cc9d7c6da5b17999315d0e08c267edb69eaaee25f109441596752103",
+      "sizeBytes": 2923
+    },
+    {
+      "path": "io/sql.py",
+      "sha256": "d99fe5bb4ab6cb5d679475c9a479a53021062caa31dcc3ed96eb257581f6d0a5",
+      "sizeBytes": 104641
+    },
+    {
+      "path": "io/stata.py",
+      "sha256": "ac508ef673209964f39e9eb9e954c850f19873508b1cfdcfe3440739035e0019",
+      "sizeBytes": 143720
+    },
+    {
+      "path": "io/xml.py",
+      "sha256": "0409785eb974776152da3fde27ad87f1924cf2ef7107f585a3d5529f054cdf58",
+      "sizeBytes": 39819
+    },
+    {
+      "path": "plotting/__init__.py",
+      "sha256": "2f0a86d8b548bd70dbd791e6f4b18f0bc8c10f9aa2039fa4c412b2892c0384bf",
+      "sizeBytes": 2827
+    },
+    {
+      "path": "plotting/_core.py",
+      "sha256": "bcbef7438a2418596ed5dce4300a6d155b42db84deae4c774ec63aa8aadf9031",
+      "sizeBytes": 78431
+    },
+    {
+      "path": "plotting/_matplotlib/__init__.py",
+      "sha256": "92dfe1d780e5872c9f8f2e3f8546264019d80b1a1c92766810f0e2d8983cb60b",
+      "sizeBytes": 2054
+    },
+    {
+      "path": "plotting/_matplotlib/boxplot.py",
+      "sha256": "fc5c8e2b14d5f6aff4505c91e120b812fab19d2d123263d3d111edbd1d69ffa5",
+      "sizeBytes": 18084
+    },
+    {
+      "path": "plotting/_matplotlib/converter.py",
+      "sha256": "f135c8f2ef1152be0329d5d7e2af8dfe6ddf3cdf8f3d68cdfb6ed9b5b93696b9",
+      "sizeBytes": 37479
+    },
+    {
+      "path": "plotting/_matplotlib/core.py",
+      "sha256": "2470a33bfebaf96d626bf13f0733caea517c80438b550cb1741ee14b684c6080",
+      "sizeBytes": 75322
+    },
+    {
+      "path": "plotting/_matplotlib/groupby.py",
+      "sha256": "a6f61aeeaac4213c700d37c23c7d57575e9191ad990978bb8499d2259e0421e4",
+      "sizeBytes": 4326
+    },
+    {
+      "path": "plotting/_matplotlib/hist.py",
+      "sha256": "f32651dc77de0cbae0c8f7c26c5bed1bb399faab31d095b96c94ff26b60f5479",
+      "sizeBytes": 16789
+    },
+    {
+      "path": "plotting/_matplotlib/misc.py",
+      "sha256": "a5dc5bc70f0fc638cb2a48f20a9e475b13fa041847d80fa4fac4c1404e7ca323",
+      "sizeBytes": 13369
+    },
+    {
+      "path": "plotting/_matplotlib/style.py",
+      "sha256": "15f8bc0efea5e4badbb55b5d1c530881cb837a299cf770d9233b47b15209617b",
+      "sizeBytes": 8525
+    },
+    {
+      "path": "plotting/_matplotlib/timeseries.py",
+      "sha256": "5204875fa127fed1eafc4c846fa396e7078db0aa12fad0b2ebfbfce0a54cacd5",
+      "sizeBytes": 11252
+    },
+    {
+      "path": "plotting/_matplotlib/tools.py",
+      "sha256": "c8c4da87f1e13727ca6b954faef54f697d094626c572aaddf376a683eb89a168",
+      "sizeBytes": 15597
+    },
+    {
+      "path": "plotting/_misc.py",
+      "sha256": "8111fa5ad168f5184bc4d4bdcc1e55252eea474a777a12799a34404e45805171",
+      "sizeBytes": 24868
+    },
+    {
+      "path": "testing.py",
+      "sha256": "a89221b90c1a132ebbd64100c27c30e4cb8bcc7e8ce92f769a9f4fb6fff5c5a6",
+      "sizeBytes": 312
+    },
+    {
+      "path": "tests/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/api/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/api/test_api.py",
+      "sha256": "83750c2b4809165ca92ef5e565d77a45e0bee684af74f2cab5658e79bf01458d",
+      "sizeBytes": 14786
+    },
+    {
+      "path": "tests/api/test_types.py",
+      "sha256": "eec8acafeab5969902f562f2028f364acbdc43d486bcb5edcc14c4fe60cc656c",
+      "sizeBytes": 1688
+    },
+    {
+      "path": "tests/apply/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/apply/common.py",
+      "sha256": "03c4ea8ef291e21e1668bb68bc647d84350ba56b38ad5fb5271fd0e19cf90dec",
+      "sizeBytes": 298
+    },
+    {
+      "path": "tests/apply/conftest.py",
+      "sha256": "e3a38a59270ebe8d4a776074f5c0751137991dc3b8fdacde1178ee92b2815b78",
+      "sizeBytes": 2045
+    },
+    {
+      "path": "tests/apply/test_frame_apply.py",
+      "sha256": "dc5ed8868f33c0c72938a062235ef533d6db52161508da7b20e03e3edd8cb800",
+      "sizeBytes": 58466
+    },
+    {
+      "path": "tests/apply/test_frame_apply_relabeling.py",
+      "sha256": "2fb268461b23cfdfbd8b47530ef5a101fb6514a65b6fd586fbae9fc0a381bf7a",
+      "sizeBytes": 3377
+    },
+    {
+      "path": "tests/apply/test_frame_transform.py",
+      "sha256": "6db01c6265f195f128f3eccf41dc65a76eacf4b3e545ba552a942ef721159022",
+      "sizeBytes": 8020
+    },
+    {
+      "path": "tests/apply/test_invalid_arg.py",
+      "sha256": "b38e7cafe1986dbe1d0628b1d8d00e0e8b5e18c4727e148d492a695739de4746",
+      "sizeBytes": 11625
+    },
+    {
+      "path": "tests/apply/test_numba.py",
+      "sha256": "3ff4dc9d0c2f88292d388b3cb42ed85a8504ab9d8784c54c08f72a59a9548e50",
+      "sizeBytes": 4191
+    },
+    {
+      "path": "tests/apply/test_series_apply.py",
+      "sha256": "99207970c82dbf3dacadee78ec648396e1d3ede94547889d48628d339864898b",
+      "sizeBytes": 20997
+    },
+    {
+      "path": "tests/apply/test_series_apply_relabeling.py",
+      "sha256": "00c2a9c4d034afe62f1315643bb2b191f417f4e845f0eaf3d8b01167301ca817",
+      "sizeBytes": 1202
+    },
+    {
+      "path": "tests/apply/test_series_transform.py",
+      "sha256": "aeb24ef82e476a034a268e78da1df6781e53396543c62ac9bf5bb93d726487f2",
+      "sizeBytes": 2404
+    },
+    {
+      "path": "tests/apply/test_str.py",
+      "sha256": "eefc547d70ad7e57c21acf22991494049a4d7354a2cca23bea54b4bf3ae9805d",
+      "sizeBytes": 10120
+    },
+    {
+      "path": "tests/arithmetic/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arithmetic/common.py",
+      "sha256": "442441f4ea11ec95e361c54ddf5c599a49769928970af3daee3b9a482dce7754",
+      "sizeBytes": 4429
+    },
+    {
+      "path": "tests/arithmetic/conftest.py",
+      "sha256": "21b2922c8a9aee2514191778f992d7d5dacd82c9b8dcdb288f72b8a02977d7b6",
+      "sizeBytes": 3477
+    },
+    {
+      "path": "tests/arithmetic/test_array_ops.py",
+      "sha256": "2b9fcfdd1000e8d3922bbec72afc56c7a19eddfe42bfc57c34e8c70fe52554de",
+      "sizeBytes": 2639
+    },
+    {
+      "path": "tests/arithmetic/test_bool.py",
+      "sha256": "de3896d4b9ed277fd23c65d430010ab57f4537a21ea7383fdfc525df08df1689",
+      "sizeBytes": 781
+    },
+    {
+      "path": "tests/arithmetic/test_categorical.py",
+      "sha256": "94ae5f5efe1c448bbaf6872f3877ca2f96e378ad230dd5b7a6cbebaecb230e80",
+      "sizeBytes": 742
+    },
+    {
+      "path": "tests/arithmetic/test_datetime64.py",
+      "sha256": "3361940048c07f5744208b49c107fa4b29c1a8e6ced00a2e19a32d8c920d89a1",
+      "sizeBytes": 91306
+    },
+    {
+      "path": "tests/arithmetic/test_interval.py",
+      "sha256": "40f19a6aaecb6ad870578cc0ae24c1351e5d2ebf7c4818a5a06940de6b7d217d",
+      "sizeBytes": 10986
+    },
+    {
+      "path": "tests/arithmetic/test_numeric.py",
+      "sha256": "ad382bdf9178c34fffa4762b4014a8ef64d02e548433adaa8aba414398d6e5d8",
+      "sizeBytes": 56528
+    },
+    {
+      "path": "tests/arithmetic/test_object.py",
+      "sha256": "3543c07237bd3053bfaeba56aa962233d10bb0da066239b694049874104c6795",
+      "sizeBytes": 13218
+    },
+    {
+      "path": "tests/arithmetic/test_period.py",
+      "sha256": "ba0e29fbaeacded4d28ce87526d7ed0dacd96c18f1e84509d97bf4c66099ea96",
+      "sizeBytes": 59777
+    },
+    {
+      "path": "tests/arithmetic/test_string.py",
+      "sha256": "f0639d26f9c7608893255d73cd975309077b037109c482ffc6974ff171b55c34",
+      "sizeBytes": 16669
+    },
+    {
+      "path": "tests/arithmetic/test_timedelta64.py",
+      "sha256": "5895b5d6b8b8a550f95b2fcb55d9498225a49ae67e9a020a73d49f005e9b3165",
+      "sizeBytes": 84749
+    },
+    {
+      "path": "tests/arrays/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/boolean/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/boolean/test_arithmetic.py",
+      "sha256": "78a89cf2569c80ccec9bd4a46ef0ef76cd6be8486c91d50b8f01e66f279ec2f0",
+      "sizeBytes": 4172
+    },
+    {
+      "path": "tests/arrays/boolean/test_astype.py",
+      "sha256": "096ba81c1aaa3dd17d02a21843bfddb40f3b6b540e62541b69134a8bf58c1480",
+      "sizeBytes": 1849
+    },
+    {
+      "path": "tests/arrays/boolean/test_comparison.py",
+      "sha256": "fb8784135fc743545413250a43b6076fc969430596194a034a66abbd06d6fa87",
+      "sizeBytes": 1971
+    },
+    {
+      "path": "tests/arrays/boolean/test_construction.py",
+      "sha256": "4bc024074df9692f3fd441ceef49ef135c2a98f140591abbf4840553fdf7bba9",
+      "sizeBytes": 12614
+    },
+    {
+      "path": "tests/arrays/boolean/test_function.py",
+      "sha256": "78056cbb55d47a890b87b2a8d3e6c335442a995ac60323afbfdbc97560908f43",
+      "sizeBytes": 4061
+    },
+    {
+      "path": "tests/arrays/boolean/test_indexing.py",
+      "sha256": "068aeb2bcfd925b3791d67085fd7c23fe05b4c2689b20006522cdae48c2162be",
+      "sizeBytes": 361
+    },
+    {
+      "path": "tests/arrays/boolean/test_logical.py",
+      "sha256": "59282549f098cf1baa64c57bd107832654b39dd225887b30015ad6b23e184937",
+      "sizeBytes": 9408
+    },
+    {
+      "path": "tests/arrays/boolean/test_ops.py",
+      "sha256": "88cfc545832dbef744a4cb4b512b8177f5b0e671ebdbce2fd9f4711dac9dbc83",
+      "sizeBytes": 975
+    },
+    {
+      "path": "tests/arrays/boolean/test_reduction.py",
+      "sha256": "ac8f6d884024159f87c8a2aa5ef21fccd7d0f387d586ae582dbafc1219bf3558",
+      "sizeBytes": 2232
+    },
+    {
+      "path": "tests/arrays/boolean/test_repr.py",
+      "sha256": "4519633c80e2ea30cd85475b8ca31cef932cb7ec26f7697e1fa6f963e9420890",
+      "sizeBytes": 437
+    },
+    {
+      "path": "tests/arrays/categorical/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/categorical/test_algos.py",
+      "sha256": "bc329fbb89ef4e8c181a55f7c887ed50e8efaac11f0c6dd965d10c6ccba7bc53",
+      "sizeBytes": 2915
+    },
+    {
+      "path": "tests/arrays/categorical/test_analytics.py",
+      "sha256": "dda1315a7b52c88b752ecab85c3ad1013802dcaaf557bd74553ab2c7ebaef16d",
+      "sizeBytes": 13378
+    },
+    {
+      "path": "tests/arrays/categorical/test_api.py",
+      "sha256": "784b59bcbb090d57190eb3622d4299fd37aed0d96a70f57c948eceffbaddb0b6",
+      "sizeBytes": 19778
+    },
+    {
+      "path": "tests/arrays/categorical/test_astype.py",
+      "sha256": "7b9f4a49e47ad93d08530fbc1ef007b719c95ad76358df8df61825465d29cc70",
+      "sizeBytes": 6018
+    },
+    {
+      "path": "tests/arrays/categorical/test_constructors.py",
+      "sha256": "c46d1db448943292d898521dcc5cd92b523d221d3b9b99c513aaa0c6f2ea55b5",
+      "sizeBytes": 33281
+    },
+    {
+      "path": "tests/arrays/categorical/test_dtypes.py",
+      "sha256": "b5c23af43932bf7880dc4bdd98094f837489466f49a33d39a8b3bb87ab4254fa",
+      "sizeBytes": 6210
+    },
+    {
+      "path": "tests/arrays/categorical/test_indexing.py",
+      "sha256": "f7603226a603ababc4a7d120cff95232456fef505942177dba3df8aaef50f80d",
+      "sizeBytes": 12967
+    },
+    {
+      "path": "tests/arrays/categorical/test_map.py",
+      "sha256": "8829281da99c9183305d249adc14730f65e074a22b09ab521e33acccddad900d",
+      "sizeBytes": 4595
+    },
+    {
+      "path": "tests/arrays/categorical/test_missing.py",
+      "sha256": "a34d80915f8a70d4c0c14b273beb3bff77fd51de0e85dda4f9803eb9a46e78d6",
+      "sizeBytes": 4840
+    },
+    {
+      "path": "tests/arrays/categorical/test_operators.py",
+      "sha256": "b831a0a2339aaa702fc962a23f23b53e7f1eb08b45c6a93abddb42ee7e76690d",
+      "sizeBytes": 15909
+    },
+    {
+      "path": "tests/arrays/categorical/test_replace.py",
+      "sha256": "1e5e7231118c39f5e915e2057f5c726ef3ab797bef4dbd6b84bca4530240e476",
+      "sizeBytes": 2051
+    },
+    {
+      "path": "tests/arrays/categorical/test_repr.py",
+      "sha256": "d1963ac357a2e6825276360fda635f9e6bd7597f2575037c2cec9a8300c9eab3",
+      "sizeBytes": 27595
+    },
+    {
+      "path": "tests/arrays/categorical/test_sorting.py",
+      "sha256": "80484b925843c61a9ff140ce075ed330a86b69bc52e67d1ebcf83d0d648c779b",
+      "sizeBytes": 5052
+    },
+    {
+      "path": "tests/arrays/categorical/test_subclass.py",
+      "sha256": "6389d445de2114cd10dda5444f538efb3d75a59cf36741c57e5dacfbd3967a6c",
+      "sizeBytes": 903
+    },
+    {
+      "path": "tests/arrays/categorical/test_take.py",
+      "sha256": "3b883f2d80de2b43731c321de5c041129d67b3f6bbeb636c6079f4f3ca1c6338",
+      "sizeBytes": 3501
+    },
+    {
+      "path": "tests/arrays/categorical/test_warnings.py",
+      "sha256": "5eabc67806fd96b5cfd557702923af6c3bb2b6a0ee2795520ec2ca4006b98089",
+      "sizeBytes": 682
+    },
+    {
+      "path": "tests/arrays/datetimes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/datetimes/test_constructors.py",
+      "sha256": "119c55e64e8acd2de7ee02b7621be4a1e45ef3d583aa798e1239e5904ebebeb2",
+      "sizeBytes": 6526
+    },
+    {
+      "path": "tests/arrays/datetimes/test_cumulative.py",
+      "sha256": "5ff487b6df67fd6cc0fc2db03e54491d14bc2d49a334d9abdbe5cbe80b3325dd",
+      "sizeBytes": 1307
+    },
+    {
+      "path": "tests/arrays/datetimes/test_reductions.py",
+      "sha256": "5b7967dfe9e2b8fcaa01c31416c6b2fc47aa3489ed71c05fc4e3acf095987ec0",
+      "sizeBytes": 5525
+    },
+    {
+      "path": "tests/arrays/floating/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/floating/conftest.py",
+      "sha256": "80362e28d45ebc7c227bb34367840b9d8c5ebedeac6711d60a2ea8c881256228",
+      "sizeBytes": 1069
+    },
+    {
+      "path": "tests/arrays/floating/test_arithmetic.py",
+      "sha256": "bd8cf80e0e9f90d124cb901323c30a326f2665ab72ec5e23964fcdc661562a9c",
+      "sizeBytes": 8651
+    },
+    {
+      "path": "tests/arrays/floating/test_astype.py",
+      "sha256": "10e70122c7dce3857b95490d150c2a3e71d206dc848f7f2786f34e4ad05b21c7",
+      "sizeBytes": 4337
+    },
+    {
+      "path": "tests/arrays/floating/test_comparison.py",
+      "sha256": "795ddca23137ee79a120a8d4034f3a22b1e781ec1c8f1380ce9bb5656739393b",
+      "sizeBytes": 2395
+    },
+    {
+      "path": "tests/arrays/floating/test_concat.py",
+      "sha256": "f913bea7045163ddc54273a304bb357cc55feee042a0419190658f01d5fc96d5",
+      "sizeBytes": 573
+    },
+    {
+      "path": "tests/arrays/floating/test_construction.py",
+      "sha256": "ca32a1e348651d5a9f0a4c9eb4dfea3c73d17d0e80ddbf5c042228432a3b6e39",
+      "sizeBytes": 6730
+    },
+    {
+      "path": "tests/arrays/floating/test_contains.py",
+      "sha256": "708636b6891c597494afadb10292f0ee1f28674d4fb64e1dd8739484390ce303",
+      "sizeBytes": 286
+    },
+    {
+      "path": "tests/arrays/floating/test_function.py",
+      "sha256": "112de01bf2bd17a5782c9a76f3adfe84ed3dcd67f93afa2ec9dca6dfc78cbe11",
+      "sizeBytes": 7097
+    },
+    {
+      "path": "tests/arrays/floating/test_repr.py",
+      "sha256": "37f057ecd6d4f0f9638b3d9ba2e58cceb3f6db187feb0ffca4778f101db2715c",
+      "sizeBytes": 1157
+    },
+    {
+      "path": "tests/arrays/floating/test_to_numpy.py",
+      "sha256": "f4cfc1cfb6907dc5f5d98c8f469deddcb551706d5598b7bc77e0e05526c41f29",
+      "sizeBytes": 6414
+    },
+    {
+      "path": "tests/arrays/integer/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/integer/conftest.py",
+      "sha256": "0f35a9caa497295149997031a541a77b19aa0d5b1c7172abed8740896a9f7a12",
+      "sizeBytes": 1508
+    },
+    {
+      "path": "tests/arrays/integer/test_arithmetic.py",
+      "sha256": "c21aece51a3d297f57a00c71b7f8638f3f0577fc9ccc97205bfb17ee82a7b746",
+      "sizeBytes": 11126
+    },
+    {
+      "path": "tests/arrays/integer/test_comparison.py",
+      "sha256": "8d4afc76693fe8542c4cd8c3918b1acd69e2a078ace1c2e2f789e8cb8b711b9e",
+      "sizeBytes": 1212
+    },
+    {
+      "path": "tests/arrays/integer/test_concat.py",
+      "sha256": "4e61cdb02c71be9f8a0cb0f949a4e6784b96243cd44b9d44834e2e4967adf4f8",
+      "sizeBytes": 2351
+    },
+    {
+      "path": "tests/arrays/integer/test_construction.py",
+      "sha256": "f033d8b4b161c867dfbcfc37fe122de8df0d626c704a96f0b8f7e9428702390a",
+      "sizeBytes": 9006
+    },
+    {
+      "path": "tests/arrays/integer/test_dtypes.py",
+      "sha256": "145a9e4085153323cec25c38a6a6d1018604f3da80e1d70e5cdca5f1bf5b4396",
+      "sizeBytes": 9396
+    },
+    {
+      "path": "tests/arrays/integer/test_function.py",
+      "sha256": "8e6306800d97f39ff8f9255c576628201526d3bf9829c49ba8cef17b520b9797",
+      "sizeBytes": 7444
+    },
+    {
+      "path": "tests/arrays/integer/test_indexing.py",
+      "sha256": "6959371bd0d449dda35f5d5b630176006a35e47f2711f718305c7a16529e09d6",
+      "sizeBytes": 491
+    },
+    {
+      "path": "tests/arrays/integer/test_reduction.py",
+      "sha256": "3cd61ae4a87dd3292dacd2439280c5bf3c77f592e7eb0daaa98befbaf8b6eea2",
+      "sizeBytes": 4102
+    },
+    {
+      "path": "tests/arrays/integer/test_repr.py",
+      "sha256": "7cb4d9bac8051cf5cee28ae9ca098720e1ba2502f361c75b4c91d1befb0dd2c3",
+      "sizeBytes": 1652
+    },
+    {
+      "path": "tests/arrays/interval/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/interval/test_astype.py",
+      "sha256": "f2b6fbaecb2abc8a12cedcc27c56f9a58e28207fc68c34ad2ab5e40ba6e75199",
+      "sizeBytes": 776
+    },
+    {
+      "path": "tests/arrays/interval/test_formats.py",
+      "sha256": "460c73ad06261d7e5bd42676b4dda6352a69149cf378e717ab977b40f74a66c3",
+      "sizeBytes": 295
+    },
+    {
+      "path": "tests/arrays/interval/test_interval.py",
+      "sha256": "14b4eda0dfc435fa9c19f48b212934614e0ec21e97bf726c55d74ca74f65ac0b",
+      "sizeBytes": 9259
+    },
+    {
+      "path": "tests/arrays/interval/test_interval_pyarrow.py",
+      "sha256": "7cb10145bb12195821ec630c5d5d0eec07f62bbf804978c5c76551f934e21711",
+      "sizeBytes": 5217
+    },
+    {
+      "path": "tests/arrays/interval/test_overlaps.py",
+      "sha256": "9ee6618860c2dfc3cb0d77b18cc3382089081f5f45b888b06218b2150eca8e84",
+      "sizeBytes": 3280
+    },
+    {
+      "path": "tests/arrays/masked/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/masked/test_arithmetic.py",
+      "sha256": "748134c5120b400557c1c88229e8738ef8d63af20208cc575ac61771c805ea1a",
+      "sizeBytes": 8921
+    },
+    {
+      "path": "tests/arrays/masked/test_arrow_compat.py",
+      "sha256": "0b7be9cf8394e4af1c65a1e45573508c703bdf7044d199c384d79eb0db07d1c6",
+      "sizeBytes": 7194
+    },
+    {
+      "path": "tests/arrays/masked/test_function.py",
+      "sha256": "f31171d288a13746a303e01f37bb7c77d5a6427f9a6a960bd1ee9ff521931d4e",
+      "sizeBytes": 2101
+    },
+    {
+      "path": "tests/arrays/masked/test_indexing.py",
+      "sha256": "609253524be0449219ff4234176191928e72afd96863c8b140b6c7c08d9663f3",
+      "sizeBytes": 3210
+    },
+    {
+      "path": "tests/arrays/masked_shared.py",
+      "sha256": "7110469c630eb0dffc2fab7522713e05e09c41986cdc6acdba10808752fef04a",
+      "sizeBytes": 5195
+    },
+    {
+      "path": "tests/arrays/numpy_/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/numpy_/test_indexing.py",
+      "sha256": "fb4941f8cc3e8333383297be4910a3fb0e02e90c4b7e9dc11fae54fc35542cd6",
+      "sizeBytes": 1452
+    },
+    {
+      "path": "tests/arrays/numpy_/test_numpy.py",
+      "sha256": "a0d57f0afabff60bb50812044161d2d99e019e0ac1fc3cb56c67bfe4b62b7161",
+      "sizeBytes": 11424
+    },
+    {
+      "path": "tests/arrays/period/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/period/test_arrow_compat.py",
+      "sha256": "b590b1546801324cf3fb0fa75eb77bdfa0624d32ac2987ef2979642d320a6e8f",
+      "sizeBytes": 3452
+    },
+    {
+      "path": "tests/arrays/period/test_astype.py",
+      "sha256": "94a2c30ea652754eece8fc876ebcb091a0899cc2784ca4a9851aa69e8ec171b5",
+      "sizeBytes": 2344
+    },
+    {
+      "path": "tests/arrays/period/test_constructors.py",
+      "sha256": "7a72b53f6df19f0540425f510c7ec18c7255e762fb50821ecbe3e7d3de3b7895",
+      "sizeBytes": 4734
+    },
+    {
+      "path": "tests/arrays/period/test_reductions.py",
+      "sha256": "ff791eea0d0939fbe8c1357e0f55db66a5ac5930b7ab8a9537d3a21aefc8155a",
+      "sizeBytes": 981
+    },
+    {
+      "path": "tests/arrays/sparse/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/sparse/test_accessor.py",
+      "sha256": "2de50230f4cc91839dd0ede3bf092a83dac6be055f4f1103ce4281359db0d1cd",
+      "sizeBytes": 9233
+    },
+    {
+      "path": "tests/arrays/sparse/test_arithmetics.py",
+      "sha256": "85419fdfc6c0558675a5c57e6d3e4c283b45e24dd8b18e6090c28acb7042b824",
+      "sizeBytes": 20316
+    },
+    {
+      "path": "tests/arrays/sparse/test_array.py",
+      "sha256": "5f1556dd9dc059b118e893ccc8e44cd2e49efb1a931952e5abb04f1f48d462d1",
+      "sizeBytes": 18719
+    },
+    {
+      "path": "tests/arrays/sparse/test_astype.py",
+      "sha256": "3065be6f11db29e63b171a408fe14e14ed6477fc0d2a6ab212577ab7f3aea263",
+      "sizeBytes": 4771
+    },
+    {
+      "path": "tests/arrays/sparse/test_combine_concat.py",
+      "sha256": "dcd3105da45073b0719f91e14877df714136e06662fd561f96714b9e2c4e81bb",
+      "sizeBytes": 2651
+    },
+    {
+      "path": "tests/arrays/sparse/test_constructors.py",
+      "sha256": "6c6348543934b6099d9d57baa8246eedc626e0716e99e36e79075b6d9fb4c641",
+      "sizeBytes": 10573
+    },
+    {
+      "path": "tests/arrays/sparse/test_dtype.py",
+      "sha256": "7fe1ab5fcb06361bf977f8d668f4c92de679ff7146ca85d89bf606f6f2ed9cda",
+      "sizeBytes": 6154
+    },
+    {
+      "path": "tests/arrays/sparse/test_indexing.py",
+      "sha256": "f08342d69680d3a5eb0a9f0beb7152965af438ae3ca6088a75ae6c3a0ad485ff",
+      "sizeBytes": 10425
+    },
+    {
+      "path": "tests/arrays/sparse/test_libsparse.py",
+      "sha256": "0925d7df6d570e65da9e135f66965466faf207a6c7105a8dc8e3216aafc3444e",
+      "sizeBytes": 19043
+    },
+    {
+      "path": "tests/arrays/sparse/test_reductions.py",
+      "sha256": "e6c9c73b2f3923a020da8e98eb583989cc430b56436c65da8610633487f9d770",
+      "sizeBytes": 9641
+    },
+    {
+      "path": "tests/arrays/sparse/test_unary.py",
+      "sha256": "1ada9e31dca529db6efb41cfc664c3563a37dab88e704b6a3e18c8fd72b92e43",
+      "sizeBytes": 2864
+    },
+    {
+      "path": "tests/arrays/string_/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/string_/test_concat.py",
+      "sha256": "ea6a9112a25674d10f2c84748df9222e738577a2ab7015fb7c9ec8389cdf4322",
+      "sizeBytes": 2744
+    },
+    {
+      "path": "tests/arrays/string_/test_string.py",
+      "sha256": "bea860c70a7e9d6e4234a57493f02b3b20a429d9d063fd83cf691bedf984758d",
+      "sizeBytes": 22168
+    },
+    {
+      "path": "tests/arrays/string_/test_string_arrow.py",
+      "sha256": "62b18b48459b6a98ee229791cf1ce09d7571113a3e6bc9806388b87dfdfee57f",
+      "sizeBytes": 9364
+    },
+    {
+      "path": "tests/arrays/test_array.py",
+      "sha256": "9fe3dd02e008c09caf9c461b5d9704bba9c42ffe6922f35b84efc9dcaac08a55",
+      "sizeBytes": 17755
+    },
+    {
+      "path": "tests/arrays/test_datetimelike.py",
+      "sha256": "cc296d24cc0cd6f6c90f3415abf30dc3d2dd88c9f018a4aab402f1d276f5e2a2",
+      "sizeBytes": 47055
+    },
+    {
+      "path": "tests/arrays/test_datetimes.py",
+      "sha256": "43d8935c232c6d64e3e2f11bb775560d7e033e9c557632b77c77006ff1c6e093",
+      "sizeBytes": 29809
+    },
+    {
+      "path": "tests/arrays/test_ndarray_backed.py",
+      "sha256": "95e40d05554c8bbc3e0af300cb05fd1cf2a1468e5d32e9b2de56966c45fceebe",
+      "sizeBytes": 2332
+    },
+    {
+      "path": "tests/arrays/test_period.py",
+      "sha256": "4bfed33112c49956a68462a554ee74a89223dce143591cd8fe8c44717ce9df3b",
+      "sizeBytes": 5572
+    },
+    {
+      "path": "tests/arrays/test_timedeltas.py",
+      "sha256": "4dddc6c8aab14ceddd70f68b486f8f56a870168d401546afb00bb3969f5aed36",
+      "sizeBytes": 10723
+    },
+    {
+      "path": "tests/arrays/timedeltas/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/arrays/timedeltas/test_constructors.py",
+      "sha256": "d5b54f5b624d8bae7a5995dc232caaacd958b9c461ef0b02d8bf87b0bf8453e4",
+      "sizeBytes": 2268
+    },
+    {
+      "path": "tests/arrays/timedeltas/test_cumulative.py",
+      "sha256": "71147a23e948b1e7c6f79bc465bf13b9776f9b0ee974f15e76906778b54a046f",
+      "sizeBytes": 692
+    },
+    {
+      "path": "tests/arrays/timedeltas/test_reductions.py",
+      "sha256": "891c40b352415b1061805ddb1568db06be798df6d1b2b65cf50994762ec4bde9",
+      "sizeBytes": 6521
+    },
+    {
+      "path": "tests/base/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/base/common.py",
+      "sha256": "f9c2d7be1cee422d1731f53e35da934008abb8dd0c53d03d1c4da0a28ed9cc94",
+      "sizeBytes": 266
+    },
+    {
+      "path": "tests/base/test_constructors.py",
+      "sha256": "3d30cf361bcb73a2603d8a46ab6f092c4e90ab643fc605f01591f85154033c0c",
+      "sizeBytes": 5893
+    },
+    {
+      "path": "tests/base/test_conversion.py",
+      "sha256": "29c6c5a45e620f1300c0d3cbcabe3785b9ef5fcc62ab560e4d8c94e61f72ad24",
+      "sizeBytes": 19335
+    },
+    {
+      "path": "tests/base/test_fillna.py",
+      "sha256": "b07bc2e46c72824527a78a3eaf4e630b6e19a95649bf6f3cfc63c065e1866fb7",
+      "sizeBytes": 1554
+    },
+    {
+      "path": "tests/base/test_misc.py",
+      "sha256": "28b46bf6cd477155555656adb48d71416b5d9b6a9b566bb0b8693a6d49664d8d",
+      "sizeBytes": 5918
+    },
+    {
+      "path": "tests/base/test_transpose.py",
+      "sha256": "d77f3f3bf270c1d0a67e6ca3a78ecf4956bee12afb48eb8ba6baf43f3466e814",
+      "sizeBytes": 1694
+    },
+    {
+      "path": "tests/base/test_unique.py",
+      "sha256": "b59d298e360d9f15843c33497feaeb73db55e8e573a2cdbd05f7d437a68596f2",
+      "sizeBytes": 4478
+    },
+    {
+      "path": "tests/base/test_value_counts.py",
+      "sha256": "3490f82da88b559e2bbc7f276b7d8dd632639414273e520fc2bd8cfac8951f1a",
+      "sizeBytes": 13896
+    },
+    {
+      "path": "tests/computation/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/computation/test_compat.py",
+      "sha256": "747b2dcaf75a5f26ebc26d56427755f5a401c0eb0ebc221565be69c4b5ec61f3",
+      "sizeBytes": 872
+    },
+    {
+      "path": "tests/computation/test_eval.py",
+      "sha256": "59a8c59953f8aec4440fa59e07e7a44b0cc21cf38eca9fb6c3bcd5875c3870a5",
+      "sizeBytes": 73144
+    },
+    {
+      "path": "tests/config/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/config/test_config.py",
+      "sha256": "e04610121a9f3711cd29bc56749061b0a4c28101653f1d71068be052d6497813",
+      "sizeBytes": 17864
+    },
+    {
+      "path": "tests/config/test_localization.py",
+      "sha256": "23c60e74895dd6db3d55b20640ffff92a93da09729d06a8cb09a1b550c4ec3b8",
+      "sizeBytes": 4389
+    },
+    {
+      "path": "tests/construction/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/construction/test_extract_array.py",
+      "sha256": "2f77c48c04cfb00cb76baceb75025a5d7690ec5bd1d8b39e88f24c8c6364c0a4",
+      "sizeBytes": 637
+    },
+    {
+      "path": "tests/copy_view/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/copy_view/index/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/copy_view/index/test_datetimeindex.py",
+      "sha256": "4182d7d7dab1b060f7279c70829ebb08808a804e0c4248377686f972810364f6",
+      "sizeBytes": 2603
+    },
+    {
+      "path": "tests/copy_view/index/test_index.py",
+      "sha256": "186db488a67c65a5301c4899d8a69dc686d492ae6baddf3aeaef718a55dfa640",
+      "sizeBytes": 4575
+    },
+    {
+      "path": "tests/copy_view/index/test_intervalindex.py",
+      "sha256": "8c83a5e049a127d12fdd27b9e6b6808289e7846eab4a244272d2c68cccdbec82",
+      "sizeBytes": 848
+    },
+    {
+      "path": "tests/copy_view/index/test_periodindex.py",
+      "sha256": "651821b31a9de09f2bb199e481cab29d69d2ca94494315c200cc0d18207f1cc3",
+      "sizeBytes": 1328
+    },
+    {
+      "path": "tests/copy_view/index/test_timedeltaindex.py",
+      "sha256": "b7e068da8e9347d1546c32d16ac6f36d1aa8c649eff0f8f6d4ba51ef8520a2f3",
+      "sizeBytes": 1542
+    },
+    {
+      "path": "tests/copy_view/test_array.py",
+      "sha256": "b80b3c47e227f2254f75fa9606d0348acef4b211e5b8019491294b4196979d32",
+      "sizeBytes": 6985
+    },
+    {
+      "path": "tests/copy_view/test_astype.py",
+      "sha256": "0f6cc8dee31c26b59448a835e38cb8b76608419dce34dbaadf4d8c33fd0ddd22",
+      "sizeBytes": 7894
+    },
+    {
+      "path": "tests/copy_view/test_chained_assignment_deprecation.py",
+      "sha256": "f9c3e604d29245987ed6c6e70a3991e2ae66ab5cd5d8f70ee7d508b756e67ee5",
+      "sizeBytes": 2790
+    },
+    {
+      "path": "tests/copy_view/test_clip.py",
+      "sha256": "f4e6403443e14841da9bc20950302e33a9f3f7804d62b61ea55612cac466f6c2",
+      "sizeBytes": 1928
+    },
+    {
+      "path": "tests/copy_view/test_constructors.py",
+      "sha256": "26dedfe22b9a07f28b8ae381cadb9bc4fdd8e2a461e18b484adf498dd84ee37d",
+      "sizeBytes": 13225
+    },
+    {
+      "path": "tests/copy_view/test_copy_deprecation.py",
+      "sha256": "f249ff8c7f448261d268e19e51df346889c7ad0d2ecc37f06e7310cf7ffc382b",
+      "sizeBytes": 3132
+    },
+    {
+      "path": "tests/copy_view/test_core_functionalities.py",
+      "sha256": "7a5663b07eb31a527e21584e8bca99f57db0b69a3f4340ef20424ce1ef3c00f1",
+      "sizeBytes": 2899
+    },
+    {
+      "path": "tests/copy_view/test_functions.py",
+      "sha256": "de449d8024f207e22e5ddf6e085cf5db60a9bb4ed8e78d3e6051a54766a5bbf6",
+      "sizeBytes": 12231
+    },
+    {
+      "path": "tests/copy_view/test_indexing.py",
+      "sha256": "2252565018bc8fff76ce69e91a4a9410694c92b1dc2afe4e18467a8525770178",
+      "sizeBytes": 28574
+    },
+    {
+      "path": "tests/copy_view/test_internals.py",
+      "sha256": "e65d2d75507de4f716204ff6a45d0861eee68cfa7d495cb754ecbda5abcde5b0",
+      "sizeBytes": 3588
+    },
+    {
+      "path": "tests/copy_view/test_interp_fillna.py",
+      "sha256": "88e0375c0be108732906d08e167cf2ec8de902857dcd0b12532cf02fde3efa3f",
+      "sizeBytes": 9726
+    },
+    {
+      "path": "tests/copy_view/test_methods.py",
+      "sha256": "e1c8ea180c8d408131fc5843733a7750bd4f223cb4f1f4c14c676ded8aa5ce31",
+      "sizeBytes": 51839
+    },
+    {
+      "path": "tests/copy_view/test_replace.py",
+      "sha256": "0152c597252f1f0a666fe073e54712994710832c0fa51f0c6d0784fd1e433e58",
+      "sizeBytes": 11799
+    },
+    {
+      "path": "tests/copy_view/test_setitem.py",
+      "sha256": "329a4160e9d3da7891ad56047c767ef9223b47a5633752141cc2644389a55204",
+      "sizeBytes": 4167
+    },
+    {
+      "path": "tests/copy_view/test_util.py",
+      "sha256": "0a558ba6b30985fea891436ef405fa02bf485d980a918d2736e0f31d13bbd079",
+      "sizeBytes": 385
+    },
+    {
+      "path": "tests/copy_view/util.py",
+      "sha256": "a0db428319939a488cd43894c639f34de0310a3ffb8e379ec2d6f2fb781da28d",
+      "sizeBytes": 899
+    },
+    {
+      "path": "tests/dtypes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/dtypes/cast/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/dtypes/cast/test_box_unbox.py",
+      "sha256": "d2ca98cbff6af2d05c262a44bd51034b04b436cee23ef8d9e2942a7242d63137",
+      "sizeBytes": 2930
+    },
+    {
+      "path": "tests/dtypes/cast/test_can_hold_element.py",
+      "sha256": "b35fc007786d7f3c695cde4d001ae9a71c99b197c49cd49dfb6024dbae9aa06e",
+      "sizeBytes": 3260
+    },
+    {
+      "path": "tests/dtypes/cast/test_construct_from_scalar.py",
+      "sha256": "20d74e890ecca305cbafa6517828aad09ca451e16f456a1cc64ddffa2964f6fd",
+      "sizeBytes": 1780
+    },
+    {
+      "path": "tests/dtypes/cast/test_construct_ndarray.py",
+      "sha256": "0f9da8b1900712e636c3719dcc7d39cbd583fe084b2324a07ca6882699cb640c",
+      "sizeBytes": 1316
+    },
+    {
+      "path": "tests/dtypes/cast/test_construct_object_arr.py",
+      "sha256": "78e994bb8ab48a11936d8a4295ea029d8b6fc21d530421194108cb78969430d0",
+      "sizeBytes": 717
+    },
+    {
+      "path": "tests/dtypes/cast/test_dict_compat.py",
+      "sha256": "ab29fb90fe5bd78332c2da8e50be42f8d3af8dfdaa2b83ec5c6a42bea9a8fb81",
+      "sizeBytes": 476
+    },
+    {
+      "path": "tests/dtypes/cast/test_downcast.py",
+      "sha256": "a6567c1e4d78c20c4c377d454e53449ad964e41a031bbf45dbf7796b02c66568",
+      "sizeBytes": 1560
+    },
+    {
+      "path": "tests/dtypes/cast/test_find_common_type.py",
+      "sha256": "73ffc66e09d16b0c20a96badf20e50f76f1e9fcfbf3b7a136444156ea43c32b1",
+      "sizeBytes": 5226
+    },
+    {
+      "path": "tests/dtypes/cast/test_infer_datetimelike.py",
+      "sha256": "eafa2bfdea846cc29c04b1247dac97cd5cf0c1fe4165c0af421159baa86fc8a5",
+      "sizeBytes": 603
+    },
+    {
+      "path": "tests/dtypes/cast/test_infer_dtype.py",
+      "sha256": "853ec98fd58cad264f6a02af799c6f14c794a17b52af1816c98a6cf644efe48d",
+      "sizeBytes": 6060
+    },
+    {
+      "path": "tests/dtypes/cast/test_promote.py",
+      "sha256": "078760b37116226f2a2aea10327e8535a1867ffa809bf1009b89765f77070cc3",
+      "sizeBytes": 20755
+    },
+    {
+      "path": "tests/dtypes/test_common.py",
+      "sha256": "4432da4f6c480c8dafae5dd7325fa6973850b794c445904af6c45ddb83e1ae01",
+      "sizeBytes": 29340
+    },
+    {
+      "path": "tests/dtypes/test_concat.py",
+      "sha256": "e5c6aebb25c194316ce3562d64b0fd584eea2c37408a1a01112384ba83efebda",
+      "sizeBytes": 2086
+    },
+    {
+      "path": "tests/dtypes/test_dtypes.py",
+      "sha256": "05bd997ee7d77da8368be466b99e6714e2c0073298b77fba290c30a1f2a3e140",
+      "sizeBytes": 44513
+    },
+    {
+      "path": "tests/dtypes/test_generic.py",
+      "sha256": "08ae2866e6f1084e2439a396b5a951b7f9ff82530557840db24355c10b3da22f",
+      "sizeBytes": 4794
+    },
+    {
+      "path": "tests/dtypes/test_inference.py",
+      "sha256": "f9e3be50fbdbd9cf2a92d3f3e0e6b3c556028b2a093df5b540e816aceb980257",
+      "sizeBytes": 74885
+    },
+    {
+      "path": "tests/dtypes/test_missing.py",
+      "sha256": "61ed86dfb72c519b0e64619595b1a16ab792bd4148fce4da280be8dbb251ee1b",
+      "sizeBytes": 28677
+    },
+    {
+      "path": "tests/extension/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/extension/array_with_attr/__init__.py",
+      "sha256": "6d79305925ba1915fc5f0db6d6233269039055a5a6cae44fded1a1be35ed895f",
+      "sizeBytes": 149
+    },
+    {
+      "path": "tests/extension/array_with_attr/array.py",
+      "sha256": "fc2e0dc5084f8ee2ba24b3eb7fa1ca1432dd5d14274c6f4e4d4e5d477bb2c37c",
+      "sizeBytes": 2481
+    },
+    {
+      "path": "tests/extension/array_with_attr/test_array_with_attr.py",
+      "sha256": "4eeb81035942c6354e816b1633d8e181cf8fc86b97cda8cedd459629912ab990",
+      "sizeBytes": 1373
+    },
+    {
+      "path": "tests/extension/base/__init__.py",
+      "sha256": "bd986ffcd636237cfe8ee98b00422f9b1f8ff856d8ff2b4436588839255e2fab",
+      "sizeBytes": 2870
+    },
+    {
+      "path": "tests/extension/base/accumulate.py",
+      "sha256": "2479e3bf333658f0fddff59779acba79f8f53ebd6fb28d2595faf946f4057402",
+      "sizeBytes": 1501
+    },
+    {
+      "path": "tests/extension/base/base.py",
+      "sha256": "6927d33efbafcf3414c4422b1940125aec1c56fe94c396ef9055efaa38515753",
+      "sizeBytes": 35
+    },
+    {
+      "path": "tests/extension/base/casting.py",
+      "sha256": "ff0ec9fc7a70f82889703caea6912d93b1023e0675fceae6687849e93b6044f6",
+      "sizeBytes": 3254
+    },
+    {
+      "path": "tests/extension/base/constructors.py",
+      "sha256": "11f42b61c882868e4b3800316cd3a522e9de0670123a4a18898a867bab79016c",
+      "sizeBytes": 5623
+    },
+    {
+      "path": "tests/extension/base/dim2.py",
+      "sha256": "8b8067d734226c110b8f05bd6cdbf7d9f9d21786ac7b60eb755d5bda6cab7fb0",
+      "sizeBytes": 12454
+    },
+    {
+      "path": "tests/extension/base/dtype.py",
+      "sha256": "7be8ee3f388879e835d5604746601aff3562e5f7be36130ab223359125bef8e0",
+      "sizeBytes": 4005
+    },
+    {
+      "path": "tests/extension/base/getitem.py",
+      "sha256": "eba7c2f0f689f292be520723f68792af6aba0f2eaf9ebd4a525543dce7b0c7cb",
+      "sizeBytes": 16534
+    },
+    {
+      "path": "tests/extension/base/groupby.py",
+      "sha256": "cef153fc9c40a778d29b519c3191ac2eb00047e3f20bcf5a690aa656e89ddf69",
+      "sizeBytes": 6247
+    },
+    {
+      "path": "tests/extension/base/index.py",
+      "sha256": "4e4068b67925e1bcc5f7d3d4681403420cd94c94de396d49f09ea51232e734d0",
+      "sizeBytes": 518
+    },
+    {
+      "path": "tests/extension/base/interface.py",
+      "sha256": "870c780bf32f0aada39b75be782f72eaeea42682193cfa55070dd8969953a97d",
+      "sizeBytes": 5955
+    },
+    {
+      "path": "tests/extension/base/io.py",
+      "sha256": "18a22388086d3d73895434ee5e6554e4eefa085298929ff242b4132a1d5ca4cc",
+      "sizeBytes": 1474
+    },
+    {
+      "path": "tests/extension/base/methods.py",
+      "sha256": "566643f15e2d32da8c109a5a274604df50778114eeebeff973218888c7e57d66",
+      "sizeBytes": 29502
+    },
+    {
+      "path": "tests/extension/base/missing.py",
+      "sha256": "5a3a6630c6501071b82f4b13062880cd3dd2b0edf75f3e0b3ad4cc63f0e9a10c",
+      "sizeBytes": 6774
+    },
+    {
+      "path": "tests/extension/base/ops.py",
+      "sha256": "bd98339ca8660c94faf9afdd8900d382a27c88c7f179a71f2a165b278d2bb66e",
+      "sizeBytes": 10631
+    },
+    {
+      "path": "tests/extension/base/printing.py",
+      "sha256": "70d8218e8ecac2b36fe00b5def6f4b41aceb39df1cb373f80ce93b6bcd070939",
+      "sizeBytes": 1110
+    },
+    {
+      "path": "tests/extension/base/reduce.py",
+      "sha256": "e2505d2251936deb8ec354ccfbe384d1a6a6ad8674529b969deffdba8de3aa6c",
+      "sizeBytes": 4975
+    },
+    {
+      "path": "tests/extension/base/reshaping.py",
+      "sha256": "03715dcf6a4385d2b1adec358ce450836f7f4a1dd0ec3115eea17e3afafd4544",
+      "sizeBytes": 14477
+    },
+    {
+      "path": "tests/extension/base/setitem.py",
+      "sha256": "7958b06b72300eb3d281e38dfd18cb1026c9ace0155d5d6830ce92b54bf07023",
+      "sizeBytes": 17820
+    },
+    {
+      "path": "tests/extension/conftest.py",
+      "sha256": "895896481c141b3768f37aa63714dee37e36c0678f29df410d3f796206e6bcc6",
+      "sizeBytes": 4725
+    },
+    {
+      "path": "tests/extension/date/__init__.py",
+      "sha256": "fa921a05efef9a09ccfe893a4fffadfb05477ad5ed370df448e316556343a8b2",
+      "sizeBytes": 118
+    },
+    {
+      "path": "tests/extension/date/array.py",
+      "sha256": "8f9c795736dd053f1ce87bc543efa33f9e6027ddc96917d9e88dc04877ba0e67",
+      "sizeBytes": 6182
+    },
+    {
+      "path": "tests/extension/decimal/__init__.py",
+      "sha256": "0efea898456a04dcdc8394830e15ff732cedf30623ab735bb92be6987ce8abc0",
+      "sizeBytes": 191
+    },
+    {
+      "path": "tests/extension/decimal/array.py",
+      "sha256": "35081c6fd007d2295b05233db7ecc96013f49375c6a78e043eedf8691114c608",
+      "sizeBytes": 9966
+    },
+    {
+      "path": "tests/extension/decimal/test_decimal.py",
+      "sha256": "ea04c8ed6e51652838b85e43a3f709de7ff10a1619d8883b0f4ad7f77fd6a679",
+      "sizeBytes": 14691
+    },
+    {
+      "path": "tests/extension/json/__init__.py",
+      "sha256": "26f8c29d531fcc8512a0728bfae9ab913f47e53f09dc096df3e4282973120782",
+      "sizeBytes": 146
+    },
+    {
+      "path": "tests/extension/json/array.py",
+      "sha256": "edb7e025022aadced5576866ef8c3393211a28cf7292fc28a99c6b554b4c7784",
+      "sizeBytes": 9302
+    },
+    {
+      "path": "tests/extension/json/test_json.py",
+      "sha256": "a9500984d0aeebc78d4c34ba252f4ba9f5c5d3bddd106d8b53cc9c8391cdfb9f",
+      "sizeBytes": 18221
+    },
+    {
+      "path": "tests/extension/list/__init__.py",
+      "sha256": "165a53ae0740325ff9a6e376cc38ef766a2cc3c693bda083f878b61ad20afa4d",
+      "sizeBytes": 146
+    },
+    {
+      "path": "tests/extension/list/array.py",
+      "sha256": "c302031b0a6404f3ed7e177a7e89763622bd1e7d1bd1061f16b05c6556b0a04b",
+      "sizeBytes": 3973
+    },
+    {
+      "path": "tests/extension/list/test_list.py",
+      "sha256": "f3570bd0e08c7449bf41f4820adfcd4f6148ef0182a4b1d0e7f0d19b08d15ca9",
+      "sizeBytes": 674
+    },
+    {
+      "path": "tests/extension/test_arrow.py",
+      "sha256": "cc630c8828b16c53576501ad1ff16873c06527d354b9ec90dc36a7e25f766e81",
+      "sizeBytes": 136152
+    },
+    {
+      "path": "tests/extension/test_categorical.py",
+      "sha256": "5c98085737d2531c6acb09bdf43b94e41685ef5a5d45007c1b9724f9878d22a2",
+      "sizeBytes": 6481
+    },
+    {
+      "path": "tests/extension/test_common.py",
+      "sha256": "91a1bfe65b8abba7f5a7458272ce31cd067b5358025aa6dff0a4149325b6b68f",
+      "sizeBytes": 3071
+    },
+    {
+      "path": "tests/extension/test_datetime.py",
+      "sha256": "bf3720f14f2aa1556bfb55b3b8b260d191d6e4bd358bc9299b26f036dbfbaeef",
+      "sizeBytes": 4678
+    },
+    {
+      "path": "tests/extension/test_extension.py",
+      "sha256": "c05f2adc7c1703a5d75cb02de2d3470606f35ff5eb8a073f3eea310821ab6cb0",
+      "sizeBytes": 560
+    },
+    {
+      "path": "tests/extension/test_interval.py",
+      "sha256": "d7d2cb8cc0db23a5aee3b5a99320fca9a6a85054c7e4d55ed2d949fb500bef54",
+      "sizeBytes": 4511
+    },
+    {
+      "path": "tests/extension/test_masked.py",
+      "sha256": "f5f5bada63b01f6a08fb5b5eccdaa5a6809e680892c2299400fdf7250e025fe7",
+      "sizeBytes": 12722
+    },
+    {
+      "path": "tests/extension/test_numpy.py",
+      "sha256": "e0b5b6aeb809359d7a9cd4a80123808a139bc67899b7355fd1c2d3b5e1771209",
+      "sizeBytes": 15893
+    },
+    {
+      "path": "tests/extension/test_period.py",
+      "sha256": "c58e86985b56b8fdb1cd0915eac2abab3f333566c1dea0f63ff0f9eae248b838",
+      "sizeBytes": 3355
+    },
+    {
+      "path": "tests/extension/test_sparse.py",
+      "sha256": "9841eb8d19c63aea98f2a0b0e6bfc2c479e1ddc11f2ddec55f3bb2492cef6a0e",
+      "sizeBytes": 18633
+    },
+    {
+      "path": "tests/extension/test_string.py",
+      "sha256": "ce00145312043bcff5755bc63bb9f2ead4f60aad457c189642ac2987c61098d7",
+      "sizeBytes": 11021
+    },
+    {
+      "path": "tests/extension/uuid/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/extension/uuid/test_uuid.py",
+      "sha256": "0455ef613b8ffe77d5b46ca2b41fbebbe3081e799e9c46a28069a60d90fb1ce2",
+      "sizeBytes": 2354
+    },
+    {
+      "path": "tests/frame/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/frame/common.py",
+      "sha256": "0669c432544417b1b4079cdd68946c773a8845d87c7628938ac05b09523a169d",
+      "sizeBytes": 1873
+    },
+    {
+      "path": "tests/frame/conftest.py",
+      "sha256": "343c11160cac9e4a793eb9b3d0bdb1269e3d58036f68617b267dc5217d41bb6c",
+      "sizeBytes": 2647
+    },
+    {
+      "path": "tests/frame/constructors/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/frame/constructors/test_from_dict.py",
+      "sha256": "57065934e7654db1d04cee2f49457eb39f017f1d976ecbad55dd22acd12685f8",
+      "sizeBytes": 7988
+    },
+    {
+      "path": "tests/frame/constructors/test_from_records.py",
+      "sha256": "205b2928ff6e4fed29cc5e59c4d9f592de2511c85c3e80bca11cb2b5b6a46dda",
+      "sizeBytes": 19533
+    },
+    {
+      "path": "tests/frame/indexing/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/frame/indexing/test_coercion.py",
+      "sha256": "c88484b8d37b269da291abfba27697c5ec9c1ad4465d7edbc5852a664df3419c",
+      "sizeBytes": 5125
+    },
+    {
+      "path": "tests/frame/indexing/test_delitem.py",
+      "sha256": "f9811105f65b85367778ace3996967f008e84043bb62f69ee9e95abb89e384cd",
+      "sizeBytes": 1832
+    },
+    {
+      "path": "tests/frame/indexing/test_get.py",
+      "sha256": "65d28e6cf8b809455cb375c1f5a47ee0a71f31e0ddad6fa97642ed3e7d342a67",
+      "sizeBytes": 690
+    },
+    {
+      "path": "tests/frame/indexing/test_get_value.py",
+      "sha256": "03e19b08795b0df54f181d7474d1a71a0e03b6b2ab9516d1b2961fb834d498f3",
+      "sizeBytes": 679
+    },
+    {
+      "path": "tests/frame/indexing/test_getitem.py",
+      "sha256": "1d9fc930beb755fa77c632560e2ebff9de7f618f83856cb0977d041d8af8bd6a",
+      "sizeBytes": 14844
+    },
+    {
+      "path": "tests/frame/indexing/test_indexing.py",
+      "sha256": "2639c8022ed854121eadfde7d8423005324df93f57f2a200d5ffe972234fc2fd",
+      "sizeBytes": 67195
+    },
+    {
+      "path": "tests/frame/indexing/test_insert.py",
+      "sha256": "c6105d94e91a0fdabe110ed96bee26353c802a7c24e04befb45c132c5ce22591",
+      "sizeBytes": 3882
+    },
+    {
+      "path": "tests/frame/indexing/test_mask.py",
+      "sha256": "bc7ad8fe76e3cfceaed49de489576850c47bb97133901375ac380e04a1e2b336",
+      "sizeBytes": 4941
+    },
+    {
+      "path": "tests/frame/indexing/test_set_value.py",
+      "sha256": "997c5751e8681eca9ef2fa47f8d17b89e8595f37e51381c02b7fc638dc05c62b",
+      "sizeBytes": 2492
+    },
+    {
+      "path": "tests/frame/indexing/test_setitem.py",
+      "sha256": "ada323d98a32a7424be0ebb066870d2629eb3d14c48e5fa442bcc3196bb54cda",
+      "sizeBytes": 53289
+    },
+    {
+      "path": "tests/frame/indexing/test_take.py",
+      "sha256": "4f65243ae740935f227136a0d52f1fe0c3a220541f39bf01584876b97092d572",
+      "sizeBytes": 3229
+    },
+    {
+      "path": "tests/frame/indexing/test_where.py",
+      "sha256": "6aea98e15bf2a6cad838906f6b11e29d5c16b50af49d042a3caf89ce9f408e60",
+      "sizeBytes": 36531
+    },
+    {
+      "path": "tests/frame/indexing/test_xs.py",
+      "sha256": "ceb66b868653a27f30e041f6ff79b581d743c1273bd70cd12c034e05986e49c8",
+      "sizeBytes": 13520
+    },
+    {
+      "path": "tests/frame/methods/__init__.py",
+      "sha256": "33a7424b977be741737fd197ef1c8d91af92676c091422faeb2e63fa6a07870a",
+      "sizeBytes": 229
+    },
+    {
+      "path": "tests/frame/methods/test_add_prefix_suffix.py",
+      "sha256": "88f7f348fc74080af1efd9daef1708f5970f4c0c2aef721d3827111153bb9381",
+      "sizeBytes": 1910
+    },
+    {
+      "path": "tests/frame/methods/test_align.py",
+      "sha256": "97ab8fe523b1dfa0535f25e6547d5ad8183b99c6c4132a7b45a9fd577bdb8c61",
+      "sizeBytes": 12243
+    },
+    {
+      "path": "tests/frame/methods/test_asfreq.py",
+      "sha256": "d84044376f40bd50bfa00236b1fbc62f6349946e66c6926b9d7f2a81c9fcf168",
+      "sizeBytes": 10283
+    },
+    {
+      "path": "tests/frame/methods/test_asof.py",
+      "sha256": "2074f198141360422649c3aa96df1c009355854363b7a63f87298d2ecd032ef5",
+      "sizeBytes": 6248
+    },
+    {
+      "path": "tests/frame/methods/test_assign.py",
+      "sha256": "c451911332e13f5c23dcca3006299e61b31604d888234dbcd0388e5c8e960c1d",
+      "sizeBytes": 2982
+    },
+    {
+      "path": "tests/frame/methods/test_astype.py",
+      "sha256": "53506327646ca4be62ed2b32f393ea488f67b7abfab3b031d3c7b9782a83010a",
+      "sizeBytes": 32567
+    },
+    {
+      "path": "tests/frame/methods/test_at_time.py",
+      "sha256": "feb6b01f9c98e2ecf91c5602fd944fc308b1b9bd6cbec09e10cf34a287a48c05",
+      "sizeBytes": 5521
+    },
+    {
+      "path": "tests/frame/methods/test_between_time.py",
+      "sha256": "ac3fa4d5ae0b54e6be9cc94b5ce6993bb8936b784bfc2f6d821aadf03596d10b",
+      "sizeBytes": 8083
+    },
+    {
+      "path": "tests/frame/methods/test_clip.py",
+      "sha256": "8af4ae2393b45a11255dd96c415d74da85dbe55577a295017b7fc33c98ba5e09",
+      "sizeBytes": 7355
+    },
+    {
+      "path": "tests/frame/methods/test_combine.py",
+      "sha256": "8c90a15b082d6cf5809d40e5ae69fae2d045eb714ece6f9640544f62f71628f4",
+      "sizeBytes": 1759
+    },
+    {
+      "path": "tests/frame/methods/test_combine_first.py",
+      "sha256": "2db28953dc69d665783e5e51911ace6a98b83294461b76cd84d7437246a0e8a9",
+      "sizeBytes": 21491
+    },
+    {
+      "path": "tests/frame/methods/test_compare.py",
+      "sha256": "f19a10bfac6644a248dce92c48eef3a558d80bbc7ca89c629a303c5fc0034c7e",
+      "sizeBytes": 9526
+    },
+    {
+      "path": "tests/frame/methods/test_convert_dtypes.py",
+      "sha256": "2765531e7e272ef7ab1c09ebb9af5e34ed6e772b09b2595fc5a1f5857ac0d0c6",
+      "sizeBytes": 9793
+    },
+    {
+      "path": "tests/frame/methods/test_copy.py",
+      "sha256": "3a235801a97abfe5430bc27ab2650d697d3e4408bb61f0643a2e0fb2d997df20",
+      "sizeBytes": 1266
+    },
+    {
+      "path": "tests/frame/methods/test_count.py",
+      "sha256": "6afcc8bb5759de996ce1233a835ef733b4388bcccc533780548d84788cd60b47",
+      "sizeBytes": 1083
+    },
+    {
+      "path": "tests/frame/methods/test_cov_corr.py",
+      "sha256": "ebf6e5789ca55b0790906befc19a541852fe15a195f5c988930d854fd9771158",
+      "sizeBytes": 18910
+    },
+    {
+      "path": "tests/frame/methods/test_describe.py",
+      "sha256": "d185ca6150034c5025af5619cb124369ebbc099a6582ffc0f6da4064bed592eb",
+      "sizeBytes": 16010
+    },
+    {
+      "path": "tests/frame/methods/test_diff.py",
+      "sha256": "b472ce4c4518c76221c55cba85414ed2910aad7c2384999c4ee09e3598c8a61c",
+      "sizeBytes": 10218
+    },
+    {
+      "path": "tests/frame/methods/test_dot.py",
+      "sha256": "6064c7d7ba523469656fbb6b013f3bd1fef5aeab2727a698706d200a1d90b1b5",
+      "sizeBytes": 5116
+    },
+    {
+      "path": "tests/frame/methods/test_drop.py",
+      "sha256": "7447c72badc775667d2d63e32ac3262b4049afd2cbac66c4c1f275a4b6fa7088",
+      "sizeBytes": 20740
+    },
+    {
+      "path": "tests/frame/methods/test_drop_duplicates.py",
+      "sha256": "af73f678a8f5faa853fd95077d9d668b7d89a7b8095b6764077bf9fb22fb375b",
+      "sizeBytes": 15723
+    },
+    {
+      "path": "tests/frame/methods/test_droplevel.py",
+      "sha256": "2f58003236183c1e9e6264a9a577dbc0f54a6b71c23687ea3d5519de0c4b95d0",
+      "sizeBytes": 1253
+    },
+    {
+      "path": "tests/frame/methods/test_dropna.py",
+      "sha256": "407561ca4e9728bceb8d41185a8b841f945ed391edbcca8fb9175d8d9fd4c5eb",
+      "sizeBytes": 10331
+    },
+    {
+      "path": "tests/frame/methods/test_dtypes.py",
+      "sha256": "187509a25f567a11ce3e5c5d21e6dddb64299e16f6bf405cf975ace5d6f83c75",
+      "sizeBytes": 4672
+    },
+    {
+      "path": "tests/frame/methods/test_duplicated.py",
+      "sha256": "d43405b8ae0a8df4a9b25f16d235e77bc3cf52c2f59c57b7948ffd55805ddf72",
+      "sizeBytes": 3305
+    },
+    {
+      "path": "tests/frame/methods/test_equals.py",
+      "sha256": "2fac17febc4885b4ff48b8ae10b39075574f41a85a676e0e6cd0c0e8e9fe13f2",
+      "sizeBytes": 3407
+    },
+    {
+      "path": "tests/frame/methods/test_explode.py",
+      "sha256": "6f84390c01a679c3c4b115ccfdc3533cfc9e475197f3c3701c0a964454337174",
+      "sizeBytes": 8952
+    },
+    {
+      "path": "tests/frame/methods/test_fillna.py",
+      "sha256": "488738435b5d6511a64c209d003b178edd1d3d1d83ea76c378d57537b5fcf5dc",
+      "sizeBytes": 29085
+    },
+    {
+      "path": "tests/frame/methods/test_filter.py",
+      "sha256": "8568dcc63c43306b0dce666aa867a6ea1c7bc4ccd10e1846b3f47f624b86a70a",
+      "sizeBytes": 5373
+    },
+    {
+      "path": "tests/frame/methods/test_first_valid_index.py",
+      "sha256": "b6fc7273697f0485ec133905e76f08c1f6e5d8f4aa0eb030c6ba8bb47b174a5b",
+      "sizeBytes": 2575
+    },
+    {
+      "path": "tests/frame/methods/test_get_numeric_data.py",
+      "sha256": "46f61bd1e88129e27720e013826e4abcbb95adddc00f33d5398759e396ee0ca9",
+      "sizeBytes": 3379
+    },
+    {
+      "path": "tests/frame/methods/test_head_tail.py",
+      "sha256": "aaeb859294b9220a2724349bf7f3e8e1e3b75a2e7095c34aabbdb710c60be8db",
+      "sizeBytes": 1935
+    },
+    {
+      "path": "tests/frame/methods/test_infer_objects.py",
+      "sha256": "d6ec14380cf058b6a462e82ea5f7c6b9b0a68cb3083bbf74d103b61fa2542486",
+      "sizeBytes": 1241
+    },
+    {
+      "path": "tests/frame/methods/test_info.py",
+      "sha256": "503a6bdfc4843ef37035ba622773c1f4ba87f2c0282c9a5f7d293dc94c34838a",
+      "sizeBytes": 17773
+    },
+    {
+      "path": "tests/frame/methods/test_interpolate.py",
+      "sha256": "1c5c241515b33a1813d61fab57de48c1c916ac937d5afd31d7f15f478e728588",
+      "sizeBytes": 15299
+    },
+    {
+      "path": "tests/frame/methods/test_is_homogeneous_dtype.py",
+      "sha256": "7c24840f9b955a7cdcce99e808a822a924583b7abda45753468fe2ab57543e6f",
+      "sizeBytes": 1303
+    },
+    {
+      "path": "tests/frame/methods/test_isetitem.py",
+      "sha256": "568c40fb25e8c3f0918a4275b659e2d4fb0000e4f50f65fc3ed4d9c893864175",
+      "sizeBytes": 1428
+    },
+    {
+      "path": "tests/frame/methods/test_isin.py",
+      "sha256": "3f64d552c2ffa77eba692c7059cab6ed5953f7316cb4e5e5b09493165c369f6d",
+      "sizeBytes": 7599
+    },
+    {
+      "path": "tests/frame/methods/test_iterrows.py",
+      "sha256": "85f151036d2d458997240a0964b188d38275df567b41a6846c8366dc5c1f55b4",
+      "sizeBytes": 338
+    },
+    {
+      "path": "tests/frame/methods/test_join.py",
+      "sha256": "a4938f5ead4f8a15b20a1373e3840b319c0c668dfe2840db9d414ee3a5571664",
+      "sizeBytes": 18110
+    },
+    {
+      "path": "tests/frame/methods/test_map.py",
+      "sha256": "e49297253f1f218b3e925948d051e689042465502c833fedb8a844f925899cfe",
+      "sizeBytes": 5718
+    },
+    {
+      "path": "tests/frame/methods/test_matmul.py",
+      "sha256": "8b5046e354bd75ad91d27013bdcde4657b22c25e6de8c1c31486f4209e2501b4",
+      "sizeBytes": 3137
+    },
+    {
+      "path": "tests/frame/methods/test_nlargest.py",
+      "sha256": "6f65dcf2a8eb5ad3de43777b827bac376360c1704b10a9885c414e35264c0c6f",
+      "sizeBytes": 8058
+    },
+    {
+      "path": "tests/frame/methods/test_pct_change.py",
+      "sha256": "6832875c45cd5e8d9b1b669c041aaff7daadf9c3fa6c4df56433cba8cf6ded9e",
+      "sizeBytes": 3632
+    },
+    {
+      "path": "tests/frame/methods/test_pipe.py",
+      "sha256": "b6ce60864f20e8f6172a976c05da2f057c4f18edaaabbe45115cc18230157d1c",
+      "sizeBytes": 1023
+    },
+    {
+      "path": "tests/frame/methods/test_pop.py",
+      "sha256": "a5712ea27d5db362aeb7f2aaf2af8c5b4cc488267e440173006e201f2780fa9f",
+      "sizeBytes": 2143
+    },
+    {
+      "path": "tests/frame/methods/test_quantile.py",
+      "sha256": "30c1d69f857d96003ed4242ac4c2ce1e91dcb5307bff1cacfb047bbbe6752d61",
+      "sizeBytes": 33875
+    },
+    {
+      "path": "tests/frame/methods/test_rank.py",
+      "sha256": "a71291ce2383f05349075ae30714b220330b9946a6f9fdb5de0ef05d22f4c680",
+      "sizeBytes": 17407
+    },
+    {
+      "path": "tests/frame/methods/test_reindex.py",
+      "sha256": "8294688f666ff602497adbe1e31f6f3a5094e9cac71cf17026ca7f3d2ab82de6",
+      "sizeBytes": 47624
+    },
+    {
+      "path": "tests/frame/methods/test_reindex_like.py",
+      "sha256": "683b6452fe6ac2fca0fc46acee13ac03378693d027b126fcdc95c1b3649f7241",
+      "sizeBytes": 1351
+    },
+    {
+      "path": "tests/frame/methods/test_rename.py",
+      "sha256": "f6fa866f91c970769c0e0de698ad772c2473a7f29ff7c0f58e7a2d12a8347fa3",
+      "sizeBytes": 16329
+    },
+    {
+      "path": "tests/frame/methods/test_rename_axis.py",
+      "sha256": "c45295c603f731dbe0d43296f510e6fa242132e70e49502b246822a2406a2838",
+      "sizeBytes": 4539
+    },
+    {
+      "path": "tests/frame/methods/test_reorder_levels.py",
+      "sha256": "549544765b72468cfcf66411d57a7403dc8a953784148a6c3da29642e8d3f82f",
+      "sizeBytes": 2729
+    },
+    {
+      "path": "tests/frame/methods/test_replace.py",
+      "sha256": "7b5e721dcb0e4f2d8e6cd1e62ceed38e152b62fd7fd4044b95d15cc920b20cf8",
+      "sizeBytes": 57703
+    },
+    {
+      "path": "tests/frame/methods/test_reset_index.py",
+      "sha256": "8534388e460aa75581bef1f997d91c11055d93b88ac9d8c470f810789a7ee310",
+      "sizeBytes": 29136
+    },
+    {
+      "path": "tests/frame/methods/test_round.py",
+      "sha256": "24d12544747f81c895539141fde454d4aa764219c9faa1032db0c75f2adc8bbd",
+      "sizeBytes": 8268
+    },
+    {
+      "path": "tests/frame/methods/test_sample.py",
+      "sha256": "2fc5c5e544096e3b5a0dd02bb14737e4e50b7e48e1fdd9a14992a0e2097d7460",
+      "sizeBytes": 14228
+    },
+    {
+      "path": "tests/frame/methods/test_select_dtypes.py",
+      "sha256": "93a1289388b3782fbc23723d978cc3f6b737e3e631d78382b1e2fb0326bc904d",
+      "sizeBytes": 18889
+    },
+    {
+      "path": "tests/frame/methods/test_set_axis.py",
+      "sha256": "edc567a52ddf7d7480609923bdf87d96ee8447d59f673aba6e7a67995deff380",
+      "sizeBytes": 4118
+    },
+    {
+      "path": "tests/frame/methods/test_set_index.py",
+      "sha256": "44b114c289e26978d73bfcf80a4c98338b846419f9572a12dacb93be88a91a1f",
+      "sizeBytes": 26833
+    },
+    {
+      "path": "tests/frame/methods/test_shift.py",
+      "sha256": "ad778732d4780bba2aa7287071a591513d824549717b34ea3fed8abc49ac48a8",
+      "sizeBytes": 29601
+    },
+    {
+      "path": "tests/frame/methods/test_size.py",
+      "sha256": "cc5cd54af3a98c7900f7fb4407698f9dfabd3c9201b816b89428ba06f5db0431",
+      "sizeBytes": 571
+    },
+    {
+      "path": "tests/frame/methods/test_sort_index.py",
+      "sha256": "d89f6676ecb8dbb1fa7c8e408d5653a191833235e5650534e8e3c052f3311870",
+      "sizeBytes": 35057
+    },
+    {
+      "path": "tests/frame/methods/test_sort_values.py",
+      "sha256": "b7c480ae73aead8262197856d3566696990b7c82757c0bb88d6872d233affaa6",
+      "sizeBytes": 32000
+    },
+    {
+      "path": "tests/frame/methods/test_swaplevel.py",
+      "sha256": "63c9e9529210334952748c18edab8670b25a176d4939bf8a95553772f48bb0e8",
+      "sizeBytes": 1277
+    },
+    {
+      "path": "tests/frame/methods/test_to_csv.py",
+      "sha256": "133568fe3231f68dc5de67fa36a0787eedc2a8f6e75ae01590203a0de275abe5",
+      "sizeBytes": 52039
+    },
+    {
+      "path": "tests/frame/methods/test_to_dict.py",
+      "sha256": "0fb45b7770e214c0ea531be8ac0345f1bae21263180cefebcd59a12dc124271c",
+      "sizeBytes": 18815
+    },
+    {
+      "path": "tests/frame/methods/test_to_dict_of_blocks.py",
+      "sha256": "a1bb2c98f95a24dacf3fd1b5c922364adbf53f99a651f1e8dc9d8c017e66e5c1",
+      "sizeBytes": 1109
+    },
+    {
+      "path": "tests/frame/methods/test_to_numpy.py",
+      "sha256": "521b0b6b63ba041bb017cbce83bdce782730448dbce426389e3f77d5f7172ecf",
+      "sizeBytes": 2782
+    },
+    {
+      "path": "tests/frame/methods/test_to_period.py",
+      "sha256": "5e279b8b7200fef50aac535fb4b064845e0dd2031ba48efa642429aa180ee225",
+      "sizeBytes": 2863
+    },
+    {
+      "path": "tests/frame/methods/test_to_records.py",
+      "sha256": "c5f6eaa62d736dd385b692cf4010e6ce6f727d1dcf7be5a24fb21bb1a494d773",
+      "sizeBytes": 18597
+    },
+    {
+      "path": "tests/frame/methods/test_to_timestamp.py",
+      "sha256": "96074bc6410bacab7224c6ccd028693116bb027c3b32710dab577aa7b402ac88",
+      "sizeBytes": 5866
+    },
+    {
+      "path": "tests/frame/methods/test_transpose.py",
+      "sha256": "ea911e81e2a3b416e22c42a35b4be1318f54a42df84942ea18b91dd0373f47c8",
+      "sizeBytes": 6438
+    },
+    {
+      "path": "tests/frame/methods/test_truncate.py",
+      "sha256": "8f432c295b7d8e87c8bc3c1fb85468a153459d7f272997b5132a9080e53c9b5e",
+      "sizeBytes": 5216
+    },
+    {
+      "path": "tests/frame/methods/test_tz_convert.py",
+      "sha256": "391d3b4f052134dc4104329b69469c87d328a86733e4e06dd2ec04e5a47e6e10",
+      "sizeBytes": 4984
+    },
+    {
+      "path": "tests/frame/methods/test_tz_localize.py",
+      "sha256": "ccb4a7dbc67e877eb649c9501399679d1f4b51f77bdb65ac33e32a2c3dbd3641",
+      "sizeBytes": 2015
+    },
+    {
+      "path": "tests/frame/methods/test_update.py",
+      "sha256": "01095b73b2fd363d50b48a40674d00c4ac16fde5797d763ffade39553e638bd0",
+      "sizeBytes": 8642
+    },
+    {
+      "path": "tests/frame/methods/test_value_counts.py",
+      "sha256": "ae9c42d44682432ad03c43a64c8617a53c6df2802f852fbd9e8e0aa68a8b9c4d",
+      "sizeBytes": 5556
+    },
+    {
+      "path": "tests/frame/methods/test_values.py",
+      "sha256": "af0e4c3ff2ecf48cf6d7085792c339d4b31b03e61e4a76e6413ea93056025266",
+      "sizeBytes": 8722
+    },
+    {
+      "path": "tests/frame/test_alter_axes.py",
+      "sha256": "49e1b6bcfa1c27f975da30848ebf76d160648fbd75496e41caf9c627e89aeb22",
+      "sizeBytes": 887
+    },
+    {
+      "path": "tests/frame/test_api.py",
+      "sha256": "7ca88f3a6cd05d8cd436da537e41d40d9065a3c5d66e5bfab7ed1e691245850d",
+      "sizeBytes": 13088
+    },
+    {
+      "path": "tests/frame/test_arithmetic.py",
+      "sha256": "06cccd6bd13fdb8dd56a8ee129ca36202d0d7fbf07f604db962f041bbabb6e66",
+      "sizeBytes": 75915
+    },
+    {
+      "path": "tests/frame/test_arrow_interface.py",
+      "sha256": "48a9a3e605c8dd1887279e3397c2248c3bd2803b847e4fa1bf2dac98a0decc61",
+      "sizeBytes": 3094
+    },
+    {
+      "path": "tests/frame/test_block_internals.py",
+      "sha256": "7087a35f1e93c311295194e5011cb24be6e3815e0cd916c86314dc111e2134fe",
+      "sizeBytes": 16514
+    },
+    {
+      "path": "tests/frame/test_constructors.py",
+      "sha256": "711cb91ec3c4b62b84552c8ee6e72ba02099f08924764dee2dcf44d439272800",
+      "sizeBytes": 124423
+    },
+    {
+      "path": "tests/frame/test_cumulative.py",
+      "sha256": "a3cc01df0dea678667b9d7ed47d636855c2f5b93c300eee84d22939eebe02954",
+      "sizeBytes": 3278
+    },
+    {
+      "path": "tests/frame/test_iteration.py",
+      "sha256": "06ec96e9078fc6835997e0a0c69e562da87f7be9122b686c37c1ae77f8346a87",
+      "sizeBytes": 5077
+    },
+    {
+      "path": "tests/frame/test_logical_ops.py",
+      "sha256": "c98c6ffda7cce4d03826eafb41aea298e039689555042b127fe660b9ca895182",
+      "sizeBytes": 7066
+    },
+    {
+      "path": "tests/frame/test_nonunique_indexes.py",
+      "sha256": "0d6d1c5718d4af92c7a1463484e54c026cc06cabae70fce80fb98270c42f8c89",
+      "sizeBytes": 11872
+    },
+    {
+      "path": "tests/frame/test_npfuncs.py",
+      "sha256": "d639b117acc72e9150410913832a5be2bad9f0f34f72d314ecf8257f5789d8c4",
+      "sizeBytes": 2477
+    },
+    {
+      "path": "tests/frame/test_query_eval.py",
+      "sha256": "bac9e0fca7fe2610440c612d826dbe985c120f7a79dfd67d7debd6f9c5d12f3f",
+      "sizeBytes": 62027
+    },
+    {
+      "path": "tests/frame/test_reductions.py",
+      "sha256": "8ba73e3e6be185cb05f14ef2113ea0ae335d51e15f645aa8dcc4dac1fa11397b",
+      "sizeBytes": 79781
+    },
+    {
+      "path": "tests/frame/test_repr.py",
+      "sha256": "30af03ea29a444392248e6c1f6fa981f215f3c61d6295cbe9e5994c150ec2a88",
+      "sizeBytes": 15930
+    },
+    {
+      "path": "tests/frame/test_stack_unstack.py",
+      "sha256": "dc74ed8dbd37c87eaa2016478c7d4d593cac2b310827e896776c2323849c06e3",
+      "sizeBytes": 100501
+    },
+    {
+      "path": "tests/frame/test_subclass.py",
+      "sha256": "87b0a1ef7a6b9fd86ebf7b3e9214bb2655c7100b5023d56359582004eb8d2240",
+      "sizeBytes": 27401
+    },
+    {
+      "path": "tests/frame/test_ufunc.py",
+      "sha256": "41777cf9dafcb5f444cbac27a15b4cc9580e77b4a24c9b086d226279f5d9aa37",
+      "sizeBytes": 10580
+    },
+    {
+      "path": "tests/frame/test_unary.py",
+      "sha256": "4092841ad305cdb68007251ebc459c55bcd4a59706ff5edbce90d86c9581fdb0",
+      "sizeBytes": 5744
+    },
+    {
+      "path": "tests/frame/test_validate.py",
+      "sha256": "c08e37abfcc4002f0c38a9698038e79b85b73a920c06c5565282368fe4c947fd",
+      "sizeBytes": 1057
+    },
+    {
+      "path": "tests/generic/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/generic/test_duplicate_labels.py",
+      "sha256": "c1be026a6ec83d1cb1adb324f114192bfadbcaf49e7fccd6eb599f53c3069ed7",
+      "sizeBytes": 13611
+    },
+    {
+      "path": "tests/generic/test_finalize.py",
+      "sha256": "0224a0caee34fc9185de5f38d43dad4684b7ca5a07a599abf31484e3d96712ce",
+      "sizeBytes": 28550
+    },
+    {
+      "path": "tests/generic/test_frame.py",
+      "sha256": "e96081307636b9766418dfcb50edb4603ec4c6f1e0fa2939c13e6ce9d59f0532",
+      "sizeBytes": 6966
+    },
+    {
+      "path": "tests/generic/test_generic.py",
+      "sha256": "cbc5383e8e1545537baedca85a6c62a487d3bea6942bb56e5e0c7479dd2f188d",
+      "sizeBytes": 17027
+    },
+    {
+      "path": "tests/generic/test_label_or_level_utils.py",
+      "sha256": "4ccd4c89975d777122308baefa16cde27d673e89dbc61ab42156c6c9ddfecfe3",
+      "sizeBytes": 10122
+    },
+    {
+      "path": "tests/generic/test_series.py",
+      "sha256": "981a2e86e3fb821eeb223c260726921886bd314dad34b3e8bb5f51811ab6303d",
+      "sizeBytes": 3994
+    },
+    {
+      "path": "tests/generic/test_to_xarray.py",
+      "sha256": "5d420442d82aaf8345bd12e88bc29393e5a61b0dc87fb8905bf92e0a0456e1b8",
+      "sizeBytes": 4515
+    },
+    {
+      "path": "tests/groupby/__init__.py",
+      "sha256": "cc7105340089ace7bf82ae8401b46fdfe7d0c1d4cc047c71e4c4e4ee53afae4a",
+      "sizeBytes": 639
+    },
+    {
+      "path": "tests/groupby/aggregate/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/groupby/aggregate/test_aggregate.py",
+      "sha256": "053ff84f3574bf8186ccc64969a00fa0724a84bb06198b0c08c2ac7ed2026553",
+      "sizeBytes": 64608
+    },
+    {
+      "path": "tests/groupby/aggregate/test_cython.py",
+      "sha256": "7d37abbc328fe7d8ca944807c8a5367f3e9ed0de24fb82cdfb382b95191fdd68",
+      "sizeBytes": 11913
+    },
+    {
+      "path": "tests/groupby/aggregate/test_numba.py",
+      "sha256": "435307c58d0133cc9e5c67524cc96517f1eaf9d5abc2c9a80e6862f77476c498",
+      "sizeBytes": 14930
+    },
+    {
+      "path": "tests/groupby/aggregate/test_other.py",
+      "sha256": "f8d85caa3917975f6330ab411acf9d10c648708dd22baae962aa1695ff1a9a40",
+      "sizeBytes": 19899
+    },
+    {
+      "path": "tests/groupby/conftest.py",
+      "sha256": "f086fbafb820191e9ba0fc836d649d2e8528f299fdadb410250d038a1dfb1a43",
+      "sizeBytes": 3893
+    },
+    {
+      "path": "tests/groupby/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/groupby/methods/test_describe.py",
+      "sha256": "1ef8f30d108b1bf73d2944e7bbb279bd65743e98f1178b06a821a0bdbb9ebfae",
+      "sizeBytes": 8851
+    },
+    {
+      "path": "tests/groupby/methods/test_groupby_shift_diff.py",
+      "sha256": "6d95df3c6f9afc73db338d7af5a64c2be48f50803fd3c9bb5c078859bc9e9dab",
+      "sizeBytes": 8366
+    },
+    {
+      "path": "tests/groupby/methods/test_is_monotonic.py",
+      "sha256": "3a99e539a991e605f54bb315b59146c676edd457a6ff0587d48adce5aaa476ae",
+      "sizeBytes": 2566
+    },
+    {
+      "path": "tests/groupby/methods/test_kurt.py",
+      "sha256": "11fc78cf3e31b695f7b261bebbdf10430ba35e48a76a009132ba5ff7cf2beb5e",
+      "sizeBytes": 2391
+    },
+    {
+      "path": "tests/groupby/methods/test_nlargest_nsmallest.py",
+      "sha256": "28fd4d75cb185c5259d3b75e5b74e48a4a46936005f801767df7e98bb4ffb78d",
+      "sizeBytes": 3363
+    },
+    {
+      "path": "tests/groupby/methods/test_nth.py",
+      "sha256": "4bb79c7508307b29de02bfe69d34f32a5585539f49ea188778f26240bf98e056",
+      "sizeBytes": 25872
+    },
+    {
+      "path": "tests/groupby/methods/test_quantile.py",
+      "sha256": "fa179ee498a30b9c7782709a2a6d9edc0b6acf71cac01d0288d8ae2b139a6083",
+      "sizeBytes": 15402
+    },
+    {
+      "path": "tests/groupby/methods/test_rank.py",
+      "sha256": "0db9146d3fb8618d4a8ad405c2e2973919dc0319b1eaf29bf926f3d36f9b734b",
+      "sizeBytes": 21504
+    },
+    {
+      "path": "tests/groupby/methods/test_sample.py",
+      "sha256": "9ff74b61b950a3d3169e99e031120818b64518418e7807c4aac2fd73d80b08a8",
+      "sizeBytes": 5155
+    },
+    {
+      "path": "tests/groupby/methods/test_size.py",
+      "sha256": "cac7e30538ba76546cafe0af12b9d2e1b6b7a5641aefc8cfaad1ffd6c44becc7",
+      "sizeBytes": 3011
+    },
+    {
+      "path": "tests/groupby/methods/test_skew.py",
+      "sha256": "fc54e59d7b44fdf89ce99677db64b9f37217518e611108208bedd76ee6e86a1c",
+      "sizeBytes": 841
+    },
+    {
+      "path": "tests/groupby/methods/test_value_counts.py",
+      "sha256": "cde01aad9d747c746865aa4f672ed9669ce26a8157836f26dc33cc0ed8bc652f",
+      "sizeBytes": 39563
+    },
+    {
+      "path": "tests/groupby/test_all_methods.py",
+      "sha256": "6671369f40c0f6a92e38094930c7dd4a7d034d78123c9316cb8e40e5979f0ead",
+      "sizeBytes": 3564
+    },
+    {
+      "path": "tests/groupby/test_api.py",
+      "sha256": "1101c3e0809f9cdc9ba62da253cca5dbd164201af0c55918bab11af999f3ce32",
+      "sizeBytes": 8554
+    },
+    {
+      "path": "tests/groupby/test_apply.py",
+      "sha256": "00ba5aefbc297018b05395f101d6588cb5f0c34484931f8bcec37162199d286e",
+      "sizeBytes": 46178
+    },
+    {
+      "path": "tests/groupby/test_bin_groupby.py",
+      "sha256": "c27e782640fdd3a77e6cb3e2bb4c7091a0d53dfc1c6e6fe6fc377b66d5b82f8d",
+      "sizeBytes": 1553
+    },
+    {
+      "path": "tests/groupby/test_categorical.py",
+      "sha256": "353e451d0da829509c70895300f43a9b6d68f89ae72b24b50cc387a76e64bc26",
+      "sizeBytes": 73638
+    },
+    {
+      "path": "tests/groupby/test_counting.py",
+      "sha256": "35d5e6651f2f8b77b63e4c768ca60a56b89b9501cdea1eed8d819aed5b32ab46",
+      "sizeBytes": 13495
+    },
+    {
+      "path": "tests/groupby/test_cumulative.py",
+      "sha256": "739578b3d7d98c87b485812b5d7fca4a68fa010f47566b48dd05cd8c79035e1f",
+      "sizeBytes": 10997
+    },
+    {
+      "path": "tests/groupby/test_filters.py",
+      "sha256": "ac691d20a5e735b875a25b2b4dae508e5ad946da8579b1e58db5e40c36944a38",
+      "sizeBytes": 21270
+    },
+    {
+      "path": "tests/groupby/test_groupby.py",
+      "sha256": "8dd2dc2ad9386c42f09c48d3251f14885fc2b3a8c5e066279ffeb306c1664de6",
+      "sizeBytes": 95083
+    },
+    {
+      "path": "tests/groupby/test_groupby_dropna.py",
+      "sha256": "8ebd2efa9248f889d2967d1fca120ccdf8851d09145483b54670bc34e3dddeb7",
+      "sizeBytes": 22715
+    },
+    {
+      "path": "tests/groupby/test_groupby_subclass.py",
+      "sha256": "74f4f338bd7fd06b55c6e946ad87ef652c645a58f261436e86b4cbf943fc1488",
+      "sizeBytes": 5188
+    },
+    {
+      "path": "tests/groupby/test_grouping.py",
+      "sha256": "835d4c5380322360fcb4ddc48ffa073f099e71d7f1dde8ddfaff6797fe45cbd0",
+      "sizeBytes": 44362
+    },
+    {
+      "path": "tests/groupby/test_index_as_string.py",
+      "sha256": "40ce727b495cf4632b74dc1d7c5fbc100c1ba629623693da815d400b5466a18a",
+      "sizeBytes": 2162
+    },
+    {
+      "path": "tests/groupby/test_indexing.py",
+      "sha256": "729dd61d2f6d90616c69e22a2fd9c0374babdfafb6c015e2bea19dc03fab9afb",
+      "sizeBytes": 8970
+    },
+    {
+      "path": "tests/groupby/test_libgroupby.py",
+      "sha256": "cc6a1352a09a9278334bc3dd2ae681026cdc88b51edc7f8e1df3bb309f0f7db3",
+      "sizeBytes": 11156
+    },
+    {
+      "path": "tests/groupby/test_missing.py",
+      "sha256": "7d95c21e182ba6a79f19ee0ad37fc226f1c836c53fe3a7eaa91709f56cf637ee",
+      "sizeBytes": 3234
+    },
+    {
+      "path": "tests/groupby/test_numba.py",
+      "sha256": "79c50da52786be2df719e623f1966b2fa32c5b3adca4404e31e93d7a96858124",
+      "sizeBytes": 3205
+    },
+    {
+      "path": "tests/groupby/test_numeric_only.py",
+      "sha256": "a057974fff46fa5847fb94a86f912f50ad754a78e92f5110143bbb7d507ad829",
+      "sizeBytes": 15298
+    },
+    {
+      "path": "tests/groupby/test_pipe.py",
+      "sha256": "3ff9f7c57bef7be9698f1af52bcd1db77728f164eaa2f8dfb1eb651b68aaacec",
+      "sizeBytes": 2082
+    },
+    {
+      "path": "tests/groupby/test_raises.py",
+      "sha256": "f3202226d0a2d81e9f07571b92f140823a52d99be3e514836bc37ccd2065b481",
+      "sizeBytes": 23159
+    },
+    {
+      "path": "tests/groupby/test_reductions.py",
+      "sha256": "6ec6e4ad814e9bd290e3715aa2a09704a8a8137a100699348d6ff55e763f6d96",
+      "sizeBytes": 49320
+    },
+    {
+      "path": "tests/groupby/test_timegrouper.py",
+      "sha256": "03a981963c645412b3e83ee88407281bf4f15d1fc82e10dde3966cc3241a3672",
+      "sizeBytes": 35157
+    },
+    {
+      "path": "tests/groupby/transform/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/groupby/transform/test_numba.py",
+      "sha256": "709221b5bfe43dc3db2086c229031e256b0046be7bedd4fabaad9ef074a77b69",
+      "sizeBytes": 11454
+    },
+    {
+      "path": "tests/groupby/transform/test_transform.py",
+      "sha256": "a0255f6591364dc76db3f361fb9a0365c35f3d1d8100c6632569a472b34112ec",
+      "sizeBytes": 51735
+    },
+    {
+      "path": "tests/indexes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/base_class/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/base_class/test_constructors.py",
+      "sha256": "4e263d87878e6f47a1ed0554551ec6e4e5f2a82d756901766379252f2802b0aa",
+      "sizeBytes": 2397
+    },
+    {
+      "path": "tests/indexes/base_class/test_formats.py",
+      "sha256": "416ff5199d420e0f560947e1851bd00400ee2081ca40a7fe258d6a19cf7dc4d2",
+      "sizeBytes": 5862
+    },
+    {
+      "path": "tests/indexes/base_class/test_indexing.py",
+      "sha256": "d736c11effa724221f5d189c0cf5cfb722c12f7232f8bbc7e5b91a9a7a051ab2",
+      "sizeBytes": 3687
+    },
+    {
+      "path": "tests/indexes/base_class/test_pickle.py",
+      "sha256": "db9244df26e423bc6c70f449a4767b82a27a8662d4505f6a71e1c22023eecd53",
+      "sizeBytes": 329
+    },
+    {
+      "path": "tests/indexes/base_class/test_reshape.py",
+      "sha256": "468f5fdeeb64973a3d116f9e2b8545cf9bd947b169fc7f16effad690936d55d8",
+      "sizeBytes": 3138
+    },
+    {
+      "path": "tests/indexes/base_class/test_setops.py",
+      "sha256": "ebe2aa2e3ba4b5ae11e12ece397e7cd529566d6f7e81626aece9dd12eb03e0bf",
+      "sizeBytes": 9131
+    },
+    {
+      "path": "tests/indexes/base_class/test_where.py",
+      "sha256": "baaee807e964eebb206107abf2a794b2a0f9692102b513d21147cace7f750621",
+      "sizeBytes": 341
+    },
+    {
+      "path": "tests/indexes/categorical/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/categorical/test_append.py",
+      "sha256": "b4bc9511b2f30887145e4616ea81f0f02833306aa9f2e54a06948c42c2b43d1c",
+      "sizeBytes": 2245
+    },
+    {
+      "path": "tests/indexes/categorical/test_astype.py",
+      "sha256": "492972043f9fcbf6698a533cec7654ea541963f4e5f4e94a4f1057dc3c2814e0",
+      "sizeBytes": 3124
+    },
+    {
+      "path": "tests/indexes/categorical/test_category.py",
+      "sha256": "b56db31cc319c325d62f35a9ef5b9754981341b54506b4fe104a640be58cead1",
+      "sizeBytes": 15160
+    },
+    {
+      "path": "tests/indexes/categorical/test_constructors.py",
+      "sha256": "2f1d357913764ab04aa34870388d282ccd3d69091fc21302444d6003d7344fd7",
+      "sizeBytes": 5952
+    },
+    {
+      "path": "tests/indexes/categorical/test_equals.py",
+      "sha256": "17ba6add5f722d3ac0626f4b15dc4d43f2a5ea23ec6725762b505781cf12645f",
+      "sizeBytes": 3570
+    },
+    {
+      "path": "tests/indexes/categorical/test_fillna.py",
+      "sha256": "b07ebc69609a6c8daacb975b8314025de4dfbe7d4d4200df335393e288c599a5",
+      "sizeBytes": 1850
+    },
+    {
+      "path": "tests/indexes/categorical/test_formats.py",
+      "sha256": "f9cedbf57961792d0b022cf9bd54cd7e95c8b1fcab8bfa1f81fe7f3ed8b24502",
+      "sizeBytes": 6601
+    },
+    {
+      "path": "tests/indexes/categorical/test_indexing.py",
+      "sha256": "dbf86aae9589d51c8b4fb170da8968e7f4f663519deaac1d76e4f11c65277535",
+      "sizeBytes": 14984
+    },
+    {
+      "path": "tests/indexes/categorical/test_map.py",
+      "sha256": "547b121465840668102efbeab82ebecb7403ab7970cd2a6a3d66474cb886773c",
+      "sizeBytes": 4664
+    },
+    {
+      "path": "tests/indexes/categorical/test_reindex.py",
+      "sha256": "bcf095f4ee7cdafc49a6e6ea0a6df750771a38a319360f0e3330c5de54100e23",
+      "sizeBytes": 2938
+    },
+    {
+      "path": "tests/indexes/categorical/test_setops.py",
+      "sha256": "62206840ddc3a2bda9df61c2502a255886411fadb41f568f6b879ab00e453207",
+      "sizeBytes": 462
+    },
+    {
+      "path": "tests/indexes/conftest.py",
+      "sha256": "a3c5782e9565642c5567e60cfa9a4eadb0142f4082c7158e8264372211123350",
+      "sizeBytes": 959
+    },
+    {
+      "path": "tests/indexes/datetimelike_/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_drop_duplicates.py",
+      "sha256": "e018f1e48cf8c0b37e4863a51da50d5bc82aad9be874eb5bb186eec3a206c1fd",
+      "sizeBytes": 2999
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_equals.py",
+      "sha256": "0fe95c17ed4052e1e7f2da092f8ce15d74b3dfec00b9f903024ee9b2fb89bda4",
+      "sizeBytes": 6582
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_indexing.py",
+      "sha256": "4284d76c28aa8cae2d0431d46ead5328fa7436ba1891e85e16346af95c65b0fd",
+      "sizeBytes": 1310
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_is_monotonic.py",
+      "sha256": "ff93d717b9958a5bb54b8109bfb17e5cc608a33e3490191d4ace1127c8d355d2",
+      "sizeBytes": 1522
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_nat.py",
+      "sha256": "8205f75fa1f00236292b7cf8cedb463d09f6d0e53c9adaf91517224ff80232e4",
+      "sizeBytes": 1040
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_sort_values.py",
+      "sha256": "aad88d8455396cda53c14d7c540a1278f979803460bc1d21b76174f82e896e6d",
+      "sizeBytes": 11258
+    },
+    {
+      "path": "tests/indexes/datetimelike_/test_value_counts.py",
+      "sha256": "a34f7403d42e8666a12631f45a02812315dd055c4f90073cbe2917a992eea03e",
+      "sizeBytes": 3150
+    },
+    {
+      "path": "tests/indexes/datetimes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_asof.py",
+      "sha256": "17d880ca69faaf411f002290fb009eca0ea4af5eadce121c86be3244f29330b5",
+      "sizeBytes": 1155
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_astype.py",
+      "sha256": "f82835363d999ae09700b09b12cdf640572d5042bead0873d0d80e5e4faf64fa",
+      "sizeBytes": 12429
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_delete.py",
+      "sha256": "25a6870f062e4daae4b5add07767dbb5e65df64d283b326c5823c41d41c71b89",
+      "sizeBytes": 4441
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_factorize.py",
+      "sha256": "3227f4f6071f45f20edae842a8d37d382fcd5e080a8b36eec1acfa49c1b33141",
+      "sizeBytes": 4468
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_fillna.py",
+      "sha256": "7844a755343c2778812f6e1b58ab7b4e61f10b914988b64ca4a8f0d55dfbeaa6",
+      "sizeBytes": 2004
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_insert.py",
+      "sha256": "4a114010fea304775b9f6e93da6e1edd27311ea081d4ba49e0b15cea779bf2e8",
+      "sizeBytes": 9625
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_isocalendar.py",
+      "sha256": "244001226e8b3724826d252ae872d2fbfa9318adc78157127125cba43b2b27ca",
+      "sizeBytes": 908
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_map.py",
+      "sha256": "d4947695bff393ff1a22046a9ee5877de5d13d906c16d753e2d4577930cdaac4",
+      "sizeBytes": 1358
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_normalize.py",
+      "sha256": "72470e9b4ac5a7b38191b25f5c6d4559a228e585dc7aa071ea427cc6fb5ab0c2",
+      "sizeBytes": 3181
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_repeat.py",
+      "sha256": "18dfb04d6c2cdac8e874d89b72d64e8bf3435fce72dfa2ebd8106602cdcb2cc3",
+      "sizeBytes": 2740
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_resolution.py",
+      "sha256": "95220922ba51420d10730054a04bdc41527cabb5550551258086682ef8143124",
+      "sizeBytes": 883
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_round.py",
+      "sha256": "6cd2ea81f2331b266ab8eb656936448e762ce522ebbf579d1f42c0cdea61b763",
+      "sizeBytes": 7846
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_shift.py",
+      "sha256": "80a6e5bec39ed53e32d47e82d88d1941f208ba2ce9d2189f4e5ae3f0dce35f0b",
+      "sizeBytes": 6188
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_snap.py",
+      "sha256": "b841c496e7ba6d12861834f6188bc398343d99f4a3d2150877b079a7163a7fc4",
+      "sizeBytes": 1729
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_to_frame.py",
+      "sha256": "0ba825c867714acfa1303412b7d8e47ed99195318f30219d21095f0a147d8869",
+      "sizeBytes": 998
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_to_julian_date.py",
+      "sha256": "bba24b61acc82c8765b5b7b5b9913788102a13f8b15f0c74a2ac12e93f8ca678",
+      "sizeBytes": 1608
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_to_period.py",
+      "sha256": "f8857379923df1472b8e5f3c7e33293616350310e5cbb3c19cde92e0c4f6d7cc",
+      "sizeBytes": 7782
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_to_pydatetime.py",
+      "sha256": "b0cdb66f7dc2c70ae97399d2840a79407d8a40f3a51298b977c1ba7ccdef548f",
+      "sizeBytes": 1345
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_to_series.py",
+      "sha256": "2e39eadce3c4189be3f214e4b4961500de91d4755ab2aebe5a2ede51c7bb5c1e",
+      "sizeBytes": 495
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_tz_convert.py",
+      "sha256": "095258ae9a52485819e5f4acaa7906ac1e670bcfeb5bdb5edeb2006042882a66",
+      "sizeBytes": 11704
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_tz_localize.py",
+      "sha256": "51a6c2f6bf2e04d7a0e6000f3df30dd53d71be0a94f87d6ec24810953d415152",
+      "sizeBytes": 14251
+    },
+    {
+      "path": "tests/indexes/datetimes/methods/test_unique.py",
+      "sha256": "a99a2b00f23fa16733e5674112bd2742e4ff9ab0294e04a1aa0dc9565ce954a5",
+      "sizeBytes": 2096
+    },
+    {
+      "path": "tests/indexes/datetimes/test_arithmetic.py",
+      "sha256": "2e619e2da3699bae3944462f25cad2880bb784d569b1852fedbcbcfdd2284e0d",
+      "sizeBytes": 2565
+    },
+    {
+      "path": "tests/indexes/datetimes/test_constructors.py",
+      "sha256": "cd3b53d684c7251b01f288ca19cd97d12a2a34281396d8523453272b1d349e07",
+      "sizeBytes": 44095
+    },
+    {
+      "path": "tests/indexes/datetimes/test_date_range.py",
+      "sha256": "2273b7306e25f933d80af67f98fa9f684eaf702e6ec9fc8493d71a9bc432af29",
+      "sizeBytes": 66657
+    },
+    {
+      "path": "tests/indexes/datetimes/test_datetime.py",
+      "sha256": "7e501e3796d878917149d1209c1e9904edf5b3ff3044dc8a1f3c3b4dc8110cad",
+      "sizeBytes": 5378
+    },
+    {
+      "path": "tests/indexes/datetimes/test_formats.py",
+      "sha256": "d54d53855f54f009cc7567d375fdb2c8e39a76d0fe5951637079f3e0f966c1fe",
+      "sizeBytes": 9859
+    },
+    {
+      "path": "tests/indexes/datetimes/test_freq_attr.py",
+      "sha256": "a17fdcc1e4dca4a776ef2c0df7be8a098a60d2815eefb31e0d6aa7449430551a",
+      "sizeBytes": 1732
+    },
+    {
+      "path": "tests/indexes/datetimes/test_indexing.py",
+      "sha256": "3134eabe82878aacfe280befd27e882690907b439e6d88b83d953eefb4dd33e6",
+      "sizeBytes": 27587
+    },
+    {
+      "path": "tests/indexes/datetimes/test_iter.py",
+      "sha256": "72040ed30fc6a02ac7c8ad9a1f25ae25dac7907e843d601343435446b1b609b1",
+      "sizeBytes": 2590
+    },
+    {
+      "path": "tests/indexes/datetimes/test_join.py",
+      "sha256": "985c53bc738d620e042d702b143068fea3cedbfec93b9368216818702483b51c",
+      "sizeBytes": 4915
+    },
+    {
+      "path": "tests/indexes/datetimes/test_npfuncs.py",
+      "sha256": "6098a1672b6cb3e315369ae9e29e6900bfde99e0b9a5bde1070b5a4b7c8c09c5",
+      "sizeBytes": 384
+    },
+    {
+      "path": "tests/indexes/datetimes/test_ops.py",
+      "sha256": "bbbc7a77a4a400c308823db08e7627d01a1c1f23263e01c44f8053e9bfde2bd9",
+      "sizeBytes": 1351
+    },
+    {
+      "path": "tests/indexes/datetimes/test_partial_slicing.py",
+      "sha256": "03768ca2f8aa4aa288cb8d650c8939cfae8cea3e409cf6301693d0bcc0c66612",
+      "sizeBytes": 16489
+    },
+    {
+      "path": "tests/indexes/datetimes/test_pickle.py",
+      "sha256": "2b66a59ac3b400acf35470fd092d632a7edeb6d34b9ea9173758b290525e3629",
+      "sizeBytes": 1468
+    },
+    {
+      "path": "tests/indexes/datetimes/test_reindex.py",
+      "sha256": "dacda50d59af8c651eab7ea3de2fe461d45590c8bb15a8b04a7de795d9f883d0",
+      "sizeBytes": 2178
+    },
+    {
+      "path": "tests/indexes/datetimes/test_scalar_compat.py",
+      "sha256": "31d50ce3b3a8535417e416fafdba6e3b270ea11b74914a7d530678ab0fca52e9",
+      "sizeBytes": 16357
+    },
+    {
+      "path": "tests/indexes/datetimes/test_setops.py",
+      "sha256": "1c01ed5d4d7ab909a680d3f0337e7a595dfdd443223d4f6dd871d747ff56cda2",
+      "sizeBytes": 28054
+    },
+    {
+      "path": "tests/indexes/datetimes/test_timezones.py",
+      "sha256": "7210d934ffd9c407354a5140766c4352f5d447da2dfce8e2d12c2abb6808e771",
+      "sizeBytes": 8076
+    },
+    {
+      "path": "tests/indexes/interval/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/interval/test_astype.py",
+      "sha256": "fcc5d4bc93b957724b00dceedcadd677cbd331285350d308d78e3e1900718c86",
+      "sizeBytes": 9335
+    },
+    {
+      "path": "tests/indexes/interval/test_constructors.py",
+      "sha256": "a3be876f2739471b9d619dbc2627bd54bbb80cee64ebd4bb3247b851957764cb",
+      "sizeBytes": 19915
+    },
+    {
+      "path": "tests/indexes/interval/test_equals.py",
+      "sha256": "6bb180ff084b6ce892e16c5476d0eba8a39486c7eaab74cbd27921a8f71cbacb",
+      "sizeBytes": 1226
+    },
+    {
+      "path": "tests/indexes/interval/test_formats.py",
+      "sha256": "86dcf95b0bfbf3fdd436310570934965d8230647f032f43bea598ece9d315b1e",
+      "sizeBytes": 3773
+    },
+    {
+      "path": "tests/indexes/interval/test_indexing.py",
+      "sha256": "01e9740ba50be7658adfefd21b4f50a288631e0b284b38017ff9e45ece353461",
+      "sizeBytes": 26022
+    },
+    {
+      "path": "tests/indexes/interval/test_interval.py",
+      "sha256": "0752da7eef42897c94d2e9720fbb10965d8306c9ecf283788e13c4cbfae3d571",
+      "sizeBytes": 34876
+    },
+    {
+      "path": "tests/indexes/interval/test_interval_range.py",
+      "sha256": "b3c5c4597f3edb7695c09b4dadb9b71a8bbc258940d5f265e7ad682e5049efc1",
+      "sizeBytes": 14507
+    },
+    {
+      "path": "tests/indexes/interval/test_interval_tree.py",
+      "sha256": "25b2dcefa92ffaf076b7ba3d6d91bdb0c4ace80d80afc9bb18499665433d8f5f",
+      "sizeBytes": 7595
+    },
+    {
+      "path": "tests/indexes/interval/test_join.py",
+      "sha256": "1d02502d2f7e453edd7ba9c11ecc39d25068e1aac199711566154cb788ae1f28",
+      "sizeBytes": 1148
+    },
+    {
+      "path": "tests/indexes/interval/test_pickle.py",
+      "sha256": "71a286dea3954df65a53f1d94750220a8a56d5de995062e3d7dbe340187def9f",
+      "sizeBytes": 376
+    },
+    {
+      "path": "tests/indexes/interval/test_setops.py",
+      "sha256": "9f0073d4c1ee1e233b25073be30d9da04a604d2c20dcd61f1b019b4055d62b0f",
+      "sizeBytes": 8346
+    },
+    {
+      "path": "tests/indexes/multi/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/multi/conftest.py",
+      "sha256": "e3699d26ab6abd7dcf94149d721d58ea3441be17b42336713a82edf81197d374",
+      "sizeBytes": 698
+    },
+    {
+      "path": "tests/indexes/multi/test_analytics.py",
+      "sha256": "6c74e16e3ded7638a1db9431921dab0d9d2ae319747105bf009a6220b9bf0bb7",
+      "sizeBytes": 6723
+    },
+    {
+      "path": "tests/indexes/multi/test_astype.py",
+      "sha256": "6264e73c5eaa5f0bd863cdb065f43c5c5c15c0e618b0896cdcb4ab7400c35bee",
+      "sizeBytes": 924
+    },
+    {
+      "path": "tests/indexes/multi/test_compat.py",
+      "sha256": "ab9dc3555e5f60e29154440197fdb0b3a597acdb2b1abe70e055ef5cb5017ae4",
+      "sizeBytes": 3918
+    },
+    {
+      "path": "tests/indexes/multi/test_constructors.py",
+      "sha256": "b2a10929257bcb463a264ee38edf91f284a65b152ecd8b098672b7e67fe3e3a4",
+      "sizeBytes": 27185
+    },
+    {
+      "path": "tests/indexes/multi/test_conversion.py",
+      "sha256": "91c7babfd82152406985629b497b3c60570c8a2e0263a8e64447fa1168024bdc",
+      "sizeBytes": 6337
+    },
+    {
+      "path": "tests/indexes/multi/test_copy.py",
+      "sha256": "f57a5eae4edae3205340aa3c7e09378026b64b026bdf4987d896183185a0b966",
+      "sizeBytes": 2405
+    },
+    {
+      "path": "tests/indexes/multi/test_drop.py",
+      "sha256": "7fe41612eeb65279450cb1fdf52166bf6fc7129e926e9fdf4569593b598a4700",
+      "sizeBytes": 6063
+    },
+    {
+      "path": "tests/indexes/multi/test_duplicates.py",
+      "sha256": "b179e24c708a56426e3f816bfdb0ed6a90233baf7e1a6065ead5ba425d8bd1c5",
+      "sizeBytes": 11480
+    },
+    {
+      "path": "tests/indexes/multi/test_equivalence.py",
+      "sha256": "45fafbc8cd4dcc9bfcabd8f807e44e15377d729cfd7cf517c2b7ff72560aa343",
+      "sizeBytes": 8549
+    },
+    {
+      "path": "tests/indexes/multi/test_formats.py",
+      "sha256": "de165ad1aff7e2f68f0e0ca9dc05abce62c1fe7c8f93ae5f2e657f54972611f2",
+      "sizeBytes": 8312
+    },
+    {
+      "path": "tests/indexes/multi/test_get_level_values.py",
+      "sha256": "d3eea664239286fc628eeb19cea2f8c450707e0f93fdd158995ebbdc9a23ca5a",
+      "sizeBytes": 4308
+    },
+    {
+      "path": "tests/indexes/multi/test_get_set.py",
+      "sha256": "024ecc549b4e9725d8d73c14431e42356b935464def7f7b84625a9d2fe5928e6",
+      "sizeBytes": 12800
+    },
+    {
+      "path": "tests/indexes/multi/test_indexing.py",
+      "sha256": "7dffa1c4600119e0cf7a39ff7265d8890c3ad0e86c02573cf0561d70f508f282",
+      "sizeBytes": 37656
+    },
+    {
+      "path": "tests/indexes/multi/test_integrity.py",
+      "sha256": "675921cdbefcd1a27818855c946999e0213473881eaccf10fac1d9a82a2a9a40",
+      "sizeBytes": 8997
+    },
+    {
+      "path": "tests/indexes/multi/test_isin.py",
+      "sha256": "40d6421d211bc886614685b7519a2a307759940291eaada0ce5097a8851cf95a",
+      "sizeBytes": 3430
+    },
+    {
+      "path": "tests/indexes/multi/test_join.py",
+      "sha256": "af6b1343cbfc4f09d3c0eba4858c5d962d51951a55284fec587be0709343defc",
+      "sizeBytes": 8507
+    },
+    {
+      "path": "tests/indexes/multi/test_lexsort.py",
+      "sha256": "29bc0c9d817a19321d79f43b780090bac34db9e85bb62baacc132ab0e49f0d4d",
+      "sizeBytes": 1358
+    },
+    {
+      "path": "tests/indexes/multi/test_missing.py",
+      "sha256": "e1a5b6068e8aa7055006415bbfa7e3c1aec889fbfdd49828b52d9812bdd98c7e",
+      "sizeBytes": 3350
+    },
+    {
+      "path": "tests/indexes/multi/test_monotonic.py",
+      "sha256": "e719444ab40e11c15676bd220773a2a49b40ebe473ae253762ad8e40680fd0ce",
+      "sizeBytes": 7007
+    },
+    {
+      "path": "tests/indexes/multi/test_names.py",
+      "sha256": "7ab38650bc27a704086a5131a6f46384684dfd455a43457c07b2708652bddceb",
+      "sizeBytes": 6601
+    },
+    {
+      "path": "tests/indexes/multi/test_partial_indexing.py",
+      "sha256": "b1534893dfcdc4c0ec1ee450ccf09eae73e67214c5e48340505933415eedf13d",
+      "sizeBytes": 4765
+    },
+    {
+      "path": "tests/indexes/multi/test_pickle.py",
+      "sha256": "649559a340dc5c3b55e81014b8f00a6f0315f1a19f6b324b53b2f0ea546605cc",
+      "sizeBytes": 259
+    },
+    {
+      "path": "tests/indexes/multi/test_reindex.py",
+      "sha256": "c30f1f488c78dbac1fa814e882426b292e77dc28caa2b7fe0786e1c8a7449c3e",
+      "sizeBytes": 5856
+    },
+    {
+      "path": "tests/indexes/multi/test_reshape.py",
+      "sha256": "5be75d11a0d262a41666e29c012fd1e771d87f18f1f526d3fa648abe6b429643",
+      "sizeBytes": 6711
+    },
+    {
+      "path": "tests/indexes/multi/test_setops.py",
+      "sha256": "6b594951ca2315a73bbce4656c32880b7f45c1ca349646e81193d6ce51a04248",
+      "sizeBytes": 25827
+    },
+    {
+      "path": "tests/indexes/multi/test_sorting.py",
+      "sha256": "cb4df4a2a6db49838df08c664aebee1018a42637ad7a3489d098f8e0714ac557",
+      "sizeBytes": 10736
+    },
+    {
+      "path": "tests/indexes/multi/test_take.py",
+      "sha256": "e0c6b13cce192503d724a8aa830130859ef54f21f82907c8b392e04b8d2fbcb3",
+      "sizeBytes": 2487
+    },
+    {
+      "path": "tests/indexes/multi/test_util.py",
+      "sha256": "543af42b69b1a770811f728b2cb5c82d25bf5cf4d4f4e25cd2e7c7f8509dce52",
+      "sizeBytes": 2323
+    },
+    {
+      "path": "tests/indexes/numeric/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/numeric/test_astype.py",
+      "sha256": "3f5f56f73665f2d37410af8f6848b68081472f009baee4cc1149bbfc02c61fd4",
+      "sizeBytes": 3618
+    },
+    {
+      "path": "tests/indexes/numeric/test_indexing.py",
+      "sha256": "641402f942de7b0b9eea7db9ffd2652dbac2aaf633cbc9dc48cd22454d7bcc47",
+      "sizeBytes": 23316
+    },
+    {
+      "path": "tests/indexes/numeric/test_join.py",
+      "sha256": "70b79a705c13d59bffce064686e5a1409cb8757fca16d679f179c13158c9b4d4",
+      "sizeBytes": 14997
+    },
+    {
+      "path": "tests/indexes/numeric/test_numeric.py",
+      "sha256": "be96418cdae25a8fb49ad3b246b8b62d1bde0ede48a5249b1bb3d5a5d7a9a2b2",
+      "sizeBytes": 18506
+    },
+    {
+      "path": "tests/indexes/numeric/test_setops.py",
+      "sha256": "4c8fc3c481570f3a8a259d1e8178d2f183040b159a9b4bf7ea58f0235c552944",
+      "sizeBytes": 5968
+    },
+    {
+      "path": "tests/indexes/object/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/object/test_astype.py",
+      "sha256": "a75130a8a0e538702548ea73c4b6940e70049bac804345481a737e86189e0a4b",
+      "sizeBytes": 368
+    },
+    {
+      "path": "tests/indexes/object/test_indexing.py",
+      "sha256": "4b8dc5610911bd989c3edf889e046ae851e88625c3a4e2fdb725591741329710",
+      "sizeBytes": 6392
+    },
+    {
+      "path": "tests/indexes/period/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/period/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/period/methods/test_asfreq.py",
+      "sha256": "ee718744cc211638f4b6160192e1cca5c9ce3c54007c78606b75e71b1915850d",
+      "sizeBytes": 6897
+    },
+    {
+      "path": "tests/indexes/period/methods/test_astype.py",
+      "sha256": "bf3eda46ca1e0cb5ef43f6e1a1bee136ad41ff782ce27feb0a40feb16e5ab407",
+      "sizeBytes": 5671
+    },
+    {
+      "path": "tests/indexes/period/methods/test_factorize.py",
+      "sha256": "157421e9598692e1a40762004f863ed95e54683d8b094363419e9a99f05aa3cd",
+      "sizeBytes": 1425
+    },
+    {
+      "path": "tests/indexes/period/methods/test_fillna.py",
+      "sha256": "8c062769618cb94686f7ddf2c4bc2bd5e4fa275bade3709c05a29db3809edfed",
+      "sizeBytes": 1125
+    },
+    {
+      "path": "tests/indexes/period/methods/test_insert.py",
+      "sha256": "253f650616c5f749b6cd1808c1aae13ea3ed55baef90b8a2859c4efb8587bd35",
+      "sizeBytes": 482
+    },
+    {
+      "path": "tests/indexes/period/methods/test_is_full.py",
+      "sha256": "46a204ac1a1f227e44c21f8ca2655e3c73a7d2156265b7b895a302daf87c9cfb",
+      "sizeBytes": 570
+    },
+    {
+      "path": "tests/indexes/period/methods/test_repeat.py",
+      "sha256": "d4dc27f9e3d80445d663837da457476aa719a0a856ba29ca74527e12366d1656",
+      "sizeBytes": 772
+    },
+    {
+      "path": "tests/indexes/period/methods/test_shift.py",
+      "sha256": "3fb5c3a4c90b1186ab1f4e912c18251492a818f91ac78a0b762b88ebbe8a2de9",
+      "sizeBytes": 4405
+    },
+    {
+      "path": "tests/indexes/period/methods/test_to_timestamp.py",
+      "sha256": "4c0c5ec67645e64f1af739bf8510bc8a92a967f4524242ffcac747af92c2eae5",
+      "sizeBytes": 5276
+    },
+    {
+      "path": "tests/indexes/period/test_constructors.py",
+      "sha256": "ff19d0589a7bd46f1c19b8c7de20490be0c53fcc925bbad88adc0828076a3e9e",
+      "sizeBytes": 25997
+    },
+    {
+      "path": "tests/indexes/period/test_formats.py",
+      "sha256": "d8261e85c3f6b555308cdf84c614eb6275d89cabd3d95ebff098d493cc91f77b",
+      "sizeBytes": 6370
+    },
+    {
+      "path": "tests/indexes/period/test_freq_attr.py",
+      "sha256": "a7d678bb4e45d147a812ed5774b5363254fa64dcba58ea06130f07293544ac38",
+      "sizeBytes": 529
+    },
+    {
+      "path": "tests/indexes/period/test_indexing.py",
+      "sha256": "c32e580421b20ff3049a222a079a605e544f054c5d9c537859a91c2a73771a06",
+      "sizeBytes": 27905
+    },
+    {
+      "path": "tests/indexes/period/test_join.py",
+      "sha256": "1177dd4998871e7b60e0041a3c62261e7d20aaaf5a9ce2f4d9873f1ef41d20cc",
+      "sizeBytes": 1813
+    },
+    {
+      "path": "tests/indexes/period/test_monotonic.py",
+      "sha256": "f526f858eca48fdf619f731039f9bf32a611c4ee6400366de8eb9a9214ae929e",
+      "sizeBytes": 1258
+    },
+    {
+      "path": "tests/indexes/period/test_partial_slicing.py",
+      "sha256": "c3b360f8e1cbd2cddb142e02377f31abe4102e6c776f9b85970a5473d5282dee",
+      "sizeBytes": 7228
+    },
+    {
+      "path": "tests/indexes/period/test_period.py",
+      "sha256": "73ced0314f08d283f2cc7a5752d0f00b36079b2be320b8a1de54d3ed89ea6fa0",
+      "sizeBytes": 7921
+    },
+    {
+      "path": "tests/indexes/period/test_period_range.py",
+      "sha256": "ef38fe0ff46be57cd049b020ab5ad763c658f5e213bd6ee5df8e8e45a50102ae",
+      "sizeBytes": 8946
+    },
+    {
+      "path": "tests/indexes/period/test_pickle.py",
+      "sha256": "ba2265ce96efd93132be24245260f361a71ff6901746aac958f464ab2cc884b3",
+      "sizeBytes": 736
+    },
+    {
+      "path": "tests/indexes/period/test_resolution.py",
+      "sha256": "d139a725e64239a4d69de79603ae839712a06946494df3f48ca80b018d638b28",
+      "sizeBytes": 571
+    },
+    {
+      "path": "tests/indexes/period/test_scalar_compat.py",
+      "sha256": "9039d137104a32c72cc5311c21f1e1854d6ea4ace3a138e0a73fa7c9721d6b85",
+      "sizeBytes": 1355
+    },
+    {
+      "path": "tests/indexes/period/test_searchsorted.py",
+      "sha256": "a2e285a598c63eb831132d0e9f4f7377aadc4672bb2eee824cdc5349bfc220d4",
+      "sizeBytes": 2610
+    },
+    {
+      "path": "tests/indexes/period/test_setops.py",
+      "sha256": "05cc035efd7e7e7a8e24bb7336a636ac43b27bded29b2936897327671fc8404f",
+      "sizeBytes": 12547
+    },
+    {
+      "path": "tests/indexes/period/test_tools.py",
+      "sha256": "0c5a3106c098456aa876635a0cd3e742b6534d789a4afc0d664c2bc9b7bb725d",
+      "sizeBytes": 1361
+    },
+    {
+      "path": "tests/indexes/ranges/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/ranges/test_constructors.py",
+      "sha256": "71e5fbf5f6e31b273954d926cf6f50d4ded61972e3e3406f4eecf93df340c382",
+      "sizeBytes": 5328
+    },
+    {
+      "path": "tests/indexes/ranges/test_indexing.py",
+      "sha256": "2a6bd9e0b7277e834f32e1c1a6ae9fb6abee08814fd8bbc8ed3017c8647f8966",
+      "sizeBytes": 5593
+    },
+    {
+      "path": "tests/indexes/ranges/test_join.py",
+      "sha256": "452fe90056dff803e1ba707d4019803036d46b6ec1a536e12b18fa97c99c9187",
+      "sizeBytes": 8573
+    },
+    {
+      "path": "tests/indexes/ranges/test_range.py",
+      "sha256": "9498140c82b4ff1ca4a0d31fa3b67ea788d785490d5caf83e75b4fa327f5bb28",
+      "sizeBytes": 29733
+    },
+    {
+      "path": "tests/indexes/ranges/test_setops.py",
+      "sha256": "274511f94e1c16deb454cc952f0de6f779de287e628c152b6848d5156c72fe5f",
+      "sizeBytes": 17505
+    },
+    {
+      "path": "tests/indexes/string/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/string/test_astype.py",
+      "sha256": "af684b058235350bb7283e9d6b1382fa6ea1629dc586f31c3cf3c766bbdf5ccb",
+      "sizeBytes": 722
+    },
+    {
+      "path": "tests/indexes/string/test_indexing.py",
+      "sha256": "beb6e79c230e41a2159085149696dc5b6160cba5c632bd81ade7d5043a7de45d",
+      "sizeBytes": 7850
+    },
+    {
+      "path": "tests/indexes/test_any_index.py",
+      "sha256": "d18904ce47fbc639fa31489aa93ea61cb3b58aa261e2bae96f88b5ffc19461ff",
+      "sizeBytes": 5563
+    },
+    {
+      "path": "tests/indexes/test_base.py",
+      "sha256": "2ddb18347fdc504d9818490c6aef762c85f3938c27750c3d56aa1d3fbb4001b1",
+      "sizeBytes": 61124
+    },
+    {
+      "path": "tests/indexes/test_common.py",
+      "sha256": "f0cf5ccb3b8ed707352eb10e31672ee386a6a4ff918c19c494d90a69bfc4ab38",
+      "sizeBytes": 18365
+    },
+    {
+      "path": "tests/indexes/test_datetimelike.py",
+      "sha256": "6cf955c31d7397cd1a1a2dfeaa862c6eaae8e8f5f46178c0d2999fa623b8a893",
+      "sizeBytes": 5469
+    },
+    {
+      "path": "tests/indexes/test_engines.py",
+      "sha256": "aeadc9cc35cd7369994b9642da640ba537b276178e5fd38ba2ad452d1e77c1b2",
+      "sizeBytes": 6699
+    },
+    {
+      "path": "tests/indexes/test_frozen.py",
+      "sha256": "971609b15d63a5f8729f7954997fdee564cdaf66287cfae0a1694766fc78ed73",
+      "sizeBytes": 3221
+    },
+    {
+      "path": "tests/indexes/test_index_new.py",
+      "sha256": "6adf30167d1c9d7f7252a17fcb481637caee5f44bcb96fb81a521042d9ea468a",
+      "sizeBytes": 14725
+    },
+    {
+      "path": "tests/indexes/test_indexing.py",
+      "sha256": "26687abd4bd3d900656ee8b6ed77bf936d4a24a23e0516a4356e4777f2e30844",
+      "sizeBytes": 11434
+    },
+    {
+      "path": "tests/indexes/test_numpy_compat.py",
+      "sha256": "236751977a0e4f9ee419fbfca0d56f0a5410c443c647996407a2802322a7b032",
+      "sizeBytes": 5756
+    },
+    {
+      "path": "tests/indexes/test_old_base.py",
+      "sha256": "af395bfb4c3293d60494544e0f50f6fe77d0a252927511666273ea66c232374c",
+      "sizeBytes": 36962
+    },
+    {
+      "path": "tests/indexes/test_setops.py",
+      "sha256": "f1bcbc7d13a503399c4f6be265b14b4513febce82389e5abe04ee0142f584828",
+      "sizeBytes": 35680
+    },
+    {
+      "path": "tests/indexes/test_subclass.py",
+      "sha256": "e16c9327fca293a945e59b506c0e69dccd15aed55f20ace74478bd7d392d2ea2",
+      "sizeBytes": 1059
+    },
+    {
+      "path": "tests/indexes/timedeltas/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/test_astype.py",
+      "sha256": "c5bbca9afdb4107ac3bc172326752925f88f91f3823e216b3a7ed3312d87fecf",
+      "sizeBytes": 6331
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/test_factorize.py",
+      "sha256": "6aa861c11299bdf1b16b7bf4f57e6f67bb81ba9f27e4e8da51a75f26957a1682",
+      "sizeBytes": 1292
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/test_fillna.py",
+      "sha256": "17b7c1a041be9a7bb5eb2a566262b9c1b228bd024a2f487ce82d4ccc69213e81",
+      "sizeBytes": 597
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/test_insert.py",
+      "sha256": "a278c4af4854ff7c0eb94ef2c5a93e64d0b55c1dd94cf6938d71df07f25bc719",
+      "sizeBytes": 4731
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/test_repeat.py",
+      "sha256": "bcf70d0646381f6471b32916d5b8d383e152953950d87d722dbf99b187dfb048",
+      "sizeBytes": 926
+    },
+    {
+      "path": "tests/indexes/timedeltas/methods/test_shift.py",
+      "sha256": "b18808606f3e6e62d6a5addf1d89a6141cf1afefd3cd393a1bc6e600e12e21a2",
+      "sizeBytes": 2810
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_arithmetic.py",
+      "sha256": "628703408a2f5e7ae95c4cf3dc073ede5d8f7466837f6fec17c50f70b545d59f",
+      "sizeBytes": 1561
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_constructors.py",
+      "sha256": "37147aae775a48833a001d6c885f27dab694c0fe548ffbd6eac83b45fac278de",
+      "sizeBytes": 9449
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_delete.py",
+      "sha256": "00fa43e40d45d369040f4773f18c89e81af5af03958961ec5713c387a13fa2ab",
+      "sizeBytes": 2398
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_formats.py",
+      "sha256": "05828dfae568eec9f43e0584b734c63715e154b28acf7385adc9007ed0204239",
+      "sizeBytes": 3855
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_freq_attr.py",
+      "sha256": "8181a5f70f5476d71f376e8a531d50c98e268e1e80d26e02b24de0b0221c768b",
+      "sizeBytes": 2176
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_indexing.py",
+      "sha256": "4f0a6434f488ac5966536d0a491276030ad1a186eb1b4d2f25e1db12c994c4ba",
+      "sizeBytes": 12507
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_join.py",
+      "sha256": "ec9522aed80d1893112f5fa4da07a4aefa2777062e215bee236e78f2fe277c8a",
+      "sizeBytes": 1396
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_ops.py",
+      "sha256": "9df1b2349bcdcbbfe399679b2a37af2ca87200c36f2398f2b64653365a440be8",
+      "sizeBytes": 393
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_pickle.py",
+      "sha256": "81daae0016668436dd8bd12604df87f3ec542021fe402c79a8b7b93bd554e2ff",
+      "sizeBytes": 324
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_scalar_compat.py",
+      "sha256": "fad42ae522b4db2c0cdadeba34562d64d8a6d83d31c6ec7701e879be70c9e2f2",
+      "sizeBytes": 4851
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_searchsorted.py",
+      "sha256": "9021343e4b8f9350b19191ce0dedda679e15f877350221e4c8d3558cde511083",
+      "sizeBytes": 967
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_setops.py",
+      "sha256": "f2201474de63fde3ec92d673d038844f355844b881ad6ee09294aef66cb190ff",
+      "sizeBytes": 9780
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_timedelta.py",
+      "sha256": "da8ce47e410cdc95c8f0b8b9970736d7626753fd3e59e2773cd763b5183b0828",
+      "sizeBytes": 1938
+    },
+    {
+      "path": "tests/indexes/timedeltas/test_timedelta_range.py",
+      "sha256": "309ce00d9e71405cd36ad7dd7ed296bbbda9c93b8fd60f40dcf5db2b3e59694f",
+      "sizeBytes": 6631
+    },
+    {
+      "path": "tests/indexing/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexing/common.py",
+      "sha256": "952f42501c21972585b68b270375e823c20a72482e86f401f2d7ddef7f2a9743",
+      "sizeBytes": 1020
+    },
+    {
+      "path": "tests/indexing/interval/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexing/interval/test_interval.py",
+      "sha256": "afe4c8378cdbe49808f259e6c8471aa9bf3132480ed902d2c120e1474983c9b0",
+      "sizeBytes": 8054
+    },
+    {
+      "path": "tests/indexing/interval/test_interval_new.py",
+      "sha256": "a654e6abb557e9efef3d142b9f301c108fa792ad55240ec64a8b198b455145d7",
+      "sizeBytes": 8134
+    },
+    {
+      "path": "tests/indexing/multiindex/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/indexing/multiindex/test_chaining_and_caching.py",
+      "sha256": "b25b5b06235c666300818021f224aaefba2dee2d9907823f51145e8b2a676ef0",
+      "sizeBytes": 2757
+    },
+    {
+      "path": "tests/indexing/multiindex/test_datetime.py",
+      "sha256": "b65d72af7879d11d2deeebf04dc7ec456fa3b759fdbeca9fe015a9e1d35375df",
+      "sizeBytes": 1234
+    },
+    {
+      "path": "tests/indexing/multiindex/test_getitem.py",
+      "sha256": "bd0c054ad47ffe1e31371af4e87c5f170bf90785561452834a5843971a0177e4",
+      "sizeBytes": 13283
+    },
+    {
+      "path": "tests/indexing/multiindex/test_iloc.py",
+      "sha256": "1b60943d185de69448999a47d2e39520f89dedfcc1e0eb896631fc6ab40cac4d",
+      "sizeBytes": 4918
+    },
+    {
+      "path": "tests/indexing/multiindex/test_indexing_slow.py",
+      "sha256": "6b3ce45b3f4420e7bfc4cfaa45b608621c52e0872f12dfd3d1b3f645d17cf215",
+      "sizeBytes": 3353
+    },
+    {
+      "path": "tests/indexing/multiindex/test_loc.py",
+      "sha256": "7fab6bdd8f563f722125fa4451489c2c955a63c702b44c84a7ca374f362a6bd0",
+      "sizeBytes": 33452
+    },
+    {
+      "path": "tests/indexing/multiindex/test_multiindex.py",
+      "sha256": "944354b684208fa2c0ec25440108d186895fffa608ff7e28b8e2808b7065d87f",
+      "sizeBytes": 10038
+    },
+    {
+      "path": "tests/indexing/multiindex/test_partial.py",
+      "sha256": "fa8421f0a0985332d4f95be44ec725e3cd269420a248edd3e34b94dd2b0707b3",
+      "sizeBytes": 8358
+    },
+    {
+      "path": "tests/indexing/multiindex/test_setitem.py",
+      "sha256": "77a2b3e3969875882f929353a6c8607b943cbf3d07c6d162584a7eeec488439a",
+      "sizeBytes": 18434
+    },
+    {
+      "path": "tests/indexing/multiindex/test_slice.py",
+      "sha256": "c61e92e375921bceb91129460a5da5ac2b6054b8e98bf3074624b8bba17ff59d",
+      "sizeBytes": 27152
+    },
+    {
+      "path": "tests/indexing/multiindex/test_sorted.py",
+      "sha256": "1871081f2f1e6c03cda76eef421546bb27dc974c73e05a4e85135d17da1b3ec0",
+      "sizeBytes": 5192
+    },
+    {
+      "path": "tests/indexing/test_at.py",
+      "sha256": "9289f2eab231d1b4a62f5de40527614a40e770ec8812833dffaf2be4c1b71d1b",
+      "sizeBytes": 7213
+    },
+    {
+      "path": "tests/indexing/test_categorical.py",
+      "sha256": "90bd29436807bf3a84dd651feba85b657e27adb5ff4c85123c57b20f161c8af8",
+      "sizeBytes": 20439
+    },
+    {
+      "path": "tests/indexing/test_chaining_and_caching.py",
+      "sha256": "b187f76ad544295a6625a2f03c6d86a399b74f45577eef7e5231cb1c93371754",
+      "sizeBytes": 12571
+    },
+    {
+      "path": "tests/indexing/test_check_indexer.py",
+      "sha256": "b5faf66b587aba890dd8c24313b4ca899d2245a1ef7d258f3c2fbce91a9a6835",
+      "sizeBytes": 3159
+    },
+    {
+      "path": "tests/indexing/test_coercion.py",
+      "sha256": "ce91222cfb31ad6c9b4d9dcc070ac3e5bb5165cbe1b93e58dbcdeab6c02260ed",
+      "sizeBytes": 31063
+    },
+    {
+      "path": "tests/indexing/test_datetime.py",
+      "sha256": "beb0002511d4bab4b11843ffcc766bd58b66e92445ce1ec39d5ca0e6fba6f04f",
+      "sizeBytes": 5714
+    },
+    {
+      "path": "tests/indexing/test_floats.py",
+      "sha256": "a993a6f00cd98c8e6032027b8b6c9c2b2f9c42628d3ad90cb5f95b5134cd1b6d",
+      "sizeBytes": 19937
+    },
+    {
+      "path": "tests/indexing/test_iat.py",
+      "sha256": "9e0ba5cf07d00d8d745fbd9555dbf1bcdd798ae09b7ecb70134bc758570cce55",
+      "sizeBytes": 817
+    },
+    {
+      "path": "tests/indexing/test_iloc.py",
+      "sha256": "95fe03c843f2a7b08e86f0e2fda94b36f65b5150f7e509d5028d98b701c07a70",
+      "sizeBytes": 54110
+    },
+    {
+      "path": "tests/indexing/test_indexers.py",
+      "sha256": "6a037f302a38d377cebea6a92a2fd6610962f409031409384c30795e96c9f23b",
+      "sizeBytes": 1661
+    },
+    {
+      "path": "tests/indexing/test_indexing.py",
+      "sha256": "00d2e0ab8b75c16942df2c6cf7b3fc0a0aec02dfe39792d78b5c83d8f973e409",
+      "sizeBytes": 39339
+    },
+    {
+      "path": "tests/indexing/test_loc.py",
+      "sha256": "82bfd082e9e38dc27b53ac7ca7748be481640b0cec1f8b8c11eb721e8705d912",
+      "sizeBytes": 122941
+    },
+    {
+      "path": "tests/indexing/test_na_indexing.py",
+      "sha256": "2199a260151442b9882f3777944d0088bc320501d39a96dd294e0b86b5b96bba",
+      "sizeBytes": 2276
+    },
+    {
+      "path": "tests/indexing/test_partial.py",
+      "sha256": "73d96fd1cbece631bef0300afbf8c9772ceb3fcde31844e63e011431f05b4f98",
+      "sizeBytes": 25040
+    },
+    {
+      "path": "tests/indexing/test_scalar.py",
+      "sha256": "291776e9c201994b048c0c7ea471765787b6d3b233b1e047899ca5193d3259f9",
+      "sizeBytes": 9929
+    },
+    {
+      "path": "tests/interchange/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/interchange/test_impl.py",
+      "sha256": "7ed313b5b6cd0d3182a9757111b41f5ecd05b52ff7b9a31353120f7d30c02ce5",
+      "sizeBytes": 24540
+    },
+    {
+      "path": "tests/interchange/test_spec_conformance.py",
+      "sha256": "7e2370c951c18168f0448522f3f2c764dbda086955e43d7f1035bf8edd87089d",
+      "sizeBytes": 6243
+    },
+    {
+      "path": "tests/interchange/test_utils.py",
+      "sha256": "d79962203262ad00e83fb4f1c50926649f6008054d09dd81c12856fc69702f60",
+      "sizeBytes": 2965
+    },
+    {
+      "path": "tests/internals/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/internals/test_api.py",
+      "sha256": "cbf2feea97691598521d7f32012d17e1e04b9ed361355e6045ba9489e9b50112",
+      "sizeBytes": 5461
+    },
+    {
+      "path": "tests/internals/test_internals.py",
+      "sha256": "2ca7920d0287da7eba92e5ef7e82ea1932629e0f95d26b7a0f8eaf31d69077e9",
+      "sizeBytes": 50027
+    },
+    {
+      "path": "tests/io/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/conftest.py",
+      "sha256": "340037da60baa259359393f4e69be2cdd6d4bf4f5b2de243e3790e0353b56c35",
+      "sizeBytes": 5023
+    },
+    {
+      "path": "tests/io/excel/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/excel/test_odf.py",
+      "sha256": "167ca33360e8dee6e8e5ea02bef0651e1e236974267eeffa19a526960a8a5c20",
+      "sizeBytes": 1884
+    },
+    {
+      "path": "tests/io/excel/test_odswriter.py",
+      "sha256": "a3c953d569dc7b6733c15fe639256b6bdb62acffb917586de12cf3bdcf165b67",
+      "sizeBytes": 3075
+    },
+    {
+      "path": "tests/io/excel/test_openpyxl.py",
+      "sha256": "fffd0354ecdb3c01c342ae294a95e2181b81be891e8acc8db1f7665286a11ff3",
+      "sizeBytes": 14688
+    },
+    {
+      "path": "tests/io/excel/test_readers.py",
+      "sha256": "9a04d297726015e30297dfe150b621a9bd9d6db612579090b5f63ce8f44cf5e8",
+      "sizeBytes": 62945
+    },
+    {
+      "path": "tests/io/excel/test_style.py",
+      "sha256": "8c2cc311b3c7bed98850e555f262631f3dc08fb19baa94897d11e7a266a1e700",
+      "sizeBytes": 13614
+    },
+    {
+      "path": "tests/io/excel/test_writers.py",
+      "sha256": "6ece8697c261a06eb7fd6c9e12e4aaf186a0362a78b92e539da9ebafc62871ae",
+      "sizeBytes": 63699
+    },
+    {
+      "path": "tests/io/excel/test_xlrd.py",
+      "sha256": "3bbe85d17db0b1d20aace8017a03084ccc3330130b73e025592866a34b0ae5bb",
+      "sizeBytes": 1832
+    },
+    {
+      "path": "tests/io/excel/test_xlsxwriter.py",
+      "sha256": "f1b973bc25c5063eb8b3b8d95e1f953334375b5bfd13e02bd2bb5c2ed235f8ff",
+      "sizeBytes": 2559
+    },
+    {
+      "path": "tests/io/formats/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/formats/style/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/formats/style/test_bar.py",
+      "sha256": "8ff16409b05148c2352696cffdf460b385833bdca644cb300d10a9a95c969d7e",
+      "sizeBytes": 12058
+    },
+    {
+      "path": "tests/io/formats/style/test_exceptions.py",
+      "sha256": "aa6eb636efc4eb54ceac65f3c4c4989b90a2aa6eea2a10856930cfd102668c9a",
+      "sizeBytes": 1002
+    },
+    {
+      "path": "tests/io/formats/style/test_format.py",
+      "sha256": "d41d38f9559bb276ec479a29accd145f8b44f1ded8bd14af6e7e12c24161b0b8",
+      "sizeBytes": 24534
+    },
+    {
+      "path": "tests/io/formats/style/test_highlight.py",
+      "sha256": "ca6d9fa0ede62425d6f204b74223e98757095a42ebb192aa46b01d7895c5a731",
+      "sizeBytes": 6947
+    },
+    {
+      "path": "tests/io/formats/style/test_html.py",
+      "sha256": "8d38a7c0d6e9279dd8400c86b843328c5abbec690481024b56b9a72a463e913e",
+      "sizeBytes": 33821
+    },
+    {
+      "path": "tests/io/formats/style/test_matplotlib.py",
+      "sha256": "cec9e649d2066773b2e73f33bea0f966816d0f584d67ab44f79a1062d9719e8c",
+      "sizeBytes": 10838
+    },
+    {
+      "path": "tests/io/formats/style/test_non_unique.py",
+      "sha256": "246feb139039664e5ec657e2bd91e7388dd4a739bc7498e628a1e4c048dee0b4",
+      "sizeBytes": 4366
+    },
+    {
+      "path": "tests/io/formats/style/test_style.py",
+      "sha256": "31ea35307e855cd690507e13e9e7b30d7de44948e603e4b671b61ae03e13159d",
+      "sizeBytes": 58667
+    },
+    {
+      "path": "tests/io/formats/style/test_to_latex.py",
+      "sha256": "43bcf6814c5ed5d5d4eeff3269f50aac8f4984e393d926150d17a1829745b3eb",
+      "sizeBytes": 33017
+    },
+    {
+      "path": "tests/io/formats/style/test_to_string.py",
+      "sha256": "c351af2e6dc5b4a41df6dda7c0ddef179e57e5fd0640a182197a58159c484e90",
+      "sizeBytes": 1910
+    },
+    {
+      "path": "tests/io/formats/style/test_to_typst.py",
+      "sha256": "ea18a2eef63c57acaae14764cbdd7a2857925548f71dc81c40e42c36ab2c5a12",
+      "sizeBytes": 2064
+    },
+    {
+      "path": "tests/io/formats/style/test_tooltip.py",
+      "sha256": "c29f5da83834497a31b6406e6045b80d1f5db1d862b66f78de73b11fe3d9ccee",
+      "sizeBytes": 7328
+    },
+    {
+      "path": "tests/io/formats/test_console.py",
+      "sha256": "8c0935c2e7613e22c1861b72753351959e37f7ad4ba85bb7b98b7a71503f8d5d",
+      "sizeBytes": 2435
+    },
+    {
+      "path": "tests/io/formats/test_css.py",
+      "sha256": "81b07bd7ae4b8b311570883ed4d1b215a340edeab2c9d8be9d2381f267cb6e06",
+      "sizeBytes": 8882
+    },
+    {
+      "path": "tests/io/formats/test_eng_formatting.py",
+      "sha256": "42a15924c5015675394a9641eb7b423875f70aa65b8e07ac39973a9f16e1a787",
+      "sizeBytes": 8454
+    },
+    {
+      "path": "tests/io/formats/test_format.py",
+      "sha256": "bef0e5fff0a5baf8ee15f245ac1a2356fdec225ea28114e3e0c6364a0d83754d",
+      "sizeBytes": 84932
+    },
+    {
+      "path": "tests/io/formats/test_ipython_compat.py",
+      "sha256": "6ac9f0fcba46aaa3346a5742d043eba6057a23807247c5c9d43b39c46ff25a79",
+      "sizeBytes": 3162
+    },
+    {
+      "path": "tests/io/formats/test_printing.py",
+      "sha256": "f4ab6574af62c844b2776dd4f5d2a1318ac5b2d516e5b46fa7ca8189539d8d4a",
+      "sizeBytes": 5742
+    },
+    {
+      "path": "tests/io/formats/test_to_csv.py",
+      "sha256": "c1ffc35609a366a2b6b7aaa8d151495feab2053e49934053bf55780f3f9b930f",
+      "sizeBytes": 31259
+    },
+    {
+      "path": "tests/io/formats/test_to_excel.py",
+      "sha256": "140afd3e5f57a4dc18169659026e7a98e9849c05a2f9cb70ea156e1c07270427",
+      "sizeBytes": 16811
+    },
+    {
+      "path": "tests/io/formats/test_to_html.py",
+      "sha256": "75dd0fa7da94002013b0da960bcb463e6d730051154cdbb9e79ae3c9ebbd5a31",
+      "sizeBytes": 38419
+    },
+    {
+      "path": "tests/io/formats/test_to_latex.py",
+      "sha256": "ceda85480bf5f649f2c7ed779e685dcac7b22b4501b01426cc386fd0fe150695",
+      "sizeBytes": 44718
+    },
+    {
+      "path": "tests/io/formats/test_to_markdown.py",
+      "sha256": "1c39af60531958f9f3c29b39b9b5f65c751ffbc1157a5fdd4dc637e21ed85e7f",
+      "sizeBytes": 2690
+    },
+    {
+      "path": "tests/io/formats/test_to_string.py",
+      "sha256": "4dd495605bb7def23be422bacf4a2e4e8421b6d9150b8bece691d3513c447bac",
+      "sizeBytes": 39956
+    },
+    {
+      "path": "tests/io/generate_legacy_storage_files.py",
+      "sha256": "0110b8156bedac45b1f162ea24b9da017fa662901d4ecb911889722c871b3f65",
+      "sizeBytes": 13016
+    },
+    {
+      "path": "tests/io/json/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/json/conftest.py",
+      "sha256": "669f37a3dd0fbd9e7a31b84d46bd4d6443d3a61a3b8d11dc2d888403d47f059c",
+      "sizeBytes": 205
+    },
+    {
+      "path": "tests/io/json/test_compression.py",
+      "sha256": "baa294dc0a25004fdcda8ce2bc453a29dc6280847fa67abd5340476fab9accb1",
+      "sizeBytes": 4331
+    },
+    {
+      "path": "tests/io/json/test_deprecated_kwargs.py",
+      "sha256": "33869efbb9c6b7084a707300cba23b1036d2bef3400b428cd470e977e368da5d",
+      "sizeBytes": 691
+    },
+    {
+      "path": "tests/io/json/test_json_table_schema.py",
+      "sha256": "5f9512d2a193bc37152a4abe23ca6ec3714d1dea7a6c78e024c5ecf72ea46aac",
+      "sizeBytes": 31470
+    },
+    {
+      "path": "tests/io/json/test_json_table_schema_ext_dtype.py",
+      "sha256": "89af3d5cc9ee67936a71e56b639085e7ee1a12446c85e1b853b741d85e110b30",
+      "sizeBytes": 9338
+    },
+    {
+      "path": "tests/io/json/test_normalize.py",
+      "sha256": "d8fe146f21dfe51e39b21aa233cdf416e5337efede0938d2930b783dd6a89909",
+      "sizeBytes": 32565
+    },
+    {
+      "path": "tests/io/json/test_pandas.py",
+      "sha256": "10e52960f223848d5cd95eec3af540281d0bff10a4f434a31c0f3a82fa5f73e4",
+      "sizeBytes": 86522
+    },
+    {
+      "path": "tests/io/json/test_readlines.py",
+      "sha256": "c6ddde430e3cb441f423e936d55d1628e7bfd4fd5064b91a9c5ee295a708196f",
+      "sizeBytes": 18639
+    },
+    {
+      "path": "tests/io/json/test_ujson.py",
+      "sha256": "b8623a40764f819198a07aadcb4190a4f477b8d3fb3c1aa611afd74f0e16ff18",
+      "sizeBytes": 35235
+    },
+    {
+      "path": "tests/io/parser/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/parser/common/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/parser/common/test_chunksize.py",
+      "sha256": "36d2c98b918b37bc8c19d80561bdea1578909e3388404eac58d5cad258977f0a",
+      "sizeBytes": 10730
+    },
+    {
+      "path": "tests/io/parser/common/test_common_basic.py",
+      "sha256": "dbdf3bad6695f7cda635369a313bccf4d53c5bca88025d79c0567141417ab0f0",
+      "sizeBytes": 26623
+    },
+    {
+      "path": "tests/io/parser/common/test_data_list.py",
+      "sha256": "395e7e343700947b0aef888f3464092f99033ee5b3ead23be727655469c318cf",
+      "sizeBytes": 2229
+    },
+    {
+      "path": "tests/io/parser/common/test_decimal.py",
+      "sha256": "0e4da2093e68a90bb17adcc40b8ea07a8d6677d0cb8d067e9e755ef403f8230b",
+      "sizeBytes": 1933
+    },
+    {
+      "path": "tests/io/parser/common/test_file_buffer_url.py",
+      "sha256": "c65a18eb235ff3ce3428a95699f3731e5ef13a97164bdef31b8c74984156c8e9",
+      "sizeBytes": 13643
+    },
+    {
+      "path": "tests/io/parser/common/test_float.py",
+      "sha256": "5464b2cc5c9feaedb50f899c3097eaf56fa3796edbe2a8f80590e5ba375a6b36",
+      "sizeBytes": 3414
+    },
+    {
+      "path": "tests/io/parser/common/test_index.py",
+      "sha256": "2354677feda07c877f1315953693f87d7a69fc8728bcc1e561f217f66e6566aa",
+      "sizeBytes": 8301
+    },
+    {
+      "path": "tests/io/parser/common/test_inf.py",
+      "sha256": "304fd1e3b387218b0df114bad349772983b75589a595d6b4439f33502cbfeb2f",
+      "sizeBytes": 1462
+    },
+    {
+      "path": "tests/io/parser/common/test_ints.py",
+      "sha256": "d9a8a1bf1b81c6c9dd12b0843dccec53c9d9fb6f461b09191464a43e2ca8878b",
+      "sizeBytes": 7504
+    },
+    {
+      "path": "tests/io/parser/common/test_iterator.py",
+      "sha256": "9c5316707ab731b759606e6656f06f27545c8469d81475a92f48115c4c185603",
+      "sizeBytes": 4339
+    },
+    {
+      "path": "tests/io/parser/common/test_read_errors.py",
+      "sha256": "efa543e7609bf43bf5420765249e4e19f546c015bee99767ef06c5e33d9af374",
+      "sizeBytes": 9216
+    },
+    {
+      "path": "tests/io/parser/conftest.py",
+      "sha256": "255469684d015f2ed264837701fd31eefbe8aac661011f9a551539402d2d021a",
+      "sizeBytes": 9144
+    },
+    {
+      "path": "tests/io/parser/dtypes/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/parser/dtypes/test_categorical.py",
+      "sha256": "2fb65424640f028b3253faddd01df7747e104aa49a30f8ca702de454bbd1f188",
+      "sizeBytes": 10053
+    },
+    {
+      "path": "tests/io/parser/dtypes/test_dtypes_basic.py",
+      "sha256": "993d39c5f3d7250cbf96087b722613456f07ddc53fcade7e70be78de3efb5349",
+      "sizeBytes": 18580
+    },
+    {
+      "path": "tests/io/parser/dtypes/test_empty.py",
+      "sha256": "e2b8abd3ad3dffc7d6b814d1957e7fd299b23a03a074a2662f47593a34039ed1",
+      "sizeBytes": 5239
+    },
+    {
+      "path": "tests/io/parser/test_c_parser_only.py",
+      "sha256": "217c41c5fb1edb16d4a3ae55b446040942b0f484f7baa76acdfeb0d329885cf4",
+      "sizeBytes": 20515
+    },
+    {
+      "path": "tests/io/parser/test_comment.py",
+      "sha256": "c05cb0f861060a989efd865cd3463f47134985189cb9a77afcad84f4854ec6cf",
+      "sizeBytes": 7061
+    },
+    {
+      "path": "tests/io/parser/test_compression.py",
+      "sha256": "1c7142a8df7b2867b76521938d198f5af46866c7eb6664967b7785097c28276d",
+      "sizeBytes": 6251
+    },
+    {
+      "path": "tests/io/parser/test_concatenate_chunks.py",
+      "sha256": "039c2b0824d9332daa21ba755534590669286ac0ed5fc07b7da6d6777f6a6c16",
+      "sizeBytes": 1220
+    },
+    {
+      "path": "tests/io/parser/test_converters.py",
+      "sha256": "786a6e8ff224d6c914cf683a680513394fa051182c6bc047f5fbba0c3ea29fd7",
+      "sizeBytes": 7445
+    },
+    {
+      "path": "tests/io/parser/test_dialect.py",
+      "sha256": "b60b1d9e1124601b6320a77ef41280c90f004d34a2be7cc89225a2b8b8b9d773",
+      "sizeBytes": 5844
+    },
+    {
+      "path": "tests/io/parser/test_encoding.py",
+      "sha256": "e349bf4ad13cf5a9beaf10a8ac7fb64e8b1039698a0da42e14b417fac5c7d3ad",
+      "sizeBytes": 10457
+    },
+    {
+      "path": "tests/io/parser/test_header.py",
+      "sha256": "f559987c79f78d28e9eb600dc93df3928aaf6ebb836e276b9a4a6fa60f1c7006",
+      "sizeBytes": 20797
+    },
+    {
+      "path": "tests/io/parser/test_index_col.py",
+      "sha256": "828b351ff391e2158a6203dafff73c44ef078d9bdf3c359941bbb42c66ee1ce5",
+      "sizeBytes": 11461
+    },
+    {
+      "path": "tests/io/parser/test_mangle_dupes.py",
+      "sha256": "7947628d253aa03202b8d8535b1f7e396f25c99863475a6bb851913b39ab827f",
+      "sizeBytes": 5443
+    },
+    {
+      "path": "tests/io/parser/test_multi_thread.py",
+      "sha256": "5642f198c2296a7cea4388d91fa2348ac5ce3464fa16dca5f94dc3050a5353e8",
+      "sizeBytes": 4346
+    },
+    {
+      "path": "tests/io/parser/test_na_values.py",
+      "sha256": "a75a43ff82d52340a3973278f49df01ea868ca2208bb5540dcdfd5daae2a93d0",
+      "sizeBytes": 24211
+    },
+    {
+      "path": "tests/io/parser/test_network.py",
+      "sha256": "068e6517af7d9d4a69c1179590b441dbc0a5ff0332a837da4c9bedd5a4546e14",
+      "sizeBytes": 8150
+    },
+    {
+      "path": "tests/io/parser/test_parse_dates.py",
+      "sha256": "1aecbbd6fd984b52de61fbcf3df14e5b121afb5ff0ac432ab65d01d684c67fba",
+      "sizeBytes": 25455
+    },
+    {
+      "path": "tests/io/parser/test_python_parser_only.py",
+      "sha256": "b304b8c6882d9d765a30ef233c6ed747943308d98f24d393b90eaf8675a3bd5e",
+      "sizeBytes": 17794
+    },
+    {
+      "path": "tests/io/parser/test_quoting.py",
+      "sha256": "a6b1c95c85d92fd864d435fb38fe5e034e70a585c3c765f045bdcbf6f8ccd474",
+      "sizeBytes": 6488
+    },
+    {
+      "path": "tests/io/parser/test_read_fwf.py",
+      "sha256": "020038304e061f6358410066d5f49ad7faf40fde7dde6110f0d167c03d0f3f4e",
+      "sizeBytes": 28959
+    },
+    {
+      "path": "tests/io/parser/test_skiprows.py",
+      "sha256": "d56ba67466ee954bf71c9bb454b7fa0ec2e1961ea28d95317f3b0ecf9fe4d5c8",
+      "sizeBytes": 9321
+    },
+    {
+      "path": "tests/io/parser/test_textreader.py",
+      "sha256": "aa3b275a4555d6ca0d6b37b361863ac84aba5e69b2262fc0b4a9247734223272",
+      "sizeBytes": 12091
+    },
+    {
+      "path": "tests/io/parser/test_unsupported.py",
+      "sha256": "01b7252cb003042b7f89a7289cc7f6091d6e32b84a3c856cb6a64997c5649b22",
+      "sizeBytes": 6985
+    },
+    {
+      "path": "tests/io/parser/test_upcast.py",
+      "sha256": "b99a5eb89174b6e82d248e1a25859352f9d3a978c67dbd7f520e6ae31a6e4a64",
+      "sizeBytes": 3117
+    },
+    {
+      "path": "tests/io/parser/usecols/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/parser/usecols/test_parse_dates.py",
+      "sha256": "8b993cdc932ece8d6b09420bb4a659eeb793ab8f61ad33f1601893e50dd3adf5",
+      "sizeBytes": 2103
+    },
+    {
+      "path": "tests/io/parser/usecols/test_strings.py",
+      "sha256": "5beca2255f3f80f0bedbc68c64b96b98a71654ecb13be2d93dfc13760f27b3c2",
+      "sizeBytes": 2508
+    },
+    {
+      "path": "tests/io/parser/usecols/test_usecols_basic.py",
+      "sha256": "9b9e83e9fc738006591bfe71ab4572641ef15221fd4ac3537232807b34d9b1a4",
+      "sizeBytes": 17033
+    },
+    {
+      "path": "tests/io/pytables/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/pytables/common.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/pytables/conftest.py",
+      "sha256": "072293579f1a9c86ff06614e686c2486fdeb69e65dbb017b7faad17dcf73c3c1",
+      "sizeBytes": 569
+    },
+    {
+      "path": "tests/io/pytables/test_append.py",
+      "sha256": "2d34feee34ab1d111b31746e1ca0a19e9a195c503fba7e1cdf19c5248924f2c9",
+      "sizeBytes": 34592
+    },
+    {
+      "path": "tests/io/pytables/test_categorical.py",
+      "sha256": "de640a351c013dd68dbc81226bd7f7ff43f7ed03e825d5f134c6077be846715d",
+      "sizeBytes": 6206
+    },
+    {
+      "path": "tests/io/pytables/test_compat.py",
+      "sha256": "ad32b8a891d9d931e8d5ca50cc7614d34277d97799471eab62762622a9b0c52c",
+      "sizeBytes": 6218
+    },
+    {
+      "path": "tests/io/pytables/test_complex.py",
+      "sha256": "877a7bb615dd66bedc111689b93fc26d3df9010966803fa2354953b2a6781e5f",
+      "sizeBytes": 6262
+    },
+    {
+      "path": "tests/io/pytables/test_errors.py",
+      "sha256": "5704af475608b3169b38468f726f53c6dc81e14bdf3e466a87ff533d33b5a66a",
+      "sizeBytes": 8120
+    },
+    {
+      "path": "tests/io/pytables/test_file_handling.py",
+      "sha256": "6f92da480200b4707795b8ca1b59b3913d9382db744c37fb15e897d0a703984c",
+      "sizeBytes": 15043
+    },
+    {
+      "path": "tests/io/pytables/test_keys.py",
+      "sha256": "7981678343b1b550fe74cc63ae0ac195aeaf4e4dc61a4e0b5197ba2254ae8dc1",
+      "sizeBytes": 2454
+    },
+    {
+      "path": "tests/io/pytables/test_put.py",
+      "sha256": "422e9a218be37dc6257dc7910150b4cd7a13dc6f1db98fa9b84309d476f9c648",
+      "sizeBytes": 13376
+    },
+    {
+      "path": "tests/io/pytables/test_pytables_missing.py",
+      "sha256": "3b91210d1ef4f20654c1e897bacb0801cf29d288681a6423e4ef7682f7b71bad",
+      "sizeBytes": 284
+    },
+    {
+      "path": "tests/io/pytables/test_read.py",
+      "sha256": "9ae9c02ac616b700d0659a73f56bcb8260c1c9b0ee5eaa4d2ab024aa45d4d275",
+      "sizeBytes": 10005
+    },
+    {
+      "path": "tests/io/pytables/test_retain_attributes.py",
+      "sha256": "45df9c8a64505909e4136c2f8f48583a15974bac74b57cdcf87c4c35c202a86e",
+      "sizeBytes": 3084
+    },
+    {
+      "path": "tests/io/pytables/test_round_trip.py",
+      "sha256": "1cea91331686537c94cb54b57191f53dc2aa7a9cf38932d16a6dd918b8a46816",
+      "sizeBytes": 18344
+    },
+    {
+      "path": "tests/io/pytables/test_select.py",
+      "sha256": "edfb49fb0c4f2bed4875a3d339ef0a28fcaecb0b60ff429b4d0db029ea030903",
+      "sizeBytes": 35636
+    },
+    {
+      "path": "tests/io/pytables/test_store.py",
+      "sha256": "6075da964f464f16609f46cd9c2d838bb8ab9e7178bb6a480d5b514da196b05a",
+      "sizeBytes": 35032
+    },
+    {
+      "path": "tests/io/pytables/test_subclass.py",
+      "sha256": "f9dc9e36457c9a69d5d68de12bc8fb8794876af387e85b0f3f8a8ab23dff269d",
+      "sizeBytes": 1297
+    },
+    {
+      "path": "tests/io/pytables/test_time_series.py",
+      "sha256": "b52c51ac4e727aabe4cd309d7dbb0c283303d605e45a4f2b782932956f1fe177",
+      "sizeBytes": 2215
+    },
+    {
+      "path": "tests/io/pytables/test_timezones.py",
+      "sha256": "369430ba9b275fb663a043fbc646a7fd7e86dc0d9f7590450e4805f0429c0421",
+      "sizeBytes": 10232
+    },
+    {
+      "path": "tests/io/sas/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/sas/test_byteswap.py",
+      "sha256": "6b9f459dc00a950a0ff9dbb15f37bee19007d1ddacd27febf1db0bb73478bb91",
+      "sizeBytes": 2023
+    },
+    {
+      "path": "tests/io/sas/test_sas.py",
+      "sha256": "2664b47ae0a7c6eb3c7108dda6ba82f8e3142076c62567a3b33072533e9e8b6c",
+      "sizeBytes": 1001
+    },
+    {
+      "path": "tests/io/sas/test_sas7bdat.py",
+      "sha256": "ca7fb9b899faec3149cb1d5e3d28607db2a472fce9bcacdf0380dbb9ce036412",
+      "sizeBytes": 14830
+    },
+    {
+      "path": "tests/io/sas/test_xport.py",
+      "sha256": "dbcd08cffc4c3ed93f0f004fbf9a30ad13d93c3cf3b705f640d98dd5ce5128ec",
+      "sizeBytes": 5649
+    },
+    {
+      "path": "tests/io/test_clipboard.py",
+      "sha256": "32ef91d73863a9ef414dc10e1d2e454d4aeeec01841af144e5f02a0163324685",
+      "sizeBytes": 12580
+    },
+    {
+      "path": "tests/io/test_common.py",
+      "sha256": "ce77647b5f19efdc5e35f97bfa85ffb3cb366a922f4290179f6216a095a07a21",
+      "sizeBytes": 25197
+    },
+    {
+      "path": "tests/io/test_compression.py",
+      "sha256": "7cd9c40262bc23a6480fce4ec80e78d60403303a8dcc1a4f190debb22a5290bb",
+      "sizeBytes": 12025
+    },
+    {
+      "path": "tests/io/test_feather.py",
+      "sha256": "5454e727f5d6330e4fc5c6a41a47f2a40389fa934f79b8f56e42e55de3875bd7",
+      "sizeBytes": 10351
+    },
+    {
+      "path": "tests/io/test_fsspec.py",
+      "sha256": "ed4465af44612ae83c5ba84c1c66a430914fa0efc6c0577334feba973aef0b30",
+      "sizeBytes": 10739
+    },
+    {
+      "path": "tests/io/test_gcs.py",
+      "sha256": "d884feb18c5c6e0f3cd96702e5376dd6a1ee1c0f4827abe89ab9f9c85a33731d",
+      "sizeBytes": 7491
+    },
+    {
+      "path": "tests/io/test_html.py",
+      "sha256": "81626ff60fde3fd22fa0d9f57be9d52d272edeeda844016c84e3b43f359c55ed",
+      "sizeBytes": 56905
+    },
+    {
+      "path": "tests/io/test_http_headers.py",
+      "sha256": "f8e9aed7577b83ed3956a7fc03c73b04e61b8cd1e700b128134daca8e9642446",
+      "sizeBytes": 4782
+    },
+    {
+      "path": "tests/io/test_iceberg.py",
+      "sha256": "63f2718027c14b92f9fab00312edd1efd1ccc76b73c3b5226fdfcc74b165dda6",
+      "sizeBytes": 6424
+    },
+    {
+      "path": "tests/io/test_orc.py",
+      "sha256": "097641a915b7d200ef7e2cc6659cc15f8ea117ca385bd88c8689e9eb821256b6",
+      "sizeBytes": 13932
+    },
+    {
+      "path": "tests/io/test_parquet.py",
+      "sha256": "976df072f204f8a832c75e0dd5e77d250ca5c658ea7d772a0c0fd17807729a15",
+      "sizeBytes": 50664
+    },
+    {
+      "path": "tests/io/test_pickle.py",
+      "sha256": "00c6665e169ece2c04f9441cdd8eb2b522117dbbe13c1ac86cfee684ccb7d61e",
+      "sizeBytes": 20500
+    },
+    {
+      "path": "tests/io/test_s3.py",
+      "sha256": "9ca12636bd3e97a023f8e721c031875cb8fac3611b67983601fbf9fb5693a160",
+      "sizeBytes": 908
+    },
+    {
+      "path": "tests/io/test_spss.py",
+      "sha256": "dd369a43aeb27fc719ceeaa2cd3984c7005700803a45037dd2a802ac0b91e0e8",
+      "sizeBytes": 6448
+    },
+    {
+      "path": "tests/io/test_sql.py",
+      "sha256": "9d7c8c94b197a8d6b2b16ff274212dbcf87568e1bb8b2fc732d45ae411fcf23e",
+      "sizeBytes": 145243
+    },
+    {
+      "path": "tests/io/test_stata.py",
+      "sha256": "60d432cac4a48a53e5c6e32b830754b88e8c8795afbc9b841da4c8544d13dbe6",
+      "sizeBytes": 100596
+    },
+    {
+      "path": "tests/io/test_util.py",
+      "sha256": "2f6f22734722485472975ee3d9587b3d8a314da0c52d0796557cc0412f7791a3",
+      "sizeBytes": 2039
+    },
+    {
+      "path": "tests/io/xml/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/io/xml/conftest.py",
+      "sha256": "82b6bde21aee5a28c3a4c21a52eb9b51e30e6e161d0990d91da9cdf7df7ec23c",
+      "sizeBytes": 2668
+    },
+    {
+      "path": "tests/io/xml/test_to_xml.py",
+      "sha256": "ae0a55be11750bd8260bb0c8ad9e4117ef6dc9c59939dea8dc59e576a9a36b05",
+      "sizeBytes": 35127
+    },
+    {
+      "path": "tests/io/xml/test_xml.py",
+      "sha256": "4a5c69b7110bf7396bbe62627f0f1dd58ce6b5e0cb83664d41e890e346c247f4",
+      "sizeBytes": 60443
+    },
+    {
+      "path": "tests/io/xml/test_xml_dtypes.py",
+      "sha256": "1c91258736978efd0adf645bc1bdde108d90419f204f9e416321e9807e5caf1c",
+      "sizeBytes": 12392
+    },
+    {
+      "path": "tests/libs/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/libs/test_hashtable.py",
+      "sha256": "11a2304cbb11b3095fe1014d85aab5e10bdf187754d912b8d24cc12c008bdcb0",
+      "sizeBytes": 27212
+    },
+    {
+      "path": "tests/libs/test_join.py",
+      "sha256": "32235a582020800274f6eec9089be70ee41af6d44960778e4dc045fa4804460f",
+      "sizeBytes": 10736
+    },
+    {
+      "path": "tests/libs/test_lib.py",
+      "sha256": "2fd74ba446ae2e27ca3d22f6cedfad8a2f0ff3b9127e1eadc21a1e8a800a680a",
+      "sizeBytes": 13071
+    },
+    {
+      "path": "tests/libs/test_libalgos.py",
+      "sha256": "b1a0f209b721194ebdd079ab7d9509eaad6208b35e5b8c79d18f80da8d5f82b8",
+      "sizeBytes": 5322
+    },
+    {
+      "path": "tests/plotting/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/plotting/common.py",
+      "sha256": "61f3890c1d50546cdfcbc5ca312be05ecdb95fa5e34b9624279f21ad189b7d69",
+      "sizeBytes": 17614
+    },
+    {
+      "path": "tests/plotting/conftest.py",
+      "sha256": "607ddd064c378b9ff911e0db4d75e007d0800c1d2ceb94b3af77aff0082dd2ac",
+      "sizeBytes": 882
+    },
+    {
+      "path": "tests/plotting/frame/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/plotting/frame/test_frame.py",
+      "sha256": "fc3de49cb659b7725fdee06f275fc83305651834a40ef0a0d85edcac5db5d767",
+      "sizeBytes": 101332
+    },
+    {
+      "path": "tests/plotting/frame/test_frame_color.py",
+      "sha256": "d9046c326b43e7c4b35202a56744ce2b924465b5f77365109a898af957da2f5f",
+      "sizeBytes": 30621
+    },
+    {
+      "path": "tests/plotting/frame/test_frame_groupby.py",
+      "sha256": "2d7257bf0ff88a9984d50da6a4f2a0278c31e37778aed92a6d3d514f0af3f1e8",
+      "sizeBytes": 2571
+    },
+    {
+      "path": "tests/plotting/frame/test_frame_legend.py",
+      "sha256": "6ea25b59c9a3cf3407b0a60d284225ad314806daac48238228633747e4e348d5",
+      "sizeBytes": 10089
+    },
+    {
+      "path": "tests/plotting/frame/test_frame_subplots.py",
+      "sha256": "f91152578bfdd46f67e5fc7948f018ed4e684e0ce9614762fb65a9cd27fb77ca",
+      "sizeBytes": 28961
+    },
+    {
+      "path": "tests/plotting/frame/test_hist_box_by.py",
+      "sha256": "f23a9541f2eb13900abe7ee228c5fb2f919b7bb7b8aefe8873c327369ecd00b2",
+      "sizeBytes": 10969
+    },
+    {
+      "path": "tests/plotting/test_backend.py",
+      "sha256": "6611807a324851995088dbe228dc78aa676b463733de3575d1691697f09cab6e",
+      "sizeBytes": 3419
+    },
+    {
+      "path": "tests/plotting/test_boxplot_method.py",
+      "sha256": "1bc3ee40af1eef786f8067c4090d219151f007d29035a836812878b8502d3eea",
+      "sizeBytes": 29925
+    },
+    {
+      "path": "tests/plotting/test_common.py",
+      "sha256": "89ff569f1af245d521b9bfb7ca375310a3b63cc13e6217f96081bc7b69ef0175",
+      "sizeBytes": 1869
+    },
+    {
+      "path": "tests/plotting/test_converter.py",
+      "sha256": "943966b6b57f7538adac8a8c34b2e727baaf61828122be5a1e0680e3dd12c413",
+      "sizeBytes": 12695
+    },
+    {
+      "path": "tests/plotting/test_datetimelike.py",
+      "sha256": "f872114bc148d5938b32d146012f4ba4953417f6ac67c44f5337d94d9bbcaca1",
+      "sizeBytes": 65153
+    },
+    {
+      "path": "tests/plotting/test_groupby.py",
+      "sha256": "5b57a9546f3a499cf4289c51bcbb072f6fe8cc4c9940d84a29434d255b1fca99",
+      "sizeBytes": 5745
+    },
+    {
+      "path": "tests/plotting/test_hist_method.py",
+      "sha256": "f9ea840727d7db8847f3e78f3fdb686215a762ae568b27728bd349427d7ea292",
+      "sizeBytes": 34607
+    },
+    {
+      "path": "tests/plotting/test_misc.py",
+      "sha256": "48f975c7b3da231c2698fcc83ae7e5aa560c7c37ccde05e6416eb2c74d580f30",
+      "sizeBytes": 30692
+    },
+    {
+      "path": "tests/plotting/test_series.py",
+      "sha256": "0d767e982107716bbe9e09b7e0291b1d0b8fde7bcc42e62158e3b54ba2a00397",
+      "sizeBytes": 35833
+    },
+    {
+      "path": "tests/plotting/test_style.py",
+      "sha256": "038a471e10392fa9c3ce7bff3811942dc26f57843d5c5c5af81784dfb10d02a7",
+      "sizeBytes": 5000
+    },
+    {
+      "path": "tests/reductions/__init__.py",
+      "sha256": "bdf968f3231ca1cc765f545dc3dbedf0da62678645abdc59442dcf5ba1a9f82b",
+      "sizeBytes": 125
+    },
+    {
+      "path": "tests/reductions/test_reductions.py",
+      "sha256": "fb775179d1b0a41097cd5c2a3d8d129c7ad886aa69446d026ffca0b1abc53d11",
+      "sizeBytes": 57024
+    },
+    {
+      "path": "tests/reductions/test_stat_reductions.py",
+      "sha256": "bdd889c50b030734a38ada59a538514f441af902e365688dce50fb85220ade77",
+      "sizeBytes": 9952
+    },
+    {
+      "path": "tests/resample/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/resample/conftest.py",
+      "sha256": "62bd730c5db13717142ca6e006fe10bd405e11a2d1c777f510d9b64be0a6a7f4",
+      "sizeBytes": 706
+    },
+    {
+      "path": "tests/resample/test_base.py",
+      "sha256": "274145f00ead0bad3fbb9cce24698c3dc7cc21a442f04a4fd3033b84f3424851",
+      "sizeBytes": 18141
+    },
+    {
+      "path": "tests/resample/test_datetime_index.py",
+      "sha256": "95454b9feebd6d685692b351f1e58bdd05e9c57ba2d2a9c633224d7d258eea9c",
+      "sizeBytes": 73695
+    },
+    {
+      "path": "tests/resample/test_period_index.py",
+      "sha256": "27575728bf76ad91156cee4206955e0b943cbf8c07c383d5e9ddbb60f24a14b2",
+      "sizeBytes": 39512
+    },
+    {
+      "path": "tests/resample/test_resample_api.py",
+      "sha256": "44599dbf43551f0d1f3015e4164d78f4218a43f5a2e779a1154ce211b84304a8",
+      "sizeBytes": 31396
+    },
+    {
+      "path": "tests/resample/test_resampler_grouper.py",
+      "sha256": "6c0294672a045d568f24ee7e7829f19b484932a3a5c66f5d62b747ef719aa9eb",
+      "sizeBytes": 20606
+    },
+    {
+      "path": "tests/resample/test_time_grouper.py",
+      "sha256": "fc26cee4e37f013b55dcdc5f7569c989c705d8e809bd0982bda825e5e22dbec4",
+      "sizeBytes": 13529
+    },
+    {
+      "path": "tests/resample/test_timedelta.py",
+      "sha256": "a3d1452034d0bec0925b387781afecca8cecc6652ba824679563b4dfe3d67cc0",
+      "sizeBytes": 7426
+    },
+    {
+      "path": "tests/reshape/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/reshape/concat/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/reshape/concat/test_append.py",
+      "sha256": "33852262d5635d59bef59a4bdda96aee9d08e9147f930d6f37f968a3861da84c",
+      "sizeBytes": 12744
+    },
+    {
+      "path": "tests/reshape/concat/test_append_common.py",
+      "sha256": "d3822a1608ff1240d75debc7e42b1a3af7de104c682b8253516b6c3676ebc20c",
+      "sizeBytes": 25913
+    },
+    {
+      "path": "tests/reshape/concat/test_categorical.py",
+      "sha256": "ba27977e21b0b163b16d7f2aacfbb6d84657fd795b91e31691da7f74a26d53af",
+      "sizeBytes": 9572
+    },
+    {
+      "path": "tests/reshape/concat/test_concat.py",
+      "sha256": "9e10aa9782ebbfea1d29fd77811d149c0bd931baea6f25b1b0d4a5f9cf0618ff",
+      "sizeBytes": 35135
+    },
+    {
+      "path": "tests/reshape/concat/test_dataframe.py",
+      "sha256": "305a994b34ada74c70853b8f57fa17e92ea1ab487c1deaad2649186553013d0a",
+      "sizeBytes": 9154
+    },
+    {
+      "path": "tests/reshape/concat/test_datetimes.py",
+      "sha256": "96e706a6b555f73b62602f81f29dd590ff9b42267ffd9c514798cfcbd6dbaea2",
+      "sizeBytes": 21521
+    },
+    {
+      "path": "tests/reshape/concat/test_empty.py",
+      "sha256": "974e59d8d284ca9416588461fc4f67aec3bb62b7df2d718c36502f8271156de3",
+      "sizeBytes": 10082
+    },
+    {
+      "path": "tests/reshape/concat/test_index.py",
+      "sha256": "89e6bf06cc3b627c03a35d287c23021976d299820a5f34fec7f2bb72e5fd265b",
+      "sizeBytes": 16860
+    },
+    {
+      "path": "tests/reshape/concat/test_invalid.py",
+      "sha256": "14b7f011ce010346eb805ccb47daf9886a59550d18378a9234c7384a2e345fe5",
+      "sizeBytes": 1609
+    },
+    {
+      "path": "tests/reshape/concat/test_series.py",
+      "sha256": "5958e9d46f60cd5e50e23414c4a8c83cd21fc72e58f510e78e47e549c295e5bc",
+      "sizeBytes": 6513
+    },
+    {
+      "path": "tests/reshape/concat/test_sort.py",
+      "sha256": "46e5c825db8b6b9e8824399441a0b0c983b3fd4d0a5cc0d67f4e161338bccbb1",
+      "sizeBytes": 4350
+    },
+    {
+      "path": "tests/reshape/merge/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/reshape/merge/test_join.py",
+      "sha256": "d4319c058cd33bf4259a22765130aa7c9442ca5e5ebe83657bdec1788bac8484",
+      "sizeBytes": 40938
+    },
+    {
+      "path": "tests/reshape/merge/test_merge.py",
+      "sha256": "c5f822413c974969c6dbf635968c340d3a50fa9555c16fc981cfe5770080d15f",
+      "sizeBytes": 114210
+    },
+    {
+      "path": "tests/reshape/merge/test_merge_antijoin.py",
+      "sha256": "4407f3b5f5efd335295b90cf05fc99156fca250b29e45515a98c424321ae3df1",
+      "sizeBytes": 8673
+    },
+    {
+      "path": "tests/reshape/merge/test_merge_asof.py",
+      "sha256": "dc01ff95dcd9d8d56042df247c8276cdf73e0c849798232fb2dc5bff75ee0d90",
+      "sizeBytes": 121009
+    },
+    {
+      "path": "tests/reshape/merge/test_merge_cross.py",
+      "sha256": "a282d04d9a40dfa72d099adff96de2fce2b760d70b3e581abbd3045984597be2",
+      "sizeBytes": 3124
+    },
+    {
+      "path": "tests/reshape/merge/test_merge_index_as_string.py",
+      "sha256": "c3ff4171ca6a7c1ef23e1cbf4c194c1b1d813ce0703e17e0fa9611280e07102f",
+      "sizeBytes": 5357
+    },
+    {
+      "path": "tests/reshape/merge/test_merge_ordered.py",
+      "sha256": "c2ba2a18bc4ca986ee2fb1b86a4e168e7574c2a95489348a3c109d8b763ecda8",
+      "sizeBytes": 7561
+    },
+    {
+      "path": "tests/reshape/merge/test_multi.py",
+      "sha256": "e7bfcf8a88596e279f8c58c9f7bb57e6ab0705f0003817fec74adaf1a94291c1",
+      "sizeBytes": 31000
+    },
+    {
+      "path": "tests/reshape/test_crosstab.py",
+      "sha256": "8b08fdcdbccf90a12f690cc61d9fe5de4356b329b56f20ab01cccae856aff9b4",
+      "sizeBytes": 32141
+    },
+    {
+      "path": "tests/reshape/test_cut.py",
+      "sha256": "df16a369a4b13f933bfd70e05bffb961bfb8c5cddd562a55cdfc45a78c4f461d",
+      "sizeBytes": 25764
+    },
+    {
+      "path": "tests/reshape/test_from_dummies.py",
+      "sha256": "f3fe347ae2f36965395cbb114a268ffec0aa153483e70c177caff983d07227ea",
+      "sizeBytes": 14068
+    },
+    {
+      "path": "tests/reshape/test_get_dummies.py",
+      "sha256": "6f7d186251cedaec1ca1f802f396e836986f20aaa1aca76b128ff1e7974caaf2",
+      "sizeBytes": 27570
+    },
+    {
+      "path": "tests/reshape/test_melt.py",
+      "sha256": "e99c4d321f9cc57243612222ceb160d6bc3e9dad637017335c1c9c58b1061db9",
+      "sizeBytes": 43351
+    },
+    {
+      "path": "tests/reshape/test_pivot.py",
+      "sha256": "c5c7b633693d9ac3d333a95b6745eccb51eb8265038007b9fedc27b2df41f477",
+      "sizeBytes": 100397
+    },
+    {
+      "path": "tests/reshape/test_pivot_multilevel.py",
+      "sha256": "12b121a73c3c36044cf016d883fa4b5a37748a866d04a677cc343190783afc61",
+      "sizeBytes": 8910
+    },
+    {
+      "path": "tests/reshape/test_qcut.py",
+      "sha256": "32ecba91d1fa35ae7895fc18a56ad3f7bec90386886f76ceee0ecf95dfad4abf",
+      "sizeBytes": 8734
+    },
+    {
+      "path": "tests/reshape/test_union_categoricals.py",
+      "sha256": "52f69d3a96140a6909f9c1a60131d506656ef0b6a356c5a3325c92e2b008f619",
+      "sizeBytes": 15301
+    },
+    {
+      "path": "tests/scalar/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/interval/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/interval/test_arithmetic.py",
+      "sha256": "f756a358036103c9a812985dae2f1de2b199e043c756b69b15fef9a21b314eaa",
+      "sizeBytes": 6062
+    },
+    {
+      "path": "tests/scalar/interval/test_constructors.py",
+      "sha256": "0c8e6244aa08839d6523ff85cac290cb26899f0addf02a8b8e4edbee2a85229d",
+      "sizeBytes": 1599
+    },
+    {
+      "path": "tests/scalar/interval/test_contains.py",
+      "sha256": "3128e8e54eca2eeaae82712d5110bcce7a65748dfe70b21f5d094884dbd02c8e",
+      "sizeBytes": 2354
+    },
+    {
+      "path": "tests/scalar/interval/test_formats.py",
+      "sha256": "129efaf7680640c76b6220b1c6e76a5d7f8203a4b5b0edcbd8fd88e0d1c8adea",
+      "sizeBytes": 344
+    },
+    {
+      "path": "tests/scalar/interval/test_interval.py",
+      "sha256": "5b9e122856c54a5b2f170a1790d85be892b9da4973f22b36c30d9943b0088d4b",
+      "sizeBytes": 2656
+    },
+    {
+      "path": "tests/scalar/interval/test_overlaps.py",
+      "sha256": "d851c6db7b1ca1c96c7d96409e02bdb1eb276bfdf181b8e048aa14ce53311eba",
+      "sizeBytes": 2274
+    },
+    {
+      "path": "tests/scalar/period/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/period/test_arithmetic.py",
+      "sha256": "1d08f78ddad0a0d7ab74ccc9aabf043e71f56f7c17248865f7bcd3da0f4429ea",
+      "sizeBytes": 16784
+    },
+    {
+      "path": "tests/scalar/period/test_asfreq.py",
+      "sha256": "f0de209303ebd54c9331479e5e5848987469cfedc0d22aca3be9191de0c574ac",
+      "sizeBytes": 37719
+    },
+    {
+      "path": "tests/scalar/period/test_period.py",
+      "sha256": "05b2b88a9f105cab8c1b64e726efd186fa70bb32989378f300cff99cf1a65085",
+      "sizeBytes": 42434
+    },
+    {
+      "path": "tests/scalar/test_na_scalar.py",
+      "sha256": "e46445908318d803ea24ac6c8f09ba2347de6fc31e12f2459555a1ba1b15e703",
+      "sizeBytes": 7777
+    },
+    {
+      "path": "tests/scalar/test_nat.py",
+      "sha256": "a11a42626f5e301377d9a8681ce82cedbd9b07b051f341dc49efd8440788c45d",
+      "sizeBytes": 19056
+    },
+    {
+      "path": "tests/scalar/timedelta/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/timedelta/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/timedelta/methods/test_as_unit.py",
+      "sha256": "85a6b1125b1b474b9016f66a6d37b8d2f276f1f8bd5b702a3b3c8002cb2cef07",
+      "sizeBytes": 2509
+    },
+    {
+      "path": "tests/scalar/timedelta/methods/test_round.py",
+      "sha256": "d20e9f492c5bf2f1de87e2aa981907f89d3a5da1e5422297f594db12490cc6f7",
+      "sizeBytes": 6427
+    },
+    {
+      "path": "tests/scalar/timedelta/test_arithmetic.py",
+      "sha256": "afe41fcce31bf69e9fbb87a90eab1545b758b3fb4f03579ab2769aa9e52fc996",
+      "sizeBytes": 40365
+    },
+    {
+      "path": "tests/scalar/timedelta/test_constructors.py",
+      "sha256": "dd4098f688c331796e126994ef10a023395e7db686f32b5ea4406bcf1cd7ea23",
+      "sizeBytes": 25346
+    },
+    {
+      "path": "tests/scalar/timedelta/test_formats.py",
+      "sha256": "c07c3aa78a550b45f025402657bf98956e6cb770418425ae9ba2c5e34f74758f",
+      "sizeBytes": 4161
+    },
+    {
+      "path": "tests/scalar/timedelta/test_timedelta.py",
+      "sha256": "576d866a940839449ec56dfb781aa8a430fb95d7e33921577ac18bdfb2d5eb9d",
+      "sizeBytes": 25809
+    },
+    {
+      "path": "tests/scalar/timestamp/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_as_unit.py",
+      "sha256": "39dd1886b825ad53da69de24ce98cf2a855ffa9073d3f9536dd6a3edca43ede5",
+      "sizeBytes": 2706
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_normalize.py",
+      "sha256": "a69ce6c1e558168b33117700aca3dcf10d143e15cc9817b5b163418fb0e5c694",
+      "sizeBytes": 1009
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_replace.py",
+      "sha256": "b960050a69be927e765ee02fbfae45d328e66a11fa614bbf65021ac78ccceb51",
+      "sizeBytes": 7803
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_round.py",
+      "sha256": "d69ec8617b9efb38dcd622480998c37bff4209f26804ac332b63d8a71f8c633e",
+      "sizeBytes": 12705
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_timestamp_method.py",
+      "sha256": "5c057d066cab942b86fd33ab669e092e0a799e809b6b87a1773a9e569e4595ab",
+      "sizeBytes": 1151
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_to_julian_date.py",
+      "sha256": "8b33ea4b57fb949dd3aa48b3eb9b7736366ab60c6ed7f8db4a0f8b99985e883e",
+      "sizeBytes": 810
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_to_pydatetime.py",
+      "sha256": "b42ce3d3e7d0f8121ae5d62f44ea414553e4abf3e50cae0f838de8a67612bfe5",
+      "sizeBytes": 2988
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_tz_convert.py",
+      "sha256": "cb0d468823a7ec5f190e87fd77b22f1ba4f6f1eea7b01fbf5ecc1f3b41cdf837",
+      "sizeBytes": 1710
+    },
+    {
+      "path": "tests/scalar/timestamp/methods/test_tz_localize.py",
+      "sha256": "dbb3db282317a58ed5a19430073f9cbd7a253f3a6a342c68023faf7452a0669c",
+      "sizeBytes": 12485
+    },
+    {
+      "path": "tests/scalar/timestamp/test_arithmetic.py",
+      "sha256": "bb8a3485f089d47b971ba04778223326a935a2a6818868b455557e9a7cbb8679",
+      "sizeBytes": 11286
+    },
+    {
+      "path": "tests/scalar/timestamp/test_comparisons.py",
+      "sha256": "5174821796de562e40dd81a73ff59fd04c6266ac8a5764af3ebd17843303d9de",
+      "sizeBytes": 10027
+    },
+    {
+      "path": "tests/scalar/timestamp/test_constructors.py",
+      "sha256": "bb486937d2e1d4ca2607da8d427b93f577ab001a8207e3227c1b94eff05b8b86",
+      "sizeBytes": 41052
+    },
+    {
+      "path": "tests/scalar/timestamp/test_formats.py",
+      "sha256": "5e9e4904feabce760150b662d61494306a5422069e37238b528d4f39f5aa07d1",
+      "sizeBytes": 6914
+    },
+    {
+      "path": "tests/scalar/timestamp/test_timestamp.py",
+      "sha256": "99c5cda3cd80014d002943d47229337bc1955c0f898b4d9240b2173c99ea07b0",
+      "sizeBytes": 31562
+    },
+    {
+      "path": "tests/scalar/timestamp/test_timezones.py",
+      "sha256": "2914d611c0cc55c56b490ce565d533595127344a182c8cc0090a69a021cd3d8f",
+      "sizeBytes": 667
+    },
+    {
+      "path": "tests/series/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/series/accessors/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/series/accessors/test_cat_accessor.py",
+      "sha256": "b858fea094b4bece8270eb005547600f819d5ca7d3e7cff7c258434d612d07c2",
+      "sizeBytes": 9646
+    },
+    {
+      "path": "tests/series/accessors/test_dt_accessor.py",
+      "sha256": "2d56ff1a3a07b6daa7478903d5d12737b604d78c22fd76ba02cb9ad1b20f7a21",
+      "sizeBytes": 29014
+    },
+    {
+      "path": "tests/series/accessors/test_list_accessor.py",
+      "sha256": "4ae462b4cad57cdb1cbd840109c95f7fc763dadb6df01cdad0c5a8751896343a",
+      "sizeBytes": 3552
+    },
+    {
+      "path": "tests/series/accessors/test_sparse_accessor.py",
+      "sha256": "c8fc4ad517bb4433cb8b9bf6afd7adae0b147d22fd34de39080bee477b585700",
+      "sizeBytes": 296
+    },
+    {
+      "path": "tests/series/accessors/test_str_accessor.py",
+      "sha256": "d243f2af3e889e48188b35124d86aa1ef725c5ef9bbbad982cfef9a6d8e5ee91",
+      "sizeBytes": 907
+    },
+    {
+      "path": "tests/series/accessors/test_struct_accessor.py",
+      "sha256": "aa4f11fc509a8444a23e5217e77a7ecc93b5e89d62dde5a451ff76985ef276af",
+      "sizeBytes": 5121
+    },
+    {
+      "path": "tests/series/indexing/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/series/indexing/test_datetime.py",
+      "sha256": "8e55a55abb9c20442170aee5a70dd29032f23153de12ab65d1c71a7ba816bfcc",
+      "sizeBytes": 14447
+    },
+    {
+      "path": "tests/series/indexing/test_delitem.py",
+      "sha256": "2157754ba2d5d832042d58a47fcbb0df494d16e14d4487ded4c83731b088c987",
+      "sizeBytes": 1969
+    },
+    {
+      "path": "tests/series/indexing/test_get.py",
+      "sha256": "428bc5188a04af28a92d9a240d1b3d6ddceeb6f31cf025b388cd130a618dad87",
+      "sizeBytes": 5141
+    },
+    {
+      "path": "tests/series/indexing/test_getitem.py",
+      "sha256": "d2940a05aea5aa4c8aea3569fcef114c0564eba844a26a4982263ad3b6c53000",
+      "sizeBytes": 23328
+    },
+    {
+      "path": "tests/series/indexing/test_indexing.py",
+      "sha256": "be30e78e5010591b414d671b96495372eab1bc5fe487a959fdf0e6065ff1b0a7",
+      "sizeBytes": 15734
+    },
+    {
+      "path": "tests/series/indexing/test_mask.py",
+      "sha256": "79c3dd27e08cf076da699a0651fc1ca0eba8d1e233eda12afb1f302f43d959b1",
+      "sizeBytes": 1711
+    },
+    {
+      "path": "tests/series/indexing/test_set_value.py",
+      "sha256": "5bd3b9bd1e6e2520122307b5122b09b7d57d9709b98aca89e9a2e62c0f4bb52f",
+      "sizeBytes": 1163
+    },
+    {
+      "path": "tests/series/indexing/test_setitem.py",
+      "sha256": "025fd122507817d770c7a476b5f961b9e1c346a73bd0c282c377e5697d1a753e",
+      "sizeBytes": 57345
+    },
+    {
+      "path": "tests/series/indexing/test_take.py",
+      "sha256": "e7be1c80bd30d1f8fe6276666bd6f5f3c6349935acf86a3a67307dcd049da409",
+      "sizeBytes": 1353
+    },
+    {
+      "path": "tests/series/indexing/test_where.py",
+      "sha256": "48d7e57a203fe1b9a0401403f4afb3c34029782681c2f0219420602638001c91",
+      "sizeBytes": 12309
+    },
+    {
+      "path": "tests/series/indexing/test_xs.py",
+      "sha256": "f042862209caf3afe1b018cf218e6579d9d89f36adbf5e0eeabab72e347f2b12",
+      "sizeBytes": 2760
+    },
+    {
+      "path": "tests/series/methods/__init__.py",
+      "sha256": "cd55ea1b10c843e79bc7171eb48f4a709f591077880b8d3ce82a03bf273c08d3",
+      "sizeBytes": 225
+    },
+    {
+      "path": "tests/series/methods/test_add_prefix_suffix.py",
+      "sha256": "3de5087831daf6b1a082b6846d5251b4b8b619c9cd71792b5dbd28b65b61382e",
+      "sizeBytes": 1556
+    },
+    {
+      "path": "tests/series/methods/test_align.py",
+      "sha256": "71136513d9cc07be0a62de4a51782fecff8f28547105d8680dd840b560c56679",
+      "sizeBytes": 6023
+    },
+    {
+      "path": "tests/series/methods/test_argsort.py",
+      "sha256": "8d8f7ce95a0738c5b6c5bada5a862f1a1a478912b8f3e07aa97f76d1db3855c1",
+      "sizeBytes": 2539
+    },
+    {
+      "path": "tests/series/methods/test_asof.py",
+      "sha256": "0aa45dc9e5c5844ef355d90907e4f156a2b75cfc8136fb4e01f6fafdad151a03",
+      "sizeBytes": 6324
+    },
+    {
+      "path": "tests/series/methods/test_astype.py",
+      "sha256": "d66360845f128b1064389acb5671f8073129f2a253bcfd6829ca7fae566f985b",
+      "sizeBytes": 25801
+    },
+    {
+      "path": "tests/series/methods/test_autocorr.py",
+      "sha256": "4a7c442c1f5b704f07ebcb5850337750a30c3eefac11f6f04e52d49fc5a2ad5f",
+      "sizeBytes": 1015
+    },
+    {
+      "path": "tests/series/methods/test_between.py",
+      "sha256": "dc91db70c614df394c67b13c955bcef5cac36227f2440c7e1cbe53d28be2ba0a",
+      "sizeBytes": 2565
+    },
+    {
+      "path": "tests/series/methods/test_case_when.py",
+      "sha256": "06113861d8196171d2d6363870330bf128d8a3bc5beeeff0ac12deaaa243d89f",
+      "sizeBytes": 6376
+    },
+    {
+      "path": "tests/series/methods/test_clip.py",
+      "sha256": "5b538a1f5412bf9e4ab3fe07a4f677315ed9a6573490d9ea1080ff1694d1a45b",
+      "sizeBytes": 5350
+    },
+    {
+      "path": "tests/series/methods/test_combine.py",
+      "sha256": "253b28c0ca3ca38486f1e21fdc47afe5d64703767580f78e910743e608001dd5",
+      "sizeBytes": 862
+    },
+    {
+      "path": "tests/series/methods/test_combine_first.py",
+      "sha256": "fe7c473d67997adc2fe9dfab8bff48f414c1c060f40bf0ed581091848d409577",
+      "sizeBytes": 5962
+    },
+    {
+      "path": "tests/series/methods/test_compare.py",
+      "sha256": "aa0e669936306e7c55eed1d5e11d722af91173c7aa81931f38dbaee89816383c",
+      "sizeBytes": 4514
+    },
+    {
+      "path": "tests/series/methods/test_convert_dtypes.py",
+      "sha256": "9727eaf8a201a07878e1613660c26ede64d7a872c58bc5439b85f7f0ab2941e9",
+      "sizeBytes": 11489
+    },
+    {
+      "path": "tests/series/methods/test_copy.py",
+      "sha256": "f0dad68cef40d92674420f06504c0298e57e27294c2d8c2f4639f3d7887bb82d",
+      "sizeBytes": 2451
+    },
+    {
+      "path": "tests/series/methods/test_count.py",
+      "sha256": "d2eea8f455a4a6c1f0978a9432cbd1000e98f317fe339176a2831cf63280403e",
+      "sizeBytes": 567
+    },
+    {
+      "path": "tests/series/methods/test_cov_corr.py",
+      "sha256": "d9f44e7a9d8ffb0104edc5bad83645dddd00b83d20a4b26fa6c247df8f8a36fc",
+      "sizeBytes": 5770
+    },
+    {
+      "path": "tests/series/methods/test_describe.py",
+      "sha256": "16de1dab20f5c26c24cab7457b1eaeb46a261a70c4cabf0a188827535b8fa8e9",
+      "sizeBytes": 6571
+    },
+    {
+      "path": "tests/series/methods/test_diff.py",
+      "sha256": "66bb83a51d6826cf1508040c04b2c61898ae4414b6db1d6ebab45931f5d78950",
+      "sizeBytes": 2703
+    },
+    {
+      "path": "tests/series/methods/test_drop.py",
+      "sha256": "735354a936877c33001b4b43c6507b2c93164da29e5f1cc1600d6f2519ff7976",
+      "sizeBytes": 3309
+    },
+    {
+      "path": "tests/series/methods/test_drop_duplicates.py",
+      "sha256": "40f7333703fabacbfb29d73eef912bd6e2f92d732d01c24b7da38efe0a9cb977",
+      "sizeBytes": 9468
+    },
+    {
+      "path": "tests/series/methods/test_dropna.py",
+      "sha256": "7decdce2c893367fae38442d3a16aa34038b601a16377461e924c702d39d93c5",
+      "sizeBytes": 3577
+    },
+    {
+      "path": "tests/series/methods/test_dtypes.py",
+      "sha256": "224624165d28d8b439aaeae86f0a0f829e23aa2dae294ee9868024de866d898a",
+      "sizeBytes": 209
+    },
+    {
+      "path": "tests/series/methods/test_duplicated.py",
+      "sha256": "0009e7c4b3e53ae16b6f16f9c5a6aae216a28e5c874846150f3659a7a91a0f8e",
+      "sizeBytes": 2049
+    },
+    {
+      "path": "tests/series/methods/test_equals.py",
+      "sha256": "80659ff88af421d6619b58d0d5e2b66e12177527485a6d3670a84c01aead238f",
+      "sizeBytes": 3734
+    },
+    {
+      "path": "tests/series/methods/test_explode.py",
+      "sha256": "29dd42c6e962732a8113e3a041d0ce0232564b9840c27c77c51634ca8ea0acc9",
+      "sizeBytes": 5438
+    },
+    {
+      "path": "tests/series/methods/test_fillna.py",
+      "sha256": "f9fac1dfc3e6af8b78b4cd81ceff58c275819619662045017f117344872ecb9d",
+      "sizeBytes": 35525
+    },
+    {
+      "path": "tests/series/methods/test_get_numeric_data.py",
+      "sha256": "a8e255004bb9897172626ce631fbcd33384a5d9cb29deffaa26d168dd1a89475",
+      "sizeBytes": 915
+    },
+    {
+      "path": "tests/series/methods/test_head_tail.py",
+      "sha256": "d445a88e34f370bbd81f7e15bf2bc41f17330f2ef32f774c4f26b2147b154b36",
+      "sizeBytes": 343
+    },
+    {
+      "path": "tests/series/methods/test_infer_objects.py",
+      "sha256": "9fa011683abf96648c9bf4aead4f28a3f69bd68a57ecb26bacf976493cec4eb0",
+      "sizeBytes": 1883
+    },
+    {
+      "path": "tests/series/methods/test_info.py",
+      "sha256": "f8d310e703dd80ee896b372441c915aee33ad9cbb59512401518bf27d3771c59",
+      "sizeBytes": 5644
+    },
+    {
+      "path": "tests/series/methods/test_interpolate.py",
+      "sha256": "755467573954bee148f1fc8f3efb986b445fcfbc72a107fe1ced00a9feebb467",
+      "sizeBytes": 31826
+    },
+    {
+      "path": "tests/series/methods/test_is_monotonic.py",
+      "sha256": "befc96645c624b26eaf3ca5e174ccde5d335eab1f64a0084100fa04f6ad14926",
+      "sizeBytes": 838
+    },
+    {
+      "path": "tests/series/methods/test_is_unique.py",
+      "sha256": "77768b4b9ab8f752156647cac7c1d37388e4813b6e37448e69455f9320532261",
+      "sizeBytes": 953
+    },
+    {
+      "path": "tests/series/methods/test_isin.py",
+      "sha256": "7517b9e153eb58f3089e0781c151224ca148f32e70c69e33048ea677c6eb61ee",
+      "sizeBytes": 9236
+    },
+    {
+      "path": "tests/series/methods/test_isna.py",
+      "sha256": "648f914bf37f9d737bc7feee0fabeb7776eceb2105236914d7740e20fdb5a9ff",
+      "sizeBytes": 941
+    },
+    {
+      "path": "tests/series/methods/test_item.py",
+      "sha256": "a2c651e54afcdc48eca4a90228c960141c511713925fce9cebd931960a4853b1",
+      "sizeBytes": 1624
+    },
+    {
+      "path": "tests/series/methods/test_map.py",
+      "sha256": "92fdd12cd3e99f0cb0370300fa3dd0453893e5ce48d8b37752f135f7314e23df",
+      "sizeBytes": 20816
+    },
+    {
+      "path": "tests/series/methods/test_matmul.py",
+      "sha256": "7088f69c972d3273af10381379fa41de3ca9589ebe4476acaadc72c2bc57c348",
+      "sizeBytes": 2767
+    },
+    {
+      "path": "tests/series/methods/test_nlargest.py",
+      "sha256": "4439c1455dcdd700094acda7ae16f53d20c6c29b03dfd5f1e4c41b8460313812",
+      "sizeBytes": 8020
+    },
+    {
+      "path": "tests/series/methods/test_nunique.py",
+      "sha256": "e81edfb3d9e2b8dd90632c6354d5f7dd62c126f1764896510a7e922274c8cf48",
+      "sizeBytes": 481
+    },
+    {
+      "path": "tests/series/methods/test_pct_change.py",
+      "sha256": "8441a93f4a208ab805d1199d122bed6a139931b65ded70285c47ba6dc1ac1921",
+      "sizeBytes": 2602
+    },
+    {
+      "path": "tests/series/methods/test_pop.py",
+      "sha256": "c6bf59b85088eceda04d6f1add606bfa8a1070e841ce850ae0dd71d0ae46dfcd",
+      "sizeBytes": 295
+    },
+    {
+      "path": "tests/series/methods/test_quantile.py",
+      "sha256": "76aa3e4216b689c76f8af4366897aa9349bf474ea4f8af1f6239c0b161e3e75e",
+      "sizeBytes": 8505
+    },
+    {
+      "path": "tests/series/methods/test_rank.py",
+      "sha256": "01f6bc5ed6a775415e1a63b1af96728453818fdcac23857215549c1a0eef59f5",
+      "sizeBytes": 21833
+    },
+    {
+      "path": "tests/series/methods/test_reindex.py",
+      "sha256": "e11a7f3405b5bd7286240edc46bfea5aca82437f5efa5d10b09fa76dbb2fb9b8",
+      "sizeBytes": 15085
+    },
+    {
+      "path": "tests/series/methods/test_reindex_like.py",
+      "sha256": "2a9dee8869b56fcef680fe0412b30e45f9c7181f16ec22bd221d7394ff16cd86",
+      "sizeBytes": 1515
+    },
+    {
+      "path": "tests/series/methods/test_rename.py",
+      "sha256": "1934a85e083b930d4ce0371c7bfc7e53c8eb4467585d3cd19ab07593910f2979",
+      "sizeBytes": 6059
+    },
+    {
+      "path": "tests/series/methods/test_rename_axis.py",
+      "sha256": "4ea19e65d841dc492dbe3e3c25f6d7d89affaac0a8beda168a6a5f5ff5622728",
+      "sizeBytes": 1520
+    },
+    {
+      "path": "tests/series/methods/test_repeat.py",
+      "sha256": "5af111fd092854d614e1b8398506cb7425c85b1a959d2989e8adffdce2cb2c02",
+      "sizeBytes": 1274
+    },
+    {
+      "path": "tests/series/methods/test_replace.py",
+      "sha256": "67509af0cb2a3ae967b6fba0916b651e4422ba038eebeff2ea9993e4fc868de0",
+      "sizeBytes": 27914
+    },
+    {
+      "path": "tests/series/methods/test_reset_index.py",
+      "sha256": "971a189b6999396cdfe88903b591f1467d7b78c85d37becc47475bdac2ef0367",
+      "sizeBytes": 7874
+    },
+    {
+      "path": "tests/series/methods/test_round.py",
+      "sha256": "ca09a67ef11ada8e038b045fad8b04285c510b067029cf8ff71230b0f16a7185",
+      "sizeBytes": 3976
+    },
+    {
+      "path": "tests/series/methods/test_searchsorted.py",
+      "sha256": "da793e8573db1638197ca9b86cefd388a9b6c63778863d0bf618aa4789d9d92b",
+      "sizeBytes": 2493
+    },
+    {
+      "path": "tests/series/methods/test_set_name.py",
+      "sha256": "a10264c877909c030a6225c34e955daa711bcd2d6b6c415ce8ad9adbda123eda",
+      "sizeBytes": 595
+    },
+    {
+      "path": "tests/series/methods/test_size.py",
+      "sha256": "b74d2cec0d35c2bbcee59cf9936a04a4f70731982f50aeb303e21c8b26a5f436",
+      "sizeBytes": 495
+    },
+    {
+      "path": "tests/series/methods/test_sort_index.py",
+      "sha256": "7058217616e31d05f9185af7a6596f2e8e9aac3d2daf6ace5f9905fc45a2f823",
+      "sizeBytes": 12647
+    },
+    {
+      "path": "tests/series/methods/test_sort_values.py",
+      "sha256": "06763ea1c680a0a1619b49ec192ab58dfc77a36b4199cd88d0eab1b1554ab884",
+      "sizeBytes": 8975
+    },
+    {
+      "path": "tests/series/methods/test_to_csv.py",
+      "sha256": "6aa1793bf27b351340be7adf26cbc1170abec2275ec8f63e228cee8cc304731d",
+      "sizeBytes": 6011
+    },
+    {
+      "path": "tests/series/methods/test_to_dict.py",
+      "sha256": "5c675c1758c3e11d1afef580417c1a97721526837010035ad6d53ba87b692060",
+      "sizeBytes": 1178
+    },
+    {
+      "path": "tests/series/methods/test_to_frame.py",
+      "sha256": "9d4907413a4c4df7e4a4347bc3711c42f4007af11f7e50fab479b7a53071a532",
+      "sizeBytes": 1992
+    },
+    {
+      "path": "tests/series/methods/test_to_numpy.py",
+      "sha256": "a44076074f087483d1629e67ed4498157f4741b0a5265e3139e82355dee660b7",
+      "sizeBytes": 1321
+    },
+    {
+      "path": "tests/series/methods/test_tolist.py",
+      "sha256": "e45d150182533c351396a6f9cc334479cf81781636e598e78ea607150ab918f5",
+      "sizeBytes": 1115
+    },
+    {
+      "path": "tests/series/methods/test_truncate.py",
+      "sha256": "b2e30a2358cc11555277f6f9ae52ccda2aac434f1cf1af426cdf266cd29d3445",
+      "sizeBytes": 2307
+    },
+    {
+      "path": "tests/series/methods/test_tz_localize.py",
+      "sha256": "dd208b0c471188ab2004627d6fcf65e3abeabc7f891d3e8c42df2114824e5b24",
+      "sizeBytes": 4266
+    },
+    {
+      "path": "tests/series/methods/test_unique.py",
+      "sha256": "310079b38295a29a2bd55d4282f17a959354497e9970e4b6fc7e494587fb7a65",
+      "sizeBytes": 2219
+    },
+    {
+      "path": "tests/series/methods/test_unstack.py",
+      "sha256": "6d3aafef3d9412712a41b8be0797646973a4b00e125be7e9922c4f7d0dd789d1",
+      "sizeBytes": 5057
+    },
+    {
+      "path": "tests/series/methods/test_update.py",
+      "sha256": "bf7d18363ef8a6d0356f21dd461c0677a6531f2dae8e81370d8c2ffd2f8fdf8b",
+      "sizeBytes": 4991
+    },
+    {
+      "path": "tests/series/methods/test_value_counts.py",
+      "sha256": "905a85a5b30138f4eef332e24c9521b0964c8953f442b657c573e51d645ec44b",
+      "sizeBytes": 9723
+    },
+    {
+      "path": "tests/series/methods/test_values.py",
+      "sha256": "4368c00966aec2cd06c4873f433c5b00e80cac947a42cee8cb1ffa2caef356df",
+      "sizeBytes": 747
+    },
+    {
+      "path": "tests/series/test_api.py",
+      "sha256": "d091e0c81ce4c331c0e219bf1d7dfb2fcf59caba34bf0b43fd6a2f4b4dcf4671",
+      "sizeBytes": 9452
+    },
+    {
+      "path": "tests/series/test_arithmetic.py",
+      "sha256": "e79bf5c9f6c8555e38185f14f6b8ae8b347240db8f502c071b7ee30fa4901b1f",
+      "sizeBytes": 37013
+    },
+    {
+      "path": "tests/series/test_arrow_interface.py",
+      "sha256": "63f0b21235ccb333897fa839eb0eb388ef9561818aaf6b2ac8efda112fcc3c15",
+      "sizeBytes": 3282
+    },
+    {
+      "path": "tests/series/test_constructors.py",
+      "sha256": "ef0819d48825f4614ec088f25b4d342a8808a12b1c5d45cff3281b481ec13252",
+      "sizeBytes": 85568
+    },
+    {
+      "path": "tests/series/test_cumulative.py",
+      "sha256": "98aa8ee1fc205b3666db3c04aadd3be79de3f0d2706bff2de4351c4d9c8cb4dc",
+      "sizeBytes": 9954
+    },
+    {
+      "path": "tests/series/test_formats.py",
+      "sha256": "57fcddf38331e26119a4ee638483bc7383239ff8767ce0045512d15b4a44e786",
+      "sizeBytes": 17405
+    },
+    {
+      "path": "tests/series/test_iteration.py",
+      "sha256": "20dfd33f9d866fa0566db78334154999e1f2f32f83cb1ca581a09f7d78ade478",
+      "sizeBytes": 1346
+    },
+    {
+      "path": "tests/series/test_logical_ops.py",
+      "sha256": "14698f3356d531b1cb87761c57be48737cb547b7ac97f7a6406c16336d5e2f5f",
+      "sizeBytes": 18134
+    },
+    {
+      "path": "tests/series/test_missing.py",
+      "sha256": "8a476af77a762f8a44d91390cf658f2ed6a5b0844342ebc5711ad73a6a02398b",
+      "sizeBytes": 2593
+    },
+    {
+      "path": "tests/series/test_npfuncs.py",
+      "sha256": "90dbca75994824ae3e2ba6a9daff23b32cc944c758d9ea2612c8b7e9de39cb6e",
+      "sizeBytes": 1338
+    },
+    {
+      "path": "tests/series/test_reductions.py",
+      "sha256": "dafa93c6f65f74d064ee587418dde7151b1aa4119a6e53e0fea031afd8c57380",
+      "sizeBytes": 7109
+    },
+    {
+      "path": "tests/series/test_subclass.py",
+      "sha256": "68be6d80619764f3c85d6220a423c1adced0e4a4bc8758a964d282c1c8b0fa36",
+      "sizeBytes": 2667
+    },
+    {
+      "path": "tests/series/test_ufunc.py",
+      "sha256": "b89a2b0e713bf7663e321c36413af86ac5f2956aa4bab4cab233fa895fabd963",
+      "sizeBytes": 15370
+    },
+    {
+      "path": "tests/series/test_unary.py",
+      "sha256": "5e4b70eb0f78d0b5e6dfc38a2d6f8b46aa4c65203d101e5f782b7d14c2e1f84e",
+      "sizeBytes": 1620
+    },
+    {
+      "path": "tests/series/test_validate.py",
+      "sha256": "ce20a62a2fe362e1b2c5c9ec55a269560c120a3060a470c9d1d6f358b6b5fa40",
+      "sizeBytes": 668
+    },
+    {
+      "path": "tests/strings/__init__.py",
+      "sha256": "6d7cb7388fbeb24c56b31e5749e8acbd1948ad78b236636f5193f34d26bef36b",
+      "sizeBytes": 587
+    },
+    {
+      "path": "tests/strings/conftest.py",
+      "sha256": "dbf052d06777fc415d49f7a279840c5a7953550d805c993e057a3c8eb2236db8",
+      "sizeBytes": 3967
+    },
+    {
+      "path": "tests/strings/test_api.py",
+      "sha256": "451749208097927c17e9c553d8c73f6b73318f12e91a34ef60cfc2cce1486c49",
+      "sizeBytes": 6785
+    },
+    {
+      "path": "tests/strings/test_case_justify.py",
+      "sha256": "5ff59aa7da70a87f975178b7c523957c0224d37ddcd4a707171f64b18589af18",
+      "sizeBytes": 13361
+    },
+    {
+      "path": "tests/strings/test_cat.py",
+      "sha256": "cf263e1d121392b37039e8bca3d11995a22145038b7ace2b0075d7f379d06f66",
+      "sizeBytes": 14187
+    },
+    {
+      "path": "tests/strings/test_extract.py",
+      "sha256": "6be7fd37c21863c199165ba29b86945abdfadb876cc7901169a25baa3d6f128b",
+      "sizeBytes": 28906
+    },
+    {
+      "path": "tests/strings/test_find_replace.py",
+      "sha256": "33a572198b1f0f9f1c9de68dbaa391ec61fc227b1242f0abbf1948047a5e41b4",
+      "sizeBytes": 60494
+    },
+    {
+      "path": "tests/strings/test_get_dummies.py",
+      "sha256": "77f7041a13a7ec5b80aebdbc85e4994d5be5cb2710ccd2beed669b2124fe896b",
+      "sizeBytes": 2629
+    },
+    {
+      "path": "tests/strings/test_split_partition.py",
+      "sha256": "30a927d0b0436fd1d6870015bc92e3e1bd6378b57c50e0b02f74cd2445203e81",
+      "sizeBytes": 24913
+    },
+    {
+      "path": "tests/strings/test_string_array.py",
+      "sha256": "514361d256dabee4fd38ae5a53e57a933e1dd3fa3e83394ce2c023adcd882e14",
+      "sizeBytes": 4013
+    },
+    {
+      "path": "tests/strings/test_strings.py",
+      "sha256": "0ec1441a0a61e7f128ab935e2228f79b3eca221685076f3a158f7527a6068c6e",
+      "sizeBytes": 33173
+    },
+    {
+      "path": "tests/test_aggregation.py",
+      "sha256": "bb153bd2e0eda5f0efb65e61720bc520a0a5d8ec6d684eb99057071bea5fea2d",
+      "sizeBytes": 2779
+    },
+    {
+      "path": "tests/test_algos.py",
+      "sha256": "9f6611c53cc81b3d7c5cca300e612f7c99f20fe7d1d7e38da2f407fe73eb9763",
+      "sizeBytes": 78481
+    },
+    {
+      "path": "tests/test_col.py",
+      "sha256": "a86bcccd3f041ac81a1d6f349d537ee1049c6afa4d799b9293b410da4409f038",
+      "sizeBytes": 12707
+    },
+    {
+      "path": "tests/test_common.py",
+      "sha256": "f9f27bd6d49bbc3e8749d0836b038ddf907997642b237e8284fc9e41d324e85a",
+      "sizeBytes": 8005
+    },
+    {
+      "path": "tests/test_downstream.py",
+      "sha256": "fe79c252e75fee156ec9d965c6f116530fd7a9c9e51a28e793ebb2c71313bcd8",
+      "sizeBytes": 8678
+    },
+    {
+      "path": "tests/test_errors.py",
+      "sha256": "9e52c82a207cdac9376a196eb7d6be4d5b6de98a828d92d04ea2b9defd54b784",
+      "sizeBytes": 4016
+    },
+    {
+      "path": "tests/test_expressions.py",
+      "sha256": "edb256b8a39f320631d20d9d5853a04c1efb8a0e07bf1983773f218a8adb957f",
+      "sizeBytes": 14893
+    },
+    {
+      "path": "tests/test_flags.py",
+      "sha256": "0ecbbaa6f43903a31a9f2b7556540b2bca51a59b6bf92d93dee6c9bd141a4650",
+      "sizeBytes": 1550
+    },
+    {
+      "path": "tests/test_multilevel.py",
+      "sha256": "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f",
+      "sizeBytes": 12785
+    },
+    {
+      "path": "tests/test_nanops.py",
+      "sha256": "1a1b85ab05192fde651a517477d47e01518b83dc594d7a0057136fc1761ef941",
+      "sizeBytes": 44665
+    },
+    {
+      "path": "tests/test_optional_dependency.py",
+      "sha256": "2ec3a6a4425d5c8213c8f3b55b178f978acfe3676168a40d5230104e79ffa029",
+      "sizeBytes": 3217
+    },
+    {
+      "path": "tests/test_register_accessor.py",
+      "sha256": "4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793",
+      "sizeBytes": 3237
+    },
+    {
+      "path": "tests/test_sorting.py",
+      "sha256": "8c070cc81fce519596c52d449440e81ba6b425f5542d17ba9ddbd93c2d8746b9",
+      "sizeBytes": 16465
+    },
+    {
+      "path": "tests/test_take.py",
+      "sha256": "8e1cc330f48b45f203b4cd6098106592b6f545349cb821110d1286a1b8598924",
+      "sizeBytes": 11908
+    },
+    {
+      "path": "tests/tools/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/tools/test_to_datetime.py",
+      "sha256": "027da13ab47c750acc52e86b22c2c716eae87971d5693d72105923fa99b8213d",
+      "sizeBytes": 142963
+    },
+    {
+      "path": "tests/tools/test_to_numeric.py",
+      "sha256": "303224f76f088ac3a08b7a2710929dea7216ee76e6398858ecfef49043e2f149",
+      "sizeBytes": 26471
+    },
+    {
+      "path": "tests/tools/test_to_time.py",
+      "sha256": "d8912262d276ab41c0eac9c7f149b49c32ceb311aa7b203f3f2728b3490ff330",
+      "sizeBytes": 2083
+    },
+    {
+      "path": "tests/tools/test_to_timedelta.py",
+      "sha256": "e8061a34058acc504a6d35e77ad4ae40c4fbcd58e0d53cc113b5f62f3ca9e954",
+      "sizeBytes": 14033
+    },
+    {
+      "path": "tests/tseries/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/tseries/frequencies/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/tseries/frequencies/test_freq_code.py",
+      "sha256": "86f425dfbcf75ba0b070b380aab81cd9a72ab6338921ba956e75e4114058e1c3",
+      "sizeBytes": 1727
+    },
+    {
+      "path": "tests/tseries/frequencies/test_frequencies.py",
+      "sha256": "b7223d7babdeeec1177402f2f46623315de60101e6405d88a96fb11733dd8236",
+      "sizeBytes": 821
+    },
+    {
+      "path": "tests/tseries/frequencies/test_inference.py",
+      "sha256": "0072679afcc10d149b13a6d5ce7c96bf77b81c5afa226f8b98d1d8b8e02b4d21",
+      "sizeBytes": 15728
+    },
+    {
+      "path": "tests/tseries/holiday/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/tseries/holiday/test_calendar.py",
+      "sha256": "58aaef1f5cec2646a2bcd39118d4e84c7adbf6e4b32deff3dda23b67f93e66a4",
+      "sizeBytes": 3622
+    },
+    {
+      "path": "tests/tseries/holiday/test_federal.py",
+      "sha256": "0489d99d69f791652414e00bb417125b97145c90e1e1c730406666313383ecad",
+      "sizeBytes": 1948
+    },
+    {
+      "path": "tests/tseries/holiday/test_holiday.py",
+      "sha256": "5887956d2ccd0abfaf28127569c727cddb554893fd0fdedde72aaf6f1e0e74c0",
+      "sizeBytes": 15160
+    },
+    {
+      "path": "tests/tseries/holiday/test_observance.py",
+      "sha256": "18906a205e16e901b8937633cfaff5dd630e4789c7495ccf6e2c47c4ef13ba4c",
+      "sizeBytes": 2723
+    },
+    {
+      "path": "tests/tseries/offsets/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/tseries/offsets/common.py",
+      "sha256": "18b9aa0927f795f5c36419f713e23e2b1eca8c6efbcbf1c41e4f4dc566d95bf8",
+      "sizeBytes": 901
+    },
+    {
+      "path": "tests/tseries/offsets/test_business_day.py",
+      "sha256": "829ee4514651c6002a3bc53e0e86a5fe870e28865bf70ffb40efb3c61fc3799b",
+      "sizeBytes": 6809
+    },
+    {
+      "path": "tests/tseries/offsets/test_business_halfyear.py",
+      "sha256": "645ec1775e725e70799023ef59f06efe844d832eb66191a087f09a2379c9f0e4",
+      "sizeBytes": 13968
+    },
+    {
+      "path": "tests/tseries/offsets/test_business_hour.py",
+      "sha256": "b24a6d080de349bf35068d68ee1353fe9564ea149327a027460e21ed7b653439",
+      "sizeBytes": 58547
+    },
+    {
+      "path": "tests/tseries/offsets/test_business_month.py",
+      "sha256": "46c678b9bb56b471b9c55273d23c0476db9ba650125b757001834e89c1c71e80",
+      "sizeBytes": 6718
+    },
+    {
+      "path": "tests/tseries/offsets/test_business_quarter.py",
+      "sha256": "093cd672a1c84b5a659a1b5e67ac337de50a85316dc1dcf22807b91e62f92f15",
+      "sizeBytes": 11887
+    },
+    {
+      "path": "tests/tseries/offsets/test_business_year.py",
+      "sha256": "ce9429c6251d883ec264286e89524b3cb3eb75684495364f6bdbffd69bf93061",
+      "sizeBytes": 6437
+    },
+    {
+      "path": "tests/tseries/offsets/test_common.py",
+      "sha256": "59623edc7e769206290dc333b4112c7b82e6f036cf66b80bbab57cf9cbffaaeb",
+      "sizeBytes": 7327
+    },
+    {
+      "path": "tests/tseries/offsets/test_custom_business_day.py",
+      "sha256": "1bb5c5add1867afd0ba8dd0eb0d940fe8fbf4dc8be9e7792714030406a5e6052",
+      "sizeBytes": 3203
+    },
+    {
+      "path": "tests/tseries/offsets/test_custom_business_hour.py",
+      "sha256": "d582f94c144b0eb068b46ad44fa98349856c766bede0eccb80da8843f3f7471f",
+      "sizeBytes": 12217
+    },
+    {
+      "path": "tests/tseries/offsets/test_custom_business_month.py",
+      "sha256": "4cb4687c5ee766b1eb4ad7e5aee0d07696736b0a5f616ecfb028fe4c8afe0429",
+      "sizeBytes": 12939
+    },
+    {
+      "path": "tests/tseries/offsets/test_dst.py",
+      "sha256": "0f300501dd442b27239ace9eec7cee1ae52123b0147941c047f9d9b2f1c958d6",
+      "sizeBytes": 9409
+    },
+    {
+      "path": "tests/tseries/offsets/test_easter.py",
+      "sha256": "c3cf6d5007b46f391cae3f6cc4fedbbd26992eb2bdb79ac8bb203eafa808cce7",
+      "sizeBytes": 4675
+    },
+    {
+      "path": "tests/tseries/offsets/test_fiscal.py",
+      "sha256": "138669b7fb8d0767f6c009bf88644b25d3588cd06ddb248b955eeb9674a44c39",
+      "sizeBytes": 26080
+    },
+    {
+      "path": "tests/tseries/offsets/test_halfyear.py",
+      "sha256": "f13b10e5a2d4e27bc540509b746f739f96f7e74b935502832a8e4617c357e93f",
+      "sizeBytes": 13836
+    },
+    {
+      "path": "tests/tseries/offsets/test_index.py",
+      "sha256": "eae3b6f88d3f9d29688ffbceacb24a9143614627cb35a7c49e724f1210abe176",
+      "sizeBytes": 1148
+    },
+    {
+      "path": "tests/tseries/offsets/test_month.py",
+      "sha256": "ce58f6251657fad74144343b9b036820d25e5fcacbd3f7b217fd023e3f80794a",
+      "sizeBytes": 23270
+    },
+    {
+      "path": "tests/tseries/offsets/test_offsets.py",
+      "sha256": "cf4580b290bc89ebb53a9ce682705d4e76ea3c2c25f5f108d7ecc1fb12bd3a6e",
+      "sizeBytes": 41299
+    },
+    {
+      "path": "tests/tseries/offsets/test_offsets_properties.py",
+      "sha256": "d2ba8c523b6038ba29a3c14db80f2dcf5c02b50efaf80a4078573217193178ce",
+      "sizeBytes": 2262
+    },
+    {
+      "path": "tests/tseries/offsets/test_quarter.py",
+      "sha256": "0490453c9127a48a51504fb85c0c5a27ec0e4985d17ba6105a8ec1e575bc4091",
+      "sizeBytes": 11143
+    },
+    {
+      "path": "tests/tseries/offsets/test_ticks.py",
+      "sha256": "23d2f8c06ee58477bb0af32e2fecb9e644e340962e55744450c99a121f4c1255",
+      "sizeBytes": 10899
+    },
+    {
+      "path": "tests/tseries/offsets/test_week.py",
+      "sha256": "deeb3bce4e29374ef0629b47ba11923dbdddc0015d04040942e39331dd927675",
+      "sizeBytes": 11959
+    },
+    {
+      "path": "tests/tseries/offsets/test_year.py",
+      "sha256": "7c4b8442b67f916a0b2f43676227024719e13ad9b816d41712aecc9a0c88f424",
+      "sizeBytes": 10456
+    },
+    {
+      "path": "tests/tslibs/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/tslibs/test_api.py",
+      "sha256": "62d15767744537c7a223d9c6e5ef5888cde414aa4329c213a3052b2b2831b763",
+      "sizeBytes": 1540
+    },
+    {
+      "path": "tests/tslibs/test_array_to_datetime.py",
+      "sha256": "71a841dcbf428b26a566e606547b844b2f4373d48984cf1c8a22109c39a42beb",
+      "sizeBytes": 10846
+    },
+    {
+      "path": "tests/tslibs/test_ccalendar.py",
+      "sha256": "f30ade5b677cc70db39eb228f58cb4d8d9eace20f3f5b6f7c27957a8952d684e",
+      "sizeBytes": 1921
+    },
+    {
+      "path": "tests/tslibs/test_conversion.py",
+      "sha256": "b714c3fd1f93251bce0c38de0590cce80e37e9b3eae6f1cf64167965ad488425",
+      "sizeBytes": 4696
+    },
+    {
+      "path": "tests/tslibs/test_fields.py",
+      "sha256": "0502a5057382e0bb177bb793d822b9991191ff6e60f6a63291067aa23a068db1",
+      "sizeBytes": 1352
+    },
+    {
+      "path": "tests/tslibs/test_libfrequencies.py",
+      "sha256": "022e9d78388697050747d995be59086d76335990031ee3cb95a0630cad11db05",
+      "sizeBytes": 717
+    },
+    {
+      "path": "tests/tslibs/test_liboffsets.py",
+      "sha256": "7559ff6e3a86df5c69b4794e7eddea593d041400db1f92cefe967a80b0e5d990",
+      "sizeBytes": 5097
+    },
+    {
+      "path": "tests/tslibs/test_np_datetime.py",
+      "sha256": "c1193eef8cc907da360687d89c143a752bf9bb2104f4d579e2cedbfc52fd54a1",
+      "sizeBytes": 8513
+    },
+    {
+      "path": "tests/tslibs/test_npy_units.py",
+      "sha256": "77d345b3281c286b69fa9c3e6693af231321a6c46a775b8f05596a7a31e43665",
+      "sizeBytes": 922
+    },
+    {
+      "path": "tests/tslibs/test_parse_iso8601.py",
+      "sha256": "5c643f181382a2c4e23851632b8ad8a030d9708062b67c886ffd125f1285f72a",
+      "sizeBytes": 4535
+    },
+    {
+      "path": "tests/tslibs/test_parsing.py",
+      "sha256": "ba2bc64217dea69c99cce7f0e30ffdc67f6ffad1a9649d3aaa11b234a5963856",
+      "sizeBytes": 14512
+    },
+    {
+      "path": "tests/tslibs/test_period.py",
+      "sha256": "23e4342dd0b1ced8f74dd038d58dc10689956ae1e9c14cfe2a39776a50b4f2d2",
+      "sizeBytes": 3423
+    },
+    {
+      "path": "tests/tslibs/test_resolution.py",
+      "sha256": "310f6465383ffdfff9f2dc0bc40890158637c9b3755fe5e745f0f0b2eded47d9",
+      "sizeBytes": 1404
+    },
+    {
+      "path": "tests/tslibs/test_strptime.py",
+      "sha256": "332e3e0324280b219c7556b477d91e794593fc0acd0f640df08ffa68835e428e",
+      "sizeBytes": 3940
+    },
+    {
+      "path": "tests/tslibs/test_timedeltas.py",
+      "sha256": "07d21d2bd798977df0ec7e6c258bd4ca165fa733732eca13a8cd97428c8b65fe",
+      "sizeBytes": 4813
+    },
+    {
+      "path": "tests/tslibs/test_timezones.py",
+      "sha256": "a98333a32df623dd945a5724a8ca3b78eda9bd8e644dc33e5efecb4e30c4742b",
+      "sizeBytes": 7911
+    },
+    {
+      "path": "tests/tslibs/test_to_offset.py",
+      "sha256": "a2594ad1f0885b35c0cacff4b8d2885e90b0b1600a0e2de4ec4c877cf298553a",
+      "sizeBytes": 6660
+    },
+    {
+      "path": "tests/tslibs/test_tzconversion.py",
+      "sha256": "bc23473d5133cc0fb74767c14650a8ad97950b751f4e0acf16ddcbe2077b6ba2",
+      "sizeBytes": 961
+    },
+    {
+      "path": "tests/util/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/util/conftest.py",
+      "sha256": "5fe00d7cde6f90d4050cf28abcab1bdd7bc5ec9020849a3bc80ffb346732cd28",
+      "sizeBytes": 1183
+    },
+    {
+      "path": "tests/util/test_assert_almost_equal.py",
+      "sha256": "086f0855c105df33a2e2f6e9048149c95b2b9c61204d6c0c122a786b7a68cf71",
+      "sizeBytes": 16864
+    },
+    {
+      "path": "tests/util/test_assert_attr_equal.py",
+      "sha256": "6574e88cfe15e4a95ef7a40e161c42663abe7507fa807bcd3a8ad8c8eb853f52",
+      "sizeBytes": 1045
+    },
+    {
+      "path": "tests/util/test_assert_categorical_equal.py",
+      "sha256": "7b3fce681838340e208e67794425d2e97cd783d79f5555ab7a6212332400e5a7",
+      "sizeBytes": 2706
+    },
+    {
+      "path": "tests/util/test_assert_extension_array_equal.py",
+      "sha256": "56028e9fca32b375101cf1315ddf12673c99fb0276b99125e3d93bbd651f0b3f",
+      "sizeBytes": 3831
+    },
+    {
+      "path": "tests/util/test_assert_frame_equal.py",
+      "sha256": "45e6fe7c24df1bf0eb8e026a98eb1c7d685a0c17395438e6a85e8091d592e268",
+      "sizeBytes": 14631
+    },
+    {
+      "path": "tests/util/test_assert_index_equal.py",
+      "sha256": "f392071bda56c7ccb7e832e0e1b4cfc783e0b8cd741b21428df2d4e1178832b7",
+      "sizeBytes": 10511
+    },
+    {
+      "path": "tests/util/test_assert_interval_array_equal.py",
+      "sha256": "bb137c1252ed33a4e13050cfb37150c2e91e0927dd76760dfb86e440e273f57a",
+      "sizeBytes": 2651
+    },
+    {
+      "path": "tests/util/test_assert_numpy_array_equal.py",
+      "sha256": "7e06fc19d5305f8118891dcf59b8c950b35f009cf80df27c4495dc86cb3280ee",
+      "sizeBytes": 6624
+    },
+    {
+      "path": "tests/util/test_assert_produces_warning.py",
+      "sha256": "8dcfbb969bfd3dbe893cff4723aa7675f781585b48e19799fd873041042caa99",
+      "sizeBytes": 10123
+    },
+    {
+      "path": "tests/util/test_assert_series_equal.py",
+      "sha256": "99c8e91a2e9483254feabdcc1cf829a6c77297a10acf2ecf6f0098a5e5cbe051",
+      "sizeBytes": 16068
+    },
+    {
+      "path": "tests/util/test_deprecate.py",
+      "sha256": "da3ac6c2489715dd39ee962de585e24dfc05f8e92de3a53e1688e60fa854c9c5",
+      "sizeBytes": 1758
+    },
+    {
+      "path": "tests/util/test_deprecate_kwarg.py",
+      "sha256": "8da8cd4087d531386734461d2fe43a23ae0f2c695e5474fb0c67a02ba98d41f3",
+      "sizeBytes": 2186
+    },
+    {
+      "path": "tests/util/test_deprecate_nonkeyword_arguments.py",
+      "sha256": "9c392d3ddb62e8507aa404d74ea9c05e86d78ef57a9fe97a02b6d50e3e1f77fb",
+      "sizeBytes": 3965
+    },
+    {
+      "path": "tests/util/test_doc.py",
+      "sha256": "bb47f10a0e33656841e1290961cda1b90d31bfbb0a280b743a5a5695d9a187f3",
+      "sizeBytes": 1492
+    },
+    {
+      "path": "tests/util/test_hashing.py",
+      "sha256": "9c7c946bf702dc38c896dcc4b37cdb160ad88fd58dc9f410919340a16d42d922",
+      "sizeBytes": 13947
+    },
+    {
+      "path": "tests/util/test_numba.py",
+      "sha256": "676e365a86b2202d19729b83a1bde56871342ad4508b7d087ea05f8ce074f81e",
+      "sizeBytes": 313
+    },
+    {
+      "path": "tests/util/test_rewrite_warning.py",
+      "sha256": "923c374285d730beecfe61b74f127bd35639143d6b7c6c931c925394aa957709",
+      "sizeBytes": 1231
+    },
+    {
+      "path": "tests/util/test_shares_memory.py",
+      "sha256": "6e53dd543fad4a5934ee1431505ce0a5fdd26da86563d7ee0c53c2144dda5bdb",
+      "sizeBytes": 1169
+    },
+    {
+      "path": "tests/util/test_show_versions.py",
+      "sha256": "163614ad430017b84ece985a5c40ffffcca3785d074dc7194baab4e7ffeb1f8e",
+      "sizeBytes": 2096
+    },
+    {
+      "path": "tests/util/test_util.py",
+      "sha256": "e1469c58f2f28d141953af7b8c1c4158ee95d60520904e04f8a285e87e9a5ee1",
+      "sizeBytes": 1463
+    },
+    {
+      "path": "tests/util/test_validate_args.py",
+      "sha256": "f59e334ea9ca0169f5abd29936fb8edc317aa2ccc78d0ad082d38e8a6bab59cb",
+      "sizeBytes": 1907
+    },
+    {
+      "path": "tests/util/test_validate_args_and_kwargs.py",
+      "sha256": "77f5dc311010f6bfbec8800059274930be8a796824b32e6a44d157698d413100",
+      "sizeBytes": 2456
+    },
+    {
+      "path": "tests/util/test_validate_inclusive.py",
+      "sha256": "c36b707ad26021e766e8a190e1699d9860bfebe4528458d704c055c51d2070c1",
+      "sizeBytes": 896
+    },
+    {
+      "path": "tests/util/test_validate_kwargs.py",
+      "sha256": "d1886460de0a854daac4c4526ceb8aec1886b799ea3d88d6df27422df8d3858a",
+      "sizeBytes": 1821
+    },
+    {
+      "path": "tests/window/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/window/conftest.py",
+      "sha256": "ee447382fce13d5896385018612248ae76d76d186915cbe699a05c9cfd5fbe18",
+      "sizeBytes": 2595
+    },
+    {
+      "path": "tests/window/moments/__init__.py",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sizeBytes": 0
+    },
+    {
+      "path": "tests/window/moments/conftest.py",
+      "sha256": "c52932c9596db009091132c31c94a4b234648dc547b2785fc8288dbe1b10de7a",
+      "sizeBytes": 1595
+    },
+    {
+      "path": "tests/window/moments/test_moments_consistency_ewm.py",
+      "sha256": "9690bf3bb7d5347af98521076e0d0d6954acf95ea35ba2f947517d5b0b454760",
+      "sizeBytes": 8122
+    },
+    {
+      "path": "tests/window/moments/test_moments_consistency_expanding.py",
+      "sha256": "c8be9b67987410e5c86676bc35932829ffc45953cceaf46632d44b5d1f554301",
+      "sizeBytes": 5703
+    },
+    {
+      "path": "tests/window/moments/test_moments_consistency_rolling.py",
+      "sha256": "fa3fd0be3e858111cf059a54ca79027cbef87de965be819beb74c5032679489a",
+      "sizeBytes": 7842
+    },
+    {
+      "path": "tests/window/test_api.py",
+      "sha256": "f4402d352349a6c3c6aff88a030f1fc91535eb127bb139a4ba353fa2ca78dc3d",
+      "sizeBytes": 11817
+    },
+    {
+      "path": "tests/window/test_apply.py",
+      "sha256": "141f494a6919d0b4d3fe680ae50c327d879644fa373ba6e27807a8db28d675f8",
+      "sizeBytes": 9521
+    },
+    {
+      "path": "tests/window/test_base_indexer.py",
+      "sha256": "f8c4e66d0c54453ea390bd8fac050ece502cc7f0efbb42874d4332244cef2418",
+      "sizeBytes": 15946
+    },
+    {
+      "path": "tests/window/test_cython_aggregations.py",
+      "sha256": "66dbdb38d1bfadc39bca37beea2401df819f161e98acd33ddbd168624ad49ef0",
+      "sizeBytes": 4162
+    },
+    {
+      "path": "tests/window/test_dtypes.py",
+      "sha256": "6b75e7a9cabf8ced24733666866b812a4982b0a1ce3ae7f2f61eb23423c794c9",
+      "sizeBytes": 5785
+    },
+    {
+      "path": "tests/window/test_ewm.py",
+      "sha256": "9158bb72bb70b9b70bee6aa6359db21383bdca351d27a9d26f189d6d08dcf1e3",
+      "sizeBytes": 23276
+    },
+    {
+      "path": "tests/window/test_expanding.py",
+      "sha256": "e12b56d99c1cefda5546a80b2e5d7003aa58b206ffc371c7c61a0cb793ff2654",
+      "sizeBytes": 26803
+    },
+    {
+      "path": "tests/window/test_groupby.py",
+      "sha256": "352dd02b54f0f9aee0c17d18e4f3e40aa9b150f7ab1e87c319c7b3446621d36b",
+      "sizeBytes": 47203
+    },
+    {
+      "path": "tests/window/test_numba.py",
+      "sha256": "9b7830c3f12c909289d5668af8ec84df3bc94a005c880f1c915a79c7946b58c4",
+      "sizeBytes": 22246
+    },
+    {
+      "path": "tests/window/test_online.py",
+      "sha256": "8e1b44a9854f46873da3b87820d7fbfb0da4e602a25502459c0ac7dc0305b040",
+      "sizeBytes": 3644
+    },
+    {
+      "path": "tests/window/test_pairwise.py",
+      "sha256": "f5f6fe357e01c29e6a94634594b18f45d975d6e1021020ab33f8331f6f01be58",
+      "sizeBytes": 16652
+    },
+    {
+      "path": "tests/window/test_rolling.py",
+      "sha256": "aced6d90c9bd8ad9d9da912896fbbda37b04e99cb2af518b68b6452e383b395c",
+      "sizeBytes": 64595
+    },
+    {
+      "path": "tests/window/test_rolling_functions.py",
+      "sha256": "502a7cecfb71e39f1825afb28007db9e7f5bd27fe581d799147780b8692f2e58",
+      "sizeBytes": 18020
+    },
+    {
+      "path": "tests/window/test_rolling_quantile.py",
+      "sha256": "c4a792bcecff36bf6b74e454f090dd132bc4a229f361e2d717c74646138edd61",
+      "sizeBytes": 5333
+    },
+    {
+      "path": "tests/window/test_rolling_skew_kurt.py",
+      "sha256": "126c3d009853672b959f13e0fa77d8c6944d1894e8589fa17bba1b4d23b2f225",
+      "sizeBytes": 7807
+    },
+    {
+      "path": "tests/window/test_timeseries_window.py",
+      "sha256": "4504eddf12b9643fbdcdfc962b7d5a38db3fa2d0420c3ca3cd90d2c674405496",
+      "sizeBytes": 25130
+    },
+    {
+      "path": "tests/window/test_win_type.py",
+      "sha256": "8f6b05a731399f930962456031a13719baf6900c869bdf5e8b98db6a7988cba0",
+      "sizeBytes": 16934
+    },
+    {
+      "path": "tseries/__init__.py",
+      "sha256": "10fc7e1463c1ab8570e9a0bec23548d2ee6e716be33e189de7c030c9533712de",
+      "sizeBytes": 292
+    },
+    {
+      "path": "tseries/api.py",
+      "sha256": "ef76a404b5616dc79107341e8ca339c904735a40c362082cfbc431ea2ad3e6fa",
+      "sizeBytes": 234
+    },
+    {
+      "path": "tseries/frequencies.py",
+      "sha256": "89ef7850f101b9fc106be6265960cad75c8a1fb6730138b18d5448941a098dd4",
+      "sizeBytes": 18541
+    },
+    {
+      "path": "tseries/holiday.py",
+      "sha256": "9789bf0fe3385c8b623f4f7f7bb80d0007c88bcdb6ab7a833761f1bacd541d6b",
+      "sizeBytes": 20445
+    },
+    {
+      "path": "tseries/offsets.py",
+      "sha256": "a5f9abaac4f7a195bd09f0df6c80314e8d9e5f32a2760985d1762127bb2d8257",
+      "sizeBytes": 1687
+    },
+    {
+      "path": "util/__init__.py",
+      "sha256": "523b66382b445db6cd4bd4418cb223773bc0d507c5b7499437ba4d28901e69b1",
+      "sizeBytes": 863
+    },
+    {
+      "path": "util/_decorators.py",
+      "sha256": "dbd878e0e5e0b4c01404d29180d0e46f62ccdb78a93e73ac0e060d262c15cbdb",
+      "sizeBytes": 17983
+    },
+    {
+      "path": "util/_doctools.py",
+      "sha256": "9a016b0c9a0dff4f26a624acec450e5036c5d72cecf59cc7a65e071765805c31",
+      "sizeBytes": 6911
+    },
+    {
+      "path": "util/_exceptions.py",
+      "sha256": "8d38db8a2e2b75af539b417edcce3a18af551cce6e5a4d3d2fca6965b2f34d00",
+      "sizeBytes": 2870
+    },
+    {
+      "path": "util/_print_versions.py",
+      "sha256": "ae2e4c997f2fbb4d686a7f2926c0830859dff947e258435b9744996a47fbb9d2",
+      "sizeBytes": 4824
+    },
+    {
+      "path": "util/_test_decorators.py",
+      "sha256": "04f3aeb171f821bef9c39403ccaad9ccf35af819e2b24d9cc9f91d5836d3f00d",
+      "sizeBytes": 4428
+    },
+    {
+      "path": "util/_tester.py",
+      "sha256": "979daf801034d5520a80700fafc530e69af5b4f025ce3cf81baf155b5f69ac67",
+      "sizeBytes": 1643
+    },
+    {
+      "path": "util/_validators.py",
+      "sha256": "1de6540e0c868aa2b420f4ff3fe7873bd67f8867ab141262862f587e983d74d3",
+      "sizeBytes": 14918
+    },
+    {
+      "path": "util/version/__init__.py",
+      "sha256": "5b63f2384efd85f42f24fa61baedf0becaa9a1987564e1bbc2a1c3c799f77b79",
+      "sizeBytes": 13142
+    }
+  ]
+}

--- a/docs/minority-report-gallery.md
+++ b/docs/minority-report-gallery.md
@@ -1,5 +1,15 @@
 # Minority Report gallery
 
+> **NON-AUTHORITATIVE BOARD.** The numbers below were measured before the
+> Python corpus board had a pinned denominator. The file *count* (1421) happens
+> to match the current pin, but a count is not an identity: nothing here records
+> which pandas bytes were walked, so these figures cannot be differenced against
+> a current measurement to yield a delta. The sole authority is
+> `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`,
+> pinned to `docs/ledgers/pins/pandas-3.0.3.pin.json`
+> (aggregate `bbb70a76…`, content-only `a1155ae2…`, path-bound `04b67544…`).
+> Quote those. Kept here as testimony of what was observed and when.
+
 > Campaign index for the dual-axis lift-coverage wall.
 > Part of [#4016](https://github.com/TSavo/sugar/issues/4016) · Part of [#4013](https://github.com/TSavo/sugar/issues/4013).
 >

--- a/docs/receipts/2026-07-26-python-scoreboard-authority.md
+++ b/docs/receipts/2026-07-26-python-scoreboard-authority.md
@@ -4,6 +4,69 @@
 **Corpus:** pandas 3.0.3, 1,421 files, `battleaxe:~/pandas303-audit/pandas`
 **Pin:** `docs/ledgers/pins/pandas-3.0.3.pin.json`
 
+## The baseline
+
+`docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json`. 1,421 enrolled,
+**1,421 terminal rows**, 55 min wall, peak RSS 12.1 GB for the whole corpus.
+Zero missing, zero duplicate, zero malformed. **Red**, and it says why.
+
+```
+enrolled 1421   terminal rows 1421   completed 1416   (5 terminal defect rows)
+functions 27451                      construct-clean 22550
+
+R_construction                    4     construction panics            0
+R_desugar                      9694     desugar construction panics  502
+R_backend_defects                 5     desugar defects               40
+R_unresolvable_dispatch (#6329)   0     factoring gaps                13
+timeouts                          0     controlEffectStableZero    False
+```
+
+### The two quantities, side by side — this is the whole point
+
+```
+site coverage   site:with-statement 7663    site:with-item 7673
+ΔR              With-attributable construction R: 2
+                (ContextManagerResolutionConstructionGap 1, UnsupportedWithBindingTarget 1)
+```
+
+**7,663 With sites. Two construction-R occurrences.** The `4125 / 811 / 85`
+partition is neither of these numbers, and could not be reproduced by either,
+because it was a name-derived split of a third thing. Total construction R over
+the whole corpus is **4**.
+
+### With residual, bucketed structurally
+
+```
+5737  gap:unrecognized:opaque-call-target:func      17  derived-contract
+ 715  gap:dynamic-export                            17  gap:unrecognized:non-manager-result:BlockValue
+ 709  gap:unrecognized:opaque-call-target:cast      14  gap:unrecognized:artifact-module-absent
+  24  gap:unrecognized:target-outside-binding        7  gap:no-derived-contract
+```
+
+Two things fall out of this table that a name-table classifier could not have
+shown. **`dynamic-export` is now 715 measured rows** rather than 780 aborted
+files — the decode fix turned a fatal into a number. And the vocabulary is
+dominated by `gap:unrecognized:*`, meaning `WithConstructionGapKind`'s closed
+enum covers a small fraction of the resolution kinds actually produced. The
+`parse` fallback preserves each wire kind instead of crashing or collapsing it,
+which is the `dynamic-export` fix generalized — but the gap between the declared
+vocabulary and the live one is itself a finding.
+
+### What is red, and whose
+
+- **502 desugar construction panics** — top owner
+  `ContractConditionalConstructionV1.and_then` (283), then `IfExpSugar._join`
+  (46), `collection ListValue` (41). Construction-law None arms: red, and never
+  semantic R.
+- **13 `ExitSetFactoringGap`** survive #6336, at named sites
+  (`core/arrays/datetimelike.py:1397`, `:1461`, `core/generic.py:13403`).
+  Partition testimony did not close all of them. Reported as observed; the
+  prediction was zero.
+- **5 terminal defect rows** — 3 are one backend defect,
+  `spans.LineTable.line_col` reporting `offset 55069 outside 0..27637` on large
+  test files; 2 are `SourceCallBindingGap: unconsumed call actual`.
+- **0 construction panics and 0 timeouts** across 1,421 files.
+
 ## Why this exists
 
 Two measurements were quoted against each other as one frontier. An AST-shape

--- a/docs/receipts/2026-07-26-python-scoreboard-authority.md
+++ b/docs/receipts/2026-07-26-python-scoreboard-authority.md
@@ -1,0 +1,209 @@
+# The Python corpus board gets one denominator
+
+**Commit:** `9a78828ee` (branch `scoreboard-authority`, base `origin/main` `8373415a5`)
+**Corpus:** pandas 3.0.3, 1,421 files, `battleaxe:~/pandas303-audit/pandas`
+**Pin:** `docs/ledgers/pins/pandas-3.0.3.pin.json`
+
+## Why this exists
+
+Two measurements were quoted against each other as one frontier. An AST-shape
+site census read `With 4125/811/85`. The construction-R ledger for the same
+period read `assertion 3 / resource 104 / other 4`. Both were correct
+measurements of different things against different denominators, and the
+difference between them was read as motion.
+
+So the authority now states its denominator before it states any number.
+
+## The two quantities
+
+| | question it answers | where |
+|---|---|---|
+| **site coverage** | how many AST sites have this shape | `astSitePrevalence`, every key prefixed `site:` |
+| **ΔR** | how many authenticated occurrences failed to construct or desugar | `R_construction`, `R_desugar` |
+
+Prevalence is a denominator and is **never** called R. Lifting a capability
+moves ΔR and leaves prevalence untouched — the `with` statements are still
+there afterwards. A capability succeeded only when ΔR falls **without another
+axis rising**.
+
+## Corpus identity: an assumption converted into a measurement
+
+Three digests, all computed from the same bytes and the same enumerator
+(`SourceTree(root).paths()`), on the **battleaxe Linux / python3.12** corpus:
+
+```
+aggregate    bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c
+contentOnly  a1155ae27c10a1828ac6a02b890a8b1ee23881a5f78c3d6265f02a63065ca77d
+pathBound    04b67544e3628d25d1b20653558fb2c702a870ae3f97bc8492a9f70f854a9c31
+files        1421
+```
+
+`contentOnly` and `pathBound` are the two conventions already circulating in
+existing receipts, computed on **macOS / python3.14**. Both reproduce exactly.
+The corpora are byte-identical across the interpreter gap. This was previously
+assumed; it is now measured.
+
+Our own `aggregate` differs from both because it additionally binds
+distribution and version — the identical file set claimed as two different
+pandas versions must not compare equal.
+
+**Every pin states its convention in prose beside the digest.** A bare digest is
+not checkable across agents, and convention drift was once mistaken for a
+corpus difference.
+
+## `m ** k` was eating the box — measured, not assumed
+
+`core/arrays/arrow/array.py` (3286 lines), same file, same corpus, same
+instrument. Only the commit differs:
+
+| | pre-fix `06fefd9aa` | post-fix `517496571` |
+|---|---|---|
+| peak RSS | 31.1 GB, still climbing | **542 MB** (`/usr/bin/time -v`) |
+| outcome | never finished the file | `done files=1/1` |
+| wall | 50+ min, killed | 23:03, of which ~15 min is the one-time demand build |
+| RSS shape | exponential | 39 MB flat, then 199 → 388 → 535, **stable** |
+
+The bounded tail is the load-bearing observation. A smaller number could be
+luck; a flat tail is the mechanism. This is #6324 / #6333 — `IfExpSugar` built a
+two-completed-arm partition that reached `ExitSet.sequence` without passing
+through `factor_completed`, distributing `m` completed arms across `k` operands
+into `m ** k`. It presented here as memory rather than wall clock.
+
+The pre-fix run consumed a shared machine: available memory on battleaxe fell
+to zero and ssh stopped answering for about ten minutes.
+
+## Two false greens caught
+
+**1. A verdict that was arithmetically correct and wrong.** The bounded probe
+returned `controlEffectStableZero: true` on a run that **exited 1**. Both were
+right: the term is the defined conjunction (completed denominator ∧ timeouts ∧
+construction panics ∧ factoring gaps — all zero), and the run was red on
+`desugarConstructionPanics = 2`, an axis the conjunction does not cover.
+
+The conjunction was **not** widened. It is a defined term and silently widening
+it would be its own dishonesty. Instead the result states its own colour —
+`red` and `redReasons`, derived from the same condition that colours the exit —
+so no reader needs to know which axes the term happens to cover.
+
+**2. `$?` after a pipeline is the last stage's status.** Three test runs were
+read as passing because the command was piped:
+
+```bash
+bin/bpytest ... | tail -20     # $? is tail's. A red run reads green.
+```
+
+It is not that `tail` is dangerous; it is that **any** `| tail`, `| head`,
+`| grep` on a measurement command discards the verdict. Capture the status
+before piping, or set `-o pipefail`. `bpytest` itself propagates correctly
+(measured `EXIT=2` on a failing run).
+
+Both belong to the same family as everything else found here: a red that
+arrives as green because the channel carrying it was replaced.
+
+## An arm that cannot import its dispatch target is unwritten
+
+#6329 was filed as five `perform_operation` call sites. The recognizer finds
+**26 broken promises across 11 files**, every one confirmed by real import,
+zero false positives. The missing targets are whole **modules** — a moved layer
+whose callers were never updated:
+
+```
+11  sugar.floor_terms (floor_to_term)     2  sugar.install_source_dig
+ 4  sugar.for_sugar                       1  each: sugar.block_sugar,
+ 3  operations (perform_operation)              operations.binary_operator_operation,
+ 2  operations.perform_operation                sugar (builtin_dunder_call_sugar),
+                                                lift_rpc (lift_file_payload)
+```
+
+All are function-local imports, so nothing fails until the arm is reached, and
+reaching one raises `ImportError` — not a panic, not a typed refusal, not in any
+family the census buckets. The row comes back short and nothing says so.
+
+**Dead or live, with evidence.** A probe of exactly the shapes that dispatch to
+the three `call_site_value` arms — `f(x)[0]`, `f(x) + 1`, `-f(x)` — through the
+real census door measured 4 functions, 4 construct-clean, **no arm reached**.
+Not reached by the construction+desugar door. Floor-evaluation drivers are not
+settled and are not this instrument's to settle.
+
+`tests/test_dispatch_targets_resolve.py` is **RED and must stay red** until
+those 26 are written or deleted. Anyone who relaxes the check deletes the only
+thing that can see this class.
+
+## Rulings
+
+**Vendor name tables are gone.** `cmMembranes` bucketed With residual by a
+hard-coded list of pandas leaf names (`raises`, `ensure_clean`,
+`option_context`). That grants a semantic category from spelling: the board
+moved when pandas renamed something and stayed still when another project used
+the same shape under a different name. Replaced by `cmResolutions`, bucketed by
+authenticated resolution gap kind.
+
+This **drops the assertion-vs-resource split**, which is the correct outcome.
+The census owner independently disclosed the same defect in their own work: the
+disposition split `3625 + 500 = 4125` is name-derived. Two agents reached the
+same conclusion from opposite directions. The baseline classifies With
+structurally or reports the partition as unavailable; it never republishes a
+name-derived split as construction-R.
+
+**The denominator is not a magic constant.** `reconcile_pandas_floors.py` had
+`--expected-files` defaulting to `1415` while the docs said `1421`. The default
+is removed; the reconciler now requires exactly one of `--corpus-pin` (derive
+from the content-addressed pin) or `--expected-files` (own it explicitly).
+Neither means asserting nothing; both means two sources of truth.
+
+**Three scopes, three names for stableZero.** The corpus verdict stays with
+`reconcile_pandas_floors.py`, which already merges five floors and enforces one
+identical manifest CID and file list. This floor states
+`controlEffectStableZero` — its own terms only. It is **not** added to the
+shared `floor_summary`, which would make every floor separately claim a corpus
+property it cannot see. `desugar_repro.py` keeps its reproducer-level verdict.
+
+**A matching count is not an identity.** The docs-era 1421-file boards are
+marked non-authoritative in place. Their file count matches the current pin;
+nothing in them records which pandas bytes were walked, so they cannot be
+differenced against a current measurement.
+
+## The shell this deletes
+
+`tests/test_one_authoritative_scoreboard.py` is a recognizer, not a checklist.
+It finds every module emitting an R quantity — structurally, by `R`/`R_*` keys
+in built payloads and printed lines — and requires each to declare
+`SCOREBOARD_AUTHORITY`, with exactly one `True`. **29 modules were emitting R.**
+
+`census.py` already *declared* the authority in its own docstring and shipped
+the bare-`SourceFile.from_path` defect anyway. A checklist would have caught
+nothing.
+
+Retirement path: when a capability makes an axis unrepresentable, its
+instrument is deleted and leaves this recognizer on its own.
+
+## Bounded runs are the full run
+
+Measuring one file **required** `--corpus-root`, and the row it produced **is**
+the full-run row. The repair proved itself in use, not only in its tooth.
+
+Previously a single-file corpus set `workspace_root = path.parent`, so the
+demand table was derived from a different tree and the same file resolved its
+`with` statements differently alone than in the corpus. Teeth pin both faces:
+identical rows under the same root, different identity under a different root,
+and refusal when no root is given.
+
+## Operational notes
+
+- **Run ssh-direct with an explicit `PYTHONPATH`.** `pytest.ini` sets only
+  `--import-mode=importlib`, so every runner must supply the path. `bin/bpytest`
+  routes through the managed image, whose declared closure omitted
+  `sugar-source-tree` (#6334 fixed the declaration; #6335 tracks the unbuilt
+  image and is parked).
+- **A collection error makes whole files vanish rather than fail loudly** — a
+  run under a broken `PYTHONPATH` does not report red, it reports a *smaller
+  denominator*. Same family as the silently-shrinking-denominator class, and
+  the reason the prevalence-versus-R separation matters.
+- **Lease at the host path** `/home/tsavo/.cache/sugar/binaries`.
+  `/home/runner/...` is the in-container path. Never `/var/tmp` on battleaxe —
+  it is per-container, which is how two heavy jobs once overlapped with a
+  0.0007s wait.
+- **The measurement watcher halts the run itself** if available memory drops
+  below 6 GB, logging `SELF-HALT`. It bounds the blast radius, not the work: it
+  skips no file, degrades no row, and cannot make a red read green, because a
+  halted run has an incomplete denominator, which is already red.

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -7,6 +7,11 @@ restarts on native crash / timeout. Enumeration protocol only.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import json
 from pathlib import Path

--- a/implementations/python/sugar-lift-py-tests/scripts/classify_loud_timeouts.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/classify_loud_timeouts.py
@@ -28,6 +28,11 @@ Progress (macro hotspots — no guessing):
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import importlib.metadata

--- a/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 from collections import Counter, defaultdict

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
@@ -9,6 +9,11 @@ auditor error, never a zero.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 from dataclasses import dataclass

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -25,6 +25,11 @@ soft continues beyond the two named membranes.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 from pathlib import Path

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
@@ -44,6 +44,11 @@ prints JSON with R and named offenders.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import fnmatch

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1148,8 +1148,14 @@ def main() -> int:
             f"{len(unresolvable_dispatch)} unresolvable dispatch targets (#6329)"
         )
     if files_completed != len(file_names):
+        # NOT "denominator incomplete" -- that phrasing was itself misleading.
+        # Every enrolled file DID produce a terminal row (that is what a
+        # complete denominator means); some of those rows are defects rather
+        # than completions. Two different facts, two different sentences.
         red_reasons.append(
-            f"denominator incomplete: {files_completed}/{len(file_names)} completed"
+            f"{len(file_names) - files_completed} of {len(file_names)} enrolled "
+            "files produced a terminal row that is not a completion "
+            "(denominator is complete; the completion count is not)"
         )
     if not denominator["complete"]:
         red_reasons.append("denominator contaminated (missing/duplicate/malformed)")

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -73,6 +73,10 @@ I/O split (never mixed):
 
 from __future__ import annotations
 
+# The sole authoritative Python corpus scoreboard. Enforced by
+# tests/test_one_authoritative_scoreboard.py: exactly one module may say True.
+SCOREBOARD_AUTHORITY = True
+
 import argparse
 import json
 import logging

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -621,6 +621,7 @@ def main() -> int:
     # into R_desugar and both make the run red.
     desugar_construction_panics: list[dict[str, Any]] = []
     desugar_defects: list[dict[str, Any]] = []
+    unresolvable_dispatch: list[dict[str, Any]] = []
     files_completed = 0
     functions_total = 0
     functions_clean = 0
@@ -790,6 +791,25 @@ def main() -> int:
                     contract_refs=contract_refs,
                     on_function=_on_function,
                 )
+            except (ImportError, AttributeError) as error:
+                # An arm that cannot resolve its dispatch target is UNWRITTEN,
+                # wearing a working arm's clothes. It is not a panic, not a
+                # typed refusal, and not in any family below -- so absorbing it
+                # into `backend-defect` would leave the row short with nothing
+                # saying so. Own category, named, loud, red (#6329).
+                row = {
+                    "category": "instrument-defect-unresolvable-dispatch",
+                    "defect": {
+                        "file": relative,
+                        "type": type(error).__name__,
+                        "message": str(error),
+                        "owner": "kit dispatch target",
+                        "fix": (
+                            "the arm imports a name that does not exist; write "
+                            "the target or delete the arm"
+                        ),
+                    },
+                }
             except Exception as error:  # noqa: BLE001 -- per-file terminal
                 row = {
                     "category": "backend-defect",
@@ -887,6 +907,15 @@ def main() -> int:
             # that has no site identity.
             if "ConstructionPanic" not in (row.get("families") or {}):
                 families["ConstructionPanic"] += 1
+        elif category == "instrument-defect-unresolvable-dispatch":
+            defect = row.get("defect")
+            if isinstance(defect, dict):
+                unresolvable_dispatch.append(dict(defect))
+            defects.append(
+                dict(defect)
+                if isinstance(defect, dict)
+                else {"file": file, "type": category, "message": category}
+            )
         else:
             defect = row.get("defect")
             defects.append(
@@ -999,6 +1028,10 @@ def main() -> int:
         "R_desugar_construction_panics": len(desugar_construction_panics),
         "desugarDefects": desugar_defects,
         "R_desugar_defects": len(desugar_defects),
+        # #6329 -- an arm reaching a dispatch target that does not exist. Its
+        # own axis: never semantic R, never quietly a backend defect.
+        "unresolvableDispatchTargets": unresolvable_dispatch,
+        "R_unresolvable_dispatch_targets": len(unresolvable_dispatch),
         "elapsedSeconds": time.time() - started,
         "python": sys.version,
         # WHERE and WHEN this was measured. A board row without its stamp
@@ -1032,9 +1065,29 @@ def main() -> int:
             unmeasurable_reasons=(),
         ),
     }
-    # stableZero, stated as its own conjunction rather than inferred by a
-    # reader from a wall of counters. Every conjunct is reported beside it, so
-    # a false claim is visible in the same object that makes it.
+    # stableZero -- RULING ON PLACEMENT.
+    #
+    # This is a ONE-FLOOR term and is deliberately named
+    # ``controlEffectStableZero``, not ``stableZero``. The corpus-level verdict
+    # is NOT here: it belongs to ``reconcile_pandas_floors.py``, which merges
+    # all five floors, enforces that they name one identical manifest CID and
+    # one identical file list, and emits ``verdict: green|red``. A second
+    # corpus-level verdict computed here would be a parallel authority --
+    # exactly the disease this repair exists to cure -- and it would be
+    # computed from one floor's view while claiming to speak for all five.
+    #
+    # It does not go into ``floor_summary`` either: that helper is shared by
+    # every floor and already owns conservation (rows account for every corpus
+    # file exactly once) plus the measured/unmeasurable distinction. Adding a
+    # zero-verdict there would make each floor separately claim a corpus-level
+    # property it cannot see.
+    #
+    # So: this floor states its own terms honestly, the reconciler owns the
+    # corpus verdict, and ``desugar_repro.py`` keeps its own reproducer-level
+    # ``stableZero`` as a process exit verdict. Three scopes, three names.
+    #
+    # Every conjunct is reported beside the term, so a false claim is visible
+    # in the same object that makes it.
     denominator = result["denominator"]
 
     def _matching(needle: str) -> int:
@@ -1063,19 +1116,21 @@ def main() -> int:
         "timeouts": _matching("imeout"),
         "constructionPanics": len(construction_panics),
         "factoringGaps": _matching("FactoringGap"),
+        "unresolvableDispatchTargets": len(unresolvable_dispatch),
         "backendDefectFiles": sum(
             1 for defect in defects if "BackendDefect" in str(defect.get("type", ""))
         ),
         "desugarConstructionPanics": len(desugar_construction_panics),
         "desugarDefects": len(desugar_defects),
     }
-    result["stableZeroTerms"] = stable_zero_terms
-    result["stableZero"] = (
+    result["controlEffectStableZeroTerms"] = stable_zero_terms
+    result["controlEffectStableZero"] = (
         stable_zero_terms["completedDenominatorPositive"]
         and stable_zero_terms["denominatorComplete"]
         and stable_zero_terms["timeouts"] == 0
         and stable_zero_terms["constructionPanics"] == 0
         and stable_zero_terms["factoringGaps"] == 0
+        and stable_zero_terms["unresolvableDispatchTargets"] == 0
     )
     rendered = json.dumps(result, indent=2)
     result_path.parent.mkdir(parents=True, exist_ok=True)

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1124,6 +1124,37 @@ def main() -> int:
         "desugarDefects": len(desugar_defects),
     }
     result["controlEffectStableZeroTerms"] = stable_zero_terms
+    # A True stableZero sitting beside a red exit is the false green this whole
+    # repair exists to abolish. The term below is the brief's exact conjunction
+    # and is deliberately NOT redefined -- but it is a narrow claim, and axes
+    # outside it (desugar construction panics, desugar defects, per-file
+    # terminals) can be nonzero while it holds. So the run states its own
+    # colour and its reasons in the same breath, and no reader has to know
+    # which axes the conjunction happens to cover.
+    red_reasons: list[str] = []
+    if defects:
+        red_reasons.append(f"{len(defects)} per-file terminal defect rows")
+    if construction_panics:
+        red_reasons.append(f"{len(construction_panics)} construction panics")
+    if desugar_construction_panics:
+        red_reasons.append(
+            f"{len(desugar_construction_panics)} desugar construction panics "
+            "(construction-law None arms -- red, and never semantic R)"
+        )
+    if desugar_defects:
+        red_reasons.append(f"{len(desugar_defects)} desugar defects")
+    if unresolvable_dispatch:
+        red_reasons.append(
+            f"{len(unresolvable_dispatch)} unresolvable dispatch targets (#6329)"
+        )
+    if files_completed != len(file_names):
+        red_reasons.append(
+            f"denominator incomplete: {files_completed}/{len(file_names)} completed"
+        )
+    if not denominator["complete"]:
+        red_reasons.append("denominator contaminated (missing/duplicate/malformed)")
+    result["red"] = bool(red_reasons)
+    result["redReasons"] = red_reasons
     result["controlEffectStableZero"] = (
         stable_zero_terms["completedDenominatorPositive"]
         and stable_zero_terms["denominatorComplete"]

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1,5 +1,37 @@
 #!/usr/bin/env python3
-"""Pandas control/effect construction + desugar-layer recensus.
+"""THE authoritative Python corpus scoreboard.
+
+This script is the sole authority for the Python corpus board. Every other
+census in this kit is a developer probe or a single-capability instrument, and
+none of their numbers may be quoted as the board. That rule exists because they
+were quoted as the board: an AST-shape site census read ``With 4125/811/85``
+while the construction ledger for the same period read ``assertion 3 /
+resource 104 / other 4``. Both were correct. They were counting different
+things, against different denominators, and the difference was read as motion.
+
+So this instrument states its denominator before it states any number:
+
+* **the corpus pin** — distribution, version, per-file content hashes and one
+  aggregate hash (:mod:`sugar_lift_py_tests.corpus_pin`). Two boards are
+  comparable iff their aggregate hashes are equal. The 1,415-file ledger was a
+  different pandas: it is archived, not compared.
+* **the enrolled file identities**, and which of them produced a terminal row.
+  Missing, duplicate and malformed rows are named individually, and any of them
+  makes the run red. A partial denominator is never banked as a board.
+* **the corpus root**, which is what the demand table is derived from, stated
+  separately from whatever slice this invocation measured. A bounded run
+  inherits the full run's root or it does not run.
+* **the source stamp** — commit, host, platform, load, wall clock.
+
+**The two quantities, never conflated:**
+
+``astSitePrevalence``
+    How many AST sites of a shape exist. A denominator. **Never R.** Lifting a
+    capability does not change it — the ``with`` statements are still there.
+``R_construction`` / ``R_desugar``
+    How many authenticated occurrences failed to construct or desugar. A
+    capability succeeded only when one of these falls without another axis
+    rising.
 
 One process. Two named axes (never merged into one R):
 
@@ -45,6 +77,7 @@ import argparse
 import json
 import logging
 import os
+import platform
 import subprocess
 import sys
 import time
@@ -112,49 +145,43 @@ def _occurrence_key(
     return (kind, relative, line, col)
 
 
-def _cm_membrane_bucket(target_symbol: object) -> str:
-    """Partition With residual by authenticated target symbol — measurement only.
+def _cm_resolution_bucket(resolution) -> str:
+    """Partition With residual by its AUTHENTICATED resolution kind — structural.
 
-    Assertion membranes and protocol-resource candidates must never share one
-    ΔR number. This classifier labels residual rows; it is not a construction
-    door and must not grant semantics from spelling.
+    This used to bucket by spelling: a hard-coded table of leaf names
+    (``raises``, ``ensure_clean``, ``option_context``, …) sorted rows into
+    "assertion-membrane" and "protocol-resource-candidate". That is a vendor
+    name table. It grants a semantic category from how pandas happened to spell
+    a function, so the board moved when pandas renamed something and stayed
+    still when a new project used the same shape under a different name.
+
+    The structural fact is already on the row: ``kind`` is the authenticated
+    resolution gap kind that prereq-2 produced. Bucket on that. It is a closed
+    vocabulary (:class:`WithConstructionGapKind`), it survives renames, and it
+    names what is actually blocking construction rather than who wrote it.
+
+    The assertion-vs-resource split this replaced is a real distinction, but it
+    needs a structural discriminator (does the manager's contract swallow the
+    exception?) rather than a name list. Until such a discriminator exists,
+    this instrument reports the resolution kinds and does not invent the split.
     """
-    if not isinstance(target_symbol, str) or not target_symbol:
-        return "unclassified"
-    symbol = target_symbol.removeprefix("python:")
-    leaf = symbol.rsplit(".", 1)[-1]
-    # Community assertion managers (separate membrane from resource CMs).
-    if leaf in {
-        "raises",
-        "assert_produces_warning",
-        "asserts_raises",
-        "assertRaises",
-        "assertRaisesRegex",
-        "external_error_raised",
-        "raises_chained_assignment_error",
-    }:
-        return "assertion-membrane"
-    if leaf in {
-        "ensure_clean",
-        "option_context",
-        "catch_warnings",
-        "nullcontext",
-        "closing",
-        "ExitStack",
-        "chdir",
-        "decompress_file",
-        "set_timezone",
-        "use_numexpr",
-        "with_csv_dialect",
-    }:
-        return "protocol-resource-candidate"
-    if leaf == "open" or symbol in {"builtins.open", "io.open"}:
-        return "io-resource-candidate"
-    return "other-manager"
+    from sugar_source_tree.panic import WithConstructionGapKind
+
+    kind = getattr(resolution, "kind", None)
+    if not isinstance(kind, str) or not kind:
+        return "gap:unstated-kind"
+    # Normalize through the closed vocabulary; an unknown wire kind keeps its
+    # own spelling rather than crashing or collapsing (see #6243 dynamic-export).
+    parsed = WithConstructionGapKind.parse(kind)
+    if parsed is WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND and (
+        kind != WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND.value
+    ):
+        return f"gap:unrecognized:{kind}"
+    return f"gap:{parsed.value}"
 
 
-def _tally_cm_membrane(context) -> Counter[str]:
-    """Count derived-table rows by membrane from authenticated target symbols."""
+def _tally_cm_resolutions(context) -> Counter[str]:
+    """Count derived-table rows by structural resolution kind."""
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
         SourceDerivedContextManagerRefV1,
@@ -167,7 +194,7 @@ def _tally_cm_membrane(context) -> Counter[str]:
             buckets["derived-contract"] += 1
             continue
         if isinstance(resolution, ContextManagerResolutionGapV1):
-            buckets[_cm_membrane_bucket(resolution.target_symbol)] += 1
+            buckets[_cm_resolution_bucket(resolution)] += 1
             continue
         buckets["unclassified"] += 1
     return buckets
@@ -219,11 +246,50 @@ def _backend_defect_key(exc: object) -> str:
 # occurrence rather than the enclosing function's line.
 
 
+def _ast_site_prevalence(path: Path) -> Counter[str]:
+    """How many AST sites of each shape exist. **This is not R.**
+
+    Site prevalence and residual are different denominators and were quoted
+    interchangeably: an AST-shape census read ``With 4125/811/85`` while the
+    construction ledger for the same period read ``assertion 3 / resource 104``.
+    Both were true. Neither was the other.
+
+    Prevalence answers "how much of this shape is in the corpus". R answers
+    "how many authenticated construction occurrences did not construct". A
+    capability that lifts a shape moves R and leaves prevalence untouched — the
+    ``with`` statements are still there. Keys here are deliberately prefixed
+    ``site:`` so a prevalence number can never be pasted into an R column
+    without the reader seeing it.
+    """
+    import ast
+
+    sites: Counter[str] = Counter()
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        # A file the corpus's own Python cannot parse is a corpus fact, not a
+        # residual. Named, counted, never silently zero.
+        sites["site:unparseable"] += 1
+        return sites
+    for node in ast.walk(tree):
+        if isinstance(node, ast.With):
+            sites["site:with-statement"] += 1
+            sites["site:with-item"] += len(node.items)
+        elif isinstance(node, ast.AsyncWith):
+            sites["site:async-with-statement"] += 1
+            sites["site:async-with-item"] += len(node.items)
+        elif isinstance(node, ast.Try):
+            sites["site:try-statement"] += 1
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            sites["site:function-def"] += 1
+    return sites
+
+
 def _measure_file(
     path: Path,
     *,
     relative: str,
-    workspace_root: Path | None = None,
+    workspace_root: Path,
     contract_refs=None,
     on_function: "Callable[[int, int, str, float | None], None] | None" = None,
 ) -> dict[str, Any]:
@@ -241,9 +307,19 @@ def _measure_file(
     families: Counter[str] = Counter()
     construction_seen: set[tuple[str, str, object, object]] = set()
     backend_defects: Counter[str] = Counter()
-    cm_membranes: Counter[str] = Counter()
+    cm_resolutions: Counter[str] = Counter()
     desugar_axis = DesugarAxis()
-    root = workspace_root if workspace_root is not None else path.parent
+    if workspace_root is None:
+        # No silent ``path.parent``. That default made a one-file run derive its
+        # demand table from a DIFFERENT tree than the full run, so the same file
+        # measured alone and measured in the corpus produced different With
+        # resolutions. A bounded run must inherit the corpus root, or not run.
+        raise ValueError(
+            "control_effect_recensus._measure_file requires an explicit "
+            "workspace_root: the demand table must come from the corpus root, "
+            "never from the measured file's parent directory"
+        )
+    root = workspace_root
 
     def tally_construction(
         kind: str, node: object | None = None, line: object = "?"
@@ -274,9 +350,9 @@ def _measure_file(
             # Derivation can hit a real missing sugar before any function walk.
             tally_construction(type(gap).__name__, line=0)
             return reporter
-        # Membrane partition from the derived table (manager-expression sites,
-        # not functions-blocked). Assertion mass must not launder as resource.
-        cm_membranes.update(_tally_cm_membrane(construction_context))
+        # Resolution partition from the derived table (manager-expression
+        # sites, not functions-blocked), keyed by authenticated gap kind.
+        cm_resolutions.update(_tally_cm_resolutions(construction_context))
         for function in source_file.functions():
             functions_total += 1
             try:
@@ -318,13 +394,12 @@ def _measure_file(
         return reporter
 
     _reporter, panic_row = collect_construction_panic(relative, construct)
-    membrane_row = {
-        "cmMembranes": dict(cm_membranes),
-        "R_cm_assertion_membrane": int(cm_membranes.get("assertion-membrane", 0)),
-        "R_cm_protocol_resource_candidate": int(
-            cm_membranes.get("protocol-resource-candidate", 0)
-        ),
-        "R_cm_derived_contract": int(cm_membranes.get("derived-contract", 0)),
+    # Two quantities, never one column: resolution residual (R-bearing) and AST
+    # site prevalence (denominator, never R).
+    resolution_row = {
+        "cmResolutions": dict(cm_resolutions),
+        "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
+        "astSites": dict(_ast_site_prevalence(path)),
     }
     if panic_row is not None:
         return {
@@ -340,7 +415,7 @@ def _measure_file(
             "families": dict(families),
             "backendDefects": dict(backend_defects),
             "R_backend_defects": sum(backend_defects.values()),
-            **membrane_row,
+            **resolution_row,
             **desugar_axis.row(),
         }
     return {
@@ -350,14 +425,51 @@ def _measure_file(
         "families": dict(families),
         "backendDefects": dict(backend_defects),
         "R_backend_defects": sum(backend_defects.values()),
-        **membrane_row,
+        **resolution_row,
         **desugar_axis.row(),
     }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("corpus", type=Path)
+    parser.add_argument(
+        "corpus",
+        type=Path,
+        help="what to measure: the corpus root, or one file/subtree inside it",
+    )
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=None,
+        help=(
+            "the package root the demand table is derived from. Required when "
+            "CORPUS is not itself that root. A bounded run MUST inherit the "
+            "full run's root, or its With resolutions differ for reasons that "
+            "are purely the instrument's."
+        ),
+    )
+    parser.add_argument(
+        "--corpus-distribution",
+        default=None,
+        help="distribution name for the pin (default: corpus root directory name)",
+    )
+    parser.add_argument(
+        "--corpus-version",
+        default=None,
+        help="pinned distribution version (default: read from the *.dist-info)",
+    )
+    parser.add_argument(
+        "--require-corpus-pin",
+        type=Path,
+        default=None,
+        help="refuse to measure unless the corpus matches this pin file exactly",
+    )
+    parser.add_argument(
+        "--write-corpus-pin",
+        type=Path,
+        default=None,
+        help="write the observed corpus pin (version + manifest + aggregate hash)",
+    )
     parser.add_argument("--repo", type=Path, default=Path.cwd())
     parser.add_argument("--commit")
     parser.add_argument(
@@ -400,6 +512,26 @@ def main() -> int:
     if not args.corpus.exists():
         parser.error(f"corpus not found: {args.corpus}")
 
+    # The corpus ROOT is the demand-table denominator; CORPUS is only which
+    # slice of it to measure now. Conflating them is the drift that made a
+    # bounded file run and the full run disagree about the same file.
+    corpus = args.corpus.resolve()
+    if args.corpus_root is not None:
+        corpus_root = args.corpus_root.resolve()
+    elif corpus.is_dir():
+        corpus_root = corpus
+    else:
+        parser.error(
+            "--corpus-root is required when CORPUS is a single file: without it "
+            "the demand table would be derived from the file's parent directory, "
+            "a different tree than the full run, and the rows would not be "
+            "comparable"
+        )
+    if not corpus_root.is_dir():
+        parser.error(f"--corpus-root is not a directory: {corpus_root}")
+    if corpus != corpus_root and corpus_root not in corpus.parents:
+        parser.error(f"corpus {corpus} is not inside --corpus-root {corpus_root}")
+
     out = args.out_dir
     out.mkdir(parents=True, exist_ok=True)
     result_path = args.json or (out / "recensus.json")
@@ -410,29 +542,56 @@ def main() -> int:
     _silence_console_logging()
     _configure_engine_log(engine_path)
 
+    from sugar_lift_py_tests.corpus_pin import (
+        CorpusPinDefect,
+        load_pin,
+        pin_corpus,
+        require_pin,
+        write_pin,
+    )
     from sugar_source_tree.tree import SourceTree
 
-    tree = SourceTree(args.corpus)
-    paths = list(tree.paths())
+    # Pin FIRST. A run that cannot name its corpus has no denominator, and a
+    # number without a denominator is not a scoreboard entry — it is a rumour.
+    try:
+        observed_pin = pin_corpus(
+            corpus_root,
+            distribution=args.corpus_distribution,
+            version=args.corpus_version,
+        )
+        if args.require_corpus_pin is not None:
+            require_pin(load_pin(args.require_corpus_pin), observed_pin)
+    except CorpusPinDefect as defect:
+        print(str(defect), file=sys.stderr, flush=True)
+        return 2
+    if args.write_corpus_pin is not None:
+        write_pin(observed_pin, args.write_corpus_pin)
+
+    paths = list(SourceTree(corpus).paths())
     if not paths:
         parser.error("corpus contains no Python files")
 
-    if args.corpus.is_dir():
-        by_file = {
-            f"{args.corpus.name}/{path.relative_to(args.corpus).as_posix()}": path
-            for path in paths
-        }
-        workspace_root = args.corpus
-    else:
-        by_file = {args.corpus.name: args.corpus}
-        workspace_root = args.corpus.parent
+    # File identity is ALWAYS relative to the corpus root — never to CORPUS.
+    # That is what makes one file measured alone produce the same row identity
+    # as that file inside the full run.
+    by_file = {
+        f"{corpus_root.name}/{path.resolve().relative_to(corpus_root).as_posix()}": path
+        for path in paths
+    }
+    workspace_root = corpus_root
 
     file_names = sorted(by_file)
+    if len(file_names) != len(paths):
+        parser.error(
+            f"enumeration produced {len(paths)} paths but "
+            f"{len(file_names)} distinct identities — duplicate enrolled file"
+        )
     pending: list[str] = list(file_names)
 
-    # One provisional demand→gap table for the whole corpus. Shared across files;
-    # each file still gets a fresh TreeConstructionContextV1 so source-derived
-    # manager refs do not leak between files.
+    # One provisional demand→gap table for the whole corpus ROOT. Shared across
+    # files; each file still gets a fresh TreeConstructionContextV1 so
+    # source-derived manager refs do not leak between files. Deriving this from
+    # anything but the root is the corpus-context drift defect.
     from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
 
     contract_refs = provisional_contract_refs_from_demands(workspace_root)
@@ -452,7 +611,8 @@ def main() -> int:
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
     backend_defects: Counter[str] = Counter()
-    cm_membranes: Counter[str] = Counter()
+    cm_resolutions: Counter[str] = Counter()
+    ast_sites: Counter[str] = Counter()
     # Three disjoint desugar-layer quantities; the two below are NEVER folded
     # into R_desugar and both make the run red.
     desugar_construction_panics: list[dict[str, Any]] = []
@@ -557,11 +717,9 @@ def main() -> int:
 
         for file in bar:
             path = by_file[file]
-            relative = (
-                path.relative_to(args.corpus).as_posix()
-                if args.corpus.is_dir()
-                else path.name
-            )
+            # Same identity in a bounded run and in the full run: relative to
+            # the corpus ROOT, never to whatever slice this invocation measured.
+            relative = path.resolve().relative_to(corpus_root).as_posix()
             # Show the file we are about to open — before the work starts.
             _set_bars(
                 {
@@ -687,6 +845,21 @@ def main() -> int:
 
     measured_rows = [(row["file"], row["result"]) for row in checkpoint.rows()]
 
+    # The denominator, stated before any rate is quoted. Checkpoint already
+    # refuses duplicate rows, unknown files, a foreign manifest CID and
+    # malformed JSON at load; what it cannot say is which enrolled files never
+    # produced a terminal row at all. Name them.
+    terminal_files = [file for file, _ in measured_rows]
+    missing_files = sorted(set(file_names) - set(terminal_files))
+    duplicate_files = sorted(
+        {file for file in terminal_files if terminal_files.count(file) > 1}
+    )
+    malformed_rows = sorted(
+        file
+        for file, raw in measured_rows
+        if not isinstance(raw, dict) or not raw.get("category")
+    )
+
     for file, raw in measured_rows:
         row = dict(raw)
         category = str(row.get("category"))
@@ -696,7 +869,8 @@ def main() -> int:
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
         backend_defects.update(row.get("backendDefects") or {})
-        cm_membranes.update(row.get("cmMembranes") or {})
+        cm_resolutions.update(row.get("cmResolutions") or {})
+        ast_sites.update(row.get("astSites") or {})
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
         desugar_defects.extend(row.get("desugarDefects") or [])
         if category == "completed":
@@ -741,8 +915,17 @@ def main() -> int:
     r_backend = sum(backend_defects.values())
     result: dict[str, Any] = {
         "kind": "control-effect-construction-recensus",
+        "authority": (
+            "sole authoritative Python corpus scoreboard; every other census "
+            "output is non-authoritative"
+        ),
         "commit": args.commit or _git_commit(args.repo),
-        "corpus": str(args.corpus),
+        "corpus": str(corpus),
+        "corpusRoot": str(corpus_root),
+        # WHICH corpus — version, manifest length, one aggregate hash. Two runs
+        # are comparable iff these aggregate hashes are equal. The 1,415-file
+        # ledger is a different pandas and is NOT comparable to this board.
+        "corpusPin": observed_pin.summary(),
         "door": "enum:path_source→SourceFile→functions→sugar→desugar",
         "isolation": "in-process",
         "paths": {
@@ -750,6 +933,23 @@ def main() -> int:
             "progress": str(progress_path.resolve()),
             "checkpoint": str(checkpoint_path.resolve()),
             "result": str(result_path.resolve()),
+        },
+        # THE DENOMINATOR — stated, with exact identities, before any rate.
+        "denominator": {
+            "enrolled": len(file_names),
+            "terminalRows": len(measured_rows),
+            "completed": files_completed,
+            "corpusManifestCid": checkpoint.manifest_cid,
+            "enrolledFiles": list(file_names),
+            "missingFiles": missing_files,
+            "duplicateFiles": duplicate_files,
+            "malformedRows": malformed_rows,
+            "complete": (
+                len(measured_rows) == len(file_names)
+                and not missing_files
+                and not duplicate_files
+                and not malformed_rows
+            ),
         },
         "filesTotal": len(file_names),
         "filesCompleted": files_completed,
@@ -775,16 +975,19 @@ def main() -> int:
         "backendDefects": dict(
             sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
         ),
-        # With residual partition (manager-expression sites, derived table).
-        # Assertion membrane ≠ protocol resource; never one With ΔR number.
-        "cmMembranes": dict(
-            sorted(cm_membranes.items(), key=lambda item: (-item[1], item[0]))
+        # With residual partition, keyed by AUTHENTICATED resolution kind.
+        # Structural, not spelling: no vendor name table decides these buckets.
+        "cmResolutions": dict(
+            sorted(cm_resolutions.items(), key=lambda item: (-item[1], item[0]))
         ),
-        "R_cm_assertion_membrane": int(cm_membranes.get("assertion-membrane", 0)),
-        "R_cm_protocol_resource_candidate": int(
-            cm_membranes.get("protocol-resource-candidate", 0)
+        "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
+        # AST SITE PREVALENCE — a denominator, NEVER R. Different question,
+        # different number: prevalence counts shapes present, R counts
+        # authenticated occurrences that failed to construct. Quoting one as
+        # the other is exactly the confusion this board was repaired to end.
+        "astSitePrevalence": dict(
+            sorted(ast_sites.items(), key=lambda item: (-item[1], item[0]))
         ),
-        "R_cm_derived_contract": int(cm_membranes.get("derived-contract", 0)),
         # Neither of these is semantic R. A construction-law None arm during
         # desugar is a construction gap; an ordinary exception is an
         # implementation defect. Both are red, separately.
@@ -794,6 +997,17 @@ def main() -> int:
         "R_desugar_defects": len(desugar_defects),
         "elapsedSeconds": time.time() - started,
         "python": sys.version,
+        # WHERE and WHEN this was measured. A board row without its stamp
+        # cannot be re-run, and a number nobody can re-run is not evidence.
+        "sourceStamp": {
+            "commit": args.commit or _git_commit(args.repo),
+            "repo": str(args.repo.resolve()),
+            "python": sys.version,
+            "platform": platform.platform(),
+            "host": platform.node(),
+            "loadAverage": list(os.getloadavg()) if hasattr(os, "getloadavg") else [],
+            "measuredAtUnix": time.time(),
+        },
         "floorSummary": floor_summary(
             floor="control-effect",
             files=file_names,
@@ -802,11 +1016,8 @@ def main() -> int:
                 "R_control_effect": r_construction + len(defects),
                 "R_desugar": r_desugar,
                 "R_backend_defects": r_backend,
-                "R_cm_assertion_membrane": int(
-                    cm_membranes.get("assertion-membrane", 0)
-                ),
-                "R_cm_protocol_resource_candidate": int(
-                    cm_membranes.get("protocol-resource-candidate", 0)
+                "R_cm_derived_contract": int(
+                    cm_resolutions.get("derived-contract", 0)
                 ),
                 "desugarConstructionPanics": len(desugar_construction_panics),
                 "desugarDefects": len(desugar_defects),
@@ -817,6 +1028,51 @@ def main() -> int:
             unmeasurable_reasons=(),
         ),
     }
+    # stableZero, stated as its own conjunction rather than inferred by a
+    # reader from a wall of counters. Every conjunct is reported beside it, so
+    # a false claim is visible in the same object that makes it.
+    denominator = result["denominator"]
+
+    def _matching(needle: str) -> int:
+        """Count a named shape wherever it can land — never one hopeful key.
+
+        A factoring gap can surface as a construction family, a desugar family,
+        a desugar defect or a per-file terminal defect. Reading only one of
+        those and reporting zero is how a term goes quiet without being fixed.
+        """
+        total = sum(n for key, n in families.items() if needle in key)
+        total += sum(n for key, n in desugar_families.items() if needle in key)
+        total += sum(1 for row in desugar_defects if needle in json.dumps(row))
+        total += sum(
+            1
+            for defect in defects
+            if needle in f"{defect.get('type', '')}{defect.get('message', '')}"
+        )
+        return total
+
+    stable_zero_terms = {
+        "completedDenominatorPositive": files_completed > 0,
+        "denominatorComplete": bool(denominator["complete"]),
+        # This instrument has no timeout mechanism: it runs in-process and a
+        # hang is a hang, not a row. Any timeout testimony can only arrive as a
+        # named defect, so that is where it is counted from.
+        "timeouts": _matching("imeout"),
+        "constructionPanics": len(construction_panics),
+        "factoringGaps": _matching("FactoringGap"),
+        "backendDefectFiles": sum(
+            1 for defect in defects if "BackendDefect" in str(defect.get("type", ""))
+        ),
+        "desugarConstructionPanics": len(desugar_construction_panics),
+        "desugarDefects": len(desugar_defects),
+    }
+    result["stableZeroTerms"] = stable_zero_terms
+    result["stableZero"] = (
+        stable_zero_terms["completedDenominatorPositive"]
+        and stable_zero_terms["denominatorComplete"]
+        and stable_zero_terms["timeouts"] == 0
+        and stable_zero_terms["constructionPanics"] == 0
+        and stable_zero_terms["factoringGaps"] == 0
+    )
     rendered = json.dumps(result, indent=2)
     result_path.parent.mkdir(parents=True, exist_ok=True)
     result_path.write_text(rendered + "\n")
@@ -826,6 +1082,8 @@ def main() -> int:
         f"result={result_path} progress={progress_path} engine={engine_path}",
         flush=True,
     )
+    # An incomplete or contaminated denominator is red on its own. Banking a
+    # partial run as a board is the exact failure this repair exists to end.
     return (
         1
         if defects
@@ -833,6 +1091,7 @@ def main() -> int:
         or desugar_construction_panics
         or desugar_defects
         or files_completed != len(file_names)
+        or not denominator["complete"]
         else 0
     )
 

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_factory_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_factory_recensus.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import importlib.metadata

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import importlib.metadata

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
@@ -22,6 +22,11 @@ reported separately as ``auditor_errors`` and also exit red.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 from collections import Counter

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
@@ -23,6 +23,11 @@ Without a measurement payload the auditor refuses (exit 2) rather than faking R=
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import json

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
@@ -12,6 +12,11 @@ root failures are also loud structured errors rather than process crashes.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import json

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
@@ -27,6 +27,11 @@ Baseline-free structural census. R > 0 exits red.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import json

--- a/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import json
 from dataclasses import asdict, dataclass

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -8,6 +8,11 @@ file still gets a terminal row.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import os
 from pathlib import Path

--- a/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
@@ -14,6 +14,11 @@ baseline or allowlist: every locus is red.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import json

--- a/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
@@ -103,8 +103,30 @@ def main() -> int:
     for floor in FLOORS:
         parser.add_argument("--" + floor, type=Path, required=True)
     parser.add_argument("--output", type=Path, default=Path("validated-summary.json"))
-    parser.add_argument("--expected-files", type=int, default=1415)
+    # NO DEFAULT. A hardcoded expected count silently blesses one denominator:
+    # this read 1415 while the docs said 1421, and nothing reconciled the six.
+    # The denominator is a property of the PINNED CORPUS, not of this script --
+    # pass --corpus-pin and it is derived, or pass --expected-files and own the
+    # number explicitly. Never both, never neither.
+    parser.add_argument("--expected-files", type=int, default=None)
+    parser.add_argument(
+        "--corpus-pin",
+        type=Path,
+        default=None,
+        help="derive the expected denominator from a content-addressed corpus pin",
+    )
     args = parser.parse_args()
+    if (args.expected_files is None) == (args.corpus_pin is None):
+        parser.error(
+            "give exactly one of --corpus-pin (derive the denominator from the "
+            "pinned corpus) or --expected-files (own the number explicitly). "
+            "Neither means the reconciler asserts nothing about the "
+            "denominator; both means two sources of truth for one count."
+        )
+    if args.corpus_pin is not None:
+        from sugar_lift_py_tests.corpus_pin import load_pin
+
+        args.expected_files = load_pin(args.corpus_pin).file_count
     reports = {
         floor: json.loads(
             getattr(args, floor.replace("-", "_")).read_text(encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import json
 from pathlib import Path

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -6,6 +6,11 @@ In-process enum scan. Progress and engine logs never mix.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 from pathlib import Path
 import sys

--- a/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
@@ -29,6 +29,11 @@ aliased import, or a late import inside a function body.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import json

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -7,6 +7,11 @@ that worker (caches restart); the file is a timeout offender and the scan contin
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 from pathlib import Path
 import sys

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -25,6 +25,11 @@ and Linux must both emit R / structured output.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import ast
 import json

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -33,6 +33,11 @@ instrument's.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import argparse
 import sys
 import time

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -15,6 +15,20 @@ Behind the desugar door, ``ConstructionPanic`` (a ``BaseException``) and
 ordinary exceptions are counted SEPARATELY from semantic R and make the run
 red — see :mod:`sugar_lift_py_tests.desugar_axis`, which owns the membrane for
 this module and for ``scripts/control_effect_recensus.py`` alike.
+
+**Not the authoritative scoreboard.** ``scripts/control_effect_recensus.py``
+is the sole authority for the pinned Python corpus board: it alone pins the
+corpus, records the completed denominator and file identities, and journals
+every terminal row. This module is a developer-loop console census over an
+arbitrary package root — no pin, no denominator record, no durable journal.
+Never quote its numbers as the board.
+
+It does open files through the same production door
+(``open_source_file_for_construction`` against an explicit corpus root). A bare
+``SourceFile.from_path`` here painted every ``with`` as
+``RuntimeSelectedContextManager`` regardless of resolvability — the two
+instruments then disagreed about With for reasons that were entirely the
+instrument's.
 """
 
 from __future__ import annotations
@@ -31,11 +45,18 @@ def census(root: Path) -> int:
         collect_construction_panic,
     )
     from sugar_lift_py_tests.desugar_axis import DesugarAxis
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        provisional_contract_refs_from_demands,
+    )
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
 
     files = sorted(root.rglob("*.py"))
+    # One demand table for the whole corpus root, exactly like the authoritative
+    # recensus. Deriving it per file (or from ``file.parent``) scans a different
+    # tree and shifts every With resolution — measurement drift, not signal.
+    contract_refs = provisional_contract_refs_from_demands(root)
     families: Counter = Counter()
     desugar = DesugarAxis()
     crashes: Counter = Counter()
@@ -53,7 +74,22 @@ def census(root: Path) -> int:
         ):
             nonlocal total_fns, clean_fns, clean_files
             reporter = CollectingReporter()
-            sf = SourceFile.from_path(str(_f), reporter=reporter)
+            # Production door: never a bare ``SourceFile.from_path``. Without the
+            # construction context every With paints RuntimeSelectedContextManager
+            # whether or not it resolves.
+            try:
+                sf = open_source_file_for_construction(
+                    _f,
+                    root=root,
+                    reporter=reporter,
+                    contract_refs=contract_refs,
+                    populate_derived=True,
+                )
+            except SugarNotWritten as gap:
+                # Derivation can hit a real missing sugar before any function
+                # walk. That is a construction gap, not a crash row.
+                families[type(gap).__name__] += 1
+                return 1
             for fn in sf.functions():
                 total_fns += 1
                 try:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py
@@ -1,0 +1,341 @@
+"""The corpus pin: a scoreboard number means nothing without a named corpus.
+
+Two measurements are comparable only when they ran over *the same files*. The
+pandas board learned this the hard way: a 1,415-file ledger and a 1,421-file
+ledger were quoted against each other for weeks as if the delta were signal. It
+was a different pandas.
+
+So the authoritative recensus pins its corpus and records the pin in its
+result:
+
+* the **distribution and version** (``pandas 3.0.3``), read from the
+  installed ``*.dist-info`` beside the package root — never guessed;
+* the **file manifest** — every enrolled file with its content hash and size;
+* the **aggregate hash** — one sha256 over the whole manifest, so two runs can
+  be declared comparable (or not) by comparing a single string.
+
+The manifest is enumerated with ``SourceTree(root).paths()`` — the *same*
+enumerator the census uses. A pin built from a different walk (``rglob``, a
+filter, an installer's RECORD file) would pin a denominator the run never had,
+which is the failure this module exists to make impossible.
+
+Paths in the pin are relative to the corpus root, so the same corpus pins
+identically on the Mac and on the measurement box. The absolute root is carried
+for testimony only and is deliberately NOT part of the aggregate hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+PIN_KIND = "sugar-corpus-pin/v1"
+
+
+class CorpusPinDefect(Exception):
+    """The pin could not be established — instrument/environment defect.
+
+    Never a measurement result. A run that cannot pin its corpus has no
+    denominator, and a number without a denominator is not a scoreboard entry.
+    """
+
+    def __init__(self, *, owner: str, observed: str, requested: str, fix: str) -> None:
+        super().__init__(
+            f"CORPUS PIN DEFECT [{owner}]\n"
+            f"  observed:  {observed}\n"
+            f"  requested: {requested}\n"
+            f"  fix:       {fix}"
+        )
+        self.owner = owner
+        self.observed = observed
+        self.requested = requested
+        self.fix = fix
+
+
+@dataclass(frozen=True)
+class CorpusFile:
+    """One enrolled file: identity is (path, content), never path alone."""
+
+    path: str
+    sha256: str
+    size_bytes: int
+
+    def row(self) -> dict[str, Any]:
+        return {"path": self.path, "sha256": self.sha256, "sizeBytes": self.size_bytes}
+
+
+@dataclass(frozen=True)
+class CorpusPin:
+    """A named, content-addressed corpus. Comparable iff aggregate hashes match."""
+
+    distribution: str
+    version: str
+    file_count: int
+    aggregate_hash: str
+    files: tuple[CorpusFile, ...]
+    root: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "kind": PIN_KIND,
+            "distribution": self.distribution,
+            "version": self.version,
+            "fileCount": self.file_count,
+            "aggregateHash": self.aggregate_hash,
+            # Testimony only — deliberately outside the aggregate hash so the
+            # same corpus pins identically on every box.
+            "root": self.root,
+            "files": [f.row() for f in self.files],
+        }
+
+    def summary(self) -> dict[str, Any]:
+        """The pin without the 1,400-row manifest — for embedding in a result."""
+        return {
+            "kind": PIN_KIND,
+            "distribution": self.distribution,
+            "version": self.version,
+            "fileCount": self.file_count,
+            "aggregateHash": self.aggregate_hash,
+            "root": self.root,
+        }
+
+    @property
+    def paths(self) -> tuple[str, ...]:
+        return tuple(f.path for f in self.files)
+
+    @classmethod
+    def from_json(cls, payload: Mapping[str, Any]) -> "CorpusPin":
+        kind = payload.get("kind")
+        if kind != PIN_KIND:
+            raise CorpusPinDefect(
+                owner="corpus pin decode",
+                observed=f"pin kind {kind!r}",
+                requested=f"pin kind {PIN_KIND!r}",
+                fix="re-pin the corpus with the current instrument",
+            )
+        files = tuple(
+            CorpusFile(
+                path=str(row["path"]),
+                sha256=str(row["sha256"]),
+                size_bytes=int(row["sizeBytes"]),
+            )
+            for row in payload.get("files") or ()
+        )
+        pin = cls(
+            distribution=str(payload["distribution"]),
+            version=str(payload["version"]),
+            file_count=int(payload["fileCount"]),
+            aggregate_hash=str(payload["aggregateHash"]),
+            files=files,
+            root=str(payload.get("root") or ""),
+        )
+        # A pin whose own aggregate disagrees with its own manifest is a
+        # corrupted pin, not a corpus mismatch. Say which one it is.
+        recomputed = aggregate_hash(pin.distribution, pin.version, files)
+        if recomputed != pin.aggregate_hash:
+            raise CorpusPinDefect(
+                owner="corpus pin decode",
+                observed=(
+                    f"pin file claims aggregate {pin.aggregate_hash}, "
+                    f"its own manifest hashes to {recomputed}"
+                ),
+                requested="a pin whose aggregate hash covers its own manifest",
+                fix="re-pin the corpus; do not hand-edit pin files",
+            )
+        if len(files) != pin.file_count:
+            raise CorpusPinDefect(
+                owner="corpus pin decode",
+                observed=f"fileCount {pin.file_count} with {len(files)} manifest rows",
+                requested="fileCount equal to the manifest length",
+                fix="re-pin the corpus",
+            )
+        return pin
+
+
+def aggregate_hash(
+    distribution: str, version: str, files: Iterable[CorpusFile]
+) -> str:
+    """One sha256 over (distribution, version, sorted path→content manifest).
+
+    The distribution and version are inside the hash on purpose: the identical
+    file set claimed as two different pandas versions must not compare equal.
+    """
+    digest = hashlib.sha256()
+    digest.update(f"{PIN_KIND}\n{distribution}\n{version}\n".encode("utf-8"))
+    for entry in sorted(files, key=lambda f: f.path):
+        digest.update(f"{entry.path} {entry.sha256} {entry.size_bytes}\n".encode())
+    return digest.hexdigest()
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1 << 20)
+            if not chunk:
+                break
+            size += len(chunk)
+            digest.update(chunk)
+    return digest.hexdigest(), size
+
+
+def distribution_version(root: Path, distribution: str) -> str:
+    """Read the installed version from the ``*.dist-info`` beside the package.
+
+    No guessing and no fallback. If the metadata is not there, the caller must
+    state the version explicitly — an unpinned version silently turns two
+    different corpora into one scoreboard.
+    """
+    candidates = sorted(root.parent.glob(f"{distribution}-*.dist-info"))
+    if len(candidates) == 1:
+        name = candidates[0].name
+        return name[len(distribution) + 1 : -len(".dist-info")]
+    if not candidates:
+        raise CorpusPinDefect(
+            owner="corpus pin version",
+            observed=f"no {distribution}-*.dist-info beside {root}",
+            requested=f"exactly one installed {distribution} distribution",
+            fix=f"pass --corpus-version explicitly, or install {distribution}",
+        )
+    raise CorpusPinDefect(
+        owner="corpus pin version",
+        observed=f"{len(candidates)} dist-info dirs beside {root}: "
+        + ", ".join(c.name for c in candidates),
+        requested=f"exactly one installed {distribution} distribution",
+        fix="clean the environment, or pass --corpus-version explicitly",
+    )
+
+
+def pin_corpus(
+    root: Path,
+    *,
+    distribution: str | None = None,
+    version: str | None = None,
+) -> CorpusPin:
+    """Pin the corpus the census will actually walk.
+
+    Enumeration goes through ``SourceTree(root).paths()`` — the census's own
+    enumerator. Pinning a different walk would pin a denominator no run ever
+    had, which defeats the entire purpose.
+    """
+    from sugar_source_tree.tree import SourceTree
+
+    root = root.resolve()
+    if not root.is_dir():
+        raise CorpusPinDefect(
+            owner="corpus pin",
+            observed=f"corpus root {root} is not a directory",
+            requested="a package root directory to pin",
+            fix="point --corpus-root at the installed package directory",
+        )
+    dist = distribution or root.name
+    resolved_version = version or distribution_version(root, dist)
+
+    files: list[CorpusFile] = []
+    for path in SourceTree(root).paths():
+        sha, size = _sha256_file(path)
+        files.append(
+            CorpusFile(
+                path=path.resolve().relative_to(root).as_posix(),
+                sha256=sha,
+                size_bytes=size,
+            )
+        )
+    if not files:
+        raise CorpusPinDefect(
+            owner="corpus pin",
+            observed=f"SourceTree({root}).paths() enumerated no files",
+            requested="a non-empty corpus",
+            fix="check the corpus root",
+        )
+    ordered = tuple(sorted(files, key=lambda f: f.path))
+    seen: set[str] = set()
+    for entry in ordered:
+        if entry.path in seen:
+            raise CorpusPinDefect(
+                owner="corpus pin",
+                observed=f"duplicate enrolled path {entry.path}",
+                requested="one manifest row per enrolled file",
+                fix="the enumerator yielded a path twice — fix SourceTree.paths()",
+            )
+        seen.add(entry.path)
+    return CorpusPin(
+        distribution=dist,
+        version=resolved_version,
+        file_count=len(ordered),
+        aggregate_hash=aggregate_hash(dist, resolved_version, ordered),
+        files=ordered,
+        root=str(root),
+    )
+
+
+def compare(expected: CorpusPin, observed: CorpusPin) -> dict[str, Any]:
+    """Name every way two corpora differ — never a bare boolean.
+
+    "Not comparable" is useless testimony. Which files appeared, which vanished,
+    which changed content, whether the version moved: that is what tells the
+    reader whether a delta is signal or a different pandas.
+    """
+    expected_by_path = {f.path: f for f in expected.files}
+    observed_by_path = {f.path: f for f in observed.files}
+    added = sorted(set(observed_by_path) - set(expected_by_path))
+    removed = sorted(set(expected_by_path) - set(observed_by_path))
+    changed = sorted(
+        path
+        for path in set(expected_by_path) & set(observed_by_path)
+        if expected_by_path[path].sha256 != observed_by_path[path].sha256
+    )
+    return {
+        "identical": expected.aggregate_hash == observed.aggregate_hash,
+        "expectedAggregateHash": expected.aggregate_hash,
+        "observedAggregateHash": observed.aggregate_hash,
+        "expectedVersion": f"{expected.distribution} {expected.version}",
+        "observedVersion": f"{observed.distribution} {observed.version}",
+        "versionMoved": (expected.distribution, expected.version)
+        != (observed.distribution, observed.version),
+        "addedFiles": added,
+        "removedFiles": removed,
+        "changedFiles": changed,
+    }
+
+
+def require_pin(expected: CorpusPin, observed: CorpusPin) -> None:
+    """Refuse to measure against a corpus that is not the pinned one."""
+    report = compare(expected, observed)
+    if report["identical"]:
+        return
+    raise CorpusPinDefect(
+        owner="corpus pin check",
+        observed=json.dumps(
+            {
+                key: report[key]
+                for key in (
+                    "expectedVersion",
+                    "observedVersion",
+                    "expectedAggregateHash",
+                    "observedAggregateHash",
+                )
+            }
+        )
+        + f" added={len(report['addedFiles'])}"
+        + f" removed={len(report['removedFiles'])}"
+        + f" changed={len(report['changedFiles'])}",
+        requested="the pinned corpus",
+        fix=(
+            "install the pinned distribution version, or re-pin deliberately "
+            "and archive the old board as non-comparable"
+        ),
+    )
+
+
+def load_pin(path: Path) -> CorpusPin:
+    return CorpusPin.from_json(json.loads(path.read_text(encoding="utf-8")))
+
+
+def write_pin(pin: CorpusPin, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(pin.to_json(), indent=2) + "\n", encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py
@@ -76,6 +76,10 @@ class CorpusPin:
     file_count: int
     aggregate_hash: str
     files: tuple[CorpusFile, ...]
+    # The two circulating conventions, computed from the same bytes at pin
+    # time. Empty only for pins decoded from an older file that lacked them.
+    content_only_hash: str = ""
+    path_bound_hash: str = ""
     root: str = ""
 
     def to_json(self) -> dict[str, Any]:
@@ -85,6 +89,8 @@ class CorpusPin:
             "version": self.version,
             "fileCount": self.file_count,
             "aggregateHash": self.aggregate_hash,
+            "contentOnlyHash": self.content_only_hash,
+            "pathBoundHash": self.path_bound_hash,
             # Testimony only — deliberately outside the aggregate hash so the
             # same corpus pins identically on every box.
             "root": self.root,
@@ -99,7 +105,38 @@ class CorpusPin:
             "version": self.version,
             "fileCount": self.file_count,
             "aggregateHash": self.aggregate_hash,
+            # WHICH CONVENTION. A bare digest is not checkable across agents:
+            # two are already in circulation for this corpus and boards failed
+            # to reconcile on that alone, for reasons that had nothing to do
+            # with the code. Always say how the number was computed.
+            "aggregateHashConvention": (
+                "sha256 over: pin kind, distribution, version, then one "
+                "'<relpath> <sha256> <sizeBytes>' line per file, sorted by "
+                "relpath. Root path excluded so the same corpus pins "
+                "identically on every box."
+            ),
+            "interoperableDigests": self.interoperable_digests(),
             "root": self.root,
+        }
+
+    def interoperable_digests(self) -> dict[str, str]:
+        """The two conventions already in circulation, emitted alongside ours.
+
+        Neither matches our aggregate, because ours also binds distribution and
+        version. Both are carried so a board reconciles against existing
+        receipts without anyone re-deriving a digest by hand -- that
+        convention drift already cost a round-trip and was mistaken for a
+        corpus difference.
+
+        ``contentOnly`` -- raw file bytes concatenated in sorted-relpath order,
+        path-blind. Independently agreed by two agents for this corpus.
+        ``pathBound`` -- per file ``sha256(relpath_utf8 || sha256_hex_ascii)``,
+        concatenated in sorted-relpath order.
+        """
+        return {
+            "contentOnly": self.content_only_hash,
+            "pathBound": self.path_bound_hash,
+            "enumerator": "SourceTree(root).paths()",
         }
 
     @property
@@ -130,6 +167,8 @@ class CorpusPin:
             file_count=int(payload["fileCount"]),
             aggregate_hash=str(payload["aggregateHash"]),
             files=files,
+            content_only_hash=str(payload.get("contentOnlyHash") or ""),
+            path_bound_hash=str(payload.get("pathBoundHash") or ""),
             root=str(payload.get("root") or ""),
         )
         # A pin whose own aggregate disagrees with its own manifest is a
@@ -236,15 +275,12 @@ def pin_corpus(
     resolved_version = version or distribution_version(root, dist)
 
     files: list[CorpusFile] = []
+    by_path: dict[str, Path] = {}
     for path in SourceTree(root).paths():
         sha, size = _sha256_file(path)
-        files.append(
-            CorpusFile(
-                path=path.resolve().relative_to(root).as_posix(),
-                sha256=sha,
-                size_bytes=size,
-            )
-        )
+        relative = path.resolve().relative_to(root).as_posix()
+        by_path[relative] = path
+        files.append(CorpusFile(path=relative, sha256=sha, size_bytes=size))
     if not files:
         raise CorpusPinDefect(
             owner="corpus pin",
@@ -263,12 +299,22 @@ def pin_corpus(
                 fix="the enumerator yielded a path twice — fix SourceTree.paths()",
             )
         seen.add(entry.path)
+    # The two circulating conventions, over the SAME bytes and the SAME
+    # enumeration, so a reader never has to guess which walk produced them.
+    content = hashlib.sha256()
+    path_bound = hashlib.sha256()
+    for entry in ordered:
+        content.update(by_path[entry.path].read_bytes())
+        path_bound.update(entry.path.encode("utf-8"))
+        path_bound.update(entry.sha256.encode("ascii"))
     return CorpusPin(
         distribution=dist,
         version=resolved_version,
         file_count=len(ordered),
         aggregate_hash=aggregate_hash(dist, resolved_version, ordered),
         files=ordered,
+        content_only_hash=content.hexdigest(),
+        path_bound_hash=path_bound.hexdigest(),
         root=str(root),
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -39,6 +39,11 @@ is, which is exactly the silent skip this axis exists to eliminate.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import dataclasses
 from collections import Counter
 from enum import Enum

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/construction_panic_fronts.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/construction_panic_fronts.py
@@ -13,6 +13,11 @@ name construction residual so the next floor has a measured address.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping
 from typing import Any

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/guarded_loop_recurrence.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import ast
 from dataclasses import asdict, dataclass
 from pathlib import Path

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py
@@ -12,6 +12,11 @@ recensus and floor drain share one owner map.
 
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 import ast
 import json
 import os

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/render_dunder_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/render_dunder_frontier.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 from .dunder_frontier_report import DunderFrontierReport
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/render_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/render_panic_audit.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 from .panic_audit_report import PanicAuditReport
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/render_temporal_dispatch_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/render_temporal_dispatch_frontier.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+# Not the board. This module measures its own named denominator; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
 from .temporal_dispatch_report import TemporalDispatchReport
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from sugar_lift_py_tests import lift_rpc
 from sugar_lift_py_tests.census import census
 from sugar_source_tree.panic import BackendDefect
-from sugar_source_tree.tree import SourceFile
 
 
 def test_census_returns_nonzero_when_construction_hits_backend_defect(
@@ -22,7 +22,11 @@ def test_census_returns_nonzero_when_construction_hits_backend_defect(
             fix="repair the backend",
         )
 
-    monkeypatch.setattr(SourceFile, "from_path", backend_crash)
+    # Plant the defect at the door the census actually opens. The census now
+    # opens files through ``open_source_file_for_construction``; this tooth
+    # used to patch ``SourceFile.from_path``, which that door never calls, so
+    # it would have gone green while measuring nothing.
+    monkeypatch.setattr(lift_rpc, "open_source_file_for_construction", backend_crash)
 
     assert census(tmp_path) != 0
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_dispatch_targets_resolve.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dispatch_targets_resolve.py
@@ -1,0 +1,139 @@
+"""An arm that cannot import its dispatch target is unwritten, not working.
+
+`perform_operation` was deleted with the operations layer (`b0aadef50`). #6316
+later created a *new* `operations` package holding one unrelated module. The
+name never came back, and five call sites still reach for it — three in
+`floor/call_site_value.py`, one in `floor/symbolic_value.py`, one in
+`floor/block_value.py`. All five import it lazily, inside the function body, so
+nothing fails until the arm is actually reached.
+
+**Why this is a scoreboard defect and not a floor bug.** Reaching one of those
+arms raises `ImportError` / `ModuleNotFoundError`. That is not a
+`ConstructionPanic`, not a typed refusal, and not in any family the census
+buckets. The row comes back short and nothing says so — an unwritten arm
+wearing a working arm's clothes. It is the same class as an instrument that
+cannot see what it reports, except this one *corrupts* counts instead of
+producing a visible zero, which is strictly harder to notice.
+
+A lazy import is a promise that the name exists. This test collects every such
+promise in the kit's source and checks it, so the promise cannot be broken
+silently again. It reads the SOURCE rather than executing the arms: these paths
+are reached from vendor source shapes, not from unit tests, so "the suite
+passes" says nothing about them.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.util
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+
+def _function_local_imports(tree: ast.AST) -> list[tuple[str, str, int]]:
+    """Every ``from X import Y`` that lives inside a function body.
+
+    Module-level imports fail loudly at import time and cannot hide. A
+    function-local import is the one that waits until the arm is reached.
+    """
+    promises: list[tuple[str, str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.ImportFrom) and inner.module and inner.level == 0:
+                for alias in inner.names:
+                    promises.append((inner.module, alias.name, inner.lineno))
+    return promises
+
+
+def _resolves(module: str, name: str) -> bool:
+    """Does ``from <module> import <name>`` actually have something to bind?
+
+    Checked without importing: a submodule on disk, or a name bound at the
+    module's top level. Importing the whole kit here would drag in the engine
+    and turn a source audit into an integration test.
+    """
+    try:
+        spec = importlib.util.find_spec(module)
+    except (ImportError, AttributeError):
+        return False
+    if spec is None:
+        return False
+    # Only ask about a submodule when the parent is actually a package.
+    # ``find_spec("some.module.Name")`` RAISES rather than returning None when
+    # ``some.module`` is a plain module -- which is most of them.
+    if spec.submodule_search_locations is not None:
+        try:
+            if importlib.util.find_spec(f"{module}.{name}") is not None:
+                return True
+        except (ImportError, AttributeError):
+            pass
+    origin = spec.origin
+    if not origin or not origin.endswith(".py"):
+        return False
+    tree = ast.parse(Path(origin).read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == name:
+                return True
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return True
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == name:
+                return True
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if (alias.asname or alias.name.split(".")[0]) == name:
+                    return True
+    return False
+
+
+def _broken_promises() -> list[str]:
+    broken: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for module, name, line in _function_local_imports(tree):
+            if not module.startswith("sugar_"):
+                continue  # third-party availability is the closure's business
+            if not _resolves(module, name):
+                broken.append(f"{path.relative_to(SRC)}:{line} from {module} import {name}")
+    return broken
+
+
+def test_every_lazy_dispatch_target_resolves() -> None:
+    broken = _broken_promises()
+    assert not broken, (
+        "these arms import a dispatch target that does not exist. Reaching one "
+        "raises ImportError, which is not a panic, not a typed refusal, and not "
+        "in any family the census buckets -- the row comes back short and "
+        "nothing says so:\n  " + "\n  ".join(broken)
+    )
+
+
+def test_the_audit_actually_recognizes(tmp_path) -> None:
+    """Discriminating face: a real name resolves, an invented one does not."""
+    # A name that genuinely exists in the kit.
+    assert _resolves("sugar_lift_py_tests.corpus_pin", "pin_corpus")
+    # A submodule, reached the other way.
+    assert _resolves("sugar_lift_py_tests", "corpus_pin")
+    # The shapes that must NOT pass.
+    assert not _resolves("sugar_lift_py_tests.corpus_pin", "perform_operation")
+    assert not _resolves("sugar_lift_py_tests.operations.perform_operation", "x")
+    assert not _resolves("sugar_lift_py_tests.no_such_module_at_all", "anything")
+
+    # And the walker must actually see a function-local import, not just
+    # module-level ones -- that distinction is the whole point.
+    tree = ast.parse(
+        "import os\n"
+        "def f():\n"
+        "    from sugar_x.y import z\n"
+        "    return z\n"
+    )
+    assert _function_local_imports(tree) == [("sugar_x.y", "z", 3)]

--- a/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
@@ -1,0 +1,117 @@
+"""Exactly one module may be the board. Everything else must say it is not.
+
+The Python corpus was being read from several instruments at once, each with a
+different denominator, and their numbers were quoted interchangeably. An
+AST-shape site census said ``With 4125/811/85``; the construction ledger for
+the same period said ``assertion 3 / resource 104 / other 4``. Nobody was
+lying. There was simply no fact of the matter about which one was "the board".
+
+So this is a recognizer, not a checklist. It finds every module in the kit that
+*emits an R quantity* — structurally, by looking for ``R``/``R_*`` keys in the
+payloads it builds and the lines it prints — and requires each one to declare,
+in its own source, whether it is the authority. Exactly one may say yes.
+
+A new census cannot quietly join the board: the moment it emits an ``R_*``
+quantity this test names it and stays red until it declares itself. That is the
+retirement path too — when a capability makes an axis unrepresentable, its
+instrument is deleted and disappears from this recognizer on its own.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+KIT = Path(__file__).resolve().parents[1]
+SEARCHED = (KIT / "scripts", KIT / "src" / "sugar_lift_py_tests")
+
+DECLARATION = "SCOREBOARD_AUTHORITY"
+
+
+def _is_r_quantity(name: str) -> bool:
+    """``R`` or ``R_<axis>`` — the shape every residual quantity is spelled in."""
+    return name == "R" or (name.startswith("R_") and len(name) > 2)
+
+
+def _emits_r_quantity(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        # A payload key: {"R_construction": ...} — the JSON board shape.
+        if isinstance(node, ast.Dict):
+            for key in node.keys:
+                if (
+                    isinstance(key, ast.Constant)
+                    and isinstance(key.value, str)
+                    and _is_r_quantity(key.value)
+                ):
+                    return True
+        # A printed line: "R_construction = {n}" — the console board shape.
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            head = node.value.strip().split(" ", 1)[0].rstrip("=:")
+            if _is_r_quantity(head) and ("=" in node.value or ":" in node.value):
+                return True
+    return False
+
+
+def _declared_authority(tree: ast.AST) -> bool | None:
+    """The module's own statement about itself, or None if it never made one."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == DECLARATION:
+                    if isinstance(node.value, ast.Constant) and isinstance(
+                        node.value.value, bool
+                    ):
+                        return node.value.value
+    return None
+
+
+def _board_producers() -> dict[Path, bool | None]:
+    found: dict[Path, bool | None] = {}
+    for directory in SEARCHED:
+        for path in sorted(directory.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            if _emits_r_quantity(tree):
+                found[path] = _declared_authority(tree)
+    return found
+
+
+def test_every_module_that_emits_an_r_quantity_declares_its_authority() -> None:
+    producers = _board_producers()
+    assert producers, "recognizer found no R-emitting module — it walked the wrong tree"
+    undeclared = sorted(
+        str(path.relative_to(KIT)) for path, declared in producers.items()
+        if declared is None
+    )
+    assert not undeclared, (
+        "these modules emit an R quantity but never say whether they are the "
+        f"board: {undeclared}. Add `{DECLARATION} = False` (and say in the "
+        "docstring what denominator they DO measure), or True if this is "
+        "genuinely the authority."
+    )
+
+
+def test_exactly_one_module_claims_to_be_the_authority() -> None:
+    claimants = sorted(
+        str(path.relative_to(KIT))
+        for path, declared in _board_producers().items()
+        if declared is True
+    )
+    assert claimants == ["scripts/control_effect_recensus.py"], (
+        "the Python corpus board has exactly one authority; claimants were "
+        f"{claimants}"
+    )
+
+
+def test_the_recognizer_actually_recognizes(tmp_path) -> None:
+    """The discriminating face: a planted board must be caught, a probe must not."""
+    board = ast.parse('result = {"R_construction": 7}\n')
+    assert _emits_r_quantity(board)
+    printer = ast.parse('print(f"R_desugar = {n}")\n')
+    assert _emits_r_quantity(printer)
+    # Not a board: no R quantity emitted, however much it talks about them.
+    probe = ast.parse('"""Counts With sites."""\nsites = {"withStatements": 4125}\n')
+    assert not _emits_r_quantity(probe)
+    assert _declared_authority(ast.parse("SCOREBOARD_AUTHORITY = False\n")) is False
+    assert _declared_authority(ast.parse("x = 1\n")) is None

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
@@ -22,14 +22,56 @@ rather than silently inventing one.
 
 from __future__ import annotations
 
+import importlib.util
 import json
-import subprocess
 import sys
 from pathlib import Path
 
-SCRIPT = (
-    Path(__file__).resolve().parents[1] / "scripts" / "control_effect_recensus.py"
-)
+# Import the tree package here, at module scope, the way every other test in
+# this kit does. Deferring it to the moment the CLI runs left it unresolvable in
+# the managed closure, which looked like a measurement failure and was an import
+# ordering artefact.
+import sugar_source_tree.tree  # noqa: F401,E402  (path warm-up, load-bearing)
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+SCRIPT = SCRIPTS / "control_effect_recensus.py"
+
+
+def _recensus():
+    """Load the CLI as a module and drive its real ``main``.
+
+    In-process on purpose. A subprocess would need this interpreter's import
+    path reconstructed by hand, and under the managed test closure that
+    reconstruction is exactly the kind of environment guess that produces a
+    green test measuring nothing. ``main`` still parses argv, so the argument
+    handling these teeth are about is genuinely exercised.
+    """
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location("control_effect_recensus", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Completed:
+    def __init__(self, returncode: int, stderr: str) -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def _invoke(argv: list[str], capsys=None) -> Completed:
+    module = _recensus()
+    saved = sys.argv
+    sys.argv = ["control_effect_recensus.py", *argv]
+    try:
+        code = module.main()
+    except SystemExit as exit_:  # argparse refusals arrive this way
+        code = exit_.code if isinstance(exit_.code, int) else 1
+    finally:
+        sys.argv = saved
+    captured = capsys.readouterr() if capsys is not None else None
+    return Completed(int(code or 0), captured.err if captured else "")
 
 
 def _corpus(tmp_path: Path) -> Path:
@@ -62,11 +104,16 @@ def _corpus(tmp_path: Path) -> Path:
     return root
 
 
-def _run(corpus: Path, *, root: Path, out: Path, extra: list[str] | None = None):
-    return subprocess.run(
+def _run(
+    corpus: Path,
+    *,
+    root: Path,
+    out: Path,
+    extra: list[str] | None = None,
+    capsys=None,
+) -> Completed:
+    return _invoke(
         [
-            sys.executable,
-            str(SCRIPT),
             str(corpus),
             "--corpus-root",
             str(root),
@@ -78,8 +125,7 @@ def _run(corpus: Path, *, root: Path, out: Path, extra: list[str] | None = None)
             "test-pin",
             *(extra or []),
         ],
-        capture_output=True,
-        text=True,
+        capsys=capsys,
     )
 
 
@@ -140,12 +186,10 @@ def test_a_different_root_does_not_produce_the_same_row(tmp_path) -> None:
     assert drifted_rows[0]["file"] != TARGET
 
 
-def test_single_file_run_without_corpus_root_is_refused(tmp_path) -> None:
+def test_single_file_run_without_corpus_root_is_refused(tmp_path, capsys) -> None:
     root = _corpus(tmp_path)
-    result = subprocess.run(
+    result = _invoke(
         [
-            sys.executable,
-            str(SCRIPT),
             str(root / "sub" / "uses.py"),
             "--out-dir",
             str(tmp_path / "refused"),
@@ -154,20 +198,23 @@ def test_single_file_run_without_corpus_root_is_refused(tmp_path) -> None:
             "--corpus-version",
             "test-pin",
         ],
-        capture_output=True,
-        text=True,
+        capsys=capsys,
     )
     assert result.returncode != 0
     assert "--corpus-root is required" in result.stderr
 
 
-def test_corpus_pin_refuses_a_changed_corpus(tmp_path) -> None:
+def test_corpus_pin_refuses_a_changed_corpus(tmp_path, capsys) -> None:
     """A board is comparable only against the corpus it was pinned to."""
     root = _corpus(tmp_path)
     pin = tmp_path / "corpus.pin.json"
 
     first = _run(
-        root, root=root, out=tmp_path / "pinned", extra=["--write-corpus-pin", str(pin)]
+        root,
+        root=root,
+        out=tmp_path / "pinned",
+        extra=["--write-corpus-pin", str(pin)],
+        capsys=capsys,
     )
     assert pin.exists(), first.stderr
 
@@ -176,6 +223,7 @@ def test_corpus_pin_refuses_a_changed_corpus(tmp_path) -> None:
         root=root,
         out=tmp_path / "same",
         extra=["--require-corpus-pin", str(pin)],
+        capsys=capsys,
     )
     assert "CORPUS PIN DEFECT" not in same.stderr
 
@@ -185,6 +233,7 @@ def test_corpus_pin_refuses_a_changed_corpus(tmp_path) -> None:
         root=root,
         out=tmp_path / "changed",
         extra=["--require-corpus-pin", str(pin)],
+        capsys=capsys,
     )
     assert changed.returncode == 2
     assert "CORPUS PIN DEFECT" in changed.stderr

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
@@ -27,12 +27,6 @@ import json
 import sys
 from pathlib import Path
 
-# Import the tree package here, at module scope, the way every other test in
-# this kit does. Deferring it to the moment the CLI runs left it unresolvable in
-# the managed closure, which looked like a measurement failure and was an import
-# ordering artefact.
-import sugar_source_tree.tree  # noqa: F401,E402  (path warm-up, load-bearing)
-
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 SCRIPT = SCRIPTS / "control_effect_recensus.py"
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
@@ -1,0 +1,190 @@
+"""A bounded run must produce the SAME row as the full run — or it is a rumour.
+
+The pandas board was quoted from two kinds of run: the full corpus, and a
+handful of files re-measured alone to check a capability. Those were treated as
+one frontier. They were not comparable: a file corpus set the workspace root to
+the measured file's *parent directory*, so
+``provisional_contract_refs_from_demands`` walked a different tree, produced a
+different demand table, and resolved the same ``with`` statements differently.
+The instrument, not the code, moved the number.
+
+These teeth pin the repair from both faces:
+
+* **positive** — one file measured alone under the corpus root produces a row
+  byte-identical to that file's row inside the full run;
+* **discrimination** — the same file measured under a *different* root does NOT
+  produce that row, so the tooth above is actually load-bearing and would go
+  red if the root stopped mattering.
+
+Plus the refusal: a single-file run with no ``--corpus-root`` is rejected,
+rather than silently inventing one.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "scripts" / "control_effect_recensus.py"
+)
+
+
+def _corpus(tmp_path: Path) -> Path:
+    """A corpus whose ``with`` resolution depends on a sibling module.
+
+    ``pkg/uses.py`` opens a manager imported from ``pkg/managers.py``. Rooted at
+    ``pkg`` the demand table can see the definition; rooted at ``pkg/sub`` it
+    cannot. That is exactly the drift the repair removes, in miniature.
+    """
+    root = tmp_path / "pkg"
+    (root / "sub").mkdir(parents=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    (root / "managers.py").write_text(
+        "import contextlib\n"
+        "\n"
+        "@contextlib.contextmanager\n"
+        "def held():\n"
+        "    yield 1\n",
+        encoding="utf-8",
+    )
+    (root / "sub" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "sub" / "uses.py").write_text(
+        "from pkg.managers import held\n"
+        "\n"
+        "def run():\n"
+        "    with held() as value:\n"
+        "        return value\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _run(corpus: Path, *, root: Path, out: Path, extra: list[str] | None = None):
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(corpus),
+            "--corpus-root",
+            str(root),
+            "--out-dir",
+            str(out),
+            "--commit",
+            "test",
+            "--corpus-version",
+            "test-pin",
+            *(extra or []),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _row_for(out: Path, wanted: str) -> str:
+    """The measured result for one file, canonicalized — compared as bytes.
+
+    The enclosing journal row also carries ``corpusManifestCid``, which is the
+    CID of *this run's enrollment* and is legitimately different when one file
+    is enrolled instead of four. What must not differ is the measurement: every
+    family, resolution bucket, site count and desugar row. That is what is
+    compared here, byte for byte, not a summary number derived from it.
+    """
+    rows = [
+        json.loads(line)
+        for line in (out / "checkpoint.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    matching = [row for row in rows if row["file"] == wanted]
+    assert len(matching) == 1, f"expected exactly one row for {wanted}, got {matching}"
+    return json.dumps(matching[0]["result"], sort_keys=True, separators=(",", ":"))
+
+
+TARGET = "pkg/sub/uses.py"
+
+
+def test_file_measured_alone_matches_its_row_in_the_full_run(tmp_path) -> None:
+    root = _corpus(tmp_path)
+
+    full = _run(root, root=root, out=tmp_path / "full")
+    assert (tmp_path / "full" / "checkpoint.jsonl").exists(), full.stderr
+
+    alone = _run(root / "sub" / "uses.py", root=root, out=tmp_path / "alone")
+    assert (tmp_path / "alone" / "checkpoint.jsonl").exists(), alone.stderr
+
+    assert _row_for(tmp_path / "alone", TARGET) == _row_for(tmp_path / "full", TARGET)
+
+
+def test_a_different_root_does_not_produce_the_same_row(tmp_path) -> None:
+    """The discriminating face: if this passed too, the tooth above proved nothing."""
+    root = _corpus(tmp_path)
+
+    full = _run(root, root=root, out=tmp_path / "full")
+    assert (tmp_path / "full" / "checkpoint.jsonl").exists(), full.stderr
+
+    drifted = _run(
+        root / "sub" / "uses.py", root=root / "sub", out=tmp_path / "drifted"
+    )
+    assert (tmp_path / "drifted" / "checkpoint.jsonl").exists(), drifted.stderr
+
+    # Under the wrong root the file is not even the same identity, and its
+    # resolutions come from a table that never saw pkg/managers.py.
+    drifted_rows = [
+        json.loads(line)
+        for line in (tmp_path / "drifted" / "checkpoint.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert [row["file"] for row in drifted_rows] == ["sub/uses.py"]
+    assert drifted_rows[0]["file"] != TARGET
+
+
+def test_single_file_run_without_corpus_root_is_refused(tmp_path) -> None:
+    root = _corpus(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(root / "sub" / "uses.py"),
+            "--out-dir",
+            str(tmp_path / "refused"),
+            "--commit",
+            "test",
+            "--corpus-version",
+            "test-pin",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--corpus-root is required" in result.stderr
+
+
+def test_corpus_pin_refuses_a_changed_corpus(tmp_path) -> None:
+    """A board is comparable only against the corpus it was pinned to."""
+    root = _corpus(tmp_path)
+    pin = tmp_path / "corpus.pin.json"
+
+    first = _run(
+        root, root=root, out=tmp_path / "pinned", extra=["--write-corpus-pin", str(pin)]
+    )
+    assert pin.exists(), first.stderr
+
+    same = _run(
+        root,
+        root=root,
+        out=tmp_path / "same",
+        extra=["--require-corpus-pin", str(pin)],
+    )
+    assert "CORPUS PIN DEFECT" not in same.stderr
+
+    (root / "managers.py").write_text("# corpus moved\n", encoding="utf-8")
+    changed = _run(
+        root,
+        root=root,
+        out=tmp_path / "changed",
+        extra=["--require-corpus-pin", str(pin)],
+    )
+    assert changed.returncode == 2
+    assert "CORPUS PIN DEFECT" in changed.stderr


### PR DESCRIPTION
## What this is

The Python corpus board had no single denominator. An AST-shape site census read `With 4125/811/85`; the construction-R ledger for the same period read `assertion 3 / resource 104 / other 4`. Both were correct measurements of different things, quoted against each other as if the difference were motion. This makes `scripts/control_effect_recensus.py` the sole authority, and makes it state its denominator before it states any number.

**Does not close anything. Do not merge yet** — see Inherited red.

## The two quantities, now structurally separate

| | question | key |
|---|---|---|
| site coverage | how many AST sites have this shape | `astSitePrevalence`, every key prefixed `site:` |
| ΔR | how many authenticated construction/desugar occurrences failed | `R_construction`, `R_desugar` |

Prevalence is a denominator and is never called R. A capability moves ΔR and leaves prevalence untouched — the `with` statements are still there afterwards.

## What changed

**`sugar_lift_py_tests/corpus_pin.py` (new).** Distribution + version + per-file content manifest + one aggregate hash. Enumerated through `SourceTree(root).paths()` — the census's own enumerator, so the pin denominator *is* the run denominator. Version is read from the installed `*.dist-info`, never guessed. `--require-corpus-pin` refuses to measure a corpus that is not the pinned one; `compare()` names *how* two corpora differ (added / removed / changed / version moved) rather than returning a bare boolean.

**Corpus-context drift, removed.** `--corpus-root` is explicit and required for any bounded run. The old default set `workspace_root = path.parent` for a single-file corpus, so `provisional_contract_refs_from_demands` walked a different tree, produced a different demand table, and resolved the same `with` statements differently. File identity is now always relative to the corpus root, so a bounded row *is* the full-run row. `_measure_file` raises rather than defaulting.

**No more vendor name table.** `cmMembranes` bucketed With residual by a hard-coded list of pandas leaf names (`raises`, `ensure_clean`, `option_context`, …). That grants a semantic category from spelling: the board moved when pandas renamed something and stayed still when another project used the same shape under a different name. Replaced by `cmResolutions`, bucketed by the authenticated resolution gap kind — a closed vocabulary that survives renames.

⚠️ **This drops the assertion-vs-resource split.** It is a real distinction and it needs a structural discriminator (does the manager's contract swallow the exception?), not a name list. `R_cm_assertion_membrane` and `R_cm_protocol_resource_candidate` are gone until someone builds one. If you were reading those, say so.

**The denominator, recorded.** `denominator{}` carries enrolled / terminalRows / completed / corpusManifestCid / every enrolled identity / missing / duplicate / malformed. Any of those being wrong makes the run red — a partial denominator is never banked as a board. `stableZeroTerms{}` states the conjunction with every conjunct beside it, and each term is counted wherever it can land rather than from one hopeful key. `sourceStamp{}` carries commit, host, platform, load, wall clock.

**`census.py`** now opens through `open_source_file_for_construction` against an explicit root instead of a bare `SourceFile.from_path`, which painted every `with` as `RuntimeSelectedContextManager` regardless of resolvability — the two instruments disagreed about With for reasons that were entirely the instrument's. It is marked non-authoritative.

## The shell this deletes

`tests/test_one_authoritative_scoreboard.py` is a recognizer, not a checklist. It walks the kit, finds every module that emits an R quantity — structurally, by `R`/`R_*` keys in the payloads it builds and the lines it prints — and requires each to declare `SCOREBOARD_AUTHORITY`. Exactly one may say `True`. 29 modules were emitting R. A new census cannot quietly join the board: the moment it emits an `R_*` quantity this test names it and stays red until it declares itself.

Retirement path: when a capability makes an axis unrepresentable, its instrument is deleted and leaves this recognizer on its own.

## Teeth

- a file measured alone under the corpus root produces a **byte-identical result row** to that file inside the full run;
- **discriminating face** — the same file under a *different* root does not produce that row;
- a single-file run without `--corpus-root` is refused;
- a changed corpus is refused against its pin;
- the recognizer is itself exercised on a planted board, a planted printer, and a non-board probe.

## Archived, not compared

`docs/ledgers/pass3-pandas-control-effect-d94f67a31.md` is marked **NON-COMPARABLE** in place, with both reasons: a different pandas, and 780 of its 1,415 files aborted at `ValueError: 'dynamic-export' is not a valid WithConstructionGapKind` before their gaps could be tallied — its With mass is a floor over 635 files, not a measurement over 1,415. (That decode defect is already fixed on main by `WithConstructionGapKind.parse`.)

## Inherited red — blocking the baseline

**`sugar_source_tree` is not importable in the managed Python test closure.** Untouched main code reproduces it:

```
bin/bpytest -q --collect-only implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
-> EXIT=2  ModuleNotFoundError: No module named 'sugar_source_tree'
```

Same under `--task python-unit` and `--task python-lift`, and for a bare ssh interpreter on the box. It fails at **collection**, so whole files vanish rather than failing loudly. Until it is repaired, no Python test can be verified remotely and the 1,421-file baseline cannot run.

The pinned corpus is located and confirmed: `battleaxe:~/pandas303-audit/pandas`, pandas 3.0.3, exactly 1,421 `.py` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin the test corpus and enforce a single authoritative scoreboard for the pandas control-effect recensus
> - Adds [corpus_pin.py](https://github.com/TSavo/sugar/pull/6332/files#diff-818691ec42403ba7511bf3300ad0e32efc0dec58190bf12edc602614c9fda172) with `CorpusPin`/`CorpusFile` dataclasses, content-addressed aggregate hashing, and `pin_corpus`/`require_pin`/`load_pin`/`write_pin` helpers to lock the measured file set across runs.
> - Rewrites [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/6332/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to require an explicit `--corpus-root`, support `--corpus-pin` write/enforce flags, bucket context-manager resolutions by authenticated `WithConstructionGapKind` instead of symbol names, and emit `cmResolutions`, `astSitePrevalence`, `denominator`, and `sourceStamp` in output.
> - Adds `SCOREBOARD_AUTHORITY = True` to the recensus script and `SCOREBOARD_AUTHORITY = False` to every other R-emitting script/module; new tests in [test_one_authoritative_scoreboard.py](https://github.com/TSavo/sugar/pull/6332/files#diff-44723364a68ca48bc2d0b3d88250c33f9aad4f5e2b5c4be39329411ad02f514f) enforce exactly one authority exists.
> - Adds [test_recensus_bounded_run_equivalence.py](https://github.com/TSavo/sugar/pull/6332/files#diff-d26adb83d69a12172a3bf21fbceb2790ca9444d80530a170012f532e9f910ef7) to assert single-file results match full-corpus rows, corpus-root is required for single-file runs, and corpus pin defects are signaled with exit code 2.
> - Prepends non-authoritative disclaimers to older audit docs and archives the earlier ledger as non-comparable; adds the pinned pandas 3.0.3 corpus pin at [docs/ledgers/pins/pandas-3.0.3.pin.json](https://github.com/TSavo/sugar/pull/6332/files#diff-ffc0ed34bd54253d1e8a0e9f1753659c161b064299ffa8edab2aed053c7a262a) and a new control-effect ledger at [docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json](https://github.com/TSavo/sugar/pull/6332/files#diff-19633c4ef4348a0508924175f5d28c9a76302db3bed09dc4372805ab10df3316).
> - Behavioral Change: `reconcile_pandas_floors.py` no longer has a default for `--expected-files`; callers must pass either `--expected-files` or `--corpus-pin` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 959bf3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->