### PR TITLE
rust-cargo-test-witness constructs through sugar.enumerate, not the retired lift

### DIFF
--- a/implementations/rust/sugar-lift-rust-cargo-test-witness/src/bin/witness_rpc.rs
+++ b/implementations/rust/sugar-lift-rust-cargo-test-witness/src/bin/witness_rpc.rs
@@ -22,6 +22,12 @@ const SURFACE: &str = "rust-cargo-test-witness";
 const KIT_DECLARATION_RPC_METHOD: &str = "sugar.plugin.kit_declaration";
 const COMPONENT_PLAN_RPC_METHOD: &str = "sugar.component.plan";
 const RESOLVE_WITNESS_RPC_METHOD: &str = "sugar.plugin.resolve_witness";
+// The ONE construction door. There is no `lift` kit method: full-tree
+// construction is `sugar.enumerate` over the SourceTree (#6222). This kit is
+// the Rust twin of `sugar_pytest_witness.lift_lsp`, which crossed the same
+// membrane first; the level protocol is
+// `protocol/specs/2026-07-08-enumeration-protocol.md`.
+const ENUMERATE_RPC_METHOD: &str = "sugar.enumerate";
 
 fn send(obj: &Value) {
     let mut out = std::io::stdout().lock();
@@ -74,6 +80,120 @@ fn handle_lift(id: &Value, params: &Value) -> Value {
         }),
         Err(e) => err_reply(id, e),
     }
+}
+
+// ---------------------------------------------------------------------------
+// `sugar.enumerate` -- the ONE construction door
+// ---------------------------------------------------------------------------
+
+/// Levels a SOURCE kit censuses that a witness PRODUCER has nothing to say
+/// about. Answering an empty census (rather than an error) keeps `prove`/report
+/// walks that sweep every registered surface from failing on this kit. Byte-for
+/// byte the python witness kit's `_EMPTY_CENSUS_LEVELS`.
+const EMPTY_CENSUS_LEVELS: &[&str] = &[
+    "functions",
+    "call_sites",
+    "assertions",
+    "facts",
+    "implications",
+    "exports",
+    "contract-declarations",
+    "provider-contract-members",
+    "contract-demands",
+    "context-manager-edges",
+    "parameter-contract-resume",
+];
+
+fn enumerate_result(id: &Value, nodes: Vec<Value>, gaps: Vec<Value>) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "result": {"nodes": nodes, "gaps": gaps}})
+}
+
+/// `sugar.enumerate`: `source_files` censuses the crate's real source closure;
+/// `universe` emits this kit's contribution.
+///
+/// A witness package is a WHOLE-SUITE artifact, not a per-file one, so the
+/// suite runs exactly once: the census reports every `.rs` file (so the Rust
+/// fold's `sourceMementos`/`sourceLedger` testify the real source closure), and
+/// the package's two IR rows -- the custom-evidence contract and its signed
+/// WitnessPackageMemento -- are emitted at the ANCHOR file only (the first code
+/// file in sorted order). Every other file answers an empty universe, which is
+/// the truth: it contributes no contract of its own.
+///
+/// `discover_rust_files` returns `["."]` as its test-file handle -- a stable
+/// suite identifier, not a real path -- so the anchor is taken from the CODE
+/// files, which are real files with real mementos.
+fn handle_enumerate(id: &Value, params: &Value) -> Value {
+    let level = params.get("level").and_then(Value::as_str).unwrap_or("");
+    let ws = resolve_root(params);
+
+    if level == "parameter-contract-link-units" {
+        // A witness producer enrolls no parameter-contract link units.
+        return json!({"jsonrpc": "2.0", "id": id, "result": {"rows": []}});
+    }
+    if EMPTY_CENSUS_LEVELS.contains(&level) {
+        return enumerate_result(id, Vec::new(), Vec::new());
+    }
+
+    if level == "source_files" {
+        let (code_files, _test_files) = kit::discover_rust_files(&ws);
+        let mut nodes = Vec::new();
+        let mut gaps = Vec::new();
+        for rel in &code_files {
+            match kit::file_source_memento(&ws, rel) {
+                Ok(memento) => nodes.push(
+                    json!({"memento": memento, "audit": Value::Null, "payload": Value::Null}),
+                ),
+                Err(reason) => gaps.push(json!({
+                    "memento": kit::degenerate_file_memento(rel, None),
+                    "reason": reason,
+                })),
+            }
+        }
+        return enumerate_result(id, nodes, gaps);
+    }
+
+    if level == "universe" {
+        let at = params.get("at").cloned().unwrap_or(Value::Null);
+        let file_rel = at.get("file").and_then(Value::as_str);
+        let Some(anchor) = kit::enumerate_anchor_file(&ws) else {
+            // No readable code file at all means no package -- an empty
+            // universe, not a gap (the census already testified the reason).
+            return enumerate_result(id, Vec::new(), Vec::new());
+        };
+        if file_rel != Some(anchor.as_str()) {
+            // Not the anchor: no contract of its own.
+            return enumerate_result(id, Vec::new(), Vec::new());
+        }
+        let result = match kit::lift_project(&ws) {
+            // No tests -> no witness package. An empty universe, not a gap.
+            Ok(None) => return enumerate_result(id, Vec::new(), Vec::new()),
+            Ok(Some(result)) => result,
+            Err(e) => return err_reply(id, e),
+        };
+        // Write the package bundle to disk (audit material; never fail lift).
+        let _ = kit::write_bundle_package(&ws, &result.bundle_cid, &result.bundle_bytes);
+        let anchor_memento = match kit::file_source_memento(&ws, &anchor) {
+            Ok(memento) => memento,
+            Err(reason) => return err_reply(id, reason),
+        };
+        let nodes = result
+            .ir
+            .into_iter()
+            .map(|row| {
+                json!({"memento": anchor_memento.clone(), "audit": row, "payload": Value::Null})
+            })
+            .collect();
+        return enumerate_result(id, nodes, Vec::new());
+    }
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32602,
+            "message": format!("sugar.enumerate: unknown level `{level}`"),
+        },
+    })
 }
 
 /// The ORACLE's resolve surface (mirror python `handle_resolve_witness`). Given a
