### PR TITLE
An import-bound callee head closes its coordinate instead of minting a free var

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -270,6 +270,8 @@ class _Pass:
         self.module_identities = module_identities
         self.rows: list[dict[str, Any]] = []
         self.outcomes: dict[tuple[int, int, int, int], str] = {}
+        # Per-occurrence import targets for NAME uses, from this same pass.
+        self.name_targets: dict[tuple[int, int, int, int], str] = {}
         self.module_state = module_state or {}
         self.analyze_nested = analyze_nested
         self.class_outer_states: dict[int, State] = {}
@@ -310,6 +312,20 @@ class _Pass:
 
     def expression(self, node: Node | None, state: State, scope: Node) -> None:
         if node is None:
+            return
+        if node.kind == "Name":
+            # A name USE whose sole reaching definition is an import statement
+            # is lexically bound to that import's target coordinate.  Recorded
+            # here, by the same reaching-definition state the call rows use --
+            # never by a second resolver and never by spelling.
+            reaching = state.get(node.id, frozenset({_UNBOUND}))
+            if len(reaching) == 1:
+                definition = next(iter(reaching))
+                if isinstance(definition, _ImportDef):
+                    span = node.line_col_span()
+                    self.name_targets[
+                        (span.start_line, span.start_col, span.end_line, span.end_col)
+                    ] = definition.target_symbol
             return
         if node.kind == "Call":
             self.expression(node.func, state, scope)
@@ -775,6 +791,36 @@ def authenticated_import_uses(
     )
     runner.statements(module.body, {}, module)
     return runner.rows, runner.outcomes
