### PR TITLE
python-source constructs through sugar.enumerate, not the retired lift

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import traceback
+from pathlib import Path
 from typing import Any
 
 from .compiler import compile_ir_document
-from .lifter import lift_paths
+from .lifter import _iter_python_files, lift_paths, lift_source
 
 SURFACE = "python-source"
 VERSION = "0.1.0-draft"
 KIT_DECLARATION_RPC_METHOD = "sugar.plugin.kit_declaration"
+# The ONE construction door. There is no `lift` kit method: full-tree
+# construction is `sugar.enumerate` over the SourceTree (#6222). Level protocol:
+# `protocol/specs/2026-07-08-enumeration-protocol.md`.
+ENUMERATE_RPC_METHOD = "sugar.enumerate"
 
 
 def initialize_result() -> dict[str, Any]:
@@ -39,7 +45,9 @@ def kit_declaration_result() -> dict[str, Any]:
             "methods": [
                 {"name": "initialize", "required": True},
                 {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
-                {"name": "lift", "required": True},
+                # lift is not a kit method: full-tree construction is
+                # sugar.enumerate only (#6222). Same eviction the other kits made.
+                {"name": ENUMERATE_RPC_METHOD, "required": True},
                 {"name": "compile", "required": False},
                 {"name": "shutdown", "required": False},
             ]
@@ -117,6 +125,8 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         return {"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()}
     if method == "lift":
         return _lift(msg_id, params)
+    if method == ENUMERATE_RPC_METHOD:
+        return _enumerate(msg_id, params)
     if method == "compile":
         return _compile(msg_id, params)
     if method == "shutdown":
@@ -150,6 +160,182 @@ def _lift(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
             "refusals": result.refusals,
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# `sugar.enumerate` -- the ONE construction door
+# ---------------------------------------------------------------------------
+#
+# This kit is per-file independent: `lift_source(source, display_path)` is
+# already the whole-file unit `lift_paths` loops over, and it carries no
+# cross-file state. So `universe` is exactly that call for the ONE demanded
+# file, and full-tree construction is the Rust fold walking `source_files` and
+# asking `universe` per file. There is no residency problem to solve here.
+
+
+def _degenerate_file_memento(
+    rel_path: str, source_cid: str | None = None
+) -> dict[str, Any]:
+    """The file-level locator: a `source-memento` with only `file` and the
+    file's content CID populated. A whole file has no single body span or AST
+    template, so those stay absent. Same shape every other kit seals."""
+    return {
+        "kind": "source-memento",
+        "file": rel_path,
+        "function_name": "",
+        "span": None,
+        "param_names": [],
+        "source_cid": source_cid,
+        "template_cid": None,
+    }
+
+
+def _enumerate_result(
+    msg_id: Any, nodes: list[dict[str, Any]], gaps: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {"nodes": nodes, "gaps": gaps},
+    }
+
+
+def _memento_matches(candidate: dict[str, Any], target: dict[str, Any]) -> bool:
+    """Primary-key equality for a file locator: same file, and same content CID
+    when the target pins one. A degenerate (file-only) target matches on file
+    alone."""
+    if candidate.get("file") != target.get("file"):
+        return False
+    target_cid = target.get("source_cid") or target.get("sourceCid")
+    if target_cid and candidate.get("source_cid") != target_cid:
+        return False
+    return True
+
+
+def _resolved_under_root(root: Path, rel: str) -> Path | None:
+    """A forged memento carrying an absolute path (pathlib join discards the
+    root) or a `../` traversal could otherwise enumerate files OUTSIDE the
+    workspace. Require the resolved path to stay under the resolved root."""
+    try:
+        full = (root / rel).resolve()
+    except OSError:
+        return None
+    try:
+        full.relative_to(root)
+    except ValueError:
+        return None
+    return full
+
+
+def _enumerate(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """`sugar.enumerate`: `source_files` censuses the workspace's real source
+    closure; `universe` constructs the ONE demanded file's IR.
+
+    Only the two levels full-tree construction needs are served. Every other
+    level is a LOUD refusal rather than an empty success: this kit does see
+    functions and call sites, so answering an empty census for them would be a
+    false zero, and a false zero is worse than a named gap. That is not a
+    regression -- before this door existed the whole method was
+    METHOD_NOT_FOUND.
+    """
+    from .source_oracle import SourceUnavailable, path_source
+
+    level = params.get("level")
+    root = Path(str(params.get("workspace_root", "."))).resolve()
+    at = params.get("at") if isinstance(params.get("at"), dict) else None
+    seek = bool(params.get("seek", False))
+
+    if level == "source_files":
+        nodes: list[dict[str, Any]] = []
+        gaps: list[dict[str, Any]] = []
+        for file_path in sorted(_iter_python_files(root)):
+            rel_path = os.path.relpath(file_path, root)
+            try:
+                # Identity is MINTED through the oracle, never hashed here, so
+                # this kit addresses a file exactly as every other kit does.
+                _source, _filename, cid = path_source(str(file_path))
+            except SourceUnavailable as unavailable:
+                # An unreadable/undecodable file is a loud protocol gap, never
+                # a node with a made-up identity.
+                gaps.append(
+                    {
+                        "memento": _degenerate_file_memento(rel_path),
+                        "reason": str(unavailable),
+                    }
+                )
+                continue
+            memento = _degenerate_file_memento(rel_path, cid)
+            if seek and at is not None and not _memento_matches(memento, at):
+                continue
+            nodes.append({"memento": memento, "audit": None, "payload": None})
+        return _enumerate_result(msg_id, nodes, gaps)
+
+    if level == "universe":
+        rel_path = at.get("file") if at else None
+        if not isinstance(rel_path, str) or not rel_path:
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": at,
+                        "reason": "sugar.enumerate level='universe' requires `at.file`",
+                    }
+                ],
+            )
+        full_path = _resolved_under_root(root, rel_path)
+        if full_path is None:
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": at,
+                        "reason": (
+                            f"path '{rel_path}' escapes workspace root '{root}'"
+                        ),
+                    }
+                ],
+            )
+        try:
+            source, _filename, cid = path_source(str(full_path))
+        except SourceUnavailable as unavailable:
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": _degenerate_file_memento(rel_path),
+                        "reason": str(unavailable),
+                    }
+                ],
+            )
+        memento = _degenerate_file_memento(rel_path, cid)
+        # The per-file unit `lift_paths` already loops over. Same rows, same
+        # order -- this is the SAME construction the retired `lift` performed,
+        # reached through the one door instead of the retired method.
+        file_result = lift_source(source, rel_path)
+        nodes = [
+            {"memento": memento, "audit": row, "payload": None}
+            for row in file_result.ir
+        ]
+        # A refusal is this file's construction saying why a row is absent. It
+        # is a first-class gap, never a silently shorter node list.
+        gaps = [
+            {"memento": memento, "reason": json.dumps(refusal, sort_keys=True)}
+            for refusal in file_result.refusals
+        ]
+        return _enumerate_result(msg_id, nodes, gaps)
+
+    return _error(
+        msg_id,
+        -32602,
+        f"sugar.enumerate: level {level!r} is not served by surface "
+        f"`{SURFACE}`. This kit serves `source_files` and `universe`, which "
+        f"together reproduce the construction the retired `lift` method "
+        f"performed. Serving another level means constructing it here -- "
+        f"answering an empty census would be a false zero.",
+    )
 
 
 def _compile(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:

--- a/implementations/python/sugar-lift-python-source/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_enumerate_rpc.py
@@ -1,0 +1,188 @@
+"""`sugar.enumerate` is the ONE construction door for the `python-source` seat.
+
+There is no `lift` kit method: full-tree construction is `sugar.enumerate` over
+the SourceTree (#6222). These pin the two levels this kit serves, and the two
+laws that make the census honest -- identity is minted through the oracle, and
+a file that cannot be sealed is a first-class gap rather than a node carrying a
+made-up identity.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sugar_lift_python_source.rpc import (
+    ENUMERATE_RPC_METHOD,
+    dispatch,
+    kit_declaration_result,
+)
+from sugar_lift_python_source.source_oracle import path_source
+
+
+def _enumerate(root, level, at=None, seek=False):
+    params = {"level": level, "workspace_root": str(root)}
+    if at is not None:
+        params["at"] = at
+    if seek:
+        params["seek"] = True
+    return dispatch(
+        {"jsonrpc": "2.0", "id": 1, "method": ENUMERATE_RPC_METHOD, "params": params}
+    )
+
+
+def _files(tmp_path, **sources):
+    for name, body in sources.items():
+        (tmp_path / name).write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+# ------- THE RETIRED DOOR -------
+
+
+def test_lift_is_no_longer_advertised_as_a_kit_method():
+    methods = {m["name"] for m in kit_declaration_result()["rpc"]["methods"]}
+    assert "lift" not in methods, (
+        "`lift` is retired: full-tree construction is sugar.enumerate only"
+    )
+    assert ENUMERATE_RPC_METHOD in methods
+
+
+# ------- source_files -------
+
+
+def test_source_files_censuses_every_python_file_with_oracle_identity(tmp_path):
+    _files(
+        tmp_path,
+        **{"alpha.py": "def a():\n    return 1\n", "beta.py": "def b():\n    return 2\n"},
+    )
+    (tmp_path / "notes.txt").write_text("not python", encoding="utf-8")
+
+    result = _enumerate(tmp_path, "source_files")["result"]
+
+    assert [n["memento"]["file"] for n in result["nodes"]] == ["alpha.py", "beta.py"]
+    assert result["gaps"] == []
+    # Identity comes from the oracle door, not from hashing here.
+    _source, _filename, expected_cid = path_source(str(tmp_path / "alpha.py"))
+    assert result["nodes"][0]["memento"]["source_cid"] == expected_cid
+    assert result["nodes"][0]["memento"]["span"] is None
+
+
+def test_undecodable_file_is_a_gap_not_a_node_with_a_made_up_identity(tmp_path):
+    (tmp_path / "good.py").write_text("def g():\n    return 1\n", encoding="utf-8")
+    # Lone 0x80 continuation byte: readable, but not decodable as utf-8.
+    (tmp_path / "bad.py").write_bytes(b"\x80")
+
+    result = _enumerate(tmp_path, "source_files")["result"]
+
+    assert [n["memento"]["file"] for n in result["nodes"]] == ["good.py"]
+    assert len(result["gaps"]) == 1
+    gap = result["gaps"][0]
+    assert gap["memento"]["file"] == "bad.py"
+    assert gap["memento"]["source_cid"] is None, "a gap never carries an identity"
+    assert "bad.py" in gap["reason"]
+
+
+def test_seek_returns_only_the_named_file(tmp_path):
+    _files(
+        tmp_path,
+        **{"alpha.py": "def a():\n    return 1\n", "beta.py": "def b():\n    return 2\n"},
+    )
+
+    result = _enumerate(
+        tmp_path, "source_files", at={"file": "beta.py"}, seek=True
+    )["result"]
+
+    assert [n["memento"]["file"] for n in result["nodes"]] == ["beta.py"]
+
+
+# ------- universe -------
+
+
+def test_universe_constructs_the_demanded_file(tmp_path):
+    _files(
+        tmp_path,
+        **{
+            "alpha.py": "def a(x):\n    assert x == 1\n",
+            "beta.py": "def b(y):\n    assert y == 2\n",
+        },
+    )
+    census = _enumerate(tmp_path, "source_files")["result"]
+    alpha = next(n["memento"] for n in census["nodes"] if n["memento"]["file"] == "alpha.py")
+
+    result = _enumerate(tmp_path, "universe", at=alpha)["result"]
+
+    assert result["nodes"], "the demanded file constructs its own rows"
+    # Every row is addressed to the file that was demanded -- never a sibling.
+    assert {n["memento"]["file"] for n in result["nodes"]} == {"alpha.py"}
+
+
+def test_universe_rows_match_what_the_retired_lift_produced(tmp_path):
+    """The one door reproduces the retired method's construction exactly."""
+    _files(tmp_path, **{"alpha.py": "def a(x):\n    assert x == 1\n"})
+    census = _enumerate(tmp_path, "source_files")["result"]
+    alpha = census["nodes"][0]["memento"]
+
+    through_enumerate = [
+        n["audit"] for n in _enumerate(tmp_path, "universe", at=alpha)["result"]["nodes"]
+    ]
+    through_lift = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "lift",
+            "params": {"workspace_root": str(tmp_path), "source_paths": ["alpha.py"]},
+        }
+    )["result"]["ir"]
+
+    assert through_enumerate == through_lift
+
+
+def test_universe_without_a_file_is_a_named_gap_not_an_empty_success(tmp_path):
+    result = _enumerate(tmp_path, "universe", at={})["result"]
+
+    assert result["nodes"] == []
+    assert len(result["gaps"]) == 1
+    assert "requires `at.file`" in result["gaps"][0]["reason"]
+
+
+def test_universe_refuses_a_forged_memento_that_escapes_the_workspace(tmp_path):
+    (tmp_path / "inside.py").write_text("def i():\n    return 1\n", encoding="utf-8")
+    outside = tmp_path.parent / "outside_secret.py"
+    outside.write_text("def secret():\n    return 1\n", encoding="utf-8")
+
+    result = _enumerate(
+        tmp_path, "universe", at={"file": "../outside_secret.py"}
+    )["result"]
+
+    assert result["nodes"] == [], "a traversal must never enumerate outside the root"
+    assert len(result["gaps"]) == 1
+    assert "escapes workspace root" in result["gaps"][0]["reason"]
+
+
+def test_universe_reports_a_syntax_refusal_as_a_gap(tmp_path):
+    _files(tmp_path, **{"broken.py": "def a(:\n"})
+    census = _enumerate(tmp_path, "source_files")["result"]
+    broken = census["nodes"][0]["memento"]
+
+    result = _enumerate(tmp_path, "universe", at=broken)["result"]
+
+    assert result["gaps"], "a refusal is a first-class gap, not a shorter node list"
+    assert "syntax-error" in json.dumps(result["gaps"])
+
+
+# ------- unserved levels are LOUD -------
+
+
+@pytest.mark.parametrize(
+    "level", ["functions", "call_sites", "assertions", "facts", "implications"]
+)
+def test_an_unserved_level_is_a_loud_refusal_not_a_false_empty_census(tmp_path, level):
+    response = _enumerate(tmp_path, level)
+
+    assert "result" not in response, (
+        f"level {level!r} must not answer an empty census it cannot back"
+    )
+    assert response["error"]["code"] == -32602
+    assert level in response["error"]["message"]

