### PR TITLE
Canonicalization: stop walking canonical strings character-by-character (byte-identical)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/canonicalizer.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/canonicalizer.py
@@ -24,6 +24,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re as _re
 from typing import List, Tuple, Union
 
 import blake3 as _blake3
@@ -148,23 +149,34 @@ def _encode(v: Value, out: List[str]) -> None:
         raise TypeError(f"unknown Value variant: {type(v)!r}")
 
 
+# The JCS string escape set for this canonicalizer: only `"`, `\`, and the C0
+# controls (as lowercase `\u00XX`) are escaped. `/` is NOT escaped, non-ASCII is
+# emitted verbatim (including astral characters and lone surrogates, whose
+# encoding error surfaces later at `.encode("utf-8")`). Python str -> UTF-8 at
+# encode() time produces the same bytes the Rust impl would.
+_ESCAPE_SEARCH = _re.compile(r'["\\\x00-\x1f]').search
+
+_ESCAPE_TABLE: dict[int, str] = {
+    0x22: '\\"',
+    0x5C: "\\\\",
+    **{
+        codepoint: "\\u00"
+        + "0123456789abcdef"[codepoint >> 4]
+        + "0123456789abcdef"[codepoint & 0xF]
+        for codepoint in range(0x20)
+    },
+}
+
+
 def _encode_string(s: str, out: List[str]) -> None:
-    out.append('"')
-    for c in s:
-        cp = ord(c)
-        if c == '"':
-            out.append('\\"')
-        elif c == "\\":
-            out.append("\\\\")
-        elif cp < 0x20:
-            out.append("\\u00")
-            out.append("0123456789abcdef"[(cp >> 4) & 0xF])
-            out.append("0123456789abcdef"[cp & 0xF])
-        else:
-            # U+0080..U+10FFFF: emit verbatim. Python str -> UTF-8 at
-            # encode() time produces the same bytes the Rust impl would.
-            out.append(c)
-    out.append('"')
+    # Fast path: nothing to escape (the overwhelming majority of corpus strings
+    # are identifiers and CIDs). Byte-identical to the per-character loop, which
+    # is kept verbatim as the oracle in
+    # tests/test_py_tests_canonicalizer_string_encoder_differential.py.
+    if _ESCAPE_SEARCH(s) is None:
+        out.append('"' + s + '"')
+        return
+    out.append('"' + s.translate(_ESCAPE_TABLE) + '"')
 
 
 # Hash helpers --------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -1516,9 +1516,20 @@ class TermTableBuilder:
 
 
 def _rpc_canonical_bytes(canonical: str) -> bytes:
-    """Hash the same Unicode scalar sequence that the RPC boundary transmits."""
-    if not any(0xD800 <= ord(char) <= 0xDFFF for char in canonical):
+    """Hash the same Unicode scalar sequence that the RPC boundary transmits.
+
+    The surrogate check is delegated to `str.encode("utf-8")` itself: strict
+    UTF-8 encoding raises `UnicodeEncodeError` on exactly the lone surrogates
+    U+D800..U+DFFF and on nothing else, so the try/except decides the identical
+    branch the per-character `any(...)` scan decided -- at C speed, and without
+    walking the string once per enclosing node. Canonical strings nest (a
+    parent's canonical JSON contains every descendant's), so the Python-level
+    scan cost O(subtree) per node, i.e. O(nodes x depth) across a term table.
+    """
+    try:
         return canonical.encode("utf-8")