+
+
+def import_bound_name_targets(
+    module: Module,
+    source_cid: str,
+    module_name: str = "",
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> dict[tuple[int, int, int, int], str]:
+    """Import targets per NAME occurrence, from the one lexical pass.
+
+    Same reaching-definition transfer that authenticates imported call uses --
+    read here at every name use so construction can close an import-bound head
+    into its target coordinate instead of minting an undeclared universe Var.
+    Takes the already-materialized typed Module: never a second parse.
+    """
+    identities = module_identities or {}
+    module_state = _final_module_state(
+        module=module,
+        source_cid=source_cid,
+        module_name=module_name,
+        module_identities=identities,
+    )
+    runner = _Pass(
+        source_cid=source_cid,
+        module_name=module_name,
+        module_identities=identities,
+        module_state=module_state,
+    )
+    runner.statements(module.body, {}, module)
+    return dict(runner.name_targets)
 
 
 def authenticated_import_use_receipts(

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_bound_callee_is_closed.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_bound_callee_is_closed.py
@@ -1,0 +1,100 @@
+"""An import-bound callee head is a CLOSED coordinate, never a free Var.
+
+`np.rot90(m)` under `import numpy as np` is not a method call on a value: `np`
+is a lexical import binding, so the callee names the closed coordinate
+`numpy.rot90`. Constructing the head as a receiver minted `np` as a universe
+Var that no contract ever declared, and `ScopedFormula` refused it (correctly)
+with `illegal free var(s): np`.
+
+The binding comes from the ONE lexical import pass (reaching definitions in
+``import_binding``), never from spelling. So the discrimination arm matters as
+much as the positive one: a head that is NOT uniquely import-bound -- a plain
+undeclared global, a shadowed alias -- must still mint its Var and must still
+trip the same panic. A fix that silences that case has broken the detector.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.proofir.formulas import formula_from_ir
+from sugar_lift_py_tests.proofir.scope import ScopedFormula
+from sugar_lift_py_tests.proofir.sorts import UnknownSort
+
+
+def _post(source: str):
+    directory = tempfile.mkdtemp()
+    path = os.path.join(directory, "m.py")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(source)
+    function = next(iter(SourceFile(path_source(path)).functions()))
+    return function.sugar().desugar(None).value.post()
+
+
+def _scoped(post, formals: tuple[str, ...]) -> ScopedFormula:
+    sort = UnknownSort(reason="lift is sort-silent; the compiler decides")
+    allowed = {name: sort for name in (*formals, "out")}
+    return ScopedFormula(
+        formula_from_ir(post, var_sorts=allowed), allowed_vars=allowed
+    )
+
+
+def test_module_alias_call_head_projects_a_closed_coordinate() -> None:
+    post = _post("import numpy as np\n\n\ndef turn(m):\n    return np.rot90(m)\n")
+    assert post.args[1].name == "call:numpy.rot90"
+    scoped = _scoped(post, ("m",))
+    assert scoped.formula.free_vars == {"m", "out"}
+
+
+def test_dotted_import_head_closes_the_whole_chain() -> None:
+    # `os.path.join` -- the same gap shape the pandas census catalogues with
+    # `os` (docs/audits/pandas-gap-census.md, pandas-gap-21).
+    post = _post("import os\n\n\ndef j(a, b):\n    return os.path.join(a, b)\n")
+    assert post.args[1].name == "call:os.path.join"
+    assert _scoped(post, ("a", "b")).formula.free_vars == {"a", "b", "out"}
+
+
+def test_from_import_module_binding_closes_too() -> None:
+    post = _post(
+        "from numpy import testing as t\n\n\ndef e(a, b):\n"
+        "    return t.assert_equal(a, b)\n"
+    )
+    assert post.args[1].name == "call:numpy.testing.assert_equal"
+
+
+def test_showcase_shape_binds_through_the_local_assignment() -> None:
+    post = _post(
+        "import numpy as np\n\n\ndef test_rot90_quarter_turn():\n"
+        "    r = np.rot90([[1, 2], [3, 4]])\n    return r[0][0]\n"
+    )
+    assert _scoped(post, ()).formula.free_vars == {"out"}
+
+
+def test_a_head_that_is_not_import_bound_still_refuses_scope() -> None:
+    # THE DISCRIMINATION. `zz` is bound by nothing: it must still mint a Var
+    # and ScopedFormula must still refuse the undeclared free var.
+    post = _post("def turn(m):\n    return zz.rot90(m)\n")
+    with pytest.raises(ConstructionPanic, match="illegal free var.*zz"):
+        _scoped(post, ("m",))
+
+
+def test_a_shadowed_import_alias_is_not_import_bound() -> None:
+    # The alias is rebound before the use, so the reaching definition is no
+    # longer the import: the head constructs as an ordinary receiver.
+    post = _post(
+        "import numpy as np\n\n\ndef turn(m):\n    np = m\n    return np.rot90(m)\n"
+    )
+    assert post.args[1].name == "call:rot90"
+
+
+def test_a_parameter_method_call_is_untouched() -> None:
+    post = _post("def turn(m):\n    return m.copy()\n")
+    assert post.args[1].name == "call:copy"
+    assert _scoped(post, ("m",)).formula.free_vars == {"m", "out"}

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -161,6 +161,8 @@ class SourceUnit:
     # Memo for exception_type_identity: full-module walk was ~12ms/call on
     # asserters and dominated Raise exclusive heat under Body.If.
     _exception_type_identity_cache: dict = field(init=False, default_factory=dict)
+    # Memo for the module's per-occurrence import-binding map (one lexical pass).
+    _import_bound_name_targets: object = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -182,6 +184,27 @@ class SourceUnit:
         object.__setattr__(self, "module_direct_bindings", None)
         object.__setattr__(self, "function_nodes", ())
         object.__setattr__(self, "_exception_type_identity_cache", {})
+        object.__setattr__(self, "_import_bound_name_targets", None)
+
+    def import_bound_name_target(
+        self, span: Tuple[int, int, int, int]
+    ) -> Optional[str]:
+        """The import target coordinate bound to the name USE at ``span``.
+
+        ``None`` when this module has no typed root yet or the name at that
+        occurrence is not uniquely import-bound -- a non-import name keeps its
+        ordinary construction, and stays as loud as it was.
+        """
+        targets = self._import_bound_name_targets
+        if targets is None:
+            module = self.typed_module
+            if module is None:
+                return None
+            from sugar_lift_py_tests.import_binding import import_bound_name_targets
+
+            targets = import_bound_name_targets(module, self.source_cid)
+            object.__setattr__(self, "_import_bound_name_targets", targets)
+        return targets.get(span)
 
     def bind_typed_module(self, module: "Module") -> None:
         """Attach the already-materialized Module root (SourceFile only)."""
@@ -7031,6 +7054,21 @@ class Call(Expression):
                 source_call_frame=source_call_frame,
             )
         if isinstance(self.func, Attribute):
+            closed_symbol = self._import_bound_callee_symbol()
+            if closed_symbol is not None:
+                from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+                # The head is lexically bound to an import: the callee is a
+                # CLOSED coordinate (`numpy.rot90`), so the call-site absorbs
+                # the whole dotted spelling exactly as it does for a Name
+                # callee. No receiver constructs, so no module alias is minted
+                # as a universe Var it was never declared as.
+                return CallSiteSugar(
+                    target_name=closed_symbol,
+                    args=tuple(a.sugar() for a in self.args),
+                    site=self.fragment,
+                    keywords=keyword_sugars,
+                )
             from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
 
             return MethodCallSugar(
@@ -7066,6 +7104,39 @@ class Call(Expression):
             keywords=keyword_sugars,
             source_call_frame=source_call_frame,
         )
+
+    def _import_bound_callee_symbol(self) -> Optional[str]:
+        """The closed target coordinate of a dotted callee whose head is imported.
+
+        ``np.rot90`` under ``import numpy as np`` is not a method on a value:
+        the head is a lexical import binding, so the callee names the closed
+        coordinate ``numpy.rot90``. The binding comes from the one lexical
+        import pass (reaching definitions), never from the spelling: a head
+        that is not uniquely import-bound -- a parameter, a local, a shadowed
+        or ambiguous name -- returns ``None`` and constructs as before.
+        """
+        link = self.func
+        attributes: list[str] = []
+        while isinstance(link, Attribute):
+            attributes.append(link.attr)
+            link = link.value
+        if not isinstance(link, Name):
+            return None
+        span = link.line_col_span()
+        target = self.unit.import_bound_name_target(
+            (span.start_line, span.start_col, span.end_line, span.end_col)
+        )
+        if target is None:
+            return None
+        # The spelling is absorbed into the call-site coordinate, so every node
+        # of the callee chain answers the roll call as present-inert.
+        link.discharge_by_substitution()
+        chain = self.func
+        while isinstance(chain, Attribute):
+            chain.discharge_by_substitution()
+            chain = chain.value
+        module = target[len("python:") :] if target.startswith("python:") else target
+        return ".".join([module, *reversed(attributes)])
 
     @staticmethod
     def _spread_callee_name(callee: Expression) -> Optional[str]:


### PR DESCRIPTION
Closes CI cause (A) — the `ScopedFormula` free-var construction panic behind the numpy showcase.

`np.rot90(m)` routed to `MethodCallSugar`, which desugars its receiver — the bare `Name` `np` — and `NameSugar` unconditionally mints `SymbolicValue(make_var("np"))`. That Var was never a declared formal, so `ScopedFormula` refused it.

**The panic was correct**, and `name_sugar.py`'s own docstring states the violated invariant: *"The only Name left standing is a function parameter, which is masked by substitute and therefore free."* Import-bound module aliases are never substituted, so they reached `NameSugar` and were minted as formals nobody declared.

**This closes the coordinate rather than widening the scope.** `ScopedFormula` is untouched and still refuses every undeclared free var, loudly.

```
POST (before):  call:rot90(np, m)    -> panic, illegal free var(s): np
POST (after):   call:numpy.rot90(m)  -> closed, content-addressable
```

Nothing keys off spelling: a shadowed, ambiguous, or unbound head returns `None` and constructs exactly as before.

**Verified with the fix DISABLED** (stubbing `import_bound_name_target -> None`): **4 failed, 3 passed** — the positive tests fail with the original panic, the discrimination tests still pass. So the positive arm genuinely depends on the fix, and the discrimination arm would catch a silencing one.

Discrimination, both arms run: `zz.rot90(m)` still panics; bare undeclared `zz` still panics; shadowed `np = m; np.rot90(m)` unchanged; `m.copy()` unchanged.

Roll call improves on the showcase source, R=4 → R=3, with no `Name` or `Attribute` unanswered.

**Not closed, and loud rather than silent:** non-call attribute reads on an import-bound head (`np.pi` as a value) still panic; relative-import heads are a conservative miss. Both stated in the commit message with the reasons.

**Not verified:** the numpy showcase end-to-end — no release `sugar` binary on the box, so tests shelling out to `sugar mint/prove/lift` failed on environment. The construction-layer defect and its exact panic are verified; the showcase verdict is not.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close import-bound callee heads as coordinates instead of minting free variables
> - When an `Attribute`-style call (e.g. `numpy.rot90(...)`) has a head `Name` whose sole reaching definition is an import, the call is now emitted as a `CallSiteSugar` with a closed callee coordinate (e.g. `numpy.rot90`) rather than a `MethodCallSugar` with a receiver.
> - A new `import_bound_name_targets` function in [`import_binding.py`](https://github.com/TSavo/sugar/pull/6346/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) computes a per-occurrence map from source spans to import target symbols by inspecting reaching definitions.
> - `SourceUnit` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6346/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) lazily memoizes this map and exposes it via `import_bound_name_target(span)`; `Call._import_bound_callee_symbol` walks the attribute chain, queries the map, and marks traversed nodes as substituted.
> - New tests in [`test_import_bound_callee_is_closed.py`](https://github.com/TSavo/sugar/pull/6346/files#diff-54a2302fcfda7a98ad09e79c2df35cefbf29a385ae106d7fcf0e9a7075d75869) cover bound, unbound, and shadowed name cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82146e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->