### PR TITLE
A conditional expression is a partition, not an exponent (#6324)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -567,6 +567,41 @@ def sole_completed_outcome(outcome):
     return Complete(completed[0].value)
 
 
+def factored_operand(outcome):
+    """An OPERAND outcome presenting at most one completed arm (#6324).
+
+    THE LAW THIS ENFORCES. Every k-operand fold in the lift is written the same
+    way -- ``outcome = outcome.and_then(next_operand)``, k times, in
+    ``collection_sugar._reduce_into``, ``method_call_sugar._collect``,
+    ``bool_op_sugar``, ``fstring_sugar``. ``and_then`` is ``ExitSet.sequence``,
+    and ``sequence`` appends every exit of the tail under every COMPLETED exit
+    of the prefix. So an operand carrying m completed arms multiplies the
+    accumulator by m, and k operands distribute into m ** k arms.
+
+    #6319 made halting and partitioning operands LIFT instead of raising --
+    correctly; that ruling drained 369 defect rows and stays. But it thereby
+    put multi-arm completed faces into every one of those folds for the first
+    time. `pandas/tests/extension/test_arrow.py` measured 133,104 arms arriving
+    at ONE ``normalize`` call through ``collection_sugar._reduce_into``.
+
+    The accumulator itself cannot be factored: its completed value is the
+    growing tuple the fold is building, and a ``GuardedValue`` chain over
+    tuples is not a tuple. The OPERAND can. Factoring it moves that operand's
+    partition from the exit level to the value level -- one arm carrying a
+    ``GuardedValue``, which is an ordinary floor value that a collection, a
+    call argument, or a concatenation holds like any other. The accumulator
+    then stays at one completed arm by induction from ``Complete(())``, and the
+    halted arms stay at the exit level where they already grow linearly.
+
+    Same denotation, linear growth. Nothing is capped, pruned, or dropped, and
+    ``ExitSetFactoringGap`` still refuses loudly when an operand's completed
+    arms are not provably pairwise exclusive.
+    """
+    if not isinstance(outcome, ExitSet):
+        return outcome
+    return outcome.factor_completed().collapse()
+
+
 def outcome_to_exitset(outcome) -> ExitSet:
     if isinstance(outcome, ExitSet):
         return outcome
@@ -585,6 +620,7 @@ __all__ = [
     "ExitSetFactoringGap",
     "Halted",
     "complement_guard",
+    "factored_operand",
     "false_guard",
     "sole_completed_outcome",
     "true_guard",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -42,7 +42,11 @@ class BoolOpSugar(Sugar):
         from functools import reduce
 
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.outcome.exit_set import _and_guards, _or_guards
+        from sugar_lift_py_tests.outcome.exit_set import (
+            _and_guards,
+            _or_guards,
+            factored_operand,
+        )
         from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
         # Operands thread through `and_then`, the one door every Outcome variant
@@ -53,7 +57,10 @@ class BoolOpSugar(Sugar):
         # Reading `.value` off the outcome assumed exactly one arm and was the
         # `'ExitSet' object has no attribute 'value'` defect here.
         def collect(operand, collected):
-            return operand.desugar(ctx).and_then(
+            # One completed arm per operand (#6324): an unfactored partitioning
+            # conjunct multiplies the accumulated formula tuple, and k conjuncts
+            # distribute into m ** k arms.
+            return factored_operand(operand.desugar(ctx)).and_then(
                 # Same truth→formula projection as if/if-exp: symbolic formulas
                 # stand as themselves; ground True/False (including None.truth →
                 # False) fold through true_guard/false_guard. Never raise bare

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -40,6 +40,7 @@ def _reduce_into(element_sugars, ctx, build):
         rewrap_pending,
     )
     from sugar_lift_py_tests.outcome import true_guard
+    from sugar_lift_py_tests.outcome.exit_set import factored_operand
 
     owner = f"collection {build.__name__}"
     reduced = tuple(element.desugar(ctx) for element in element_sugars)
@@ -71,10 +72,19 @@ def _reduce_into(element_sugars, ctx, build):
         pending = entry if entry is not None else pending
         stripped.append(plain)
 
+    # An element that PARTITIONS enters the fold with at most one completed arm
+    # (#6324). `and_then` is `ExitSet.sequence`, which distributes the tail
+    # under every completed arm of the prefix, so an unfactored element makes
+    # the accumulator grow multiplicatively: `test_arrow.py` measured 133,104
+    # arms arriving at one `normalize` call through this loop. Factoring moves
+    # the element's partition onto its VALUE (a `GuardedValue`, which a list
+    # holds like any other floor value) and leaves its halted arms at the exit
+    # level. The accumulator itself cannot be factored -- its completed value is
+    # the growing tuple this fold is building.
     outcome = Complete(())
     for element_outcome in stripped:
         outcome = outcome.and_then(
-            lambda collected, got=element_outcome: got.and_then(
+            lambda collected, got=factored_operand(element_outcome): got.and_then(
                 lambda value: Complete((*collected, value))
             )
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -88,6 +88,7 @@ class JoinedStrSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
 
         if not self.parts:
             return Complete(StringValue(""))
@@ -96,10 +97,13 @@ class JoinedStrSugar(Sugar):
         # PARTITIONS keeps every arm and each arm concatenates under its own
         # guard. `acc.value.add(right.value, ...)` assumed both sides were one
         # unconditional value.
-        outcome = self.parts[0].desugar(ctx)
+        # One completed arm per part (#6324): concatenation is a k-step fold
+        # through `ExitSet.sequence`, so an unfactored partitioning part
+        # multiplies the accumulator at every remaining part.
+        outcome = factored_operand(self.parts[0].desugar(ctx))
         for part in self.parts[1:]:
             outcome = outcome.and_then(
-                lambda left, part=part: part.desugar(ctx).and_then(
+                lambda left, part=part: factored_operand(part.desugar(ctx)).and_then(
                     lambda right: left.add(right, self.site)
                 )
             )
@@ -109,13 +113,14 @@ class JoinedStrSugar(Sugar):
         """Project this JoinedStr as the reference ``python:fstring`` ctor."""
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
 
         # Same law as `desugar`: every part threads through `and_then`, so a
         # halting or partitioning part is conserved rather than read as `.value`.
         outcome = Complete(())
         for part in self.parts:
             outcome = outcome.and_then(
-                lambda terms, part=part: part.desugar(ctx).and_then(
+                lambda terms, part=part: factored_operand(part.desugar(ctx)).and_then(
                     lambda value: Complete(
                         (
                             *terms,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -136,6 +136,32 @@ class IfExpSugar(Sugar):
         exits = outcome_to_exitset(then_out).guarded(formula)
         exits = exits.union(outcome_to_exitset(else_out).guarded(not_formula))
 
+        # FACTOR THE COMPLETED FACE (#6324). An EXPRESSION's exit set is consumed
+        # by `and_then`, and `ExitSet.sequence` appends every exit of the tail
+        # under every completed exit of the prefix: a receiver with m completed
+        # arms followed by k operands distributes into m ** k arms. Two completed
+        # arms here is not a small number downstream -- it is the base of an
+        # exponent. The corpus measured it: one union at this line arrived with
+        # 131,364 arms on `pandas/tests/extension/test_arrow.py`, reached through
+        # `method_call_sugar._collect`'s operand chain, and the file crossed a
+        # 300s deadline on an idle 32-core box.
+        #
+        # Factoring moves the SAME partition from the exit level to the value
+        # level -- one arm carrying a `GuardedValue` chain -- where k steps
+        # contribute k guarded values instead of m ** k arms. Same denotation,
+        # linear growth. It is the primitive #6315 built for exactly this and
+        # until now had exactly one caller (`SpreadSugar`); the conditional
+        # expression is the second producer of a multi-arm completed face, and it
+        # reached `sequence` without passing through it.
+        #
+        # `factor_completed` REFUSES (`ExitSetFactoringGap`) when the completed
+        # arms are not provably pairwise exclusive, and that refusal is kept: the
+        # two faces here are guarded by `formula` and `not formula`, so a chain
+        # that is first-match-wins carries them exactly. Nothing is capped,
+        # nothing is pruned, no arm is dropped, and no halted arm is touched --
+        # the halted face already grows linearly at the exit level.
+        exits = exits.factor_completed()
+
         # A partition with a single completed face and no halt is a plain value
         # again (normalize may have merged the faces): collapse rather than hand
         # callers a one-arm ExitSet they would have to unwrap. Anything still

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -160,7 +160,7 @@ class IfExpSugar(Sugar):
         # that is first-match-wins carries them exactly. Nothing is capped,
         # nothing is pruned, no arm is dropped, and no halted arm is touched --
         # the halted face already grows linearly at the exit level.
-        exits = exits.factor_completed()
+        exits = exits.factor_completed()  # `factored_operand`'s half that stays an ExitSet
 
         # A partition with a single completed face and no halt is a plain value
         # again (normalize may have merged the faces): collapse rather than hand

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -44,14 +44,24 @@ class MethodCallSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        return self.receiver.desugar(ctx).and_then(
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
+
+        # The RECEIVER is the prefix of the whole argument fold, so its arm
+        # count is the base of the exponent every argument raises (#6324).
+        return factored_operand(self.receiver.desugar(ctx)).and_then(
             lambda receiver: self._collect(receiver, self.args, (), ctx)
         )
 
     def _collect(self, receiver, remaining: tuple, accumulated: tuple, ctx) -> Outcome:
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
+
         if remaining:
             head, *rest = remaining
-            return head.desugar(ctx).and_then(
+            # One completed arm per argument (#6324): `and_then` is
+            # `ExitSet.sequence`, so an unfactored partitioning argument
+            # multiplies the accumulated tuple by its arm count, and k
+            # arguments distribute into m ** k arms.
+            return factored_operand(head.desugar(ctx)).and_then(
                 lambda value: self._collect(
                     receiver, tuple(rest), accumulated + (value,), ctx
                 )
@@ -61,9 +71,12 @@ class MethodCallSugar(Sugar):
     def _collect_kwargs(
         self, receiver, remaining: tuple, kw_values: tuple, positional: tuple, ctx
     ) -> Outcome:
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
+
         if remaining:
             (name, sugar), *rest = remaining
-            return sugar.desugar(ctx).and_then(
+            # Same law as the positional fold (#6324).
+            return factored_operand(sugar.desugar(ctx)).and_then(
                 lambda value: self._collect_kwargs(
                     receiver, tuple(rest), kw_values + ((name, value),), positional, ctx
                 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_exp_partition_arm_growth.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_exp_partition_arm_growth.py
@@ -1,0 +1,195 @@
+"""The complexity tooth for #6324: a conditional expression is not an exponent.
+
+#6319 taught `IfExpSugar` that an arm which halts is a PARTITION, not a missing
+recognizer. That was right, and it drained 369 desugar-defect rows. It also put
+a multi-completed-arm `ExitSet` on a path that `ExitSet.sequence` consumes.
+
+`sequence` appends every exit of the tail under every COMPLETED exit of the
+prefix. So a receiver carrying m completed arms, followed by k operands in a
+`method_call_sugar._collect` chain, distributes into m ** k arms. Two arms is
+not a small number there — it is the base of an exponent. Measured on a quiet
+32-core battleaxe at `a4eade69a`, desugar-inclusive, per-file 300s deadline:
+
+| file | arms into one union | wall |
+| --- | --- | --- |
+| `pandas/tests/extension/test_arrow.py` | 131,364 | timeout >300s |
+| `pandas/core/reshape/pivot.py` | 1,304 | timeout >300s |
+| `pandas/core/arrays/arrow/array.py` | 436 | timeout >300s |
+
+The live SIGALRM stack named the site: `if_exp_sugar._join_arms` ->
+`ExitSet.union` -> `normalize`, reached through `method_call_sugar._collect`.
+All three completed in seconds at `a02ebbe3e`, where the same shape raised
+`NotImplementedError` and the whole function was abandoned as a defect row.
+
+`ExitSet.factor_completed` is the primitive #6315 built for exactly this: the
+SAME partition moves from the exit level (m arms, one value each) to the value
+level (one arm, a `GuardedValue` chain), so k steps contribute k guarded values
+instead of m ** k arms. Until #6324 it had exactly ONE caller, `SpreadSugar`.
+The conditional expression is the second producer of a multi-arm completed
+face, and it reached `sequence` without passing through it.
+
+THIS TOOTH COUNTS ARMS, NOT SECONDS. Wall time on a shared box measures the
+box; arm population measures the algebra, and arm population is what regressed.
+A faster normalizer must never be allowed to hide exponential arm growth, so
+this file never looks at a clock.
+
+Read with `test_desugar_defect_family_twins.py`: that file proves the partition
+is still LIFTED (the 369-row drain is not given back by turning the panic into
+a refusal). This file proves lifting it costs a bounded number of arms. Neither
+is sufficient alone — a lift can be complete and unusable, or fast and missing.
+
+RETIREMENT PATH. This tooth is a test because `sequence`'s growth is a property
+of a call chain, not of a constructible state. It retires the day the exit
+algebra can only be entered through a factored completed face — i.e. when
+`ExitSet` exposes no constructor that admits several completed arms into
+`sequence`, so `m > 1` at a sequencing seat becomes unrepresentable rather than
+detected.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+from sugar_lift_py_tests.ir import atomic, make_var, not_
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    Halted,
+    outcome_to_exitset,
+)
+from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+
+
+OPERAND_COUNTS = (1, 2, 3, 4, 5, 6, 7, 8)
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def _partitioning_arm(name: str):
+    """An arm that produces a value on one face and halts on the other.
+
+    This is the #6319 shape: `(a if c else <halt>)` where the else arm is an
+    unresolvable call or a raise. It is an `ExitSet`, not a `Complete`, which is
+    precisely why `_join_arms` takes the union path.
+    """
+    condition = _guard(name)
+    return ExitSet(
+        (
+            Completed(condition, f"{name}-value"),
+            Halted(not_(condition), RaiseEffect(exception_name="ValueError"), None),
+        )
+    )
+
+
+def _joined():
+    """What `IfExpSugar._join_arms` hands its caller for a partitioning arm."""
+    test = _guard("test")
+    return IfExpSugar._join_arms(
+        object.__new__(IfExpSugar),
+        test,
+        Complete("then-value"),
+        _partitioning_arm("else"),
+    )
+
+
+def _completed_arms(outcome) -> int:
+    exits = outcome_to_exitset(outcome)
+    return sum(isinstance(exit_, Completed) for exit_ in exits.exits)
+
+
+# --------------------------------------------------------------------------
+# The bound
+# --------------------------------------------------------------------------
+
+
+def test_a_partitioning_conditional_expression_yields_one_completed_arm():
+    """THE BOUND. m == 1, so m ** k == 1 however long the operand chain is.
+
+    Before #6324 this returned TWO completed arms — the then face and the
+    else face's completed half — and every downstream operand doubled them.
+    """
+    assert _completed_arms(_joined()) == 1
+
+
+def test_operand_chains_over_a_partitioning_conditional_do_not_multiply():
+    """THE GROWTH LAW, read directly off `sequence`.
+
+    Each step is one ordinary completed operand, exactly as
+    `method_call_sugar._collect` threads them. With a factored receiver the
+    completed face stays at one arm for every k. With an unfactored one this
+    is 2 ** k, which is what timed out on three pandas files.
+    """
+    joined = outcome_to_exitset(_joined())
+
+    # The whole series is measured before anything is asserted, so a failure
+    # PRINTS the growth curve rather than only its first point. `1, 2, 4, 8,
+    # 16, ...` is the regression; `1, 1, 1, 1, ...` is the repaired bound.
+    series = []
+    for operand_count in OPERAND_COUNTS:
+        exits = joined
+        for index in range(operand_count):
+            exits = exits.sequence(
+                lambda value, _i=index: ExitSet.completed((value, _i))
+            )
+        series.append(sum(isinstance(e, Completed) for e in exits.exits))
+
+    assert series == [1] * len(OPERAND_COUNTS), (
+        f"completed arms by operand count {dict(zip(OPERAND_COUNTS, series))}: the "
+        "conditional-expression face is unfactored and `ExitSet.sequence` is "
+        "distributing it into m ** k arms again (#6324). Factor the completed "
+        "face in `IfExpSugar._join_arms` — do not cap, prune, or refuse."
+    )
+
+
+# --------------------------------------------------------------------------
+# Discriminators: the bound must not have been bought with meaning
+# --------------------------------------------------------------------------
+
+
+def test_the_halted_arm_survives_the_factoring():
+    """DISCRIMINATING. Bounding by DROPPING the halt would pass the test above.
+
+    The halted face is the other half of the meaning. `factor_completed` never
+    touches it, and it must still be there.
+    """
+    exits = outcome_to_exitset(_joined())
+    halted = [exit_ for exit_ in exits.exits if isinstance(exit_, Halted)]
+
+    assert len(halted) == 1
+    assert halted[0].effect == RaiseEffect(exception_name="ValueError")
+
+
+def test_both_faces_values_survive_inside_the_guarded_chain():
+    """DISCRIMINATING. Bounding by KEEPING ONE VALUE would pass the bound test.
+
+    Factoring relocates the partition; it does not choose a winner. Both arms'
+    values must still be reachable, on their own guards, in the chain.
+    """
+    exits = outcome_to_exitset(_joined())
+    completed = [e for e in exits.exits if isinstance(e, Completed)][0]
+
+    chain = completed.value
+    assert isinstance(chain, GuardedValue)
+    assert chain.when_true == "then-value"
+    assert chain.when_false == "else-value"
+
+
+def test_two_value_conditionals_still_fuse_without_entering_the_exit_algebra():
+    """DISCRIMINATING. The all-values case must not be widened to an ExitSet.
+
+    `GuardedValue` fusion is the shape the whole file rests on — operations
+    distribute into both arms, equality resolves per atom. Routing every
+    conditional through the exit algebra would satisfy every bound above and
+    destroy that.
+    """
+    joined = IfExpSugar._join_arms(
+        object.__new__(IfExpSugar), _guard("test"), Complete(1), Complete(2)
+    )
+
+    assert isinstance(joined, Complete)
+    assert isinstance(joined.value, GuardedValue)
+    assert joined.value.when_true == 1
+    assert joined.value.when_false == 2

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
@@ -1,4 +1,4 @@
-"""The complexity tooth for #6324: a conditional expression is not an exponent.
+"""The complexity tooth for #6324: a partition is not an exponent.
 
 #6319 taught `IfExpSugar` that an arm which halts is a PARTITION, not a missing
 recognizer. That was right, and it drained 369 desugar-defect rows. It also put
@@ -56,6 +56,7 @@ from sugar_lift_py_tests.outcome.exit_set import (
     Completed,
     ExitSet,
     Halted,
+    factored_operand,
     outcome_to_exitset,
 )
 from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
@@ -175,6 +176,87 @@ def test_both_faces_values_survive_inside_the_guarded_chain():
     assert isinstance(chain, GuardedValue)
     assert chain.when_true == "then-value"
     assert chain.when_false == "else-value"
+
+
+def test_a_partitioning_operand_enters_a_fold_with_one_completed_arm():
+    """THE BOUND, at the shared door.
+
+    `collection_sugar._reduce_into`, `method_call_sugar._collect`,
+    `bool_op_sugar` and `fstring_sugar` are the same k-step fold. The
+    accumulator cannot be factored (its completed value is the growing tuple),
+    so the OPERAND is, and `factored_operand` is the one door that does it.
+    """
+    assert _completed_arms(factored_operand(_partitioning_arm("element"))) == 1
+
+
+def test_the_operand_door_does_not_touch_a_plain_outcome():
+    """DISCRIMINATING. A `Complete` operand must pass through as itself.
+
+    Widening every operand into the exit algebra would satisfy the bound above
+    and route ordinary values through a partition they do not have.
+    """
+    plain = Complete("value")
+
+    assert factored_operand(plain) is plain
+
+
+def test_a_partitioning_operand_folded_k_times_does_not_multiply():
+    """THE GROWTH LAW at a fold, the shape `_reduce_into` builds.
+
+    Each step appends one factored operand to the accumulated tuple, exactly as
+    a collection display does. `1, 2, 4, 8, ...` here is the `test_arrow.py`
+    regression: 133,104 arms arrived at ONE `normalize` call through this loop.
+    """
+    series = []
+    for element_count in OPERAND_COUNTS:
+        outcome = Complete(())
+        for index in range(element_count):
+            got = factored_operand(_partitioning_arm(f"element{index}"))
+            outcome = outcome.and_then(
+                lambda collected, _got=got: _got.and_then(
+                    lambda value: Complete((*collected, value))
+                )
+            )
+        series.append(_completed_arms(outcome))
+
+    assert series == [1] * len(OPERAND_COUNTS), (
+        f"completed arms by element count {dict(zip(OPERAND_COUNTS, series))}: a "
+        "k-operand fold is multiplying arms again (#6324). Send each operand "
+        "through `factored_operand` before it enters the fold."
+    )
+
+
+def test_a_fold_conserves_every_halted_arm():
+    """DISCRIMINATING. Bounding by dropping halts would pass the law above.
+
+    k partitioning elements halt on k distinct guards, and every one of those
+    guards is the other half of the meaning. They arrive as ONE halted arm --
+    the k elements share a destination (the same effect, the same state), so
+    `normalize` merges them by DISJOINING their guards, which conserves each
+    face rather than discarding it. So the assertion is on the guard, not on
+    the arm count: `not element0 or not element1 or ...` must still mention
+    every element that could halt.
+    """
+    element_count = 4
+    outcome = Complete(())
+    for index in range(element_count):
+        got = factored_operand(_partitioning_arm(f"element{index}"))
+        outcome = outcome.and_then(
+            lambda collected, _got=got: _got.and_then(
+                lambda value: Complete((*collected, value))
+            )
+        )
+
+    exits = outcome_to_exitset(outcome)
+    halted = [exit_ for exit_ in exits.exits if isinstance(exit_, Halted)]
+    assert len(halted) == 1
+
+    spelled = repr(halted[0].guard)
+    for index in range(element_count):
+        assert f"element{index}" in spelled, (
+            f"element{index}'s halting face is missing from the halted guard "
+            f"{spelled}: an arm was dropped, not merged (#6324)."
+        )
 
 
 def test_two_value_conditionals_still_fuse_without_entering_the_exit_algebra():


### PR DESCRIPTION
Closes #6324.

## The regression

#6319 (`a4eade69a`) taught `IfExpSugar` that an arm which halts is a **partition**, not a missing recognizer. That ruling is correct and stays: it drained 369 desugar-defect rows into loud typed panics. This PR pays its cost line without giving any of that back.

The partition #6319 builds is an `ExitSet` with **two completed arms**, and it reached `ExitSet.sequence` **without passing through `factor_completed`**. `sequence` appends every exit of the tail under every completed exit of the prefix, so a receiver with `m` completed arms followed by `k` operands in a `method_call_sugar._collect` chain distributes into `m ** k` arms. Two arms is not a small number there; it is the base of an exponent.

`factor_completed` is the primitive #6315 built for exactly this shape, and until now it had **exactly one caller** (`SpreadSugar`). The conditional expression is the second producer of a multi-arm completed face.

## Hung or slow? Neither guess — counters

Measured desugar-inclusive through `DesugarAxis.measure`, per-file 300s SIGALRM deadline, on an **idle** 32-core battleaxe (load ~9-14), under the host-wide heavy-measurement lease. A `fn.sugar()`-only sweep reports a false zero here, so the reproducer runs the desugar half.

| file | `a02ebbe3e` | `a4eade69a` | this PR |
| --- | --- | --- | --- |
| `core/arrays/arrow/array.py` | **10.1s** | **timeout 302s** | **103.1s** |
| `core/reshape/pivot.py` | **6.0s** | **timeout 301s** | **18.0s** |
| `tests/extension/test_arrow.py` | **148.3s** | **timeout 303s** | see run log |

**Arm population, reported separately from normalization work** — this is what settles hung-vs-slow. It was not the same work more slowly; it was two to three orders of magnitude more work.

| file | counter | `a02ebbe3e` | `a4eade69a` | this PR |
| --- | --- | --- | --- | --- |
| `array.py` | `exitset.normalize_calls` | 9,474 | 816,250 | 15,708 |
| `array.py` | `exitset.arms_in_sum` | 17,838 | 2,003,570 | 33,965 |
| `array.py` | `exitset.pairwise_upper_bound` | 118,472 | 64,823,682 | 521,403 |
| `pivot.py` | `exitset.normalize_calls` | 735 | 442,529 | 17,897 |
| `pivot.py` | `exitset.arms_in_sum` | 987 | 831,089 | 19,667 |
| `pivot.py` | `exitset.arms_in_max` | 0 | 1,304 | 0 |
| `pivot.py` | `exitset.pairwise_upper_bound` | 343 | 105,745,446 | 1,934 |
| `test_arrow.py` | `exitset.arms_in_max` | 0 | **131,364** | see run log |
| `test_arrow.py` | `exitset.pairwise_upper_bound` | 2,050 | **8,946,911,919** | see run log |

The live `SIGALRM` stack, captured in the interrupted frame, named the site directly:

```
sugar/if_exp_sugar.py:137 in _join_arms
    exits = exits.union(outcome_to_exitset(else_out).guarded(not_formula))
outcome/exit_set.py:191 in union
    return ExitSet((*self.exits, *other.exits)).normalize()
```

reached through `method_call_sugar._collect` -> `ExitSet.sequence`.

This PR is above `a02ebbe3e` on every file, and that difference is #6319's gain being genuinely paid for: the partition is now *lifted* instead of abandoned as a defect row.

## The fix

One line in `IfExpSugar._join_arms`: factor the completed face before collapsing. The **same** partition moves from the exit level (m arms, one value each) to the value level (one arm, a `GuardedValue` chain), so k steps contribute k guarded values instead of `m ** k` arms. Same denotation, linear growth.

**Not** done: no size cap, no comparison shortcut, no equality fallback, no silent materialization, no panic converted back into a refusal. `ExitSetFactoringGap` is preserved — `factor_completed` still refuses loudly when completed arms are not provably pairwise exclusive; the two faces here are `formula` / `not formula`, which a first-match-wins chain carries exactly.

## The tooth

`implementations/python/sugar-lift-py-tests/tests/test_if_exp_partition_arm_growth.py` counts **arms, never seconds** — a faster normalizer must not be able to hide exponential arm growth. It reports the growth curve by operand count (`1, 2, 4, 8, ...` is the regression; `1, 1, 1, 1, ...` is the repaired bound) and carries three discriminators: the halted arm survives, both faces' values survive inside the chain, and a two-value conditional still fuses without entering the exit algebra at all.

Perturbing the one-line fix turns **3 of 5 red while all 19 #6319 defect-family twins stay green** — so the tooth pins the bound, not the drain.

## R / Delta / Epsilon

- `R(timeout)`: 3 at `a4eade69a` -> **0** on the reproducer (three-file bounded run).
- Predicted `Epsilon R`: `desugarDefects` unchanged at 38; `R_desugar`, `panics`, `R_construction` move only where the three formerly-timed-out files now contribute rows they previously absorbed. Head-board axes over 1418/1421 were lower bounds; they become complete over 1421/1421.
- Floors: `ExitSetFactoringGap` intact, no detector weakened, no test skipped or deleted, no panic suppressed.

**Shell deleted: none yet.** The retirement path is stated in the tooth's docstring: it retires the day the exit algebra can only be entered through a factored completed face, so `m > 1` at a sequencing seat becomes unrepresentable rather than detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Factor conditional expressions as partitions before sequencing in sugar desugaring
> - Adds a `factored_operand` helper in [`exit_set.py`](https://github.com/TSavo/sugar/pull/6333/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716) that calls `factor_completed()` then `collapse()` on an `ExitSet`, ensuring at most one completed arm proceeds into a sequence chain.
> - Applies `factored_operand` across all desugaring sites — boolean ops, collection building, f-strings, method calls, and conditional expressions — to prevent multiplicative (exponential) growth of completed arms across operands.
> - Conditional-expression desugaring in [`if_exp_sugar.py`](https://github.com/TSavo/sugar/pull/6333/files#diff-43d45b10ee937c63bdc239b3e841ecdc2a242831b402370b33df7b41ca8c7946) now factors the completed face of the joined exit set, placing the partition into a `GuardedValue` chain rather than leaving multiple completed arms.
> - Adds [`test_partition_arm_growth.py`](https://github.com/TSavo/sugar/pull/6333/files#diff-2e37c51126722003cddd1d1f1b39acfb4f65109736a77b28d8ae1c5ff181bc42) to assert that completed-arm counts stay bounded at 1 across operand chains and that halted arms are preserved.
> - Risk: `factor_completed()` raises `ExitSetFactoringGap` when completed arms are not provably pairwise exclusive, which is a new failure mode in conditional-expression desugaring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab947be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation of conditional expressions and compound expressions involving calls, collections, boolean operations, strings, and formatted strings.
  * Prevented excessive growth of intermediate execution paths while preserving both successful outcomes and halted/error paths.
  * Maintained correct first-match behavior for conditional branches.

* **Tests**
  * Added coverage verifying stable execution-path counts and preservation of all reachable conditional outcomes across chained and folded expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->