### PR TITLE
perf: kill auth serialization char-walk and JSON re-encode

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/canonicalizer.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/canonicalizer.py
@@ -24,6 +24,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re as _re
 from typing import List, Tuple, Union
 
 import blake3 as _blake3
@@ -148,23 +149,33 @@ def _encode(v: Value, out: List[str]) -> None:
         raise TypeError(f"unknown Value variant: {type(v)!r}")
 
 
+# The JCS string escape set for this canonicalizer: only `"`, `\`, and the C0
+# controls (as lowercase `\u00XX`) are escaped. `/` is NOT escaped, non-ASCII is
+# emitted raw (including astral characters and lone surrogates, whose encoding
+# error surfaces later at `.encode("utf-8")`).
+# Byte-identical to the per-character loop that minted every pinned CID; the
+# rewrite is pure speed (same contract as sugar_lift_python_source.canonical).
+_ESCAPE_SEARCH = _re.compile(r'["\\\x00-\x1f]').search
+
+_ESCAPE_TABLE: dict[int, str] = {
+    0x22: '\\"',
+    0x5C: "\\\\",
+    **{
+        codepoint: "\\u00"
+        + "0123456789abcdef"[codepoint >> 4]
+        + "0123456789abcdef"[codepoint & 0xF]
+        for codepoint in range(0x20)
+    },
+}
+
+
 def _encode_string(s: str, out: List[str]) -> None:
-    out.append('"')
-    for c in s:
-        cp = ord(c)
-        if c == '"':
-            out.append('\\"')
-        elif c == "\\":
-            out.append("\\\\")
-        elif cp < 0x20:
-            out.append("\\u00")
-            out.append("0123456789abcdef"[(cp >> 4) & 0xF])
-            out.append("0123456789abcdef"[cp & 0xF])
-        else:
-            # U+0080..U+10FFFF: emit verbatim. Python str -> UTF-8 at
-            # encode() time produces the same bytes the Rust impl would.
-            out.append(c)
-    out.append('"')
+    # Fast path: nothing to escape (the overwhelming majority of corpus strings
+    # are identifiers and CIDs). Byte-identical to the per-character loop.
+    if _ESCAPE_SEARCH(s) is None:
+        out.append('"' + s + '"')
+        return
+    out.append('"' + s.translate(_ESCAPE_TABLE) + '"')
 
 
 # Hash helpers --------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/formal_parameter.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/formal_parameter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import json
 from typing import Any, Literal
 
 from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
