### PR TITLE
test: pin _rpc_canonical_bytes with a differential twin whose oracle is the deleted pre-scan

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_rpc_canonical_bytes_differential.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_rpc_canonical_bytes_differential.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# THE ENCODER IS THE PROTOCOL. `ir._rpc_canonical_bytes` was rewritten from a
+# pre-scan (`any(...)` over every character, asking whether a surrogate is
+# present) into a try/except around the encode that answers the same question
+# in C. The rewrite is a pure speed change: every string must produce
+# byte-identical output, and therefore an identical CID, before and after.
+#
+# The ORACLE is the pre-scan itself, kept here verbatim. It is not a
+# re-derivation -- it is the exact code that shipped, so byte identity is
+# measured against the thing that minted every pinned CID.
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from sugar_lift_py_tests.ir import _rpc_canonical_bytes
+
+SURROGATES = range(0xD800, 0xE000)
+
+
+def _oracle_rpc_canonical_bytes(canonical: str) -> bytes:
+    """The pre-optimization pre-scan, verbatim. THE specification."""
+    if not any(0xD800 <= ord(char) <= 0xDFFF for char in canonical):
+        return canonical.encode("utf-8")
+    safe = "".join("�" if 0xD800 <= ord(char) <= 0xDFFF else char for char in canonical)
+    return safe.encode("utf-8")
+
+
+def test_encode_refuses_exactly_the_surrogate_range() -> None:
+    """The load-bearing assumption of the rewrite.
+
+    The try/except is only equivalent to the pre-scan if `str.encode("utf-8")`
+    raises on every surrogate and on nothing else. If CPython ever widened or
+    narrowed that set, the rewrite would silently change bytes -- so this is
+    asserted directly over the entire codepoint space, not sampled.
+    """
+    refused = set()
+    for codepoint in range(0x110000):
+        try:
+            chr(codepoint).encode("utf-8")
+        except UnicodeEncodeError:
+            refused.add(codepoint)
+    assert refused == set(SURROGATES)
+    assert len(refused) == 2048
+
+
+def test_byte_identity_over_every_codepoint() -> None:
+    """Exhaustive single-character twin across the whole codepoint space."""
+    mismatches = [
+        hex(codepoint)
+        for codepoint in range(0x110000)
+        if _rpc_canonical_bytes(chr(codepoint))
+        != _oracle_rpc_canonical_bytes(chr(codepoint))
+    ]
+    assert mismatches == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "a",
+        "ascii only",
+        "café",
+        "中文字",
+        "\U0001f41d",
+        "\ud800",
+        "\udfff",
+        "a\ud800b",
+        "\ud800\U0001f41d",
+        "�\ud800�",
+        "\x00\ud800",
+        "𐀀",
+    ],
+    ids=[
+        "empty",
+        "ascii-single",
+        "ascii-run",
+        "latin1",
+        "cjk",
+        "astral",
+        "lone-high",
+        "lone-low",
+        "surrogate-interior",
+        "surrogate-plus-astral",
+        "replacement-around-surrogate",
+        "nul-plus-surrogate",
+        "surrogate-pair-unpaired-in-str",
+    ],
+)
+def test_byte_identity_named_edges(value: str) -> None:
+    assert _rpc_canonical_bytes(value) == _oracle_rpc_canonical_bytes(value)
+
+
+def test_byte_identity_randomized_surrogate_heavy() -> None:
+    """Multi-character strings from a surrogate-dense alphabet.
+
+    A real corpus is overwhelmingly surrogate-free, which is exactly why the
+    slow path needs deliberate over-sampling here: it is the path a corpus run
+    would never exercise.
+    """
+    rng = random.Random(1234)
+    alphabet = [
+        chr(codepoint)
+        for codepoint in (
+            0x00,
+            0x41,
+            0xE9,
+            0x4E2D,
+            0x1F41D,
+            0xD800,
+            0xDBFF,
+            0xDC00,
+            0xDFFF,
+            0xFFFD,
+            0x10FFFF,
+        )
+    ]
+    for _ in range(20000):
+        value = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 12)))
+        assert _rpc_canonical_bytes(value) == _oracle_rpc_canonical_bytes(value), repr(
+            value
+        )
+
+
+def test_surrogates_still_become_replacement_char() -> None:
+    """Positive control: the slow path is reachable and does something.
+
+    Byte-identity twins pass trivially if both sides are wrong in the same way.
+    This pins the actual substitution independently of the oracle.
+    """
+    assert _rpc_canonical_bytes("a\ud800b") == "a�b".encode("utf-8")
+    assert _rpc_canonical_bytes("\ud800") == b"\xef\xbf\xbd"
+    assert _rpc_canonical_bytes("plain") == b"plain"


