### PR TITLE
Get main's CI green: forall body terminal effects, refusal-vocabulary ratchet, fmt

### DIFF
--- a/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs
@@ -1194,7 +1194,10 @@ mod tests {
         let (rel, asserts, discharged, refused, raw_delta, parse_ok) = &rows[0];
         assert_eq!(rel, "num/ops.rs");
         assert_eq!((*asserts, *discharged, *refused), (74, 0, 74));
-        assert_eq!(*raw_delta, 0, "raw_delta 0 keeps missing_assertions unmoved");
+        assert_eq!(
+            *raw_delta, 0,
+            "raw_delta 0 keeps missing_assertions unmoved"
+        );
         assert!(*parse_ok, "the file PARSED; it panicked during the lift");
     }
 

--- a/implementations/rust/sugar-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/lib.rs
@@ -9827,6 +9827,16 @@ enum Effect {
     /// array/range domains are genuine source boundaries owned by LiteralSugar. A
     /// nonempty finite literal domain completes before this effect can fire.
     LiteralDomain { reason: String },
+    /// FORALL-BODY-TERMINAL: a bounded `for` / `.for_each` universal whose DOMAIN is a
+    /// fine finite construction, but whose BODY assertions all closed with reasons that
+    /// already measured `Disposition::TerminalEffect` (a runtime destructure, a runtime
+    /// slice source, ...). The loop cannot state more than its body can, so the loop's
+    /// outcome IS the body's fact. `reason` is the body's own terminal string carried
+    /// VERBATIM -- never synthesized here -- so `refusal_disposition` classifies this
+    /// effect exactly as it classified the body's and the reason CID is conserved.
+    /// A body carrying any `Unclassified` reason never reaches this variant: that is
+    /// lifter work and stays a loud construction panic.
+    ForAllBodyTerminal { reason: String },
     /// STRUCT-UPDATE-REST: a struct literal using `..rest` does not write every field value
     /// at the literal site. Field projection facts are only derived from fully pinned
     /// `struct:*` ctor arguments; the rest source must be modeled explicitly before it can
@@ -10174,6 +10184,8 @@ impl Effect {
                  construction from the literal; refused by name: `{boundary}`"
             ),
             Effect::LiteralDomain { reason } => reason.clone(),
+            // Verbatim: the propagated string is the body's own already-terminal reason.
+            Effect::ForAllBodyTerminal { reason } => reason.clone(),
             Effect::StructUpdateRest { boundary } => format!(
                 "struct literal with `..rest` is not fully pinned from the literal: `{boundary}` \
                  (bin-2: rest fields are not constructed by this literal); owner=rust.struct_term; \

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs
@@ -31,11 +31,33 @@ use crate::{
     SUGAR_SEQ_CAP,
 };
 
+/// Why the bounded forall core did not produce a formula.
+///
+/// The two arms are the `panic = gap` / `named = fact` discriminator, and they are
+/// NOT interchangeable:
+///
+/// * `Gap` -- the core reached a shape it has no construction for. That is lifter
+///   WORK, it has no name, and it stays a loud construction panic at the caller.
+/// * `BodyTerminal` -- every non-inactive body assertion already closed with a reason
+///   that `refusal_disposition` classifies `TerminalEffect`: a damn good SOURCE
+///   property (a runtime destructure, a runtime slice source, ...). The loop cannot
+///   state more than its body can, so the loop's honest outcome is that same named
+///   effect. Dropping it on the floor and panicking would report a lifter gap where
+///   the lifter had in fact already named the fact.
+enum ForAllDecline {
+    Gap,
+    /// Carries the body's own terminal reason VERBATIM, so `refusal_disposition`
+    /// classifies the propagated effect exactly as it classified the body's, and the
+    /// CID of the emitted reason is conserved. Never synthesized: only ever a string
+    /// that already measured `Disposition::TerminalEffect`.
+    BodyTerminal(String),
+}
+
 /// and `try_lift_for_each_forall` (a `.for_each(|var| body)` adaptor): a `for`
 /// loop and a `.for_each` over the SAME constructed domain assert the SAME
 /// universal, so the construction is one piece of code. Returns the quantified
-/// formula and the number of body assert macros it accounts for, or None to
-/// refuse (mutation, body not point-wise, or count mismatch).
+/// formula and the number of body assert macros it accounts for, or a
+/// `ForAllDecline` (mutation, body not point-wise, or count mismatch).
 #[allow(clippy::too_many_arguments)]
 fn lift_bounded_forall(
     binding: &ForAllBinding,
@@ -52,7 +74,7 @@ fn lift_bounded_forall(
     // its concrete element in the LITERAL-INT RANGE unroll. Empty -> no index read is
     // resolved (the reads stay the EUF accessor -- the established sound floor).
     literal_arrays: &BTreeMap<String, Vec<Rc<Term>>>,
-) -> Option<(Rc<Formula>, usize, Vec<String>)> {
+) -> Result<(Rc<Formula>, usize, Vec<String>), ForAllDecline> {
     let var = binding.label();
     // Lift the body through the normal collector. Truth-table-or-gutter: every
     // body assert must lift cleanly (none refused, none missing) or we refuse
@@ -64,7 +86,7 @@ fn lift_bounded_forall(
             var = var.as_str(),
             "forall declined: body has no assertion macros"
         );
-        return None;
+        return Err(ForAllDecline::Gap);
     }
     // Purity gate: the body must not mutate anything. An assignment, a `let mut`,
     // or a `&mut` borrow means a value varies across iterations independently of
@@ -78,7 +100,7 @@ fn lift_bounded_forall(
             n_body,
             "forall declined: body mutates state"
         );
-        return None;
+        return Err(ForAllDecline::Gap);
     }
     let mut body_entries = Vec::new();
     let mut body_skipped = Vec::new();
@@ -125,7 +147,23 @@ fn lift_bounded_forall(
             skipped = ?body_skipped,
             "forall declined: body did not lift point-wise"
         );
-        return None;
+        // Split the decline by the disposition the body ALREADY measured. An
+        // `Unclassified` reason is lifter work with no name -- it must stay a loud
+        // construction gap, so it wins over any terminal sibling. Only when every
+        // non-inactive reason is a named `TerminalEffect` does the loop have a fact to
+        // report instead of a gap, and then it reports the body's own reason verbatim.
+        let unclassified_first = body_skipped
+            .iter()
+            .find(|reason| crate::refusal_disposition(reason) == Disposition::Unclassified);
+        if unclassified_first.is_none() {
+            if let Some(terminal) = body_skipped
+                .iter()
+                .find(|reason| crate::refusal_disposition(reason) == Disposition::TerminalEffect)
+            {
+                return Err(ForAllDecline::BodyTerminal(terminal.clone()));
+            }
+        }
+        return Err(ForAllDecline::Gap);
     }
     let body_conj = and_(body_entries.iter().map(|e| e.atom.clone()).collect());
 
@@ -187,7 +225,7 @@ fn lift_bounded_forall(
                 // Empty literal range (`hi <= lo`): the loop never runs -> vacuous;
                 // refuse rather than emit a vacuous `true` (mirrors the empty-array
                 // bail in `bounded_domain_from_expr`).
-                Some((lo, hi)) if hi <= lo => return None,
+                Some((lo, hi)) if hi <= lo => return Err(ForAllDecline::Gap),
                 // Runtime endpoint, or a literal range too large to unroll: the
                 // guarded universal it states, body free in `var`.
                 // forall x:Int. ( start <= x (< | <=) end ) => body[var := x]
@@ -242,7 +280,7 @@ fn lift_bounded_forall(
                 .collect(),
         ),
     };
-    Some((quantified, warranted_assertions, inactive_reasons))
+    Ok((quantified, warranted_assertions, inactive_reasons))
 }
 
 fn fold_literal_int_terms_in_formula(formula: &Rc<Formula>) -> Rc<Formula> {
@@ -487,7 +525,7 @@ impl ForAllSugar {
                 forall_gap("runtime forall domain should have returned a runtime effect")
             }
         };
