### PR TITLE
Floor panic tail: name the owner, and drain four (owner x category) laws

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bound_var.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bound_var.py
@@ -75,9 +75,12 @@ class BoundVar(FloorValue):
             # The source lawfully remains a typed Incomplete at its producer.
             # Collapsing that incomplete effect into a completed term is a missing
             # Floor recognizer: structured ConstructionPanic, never bare RuntimeError.
+            # Same law as FloorValue.to_term: the owner is THIS projection, not
+            # the requester. ``owner`` arrives as the caller's ``str(site)``
+            # fragment repr, so it joins the bound name in blame.
             construction_panic_gap(
-                owner=owner,
-                blame=self.name,
+                owner="BoundVar.to_term",
+                blame=f"{self.name} requested-by={owner}",
                 observed=type(outcome.effect).__name__,
                 requested="completed BoundVar term substitution",
                 fix=(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -40,6 +40,15 @@ class DictValue(FloorValue):
         return Complete(TermValue(len(self.entries)))
 
     def contains(self, item, site):
+        # A guarded needle is not one needle: distribute into its faces and
+        # rejoin under the same guard before this receiver's own law runs.
+        from sugar_lift_py_tests.floor.guarded_operand import (
+            distribute_guarded_predicate,
+        )
+
+        distributed = distribute_guarded_predicate(self, item, "contains", site)
+        if distributed is not None:
+            return distributed
         # Python ``k in d`` is key membership over constructed entry keys.
         from sugar_lift_py_tests.floor.set_value import (
             _bool_result,
@@ -97,6 +106,15 @@ class DictValue(FloorValue):
         from sugar_lift_py_tests.outcome import Complete
 
         return Complete(DictValue(tuple(entries)))
+
+    def attribute(self, name, site):
+        # Bound methods and fields on a constructed dict (``{{}}.get``, ``mapping.items``) stay the
+        # py.getattr coordinate -- one law, shared with StringValue and the
+        # other constructed containers. Never invent a method body or a field.
+        del site
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+
+        return getattr_coordinate(self, name, owner="DictValue.attribute")
 
     def to_term(self, *, owner: str):
         # Project as python:dict of entry pairs (layout-preserving coordinate).

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -886,21 +886,34 @@ class FloorValue:
         return self._runtime_bitwise_gap(other, site, "left_shift", "left-shift")
 
     def matrix_multiply(self, other, site):
-        self._binary_floor_gap(
-            other, site, "matrix_multiply", "matrix-multiplication"
-        )
+        self._binary_floor_gap(other, site, "matrix_multiply", "matrix-multiplication")
 
     def _runtime_bitwise_gap(self, other, site, owner, label):
         self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 
     def to_term(self, *, owner: str) -> "Term":
+        """The ONE None arm for floor-value projection.
+
+        ``owner`` names the REQUESTER — and nearly every caller in the lift
+        spells it ``str(site)``, which is a ``SourceFragment``'s ``__repr__``
+        (``<SourceFragment 'x.py' [12, 34) node=Call>``: the fragment defines
+        no ``__str__``). Passing that straight into ``ConstructionGap.owner``
+        made the panic board's dispatch key an ADDRESS, so one projection law
+        with no arm scattered into one undispatchable row per call site.
+
+        The owner of this gap is the law that has no arm: this value's own
+        projection, ``<Value>.to_term``. The requester's coordinate is what
+        ``blame`` is for, so it moves there — nothing is discarded, and the
+        board buckets by (value category × to_term) as every other floor gap
+        buckets by (value category × operation).
+        """
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 
         observed = type(self).__name__
         info = ConstructionGap(
-            owner=owner,
-            blame=observed,
+            owner=f"{observed}.to_term",
+            blame=owner,
             observed=observed,
             requested="project this floor value to a term",
             fix=f"write more Floor: implement {observed}.to_term",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/getattr_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/getattr_coordinate.py
@@ -1,0 +1,29 @@
+"""``value.name`` on a constructed value: the ``py.getattr`` coordinate.
+
+One law, written once, for every value that projects to a term and owns no
+field of its own. ``StringValue`` stated it first ("bound methods and fields on
+a constructed string stay the py.getattr coordinate -- same EUF vocabulary as
+SymbolicValue / CallSiteValue"), and the constructed containers stand in
+exactly the same place: a dict/list/tuple/set literal has no field the lift
+knows, and its methods have no body here.
+
+The coordinate is not a claim that the attribute EXISTS. It is an opaque
+function symbol over the receiver's own term and the attribute's name -- the
+same position ``SymbolicValue`` and ``CallSiteValue`` already occupy. Nothing
+is invented: no method body, no field value, no sentinel. A call through the
+coordinate is still owned by ``call_method_with``, which folds only where the
+call site is known.
+"""
+
+from __future__ import annotations
+
+
+def getattr_coordinate(value, name: str, *, owner: str):
+    """``Complete(SymbolicValue(py.getattr(<value term>, "<name>")))``."""
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.outcome import Complete
+
+    return Complete(
+        SymbolicValue(ctor("py.getattr", [value.to_term(owner=owner), str_const(name)]))
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_operand.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_operand.py
@@ -1,0 +1,34 @@
+"""A binary operation whose RIGHT operand is split by a guard.
+
+``GuardedValue`` already owns both directions of this distribution:
+``_map`` / ``_predicate`` when the guarded value is the receiver, and
+``map_from_left`` / ``predicate_from_left`` when it is the right operand. The
+second door was being reached ad hoc -- ``TermValue.add``, ``SymbolicValue
+.multiply``, ``FloorValue.less_than`` and ``CallSiteValue`` each wrote the
+check, and every receiver that did NOT write it panicked instead
+(``StringValue.contains`` observing a ``GuardedValue`` needle: "string needle,
+symbolic membership operand, or typed TypeError" -- and a guarded needle is
+none of those three, because it is not ONE needle at all).
+
+A guarded operand is not a value category a membership law has to answer for.
+It is two operands under one guard, and the answer is the two answers rejoined
+under that same guard. Distributing FIRST means each receiver law only ever
+sees an unguarded operand, which is the operand shape it was written for. The
+guard is read from the operand's own construction, never from a type name in
+source.
+"""
+
+from __future__ import annotations
+
+
+def distribute_guarded_predicate(receiver, operand, method: str, site):
+    """The rejoined predicate, or ``None`` when the operand carries no guard.
+
+    ``None`` is "this door does not apply", never a soft answer: the caller
+    falls through to its own law, whose None arm is still the honest no.
+    """
+    from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+
+    if not isinstance(operand, GuardedValue):
+        return None
+    return operand.predicate_from_left(method, receiver, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -18,6 +18,15 @@ class ListValue(FloorValue):
 
     elements: tuple
 
+    def attribute(self, name, site):
+        # Bound methods and fields on a constructed list (``[].append``, ``xs.index``) stay the
+        # py.getattr coordinate -- one law, shared with StringValue and the
+        # other constructed containers. Never invent a method body or a field.
+        del site
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+
+        return getattr_coordinate(self, name, owner="ListValue.attribute")
+
     def to_term(self, *, owner: str):
         # Project elements into FOL — assert equality / dig return faces.
         from sugar_lift_py_tests.ir import ctor
@@ -52,6 +61,15 @@ class ListValue(FloorValue):
         return Complete(TermValue(len(self.elements)))
 
     def contains(self, item, site):
+        # A guarded needle is not one needle: distribute into its faces and
+        # rejoin under the same guard before this receiver's own law runs.
+        from sugar_lift_py_tests.floor.guarded_operand import (
+            distribute_guarded_predicate,
+        )
+
+        distributed = distribute_guarded_predicate(self, item, "contains", site)
+        if distributed is not None:
+            return distributed
         # Membership over a constructed list: decide when every element has a
         # closed equality; emit a typed obligation when a member is symbolic;
         # stay loud for unconstructed member shapes (same law as SetValue).

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -51,25 +51,32 @@ class PredicateValue(FloorValue):
             )
         return super().to_term(owner=owner)
 
+    def guarded(self, formula):
+        """A carried boolean rides under a guard unchanged.
+
+        Same arm as ``CallSiteValue`` / ``ImportAliasValue``: this is a VALUE,
+        not an exit and not an obligation. A PredicateValue states no
+        ``inv_contribution`` and no ``post_contribution``, so a branch guard
+        over it is already owned by the branch's own control -- there is
+        nothing here for the guard to weaken.
+
+        Weakening the carried formula to ``formula -> self.formula`` would be a
+        different value, not a guarded one: for `x = (a == b) if c else d` it
+        would make `x` TRUE wherever `c` is false, which the source never
+        states. An assertion over this predicate is an ``InvValue``, and THAT
+        is the arm that becomes an implication (``InvValue.guarded``); the
+        obligation is weakened where the obligation lives, never here.
+        """
+        del formula
+        return self
+
     def attribute(self, name, site):
         # A boolean formula is not a field-bearing object; attribute projection
         # stays py.getattr over the predicate term (never invent a field).
         del site
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor, str_const
-        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
 
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "py.getattr",
-                    [
-                        self.to_term(owner="PredicateValue.attribute"),
-                        str_const(name),
-                    ],
-                )
-            )
-        )
+        return getattr_coordinate(self, name, owner="PredicateValue.attribute")
 
     def negate(self):
         # A predicate flips by wrapping its formula in not_ -- the formula owns

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -16,6 +16,15 @@ class SetValue(FloorValue):
 
     elements: tuple
 
+    def attribute(self, name, site):
+        # Bound methods and fields on a constructed set (``set().add``, ``s.union``) stay the
+        # py.getattr coordinate -- one law, shared with StringValue and the
+        # other constructed containers. Never invent a method body or a field.
+        del site
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+
+        return getattr_coordinate(self, name, owner="SetValue.attribute")
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 
@@ -49,6 +58,15 @@ class SetValue(FloorValue):
         return Complete(TermValue(len(self.elements)))
 
     def contains(self, item, site):
+        # A guarded needle is not one needle: distribute into its faces and
+        # rejoin under the same guard before this receiver's own law runs.
+        from sugar_lift_py_tests.floor.guarded_operand import (
+            distribute_guarded_predicate,
+        )
+
+        distributed = distribute_guarded_predicate(self, item, "contains", site)
+        if distributed is not None:
+            return distributed
         decisions = tuple(
             _closed_member_equal(item, element) for element in self.elements
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -84,9 +84,22 @@ def rewrap_pending(pending, outcome, *, owner, blame):
     # PENDING entry wants the entry to carry a demand SET; a PARTITION wants the
     # exit algebra to have an arm for a pending demand at all.
     if isinstance(outcome, ContractConditionalConstructionV1):
+        if outcome.demand.demand_cid == pending.demand.demand_cid:
+            # NOT two demands. ``demand_cid`` is the content address of the
+            # whole obligation -- owner source identity, formal coordinate,
+            # operation site, demanded formula, candidate. Equal cids mean the
+            # SAME obligation reached this join twice through a shared outcome
+            # DAG (`p[0]` read once and consumed on both faces of a fold).
+            #
+            # Conjunction is idempotent: `F and F` IS `F`. The joined outcome
+            # already carries that exact demand, so it rides on unchanged. This
+            # discharges nothing, weakens nothing and invents nothing -- it is
+            # the arithmetic of the obligation, not a fallback. Two DISTINCT
+            # demands still need a demand SET and stay loud below.
+            return outcome
         observed = (
-            f"two pending contract demands ({pending.demand.demand_cid} and "
-            f"{outcome.demand.demand_cid}) joined onto one constructed value"
+            f"two distinct pending contract demands ({pending.demand.demand_cid} "
+            f"and {outcome.demand.demand_cid}) joined onto one constructed value"
         )
         fix = (
             "widen ContractConditionalConstructionV1 to carry a demand SET; "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -139,20 +139,20 @@ class StringValue(FloorValue):
         # body; call_method_with still owns static folds when the call site is
         # known.
         del site
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor, str_const
-        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
 
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "py.getattr",
-                    [self.to_term(owner="StringValue.attribute"), str_const(name)],
-                )
-            )
-        )
+        return getattr_coordinate(self, name, owner="StringValue.attribute")
 
     def contains(self, item, site):
+        # A guarded needle is not one needle: distribute into its faces and
+        # rejoin under the same guard before this receiver's own law runs.
+        from sugar_lift_py_tests.floor.guarded_operand import (
+            distribute_guarded_predicate,
+        )
+
+        distributed = distribute_guarded_predicate(self, item, "contains", site)
+        if distributed is not None:
+            return distributed
         # Python ``needle in haystack`` for str: substring when both are strings;
         # TypeError for ground non-string needles; py.in when the needle is
         # symbolic/opaque. Never invent membership for unconstructed shapes.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -16,6 +16,15 @@ class TupleValue(FloorValue):
 
     elements: tuple
 
+    def attribute(self, name, site):
+        # Bound methods and fields on a constructed tuple (``().count``, ``t.index``) stay the
+        # py.getattr coordinate -- one law, shared with StringValue and the
+        # other constructed containers. Never invent a method body or a field.
+        del site
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+
+        return getattr_coordinate(self, name, owner="TupleValue.attribute")
+
     def to_term(self, *, owner: str):
         # Project each element; vendor digs return tuples (sign/unsign pairs,
         # return_timestamp) that must enter FOL for assert equality.
@@ -63,6 +72,15 @@ class TupleValue(FloorValue):
         return Complete(TermValue(len(self.elements)))
 
     def contains(self, item, site):
+        # A guarded needle is not one needle: distribute into its faces and
+        # rejoin under the same guard before this receiver's own law runs.
+        from sugar_lift_py_tests.floor.guarded_operand import (
+            distribute_guarded_predicate,
+        )
+
+        distributed = distribute_guarded_predicate(self, item, "contains", site)
+        if distributed is not None:
+            return distributed
         # Membership over a constructed tuple: same closed-equality law as
         # ListValue / SetValue — fold, emit typed obligation, or stay loud.
         from sugar_lift_py_tests.floor.set_value import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/info.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/info.py
@@ -7,10 +7,55 @@ lives on the audit-row boundary, not here.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict
 from typing import Never, NoReturn
+
+# ``owner`` is the panic board's DISPATCH KEY: every row is worked as
+# (owner × value category), so an owner that is not a name makes the row
+# undispatchable. Two shapes are not names and are rejected at construction:
+#
+# ``<SourceFragment 'x.py' [12, 34) node=Call>``
+#     an object projection. ``SourceFragment`` defines no ``__str__``, so
+#     ``str(fragment)`` silently yields its ``__repr__``; a call site that
+#     passed ``owner=str(self.site)`` minted a row whose owner named an
+#     address, not a law.
+# ``pandas/core/frame.py:1234:8``
+#     a source coordinate. That is ``blame``'s currency, not ``owner``'s.
+#     Threading it through ``owner`` gives every occurrence of one law a
+#     distinct owner, which scatters a single gap across the whole board.
+#
+# A name may contain spaces (``collection ListValue``) and dots
+# (``StringValue.contains``) — those are real owners on the board, so the
+# tooth names the two malformed shapes rather than whitelisting a spelling.
+_OBJECT_PROJECTION = re.compile(r"^<.*>$", re.S)
+_SOURCE_COORDINATE = re.compile(r":\d+:\d+$")
+
+
+def _reject_non_name_owner(owner: object) -> None:
+    """The owner tooth: a gap that cannot name its owner cannot be worked."""
+    if not isinstance(owner, str) or not owner:
+        raise TypeError(
+            "ConstructionGap.owner must be a non-empty name: "
+            f"owner=ConstructionGap shape={type(owner).__name__} "
+            "replacement=name the law that has no arm"
+        )
+    if _OBJECT_PROJECTION.match(owner):
+        raise TypeError(
+            "ConstructionGap.owner must be a name, not an object projection: "
+            f"owner=ConstructionGap observed={owner!r} "
+            "replacement=pass the owning law's own name (type(self).__name__ "
+            "or the method name); carry the fragment in blame"
+        )
+    if _SOURCE_COORDINATE.search(owner):
+        raise TypeError(
+            "ConstructionGap.owner must be a name, not a source coordinate: "
+            f"owner=ConstructionGap observed={owner!r} "
+            "replacement=pass the owning law's own name; a file:line:col "
+            "coordinate is blame's currency, never owner's"
+        )
 
 
 class GapKind(str, Enum):
@@ -60,6 +105,7 @@ class ConstructionGap:
                 f"shape={type(self.gap_locus).__name__} "
                 "replacement=GapLocus.CONSTRUCTION"
             )