### PR DESCRIPTION
The encode is the surrogate test: drop the pre-scan from _rpc_canonical_bytes

`_rpc_canonical_bytes` asked, in pure Python, whether a canonical string
contains a surrogate -- `any(0xD800 <= ord(c) <= 0xDFFF for c in canonical)`
over every character of every string. `str.encode("utf-8")` answers the same
question in C on the very next line, and it refuses exactly the surrogate
range and nothing else. The scan was a redundant surrogate pre-scan.

Replaced with try/except around the encode. Byte identity is by construction
-- the clean path is the same call, the surrogate path is the same join --
and is asserted directly:

  tests/test_rpc_canonical_bytes_differential.py, 17 nodes, oracle is the
  pre-scan kept VERBATIM so identity is measured against the exact code that
  minted every pinned CID. Exhaustive single-character twin over all
  0x110000 codepoints; a direct assertion that CPython refuses exactly
  range(0xD800, 0xE000), len == 2048, which is the load-bearing assumption
  of the rewrite; 20k randomized strings from a surrogate-dense alphabet,
  since a real corpus would never reach the slow path; and a positive
  control pinning the substitution independently of the oracle.

Own-baseline A/B, both halves in SEPARATE DETACHED WORKTREES at a399308,
one pinned SUGAR_BIN (sha256 294d493cdd24cbd6...) across both, expected
mechanism count asserted per half before and after each measured half:

  head 128 failed / 1283 passed / 12 skipped / 5 errors, 1738s
  base 129 failed / 1282 passed / 12 skipped / 5 errors, 1401s

Node-set delta after re-running the differing nodes 5x per half:

  fixed by this change (base 5/5 fail, head 5/5 pass)
    test_iterative_term_table_encoder.py::
      test_payload_to_rpc_encodes_a_5000_deep_spine_without_process_death
      test_reference_rpc_encodes_a_5000_deep_spine_without_recursion
  regressions: none

Both were `subprocess.run(..., timeout=20)` blowing their budget on base.
The scan is quadratic on a deep spine -- canonical strings grow with depth,
so every character of every prefix is walked again. On the same file:

  test_callsite_cycle_key_is_heap_backed_for_a_5000_deep_spine
    base 152.31s -> head 1.77s   (86x)
  whole file
    base 214.01s -> head   7.05s (30x)

Microbenchmark, timeit best-of-7 over 20k calls, python 3.14.4:

  12 ch    4.229us -> 0.575us    7.35x
  48 ch   17.446us -> 0.542us   32.22x
  240 ch  95.238us -> 0.771us  123.50x
  surrogate path 10.609us -> 11.391us (slow path pays 7%)

The new clean path is flat in string length; the old one was linear.

Scope is `_rpc_canonical_bytes` alone. `_encode_string`, `_json_to_value`
and the CID preimage are untouched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `_rpc_canonical_bytes` with a differential test suite using a pre-scan oracle
> Adds [test_rpc_canonical_bytes_differential.py](https://github.com/TSavo/sugar/pull/6348/files#diff-e62872e434b15cf703e21f005d9c353f196d282f0ccd0f5ba7b94fd22b72f2ab) with an oracle that mirrors the deleted pre-scan behavior: replace surrogate code points with the Unicode replacement character before UTF-8 encoding, and pass all other input through directly.
>
> - Exhaustive per-code-point test asserts byte-identical output between `_rpc_canonical_bytes` and the oracle for all ~1.1M Unicode code points.
> - Named edge-case test covers ASCII, Latin-1, CJK, astral, lone surrogates, NUL, and unpaired surrogate pairs.
> - Randomized test generates surrogate-heavy strings to catch boundary interactions.
> - Encoder contract test asserts `UnicodeEncodeError` is raised for exactly the surrogate range and no other code points.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51b6832.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->