-        let Some((quantified, n_body, inactive_reasons)) = lift_bounded_forall(
+        let (quantified, n_body, inactive_reasons) = match lift_bounded_forall(
             &self.binding,
             domain,
             &self.body_stmts,
@@ -498,11 +536,29 @@ impl ForAllSugar {
             ctx.macro_depth,
             ctx.factory_audits,
             &array_terms,
-        ) else {
-            if let Some(effect) = runtime_domain_effect {
-                return Err(Outcome::Incomplete(effect));
+        ) {
+            Ok(lifted) => lifted,
+            Err(decline) => {
+                if let Some(effect) = runtime_domain_effect {
+                    return Err(Outcome::Incomplete(effect));
+                }
+                match decline {
+                    // The body already NAMED why it cannot be stated, and that name
+                    // measured terminal. The loop reports that same fact rather than
+                    // discarding it and claiming an unnamed construction gap.
+                    ForAllDecline::BodyTerminal(reason) => {
+                        debug!(
+                            target: "sugar_lift_rust_tests::sugar::forall",
+                            binding = self.binding.label(),
+                            reason = reason.as_str(),
+                            "forall body closed terminal; propagating the body's named effect"
+                        );
+                        return Err(Outcome::Incomplete(Effect::ForAllBodyTerminal { reason }));
+                    }
+                    // No name -- lifter work. The floor stays loud.
+                    ForAllDecline::Gap => forall_gap("bounded forall core declined"),
+                }
             }
-            forall_gap("bounded forall core declined");
         };
         let warrant = Warrant {
             name: Some(format!(

--- a/tools/check-lift-refusal-vocabulary.py
+++ b/tools/check-lift-refusal-vocabulary.py
@@ -41,6 +41,17 @@ SCAN_PATHS = (
 
 LIFT_OUTPUT_SPEAKER = "lift-output-backlog"
 
+# Module-level names whose string members declare vendor-owned Python builtin
+# exception identities. Membership here is only half of ownership: every member
+# must still resolve to a real builtin exception class in the running
+# substrate, so adding a name here can never launder lifter-side vocabulary.
+BUILTIN_EXCEPTION_DECLS = frozenset(
+    {
+        "BUILTIN_EXCEPTION_NAMES",
+        "BUILTIN_EXCEPTION_BASES",
+    }
+)
+
 
 @dataclass(frozen=True)
 class Occurrence:
@@ -147,10 +158,10 @@ def git_files() -> list[str]:
 def declared_builtin_exceptions(path: str) -> frozenset[tuple[int, str]]:
     """Find structurally declared Python builtin exception identities.
 
-    Ownership requires both syntax (a string member of the kit's explicit
-    BUILTIN_EXCEPTION_NAMES declaration) and the running Python substrate
-    (the named builtin is an exception class).  A filename alone proves
-    neither.
+    Ownership requires both syntax (a string member of one of the kit's
+    explicit builtin-exception declarations, see BUILTIN_EXCEPTION_DECLS)
+    and the running Python substrate (the named builtin is an exception
+    class).  A filename alone proves neither.
     """
 
     try:
@@ -160,10 +171,16 @@ def declared_builtin_exceptions(path: str) -> frozenset[tuple[int, str]]:
 
     declarations: set[tuple[int, str]] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign) or not any(
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        if node.value is None or not any(
             isinstance(target, ast.Name)
-            and target.id == "BUILTIN_EXCEPTION_NAMES"
-            for target in node.targets
+            and target.id in BUILTIN_EXCEPTION_DECLS
+            for target in targets
         ):
             continue
         for member in ast.walk(node.value):
@@ -499,6 +516,25 @@ def self_test() -> int:
     if vendor.speaker != "vendor-language-identifier":
         print(
             "FAIL: canonical ConnectionRefusedError was classified as Sugar output",
+            file=sys.stderr,
+        )
+        return 1
+    bases_line = next(
+        line_no
+        for line_no, line in enumerate(
+            (ROOT / vendor_path).read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if '"ConnectionRefusedError":' in line
+    )
+    bases = classify(
+        vendor_path,
+        '"ConnectionRefusedError": (\'ConnectionError\',),',
+        bases_line,
+    )
+    if bases.speaker != "vendor-language-identifier":
+        print(
+            "FAIL: canonical ConnectionRefusedError declared in "
+            "BUILTIN_EXCEPTION_BASES was classified as Sugar output",
             file=sys.stderr,
         )
         return 1

--- a/tools/lift_refusal_vocabulary_census.json
+++ b/tools/lift_refusal_vocabulary_census.json
@@ -2,7 +2,7 @@
   "identity": "path + normalized text digest + duplicate ordinal; line is display only",
   "issue": "#3632",
   "law": "REFUSE is the verifier verb; lift outputs are reduced meaning or typed effects.",
-  "lift_output_backlog": 1829,
+  "lift_output_backlog": 1883,
   "occurrences": [
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/discharge_cli.py:523c0ad6c899be9b:1",
@@ -136,7 +136,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:c6148629b10bd3d9:1",
-      "line": 415,
+      "line": 557,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -146,7 +146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:cbbc07efb9f468e8:1",
-      "line": 346,
+      "line": 488,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -156,7 +156,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:cfef8f3e3876c262:1",
-      "line": 56,
+      "line": 61,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -272,6 +272,296 @@
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
       "speaker": "verifier-verdict-quote",
       "text": "reproduced AND every per-test witness passed; else REFUSED with the breakdown",
+      "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py:42f8e0fc20bd6e44:1",
+      "line": 8,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "2. **Desugar** \u2014 ``sugar.desugar(None)`` refusals and typed red effects,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py:5215ea32eaf5c2ef:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Yield/YieldFrom construct then refuse at desugar: construction-total, still",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:1cdfd99d904e041e:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``R_desugar`` typed refusals (``SugarNotWritten``) and typed red",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:5a22a8cc4df81f51:1",
+      "line": 330,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "a typed refusal is a measured frontier row, not a broken instrument.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:69c525740c848874:1",
+      "line": 286,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == \"refusal\":",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:6f37f5208a9cb3dd:1",
+      "line": 253,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "the true grain of a refusal (one refusal per reduction), and appears in",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:70ab45bc61822f20:1",
+      "line": 334,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _refusal_owner(gap: BaseException) -> str:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:8113597c30466169:1",
+      "line": 287,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "owner = _refusal_owner(outcome[1])",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:a397c6ec06cd75da:1",
+      "line": 268,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return (\"refusal\", gap)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:d609758c229d926f:1",
+      "line": 6,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "R_desugar typed semantic refusals/effects (door: ``sugar.desugar(None)``)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py:009ad9b93a263daf:1",
+      "line": 4,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# its closed coordinate. Not a cap: see ``repeat_sequence``, which refuses no",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py:43d19363182f42f0:1",
+      "line": 21,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "about eager memory -- there is no cardinality at which this law refuses,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py:cae40838c62d8b5b:1",
+      "line": 164,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# callable, never a member -- two tests pin that refusal deliberately. The",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py:1d746ca8d1121748:1",
+      "line": 412,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# correctly refuses to snapshot and reports as a typed gap.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py:59d42b108722f281:1",
+      "line": 15,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``AttributeError`` \u2014 permanent-floor red. Refuse as a typed construction",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py:fa887014e60c7110:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Project a single completed floor value, or refuse loudly.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py:609201548e399168:1",
+      "line": 123,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse an untyped disposition wherever it first reaches the algebra.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:0ccc14caa49a9811:1",
+      "line": 789,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``ExitSetFactoringGap`` still refuses loudly when an operand's completed",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:5704e70627417bb5:1",
+      "line": 100,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "that does not hold, and the refusal in ``factor_completed`` exists to catch",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:877c3635ffe0adde:1",
+      "line": 744,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "It REFUSES loudly when there is not exactly one completed arm, so a dropped",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:c5b1ad8a560dc1a6:1",
+      "line": 164,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refuses on a False answer rather than assuming a partition.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:d1856b0d998ccf78:1",
+      "line": 344,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "REFUSES loudly when the completed arms are not provably pairwise",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:26e7d32ef54bfbc2:1",
+      "line": 169,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# `factor_completed` REFUSES (`ExitSetFactoringGap`) when the completed",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:a54b145fd7e0f683:1",
+      "line": 170,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# arms are not provably pairwise exclusive, and that refusal is kept: the",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:c5bd5f1b169a0198:1",
+      "line": 190,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "(``outcome_to_exitset`` refuses it). It is unwrapped before the join and",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:cf014ed7bf6d54a0:1",
+      "line": 135,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# the meaning is the union, and refusing it discarded the arm that DOES",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py:a13950695d96a694:1",
+      "line": 99,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# not construct return or raise testimony` was refusing to state.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py:7bd867ef70a95cc3:1",
+      "line": 108,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"binary, or set SUGAR_BINARY_ALLOW_BUILD=0 to refuse the build rung \"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py:27906cdedbc646b8:1",
+      "line": 125,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py",
+      "reason": "AST-declared identity resolves to an exception class in Python's builtin namespace",
+      "replacement": "preserve the substrate-owned symbol exactly",
+      "speaker": "vendor-language-identifier",
+      "text": "\"ConnectionRefusedError\": ('ConnectionError',),",
       "wire_marker": "not-lift-output"
     },
     {
@@ -935,6 +1225,66 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:2a2db2da63a26692:1",
+      "line": 191,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# floor is the force-floor STAGE refusing, and becomes the stage-keyed",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:42f10ab33f901d33:1",
+      "line": 561,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "still refuse at force_floor when the builtin is not yet reducible; that is a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:bc73bee9cb585110:1",
+      "line": 186,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refused its own cycles at resolution; a repeated call identity is still",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:06d5ed5f5ae036dd:1",
+      "line": 243,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "and refuses any halt that is not a proven absent-effect halt.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:7f3c1bc287bc4c25:1",
+      "line": 277,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# does not classify. Refuse rather than let the disjunction speak",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:d44ce190644017d9:1",
+      "line": 237,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "for an outcome it does not cover, so the whole derivation refuses;",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:87bf7a4969182fe1:1",
       "line": 150,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py",
@@ -943,6 +1293,36 @@
       "speaker": "lift-output-backlog",
       "text": "\"refusals\": result.refusals,",
       "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:ca51cbbecb4713d2:1",
+      "line": 8,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "`SUGAR_BUILD_STAMP` and the gate (`refuse_split_pipeline`) is",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:cebd12063ee89a10:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused every mint that registered the `python` surface through",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:d2e87fa4ecb18b14:1",
+      "line": 143,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "same identity kind or one of them refuses every mint (#6224).",
+      "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:0ea9d3db9fed818c:1",
@@ -2606,7 +2986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:0e6e7767d79ae499:1",
-      "line": 665,
+      "line": 709,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2615,8 +2995,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:10135b1b7db7b274:1",
+      "line": 1153,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// not refused\", and until this existed nothing enforced it: mutating the bin to",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:15ed905b58ee294e:1",
-      "line": 492,
+      "line": 527,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2626,7 +3016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:1e5014f8a66d4e85:1",
-      "line": 633,
+      "line": 668,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2635,8 +3025,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:25d194c309f118ff:1",
+      "line": 1196,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "assert_eq!((*asserts, *discharged, *refused), (74, 0, 74));",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:2d0397e0ac8797da:1",
-      "line": 635,
+      "line": 670,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2646,7 +3046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:34289ec726c4ebab:1",
-      "line": 520,
+      "line": 555,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2676,7 +3076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:3fc08e98569fcb6a:1",
-      "line": 884,
+      "line": 981,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2686,7 +3086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:4488c40316e8f0c4:1",
-      "line": 592,
+      "line": 627,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2696,12 +3096,22 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:4727b2c58ea32bbe:1",
-      "line": 580,
+      "line": 615,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "rows.push((rel, census.total, discharged, refused, raw_delta, true));",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:4c05e74409e0c953:1",
+      "line": 1154,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// `totals.refused += census_total` left every other test green. Drives a panicking",
       "wire_marker": "internal-only"
     },
     {
@@ -2716,7 +3126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:596cf5c36d96feb8:1",
-      "line": 906,
+      "line": 1003,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2726,7 +3136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:6267b737805e5131:1",
-      "line": 563,
+      "line": 598,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2736,7 +3146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:67124a457f945519:1",
-      "line": 501,
+      "line": 536,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2746,12 +3156,42 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:7b32f346c7018b7e:1",
-      "line": 498,
+      "line": 533,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "let (tag, disp) = match refusal_disposition(reason) {",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:7f493f4c2c134829:1",
+      "line": 483,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// that bucket and not `refused`), so its assertions stay accounted for and `silent`",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:81a1123d930f2ee0:1",
+      "line": 940,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// UNCLASSIFIED, not `refused`. `refused` is reserved for a terminal close with a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:84f0323fb83fd66a:1",
+      "line": 1194,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "let (rel, asserts, discharged, refused, raw_delta, parse_ok) = &rows[0];",
       "wire_marker": "internal-only"
     },
     {
@@ -2766,7 +3206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:8ae319df21bdb097:1",
-      "line": 684,
+      "line": 728,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2775,8 +3215,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:8d90138e066dbb4a:1",
+      "line": 1187,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// Every reason row is tagged unclassified, never refused.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:8e48b2a88e411912:1",
-      "line": 519,
+      "line": 554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2786,7 +3236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:9092732f70ff5121:1",
-      "line": 595,
+      "line": 630,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2796,7 +3246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:9d8d217b27bb74f9:1",
-      "line": 991,
+      "line": 1091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2806,7 +3256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:a07f101d94813b27:1",
-      "line": 634,
+      "line": 669,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2816,7 +3266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:a1513d5036b6473b:1",
-      "line": 680,
+      "line": 724,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2826,7 +3276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:a5ee1c41ef91e8dc:1",
-      "line": 568,
+      "line": 603,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2836,7 +3286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:ab44f50d2f69f05a:1",
-      "line": 494,
+      "line": 529,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2845,8 +3295,28 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:ae1bbf138834cebe:1",
+      "line": 1179,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "assert_eq!(totals.refused, 0, \"a panic is NOT an earned refusal\");",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:b35f82555778dddf:1",
+      "line": 1159,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fn panic_bins_unclassified_not_refused() {",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:b3f819833f6ca04c:1",
-      "line": 948,
+      "line": 1048,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2856,7 +3326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:b70f280c0385997b:1",
-      "line": 675,
+      "line": 719,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2866,7 +3336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:bda38328e9a49062:1",
-      "line": 1032,
+      "line": 1133,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2876,7 +3346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:c037b7d093238fbf:1",
-      "line": 518,
+      "line": 553,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2885,13 +3355,33 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:c33608c3e02bc53f:1",
+      "line": 1156,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// re-bin to `refused` -- or a dropped `panicked_files` increment, or a lost",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:d41c89cad7ee9114:1",
-      "line": 574,
+      "line": 609,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "refused = refused,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:d5c38abae5d83fb7:1",
+      "line": 948,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// writes: `panic_bins_unclassified_not_refused` below is the tooth on that choice.",
       "wire_marker": "internal-only"
     },
     {
@@ -2906,7 +3396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:dff873553bdff8eb:1",
-      "line": 491,
+      "line": 526,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2916,7 +3406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:e09273d9b8f897a1:1",
-      "line": 530,
+      "line": 565,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2926,7 +3416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:e0a517ea6f2dfa5c:1",
-      "line": 953,
+      "line": 1053,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2936,7 +3426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:e3698167b503a147:1",
-      "line": 1018,
+      "line": 1119,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2956,7 +3446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:eef7ed7139517bc9:1",
-      "line": 521,
+      "line": 556,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2976,7 +3466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f120d3ba6a7d7c2b:1",
-      "line": 484,
+      "line": 519,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2986,7 +3476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f23af5f81e2e0217:1",
-      "line": 426,
+      "line": 429,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2996,7 +3486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f23af5f81e2e0217:2",
-      "line": 586,
+      "line": 621,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3006,12 +3496,32 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f33aae3637b623d8:1",
-      "line": 559,
+      "line": 594,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "totals.refused += file_terminal - from_terminal;",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f521519d0e2add9c:1",
+      "line": 479,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "// deliberate `-> !` loud refusal, but without a boundary here the FIRST such file",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs:f777e75f19099115:1",
+      "line": 944,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/coretests_sweep.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// \"work\", it keeps the gap loud in the gate rather than parked in an earned-refusal",
       "wire_marker": "internal-only"
     },
     {
@@ -5806,7 +6316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:00715bf7fa7e3989:1",
-      "line": 23484,
+      "line": 23591,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5816,7 +6326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:009b210a96e6f685:1",
-      "line": 9943,
+      "line": 10048,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5836,7 +6346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:023060f70eda31cc:1",
-      "line": 26820,
+      "line": 26927,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5846,7 +6356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0243b202c3ac7121:1",
-      "line": 14923,
+      "line": 15030,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5876,7 +6386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0408821238645fdf:1",
-      "line": 15374,
+      "line": 15481,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5886,7 +6396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:06807fc7bec5fc1d:1",
-      "line": 22571,
+      "line": 22678,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5906,7 +6416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:070a0b11e4fc45bf:1",
-      "line": 24705,
+      "line": 24812,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5916,7 +6426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:07516d6f7741ee2e:1",
-      "line": 24827,
+      "line": 24934,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5926,7 +6436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:075668c502065ada:1",
-      "line": 24793,
+      "line": 24900,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5936,7 +6446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:075f606d39c6e391:1",
-      "line": 27346,
+      "line": 27453,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5946,7 +6456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:08c968721dde4a8d:1",
-      "line": 25122,
+      "line": 25229,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5956,7 +6466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0944dc3d0836ed91:1",
-      "line": 9931,
+      "line": 10036,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5966,7 +6476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0b284fbf6398a4cb:1",
-      "line": 24497,
+      "line": 24604,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5986,7 +6496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0bb173a2cd4f6c05:1",
-      "line": 27047,
+      "line": 27154,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6006,7 +6516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0c3db6963f2b02a2:1",
-      "line": 24731,
+      "line": 24838,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6026,7 +6536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0c8194715a3902ac:1",
-      "line": 25351,
+      "line": 25458,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6036,7 +6546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0f14e7ba67ebe8a4:1",
-      "line": 27155,
+      "line": 27262,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6046,7 +6556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:0f94a77703bdfc9d:1",
-      "line": 26911,
+      "line": 27018,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6056,7 +6566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:10059f735b52c5ca:1",
-      "line": 27253,
+      "line": 27360,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6066,7 +6576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:109f387df23564d9:1",
-      "line": 22179,
+      "line": 22286,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6076,7 +6586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:10ff8727e9c73e33:1",
-      "line": 9504,
+      "line": 9599,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6106,7 +6616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:114a50ae9fc4831d:3",
-      "line": 12118,
+      "line": 12225,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6116,7 +6626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:12cb2bb838810fff:1",
-      "line": 10010,
+      "line": 10115,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6126,7 +6636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:12d81d5998c8b0a8:1",
-      "line": 14490,
+      "line": 14597,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6136,7 +6646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:130208c002b27c83:1",
-      "line": 25084,
+      "line": 25191,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6146,7 +6656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:13e32e876e53f548:1",
-      "line": 14901,
+      "line": 15008,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6156,7 +6666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:14086dd043873bae:1",
-      "line": 24732,
+      "line": 24839,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6246,7 +6756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:148133b288f12758:9",
-      "line": 16158,
+      "line": 16265,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6256,7 +6766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:156322853641dcae:1",
-      "line": 24378,
+      "line": 24485,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6266,7 +6776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1583fa2a98ff6759:1",
-      "line": 15511,
+      "line": 15618,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6276,7 +6786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:17c97ab850b80ead:1",
-      "line": 27014,
+      "line": 27121,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6306,7 +6816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:18f47275dc43c9a0:1",
-      "line": 24063,
+      "line": 24170,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6316,7 +6826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:18fe8d58cf2752cf:1",
-      "line": 26701,
+      "line": 26808,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6326,7 +6836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:190e4da1314fc567:1",
-      "line": 26676,
+      "line": 26783,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6336,7 +6846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1a0d750419a333e3:1",
-      "line": 23979,
+      "line": 24086,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6346,7 +6856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1a8a7091a2c86a79:1",
-      "line": 26725,
+      "line": 26832,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6356,7 +6866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1aa1e16daf7b4b70:1",
-      "line": 27198,
+      "line": 27305,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6366,7 +6876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1b68a15408b04149:1",
-      "line": 26775,
+      "line": 26882,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6376,7 +6886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:1",
-      "line": 27810,
+      "line": 27917,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6386,7 +6896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:2",
-      "line": 27840,
+      "line": 27947,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6396,7 +6906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1bc25fe16840761b:3",
-      "line": 27908,
+      "line": 28015,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6406,7 +6916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1c061bed085b0bc3:1",
-      "line": 25676,
+      "line": 25783,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6416,7 +6926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1c11f8f22666e7c9:1",
-      "line": 25295,
+      "line": 25402,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6436,7 +6946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1d17be5738840619:1",
-      "line": 25153,
+      "line": 25260,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6446,7 +6956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1d9987aa1f1248d2:1",
-      "line": 27741,
+      "line": 27848,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6466,7 +6976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1e8a46afdf44958a:1",
-      "line": 10025,
+      "line": 10130,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6476,7 +6986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1e96b011358871ff:1",
-      "line": 14494,
+      "line": 14601,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6486,7 +6996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1edf8dc268e9ef6f:1",
-      "line": 20061,
+      "line": 20168,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6506,7 +7016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:1fcb8c859b947b3e:1",
-      "line": 14484,
+      "line": 14591,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6546,7 +7056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:229f5eb6a6ee000f:1",
-      "line": 13673,
+      "line": 13780,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6576,7 +7086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2332f6d3742487b4:1",
-      "line": 26993,
+      "line": 27100,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6596,7 +7106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:23dea12b8732b1ce:1",
-      "line": 15020,
+      "line": 15127,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6606,7 +7116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:23fdc12df7c53f0f:1",
-      "line": 26947,
+      "line": 27054,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6616,7 +7126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2452451a489656b2:1",
-      "line": 23807,
+      "line": 23914,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6626,7 +7136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:25113e9e5dd84a8f:1",
-      "line": 24351,
+      "line": 24458,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6646,7 +7156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:26157eec2f2537ed:1",
-      "line": 15456,
+      "line": 15563,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6656,7 +7166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:26671ad396f12d1f:1",
-      "line": 10005,
+      "line": 10110,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6676,7 +7186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:276e46ed5435d002:1",
-      "line": 27712,
+      "line": 27819,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6686,7 +7196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2795eae4db9bdfee:1",
-      "line": 25050,
+      "line": 25157,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6696,7 +7206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:27aae1bb3a469a7b:1",
-      "line": 16093,
+      "line": 16200,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6706,7 +7216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:27d899e62e46b94f:1",
-      "line": 13715,
+      "line": 13822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6726,7 +7236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:28f305e462382e0b:1",
-      "line": 16235,
+      "line": 16342,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6736,7 +7246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2915f2980123103e:1",
-      "line": 25022,
+      "line": 25129,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6746,7 +7256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:29262d582b7085aa:1",
-      "line": 10035,
+      "line": 10140,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6756,7 +7266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:29720adbe087e0d0:1",
-      "line": 19605,
+      "line": 19712,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6766,7 +7276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2a279df48b093218:1",
-      "line": 12449,
+      "line": 12556,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6786,7 +7296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2accdc0895e9e669:1",
-      "line": 21119,
+      "line": 21226,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6796,7 +7306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2d6a2a5b71a0b663:1",
-      "line": 23966,
+      "line": 24073,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6806,7 +7316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2e0f48ba4665fd7a:1",
-      "line": 15381,
+      "line": 15488,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6826,7 +7336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2e5e4feee4134522:1",
-      "line": 24407,
+      "line": 24514,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6836,7 +7346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2eeb1ce255e7b055:1",
-      "line": 9867,
+      "line": 9972,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6846,7 +7356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:2eeb1ce255e7b055:2",
-      "line": 9878,
+      "line": 9983,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6856,7 +7366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:300e3dcdf4321320:1",
-      "line": 15127,
+      "line": 15234,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6876,7 +7386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3097aa95e17d1856:1",
-      "line": 26702,
+      "line": 26809,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6886,7 +7396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:30c490c5f5efa1a6:1",
-      "line": 26854,
+      "line": 26961,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6896,7 +7406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:30d932bfce308c3c:1",
-      "line": 15560,
+      "line": 15667,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6906,7 +7416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:315589ac0f502555:1",
-      "line": 27103,
+      "line": 27210,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6916,7 +7426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:31a9bad3229c70ae:1",
-      "line": 9906,
+      "line": 10011,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6926,7 +7436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:32041de6dba814ab:1",
-      "line": 24745,
+      "line": 24852,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6936,7 +7446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3218b9254d430773:1",
-      "line": 9467,
+      "line": 9562,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6946,7 +7456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:33511fdb5627662f:1",
-      "line": 16661,
+      "line": 16768,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6956,7 +7466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:336bdaeb60c76102:1",
-      "line": 15009,
+      "line": 15116,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6966,7 +7476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:339202b9416e3a33:1",
-      "line": 27272,
+      "line": 27379,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6976,7 +7486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:33ed2707c4fcfbef:1",
-      "line": 26707,
+      "line": 26814,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6986,7 +7496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:341be91c6844f3bf:1",
-      "line": 24996,
+      "line": 25103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -6996,7 +7506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:34befd82f6f8ff42:1",
-      "line": 26891,
+      "line": 26998,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7006,7 +7516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:35873b2180a27aef:1",
-      "line": 27205,
+      "line": 27312,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7016,7 +7526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:36bfc8a0cba2fca8:1",
-      "line": 14929,
+      "line": 15036,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7026,7 +7536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37c5c1d1c57a25eb:1",
-      "line": 27020,
+      "line": 27127,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7036,7 +7546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37d05f64a780c808:1",
-      "line": 10079,
+      "line": 10184,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7046,7 +7556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:37d5afe263a0145e:1",
-      "line": 25071,
+      "line": 25178,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7066,7 +7576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3a43a7e8e2e64af4:1",
-      "line": 26919,
+      "line": 27026,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7076,7 +7586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3a7cd800a11bb31a:1",
-      "line": 13674,
+      "line": 13781,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7086,7 +7596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3b639938ea9f6390:1",
-      "line": 25327,
+      "line": 25434,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7096,7 +7606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3baa5fc5fd598c0d:1",
-      "line": 27270,
+      "line": 27377,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7106,7 +7616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3bd536a29fd37e9d:1",
-      "line": 26713,
+      "line": 26820,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7126,7 +7636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3d7550b8ed5da55a:1",
-      "line": 9927,
+      "line": 10032,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7136,7 +7646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3d7a888be1d4b31a:1",
-      "line": 27320,
+      "line": 27427,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7146,7 +7656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:1",
-      "line": 22228,
+      "line": 22335,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7156,7 +7666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:10",
-      "line": 23257,
+      "line": 23364,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7166,7 +7676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:11",
-      "line": 23544,
+      "line": 23651,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7176,7 +7686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:12",
-      "line": 24103,
+      "line": 24210,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7186,7 +7696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:13",
-      "line": 24126,
+      "line": 24233,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7196,7 +7706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:14",
-      "line": 27862,
+      "line": 27969,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7206,7 +7716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:15",
-      "line": 27881,
+      "line": 27988,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7216,7 +7726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:2",
-      "line": 22252,
+      "line": 22359,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7226,7 +7736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:3",
-      "line": 22294,
+      "line": 22401,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7236,7 +7746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:4",
-      "line": 22340,
+      "line": 22447,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7246,7 +7756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:5",
-      "line": 22448,
+      "line": 22555,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7256,7 +7766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:6",
-      "line": 22479,
+      "line": 22586,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7266,7 +7776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:7",
-      "line": 22540,
+      "line": 22647,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7276,7 +7786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:8",
-      "line": 23116,
+      "line": 23223,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7286,7 +7796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3dc1b3eb88dc30a8:9",
-      "line": 23136,
+      "line": 23243,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7296,7 +7806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3e66b2e73573210b:1",
-      "line": 24222,
+      "line": 24329,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7306,7 +7816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3f69a0c862654acb:1",
-      "line": 26994,
+      "line": 27101,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7316,7 +7826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:3f71f3945e9db1a6:1",
-      "line": 13772,
+      "line": 13879,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7326,7 +7836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:41518803e7f1d22e:1",
-      "line": 26890,
+      "line": 26997,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7346,7 +7856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:423b67cd8e5f252f:1",
-      "line": 27360,
+      "line": 27467,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7356,7 +7866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4245262ff3bf67d2:1",
-      "line": 14748,
+      "line": 14855,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7366,7 +7876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:43e8d108b534f26f:1",
-      "line": 27756,
+      "line": 27863,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7396,7 +7906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:48138862d4682b0b:1",
-      "line": 26630,
+      "line": 26737,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7406,7 +7916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:48138862d4682b0b:2",
-      "line": 26665,
+      "line": 26772,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7426,7 +7936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:494ad70f963ee256:1",
-      "line": 16863,
+      "line": 16970,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7436,7 +7946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:49fbd77a370e6dd9:1",
-      "line": 16092,
+      "line": 16199,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7446,7 +7956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4b658e293164e5eb:1",
-      "line": 27140,
+      "line": 27247,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7456,7 +7966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4b6d488a0d07ccd2:1",
-      "line": 26698,
+      "line": 26805,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7466,7 +7976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c2b7d3cd8239e6e:1",
-      "line": 27251,
+      "line": 27358,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7476,7 +7986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c2f0d3a662a83c4:1",
-      "line": 22569,
+      "line": 22676,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7496,7 +8006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4c86baf8f2cc1858:1",
-      "line": 9136,
+      "line": 9231,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7506,7 +8016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4d450f07337ab83c:1",
-      "line": 9514,
+      "line": 9609,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7516,7 +8026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4d9902f5f2ca8675:1",
-      "line": 13765,
+      "line": 13872,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7536,7 +8046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4e44b1b36a47f88c:1",
-      "line": 9422,
+      "line": 9517,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7546,7 +8056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4e5e2357e6d17aa0:1",
-      "line": 24653,
+      "line": 24760,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7566,7 +8076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:4fafd457a1ae333a:1",
-      "line": 26721,
+      "line": 26828,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7576,7 +8086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:50c66875e428a050:1",
-      "line": 14417,
+      "line": 14524,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7586,7 +8096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:50c8b6beced860fa:1",
-      "line": 15118,
+      "line": 15225,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7596,7 +8106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:50d7efe1d4d19d7b:1",
-      "line": 9939,
+      "line": 10044,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7606,7 +8116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:51143f47a6e30603:1",
-      "line": 25826,
+      "line": 25933,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7626,7 +8136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:51865434a32ef559:1",
-      "line": 26950,
+      "line": 27057,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7636,7 +8146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:52b76da630c76b62:1",
-      "line": 25922,
+      "line": 26029,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7646,7 +8156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:530e2bd18bc1ba59:1",
-      "line": 12387,
+      "line": 12494,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7676,7 +8186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:55528ea495a0a42e:1",
-      "line": 15453,
+      "line": 15560,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7686,7 +8196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5593923e99a5626c:1",
-      "line": 15018,
+      "line": 15125,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7696,7 +8206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:56b258284f9642c8:1",
-      "line": 26969,
+      "line": 27076,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7706,7 +8216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5784899e947af79a:1",
-      "line": 10045,
+      "line": 10150,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7716,7 +8226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5786e71f09223cfb:1",
-      "line": 27727,
+      "line": 27834,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7746,7 +8256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:595b49ffbabd5f5b:1",
-      "line": 24772,
+      "line": 24879,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7756,7 +8266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:59b2fd0dd93011a1:1",
-      "line": 14501,
+      "line": 14608,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7766,7 +8276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5ac33c6e679925b5:1",
-      "line": 27695,
+      "line": 27802,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7786,7 +8296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5bb403bc2c0c8a31:1",
-      "line": 27219,
+      "line": 27326,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7796,7 +8306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5bbc6267b10afbef:1",
-      "line": 15481,
+      "line": 15588,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7806,7 +8316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c071c74b3d12777:1",
-      "line": 26968,
+      "line": 27075,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7816,7 +8326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c37cd89ba3adb0a:1",
-      "line": 20238,
+      "line": 20345,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7826,7 +8336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5c8c3bad631bad37:1",
-      "line": 24561,
+      "line": 24668,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7836,7 +8346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5d2809e5887813e4:1",
-      "line": 24248,
+      "line": 24355,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7846,7 +8356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5e6c117baaf5a883:1",
-      "line": 16270,
+      "line": 16377,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7856,7 +8366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5fdbd97bf81884d8:1",
-      "line": 27146,
+      "line": 27253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7866,7 +8376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:5ff2294d94dcee1b:1",
-      "line": 16896,
+      "line": 17003,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7876,7 +8386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6050aaede36b36a7:1",
-      "line": 26653,
+      "line": 26760,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7906,7 +8416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:60874978b39adfa4:1",
-      "line": 26697,
+      "line": 26804,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7916,7 +8426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6108db8d16968ac4:1",
-      "line": 14921,
+      "line": 15028,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7926,7 +8436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:62a5e622da1fc377:1",
-      "line": 14927,
+      "line": 15034,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7936,7 +8446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:62c1f77e7b6fa531:1",
-      "line": 26731,
+      "line": 26838,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7956,7 +8466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:64bf9c42441d6213:1",
-      "line": 26153,
+      "line": 26260,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7966,7 +8476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:64d68d8f77c17f16:1",
-      "line": 26687,
+      "line": 26794,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8016,7 +8526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:66f63c7bf670fe27:1",
-      "line": 13771,
+      "line": 13878,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8036,7 +8546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:68b6245dc4813486:1",
-      "line": 27711,
+      "line": 27818,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8046,7 +8556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:692c34495b7680cf:1",
-      "line": 26814,
+      "line": 26921,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8056,7 +8566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69bbb7e52ab40221:1",
-      "line": 27129,
+      "line": 27236,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8066,7 +8576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69d451ac8d3bd3ce:1",
-      "line": 26962,
+      "line": 27069,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8076,7 +8586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:69ef7af4b214d979:1",
-      "line": 25031,
+      "line": 25138,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8086,7 +8596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6a4f2b5e8293a9ac:1",
-      "line": 12391,
+      "line": 12498,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8096,7 +8606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6aa1c64145292566:1",
-      "line": 12673,
+      "line": 12780,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8106,7 +8616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6ab7ac467c7e46ad:1",
-      "line": 12744,
+      "line": 12851,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8116,7 +8626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6ae57f6321934965:1",
-      "line": 25794,
+      "line": 25901,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8136,7 +8646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6b30f3244beec783:1",
-      "line": 10040,
+      "line": 10145,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8146,7 +8656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6c0e1870b237472c:1",
-      "line": 9848,
+      "line": 9953,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8156,7 +8666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6d3dda9843aa0037:1",
-      "line": 27262,
+      "line": 27369,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8166,7 +8676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e14b3f148ea0ff4:1",
-      "line": 21142,
+      "line": 21249,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8176,7 +8686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e1b17cf2a6f1d41:1",
-      "line": 10067,
+      "line": 10172,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8186,7 +8696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e4a242955a2ec48:1",
-      "line": 23936,
+      "line": 24043,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8196,7 +8706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:6e9f58a481b3aad7:1",
-      "line": 22855,
+      "line": 22962,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8246,7 +8756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7101146e77025034:1",
-      "line": 14086,
+      "line": 14193,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8256,7 +8766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7101146e77025034:2",
-      "line": 14123,
+      "line": 14230,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8266,7 +8776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7101146e77025034:3",
-      "line": 14138,
+      "line": 14245,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8276,7 +8786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:718f849bcfcc5b0b:1",
-      "line": 26686,
+      "line": 26793,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8286,7 +8796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:71e01a0793ac86a0:1",
-      "line": 20202,
+      "line": 20309,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8306,7 +8816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:72321878ae60ef1e:1",
-      "line": 26922,
+      "line": 27029,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8316,7 +8826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:734f917a2131bff9:1",
-      "line": 26679,
+      "line": 26786,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8326,7 +8836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7382d9771bbe6149:1",
-      "line": 9701,
+      "line": 9796,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8336,7 +8846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:73de9c395f8f1def:1",
-      "line": 9418,
+      "line": 9513,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8376,7 +8886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:74e9e89d412f4189:1",
-      "line": 19613,
+      "line": 19720,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8396,7 +8906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:75a673ba752dd41b:1",
-      "line": 26728,
+      "line": 26835,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8406,7 +8916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76244b46d5d2da2d:1",
-      "line": 26718,
+      "line": 26825,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8416,7 +8926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76590ed1a25eaa1e:1",
-      "line": 24792,
+      "line": 24899,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8426,7 +8936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76ba135bffb8aaa0:1",
-      "line": 25102,
+      "line": 25209,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8446,7 +8956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:76e04beecc499d64:1",
-      "line": 12394,
+      "line": 12501,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8456,7 +8966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:77063501e138f18f:1",
-      "line": 26624,
+      "line": 26731,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8466,7 +8976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:771613ec00c7e29f:1",
-      "line": 27770,
+      "line": 27877,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8476,7 +8986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7795c8d34be5e47a:1",
-      "line": 14162,
+      "line": 14269,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8496,7 +9006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:78d181893f275a7e:1",
-      "line": 16248,
+      "line": 16355,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8506,7 +9016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:79051ad91ba65913:1",
-      "line": 27209,
+      "line": 27316,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8516,7 +9026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:796a87e2dd8a70eb:1",
-      "line": 26724,
+      "line": 26831,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8526,7 +9036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:79aa37575ef65eda:1",
-      "line": 25098,
+      "line": 25205,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8536,7 +9046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7a34e56f3d9c1a08:1",
-      "line": 16773,
+      "line": 16880,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8556,7 +9066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7afd408d37c4181c:1",
-      "line": 14937,
+      "line": 15044,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8566,7 +9076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7affee5384f21d56:1",
-      "line": 27440,
+      "line": 27547,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8576,7 +9086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7b9666433fea6d5e:1",
-      "line": 9796,
+      "line": 9901,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8586,7 +9096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7bbbdf7ffc6e3df1:1",
-      "line": 16151,
+      "line": 16258,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8596,7 +9106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7c2861be8050c186:1",
-      "line": 27058,
+      "line": 27165,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8606,7 +9116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7d6a685822818dc1:1",
-      "line": 10151,
+      "line": 10258,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8616,7 +9126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da128e0c706afdb:1",
-      "line": 23354,
+      "line": 23461,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8626,7 +9136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da1b5483d9ad6cd:1",
-      "line": 26949,
+      "line": 27056,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8636,7 +9146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7da1be41e1be5115:1",
-      "line": 9535,
+      "line": 9630,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8646,7 +9156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ec29d9f2347eac0:1",
-      "line": 26717,
+      "line": 26824,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8656,7 +9166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ee57b5220e24f1f:1",
-      "line": 14905,
+      "line": 15012,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8666,7 +9176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7ef540bfb40d7f65:1",
-      "line": 9992,
+      "line": 10097,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8676,7 +9186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:7f000eb0d9eb951d:1",
-      "line": 26614,
+      "line": 26721,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8686,7 +9196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:808bb577e2c06361:1",
-      "line": 25889,
+      "line": 25996,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8696,7 +9206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:80bfb22d8be17a6b:1",
-      "line": 9465,
+      "line": 9560,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8706,7 +9216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:80eb2ee38045f801:1",
-      "line": 25034,
+      "line": 25141,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8716,7 +9226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:814324470fc67927:1",
-      "line": 25114,
+      "line": 25221,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8726,7 +9236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:81a05b756660c1ec:1",
-      "line": 12718,
+      "line": 12825,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8736,7 +9246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:824bb54ba7f20820:1",
-      "line": 23332,
+      "line": 23439,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8746,7 +9256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:827db9276c4fa36d:1",
-      "line": 25817,
+      "line": 25924,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8756,7 +9266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:82b934014b764d2c:1",
-      "line": 27715,
+      "line": 27822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8776,7 +9286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8618e8ed78018717:1",
-      "line": 9593,
+      "line": 9688,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8796,7 +9306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:87b15a84cf481f08:1",
-      "line": 24071,
+      "line": 24178,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8806,7 +9316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:87b93b672f12efed:1",
-      "line": 9922,
+      "line": 10027,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8816,7 +9326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:88dbbb39ee6cfa4c:1",
-      "line": 24694,
+      "line": 24801,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8826,7 +9336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89f42a609aad0b01:1",
-      "line": 12165,
+      "line": 12272,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8836,7 +9346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89f42a609aad0b01:2",
-      "line": 15649,
+      "line": 15756,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8846,7 +9356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:89fe33412c371ae2:1",
-      "line": 26693,
+      "line": 26800,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8856,7 +9366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8a4a1e611861b01a:1",
-      "line": 26991,
+      "line": 27098,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8876,7 +9386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8a94c581743692f6:1",
-      "line": 9858,
+      "line": 9963,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8886,7 +9396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8ac1f27d38bb7b6d:1",
-      "line": 26801,
+      "line": 26908,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8896,7 +9406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8aedda2567afd47f:1",
-      "line": 16075,
+      "line": 16182,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8906,7 +9416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8b4450487510c885:1",
-      "line": 14749,
+      "line": 14856,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8926,7 +9436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8bf3948ed0a1931b:1",
-      "line": 15573,
+      "line": 15680,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8936,7 +9446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8c552c3fc192982d:1",
-      "line": 26861,
+      "line": 26968,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8945,8 +9455,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8ca1499488c8eb99:1",
+      "line": 9835,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// VERBATIM -- never synthesized here -- so `refusal_disposition` classifies this",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8d0ec2b606455df3:1",
-      "line": 14477,
+      "line": 14584,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8956,7 +9476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8d256950ad9c8e3d:1",
-      "line": 23996,
+      "line": 24103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8966,7 +9486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8e1c1d49a4219a05:1",
-      "line": 12634,
+      "line": 12741,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8976,7 +9496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:8e7aa9e00f882c2a:1",
-      "line": 26690,
+      "line": 26797,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8996,7 +9516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:902a433fcc62e775:1",
-      "line": 25299,
+      "line": 25406,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9006,7 +9526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:90aa18ca0541c39c:1",
-      "line": 13781,
+      "line": 13888,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9016,7 +9536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9149918b0ec95097:1",
-      "line": 9459,
+      "line": 9554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9036,7 +9556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9165073a5b34ce84:1",
-      "line": 15114,
+      "line": 15221,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9046,7 +9566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:91eaeaf1e399fcb3:1",
-      "line": 9566,
+      "line": 9661,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9056,7 +9576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:92db2724cf6c2174:1",
-      "line": 26712,
+      "line": 26819,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9076,7 +9596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:95621cdbb876cbc3:1",
-      "line": 16247,
+      "line": 16354,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9096,7 +9616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:968ebe030bdae100:1",
-      "line": 27059,
+      "line": 27166,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9106,7 +9626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:97364d430e50993e:1",
-      "line": 26809,
+      "line": 26916,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9116,7 +9636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9771949fc25f45ed:1",
-      "line": 14304,
+      "line": 14411,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9126,7 +9646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9773362e51c00aef:1",
-      "line": 10015,
+      "line": 10120,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9136,7 +9656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:983018b867872b1e:1",
-      "line": 9406,
+      "line": 9501,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9146,7 +9666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:989774411313426b:1",
-      "line": 27178,
+      "line": 27285,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9156,7 +9676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:99cac8ab20136aa1:1",
-      "line": 26927,
+      "line": 27034,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9186,7 +9706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e35a2d5547fe631:1",
-      "line": 26631,
+      "line": 26738,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9196,7 +9716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e5cc7b488c41b38:1",
-      "line": 26699,
+      "line": 26806,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9206,7 +9726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e89d1b9214ea2dc:1",
-      "line": 24886,
+      "line": 24993,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9216,7 +9736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:1",
-      "line": 24901,
+      "line": 25008,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9226,7 +9746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:2",
-      "line": 25057,
+      "line": 25164,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9236,7 +9756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:3",
-      "line": 25091,
+      "line": 25198,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9246,7 +9766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:4",
-      "line": 25121,
+      "line": 25228,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9256,7 +9776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9e929c0d9be654e7:5",
-      "line": 25179,
+      "line": 25286,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9266,7 +9786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9fdb64007f581e7e:1",
-      "line": 9442,
+      "line": 9537,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9276,7 +9796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:9fdb64007f581e7e:2",
-      "line": 9446,
+      "line": 9541,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9286,7 +9806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a008154800585d78:1",
-      "line": 24991,
+      "line": 25098,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9296,7 +9816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a0aa75f1f0042780:1",
-      "line": 14206,
+      "line": 14313,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9306,7 +9826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a18121c1ee06d132:1",
-      "line": 16150,
+      "line": 16257,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9316,7 +9836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a199c8fed871df78:1",
-      "line": 24831,
+      "line": 24938,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9326,7 +9846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a24878847e5ad418:1",
-      "line": 26985,
+      "line": 27092,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9336,7 +9856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a26afc8ffa8e1e13:1",
-      "line": 15669,
+      "line": 15776,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9346,7 +9866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a3625ce422a61fc2:1",
-      "line": 20233,
+      "line": 20340,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9356,7 +9876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a3ba8f2625938e9d:1",
-      "line": 26723,
+      "line": 26830,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9366,7 +9886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a45c19301663092e:1",
-      "line": 26817,
+      "line": 26924,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9376,7 +9896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a4926de6bb4655ef:1",
-      "line": 24789,
+      "line": 24896,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9396,7 +9916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a574c90d67c2df18:1",
-      "line": 27176,
+      "line": 27283,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9406,7 +9926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a5fa040820524297:1",
-      "line": 27375,
+      "line": 27482,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9416,7 +9936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a5fa040820524297:2",
-      "line": 27402,
+      "line": 27509,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9426,7 +9946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a7043c11ccbadf20:1",
-      "line": 26763,
+      "line": 26870,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9446,7 +9966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a72b68ffa9703bf4:1",
-      "line": 26941,
+      "line": 27048,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9456,7 +9976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a77708b7fb2f8abd:1",
-      "line": 16775,
+      "line": 16882,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9466,7 +9986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a80b0bdd416a2bed:1",
-      "line": 14271,
+      "line": 14378,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9476,7 +9996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a80b0bdd416a2bed:2",
-      "line": 14306,
+      "line": 14413,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9486,7 +10006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8bdb05f2e22e7d3:1",
-      "line": 27109,
+      "line": 27216,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9496,7 +10016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:1",
-      "line": 22197,
+      "line": 22304,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9506,7 +10026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:10",
-      "line": 24221,
+      "line": 24328,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9516,7 +10036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:11",
-      "line": 24247,
+      "line": 24354,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9526,7 +10046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:12",
-      "line": 24290,
+      "line": 24397,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9536,7 +10056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:13",
-      "line": 24318,
+      "line": 24425,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9546,7 +10066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:14",
-      "line": 24350,
+      "line": 24457,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9556,7 +10076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:15",
-      "line": 24377,
+      "line": 24484,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9566,7 +10086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:16",
-      "line": 24406,
+      "line": 24513,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9576,7 +10096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:17",
-      "line": 24439,
+      "line": 24546,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9586,7 +10106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:18",
-      "line": 24496,
+      "line": 24603,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9596,7 +10116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:19",
-      "line": 24531,
+      "line": 24638,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9606,7 +10126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:2",
-      "line": 22366,
+      "line": 22473,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9616,7 +10136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:20",
-      "line": 24560,
+      "line": 24667,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9626,7 +10146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:21",
-      "line": 24594,
+      "line": 24701,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9636,7 +10156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:22",
-      "line": 24625,
+      "line": 24732,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9646,7 +10166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:23",
-      "line": 24652,
+      "line": 24759,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9656,7 +10176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:24",
-      "line": 24693,
+      "line": 24800,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9666,7 +10186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:25",
-      "line": 25668,
+      "line": 25775,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9676,7 +10196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:3",
-      "line": 23074,
+      "line": 23181,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9686,7 +10206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:4",
-      "line": 23195,
+      "line": 23302,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9696,7 +10216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:5",
-      "line": 23458,
+      "line": 23565,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9706,7 +10226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:6",
-      "line": 23483,
+      "line": 23590,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9716,7 +10236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:7",
-      "line": 24062,
+      "line": 24169,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9726,7 +10246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:8",
-      "line": 24157,
+      "line": 24264,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9736,7 +10256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8cc5878eb70b8ef:9",
-      "line": 24191,
+      "line": 24298,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9746,7 +10266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a8eee510e8998ded:1",
-      "line": 25190,
+      "line": 25297,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9756,7 +10276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:1",
-      "line": 24924,
+      "line": 25031,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9766,7 +10286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:2",
-      "line": 24946,
+      "line": 25053,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9776,7 +10296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:3",
-      "line": 24973,
+      "line": 25080,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9786,7 +10306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:4",
-      "line": 25320,
+      "line": 25427,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9796,7 +10316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:a94a8cc219451c43:5",
-      "line": 25350,
+      "line": 25457,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9816,7 +10336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ab15be3fba5b0cd1:1",
-      "line": 27269,
+      "line": 27376,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9826,7 +10346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ab4caa51fd17b486:1",
-      "line": 23459,
+      "line": 23566,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9846,7 +10366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:abdb97e5669a0975:1",
-      "line": 27110,
+      "line": 27217,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9866,7 +10386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ac2f7fea72874fbd:1",
-      "line": 22586,
+      "line": 22693,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9876,7 +10396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ac2f7fea72874fbd:2",
-      "line": 25928,
+      "line": 26035,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9886,7 +10406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:acca0029979f4c13:1",
-      "line": 26812,
+      "line": 26919,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9896,7 +10416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:acedb1ced3aa61ea:1",
-      "line": 26926,
+      "line": 27033,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9916,7 +10436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ae5916805876ac46:1",
-      "line": 23284,
+      "line": 23391,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9926,7 +10446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ae9b7dcf35f4400c:1",
-      "line": 15025,
+      "line": 15132,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9956,7 +10476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af33bb19bb4db860:1",
-      "line": 15583,
+      "line": 15690,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9966,7 +10486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af33bb19bb4db860:2",
-      "line": 15612,
+      "line": 15719,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9976,7 +10496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:af910e58b2c77763:1",
-      "line": 23885,
+      "line": 23992,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9986,7 +10506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b04d3d556d773056:1",
-      "line": 27190,
+      "line": 27297,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10006,7 +10526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b1a3368b53032685:1",
-      "line": 15008,
+      "line": 15115,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10026,7 +10546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b2aed37dd3d7ea1c:1",
-      "line": 13467,
+      "line": 13574,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10036,7 +10556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b2c731d3da6cd11a:1",
-      "line": 27167,
+      "line": 27274,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10046,7 +10566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3241001126a4a9c:1",
-      "line": 26791,
+      "line": 26898,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10056,7 +10576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3241001126a4a9c:2",
-      "line": 26803,
+      "line": 26910,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10076,7 +10596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b3679e8328331e44:1",
-      "line": 14509,
+      "line": 14616,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10086,7 +10606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b432b2e07a83ac87:1",
-      "line": 26183,
+      "line": 26290,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10096,7 +10616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b48b5f3296d119e9:1",
-      "line": 26920,
+      "line": 27027,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10106,7 +10626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b4d76eca871110e7:1",
-      "line": 26691,
+      "line": 26798,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10116,7 +10636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b6318aa7064d9310:1",
-      "line": 24814,
+      "line": 24921,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10136,7 +10656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b6707be7cace8e0e:1",
-      "line": 24866,
+      "line": 24973,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10146,7 +10666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b7cdb99af122f74b:1",
-      "line": 9839,
+      "line": 9944,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10156,7 +10676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b7df38df0606e289:1",
-      "line": 24626,
+      "line": 24733,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10186,7 +10706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:b9722e932f1bb40e:1",
-      "line": 27182,
+      "line": 27289,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10196,7 +10716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ba7cf5bcf797d9c2:1",
-      "line": 24087,
+      "line": 24194,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10206,7 +10726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:baae9532c042bae0:1",
-      "line": 14201,
+      "line": 14308,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10226,7 +10746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb523aa660dd4687:1",
-      "line": 21140,
+      "line": 21247,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10236,7 +10756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb7ee0ec6dafecb8:1",
-      "line": 15409,
+      "line": 15516,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10246,7 +10766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bb970cf4b07065b1:1",
-      "line": 27665,
+      "line": 27772,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10256,7 +10776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bbb47521ef8392a4:1",
-      "line": 25058,
+      "line": 25165,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10266,7 +10786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bd1e1781efdc54fc:1",
-      "line": 16866,
+      "line": 16973,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10276,7 +10796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdc221e9e9c42970:1",
-      "line": 24158,
+      "line": 24265,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10286,7 +10806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:1",
-      "line": 25531,
+      "line": 25638,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10296,7 +10816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:2",
-      "line": 25567,
+      "line": 25674,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10306,7 +10826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bdeaba05874a1c0b:3",
-      "line": 25597,
+      "line": 25704,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10316,7 +10836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:be3064dcdc5f2256:1",
-      "line": 22351,
+      "line": 22458,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10326,7 +10846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:be81b848229b5bcd:1",
-      "line": 22198,
+      "line": 22305,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10336,7 +10856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bf1d5efac45b5151:1",
-      "line": 16271,
+      "line": 16378,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10346,7 +10866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:bf6f2bba1b4ea47a:1",
-      "line": 10020,
+      "line": 10125,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10376,7 +10896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c0ddc1067d953282:1",
-      "line": 24291,
+      "line": 24398,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10386,7 +10906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c14bd6eb8d20b885:1",
-      "line": 26225,
+      "line": 26332,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10396,7 +10916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c1658665cec9080a:1",
-      "line": 9997,
+      "line": 10102,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10416,7 +10936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c19c266d8e382c09:1",
-      "line": 27215,
+      "line": 27322,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10426,7 +10946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c22e71ad17e3c96c:1",
-      "line": 26625,
+      "line": 26732,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10436,7 +10956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c22e71ad17e3c96c:2",
-      "line": 26660,
+      "line": 26767,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10466,7 +10986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c35e93ca292f8cac:1",
-      "line": 24832,
+      "line": 24939,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10476,7 +10996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c40c949bdd02551f:1",
-      "line": 9871,
+      "line": 9976,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10486,7 +11006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c41f5442c55fb1dc:1",
-      "line": 12871,
+      "line": 12978,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10506,7 +11026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c551fd66ec491b8a:1",
-      "line": 25669,
+      "line": 25776,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10516,7 +11036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c57780e0a425da8d:1",
-      "line": 9960,
+      "line": 10065,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10526,7 +11046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c581c3d5741e30d2:1",
-      "line": 26794,
+      "line": 26901,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10536,7 +11056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c60d0486ef331dcc:1",
-      "line": 26719,
+      "line": 26826,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10546,7 +11066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c62475395c522d57:1",
-      "line": 25147,
+      "line": 25254,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10556,7 +11076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c62e50c844427b8e:1",
-      "line": 14474,
+      "line": 14581,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10566,7 +11086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c6dbc07c6134602c:1",
-      "line": 9902,
+      "line": 10007,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10576,7 +11096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:1",
-      "line": 25816,
+      "line": 25923,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10586,7 +11106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:2",
-      "line": 25849,
+      "line": 25956,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10596,7 +11116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:3",
-      "line": 26883,
+      "line": 26990,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10606,7 +11126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:4",
-      "line": 26910,
+      "line": 27017,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10616,7 +11136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:5",
-      "line": 26940,
+      "line": 27047,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10626,7 +11146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:6",
-      "line": 26984,
+      "line": 27091,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10636,7 +11156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c73415bd147ebee6:7",
-      "line": 27128,
+      "line": 27235,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10646,7 +11166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c76a8c403a9eb7c3:1",
-      "line": 10030,
+      "line": 10135,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10656,7 +11176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c79d8ec5ac079056:1",
-      "line": 9909,
+      "line": 10014,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10666,7 +11186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c7f7b2c61be81a89:1",
-      "line": 25180,
+      "line": 25287,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10686,7 +11206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:c9a45d1d9f764cac:1",
-      "line": 25158,
+      "line": 25265,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10696,7 +11216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cb1de15e6476961e:1",
-      "line": 18779,
+      "line": 18886,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10716,7 +11236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cba87040da6b3001:1",
-      "line": 10050,
+      "line": 10155,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10726,7 +11246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cc7438ce557ac1d0:1",
-      "line": 9970,
+      "line": 10075,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10746,7 +11266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cd8b15702b31828c:1",
-      "line": 15015,
+      "line": 15122,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10766,7 +11286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce5a9317fb3af979:1",
-      "line": 26155,
+      "line": 26262,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10776,7 +11296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce5a9317fb3af979:2",
-      "line": 26227,
+      "line": 26334,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10786,7 +11306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ce66dc6d2bf8d0d8:1",
-      "line": 15116,
+      "line": 15223,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10796,7 +11316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cf0dd1a35f3c7e34:1",
-      "line": 26709,
+      "line": 26816,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10806,7 +11326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cf80a65c884dd0be:1",
-      "line": 24907,
+      "line": 25014,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10816,7 +11336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cfc622b3360c4d77:1",
-      "line": 9918,
+      "line": 10023,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10826,7 +11346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:cfd2a0b6fb9eac51:1",
-      "line": 16265,
+      "line": 16372,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10836,7 +11356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d0c9ed7c3d2f9c83:1",
-      "line": 13669,
+      "line": 13776,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10846,7 +11366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d12154361fe4d869:1",
-      "line": 27237,
+      "line": 27344,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10856,7 +11376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d1512d6c97bf21bb:1",
-      "line": 24440,
+      "line": 24547,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10866,7 +11386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d18ee531c39bd973:1",
-      "line": 26714,
+      "line": 26821,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10876,7 +11396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d1ae247d480dcbb9:1",
-      "line": 27674,
+      "line": 27781,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10886,7 +11406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d23ddb9678b7afbd:1",
-      "line": 26756,
+      "line": 26863,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10896,7 +11416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d2cd31b21ade7118:1",
-      "line": 10181,
+      "line": 10288,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10906,7 +11426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d2d96a21a9d15a4e:1",
-      "line": 10055,
+      "line": 10160,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10916,7 +11436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d3d0a2aacce4d236:1",
-      "line": 21141,
+      "line": 21248,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10926,7 +11446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d44c3760689488cf:1",
-      "line": 15506,
+      "line": 15613,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10946,7 +11466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d48f463b7016a35f:1",
-      "line": 16662,
+      "line": 16769,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10956,7 +11476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d555a0f78ebe7ceb:1",
-      "line": 16666,
+      "line": 16773,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10966,7 +11486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d56ac28822c7f087:1",
-      "line": 13433,
+      "line": 13540,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10976,7 +11496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d5eab4193775162e:1",
-      "line": 27091,
+      "line": 27198,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10986,7 +11506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d61a627265a5186e:1",
-      "line": 14896,
+      "line": 15003,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10996,7 +11516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d68a720cb1022b84:1",
-      "line": 9524,
+      "line": 9619,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11006,7 +11526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:1",
-      "line": 24779,
+      "line": 24886,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11016,7 +11536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:2",
-      "line": 26740,
+      "line": 26847,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11026,7 +11546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:3",
-      "line": 27350,
+      "line": 27457,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11036,7 +11556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d6931fbd6071cd26:4",
-      "line": 27702,
+      "line": 27809,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11046,7 +11566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d7054ddecdecb2a0:1",
-      "line": 9559,
+      "line": 9654,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11056,7 +11576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d72d9e72d4f3a17b:1",
-      "line": 26726,
+      "line": 26833,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11076,7 +11596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d7d56a7464e8f5b3:1",
-      "line": 16087,
+      "line": 16194,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11086,7 +11606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d7f040d901d9eeee:1",
-      "line": 10119,
+      "line": 10226,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11096,7 +11616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d8482b9f8d823ef4:1",
-      "line": 26727,
+      "line": 26834,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11116,7 +11636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d8a4e503703f505e:1",
-      "line": 26916,
+      "line": 27023,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11126,7 +11646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:d95de55fab6ad5ad:1",
-      "line": 26711,
+      "line": 26818,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11136,7 +11656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:da49eb6e798c7f5f:1",
-      "line": 25330,
+      "line": 25437,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11146,7 +11666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:da83ec605d06c165:1",
-      "line": 24532,
+      "line": 24639,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11156,7 +11676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:daedfce64925a80d:1",
-      "line": 26923,
+      "line": 27030,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11166,7 +11686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:db330feea131f18a:1",
-      "line": 13766,
+      "line": 13873,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11176,7 +11696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dbb3dec0819eacfc:1",
-      "line": 23409,
+      "line": 23516,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11196,7 +11716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dc67be849666c66e:1",
-      "line": 26716,
+      "line": 26823,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11206,7 +11726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dcbba1aed804c3cc:1",
-      "line": 20417,
+      "line": 20524,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11226,7 +11746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ddbf81f68eb26ab5:1",
-      "line": 9892,
+      "line": 9997,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11236,7 +11756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:de04154d5cf655d7:1",
-      "line": 15621,
+      "line": 15728,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11246,7 +11766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:de0e408974da99ae:1",
-      "line": 13769,
+      "line": 13876,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11256,7 +11776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:debf0c272ce8934a:1",
-      "line": 15131,
+      "line": 15238,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11266,7 +11786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:def561121aa38f1a:1",
-      "line": 9528,
+      "line": 9623,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11276,7 +11796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:df7728e04a8a6114:1",
-      "line": 24595,
+      "line": 24702,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11286,7 +11806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:dfe42585aa5eda4f:1",
-      "line": 26720,
+      "line": 26827,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11296,7 +11816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e04ef1a953d86622:1",
-      "line": 25508,
+      "line": 25615,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11306,7 +11826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e1112f888f975b87:1",
-      "line": 24266,
+      "line": 24373,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11316,7 +11836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e20b40e9da433575:1",
-      "line": 9454,
+      "line": 9549,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11326,7 +11846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e20e7b50fcc22489:1",
-      "line": 9455,
+      "line": 9550,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11346,7 +11866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e37dc6e11ac68066:1",
-      "line": 14479,
+      "line": 14586,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11356,7 +11876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3bbc251d76d2cc1:1",
-      "line": 25092,
+      "line": 25199,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11366,7 +11886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3dd8738b72afdf1:1",
-      "line": 20235,
+      "line": 20342,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11376,7 +11896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e3dd8738b72afdf1:2",
-      "line": 20240,
+      "line": 20347,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11386,7 +11906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4178bcaf4b76b3d:1",
-      "line": 24192,
+      "line": 24299,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11396,7 +11916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e43a3f4befd820da:1",
-      "line": 27187,
+      "line": 27294,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11406,7 +11926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e476907fcc0d1cb0:1",
-      "line": 15480,
+      "line": 15587,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11416,7 +11936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4782afde62e5c5a:1",
-      "line": 26692,
+      "line": 26799,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11426,7 +11946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e4b0b210d7c72ff4:1",
-      "line": 27232,
+      "line": 27339,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11436,7 +11956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e53f164febfd0a64:1",
-      "line": 12563,
+      "line": 12670,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11446,7 +11966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5417e4642efa5e7:1",
-      "line": 26884,
+      "line": 26991,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11456,7 +11976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e59b272b3f6baa43:1",
-      "line": 27225,
+      "line": 27332,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11466,7 +11986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e59dc9d3c750862a:1",
-      "line": 27008,
+      "line": 27115,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11476,7 +11996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5dd080eb0079eb4:1",
-      "line": 15601,
+      "line": 15708,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11496,7 +12016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e5eeba5978209923:1",
-      "line": 9862,
+      "line": 9967,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11506,7 +12026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e60cd4a237068776:1",
-      "line": 26710,
+      "line": 26817,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11516,7 +12036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e6213dbf749b2f84:1",
-      "line": 26782,
+      "line": 26889,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11526,7 +12046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e685278893a1646e:1",
-      "line": 27672,
+      "line": 27779,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11536,7 +12056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e6c3b28dbfefcb88:1",
-      "line": 9913,
+      "line": 10018,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11546,7 +12066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e72b3e0c6f390ccd:1",
-      "line": 15375,
+      "line": 15482,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11556,7 +12076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e75ffc427ee1b257:1",
-      "line": 24319,
+      "line": 24426,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11566,7 +12086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:e8da71b12cfb5a50:1",
-      "line": 27165,
+      "line": 27272,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11576,7 +12096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ea3b059be4106cfd:1",
-      "line": 10086,
+      "line": 10193,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11586,7 +12106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eadebb8b914a8fa5:1",
-      "line": 9935,
+      "line": 10040,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11596,7 +12116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb423e1709e85420:1",
-      "line": 27245,
+      "line": 27352,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11606,7 +12126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb4b4ff72f40de81:1",
-      "line": 10074,
+      "line": 10179,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11616,7 +12136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:eb96318ae36b4913:1",
-      "line": 24813,
+      "line": 24920,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11636,7 +12156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ecfb5bbd1435c6c6:2",
-      "line": 16146,
+      "line": 16253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11656,7 +12176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee11ef9a56b0be9f:1",
-      "line": 26703,
+      "line": 26810,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11666,7 +12186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee3fb3104fc6e48d:1",
-      "line": 22590,
+      "line": 22697,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11676,7 +12196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ee5eece78e40f295:1",
-      "line": 15437,
+      "line": 15544,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11686,7 +12206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:ef7c060e201a3297:1",
-      "line": 24869,
+      "line": 24976,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11716,7 +12236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f12e9271279bd591:1",
-      "line": 15555,
+      "line": 15662,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11736,7 +12256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f1a7449a1c36dab0:1",
-      "line": 24036,
+      "line": 24143,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11756,7 +12276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f248a1e26ac5cc09:1",
-      "line": 14084,
+      "line": 14191,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11766,7 +12286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f252e7eaf9e37429:1",
-      "line": 27311,
+      "line": 27418,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11776,7 +12296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f2a482c55d4b8bfb:1",
-      "line": 24865,
+      "line": 24972,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11806,7 +12326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f35283ed599f5e1e:1",
-      "line": 27730,
+      "line": 27837,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11816,7 +12336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f36013bf14def33f:1",
-      "line": 27362,
+      "line": 27469,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11826,7 +12346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f36557089879db4a:1",
-      "line": 12106,
+      "line": 12213,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11836,7 +12356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f4078a53a7e6629d:1",
-      "line": 26789,
+      "line": 26896,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11846,7 +12366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f47a8108aa3e78d3:1",
-      "line": 9965,
+      "line": 10070,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11856,7 +12376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f48aa05c03d90298:1",
-      "line": 27319,
+      "line": 27426,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11866,7 +12386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f55d5c58fe2c4b6f:1",
-      "line": 26860,
+      "line": 26967,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11876,7 +12396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f56054e03ade4a1f:1",
-      "line": 27698,
+      "line": 27805,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11906,7 +12426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:f80071156123b2ac:1",
-      "line": 10136,
+      "line": 10243,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11936,7 +12456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:faba1e348a75ffc6:1",
-      "line": 25533,
+      "line": 25640,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11946,7 +12466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fad89e3656e32e27:1",
-      "line": 15572,
+      "line": 15679,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11956,7 +12476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:1",
-      "line": 9896,
+      "line": 10001,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11966,7 +12486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:2",
-      "line": 10140,
+      "line": 10247,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11976,7 +12496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:3",
-      "line": 10146,
+      "line": 10253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -11986,7 +12506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fae7617fc8b00e94:4",
-      "line": 10156,
+      "line": 10263,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12006,7 +12526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fb3a4e7347c17952:1",
-      "line": 14066,
+      "line": 14173,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12016,7 +12536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fb4f3aea8230a6a1:1",
-      "line": 22873,
+      "line": 22980,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12036,7 +12556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fd3ddc57e24f0f1d:1",
-      "line": 14102,
+      "line": 14209,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -12056,7 +12576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/lib.rs:fdfd2735a0b731f6:1",
-      "line": 14365,
+      "line": 14472,
       "path": "implementations/rust/sugar-lift-rust-tests/src/lib.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -13815,8 +14335,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:0b40aa60dea8615c:1",
+      "line": 157,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": ".find(|reason| crate::refusal_disposition(reason) == Disposition::Unclassified);",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:1033250d4be66b24:1",
-      "line": 188,
+      "line": 226,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -13826,7 +14356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:37717c60413c1655:1",
-      "line": 58,
+      "line": 80,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -13835,23 +14365,43 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:efd79e34f9c46f53:1",
-      "line": 38,
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:8cea511558ba116f:1",
+      "line": 42,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "/// refuse (mutation, body not point-wise, or count mismatch).",
+      "text": "/// that `refusal_disposition` classifies `TerminalEffect`: a damn good SOURCE",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:ad45c48fefb9b252:1",
+      "line": 161,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": ".find(|reason| crate::refusal_disposition(reason) == Disposition::TerminalEffect)",
       "wire_marker": "internal-only"
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:f60d51fa796eb283:1",
-      "line": 113,
+      "line": 135,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": ".filter(|reason| crate::refusal_disposition(reason) == Disposition::Inactive)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs:fffdc449b7e412d0:1",
+      "line": 49,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/forall.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// Carries the body's own terminal reason VERBATIM, so `refusal_disposition`",
       "wire_marker": "internal-only"
     },
     {
@@ -19688,11 +20238,11 @@
   "schema": 1,
   "speaker_counts": {
     "emitter-provenance-guard": 3,
-    "lift-output-backlog": 1829,
+    "lift-output-backlog": 1883,
     "provenance-oracle-guard": 53,
-    "vendor-language-identifier": 1,
+    "vendor-language-identifier": 2,
     "verifier-verdict-quote": 40,
     "verify-dialect-boundary": 42
   },
-  "total_occurrences": 1968
+  "total_occurrences": 2023
 }


### PR DESCRIPTION
Targets the `core` half of main's red CI (run 30201463414). `acid test (make ci)` is a pure aggregator and clears itself once core and showcases are green. `showcases 1/4` and `core (claim-mass tripwires)` were cancelled, not failed.

## `core (coretests invariants)` — construction panic, product defect

`forall did not reach a lawful floor: bounded forall core declined` at `sugar/forall.rs`. Corpus is rust 1.96.0 `coretests/tests/slice.rs`, `test_align_to_empty_mid`: a `for offset in 0..4` whose body destructures `let (_, mid, _) = ...align_to::<Chunk>()`.

The DOMAIN (`0..4`) is a fine finite construction. The BODY assertion closed with a reason that `refusal_disposition` **already measured** `Disposition::TerminalEffect` ("destructured source runtime, not literal for `mid`"). `lift_bounded_forall` returned a bare `Option::None`, dropping that named reason on the floor, and the caller — having nothing left to say — panicked as an *unnamed* construction gap. That is a gap reported where the lifter had in fact already named the fact.

`lift_bounded_forall` now returns `Result<_, ForAllDecline>` and splits the decline by the disposition the body already measured:

- any `Unclassified` reason **wins** → `Gap` → the panic stays loud. Lifter work keeps its sacred red floor.
- only when every non-inactive reason is a named `TerminalEffect` → `BodyTerminal`, propagated as `Effect::ForAllBodyTerminal` carrying the body's string **verbatim**, so `refusal_disposition` classifies it exactly as it classified the body's and the reason CID is conserved.

No detector weakened: the terminal classification is **derived** from the body's own measurement, never asserted here, so **no reason string was added to the terminal whitelist**.

## `core (refusal vocabulary)` — one product bug, then a re-pin

`tools/check-lift-refusal-vocabulary.py` proves vendor ownership of a Python builtin exception name structurally: membership in the kit's explicit declaration AND resolution to a real builtin exception class. It only scanned `BUILTIN_EXCEPTION_NAMES`, and only `ast.Assign`. The newer `BUILTIN_EXCEPTION_BASES: dict[...] = {...}` is an `ast.AnnAssign`, so it was invisible and its `"ConnectionRefusedError"` key was miscounted as lifter output vocabulary.

The scanner now covers both declarations and both assignment forms. The substrate check is untouched, so a non-builtin name still cannot be laundered into vendor status. Backlog drops 1876 → 1875 honestly.

The self-test gains an arm pinning the `BUILTIN_EXCEPTION_BASES` row as vendor. Verified **both ways**: it FAILS when the declaration is removed from the scanner, PASSES when restored.

The remaining 46 rows are comment/docstring prose added by recent merges, re-pinned via `--write-current` — the census's own documented remedy, consistent with prior `re-ratchet ... census` commits.

## fmt — the "clean at head" report was stale

`cargo +1.96.0 fmt --all -- --check` exits **1** at pristine `origin/main`: one file, `coretests_sweep.rs:1194`. Reformatted with the CI-pinned rustfmt; now exit 0.

## Evidence

- `cargo check -p sugar-lift-rust-tests` — clean, zero new warnings
- `cargo +1.96.0 fmt --all -- --check` — exit 0
- `tools/check-lift-refusal-vocabulary.py` — PASS; `--self-test` — PASS, and verified red when the fix is removed

## Deliberately not pinned

`implementations/rust/coretests-invariants.json` is left untouched. The sweep **aborted** on the panic, so no honest post-fix numbers exist yet — pinning it from a guess would be a fabricated measurement. CI measures it.

## Not in this PR

The showcase shards (0/4, 2/4, 3/4) fail on `Makefile:497: test-showcases`, gate `A2 must be 0`, from causes tracked separately — see the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ForAllBodyTerminal` effect to propagate bounded forall body terminal reasons and fix refusal vocabulary ratchet
> - Adds `Effect::ForAllBodyTerminal { reason }` variant in [lib.rs](https://github.com/TSavo/sugar/pull/6343/files#diff-3f0d4bf15961ed6dc96f121ab7f72b5721adf2edd21a77ae0588d14e7956a233) to carry a forall body's terminal refusal reason verbatim through the system.
> - Introduces `ForAllDecline` enum in [forall.rs](https://github.com/TSavo/sugar/pull/6343/files#diff-36a7f3f509896db2470a964e7409e1df70285227d26a1b032a407e300d02d62a) to distinguish body-terminal closures from generic construction gaps in `lift_bounded_forall`, which now returns `Result` instead of `Option`.
> - `desugar_forall` emits `Outcome::Incomplete(Effect::ForAllBodyTerminal { reason })` when all non-inactive body assertions closed terminal, preserving the body's CID-carrying reason string.
> - Extends [check-lift-refusal-vocabulary.py](https://github.com/TSavo/sugar/pull/6343/files#diff-f08ac44b48b63deb620768028410a017a0fa493be41cb9bb1abebfcc5e14138b) to recognize builtin exception declarations via annotated assignment and from both `BUILTIN_EXCEPTION_NAMES` and `BUILTIN_EXCEPTION_BASES`, and updates the census JSON accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49a156b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->