+        _reject_non_name_owner(self.owner)
 
     @property
     def message(self) -> str:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -51,16 +51,29 @@ def _reduce_into(element_sugars, ctx, build):
     # display has no guard of its own -- so it hoists at `true_guard`.
     pending = None
     stripped = []
+    # Two elements carrying the SAME obligation are not two obligations:
+    # ``demand_cid`` is the content address of the whole demand, so equal cids
+    # are the same formal, site, formula and candidate reached twice (`[p[0],
+    # p[0]]`, or one reduced element shared by a fold). Conjunction is
+    # idempotent, so one entry carries both. Only DISTINCT demands need a
+    # demand SET, and those stay loud.
     for outcome in reduced:
         entry, plain = pending_demand(outcome, true_guard())
-        if entry is not None and pending is not None:
+        if (
+            entry is not None
+            and pending is not None
+            and entry.demand.demand_cid != pending.demand.demand_cid
+        ):
             from sugar_lift_py_tests.gap.info import GapKind
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
             construction_panic_gap(
                 owner=owner,
                 blame=str(entry.source_node),
-                observed="two collection elements enrolled a contract demand",
+                observed=(
+                    "two collection elements enrolled DISTINCT contract demands "
+                    f"({pending.demand.demand_cid} and {entry.demand.demand_cid})"
+                ),
                 requested="one pending demand per constructed value",
                 fix=(
                     "widen ContractConditionalConstructionV1 to carry a demand SET "

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_gap_owner_is_a_name.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_gap_owner_is_a_name.py
@@ -1,0 +1,126 @@
+"""``ConstructionGap.owner`` is the panic board's dispatch key: it is a NAME.
+
+A panic row is worked as (owner x value category). A row whose ``owner`` field
+holds an object projection or a source coordinate names an address instead of a
+law, so it cannot be dispatched by owner at all and one law with no arm scatters
+into one undispatchable row per call site.
+
+Two faces per claim: the shape that IS a name constructs, the shape that is not
+is refused, and the refusal names the replacement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+# The exact string a caller mints today: ``SourceFragment`` defines no
+# ``__str__``, so ``str(site)`` yields its ``__repr__``.
+FRAGMENT_REPR = "<SourceFragment 'renamed_module.py' [412, 431) node=Call>"
+SOURCE_COORDINATE = "renamed_module.py:412:8"
+
+
+def _gap(owner: object) -> ConstructionGap:
+    return ConstructionGap(
+        owner=owner,  # type: ignore[arg-type]
+        blame="renamed_module.py:412:8",
+        observed="RenamedValue",
+        requested="project this floor value to a term",
+        fix="write more Floor",
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.PROJECTION,
+    )
+
+
+# --------------------------------------------------------------------------
+# the tooth: which owners are names
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "owner",
+    [
+        "add",
+        "guarded",
+        "collection ListValue",
+        "StringValue.contains",
+        "ContractConditionalConstructionV1.and_then",
+        "FunctionCallable decorator result:renamed_target",
+    ],
+)
+def test_a_name_is_admitted(owner: str) -> None:
+    """Real owners on the board: spaces, dots and colons are all part of names."""
+    assert _gap(owner).owner == owner
+
+
+def test_an_object_projection_is_refused() -> None:
+    with pytest.raises(TypeError) as excinfo:
+        _gap(FRAGMENT_REPR)
+    message = str(excinfo.value)
+    assert "must be a name, not an object projection" in message
+    assert "carry the fragment in blame" in message
+
+
+def test_a_source_coordinate_is_refused() -> None:
+    with pytest.raises(TypeError) as excinfo:
+        _gap(SOURCE_COORDINATE)
+    assert "must be a name, not a source coordinate" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("owner", ["", None, 12, object()])
+def test_an_absent_owner_is_refused(owner: object) -> None:
+    with pytest.raises(TypeError) as excinfo:
+        _gap(owner)
+    assert "must be a non-empty name" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# the mechanism: FloorValue.to_term names its own projection law
+# --------------------------------------------------------------------------
+
+
+class RenamedUnprojectableValue(FloorValue):
+    """A floor value with no ``to_term`` arm -- inherits the base None arm."""
+
+
+class RenamedProjectableValue(FloorValue):
+    """The other face: a value that CAN project answers with a term."""
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import str_const
+
+        return str_const("renamed")
+
+
+def test_to_term_gap_owner_is_the_projection_law_not_the_requester() -> None:
+    with pytest.raises(ConstructionPanic) as excinfo:
+        RenamedUnprojectableValue().to_term(owner=FRAGMENT_REPR)
+    info = excinfo.value.info
+    # The dispatch key is the law that has no arm.
+    assert info.owner == "RenamedUnprojectableValue.to_term"
+    # Nothing is discarded: the requester coordinate moves to blame.
+    assert info.blame == FRAGMENT_REPR
+    assert info.observed == "RenamedUnprojectableValue"
+    assert info.gap_locus is GapLocus.PROJECTION
+
+
+def test_a_value_that_can_project_does_not_panic() -> None:
+    """The discriminating face -- the arm exists, so no row is minted."""
+    assert RenamedProjectableValue().to_term(owner=FRAGMENT_REPR) is not None
+
+
+def test_two_requesters_of_one_missing_law_share_one_owner() -> None:
+    """The whole point: one law with no arm is ONE board bucket, not N."""
+    owners = set()
+    for requester in (
+        FRAGMENT_REPR,
+        "<SourceFragment 'other_renamed.py' [7, 9) node=BinOp>",
+        SOURCE_COORDINATE,
+    ):
+        with pytest.raises(ConstructionPanic) as excinfo:
+            RenamedUnprojectableValue().to_term(owner=requester)
+        owners.add(excinfo.value.info.owner)
+    assert len(owners) == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_panic_tail_owners.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_panic_tail_owners.py
@@ -1,0 +1,258 @@
+"""The panic tail, by (owner x value category).
+
+Four laws, each with both faces and an exact cardinality:
+
+``attribute`` x the constructed containers
+    a dict/list/tuple/set literal owns no field the lift knows and its methods
+    have no body here, so ``.name`` stays the ``py.getattr`` coordinate -- the
+    same law ``StringValue`` and ``PredicateValue`` already state. The
+    discriminating face: the coordinate carries the RECEIVER's own term, so two
+    receivers do not collapse to one shape, and a value that still has no arm
+    still panics.
+
+``guarded`` x ``PredicateValue``
+    a carried boolean is a value, not an exit and not an obligation, so it
+    rides under a guard unchanged. The discriminating face: ``InvValue`` DOES
+    weaken under a guard, because that is where the obligation lives.
+
+``contains`` x a guarded needle
+    a needle split by a guard is not one needle, so it distributes into its
+    faces and rejoins under the same guard before the receiver's own law runs.
+    The discriminating face: an unguarded needle still takes that law.
+
+``rewrap_pending`` x two pending contract demands
+    equal ``demand_cid`` is the SAME content-addressed obligation reached
+    twice, and conjunction is idempotent. The discriminating face: two DISTINCT
+    demands still panic, because carrying one would drop the other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import DictValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.floor.list_value import ListValue
+from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+from sugar_lift_py_tests.floor.set_value import SetValue
+from sugar_lift_py_tests.floor.tuple_value import TupleValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import atomic, implies
+from sugar_lift_py_tests.outcome import Complete
+
+# --------------------------------------------------------------------------
+# attribute x the constructed containers
+# --------------------------------------------------------------------------
+
+
+def _container(kind):
+    entries = (TermValue(1), TermValue(2))
+    if kind is DictValue:
+        return DictValue(((TermValue(1), TermValue(10)),))
+    return kind(entries)
+
+
+@pytest.mark.parametrize("kind", [DictValue, ListValue, TupleValue, SetValue])
+def test_container_attribute_is_the_py_getattr_coordinate(kind) -> None:
+    outcome = _container(kind).attribute("renamed_member", "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+    assert outcome.value.term.name == "py.getattr"
+
+
+@pytest.mark.parametrize("kind", [DictValue, ListValue, TupleValue, SetValue])
+def test_the_coordinate_names_the_attribute_that_was_asked_for(kind) -> None:
+    """Not one shape for every name -- the name is an argument of the symbol."""
+    first = _container(kind).attribute("renamed_alpha", "site").value.term
+    second = _container(kind).attribute("renamed_beta", "site").value.term
+    assert first != second
+
+
+def test_the_coordinate_carries_the_receivers_own_term() -> None:
+    """Two receivers of one attribute do not collapse into one coordinate."""
+    short = ListValue((TermValue(1),)).attribute("renamed_member", "site").value.term
+    long = (
+        ListValue((TermValue(1), TermValue(2)))
+        .attribute("renamed_member", "site")
+        .value.term
+    )
+    assert short != long
+
+
+def test_a_value_with_no_attribute_arm_stays_loud() -> None:
+    """The discriminating face: this drained four categories, not the floor."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    class RenamedFieldlessValue(FloorValue):
+        pass
+
+    with pytest.raises(ConstructionPanic) as excinfo:
+        RenamedFieldlessValue().attribute("renamed_member", "site")
+    assert excinfo.value.info.owner == "attribute"
+    assert excinfo.value.info.observed == "RenamedFieldlessValue"
+
+
+# --------------------------------------------------------------------------
+# guarded x PredicateValue
+# --------------------------------------------------------------------------
+
+
+def test_a_carried_predicate_rides_under_a_guard_unchanged() -> None:
+    predicate = PredicateValue(atomic("renamed_choice", []), "site")
+    assert predicate.guarded(atomic("renamed_guard", [])) is predicate
+
+
+def test_the_guard_does_not_weaken_the_carried_formula() -> None:
+    """`x = (a == b) if c else d` must not make x true wherever c is false."""
+    carried = atomic("renamed_choice", [])
+    guard = atomic("renamed_guard", [])
+    assert PredicateValue(carried, "site").guarded(guard).formula == carried
+    assert PredicateValue(carried, "site").guarded(guard).formula != implies(
+        guard, carried
+    )
+
+
+def test_an_obligation_does_weaken_under_the_same_guard() -> None:
+    """The discriminating face: an InvValue is where a guard IS an implication."""
+    from sugar_lift_py_tests.floor.inv_value import InvValue
+
+    carried = atomic("renamed_claim", [])
+    guard = atomic("renamed_guard", [])
+    guarded = InvValue(carried, "site").guarded(guard)
+    assert guarded.formula == implies(guard, carried)
+
+
+def test_a_value_with_no_guarded_arm_stays_loud() -> None:
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    class RenamedUnguardableValue(FloorValue):
+        pass
+
+    with pytest.raises(ConstructionPanic) as excinfo:
+        RenamedUnguardableValue().guarded(atomic("renamed_guard", []))
+    assert excinfo.value.info.owner == "guarded"
+    assert excinfo.value.info.observed == "RenamedUnguardableValue"
+
+
+# --------------------------------------------------------------------------
+# two pending contract demands
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _RenamedDemand:
+    demand_cid: str
+
+
+def _pending(cid: str, value):
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ContractConditionalConstructionV1,
+    )
+
+    return ContractConditionalConstructionV1(
+        source_node="renamed_module.py:1:0",
+        candidate=atomic("renamed_candidate", []),
+        candidate_cid=f"blake3-512:{cid}",
+        demand=_RenamedDemand(f"blake3-512:{cid}"),
+        value=value,
+    )
+
+
+def test_one_obligation_reached_twice_is_carried_once() -> None:
+    from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+
+    joined = _pending("aaaa", TermValue(2))
+    result = rewrap_pending(
+        _pending("aaaa", TermValue(1)),
+        joined,
+        owner="renamed_join",
+        blame="renamed_module.py:1:0",
+    )
+    assert result is joined
+    assert result.demand.demand_cid == "blake3-512:aaaa"
+
+
+def test_two_distinct_obligations_stay_loud() -> None:
+    """The discriminating face: carrying one would DROP the other."""
+    from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+
+    with pytest.raises(ConstructionPanic) as excinfo:
+        rewrap_pending(
+            _pending("aaaa", TermValue(1)),
+            _pending("bbbb", TermValue(2)),
+            owner="renamed_join",
+            blame="renamed_module.py:1:0",
+        )
+    info = excinfo.value.info
+    assert "two distinct pending contract demands" in info.observed
+    assert "blake3-512:aaaa" in info.observed
+    assert "blake3-512:bbbb" in info.observed
+    assert "demand SET" in info.fix
+
+
+def test_a_partition_still_has_nowhere_to_carry_a_demand() -> None:
+    """The third face: not a second pending, so the exit-algebra gap stands."""
+    from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    with pytest.raises(ConstructionPanic) as excinfo:
+        rewrap_pending(
+            _pending("aaaa", TermValue(1)),
+            ExitSet(()),
+            owner="renamed_join",
+            blame="renamed_module.py:1:0",
+        )
+    assert "carries no single value" in excinfo.value.info.observed
+
+
+# --------------------------------------------------------------------------
+# contains x a guarded needle
+# --------------------------------------------------------------------------
+
+
+def _guarded(when_true, when_false):
+    from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+
+    return GuardedValue(atomic("renamed_guard", []), when_true, when_false)
+
+
+def test_a_guarded_string_needle_distributes_and_rejoins() -> None:
+    from sugar_lift_py_tests.floor.string_value import StringValue
+
+    outcome = StringValue("renamed_haystack").contains(
+        _guarded(StringValue("renamed"), StringValue("absent_needle")), "site"
+    )
+    # One rejoined answer under the needle's own guard -- not a panic, and not
+    # one arm silently chosen.
+    assert isinstance(outcome, Complete)
+    assert outcome.value is not None
+
+
+@pytest.mark.parametrize("kind", [ListValue, TupleValue, SetValue])
+def test_a_guarded_sequence_needle_distributes(kind) -> None:
+    members = (TermValue(1), TermValue(2))
+    outcome = kind(members).contains(_guarded(TermValue(1), TermValue(9)), "site")
+    assert isinstance(outcome, Complete)
+
+
+def test_a_guarded_dict_key_distributes() -> None:
+    d = DictValue(((TermValue(1), TermValue(10)),))
+    assert isinstance(
+        d.contains(_guarded(TermValue(1), TermValue(9)), "site"), Complete
+    )
+
+
+def test_an_unguarded_needle_still_takes_the_receivers_own_law() -> None:
+    """The discriminating face: distribution must not swallow the real law."""
+    from sugar_lift_py_tests.floor.string_value import StringValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    hay = StringValue("renamed_haystack")
+    assert isinstance(
+        hay.contains(StringValue("renamed"), "site").value, TrueBoolLiteralSugar
+    )
+    assert isinstance(
+        hay.contains(StringValue("no_such_part"), "site").value, FalseBoolLiteralSugar
+    )


### PR DESCRIPTION
## The instrument defect first

The panic board is worked as **(owner × value category)**, so a row's `owner` field is its dispatch key. One class of row could not be dispatched at all: its owner read `<SourceFragment 'x.py' [412, 431) node=Call>`.

`SourceFragment` defines no `__str__`, so `str(site)` yields its `__repr__`. About **ninety** `to_term` call sites across the floor spell the requester as `owner=str(site)`, and `FloorValue.to_term`'s None arm passed that straight into `ConstructionGap.owner`. One projection law with no arm therefore scattered into one undispatchable row per call site.

Fixed at the **one place the gap is minted**, not at the ninety callers:

- `owner` becomes the law that has no arm — `f"{type(self).__name__}.to_term"`.
- The requester coordinate moves to `blame`, where a coordinate belongs. Nothing is discarded.
- `BoundVar.to_term` had the same shape and got the same treatment.
- **The tooth**: `ConstructionGap.__post_init__` now rejects an owner that is an object projection (`<…>`) or a source coordinate (`…:12:8`), naming the replacement. Spaces, dots and colons stay legal — `collection ListValue`, `StringValue.contains` and `FunctionCallable decorator result:x` are real owners on the board.

`sugar/spread_sugar.py` is held by another owner and needed no change: the fix is upstream of every caller.

## Four drains

Each is a general law per (owner × value category), with the category read from the value's own construction — no spelling arms, no name tables, no size caps.

**`rewrap_pending` / `collection_sugar` × two pending contract demands.** The pair was **misnamed**, the same finding shape as #6317's `add × TermValue`. `demand_cid` is the content address of the whole obligation (owner identity, formal coordinate, operation site, formula, candidate), and in over half the measured rows the two cids were **equal** — one obligation reaching one join twice through a shared outcome DAG. Conjunction is idempotent, so one entry carries both. Two **distinct** demands still need a demand SET and stay loud.

**`attribute` × {DictValue, ListValue, TupleValue, SetValue}.** A container literal owns no field the lift knows and its methods have no body here, so `.name` stays the `py.getattr` coordinate — the law `StringValue` and `PredicateValue` already state, now written once in `floor/getattr_coordinate.py` and shared by all six.

**`guarded` × `PredicateValue`.** A carried boolean is a value, not an exit and not an obligation, so it rides under a guard unchanged. Weakening it to `guard -> formula` would be a *different value*: for `x = (a == b) if c else d` it would make `x` true wherever `c` is false. An assertion over the predicate is an `InvValue`, and that is where a guard IS an implication.

**`contains` × a guarded needle.** A needle split by a guard is not one needle — which is exactly why "string needle, symbolic membership operand, or typed TypeError" had no arm for it. `GuardedValue.predicate_from_left` already owns this distribution in both directions; `floor/guarded_operand.py` routes the five membership receivers through it before their own law runs.

## Measured

1/6 pandas slice, **237/237 files, no timeouts, no crashes**, baseline and head on the same file list, the three `R(timeout)=3` files excluded, both runs from a clean build of their own tree.

| | baseline | head |
|---|---|---|
| `desugarConstructionPanics` | **75** | **54** |
| `R_desugar` | 1400 | 1407 |
| `desugarDefects` | 7 | 7 |

**ΔR on the panic axis = −21 (−28%).** Per owner:

| owner | base | head | Δ |
|---|---:|---:|---:|
| `ContractConditionalConstructionV1.and_then` | 36 | 27 | **−9** |
| `StringValue.contains` | 5 | 0 | **−5** |
| `guarded` | 5 | 2 | **−3** |
| `ListValue.contains` | 3 | 1 | **−2** |
| `collection ListValue` | 5 | 4 | −1 |
| `collection build` | 7 | 6 | −1 |
| `attribute` | 1 | 1 | 0 |
| `IfExpSugar._join` | 4 | 4 | 0 |
| `ground_index_error` | 3 | 3 | 0 |
| `bitwise_and` | 2 | 2 | 0 |
| `TupleValue.contains` / `SetValue.contains` / `collection TupleValue` / `bitwise_or` | 1 each | 1 each | 0 |

`attribute` nets to zero and that is the honest reading, not a miss: the container arm drained its row, and draining the panic that was absorbing it revealed a **new** `attribute × NoneValue` row underneath. Same mechanism as `R_desugar` **+7** — a panic absorbs the rows its function would have produced, exactly like a timeout row. No panic became a refusal.

## Stays loud, with the named reason

- `{List,Tuple,Set}Value.contains × CallSiteValue` — a call's result denotes a value of undecided identity, and no floor states that testimony yet. Already ruled deliberately loud in `_closed_member_equal`; untouched.
- `attribute × NoneValue` — `None.foo` **is** an AttributeError, an exceptional exit no arm constructs.
- `ground_index_error × absolute source locus` — the corpus is lifted through an absolute-path door. That is the census harness, not the floor.
- two **distinct** contract demands; `guarded × BlockValue`; `IfExpSugar._join` (another owner).

## Tests

`tests/test_construction_gap_owner_is_a_name.py` and `tests/test_floor_panic_tail_owners.py` — 38 tests, discrimination twins per law, both faces, exact cardinality, renamed non-vendor fixtures.

Six perturbations applied after green, each confirmed to fail exactly the tests that claim it: the idempotence arm, `PredicateValue.guarded`, `DictValue.attribute`, the owner tooth, `to_term`'s owner, and the guarded-needle distribution. Restored tree: 38 passed.

**Known inherited red**: the package's `conftest.py` resolves a release `sugar` binary before collection, and that build has been contended on this box for over an hour by peer agents. The suite therefore ran outside the package conftest (same `PYTHONPATH`, same modules); the full-suite run under conftest is unverified locally and is left to CI.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix floor panic tail owner naming and drain guarded-operand distribution laws
> - `ConstructionGap.owner` is now validated to be a proper name (not an object projection or source coordinate); `FloorValue.to_term` and `BoundVar.to_term` set `owner` to the projection law name and move the caller's identity to `blame`.
> - Adds `distribute_guarded_predicate` helper and applies it to `contains` on `StringValue`, `ListValue`, `DictValue`, `SetValue`, and `TupleValue`, distributing guarded needles across faces before applying membership checks.
> - Adds `getattr_coordinate` helper and `attribute` methods on `ListValue`, `DictValue`, `SetValue`, `TupleValue`, and `PredicateValue`, returning a symbolic `py.getattr` coordinate instead of panicking.
> - `rewrap_pending` and `_reduce_into` now handle identical pending contract demands idempotently instead of panicking; distinct demands still panic with a clearer message that includes both CIDs.
> - `PredicateValue` gains a `guarded(formula)` method that returns `self` unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ddfce5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