@@ -213,7 +333,9 @@ fn kit_declaration() -> Value {
             {"name": "initialize", "required": true},
             {"name": KIT_DECLARATION_RPC_METHOD, "required": true},
             {"name": COMPONENT_PLAN_RPC_METHOD, "required": false},
-            {"name": "lift", "required": true},
+            // lift is not a kit method: full-tree construction is
+            // sugar.enumerate only (#6222). Same eviction the python kits made.
+            {"name": ENUMERATE_RPC_METHOD, "required": true},
             {"name": RESOLVE_WITNESS_RPC_METHOD, "required": false},
             {"name": "shutdown", "required": false},
         ]},
@@ -339,6 +461,7 @@ fn main() {
                 send(&json!({"jsonrpc": "2.0", "id": id, "result": component_plan(&params)}))
             }
             "lift" => send(&handle_lift(&id, &params)),
+            ENUMERATE_RPC_METHOD => send(&handle_enumerate(&id, &params)),
             RESOLVE_WITNESS_RPC_METHOD => send(&handle_resolve_witness(&id, &params)),
             "shutdown" => {
                 send(&json!({"jsonrpc": "2.0", "id": id, "result": Value::Null}));

--- a/implementations/rust/sugar-lift-rust-cargo-test-witness/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-cargo-test-witness/src/lib.rs
@@ -845,6 +845,66 @@ pub fn blake3_of(bytes: &[u8]) -> String {
     blake3_512_of(bytes)
 }
 
+// ---------------------------------------------------------------------------
+// `sugar.enumerate` primitives (the ONE construction door -- there is no `lift`
+// kit method). The wire glue lives in `bin/witness_rpc.rs`; the identity and
+// anchor decisions live here so they are pinned by unit tests rather than only
+// by a suite-running end-to-end showcase.
+// ---------------------------------------------------------------------------
+
+/// The file-level locator: a `source-memento` carrying only `file` and the
+/// file's content CID. A whole file has no single body span or AST template, so
+/// those stay absent. Same shape the python kits seal
+/// (`lift_lsp._degenerate_file_memento`).
+pub fn degenerate_file_memento(rel: &str, source_cid: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "source-memento",
+        "file": rel,
+        "function_name": "",
+        "span": serde_json::Value::Null,
+        "param_names": [],
+        "source_cid": source_cid,
+        "template_cid": serde_json::Value::Null,
+    })
+}
+
+/// Seal one file's locator through the SAME minting door every other kit uses:
+/// read as UTF-8 text, then content-address the decoded bytes -- byte-for-byte
+/// what `path_source` does in the python source oracle. A kit that minted its
+/// own identity would address the same file differently than every other kit,
+/// and the same source would occupy two addresses.
+///
+/// Unreadable or undecodable is a LOUD `Err`, never a node with a made-up
+/// identity: the caller records it as an enumeration gap, not an absence.
+pub fn file_source_memento(project_dir: &Path, rel: &str) -> Result<serde_json::Value, String> {
+    let full = project_dir.join(rel);
+    let bytes = std::fs::read(&full).map_err(|e| format!("cannot read source `{rel}`: {e}"))?;
+    let text = String::from_utf8(bytes)
+        .map_err(|e| format!("cannot decode source `{rel}` as utf-8: {e}"))?;
+    let cid = blake3_of(text.as_bytes());
+    Ok(degenerate_file_memento(rel, Some(&cid)))
+}
+
+/// The ANCHOR file for this kit's universe: the first code file, in sorted
+/// order, whose locator the census could actually seal.
+///
+/// A witness package is a WHOLE-SUITE artifact, not a per-file one. The census
+/// must still report every file (so the fold's `sourceMementos`/`sourceLedger`
+/// testify the real source closure), but the package's IR rows are emitted at
+/// exactly one file; every other file answers an empty universe, which is the
+/// truth -- it contributes no contract of its own.
+///
+/// A file that GAPPED in the census has no memento to be asked `at`, so it can
+/// never be the anchor. `discover_rust_files` returns `["."]` for its test-file
+/// handle -- a stable suite identifier, not a real path -- which is why the
+/// anchor is taken from the code files.
+pub fn enumerate_anchor_file(project_dir: &Path) -> Option<String> {
+    let (code_files, _test_files) = discover_rust_files(project_dir);
+    code_files
+        .into_iter()
+        .find(|rel| file_source_memento(project_dir, rel).is_ok())
+}
+
 /// Read the proofData JSON out of a serialized custom-evidence EvidenceTerm (the
 /// shape `prove` writes to the temp `.proof` and hands the discharge bin):
 ///   {"kind":"evidence","proofType":"custom","certificate":{...,"proofData":"<json>"}}