--- a/implementations/python/sugar-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_lifter.py
@@ -6635,13 +6635,17 @@ def test_kit_declaration_returns_python_source_lift_surface() -> None:
     required_by_name = {
         method["name"]: method["required"] for method in result["rpc"]["methods"]
     }
+    # `lift` is NOT in this table and must never come back: full-tree
+    # construction is `sugar.enumerate` only (#6222). Still exact equality over
+    # the whole table, so an unannounced method is as red as a missing one.
     assert required_by_name == {
         "initialize": True,
         KIT_DECLARATION_RPC_METHOD: True,
-        "lift": True,
+        "sugar.enumerate": True,
         "compile": False,
         "shutdown": False,
     }
+    assert "lift" not in required_by_name
     assert result["proofResolution"] == {"strategy": "pip"}
     assert result["effectKinds"] == ["panic-freedom"]
     assert result["effectLeaves"] == RUNTIME_FAILURE_EFFECT_LEAVES


### PR DESCRIPTION
Second kit across the membrane #6222 opened, after #6347. The CLI is correct to refuse a lift-only kit at `lift_plugin.rs:417`; this one now speaks the one door.

Surface: `python-source`. Picked because it is the one kit that is genuinely per-file independent — `lift_source(source, display_path)` is already the whole-file unit `lift_paths` loops over and carries no cross-file state. **There is no residency problem here**, which is exactly what separates it from `rust_test_assertions_rpc` and `walk_rpc` (those two share one design decision and belong to one epic with its own owner).

