### PR TITLE
Acquire b3sum without apt: unblock shared Rust build (dpkg blindness, not a short retry)

### DIFF
--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -25,7 +25,9 @@ runs:
     - name: Ensure sugarbin hash tool (b3sum)
       shell: bash
       run: |
-        if ! command -v b3sum >/dev/null 2>&1; then
-          tools/ci-apt-install.sh b3sum || cargo install b3sum --locked
-        fi
+        # tools/ci-apt-install.sh owns b3sum acquisition and pins the version
+        # from sugar-build.toml. The old fallback here was an unpinned
+        # `cargo install b3sum --locked`, which could put a different hashing
+        # tool version on PATH than the one the build contract names.
+        tools/ci-apt-install.sh b3sum
         b3sum --version | head -1

--- a/tools/ci-apt-install.sh
+++ b/tools/ci-apt-install.sh
@@ -3,12 +3,72 @@ set -euo pipefail
 
 [[ $# -gt 0 ]] || { echo "usage: tools/ci-apt-install.sh PACKAGE..." >&2; exit 2; }
 
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 missing_packages() {
   local package
   for package in "$@"; do
     dpkg-query -W -f='${db:Status-Status}' "$package" 2>/dev/null | grep -Fqx installed \
       || printf '%s\n' "$package"
   done
+}
+
+# dpkg-query answers "did apt install this", which is not the question the
+# build asks. The question is "is the tool usable". A b3sum acquired through
+# cargo lives in ~/.cargo/bin and is invisible to dpkg, so the apt path was
+# being entered for a dependency that was already satisfied. Packages whose
+# provided command is known get asked the real question.
+provided_command() {
+  case "$1" in
+    b3sum) printf 'b3sum\n' ;;
+    z3) printf 'z3\n' ;;
+    cvc5) printf 'cvc5\n' ;;
+    maven) printf 'mvn\n' ;;
+    unzip) printf 'unzip\n' ;;
+    time) printf '/usr/bin/time\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+command_satisfied() {
+  local cmd
+  cmd="$(provided_command "$1")" || return 1
+  if [[ "$cmd" == /* ]]; then
+    [[ -x "$cmd" ]]
+    return
+  fi
+  command -v "$cmd" >/dev/null 2>&1
+}
+
+unsatisfied_packages() {
+  local package
+  for package in "$@"; do
+    command_satisfied "$package" || printf '%s\n' "$package"
+  done
+}
+
+# b3sum participates in content addressing (bin/sugarbin stamps, source
+# stamps, consensus digests). It is pinned in sugar-build.toml and acquired
+# from crates.io, whose index carries a sha256 for every .crate archive that
+# cargo verifies before building. That is a checksum-verified acquisition, and
+# it never touches apt, so it cannot inherit apt's lock contention.
+b3sum_pin() {
+  sed -n 's/^b3sum[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$root/sugar-build.toml" | head -1
+}
+
+install_b3sum_from_crates_io() {
+  local pin
+  pin="$(b3sum_pin)"
+  if [[ -z "$pin" ]]; then
+    echo "::error::sugar-build.toml carries no b3sum pin; refusing to acquire an unpinned hashing tool" >&2
+    return 1
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "::error::cargo unavailable; cannot acquire pinned b3sum $pin without apt" >&2
+    return 1
+  fi
+  echo "ci-apt: acquiring b3sum $pin from crates.io (checksum-verified, no apt)"
+  cargo install b3sum --locked --version "$pin"
 }
 
 # These are self-hosted runners, so the normal path is that provisioning has
@@ -20,11 +80,39 @@ if ((${#missing[@]} == 0)); then
   exit 0
 fi
 
-for attempt in $(seq 1 60); do
+mapfile -t missing < <(unsatisfied_packages "${missing[@]}")
+if ((${#missing[@]} == 0)); then
+  echo "ci-apt: already on PATH: $*"
+  exit 0
+fi
+
+# Anything acquirable without apt is acquired without apt. An eliminated apt
+# dependency cannot flake on a lock held by a stale process.
+remaining=()
+for package in "${missing[@]}"; do
+  if [[ "$package" == "b3sum" ]]; then
+    install_b3sum_from_crates_io
+    continue
+  fi
+  remaining+=("$package")
+done
+if ((${#remaining[@]} == 0)); then
+  exit 0
+fi
+wanted=("${remaining[@]}")
+missing=("${remaining[@]}")
+
+# Retry budget is a seam so the fail-loud path is testable in seconds. It is
+# not a knob for making a real failure quieter: exhausting it is still red.
+attempts="${SUGAR_CI_APT_ATTEMPTS:-60}"
+for attempt in $(seq 1 "$attempts"); do
   # A racing lane may have installed the package while this lane was waiting.
-  mapfile -t missing < <(missing_packages "$@")
+  mapfile -t missing < <(missing_packages "${wanted[@]}")
+  if ((${#missing[@]} > 0)); then
+    mapfile -t missing < <(unsatisfied_packages "${missing[@]}")
+  fi
   if ((${#missing[@]} == 0)); then
-    echo "ci-apt: installed by another lane: $*"
+    echo "ci-apt: installed by another lane: ${wanted[*]}"
     exit 0
   fi
 
@@ -37,12 +125,19 @@ for attempt in $(seq 1 60); do
     echo "ci-apt: installed: ${missing[*]}"
     exit 0
   fi
-  echo "ci-apt: native package database busy (attempt $attempt/60); retrying" >&2
+  echo "ci-apt: native package database busy (attempt $attempt/$attempts); retrying" >&2
   ps -eo pid,ppid,etimes,cmd 2>/dev/null \
     | grep -E '[a]pt-get|[d]pkg|[u]nattended-upgrade' >&2 \
     || true
   sleep 2
 done
 
-echo "::error::apt remained unavailable after 120 seconds" >&2
+# Name the holder. The observed failure was an orphaned `apt-get update`
+# (parent sudo reparented to init) holding /var/lib/apt/lists/lock for hours;
+# no retry window reaches that, so the report must point at the process rather
+# than at the clock.
+echo "::error::apt unavailable for ${missing[*]} after $attempts attempts; long-lived lock holders below (etimes = seconds alive)" >&2
+ps -eo pid,ppid,etimes,cmd 2>/dev/null \
+  | grep -E '[a]pt-get|[d]pkg|[u]nattended-upgrade' >&2 \
+  || echo "::error::no apt/dpkg process visible; the lock owner is outside this namespace or already dead" >&2
 exit 1

--- a/tools/test-ci-apt-install.sh
+++ b/tools/test-ci-apt-install.sh
@@ -27,3 +27,73 @@ output="$(PATH="$tmp:$PATH" timeout 3 "$root/tools/ci-apt-install.sh" b3sum)"
 grep -Fqx 'ci-apt: already installed: b3sum' <<<"$output"
 
 echo "ci-apt installed-package fast path: PASS"
+
+# ---------------------------------------------------------------------------
+# The failure that made main unreadable: dpkg-query reports b3sum absent
+# because it was acquired through cargo, so the script entered apt for a
+# dependency that was already satisfied and then died on a stale lists lock.
+# PATH availability is the question the build actually asks.
+# ---------------------------------------------------------------------------
+
+shadow="$tmp/shadow"
+mkdir -p "$shadow"
+for cmd in bash env dirname sed head grep ps sleep seq flock; do
+  target="$(command -v "$cmd")"
+  ln -sf "$target" "$shadow/$cmd"
+done
+
+cat >"$shadow/dpkg-query" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cat >"$shadow/sudo" <<'EOF'
+#!/usr/bin/env bash
+echo "sudo must not run: b3sum is acquirable without apt" >&2
+exit 97
+EOF
+chmod +x "$shadow/dpkg-query" "$shadow/sudo"
+
+# Arm A: dpkg says absent, but b3sum is on PATH. No apt, no cargo.
+cat >"$shadow/b3sum" <<'EOF'
+#!/usr/bin/env bash
+echo "b3sum 1.8.1"
+EOF
+cat >"$shadow/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo "cargo must not run: b3sum is already on PATH" >&2
+exit 96
+EOF
+chmod +x "$shadow/b3sum" "$shadow/cargo"
+
+output="$(timeout 5 env PATH="$shadow" "$root/tools/ci-apt-install.sh" b3sum)"
+grep -Fqx 'ci-apt: already on PATH: b3sum' <<<"$output"
+
+echo "ci-apt PATH-satisfied fast path (dpkg blind to cargo install): PASS"
+
+# Arm B: dpkg says absent and b3sum is not on PATH. Acquisition must go to
+# crates.io at the sugar-build.toml pin, never to apt.
+rm -f "$shadow/b3sum"
+cat >"$shadow/cargo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$SUGAR_TEST_CARGO_LOG"
+EOF
+chmod +x "$shadow/cargo"
+
+pin="$(sed -n 's/^b3sum[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$root/sugar-build.toml" | head -1)"
+[[ -n "$pin" ]] || { echo "sugar-build.toml lost its b3sum pin" >&2; exit 1; }
+
+timeout 5 env SUGAR_TEST_CARGO_LOG="$tmp/cargo.log" PATH="$shadow" \
+  "$root/tools/ci-apt-install.sh" b3sum >/dev/null
+grep -Fqx "install b3sum --locked --version $pin" "$tmp/cargo.log"
+
+echo "ci-apt b3sum acquired from crates.io at the sugar-build.toml pin, apt untouched: PASS"
+
+# Arm C (discrimination): a package with no non-apt door must still reach apt
+# and must still fail loudly rather than silently succeeding.
+status=0
+timeout 30 env SUGAR_CI_APT_ATTEMPTS=2 PATH="$shadow" \
+  "$root/tools/ci-apt-install.sh" z3 >/dev/null 2>"$tmp/z3.err" || status=$?
+[[ "$status" -ne 0 ]] || { echo "apt-only package must not report success behind a failing sudo" >&2; exit 1; }
+grep -Fq '::error::apt unavailable for z3' "$tmp/z3.err"
+
+echo "ci-apt apt-only package still fails loudly: PASS"


### PR DESCRIPTION
## The blocker

`shared Rust build` failed at **Install sugarbin hashing dependency** in every recent completed run on main (`30207074805`, `30205989784`, `30205826154`, `30205360927`), and every downstream job — all four showcase shards, all core jobs — was **skipped** behind it. The showcase failure set has been unreadable as a result.

## What the log actually says

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 633 (apt-get)
  632     1   16923 sudo apt-get -o DPkg::Lock::Timeout=10 update -y
  633   632   16923 apt-get -o DPkg::Lock::Timeout=10 update -y
```

`ppid 1` on the sudo, `etimes` climbing past **16,900 seconds — 4.7 hours**. This is an orphaned `apt-get update` from a cancelled job, reparented to init, holding the lists lock indefinitely. It never releases. The 120-second retry was not too short; no retry window reaches it.

## Why it hit a dependency that was already satisfied

`.github/actions/setup-rust-cache` runs **before** this step and had a fallback of `cargo install b3sum --locked`, which lands the binary in `~/.cargo/bin`. `tools/ci-apt-install.sh` then asked `dpkg-query` *"did apt install b3sum"*, got "no", and walked into apt for a tool that was on `PATH` the whole time.

`dpkg-query` answers the wrong question. The build asks whether the tool is **usable**.

## The fix

- **PATH-availability fast path** after the dpkg fast path, via an explicit package → provided-command map (`b3sum`, `z3`, `cvc5`, `maven`, `unzip`, `time`).
- **b3sum leaves apt entirely.** Acquired from crates.io at the `sugar-build.toml` pin (`1.8.1`). Cargo verifies each `.crate` archive's sha256 against the registry index, so a tool that participates in content addressing stays checksum-verified. An eliminated dependency cannot flake.
- `setup-rust-cache` drops its own **unpinned** `cargo install b3sum --locked` fallback. Acquisition now has one owner and one pin, so the hashing tool on `PATH` cannot disagree with the build contract.
- The apt path is unchanged for packages with no other door. Exhausting it is **still red**, and the error now names the long-lived lock holders instead of only reporting elapsed clock.

Nothing is skipped, made non-blocking, or given `continue-on-error`.

## Evidence

`tools/test-ci-apt-install.sh` gains three arms, all run locally, all green:

```
ci-apt installed-package fast path: PASS
ci-apt PATH-satisfied fast path (dpkg blind to cargo install): PASS
ci-apt b3sum acquired from crates.io at the sugar-build.toml pin, apt untouched: PASS
ci-apt apt-only package still fails loudly: PASS
```

**Both sides of the discriminator were run.** Against the pre-change script, arm A reproduces the CI blocker directly — b3sum on `PATH`, dpkg blind, script walks into apt and hangs:

```
ci-apt installed-package fast path: PASS
sudo must not run: b3sum is acquirable without apt
ci-apt: native package database busy (attempt 1/60); retrying
...
BASELINE_EXIT=124   (timeout)
```

That is the blocker reproduced as a test, not inferred from declarations.

Arm C is the discrimination arm: an apt-only package (`z3`) must still reach apt and still fail loudly rather than silently succeeding. A retry-count seam (`SUGAR_CI_APT_ATTEMPTS`, default 60) makes that path testable in seconds; it cannot quiet a real failure, only shorten the wait before the same red.

## Not addressed here

The **stale lock holder itself is a runner-hygiene problem** and is untouched by this PR. Any workflow still needing `z3`/`cvc5`/`maven`/`unzip` from apt on that runner will hit the same orphan and fail — correctly and loudly, now naming the holding process. Reaping pid 633 on the affected runner is a separate, unowned action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Acquire b3sum from crates.io at a pinned version to unblock shared Rust builds
> - [`ci-apt-install.sh`](https://github.com/TSavo/sugar/pull/6351/files#diff-b4e1530ac08c6327b8fcf43b4fe45338dcc772bd7b1b2515f42b23621863424e) now installs b3sum via `cargo install --locked --version <pin>` using the version pinned in `sugar-build.toml`, bypassing apt entirely for b3sum.
> - Tools already present on PATH are treated as satisfied, so apt is skipped for them even when dpkg is unaware (fixes "dpkg blindness" causing unnecessary retries).
> - The retry budget is now configurable via `SUGAR_CI_APT_ATTEMPTS` (default 60); on terminal failure the script emits `::error::` output and lists long-lived apt/dpkg processes to identify lock holders.
> - [`action.yml`](https://github.com/TSavo/sugar/pull/6351/files#diff-eaa6dcf8330017ecd02d8bc595200c70b35065d24f114e4092b3f1f3575a89f5) unconditionally delegates b3sum acquisition to `ci-apt-install.sh`, removing the unpinned `cargo install b3sum` fallback.
> - [`test-ci-apt-install.sh`](https://github.com/TSavo/sugar/pull/6351/files#diff-f2d7745bb8bf69edb1bf77e5357d3a937064837a79f3c0c5d27d8ca1566f4886) adds three test arms covering the PATH fast-path, crates.io acquisition, and loud failure for apt-only packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c949f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->