@@ -19,8 +18,8 @@ ParameterKindV1 = Literal[
 
 
 def _cid(value: Any) -> str:
-    canonical = json.loads(encode_jcs(_json_value(value)))
-    return blake3_512_of(encode_jcs(_json_value(canonical)).encode("utf-8"))
+    # One encode of the Value tree; no JSON decode/re-encode of the same bytes.
+    return blake3_512_of(encode_jcs(_json_value(value)).encode("utf-8"))
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -1253,16 +1253,20 @@ class TermTableBuilder:
                 inbound[child_id] = inbound.get(child_id, 0) + 1
                 pending.append(child)
 
-        shared_canonical: dict[int, str] = {}
+        # Shared nodes retain (canonical preimage, CID) so a second edge reuses
+        # both the expanded string and the already-minted content address.
+        shared_canonical: dict[int, tuple[str, str]] = {}
         cid_by_id: dict[int, str] = {}
         values: list[str] = []
+        cid_stack: list[str] = []
         work: list[tuple[dict[str, Any], bool]] = [(root, False)]
         while work:
             term, finishing = work.pop()
             identity = id(term)
-            cached_value = shared_canonical.get(identity)
-            if not finishing and cached_value is not None:
-                values.append(cached_value)
+            cached = shared_canonical.get(identity)
+            if not finishing and cached is not None:
+                values.append(cached[0])
+                cid_stack.append(cached[1])
                 continue
             kind = term.get("kind")
             if kind in {"ctor", "lambda"} and not finishing:
@@ -1277,8 +1281,10 @@ class TermTableBuilder:
                 args = term.get("args", []) or []
                 arity = len(args)
                 children = values[-arity:] if arity else []
+                child_cids = cid_stack[-arity:] if arity else []
                 if arity:
                     del values[-arity:]
+                    del cid_stack[-arity:]
                 canonical = (
                     '{"args":['
                     + ",".join(children)
@@ -1286,19 +1292,19 @@ class TermTableBuilder:
                     + encode_jcs(vstr(term["name"]))
                     + "}"
                 )
+                # Child CIDs were minted when each child finished — never
+                # re-walk the expanded child preimage for a term-ref edge.
                 node_payload: dict[str, Any] = {
                     "kind": "ctor",
                     "name": term["name"],
                     "args": [
-                        {
-                            "kind": "term-ref",
-                            "cid": blake3_512_of(_rpc_canonical_bytes(child)),
-                        }
-                        for child in children
+                        {"kind": "term-ref", "cid": child_cid}
+                        for child_cid in child_cids
                     ],
                 }
             elif term.get("kind") == "lambda":
                 body = values.pop()
+                body_cid = cid_stack.pop()
                 canonical = (
                     '{"body":'
                     + body
@@ -1312,21 +1318,21 @@ class TermTableBuilder:
                     "kind": "lambda",
                     "paramName": term["paramName"],
                     "paramSort": term["paramSort"],
-                    "body": {
-                        "kind": "term-ref",
-                        "cid": blake3_512_of(_rpc_canonical_bytes(body)),
-                    },
+                    "body": {"kind": "term-ref", "cid": body_cid},
                 }
             else:
                 # Leaves are shallow JSON objects — encode_jcs over the value
                 # tree is O(leaf size), not O(spine depth).
                 canonical = encode_jcs(_json_like_to_value(term))
+                # Payload is the already-canonical JCS string decoded once for
+                # the wire row; the CID preimage is that same string's bytes.
+                # Do not re-encode through Value after this point.
                 node_payload = json.loads(canonical)
 
             cid = blake3_512_of(_rpc_canonical_bytes(canonical))
             cid_by_id[identity] = cid
             if inbound.get(identity, 0) > 1:
-                shared_canonical[identity] = canonical
+                shared_canonical[identity] = (canonical, cid)
             if cid not in self.nodes:
                 self.nodes[cid] = node_payload
                 node_count = len(self.nodes)
@@ -1340,8 +1346,9 @@ class TermTableBuilder:
                         },
                     )
             values.append(canonical)
+            cid_stack.append(cid)
 
-        if len(values) != 1:
+        if len(values) != 1 or len(cid_stack) != 1:
             raise AssertionError(
                 f"iterative RPC term encoder left {len(values)} canonical values"
             )
@@ -1516,13 +1523,19 @@ class TermTableBuilder:
 
 
 def _rpc_canonical_bytes(canonical: str) -> bytes:
-    """Hash the same Unicode scalar sequence that the RPC boundary transmits."""
-    if not any(0xD800 <= ord(char) <= 0xDFFF for char in canonical):
+    """Hash the same Unicode scalar sequence that the RPC boundary transmits.
+
+    Fast path: UTF-8 encode in C. Lone surrogates raise ``UnicodeEncodeError``;
+    only then walk scalars and replace with U+FFFD (serde_json-safe). Byte-
+    identical to the previous always-scan implementation for every input.
+    """
+    try:
         return canonical.encode("utf-8")
-    safe = "".join(
-        "\ufffd" if 0xD800 <= ord(char) <= 0xDFFF else char for char in canonical
-    )
-    return safe.encode("utf-8")
+    except UnicodeEncodeError:
+        safe = "".join(
+            "\ufffd" if 0xD800 <= ord(char) <= 0xDFFF else char for char in canonical
+        )
+        return safe.encode("utf-8")
 
 
 def formula_to_value(f: Formula) -> Value:

--- a/implementations/python/sugar-lift-py-tests/tests/test_rpc_canonical_bytes_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_rpc_canonical_bytes_identity.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# THE PREIMAGE IS THE PROTOCOL. `_rpc_canonical_bytes` was rewritten from an
+# always-scan `ord` walk into encode-first with a surrogate-replacement fallback.
+# Every CID that routes through term-table materialization hashes these bytes.
+# These twins pin byte identity against the previous implementation before any
+# CID preimage can move.
+
+from __future__ import annotations
+
+import random
+import unicodedata
+
+import pytest
+
+from sugar_lift_py_tests import ir as IR
+from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs, vstr
+from sugar_lift_py_tests.ir import (
+    TermTableBuilder,
+    _Ctor,
+    _rpc_canonical_bytes,
+    make_var,
+    term_to_value,
+)
+
+
+def _oracle_rpc_canonical_bytes(canonical: str) -> bytes:
+    """The pre-optimization implementation, verbatim. THE specification."""
+    if not any(0xD800 <= ord(char) <= 0xDFFF for char in canonical):
+        return canonical.encode("utf-8")
+    safe = "".join(
+        "\ufffd" if 0xD800 <= ord(char) <= 0xDFFF else char for char in canonical
+    )
+    return safe.encode("utf-8")
+
+
+def _assert_identical(canonical: str) -> None:
+    old = _oracle_rpc_canonical_bytes(canonical)
+    new = _rpc_canonical_bytes(canonical)
+    assert old == new, f"rpc bytes diverge on {canonical!r}: {old!r} != {new!r}"
+    assert blake3_512_of(old) == blake3_512_of(new)
+
+
+def test_ascii_and_cid_strings_are_utf8():
+    for value in ["", "x", "blake3-512:" + "ab" * 64, '{"kind":"var","name":"x"}']:
+        _assert_identical(value)
+        assert _rpc_canonical_bytes(value) == value.encode("utf-8")
+
+
+def test_non_ascii_bmp_and_astral_are_verbatim_utf8():
+    for value in ["日", "日本語", "≥≠∀", "😀🎉", "👨‍👩‍👧‍👦", "é"]:
+        _assert_identical(value)
+        assert _rpc_canonical_bytes(value) == value.encode("utf-8")
+
+
+def test_combining_forms_are_not_normalized():
+    decomposed = "é"
+    precomposed = unicodedata.normalize("NFC", decomposed)
+    assert decomposed != precomposed
+    _assert_identical(decomposed)
+    _assert_identical(precomposed)
+    assert _rpc_canonical_bytes(decomposed) != _rpc_canonical_bytes(precomposed)
+
+
+def test_lone_surrogates_become_replacement_character():
+    # RPC boundary replaces unpaired surrogates with U+FFFD before hashing.
+    for value in ["\ud800", "\udfff", "a\udc00b", "\ud83d", "x\ud800y\udfffz"]:
+        _assert_identical(value)
+        expected = value.replace("\ud800", "\ufffd")
+        for cp in range(0xD800, 0xE000):
+            expected = expected.replace(chr(cp), "\ufffd")
+        # Rebuild expected via the oracle rule only (already asserted equal).
+        assert _rpc_canonical_bytes(value) == _oracle_rpc_canonical_bytes(value)
+        assert b"\xef\xbf\xbd" in _rpc_canonical_bytes(value)  # UTF-8 of U+FFFD
+
+
+def test_surrogate_mixed_with_ascii_and_bmp():
+    _assert_identical("pre\ud83dmid日post")
+    _assert_identical("\ud800" * 100 + "ok" + "\udfff" * 100)
+
+
+def test_long_canonical_preimages():
+    for value in ["x" * 200_000, "日" * 50_000, '{"k":"' + ("ab" * 10_000) + '"}']:
+        _assert_identical(value)
+
+
+def test_jcs_encoded_terms_keep_their_cids():
+    """Corpus-shaped term preimages: CIDs must not move under the rewrite."""
+    terms = [
+        make_var("leaf"),
+        _Ctor("ssa:0", (make_var("leaf"),)),
+        _Ctor("root", (_Ctor("a", (make_var("x"),)), _Ctor("b", (make_var("y"),)))),
+    ]
+    for term in terms:
+        canonical = encode_jcs(term_to_value(term))
+        _assert_identical(canonical)
+        assert blake3_512_of(_rpc_canonical_bytes(canonical)) == blake3_512_of(
+            _oracle_rpc_canonical_bytes(canonical)
+        )
+
+
+def test_term_table_cid_equals_oracle_hash_of_expanded_jcs():
+    """Typed door: table CID is blake3(_rpc_canonical_bytes(encode_jcs(term)))."""
+    leaf = make_var("leaf")
+    spine = leaf
+    for index in range(40):
+        spine = _Ctor(f"ssa:{index}", (spine,))
+    table = TermTableBuilder()
+    cid = table._cid(spine)
+    canonical = encode_jcs(term_to_value(spine))
+    expected = blake3_512_of(_oracle_rpc_canonical_bytes(canonical))
+    assert cid == expected
+    assert cid == blake3_512_of(_rpc_canonical_bytes(canonical))
+
+
+_ALPHABET = (
+    [chr(c) for c in range(0x00, 0x80)]
+    + [chr(c) for c in (0xA9, 0x2028, 0x4E2D, 0x1F600, 0x10FFFF)]
+    + [chr(c) for c in (0xD800, 0xDBFF, 0xDC00, 0xDFFF)]
+)
+
+
+def test_differential_fuzz_rpc_bytes():
+    rng = random.Random(20260726)
+    for _ in range(5_000):
+        length = rng.randint(0, 64)
+        _assert_identical("".join(rng.choice(_ALPHABET) for _ in range(length)))
+
+
+def test_encode_string_fast_path_matches_oracle_across_corpus_shapes():
+    """lift-py-tests encoder must stay byte-identical to the per-char oracle."""
+    from sugar_lift_py_tests import canonicalizer as C
+
+    def oracle(value: str, out: list[str]) -> None:
+        out.append('"')
+        for char in value:
+            codepoint = ord(char)
+            if char == '"':
+                out.append('\\"')
+            elif char == "\\":
+                out.append("\\\\")
+            elif codepoint < 0x20:
+                out.append("\\u00")
+                out.append("0123456789abcdef"[(codepoint >> 4) & 0xF])
+                out.append("0123456789abcdef"[codepoint & 0xF])
+            else:
+                out.append(char)
+        out.append('"')
+
+    samples = [
+        "",
+        "identifier",
+        "blake3-512:" + "cd" * 64,
+        'quote " and \\ and \n',
+        "日😀",
+        "\ud800",
+        "/" * 100,
+        "a" * 10_000,
+    ]
+    for value in samples:
+        old: list[str] = []
+        new: list[str] = []
+        oracle(value, old)
+        C._encode_string(value, new)
+        assert "".join(old) == "".join(new), value
+
+
+def test_rpc_materialize_does_not_rehash_child_preimages(monkeypatch):
+    """Parent edges must reuse child CIDs — one _rpc_canonical_bytes per node."""
+    calls: list[int] = []
+    original = IR._rpc_canonical_bytes
+
+    def counting(canonical: str) -> bytes:
+        calls.append(len(canonical))
+        return original(canonical)
+
+    monkeypatch.setattr(IR, "_rpc_canonical_bytes", counting)
+
+    leaf = {"kind": "var", "name": "x"}
+    # Build a spine of plain RPC dicts (source-lifter shape).
+    node = leaf
+    for index in range(30):
+        node = {"kind": "ctor", "name": f"ssa:{index}", "args": [node]}
+
+    table = TermTableBuilder()
+    table.reference_rpc(node)
+    # 1 leaf + 30 ctors = 31 nodes; never one extra walk per parent edge.
+    assert len(calls) == 31, len(calls)
+    assert len(table.nodes) == 31

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -44,12 +44,12 @@ class LiveOutwardHaltedFaceV1:
 
 
 def _formula_cid(formula) -> str:
-    import json
-
-    from sugar_lift_py_tests.canonicalizer import encode_jcs
+    # Encode the Value tree once and hash those bytes. Do not decode the
+    # canonical JCS string back through JSON merely to re-encode for the CID.
+    from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
     from sugar_lift_py_tests.ir import formula_to_value
 
-    return cid_of_json(json.loads(encode_jcs(formula_to_value(formula))))
+    return blake3_512_of(encode_jcs(formula_to_value(formula)).encode("utf-8"))
 
 
 def _seal_runtime_state(state):


### PR DESCRIPTION
## Summary

Authentication CID mint was dominated by pure-speed defects that do not change any preimage. This is bounded to **one serialization path**, byte-identical replacement, so the authoritative census can run cheaply as the drain loop.

### Changes

1. **`_rpc_canonical_bytes`** — encode-first UTF-8; walk scalars only on `UnicodeEncodeError` (lone-surrogate → U+FFFD). Eliminates the always-on generator walk.
2. **`lift-py-tests` `_encode_string`** — port the regex+`translate` fast path already proven in `sugar_lift_python_source.canonical` (#6245). Byte-identical to the per-character oracle.
3. **`reference_rpc`** — reuse child CIDs minted bottom-up; never re-hash a child’s full expanded preimage for a parent `term-ref` edge.
4. **Formula / formal-parameter CIDs** — one encode of the Value tree; no `encode → json.loads → re-encode` round trip.

### Byte identity

`test_rpc_canonical_bytes_identity.py` pins oracle equality across ASCII/CID strings, BMP/astral, combining forms, lone surrogates, long preimages, corpus-shaped terms, 5k differential fuzz, and “one hash per node” on a 30-deep RPC spine. Existing iterative term-table + encoder differential suites pass (`33 passed`).

### Profile (same synthetic: 200-deep shared spine + 50× formula encode)

| metric | before | after |
|--------|--------|-------|
| wall | ~72s | ~23s |
| `_rpc_canonical_bytes` cumtime | ~3.1s | **&lt;1ms** |
| `_encode_string` tottime | ~16.2s | ~2.2s |
| root CID | `ee2600e7…` | **identical** |
| RPC spine 100 depth hash calls | n²-ish | **101** (1/node) |

Residual time is still DAG-as-tree `formula_to_value` recomputation — out of scope for this serialization-path change.

## Validation

```bash
SUGAR_BINARY_ALLOW_BUILD=0 python3 -m pytest \
  tests/test_rpc_canonical_bytes_identity.py \
  tests/test_iterative_term_table_encoder.py \
  tests/test_canonical_string_encoder_differential.py \
  --noconftest -q
# 33 passed
```

## Out of scope

- Full 1,421-file baseline census (next, now that auth serialize is cheap)
- Content-CID memo on every immutable formula/term for DAG-as-tree encode

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant JSON parse/re-encode round trips in auth serialization and CID computation
> - Replaces per-character loops in [`_encode_string`](https://github.com/TSavo/sugar/pull/6341/files#diff-92830c63d6312c9e69b43679ed737ed611ea41817c23d537947401a842c3f367) with `str.translate` using a precomputed escape table, avoiding per-char branching.
> - Eliminates `json.loads` + re-encode round trips in [`formal_parameter._cid`](https://github.com/TSavo/sugar/pull/6341/files#diff-91502817525a4c87c23811685a6ad92ba99469f588c228c2d5ec0cacb448a4a6) and [`live_loop_construction._formula_cid`](https://github.com/TSavo/sugar/pull/6341/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094); CIDs are now computed directly from a single JCS encoding.
> - [`TermTableBuilder`](https://github.com/TSavo/sugar/pull/6341/files#diff-8f3a2315439408bdc32a92b1cc595bdea6d50c4c13626b3b3cbdbff53375ee2a) now caches child CIDs during iterative RPC materialization instead of re-hashing child canonical strings for parent term-ref edges.
> - Adds a test suite in [`test_rpc_canonical_bytes_identity.py`](https://github.com/TSavo/sugar/pull/6341/files#diff-3634e28d8cc547b9f62d0352ce409b51e51ecb0f4047299b806aa62f73c20a74) covering ASCII, non-ASCII, surrogate handling, CID materialization, and differential fuzzing to assert byte-identity of the refactored paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18bda82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->