## What changed

- **`source_files`** censuses the workspace's real source closure. Identity is minted through the SOURCE ORACLE (`path_source`), never hashed here, so this kit addresses a file exactly as every other kit does rather than giving the same source a second address. Supports `seek`.
- **`universe`** constructs the ONE demanded file through `lift_source`. A test pins that the rows reached this way are **byte-identical to what the retired `lift` produced** — the one door reproduces the retired method's construction rather than approximating it.
- **Unsealable files are gaps, not nodes.** An unreadable or undecodable file yields a gap carrying its reason and `source_cid: None` — never a node with a fabricated locator.
- **A forged memento is refused.** `../` or an absolute path in `at.file` is a named gap; the resolved path must stay under the resolved workspace root or nothing is enumerated.
- **Unserved levels are LOUD**, naming the level, rather than an empty census. This kit does see functions and call sites, so an empty answer for those would be a false zero — worse than a named gap. Not a regression: before this door existed the whole method was `METHOD_NOT_FOUND`.
- **`lift` leaves the kit declaration**, the way `lift_rpc.py:922` did it.

## The one test I changed, and why that is not weakening it

`test_kit_declaration_returns_python_source_lift_surface` pinned the exact method table *including* `"lift": True`. It pinned the law #6222 retired, so it now pins the new one. It is still **exact equality over the whole table** — an unannounced method is as red as a missing one — plus an explicit `assert "lift" not in required_by_name` so the retired door cannot quietly return. No assertion was loosened and no test was skipped or deleted.