+    except UnicodeEncodeError:
+        pass
     safe = "".join(
         "\ufffd" if 0xD800 <= ord(char) <= 0xDFFF else char for char in canonical
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_py_tests_canonicalizer_string_encoder_differential.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_py_tests_canonicalizer_string_encoder_differential.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# THE ENCODER IS THE PROTOCOL. Two hot-path serializers in the py-tests lift
+# were rewritten as pure speed changes:
+#
+#   1. `canonicalizer._encode_string` -- per-character Python loop -> regex gate
+#      plus `str.translate`.
+#   2. `ir._rpc_canonical_bytes` -- per-character `any(ord(c) in surrogates)`
+#      scan -> strict `str.encode("utf-8")` with the `UnicodeEncodeError`
+#      deciding the identical branch.
+#
+# Neither may move a single byte: every CID pinned in the corpus was minted by
+# the pre-rewrite code. The ORACLES below are that pre-rewrite code kept
+# verbatim -- not a re-derivation of RFC 8785, but the exact shipped source, so
+# byte identity is measured against the thing that minted the pins.
+#
+# The complexity tooth counts Python-level character visits, NOT wall time. The
+# box these run on is loaded and wall times are void.
+
+from __future__ import annotations
+
+import random
+import unicodedata
+
+import pytest
+
+from sugar_lift_py_tests import canonicalizer as C
+from sugar_lift_py_tests import ir as IR
+
+
+# --- oracles: the pre-rewrite implementations, verbatim ---------------------
+
+
+def _oracle_encode_string(s: str, out: list[str]) -> None:
+    """The pre-optimization JCS string encoder, verbatim. THE specification."""
+    out.append('"')
+    for c in s:
+        cp = ord(c)
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif cp < 0x20:
+            out.append("\\u00")
+            out.append("0123456789abcdef"[(cp >> 4) & 0xF])
+            out.append("0123456789abcdef"[cp & 0xF])
+        else:
+            out.append(c)
+    out.append('"')
+
+
+def _oracle_rpc_canonical_bytes(canonical: str) -> bytes:
+    """The pre-optimization surrogate scan, verbatim. THE specification."""
+    if not any(0xD800 <= ord(char) <= 0xDFFF for char in canonical):
+        return canonical.encode("utf-8")
+    safe = "".join(
+        "�" if 0xD800 <= ord(char) <= 0xDFFF else char for char in canonical
+    )
+    return safe.encode("utf-8")
+
+
+def _call(fn, value):
+    """Return ('ok', text) or ('raise', (type, message)) -- error behavior is
+    part of the contract, so it is compared, never swallowed."""
+    out: list[str] = []
+    try:
+        fn(value, out)
+    except BaseException as exc:  # noqa: BLE001 -- the exception IS the answer
+        return ("raise", (type(exc), str(exc)))
+    return ("ok", "".join(out))
+
+
+def _call1(fn, value):
+    try:
+        return ("ok", fn(value))
+    except BaseException as exc:  # noqa: BLE001
+        return ("raise", (type(exc), str(exc)))
+
+
+def _assert_encoder_identical(value: str) -> None:
+    old = _call(_oracle_encode_string, value)
+    new = _call(C._encode_string, value)
+    assert old == new, f"encoder divergence on {value!r}: {old!r} != {new!r}"
+    if old[0] == "ok":
+        # And identical at the BYTES, which is what gets hashed.
+        old_b = _call1(lambda s: s.encode("utf-8"), old[1])
+        new_b = _call1(lambda s: s.encode("utf-8"), new[1])
+        assert old_b == new_b, f"byte divergence on {value!r}"
+
+
+def _assert_rpc_bytes_identical(value: str) -> None:
+    old = _call1(_oracle_rpc_canonical_bytes, value)
+    new = _call1(IR._rpc_canonical_bytes, value)
+    assert old == new, f"_rpc_canonical_bytes divergence on {value!r}: {old!r} != {new!r}"
+
+
+# --- the adversarial corpus ------------------------------------------------
+
+_ADVERSARIAL: list[str] = [
+    "",
+    "plain",
+    "sugar_lift_py_tests.ir",
+    "blake3-512:" + "ab" * 64,
+    '"',
+    "\\",
+    '\\"',
+    '"\\"',
+    "back\\slash",
+    "quote\"inside",
+    "both\"and\\together",
+    "/slash/not/escaped/",
+    # every C0 control, individually and together
+    *[chr(cp) for cp in range(0x20)],
+    "".join(chr(cp) for cp in range(0x20)),
+    "\x00\x1f\x7f",
+    "\x7f",  # DEL is NOT escaped
+    "tab\there",
+    "line\nfeed",
+    "carriage\rreturn",
+    # combining marks and normalization traps
+    "é",  # e + combining acute
+    unicodedata.normalize("NFC", "é"),
+    "ཷ",  # a codepoint whose NFC/NFD differ wildly
+    "À́̂̃",
+    # astral plane
+    "\U0001f600",
+    "\U0010ffff",
+    "\U0001d11e",  # G-clef
+    "a\U0001f600b",
+    # non-ASCII BMP
+    "é", "中文", "אב", "�", "﻿",
+    # lone surrogates -- must raise identically at encode, and be replaced
+    # identically by _rpc_canonical_bytes
+    "\ud800",
+    "\udfff",
+    "a\ud800b",
+    '"\ud800\\',
+    "\x00\ud800\U0001f600",
+    # mixed everything
+    '{"args":[],"kind":"ctor","name":"f\\"é\U0001f600"}',
+]
+
+
+@pytest.mark.parametrize("value", _ADVERSARIAL, ids=lambda v: repr(v)[:48])
+def test_encode_string_byte_identical(value: str) -> None:
+    _assert_encoder_identical(value)
+
+
+@pytest.mark.parametrize("value", _ADVERSARIAL, ids=lambda v: repr(v)[:48])
+def test_rpc_canonical_bytes_byte_identical(value: str) -> None:
+    _assert_rpc_bytes_identical(value)
+
+
+def test_random_fuzz_both_faces() -> None:
+    """Randomized differential over the whole codepoint space, surrogates and
+    escape characters deliberately over-represented."""
+    rng = random.Random(20260726)
+    alphabet = (
+        [chr(cp) for cp in range(0x20)]
+        + list('"\\/ aZ09')
+        + [chr(cp) for cp in range(0xD800, 0xD810)]
+        + [chr(cp) for cp in range(0xDFF0, 0xE000)]
+        + ["é", "中", "́", "�", "\U0001f600", "\U0010ffff"]
+    )
+    for _ in range(3000):
+        value = "".join(rng.choice(alphabet) for _ in range(rng.randrange(0, 24)))
+        _assert_encoder_identical(value)
+        _assert_rpc_bytes_identical(value)
+
+
+def test_full_document_cid_identity() -> None:
+    """The CID, not just the string: a canonical document containing every
+    adversarial string must hash identically under both encoders."""
+    encodable = [s for s in _ADVERSARIAL if not any(0xD800 <= ord(c) <= 0xDFFF for c in s)]
+    value = C.varr([C.vstr(s) for s in encodable])
+    new_text = C.encode_jcs(value)
+
+    saved = C._encode_string
+    C._encode_string = _oracle_encode_string
+    try:
+        old_text = C.encode_jcs(value)
+    finally:
+        C._encode_string = saved
+
+    assert old_text == new_text
+    assert C.blake3_512_of(IR._rpc_canonical_bytes(old_text)) == C.blake3_512_of(
+        IR._rpc_canonical_bytes(new_text)
+    )
+    assert IR._rpc_canonical_bytes(new_text) == _oracle_rpc_canonical_bytes(new_text)
+
+
+# --- complexity tooth: counters, not wall time -----------------------------
+
+
+class _CountingStr(str):
+    """A str that records every Python-level character visit made through
+    iteration. `str.encode`, `re.search` and `str.translate` do not iterate in
+    Python, so a repaired implementation visits zero characters."""
+
+    visits: int
+
+    def __new__(cls, value: str):
+        self = super().__new__(cls, value)
+        self.visits = 0
+        return self
+
+    def __iter__(self):
+        for char in str.__iter__(self):
+            self.visits += 1
+            yield char
+
+
+def _visits(fn, value: str) -> int:
+    probe = _CountingStr(value)
+    try:
+        fn(probe)
+    except BaseException:  # noqa: BLE001 -- counting, not asserting behavior
+        pass
+    return probe.visits
+
+
+def _encoder_visits(fn, value: str) -> int:
+    probe = _CountingStr(value)
+    try:
+        fn(probe, [])
+    except BaseException:  # noqa: BLE001
+        pass
+    return probe.visits
+
+
+def test_complexity_tooth_rpc_canonical_bytes_stops_walking() -> None:
+    """The prior bound: `_rpc_canonical_bytes` walked EVERY character of the
+    canonical string on every call. Canonical strings nest -- a parent's
+    canonical JSON contains all of its descendants' -- so a term table of N
+    nodes at depth D walked O(N x D) characters. The repaired bound is zero
+    Python-level character visits, independent of length."""
+    for length in (1, 100, 10_000, 100_000):
+        payload = "x" * length
+        assert _visits(_oracle_rpc_canonical_bytes, payload) == length, (
+            "oracle must walk every character -- if it does not, the tooth is "
+            "measuring the wrong thing"
+        )
+        assert _visits(IR._rpc_canonical_bytes, payload) == 0, (
+            f"_rpc_canonical_bytes walked characters on a clean {length}-char "
+            "string; the surrogate scan has returned"
+        )
+
+    # The surrogate path is allowed to walk -- it is the rare branch, and it is
+    # the branch that must stay byte-identical, not the branch that must be fast.
+    surrogate = "x" * 1000 + "\ud800"
+    assert _visits(IR._rpc_canonical_bytes, surrogate) > 0
+    _assert_rpc_bytes_identical(surrogate)
+
+
+def test_complexity_tooth_encode_string_stops_walking() -> None:
+    """462,239 `_encode_string` calls were on the per-character path. The
+    repaired bound is zero Python-level character visits for any string with
+    nothing to escape -- which is nearly every corpus string, since they are
+    identifiers, sort names, and CIDs."""
+    for length in (1, 100, 10_000):
+        payload = "a" * length
+        assert _encoder_visits(_oracle_encode_string, payload) == length
+        assert _encoder_visits(C._encode_string, payload) == 0, (
+            f"_encode_string walked characters on a clean {length}-char string; "
+            "the per-character loop has returned"
+        )
+
+    # Even the escaping path must not iterate in Python: `str.translate` is C.
+    assert _encoder_visits(C._encode_string, 'a"b\\c\x00d') == 0
+
+
+def test_quadratic_shape_of_the_prior_walk() -> None:
+    """Names the shape the repair removed: nested canonical strings presented a
+    quadratic character mass to the walker as depth grew."""
+    walked: list[int] = []
+    for depth in (10, 20, 40):
+        canonical = '{"kind":"leaf"}'
+        total = 0
+        for _ in range(depth):
+            canonical = '{"args":[' + canonical + '],"kind":"ctor","name":"f"}'
+            total += _visits(_oracle_rpc_canonical_bytes, canonical)
+        walked.append(total)
+
+    # Doubling the depth more than doubles the walk: the growth is superlinear.
+    assert walked[1] > 2 * walked[0]
+    assert walked[2] > 2 * walked[1]
+
+    # And the repaired implementation walks nothing at any depth.
+    canonical = '{"kind":"leaf"}'
+    for _ in range(40):
+        canonical = '{"args":[' + canonical + '],"kind":"ctor","name":"f"}'
+        assert _visits(IR._rpc_canonical_bytes, canonical) == 0


### PR DESCRIPTION
## What

Two Python-level per-character walks sat on the authentication hot path and dominated construction. Both are removed **without moving a single byte**.

### 1. `ir._rpc_canonical_bytes` (`ir.py:1518`) — the 24M generator iterations

It gated surrogate replacement on `any(0xD800 <= ord(c) <= 0xDFFF for c in canonical)`: a full Python walk of the canonical string on **every call**.

Canonical strings **nest** — a ctor's canonical JSON contains every descendant's verbatim — so interning a term table of N nodes at depth D walked **O(N × D)** characters. That is the 24M generator iterations and the bulk of the 32.7M `ord()` calls.

Strict `str.encode("utf-8")` raises `UnicodeEncodeError` on exactly the lone surrogates U+D800..U+DFFF and on nothing else, so `try`/`except` selects the *identical* branch the scan selected — in C, without walking. The replacement branch is untouched.

### 2. `canonicalizer._encode_string` — the 462,239 calls / 24s

**Answer to "why is it on its slow path": it never received the optimization.** Its twin `sugar_lift_python_source.canonical._encode_string` was rewritten to a regex gate plus `str.translate` (161.52s → 12.59s tottime); the `sugar_lift_py_tests` copy — the one `ir.py` actually calls — was left as the per-character loop. Ported verbatim.

### No memo was added

The redundancy was **not** repeated work on the same authenticated value: `shared_canonical`, `self.nodes` and `_cids` already dedup that. The redundancy was **inside a single call** — an O(subtree) walk per node. #6311's `Formula` and `CallSiteValue` memos are untouched and unduplicated; a third memo would have been the wrong instrument.

## Evidence — counters, not wall time

The box is loaded (several agents running full suites concurrently). Wall times are void and **none are claimed**. The counted metric is `ord()` calls, the same metric the original profile reported.

| depth | nodes | rpc_calls | encode_string_calls | `ord()` before | after | root CID |
|---|---|---|---|---|---|---|
| 10 | 41 | 81 | 289 | 31,392 | **0** | identical |
| 20 | 81 | 161 | 569 | 112,792 | **0** | identical |
| 40 | 161 | 321 | 1,129 | 426,792 | **0** | identical |
| 80 | 321 | 641 | 2,249 | 1,659,592 | **0** | identical |

Doubling depth quadrupled the walk. The repaired bound is **zero** Python-level character visits at every depth, with the root CID identical at every depth.

## Byte identity — no repin

- **1,744 corpus JSON documents / 162,206 strings** canonicalized and CID'd under both encoders: **zero mismatches**.
- **Adversarial Unicode twins**, both faces (69 cases each): lone surrogates (`\ud800`, `\udfff`, embedded), astral plane (`U+1F600`, `U+10FFFF`, G-clef), combining marks and NFC/NFD traps, every C0 control individually and together, embedded quotes/backslashes, unescaped `/`, DEL (not escaped), BOM, replacement char.
- **3,000-case randomized differential** with surrogates and escape characters over-represented.
- **Full-document CID identity** under a swapped-in oracle encoder.

The oracles are the pre-rewrite source kept **verbatim** — not a re-derivation of RFC 8785 — so identity is measured against the code that minted every pinned CID.

## Perturbed after green — all four bite

| perturbation | caught by |
|---|---|
| encoder also escapes `/` (near-identical is a defect) | byte-identity twins + fuzz |
| `errors="replace"` (`b'?'`) instead of U+FFFD | `_rpc_canonical_bytes` twins |
| restore the per-character surrogate walk | complexity tooth + quadratic-shape tooth |
| restore the per-character `_encode_string` loop | complexity tooth |

## Scope

No formula, coordinate, effect, gap or verdict changes. No CID preimage moves. No detector weakened, no test deleted or skipped, no panic suppressed. None of the owned files (`outcome/exit_set.py`, `sugar/spread_sugar.py`, `floor/call_site_value.py`, `manager_summary_derivation.py`, `control_effect_recensus.py`) are touched.

Full-suite pytest is delegated to CI: local collection did not complete under the current box load, and the doctrine is long-running → CI, not wait. Focused twins ran green standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop character-by-character walking in canonical string encoding
> - Replaces the per-character loop in `_encode_string` ([canonicalizer.py](https://github.com/TSavo/sugar/pull/6340/files#diff-92830c63d6312c9e69b43679ed737ed611ea41817c23d537947401a842c3f367)) with a fast path using `re.compile` to check for escapable characters; strings with no escapable chars are quoted and appended in one operation, otherwise `str.translate` handles escaping.
> - Rewrites surrogate detection in `_rpc_canonical_bytes` ([ir.py](https://github.com/TSavo/sugar/pull/6340/files#diff-8f3a2315439408bdc32a92b1cc595bdea6d50c4c13626b3b3cbdbff53375ee2a)) to use `try/except UnicodeEncodeError` on `encode("utf-8")` instead of a Python-level `any(...)` scan over code points.
> - Adds differential tests ([test file](https://github.com/TSavo/sugar/pull/6340/files#diff-fc15f41103541103dc87126107747224a19829b6f0545ce527b9f368b290c30f)) that assert byte-identical output vs. the pre-optimization oracle across adversarial and fuzz inputs, and verify no character-level iteration occurs on fast paths via a `CountingStr` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dec6856.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->