--- a/implementations/rust/sugar-lift-rust-cargo-test-witness/src/tests.rs
+++ b/implementations/rust/sugar-lift-rust-cargo-test-witness/src/tests.rs
@@ -370,3 +370,126 @@ fn cid_filename_replaces_colon_with_underscore() {
         format!("{proof_stem}.witness")
     );
 }
+
+// ------- sugar.enumerate PRIMITIVES -------
+//
+// There is no `lift` kit method: full-tree construction is `sugar.enumerate`
+// over the SourceTree (#6222). These pin the two decisions the wire glue in
+// `bin/witness_rpc.rs` delegates here -- file IDENTITY and the universe ANCHOR
+// -- so neither can drift without a red test. They do not spawn `cargo test`.
+
+/// A scratch crate laid out the way `discover_rust_files` walks: `.rs` under
+/// the project root, `target/` skipped.
+fn scratch_project(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "sugar-witness-enumerate-{tag}-{}-{}",
+        std::process::id(),
+        blake3_512_of(tag.as_bytes())
+            .chars()
+            .rev()
+            .take(12)
+            .collect::<String>()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir scratch src");
+    dir
+}
+
+#[test]
+fn file_memento_mints_identity_through_the_shared_content_door() {
+    let dir = scratch_project("identity");
+    let body = "pub fn one() -> u32 { 1 }\n";
+    std::fs::write(dir.join("src").join("lib.rs"), body).expect("write source");
+
+    let memento = file_source_memento(&dir, "src/lib.rs").expect("seal the locator");
+
+    assert_eq!(memento["kind"], "source-memento");
+    assert_eq!(memento["file"], "src/lib.rs");
+    // The CID is the content address of the DECODED utf-8 bytes -- the same
+    // door `path_source` uses python-side. A kit minting its own identity would
+    // address the same file differently than every other kit.
+    assert_eq!(memento["source_cid"], blake3_of(body.as_bytes()));
+    // A whole file has no single body span or AST template.
+    assert!(memento["span"].is_null(), "file locator carries no span");
+    assert!(
+        memento["template_cid"].is_null(),
+        "file locator carries no ast template"
+    );
+    assert_eq!(memento["function_name"], "");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn undecodable_source_is_a_loud_error_never_a_made_up_identity() {
+    let dir = scratch_project("undecodable");
+    // Lone 0x80 continuation byte: valid to read, invalid utf-8.
+    std::fs::write(dir.join("src").join("lib.rs"), [0x80u8]).expect("write source");
+
+    let sealed = file_source_memento(&dir, "src/lib.rs");
+
+    let reason = sealed.expect_err("undecodable source must not seal a locator");
+    assert!(
+        reason.contains("src/lib.rs") && reason.contains("utf-8"),
+        "the gap must name the file and why it could not be sealed: {reason}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_source_is_a_loud_error_never_a_made_up_identity() {
+    let dir = scratch_project("missing");
+
+    let sealed = file_source_memento(&dir, "src/absent.rs");
+
+    let reason = sealed.expect_err("an absent file must not seal a locator");
+    assert!(
+        reason.contains("src/absent.rs"),
+        "the gap must name the file it could not read: {reason}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn universe_anchor_is_the_first_sealable_code_file_in_sorted_order() {
+    let dir = scratch_project("anchor");
+    std::fs::write(dir.join("src").join("zeta.rs"), "pub fn z() {}\n").expect("write zeta");
+    std::fs::write(dir.join("src").join("alpha.rs"), "pub fn a() {}\n").expect("write alpha");
+
+    let anchor = enumerate_anchor_file(&dir).expect("a readable code file anchors the universe");
+
+    // The witness package is a WHOLE-SUITE artifact emitted at exactly one
+    // file; sorted order is what makes that one file deterministic.
+    assert_eq!(anchor, "src/alpha.rs");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn universe_anchor_skips_a_file_that_gapped_in_the_census() {
+    let dir = scratch_project("anchor-gap");
+    // `alpha.rs` sorts first but cannot be sealed, so it has no memento to be
+    // asked `at` and can never be the anchor.
+    std::fs::write(dir.join("src").join("alpha.rs"), [0x80u8]).expect("write alpha");
+    std::fs::write(dir.join("src").join("beta.rs"), "pub fn b() {}\n").expect("write beta");
+
+    let anchor = enumerate_anchor_file(&dir).expect("the sealable file anchors the universe");
+
+    assert_eq!(anchor, "src/beta.rs");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_project_with_no_sealable_code_file_has_no_anchor() {
+    let dir = scratch_project("anchor-none");
+
+    assert!(
+        enumerate_anchor_file(&dir).is_none(),
+        "no readable code file means an empty universe, not a fabricated anchor"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What this is

Main's showcase red is not manifest drift. `a42524ee8` (#6222, two days ago) retired the `lift` JSON-RPC method and said so in its own message: *"Kits that lack enumerate and only advertise lift fail loudly."* It migrated the two Python kits and left every Rust kit behind. The CLI refusal at `implementations/rust/sugar-cli/src/lift_plugin.rs:417` is correct and untouched here; the kits are what is unfinished.

The law, from the doc comment #6222 added at `implementations/rust/sugar-compiler/src/tree.rs:1232`:

> There is no `lift` RPC. What used to be called "lift" is this walk: `source_files` -> per-file `universe` ... must never send JSON-RPC method `"lift"`.

## Migration status

Grepped for an actual server-side `sugar.enumerate` handler, not just the string:

| kit | surface | enumerate handler | state |
|---|---|---|---|
| `sugar_lift_py_tests.lift_rpc` | `python` | yes | migrated by #6222 |
| `sugar_pytest_witness.lift_lsp` | `python-pytest-witness` | yes | migrated by #6222 |
| `witness_rpc` | `rust-cargo-test-witness` | **this PR** | migrated here |
| `rust_test_assertions_rpc` | `rust-test-assertions` | no | still red |
| `walk_rpc` | `rust-fn-contracts` | no | still red |
| `sugar_lift_python_source` | `python-source` | no | still red |

## Why not the manifest

Neither manifest branch was available. These kits do not implement the level protocol at all, so advertising `sugar.enumerate` on the manifest would name a method the plugin does not implement. And setting a non-`lift` `method` would be a rename of the retired door: three of the four are whole-tree constructors (`rust_test_assertions_rpc` does its own `enumerate_rs_files` walk and returns a whole-tree `ir-document`), so a rename preserves the retired construction shape under a new spelling and converts an accurate loud refusal into silence. The `rust-implications` sibling is not a counterexample: it is a genuine `phase = "consumer"` plugin over an already-constructed tree.

**No manifest changes in this PR, and none are needed.** Method-less is *correct* under the new law, which is why the already-migrated Python kits' manifests are also method-less and green. That includes the inline manifest generated at `examples/std-core-bodyguard-precondition/run.sh:402-415` — it is a `rust-cargo-test-witness` manifest, so it goes green with the kit, not with an edit.

## What changed

`witness_rpc` serves `sugar.enumerate`:

- `source_files` censuses the crate's real source closure. An unreadable or undecodable file is a first-class gap with a reason, never a node carrying a made-up identity.
- `universe` emits the kit's two IR rows (the custom-evidence contract and its signed `WitnessPackageMemento`) at the **anchor file only**; every other file answers an empty universe, which is the truth — it contributes no contract of its own. A witness package is a whole-suite artifact, so the suite still runs exactly once. Same shape `sugar_pytest_witness.lift_lsp` already serves.
- Census levels a witness producer has nothing to say about answer empty rather than erroring, so `prove`/report sweeps over every registered surface do not fail on this kit. An unknown level is a loud `-32602`.
- `lift` leaves the kit declaration exactly the way it left the Python kits'.

File identity is minted through the shared content door — decode utf-8, then content-address the decoded bytes, byte-for-byte what `path_source` does python-side — so this kit addresses a file exactly as every other kit does rather than giving the same source a second address.

The identity and anchor decisions live in the lib rather than the wire glue, so unit tests pin them instead of only a suite-running showcase: deterministic anchor, anchor skips a file that gapped in the census, unsealable file is a loud error, no sealable file means no anchor rather than a fabricated one.

## Shot accounting

- **R component:** surfaces whose kit cannot construct through `sugar.enumerate`. `R = 4` at `8373415a5`.
- **Predicted Epsilon R:** `-1` (`rust-cargo-test-witness`). The showcases that use *only* this surface go green; the ones that also mount `rust-test-assertions` or `rust-fn-contracts` stay red on those surfaces.
- **Shell deleted:** none yet, and I will not claim one. The retirement path for this axis is that `lift` stops being reachable at all once the last kit migrates, at which point `handle_lift` and the CLI's `manifest.method` branch both become deletable. Three kits still hold that door open.
- **Floors preserved:** no detector weakened, no test skipped, no gate loosened, no assertion pattern relaxed, no refusal widened. The CLI refusal is unchanged.

## Validation (measured on battleaxe, after the box recovered)

The first bcargo green on this branch was worthless and I am recording why: it ran during the ~09:05-09:19 PDT window when another agent's baseline was in a memory blowup and thrashing the box, and I confirmed afterward that the tree it built had caught an intermediate state (the bin edits synced, the later lib extraction did not). Re-measured on the recovered box, on the final commit, with exit status captured directly and never through a pipe:

```
bcargo build -p sugar-lift-rust-cargo-test-witness --bin witness_rpc   BUILD_EXIT=0
bcargo test  -p sugar-lift-rust-cargo-test-witness --lib               TEST_EXIT=0
  test result: ok. 23 passed; 0 failed  (18 pre-existing + 5 new)
```

Remote tree confirmed to carry the final commit (`enumerate_anchor_file` present in both `lib.rs` and `bin/witness_rpc.rs`, and the new test present in `tests.rs`) before the numbers above were taken.

**Discrimination — the new tests can actually fail.** A green test that cannot go red is not an instrument, so I mutated the anchor to drop its census-gap skip (`.find(|rel| file_source_memento(..).is_ok())` -> `.find(|_rel| true)`) and re-ran:

```
MUTANT_TEST_EXIT=101
test tests::universe_anchor_skips_a_file_that_gapped_in_the_census ... FAILED
  left: "src/alpha.rs"
 right: "src/beta.rs"
test result: FAILED. 22 passed; 1 failed
```

Exactly the one test that owns that law fired, and nothing else did. Mutation reverted; working tree byte-identical to HEAD, and re-confirmed green (`RESTORED_TEST_EXIT=0`, 23 passed).

Rebased onto current `origin/main` (`31ca5580c`) so this is not measured on a stale base. Still exactly 3 files.

## Known inherited red

Showcase jobs have not actually run on main in the recent window — the last three completed CI runs on main all failed at `shared Rust build` and skipped the showcase shards — so the showcase failure set is inferred from the kit declarations, not read off a job log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `lift` RPC with `sugar.enumerate` as the construction entrypoint in rust-cargo-test-witness
> - Adds a `sugar.enumerate` JSON-RPC handler in [`witness_rpc.rs`](https://github.com/TSavo/sugar/pull/6347/files#diff-46e4914cb1381e441549d93271197423fff22889dbf1c76bb22f14104a356266) that branches by census level: returns source file nodes with per-file mementos and gaps, emits universe IR rows at a deterministic anchor file, returns empty census for a fixed set of levels, and returns a `-32602` error for unknown levels.
> - Removes `lift` from the kit declaration and replaces it with `sugar.enumerate` as the advertised required method.
> - Adds helper functions in [`lib.rs`](https://github.com/TSavo/sugar/pull/6347/files#diff-3ada30a0c1c6369c38e7f0612bcb0ceee2e81586333469d9f0bd9ce4ae4ea4d9) for building file mementos, computing blake3 content CIDs, and selecting the lexicographically first sealable file as the universe anchor.
> - Adds tests in [`tests.rs`](https://github.com/TSavo/sugar/pull/6347/files#diff-cbf19efee3740b3be747f0ca0ae300e89be825fcf149e81d766e45f5fbab4707) covering memento minting, unreadable/undecodable file error paths, and anchor selection logic.
> - Behavioral Change: the kit no longer responds to `lift` RPC calls as a construction path; callers must use `sugar.enumerate` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a90c8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `sugar.enumerate` support for discovering Rust source files and project-level results.
  - Added stable source-file mementos based on readable file contents.
  - Added graceful handling for empty census levels and unavailable source files.
  - Added clear errors for unsupported census levels and failed project lifting.

- **Bug Fixes**
  - Prevents fabricated file identities when source files are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