## Validation (measured on battleaxe, exit status captured directly, never through a pipe)

```
new enumerate tests          14 passed
full python-source suite     649 passed, 13 failed
```

**The 13 failures are inherited, not mine, and I verified that rather than assuming it.** I stashed the change, re-ran the same suite at baseline, and diffed the failure sets:

```
baseline: 13 failed
head:     14 failed
introduced by my change: test_lifter.py::test_kit_declaration_returns_python_source_lift_surface
```

That one was the declaration test above. After updating it to pin the new law, the diff is empty:

```
still introduced by me: (none)
```

The 13 inherited reds live in `test_structural_floor.py`, `test_verify_dialect.py`, `test_numpy_pandas_honest_zero.py`, `test_lifter.py`, `test_source_call_preconstruction.py`, `test_sole_path_manager_construction.py`, and `test_dependency_artifact_graph.py`. They are red on `3ff6f44b6` without this change and are somebody else's axis.

## Discrimination — both new laws can actually fail

A green test that cannot go red is not an instrument, so I mutated each load-bearing law and confirmed the right twin fires and nothing else does.

**Mutation 1** — serve an unsealable file as a node with a null-cid identity instead of recording a gap:

```
MUT1_EXIT=1
FAILED test_undecodable_file_is_a_gap_not_a_node_with_a_made_up_identity
1 failed, 13 passed
```

