### PR TITLE
ExitSet: carry authenticated partition testimony so the factoring gap cannot be constructed by a producer that owns a partition

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import signal
+import sys
 import time
+import traceback
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -29,6 +31,8 @@ def _desugar_one(
     status = "clean"
     timed_out = False
     prior_handler = None
+    detail: str | None = None
+    origin: list[str] = []
     try:
         if deadline_seconds > 0:
             prior_handler = signal.signal(signal.SIGALRM, _timeout)
@@ -40,19 +44,31 @@ def _desugar_one(
     except BaseException as exc:
         # ConstructionPanic is intentionally BaseException, not Exception.
         status = type(exc).__name__
+        # A residual axis that reports only a class name hands the next agent a
+        # count, not a fix. Carry the refusal's own message and the frames that
+        # raised it, so the owner of each residual is readable off the row.
+        detail = str(exc)
+        origin = [
+            f"{frame.filename}:{frame.lineno} {frame.name}"
+            for frame in traceback.extract_tb(exc.__traceback__)[-6:]
+        ]
     finally:
         if deadline_seconds > 0:
             signal.setitimer(signal.ITIMER_REAL, 0)
             assert prior_handler is not None
             signal.signal(signal.SIGALRM, prior_handler)
     span = function.line_col_span()
-    return {
+    row: dict[str, Any] = {
         "name": name,
         "line": span.start_line,
         "status": status,
         "timedOut": timed_out,
         "elapsedSeconds": round(time.perf_counter() - started, 6),
     }
+    if detail is not None:
+        row["detail"] = detail
+        row["origin"] = origin
+    return row
 
 
 def _report(
@@ -123,12 +139,17 @@ def main() -> int:
     source_file = _open_source_file(path, root=corpus)
     rows = []
     for index, function in enumerate(source_file.functions()):
-        rows.append(
-            _desugar_one(
-                function,
-                name=getattr(function, "name", f"function-{index}"),
-                deadline_seconds=args.deadline,
-            )
+        row = _desugar_one(
+            function,
+            name=getattr(function, "name", f"function-{index}"),
+            deadline_seconds=args.deadline,
+        )
+        rows.append(row)
+        # Progress on stderr: stdout stays exactly the one JSON report.
+        print(
+            f"[{index}] {row['name']} {row['status']} {row['elapsedSeconds']}s",
+            file=sys.stderr,
+            flush=True,
         )
     report = _report(
         file=args.file,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -65,6 +65,61 @@ class ExitSetFactoringGap(ValueError):
     """
 
 
+@dataclass(frozen=True)
+class PartitionFace:
+    """Testimony that this exit lies on ONE named side of a producer's split.
+
+    The producer that decided to branch mints both faces at that moment (see
+    ``partition``) and applies one to each arm. Two exits carrying the same
+    ``partition`` with different ``side`` provably cannot both hold, because
+    the producer SAID SO when it split — nobody re-derives it from how the
+    guards happen to be spelled.
+
+    This is the difference the factoring gap turns on. ``_are_exclusive`` is a
+    sound but shallow prover over guard SHAPE: it sees ``g`` against ``not g``
+    one literal deep and nothing else. A partition that survives a disjunctive
+    merge, a nested conjunction, or a value-level rewrite is still a partition,
+    but its shape no longer advertises it. Carried testimony does not decay
+    that way.
+    """
+
+    partition: object
+    side: object
+
+
+def partition(owner: object) -> tuple[PartitionFace, PartitionFace]:
+    """Mint the two faces of a split OWNED by ``owner``.
+
+    ``owner`` is the producing sugar's own identity for this one branch
+    decision — a site key, a fragment coordinate, anything it can content
+    address. It is testimony, not a hint: the faces are complementary because
+    this call created them as a pair, not because a formula looks negated.
+
+    A producer that does not own a genuine two-way split must not call this.
+    Handing unrelated arms faces of one partition would assert an exclusion
+    that does not hold, and the refusal in ``factor_completed`` exists to catch
+    exactly the case where no such testimony was ever earned.
+    """
+    token = ("sugar.exit_set.partition", owner)
+    return PartitionFace(token, True), PartitionFace(token, False)
+
+
+_NO_FACES: frozenset[PartitionFace] = frozenset()
+
+
+def _faces_exclusive(
+    left: frozenset[PartitionFace], right: frozenset[PartitionFace]
+) -> bool:
+    """Whether carried testimony alone proves the two arms cannot both hold."""
+    if not left or not right:
+        return False
+    sides: dict[object, object] = {face.partition: face.side for face in left}
+    for face in right:
+        if face.partition in sides and sides[face.partition] != face.side:
+            return True
+    return False
+
+
 def _conjuncts(guard: Formula) -> tuple[Formula, ...]:
     """Flatten a conjunction into its literals; anything else is one literal."""
     if getattr(guard, "kind", None) == "and":
@@ -150,6 +205,7 @@ def _destination_key(exit_: "Exit[T]") -> object:
 class Completed(Generic[T]):
     guard: Formula
     value: T
+    faces: frozenset[PartitionFace] = _NO_FACES
 
 
 @dataclass(frozen=True)
@@ -157,6 +213,7 @@ class Halted:
     guard: Formula
     effect: Effect
     state: object | None = None
+    faces: frozenset[PartitionFace] = _NO_FACES
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "effect", require_effect(self.effect))
@@ -183,22 +240,36 @@ class ExitSet(Generic[T]):
 
     @classmethod
     def conditional_halt(cls, guard: Formula, effect: Effect, state: T) -> "ExitSet[T]":
+        # A halt-or-not split this constructor owns outright: mint it rather
+        # than leave the exclusion legible only in the ``not_`` spelling.
+        halt_face, pass_face = partition(("conditional_halt", guard))
         return cls(
-            (Halted(guard, effect, state), Completed(not_(guard), state))
+            (
+                Halted(guard, effect, state, frozenset({halt_face})),
+                Completed(not_(guard), state, frozenset({pass_face})),
+            )
         ).normalize()
 
     def union(self, other: "ExitSet[T]") -> "ExitSet[T]":
         return ExitSet((*self.exits, *other.exits)).normalize()
 
-    def guarded(self, guard: Formula) -> "ExitSet[T]":
-        """Restrict every exit to one branch of an enclosing partition."""
+    def guarded(self, guard: Formula, face: PartitionFace | None = None) -> "ExitSet[T]":
+        """Restrict every exit to one branch of an enclosing partition.
+
+        ``face`` is the caller's testimony that ``guard`` is one named side of a
+        split it owns (see ``partition``). It rides along on every restricted
+        exit so that a later ``factor_completed`` can read the exclusion off the
+        arms instead of trying to re-prove it from guard shape. Omitting it is
+        the honest default for a restriction that is not a partition face.
+        """
         exits: list[Exit[T]] = []
         for exit_ in self.exits:
             combined = _and_guards(guard, exit_.guard)
+            faces = exit_.faces if face is None else exit_.faces | {face}
             if isinstance(exit_, Completed):
-                exits.append(Completed(combined, exit_.value))
+                exits.append(Completed(combined, exit_.value, faces))
             else:
-                exits.append(Halted(combined, exit_.effect, exit_.state))
+                exits.append(Halted(combined, exit_.effect, exit_.state, faces))
         return ExitSet(tuple(exits)).normalize()
 
     def factor_completed(self) -> "ExitSet[T]":
@@ -236,6 +307,13 @@ class ExitSet(Generic[T]):
 
         for index, arm in enumerate(completed):
             for other in completed[index + 1 :]:
+                # Carried testimony first: a producer that minted these as two
+                # faces of ONE split already answered this, and its answer does
+                # not decay when the guards are merged or rewritten. The
+                # shape-level prover stays as the sound fallback for arms whose
+                # producer never claimed a partition.
+                if _faces_exclusive(arm.faces, other.faces):
+                    continue
                 if not _are_exclusive(arm.guard, other.guard):
                     raise ExitSetFactoringGap(
                         "ExitSet.factor_completed cannot factor a completed face "
@@ -248,11 +326,18 @@ class ExitSet(Generic[T]):
                         "face, so it can only carry a partition. Overlapping "
                         "arms with different values are two simultaneously "
                         "reachable outcomes, and collapsing them would drop one.\n"
-                        "  fix: give the producing sugar complementary guards "
-                        "(the branch join shape ``g`` / ``not g``), or extend "
-                        "_are_exclusive to see the exclusion these two guards "
-                        "already carry. Do NOT re-materialize the product: that "
-                        "is the m ** k blow-up #6309 removed."
+                        "  fix: if the producing sugar OWNS a two-way split "
+                        "here, mint it with outcome.exit_set.partition(owner) "
+                        "and pass each face to .guarded(guard, face) — carried "
+                        "testimony survives merges and rewrites that guard "
+                        "shape does not. If it owns no split, these arms really "
+                        "are simultaneously reachable and this gap is correct: "
+                        "keep both at the exit level. Do NOT re-materialize the "
+                        "product (the m ** k blow-up #6309 removed), and do NOT "
+                        "widen _are_exclusive to guess exclusivity from how the "
+                        "formulas are spelled.\n"
+                        f"  arm A faces: {sorted(str(f) for f in arm.faces)}\n"
+                        f"  arm B faces: {sorted(str(f) for f in other.faces)}"
                     )
 
         from sugar_lift_py_tests.floor import GuardedValue
@@ -265,7 +350,14 @@ class ExitSet(Generic[T]):
         for arm in completed[1:]:
             face_guard = _or_guards(face_guard, arm.guard)
 
-        factored = Completed(face_guard, chain)
+        # The factored arm holds under the DISJUNCTION of the arms' guards, so
+        # only testimony every arm carried still holds of it. Intersection, not
+        # union: a face true of one arm says nothing about the merged face.
+        factored_faces = completed[0].faces
+        for arm in completed[1:]:
+            factored_faces = factored_faces & arm.faces
+
+        factored = Completed(face_guard, chain, factored_faces)
         exits: list[Exit[T]] = []
         placed = False
         for exit_ in self.exits:
@@ -340,14 +432,23 @@ class ExitSet(Generic[T]):
                     and exit_.effect == prior.effect
                     and exit_.state == prior.state
                 )
+                # Same destination under a DISJOINED guard: only testimony both
+                # arms carried survives the merge, for the same reason as in
+                # factor_completed. Intersecting here is what keeps a merged
+                # arm from claiming a face it only held on one side.
                 if same_completed:
                     merged[index] = Completed(
-                        _or_guards(prior.guard, exit_.guard), prior.value
+                        _or_guards(prior.guard, exit_.guard),
+                        prior.value,
+                        prior.faces & exit_.faces,
                     )
                     break
                 if same_halted:
                     merged[index] = Halted(
-                        _or_guards(prior.guard, exit_.guard), prior.effect, prior.state
+                        _or_guards(prior.guard, exit_.guard),
+                        prior.effect,
+                        prior.state,
+                        prior.faces & exit_.faces,
                     )
                     break
             else:
@@ -369,10 +470,14 @@ class ExitSet(Generic[T]):
                 continue
             for following in step(exit_.value).exits:
                 guard = _and_guards(exit_.guard, following.guard)
+                # Conjoined guard: both sets of testimony hold of the result.
+                faces = exit_.faces | following.faces
                 if isinstance(following, Completed):
-                    exits.append(Completed(guard, following.value))
+                    exits.append(Completed(guard, following.value, faces))
                 else:
-                    exits.append(Halted(guard, following.effect, following.state))
+                    exits.append(
+                        Halted(guard, following.effect, following.state, faces)
+                    )
         return ExitSet(tuple(exits)).normalize()
 
     def and_then(self, step):
@@ -405,17 +510,20 @@ class ExitSet(Generic[T]):
         for incoming in self.exits:
             for clean in cleanup_exits:
                 guard = _and_guards(incoming.guard, clean.guard)
+                faces = incoming.faces | clean.faces
                 if isinstance(clean, Halted):
-                    exits.append(Halted(guard, clean.effect, clean.state))
+                    exits.append(Halted(guard, clean.effect, clean.state, faces))
                     continue
                 if restores(clean.value):
                     if isinstance(incoming, Completed):
-                        exits.append(Completed(guard, incoming.value))
+                        exits.append(Completed(guard, incoming.value, faces))
                     else:
-                        exits.append(Halted(guard, incoming.effect, incoming.state))
+                        exits.append(
+                            Halted(guard, incoming.effect, incoming.state, faces)
+                        )
                 else:
                     # Terminal cleanup completion supersedes (return in finally).
-                    exits.append(Completed(guard, clean.value))
+                    exits.append(Completed(guard, clean.value, faces))
         return ExitSet(tuple(exits)).normalize()
 
     def and_exit(
@@ -454,8 +562,9 @@ class ExitSet(Generic[T]):
         for incoming in self.exits:
             for ex in exit_exits:
                 guard = _and_guards(incoming.guard, ex.guard)
+                faces = incoming.faces | ex.faces
                 if isinstance(ex, Halted):
-                    exits.append(Halted(guard, ex.effect, ex.state))
+                    exits.append(Halted(guard, ex.effect, ex.state, faces))
                     continue
                 carried = (
                     incoming.value
@@ -468,23 +577,41 @@ class ExitSet(Generic[T]):
                     # incoming exit leaves as BOTH faces under complementary
                     # guards, so the predicate reaches the emitted FOL instead
                     # of being admitted or dropped by silence here.
+                    #
+                    # This site OWNS that split, so it mints the partition and
+                    # stamps each side. The two guards are complementary by
+                    # construction here; downstream must not have to rediscover
+                    # that from their shape after they have been conjoined with
+                    # a prefix or merged with a sibling arm.
                     obligation = verdict.obligation
-                    for sub_guard, sub_verdict in (
-                        (_and_guards(guard, obligation), verdict.held),
+                    # Owner identity is the split itself — the deciding
+                    # predicate under the prefix it is decided beneath. No
+                    # object identity: two runs that build the same split must
+                    # agree, and a token that changes with allocation would
+                    # make the testimony unreproducible.
+                    held_face, failed_face = partition(
+                        ("and_exit.retained_obligation", obligation, guard)
+                    )
+                    for sub_guard, sub_verdict, sub_face in (
+                        (_and_guards(guard, obligation), verdict.held, held_face),
                         (
                             _and_guards(guard, complement_guard(obligation)),
                             verdict.failed,
+                            failed_face,
                         ),
                     ):
+                        sub_faces = faces | {sub_face}
                         if sub_verdict is None:
-                            exits.append(Completed(sub_guard, carried))
+                            exits.append(Completed(sub_guard, carried, sub_faces))
                         else:
-                            exits.append(Halted(sub_guard, sub_verdict, carried))
+                            exits.append(
+                                Halted(sub_guard, sub_verdict, carried, sub_faces)
+                            )
                     continue
                 if verdict is None:
-                    exits.append(Completed(guard, carried))
+                    exits.append(Completed(guard, carried, faces))
                 else:
-                    exits.append(Halted(guard, verdict, carried))
+                    exits.append(Halted(guard, verdict, carried, faces))
         return ExitSet(tuple(exits)).normalize()
 
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
@@ -502,11 +629,12 @@ class ExitSet(Generic[T]):
         for incoming in self.exits:
             for ex in exit_es.exits:
                 guard = _and_guards(incoming.guard, ex.guard)
+                faces = incoming.faces | ex.faces
                 if isinstance(ex, Halted):
-                    exits.append(Halted(guard, ex.effect, ex.state))
+                    exits.append(Halted(guard, ex.effect, ex.state, faces))
                     continue
                 if isinstance(incoming, Completed):
-                    exits.append(Completed(guard, incoming.value))
+                    exits.append(Completed(guard, incoming.value, faces))
                     continue
                 from sugar_lift_py_tests.floor import TermValue
 
@@ -519,12 +647,25 @@ class ExitSet(Generic[T]):
                     if _is_true(truth)
                     else true_guard() if _is_false(truth) else not_(truth)
                 )
-                exits.append(Completed(_and_guards(guard, truth), incoming.state))
+                # The truth predicate is a split this site owns: exactly one of
+                # truth/falsity holds. Mint it so the exclusion survives being
+                # conjoined with a prefix guard downstream.
+                truth_face, falsity_face = partition(
+                    ("and_exit_truthiness", site, truth, guard)
+                )
+                exits.append(
+                    Completed(
+                        _and_guards(guard, truth),
+                        incoming.state,
+                        faces | {truth_face},
+                    )
+                )
                 exits.append(
                     Halted(
                         _and_guards(guard, falsity),
                         incoming.effect,
                         incoming.state,
+                        faces | {falsity_face},
                     )
                 )
         return ExitSet(tuple(exits)).normalize()
@@ -583,6 +724,8 @@ __all__ = [
     "Completed",
     "ExitSet",
     "ExitSetFactoringGap",
+    "PartitionFace",
+    "partition",
     "Halted",
     "complement_guard",
     "false_guard",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field as _dataclass_field
 from typing import Callable, Generic, TypeVar
 
 from sugar_lift_py_tests.effect import Effect, require_effect
@@ -205,7 +205,13 @@ def _destination_key(exit_: "Exit[T]") -> object:
 class Completed(Generic[T]):
     guard: Formula
     value: T
-    faces: frozenset[PartitionFace] = _NO_FACES
+    # Testimony ABOUT this arm, never part of what it denotes: two arms with the
+    # same guard and destination are the same exit whether or not a producer
+    # stamped them. Excluded from compare/repr so carrying testimony cannot
+    # perturb exit equality, normalize's merge, collapse, or any golden repr.
+    faces: frozenset[PartitionFace] = _dataclass_field(
+        default=_NO_FACES, compare=False, repr=False
+    )
 
 
 @dataclass(frozen=True)
@@ -213,7 +219,9 @@ class Halted:
     guard: Formula
     effect: Effect
     state: object | None = None
-    faces: frozenset[PartitionFace] = _NO_FACES
+    faces: frozenset[PartitionFace] = _dataclass_field(
+        default=_NO_FACES, compare=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "effect", require_effect(self.effect))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -110,7 +110,10 @@ class IfExpSugar(Sugar):
     def _join_arms(self, formula, then_out, else_out) -> Outcome:
         from sugar_lift_py_tests.floor.guarded_value import GuardedValue
         from sugar_lift_py_tests.ir import not_
-        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+        from sugar_lift_py_tests.outcome.exit_set import (
+            outcome_to_exitset,
+            partition as _partition,
+        )
 
         not_formula = not_(formula)
 
@@ -133,8 +136,17 @@ class IfExpSugar(Sugar):
         # produce a value together with the arm that halts. Nothing here folds an
         # effect into a value; each arm stays on its own face under its own
         # guard, and every input arm is conserved into exactly one output arm.
-        exits = outcome_to_exitset(then_out).guarded(formula)
-        exits = exits.union(outcome_to_exitset(else_out).guarded(not_formula))
+        #
+        # This site OWNS the split, so it mints the partition and stamps each
+        # arm with its face. A conditional expression is exactly what reaches
+        # spread/call operands, where ``factor_completed`` needs the exclusion;
+        # by then the guards have been conjoined with a prefix and their shape
+        # no longer shows it. Testimony carried here does not decay.
+        then_face, else_face = _partition(("IfExpSugar", self.site, formula))
+        exits = outcome_to_exitset(then_out).guarded(formula, then_face)
+        exits = exits.union(
+            outcome_to_exitset(else_out).guarded(not_formula, else_face)
+        )
 
         # A partition with a single completed face and no halt is a plain value
         # again (normalize may have merged the faces): collapse rather than hand

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -103,6 +103,7 @@ class IfSugar(Sugar):
         from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
         from sugar_lift_py_tests.ir import not_
         from sugar_lift_py_tests.outcome import Completed, Halted, Incomplete
+        from sugar_lift_py_tests.outcome.exit_set import partition as _partition
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             reduce_block_to_exitset,
         )
@@ -128,7 +129,15 @@ class IfSugar(Sugar):
         # polarity, then the partitions normalize together. In particular, a
         # halt on one face coexists with the complementary Completed exit.
         not_formula = not_(formula)
-        exits = then_exits.guarded(formula).union(else_exits.guarded(not_formula))
+        # This If OWNS the split, so it mints the partition and stamps each
+        # branch with its face. Downstream factoring reads the exclusion off
+        # the arms as testimony instead of re-proving it from guard spelling,
+        # which stops being legible once these guards are conjoined with a
+        # prefix or merged with a sibling arm.
+        then_face, else_face = _partition(("IfSugar", self.site, formula))
+        exits = then_exits.guarded(formula, then_face).union(
+            else_exits.guarded(not_formula, else_face)
+        )
         entries = []
         for exit_ in exits.exits:
             if isinstance(exit_, Halted):

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
@@ -218,6 +218,30 @@ def test_single_completed_arm_is_returned_untouched():
     assert exits.factor_completed() is exits
 
 
+def test_testimony_does_not_change_what_an_exit_denotes():
+    """Faces are testimony ABOUT an arm, never part of its meaning.
+
+    Two arms with the same guard and destination are the same exit whether or
+    not a producer stamped one of them. Letting faces into ``__eq__`` silently
+    changed ``normalize``'s merge, ``collapse``'s fixpoint check, and every
+    caller that compares an ExitSet against an expected one — carried testimony
+    must be free to ride along without moving denotation.
+    """
+    condition = _pred("c")
+    face, _ = partition(("owner", condition))
+
+    bare = Completed(condition, "v")
+    stamped = Completed(condition, "v", frozenset({face}))
+
+    assert bare == stamped
+    assert hash(bare) == hash(stamped)
+    assert repr(bare) == repr(stamped)
+    assert stamped.faces == frozenset({face})
+
+    # And the whole set compares equal, which is what collapse/normalize use.
+    assert ExitSet((bare,)) == ExitSet((stamped,))
+
+
 def test_partition_owner_identity_is_reproducible_not_allocation_based():
     """Two mints for the SAME owner agree; different owners do not.
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
@@ -1,0 +1,234 @@
+"""Carried partition testimony: the ExitSetFactoringGap's truthful/lying twins.
+
+``factor_completed`` refuses when completed arms are not provably pairwise
+exclusive, because a ``GuardedValue`` chain is first-match-wins and can only
+carry a partition. Before #6309's follow-up the only proof available was
+``_are_exclusive``, a sound but shallow read of guard SHAPE. Shape decays: the
+moment a producer's two faces are conjoined with a prefix guard or merged with
+a sibling arm, ``g`` against ``not g`` is no longer one literal deep, and a
+producer that genuinely owned a partition hit the refusal anyway.
+
+The fix is testimony, not a better prover. A producer that owns a two-way split
+mints it with ``partition(owner)`` and stamps each arm via
+``ExitSet.guarded(guard, face)``. Exclusivity is then READ, not re-derived.
+
+Both faces are pinned here:
+
+- **truthful twin** — a producer that owns complementary faces cannot construct
+  the gap, even with guards whose shape hides the exclusion;
+- **lying twin** — a producer that owns no partition still hits the refusal,
+  and faces minted by two DIFFERENT owners never count as complementary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.ir import and_, atomic, not_, or_
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    ExitSetFactoringGap,
+    partition,
+    true_guard,
+)
+from sugar_lift_py_tests.outcome.exit_set import _are_exclusive
+
+
+def _pred(name: str):
+    return atomic(name, [])
+
+
+def _shape_opaque_pair():
+    """Two guards that are complementary in fact but not in one-literal shape.
+
+    ``c`` against ``or(not c, q)`` is exactly what a branch face looks like once
+    a sibling arm has been merged into the other face by ``normalize``. The
+    shape prover cannot see it, and that is the point of the twin: it is the
+    live condition under which a real partition used to be refused.
+    """
+    condition = _pred("c")
+    other = or_([not_(condition), _pred("q")])
+    assert not _are_exclusive(condition, other)
+    assert not _are_exclusive(other, condition)
+    return condition, other
+
+
+def test_owned_partition_makes_the_factoring_gap_unconstructable():
+    """Truthful twin: testimony carried, shape unreadable, no gap."""
+    left_guard, right_guard = _shape_opaque_pair()
+    left_face, right_face = partition(("twin-owner", "one-split"))
+
+    exits = ExitSet(
+        (
+            Completed(left_guard, "then-value", frozenset({left_face})),
+            Completed(right_guard, "else-value", frozenset({right_face})),
+        )
+    )
+
+    factored = exits.factor_completed()
+
+    # Exactly one completed arm remains, and it carries BOTH values as a chain.
+    completed = [e for e in factored.exits if isinstance(e, Completed)]
+    assert len(completed) == 1
+    chain = completed[0].value
+    assert chain.guard == left_guard
+    assert chain.when_true == "then-value"
+    assert chain.when_false == "else-value"
+
+
+def test_unowned_arms_still_hit_the_refusal():
+    """Lying twin A: no testimony, unreadable shape — the gap must fire."""
+    left_guard, right_guard = _shape_opaque_pair()
+
+    exits = ExitSet(
+        (
+            Completed(left_guard, "then-value"),
+            Completed(right_guard, "else-value"),
+        )
+    )
+
+    with pytest.raises(ExitSetFactoringGap) as raised:
+        exits.factor_completed()
+    assert "not provably exclusive" in str(raised.value)
+
+
+def test_faces_from_two_different_owners_are_not_complementary():
+    """Lying twin B: two splits are not one split.
+
+    Face identity is per MINT. Two producers that each own a genuine partition
+    say nothing about each other's arms, so stamping one arm from each must not
+    buy an exclusion neither producer testified to.
+    """
+    left_guard, right_guard = _shape_opaque_pair()
+    left_face, _ = partition(("twin-owner", "first-split"))
+    right_face, _ = partition(("twin-owner", "second-split"))
+
+    exits = ExitSet(
+        (
+            Completed(left_guard, "then-value", frozenset({left_face})),
+            Completed(right_guard, "else-value", frozenset({right_face})),
+        )
+    )
+
+    with pytest.raises(ExitSetFactoringGap):
+        exits.factor_completed()
+
+
+def test_same_partition_same_side_is_not_an_exclusion():
+    """Lying twin C: both arms on the SAME face prove nothing.
+
+    A partition token alone must not be mistaken for exclusivity — it is the
+    pair (partition, differing side) that carries the proof.
+    """
+    left_guard, right_guard = _shape_opaque_pair()
+    face, _ = partition(("twin-owner", "one-split"))
+
+    exits = ExitSet(
+        (
+            Completed(left_guard, "a", frozenset({face})),
+            Completed(right_guard, "b", frozenset({face})),
+        )
+    )
+
+    with pytest.raises(ExitSetFactoringGap):
+        exits.factor_completed()
+
+
+def test_guarded_stamps_the_face_it_is_given_and_nothing_else():
+    """The door producers use: ``.guarded(guard, face)`` carries testimony.
+
+    Without a face argument the restriction is not a partition claim, so no
+    testimony appears. That default is what keeps unrelated arms loud.
+    """
+    condition = _pred("c")
+    then_face, else_face = partition(("IfSugarLike", "site", condition))
+
+    faced = ExitSet.completed("v").guarded(condition, then_face)
+    assert faced.exits[0].faces == frozenset({then_face})
+
+    plain = ExitSet.completed("v").guarded(condition)
+    assert plain.exits[0].faces == frozenset()
+
+    joined = faced.union(
+        ExitSet.completed("w").guarded(not_(condition), else_face)
+    )
+    # The join is factorable because the producer testified, not because the
+    # guards happen to be spelled as negations of each other.
+    factored = joined.factor_completed()
+    assert len([e for e in factored.exits if isinstance(e, Completed)]) == 1
+
+
+def test_disjoining_merge_keeps_only_testimony_both_arms_carried():
+    """A merged arm holds under a DISJUNCTION, so faces intersect, never union.
+
+    If the merge unioned faces, an arm reachable on either side of a split would
+    claim to be on one named side of it — an exclusion the producer never gave,
+    and the exact way carried testimony could start lying.
+    """
+    condition = _pred("c")
+    left_face, right_face = partition(("merge-owner", condition))
+
+    merged = ExitSet(
+        (
+            Completed(condition, "same", frozenset({left_face})),
+            Completed(not_(condition), "same", frozenset({right_face})),
+        )
+    ).normalize()
+
+    assert len(merged.exits) == 1
+    assert merged.exits[0].faces == frozenset()
+
+
+def test_conjoining_composition_accumulates_both_arms_testimony():
+    """``sequence`` conjoins guards, so the result carries both face sets."""
+    condition = _pred("c")
+    outer = _pred("d")
+    face, _ = partition(("prefix-owner", condition))
+    tail_face, _ = partition(("tail-owner", outer))
+
+    prefix = ExitSet.completed("v").guarded(condition, face)
+    result = prefix.sequence(
+        lambda value: ExitSet.completed(value + "!").guarded(outer, tail_face)
+    )
+
+    assert result.exits[0].faces == frozenset({face, tail_face})
+
+
+def test_shape_level_exclusion_still_factors_without_testimony():
+    """The sound shape prover is retained, not replaced.
+
+    Arms whose producer never minted a partition but whose guards ARE one
+    literal apart still factor exactly as before this change.
+    """
+    condition = _pred("c")
+
+    factored = ExitSet(
+        (
+            Completed(condition, "a"),
+            Completed(not_(condition), "b"),
+        )
+    ).factor_completed()
+
+    assert len([e for e in factored.exits if isinstance(e, Completed)]) == 1
+
+
+def test_single_completed_arm_is_returned_untouched():
+    exits = ExitSet((Completed(true_guard(), "only"),))
+    assert exits.factor_completed() is exits
+
+
+def test_partition_owner_identity_is_reproducible_not_allocation_based():
+    """Two mints for the SAME owner agree; different owners do not.
+
+    Face tokens ride on in-memory exits and never reach emitted FOL, but they
+    must still be a function of what the producer owns — a token that changed
+    with allocation would make the same lift testify differently twice.
+    """
+    first_a, first_b = partition(("owner", "split"))
+    second_a, second_b = partition(("owner", "split"))
+    assert first_a == second_a and first_b == second_b
+    assert first_a != first_b
+
+    other_a, _ = partition(("owner", "other-split"))
+    assert other_a != first_a


### PR DESCRIPTION
## What

Takes the `ExitSetFactoringGap` residual off the `stableZero` axis by making the gap **unconstructable when the producer genuinely owns complementary faces**, without inferring exclusivity from formula appearance, without capping the product, and without special-casing any source shape.

## The defect: shape decays, testimony does not

`factor_completed` (#6315) refuses when completed arms are not provably pairwise exclusive. The refusal is correct — a `GuardedValue` chain is first-match-wins, so it can only carry a partition. The problem was never the refusal; it was that the only proof available was `_are_exclusive`, a **sound but shallow read of guard SHAPE**: it sees `g` against `not g` one literal deep and nothing else.

Shape decays. The moment a producer's two faces are conjoined with a prefix guard (`spread_sugar._collect` folds `prefix_guard` into every operand) or merged with a sibling arm by `normalize` (which **disjoins** guards on a destination match), the complementarity is no longer one literal deep. **A producer that genuinely owned a partition then hit the refusal anyway.** That is the point at which partition evidence was lost: not at the refusal, but between the branch join that owned it and the factoring that needed it — the guard formula was the only channel, and it is lossy under exactly the two rewrites the pipeline performs.

## The fix: carry it

`#6315`'s author already named the honest ceiling — *a guard that CARRIES its partition would make `ExitSetFactoringGap` unconstructable.* That is what this builds.

- `partition(owner)` mints the **two faces of one split**, at the moment the producer decides to branch. Owner identity is the producer's own key (site + deciding formula) — reproducible, not allocation-based.
- `ExitSet.guarded(guard, face)` stamps the face onto every restricted exit. Omitting `face` is the honest default for a restriction that is not a partition claim.
- Composition carries testimony with the right algebra: **conjunction unions** faces (`sequence`, `and_exit`, `and_finally`, `and_exit_truthiness`), **disjunction intersects** them (`normalize`'s merge, `factor_completed`'s factored arm). A merged arm holds under a disjunction, so it may only keep testimony *every* contributing arm carried — union there is exactly how carried testimony would start lying.
- `factor_completed` reads the exclusion off the arms first; `_are_exclusive` stays as the sound fallback for arms whose producer never claimed a partition.

Producers wired: `IfSugar`, `IfExpSugar`, `ExitSet.conditional_halt`, `and_exit`'s `RetainedObligation` split, `and_exit_truthiness`.

### Constraints honored

- **No inference from appearance.** Faces are created as a pair by the producer. A guard that merely *looks* like `¬g` buys nothing.
- **No cap.** Nothing limits arm counts or product size.
- **No vendor arm.** No file, manager, or expression shape is recognized. A producer that owns no split carries no faces and **still hits the refusal** — pinned by three lying twins.

Faces are `field(compare=False, repr=False)`: testimony about an arm, never part of what it denotes. They live on in-memory exits during desugar and never reach emitted FOL.

## Instruments

`tests/test_exit_set_partition_testimony.py`, 11 tests, both faces:

- **truthful** — owned partition + shape-opaque guards ⇒ gap unconstructable; `.guarded(guard, face)` stamps; conjunction accumulates; shape-level exclusion still factors without testimony.
- **lying** — no testimony ⇒ refusal fires; faces from **two different owners** are not complementary; **same partition, same side** is not an exclusion; disjoining merge keeps only shared testimony; testimony does not perturb equality.

**Perturbed after green**, each confirmed to fail:
- testimony never proves exclusion → truthful twin fails
- any two faces count as exclusive → lying twin fails (`DID NOT RAISE ExitSetFactoringGap`)
- merge unions instead of intersects → merge twin fails

## Rig instrumentation

`desugar_repro.py` rows now carry `detail` (the refusal's own message — which for a `ConstructionPanic` is owner/observed/requested/fix) and `origin` (the raising frames), plus per-function progress on stderr. **stdout stays exactly the one JSON report and the `stableZero` computation is unchanged** — a residual axis that reports only a class name hands the next agent a count, not a fix.

## Scope

Three residual occurrences only. Not the With drain, the assertion sites, the resource sites, the unpack family, or the panic tail.

## Floors

No test deleted or skipped; no threshold introduced; no measurement gate. The refusal stays loud for arms that earned no testimony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PartitionFace` testimony to `ExitSet` to prevent factoring gaps from producer-owned partitions
> - Introduces `PartitionFace` and `partition()` in [exit_set.py](https://github.com/TSavo/sugar/pull/6336/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716) to mint complementary face tokens that tag each arm of a two-way split with its owner's identity.
> - `Completed` and `Halted` exits now carry a `faces: frozenset[PartitionFace]` field (excluded from equality and repr) so testimony accumulates through sequencing, composition, and merging.
> - `ExitSet.factor_completed` checks `_faces_exclusive` before falling back to shape-level guard exclusivity, allowing factoring to succeed when opaque guards are stamped with complementary faces from the same partition.
> - `conditional_halt`, `and_exit`, `and_exit_truthiness`, `IfExpSugar._join_arms`, and `IfSugar.desugar` all mint and stamp faces so split ownership is carried end-to-end.
> - Risk: merge and normalize now intersect faces rather than unioning them, so any face not common to both sides of a merge is dropped from the resulting exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9eadfc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->