**Mutation 2** — answer an unserved level with an empty census instead of a loud refusal:

```
MUT2_EXIT=1
FAILED test_an_unserved_level_is_a_loud_refusal_not_a_false_empty_census[functions]
FAILED ... [call_sites]  [assertions]  [facts]  [implications]
5 failed, 9 passed
```

Both reverted; tree byte-identical to HEAD; re-confirmed `14 passed`.

## Shot accounting

- **R:** surfaces whose kit cannot construct through `sugar.enumerate`. `R = 3` after #6347.
- **Predicted Epsilon R:** `-1` (`python-source`). Unconfirmed end-to-end — see below.
- **Shell deleted:** none. `lift` becomes deletable only when the last kit migrates; two remain.
- **Floors preserved:** no detector weakened, no test skipped or deleted, no gate loosened, no refusal widened. The one changed assertion kept its exact-equality strength and gained a clause.

## Known inherited red / unmeasured

The end-to-end wire path (CLI -> `supports_rpc_method` -> `fold_enumerate_source_tree`) is **not** confirmed for this kit. My attempt to take that receipt on battleaxe died on infrastructure, not product: `sugarbin` cannot build into the shared binary cache because its `.build` subdirectories are owned by `1001:docker` and `root:root` at mode 755 while an interactive user is uid 1000 —

```
error: failed to open: /home/tsavo/.cache/sugar/binaries/.build/blake3-512_.../debug/.cargo-build-lock
Caused by: Permission denied (os error 13)
```

Re-running now against a private `SUGAR_BINARY_CACHE_DIR`, with the lease still on the shared path. Treat `Epsilon R = -1` as predicted, not measured, until that receipt lands.

CI is separately unreadable right now: `shared Rust build` has failed four consecutive runs at `Install sugarbin hashing dependency` with `apt remained unavailable after 120 seconds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace retired `lift` RPC method with `sugar.enumerate` in the Python source lifter
> - Adds a `sugar.enumerate` JSON-RPC handler supporting two levels: `source_files` (census of all Python files with oracle-backed identity and gap reporting for unreadable/undecodable files) and `universe` (per-file IR construction via `lift_source`, with syntax refusals surfaced as gaps).
> - Removes `lift` from the advertised kit methods; `sugar.enumerate` is now the required method in `kit_declaration_result`.
> - `source_files` supports seek filtering via an `at` memento; `universe` validates the requested file path stays within the workspace root.
> - Unsupported levels return a JSON-RPC error with code `-32602` rather than a silent empty census.
> - Behavioral Change: callers relying on the `lift` RPC method will no longer find it advertised; the `lift` dispatch branch remains in place but is considered retired.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 244fc58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `sugar.enumerate` RPC capability for discovering Python source files and constructing requested file data.
  * Added support for source-file selection and workspace-safe file resolution.
  * Results now include source identities, constructed rows, and explicit gaps for unavailable or invalid files.

* **Bug Fixes**
  * Invalid paths, missing requests, unreadable files, and syntax failures now return clear gaps instead of misleading empty results.
  * Unsupported enumeration levels return structured errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->