### PR TITLE
The parameter-contract carrier holds a demand SET, not one demand (#6352)

### DIFF
--- a/docs/ledgers/stablezero-demand-set-base-31ca5580c.json
+++ b/docs/ledgers/stablezero-demand-set-base-31ca5580c.json
@@ -1,0 +1,502 @@
+{
+ "schema": "stableZero-classify-isolated-v1",
+ "n_functions": 223,
+ "statuses": {
+  "ConstructionPanic": 3,
+  "ExitSetFactoringGap": 1,
+  "clean": 219
+ },
+ "R(timeout)": 0,
+ "R(construction_panics)": 3,
+ "R(factoring_gaps)": 1,
+ "R(unnamed_exceptions)": 0,
+ "completed_denominator": 223,
+ "stableZero": false,
+ "desugar_s": 30.69,
+ "wall_s": 33.21,
+ "residuals": [
+  {
+   "name": null,
+   "line": 7388,
+   "status": "ConstructionPanic",
+   "testimony": {
+    "type": "ConstructionPanic",
+    "message": "CONSTRUCTION PANIC: match(Sugar) { Some => cite_or_effect, None => panic!() }\nwrite more Floor for this Construction: owner=collection TupleValue blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=7779, start_col=47, end_line=7779, end_col=57) observed=two collection elements enrolled DISTINCT contract demands (blake3-512:044f5e517e831751c96161ee27c15d3e9a284797925adb1d71a9f2b66fafbfa07d0d7622d0dc0fbd9ac81f80ef79028f0a86fd53bd080ac3534bfe837c3409a8 and blake3-512:2acc4d3c82076e6fb8138ced9750cd2ffd962eaa4a3d2b00b97f59942b4a9336631600d60fef1c1422117cd0a420bafc22046a4e41f5a8ba509b76b3772b083b) requested=one pending demand per constructed value fix=widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements",
+    "frames": [
+     {
+      "module": "__main__",
+      "qualname": "classify",
+      "line": 149
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "FunctionUniverseSugar.desugar",
+      "line": 369
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_body",
+      "line": 303
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.if_sugar",
+      "qualname": "IfSugar.desugar",
+      "line": 126
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.if_sugar",
+      "qualname": "IfSugar.desugar",
+      "line": 125
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.if_sugar",
+      "qualname": "IfSugar.desugar",
+      "line": 125
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.return_sugar",
+      "qualname": "ReturnSugar.desugar",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.method_call_sugar",
+      "qualname": "MethodCallSugar.desugar",
+      "line": 51
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.complete",
+      "qualname": "Complete.and_then",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.method_call_sugar",
+      "qualname": "MethodCallSugar.desugar.<locals>.<lambda>",
+      "line": 52
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.method_call_sugar",
+      "qualname": "MethodCallSugar._collect",
+      "line": 64
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar.desugar",
+      "line": 64
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_generators",
+      "line": 78
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.complete",
+      "qualname": "Complete.and_then",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_generators.<locals>.<lambda>",
+      "line": 79
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_filters",
+      "line": 104
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.complete",
+      "qualname": "Complete.and_then",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_filters.<locals>.<lambda>",
+      "line": 105
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_filters",
+      "line": 88
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_generators",
+      "line": 69
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.complete",
+      "qualname": "Complete.and_then",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comprehension_sugar",
+      "qualname": "ComprehensionSugar._desugar_generators.<locals>.<lambda>",
+      "line": 70
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.collection_sugar",
+      "qualname": "TupleSugar.desugar",
+      "line": 147
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.collection_sugar",
+      "qualname": "_reduce_into",
+      "line": 71
+     },
+     {
+      "module": "sugar_lift_py_tests.gap.panic",
+      "qualname": "construction_panic_gap",
+      "line": 73
+     },
+     {
+      "module": "sugar_lift_py_tests.gap.panic",
+      "qualname": "construction_panic",
+      "line": 30
+     }
+    ],
+    "innermost": {
+     "module": "sugar_lift_py_tests.gap.panic",
+     "qualname": "construction_panic",
+     "line": 30
+    },
+    "info": {
+     "owner": "collection TupleValue",
+     "blame": "SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=7779, start_col=47, end_line=7779, end_col=57)",
+     "observed": "two collection elements enrolled DISTINCT contract demands (blake3-512:044f5e517e831751c96161ee27c15d3e9a284797925adb1d71a9f2b66fafbfa07d0d7622d0dc0fbd9ac81f80ef79028f0a86fd53bd080ac3534bfe837c3409a8 and blake3-512:2acc4d3c82076e6fb8138ced9750cd2ffd962eaa4a3d2b00b97f59942b4a9336631600d60fef1c1422117cd0a420bafc22046a4e41f5a8ba509b76b3772b083b)",
+     "requested": "one pending demand per constructed value",
+     "fix": "widen ContractConditionalConstructionV1 to carry a demand SET before building a collection from two pending elements",
+     "gap_kind": "FLOOR",
+     "gap_locus": "CONSTRUCTION"
+    }
+   },
+   "seconds": 1.4162
+  },
+  {
+   "name": null,
+   "line": 8088,
+   "status": "ConstructionPanic",
+   "testimony": {
+    "type": "ConstructionPanic",
+    "message": "CONSTRUCTION PANIC: match(Sugar) { Some => cite_or_effect, None => panic!() }\nwrite more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=8238, start_col=46, end_line=8238, end_col=58) observed=a hoisted parameter contract demand (blake3-512:4029920b5fbbe2317e3223b8f679766bee11ad0da4989db6b69cfd4ee68c41e449ed464ffc3eacabdb62411d8465426910a453d8a324080a903ba76cb09538ef) joined onto a Incomplete, which carries no single value requested=one joined value that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation",
+    "frames": [
+     {
+      "module": "__main__",
+      "qualname": "classify",
+      "line": 149
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "FunctionUniverseSugar.desugar",
+      "line": 369
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_body",
+      "line": 303
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.store_effect_sugar",
+      "qualname": "AttributeStoreEffectSugar.desugar",
+      "line": 48
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.complete",
+      "qualname": "Complete.and_then",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.store_effect_sugar",
+      "qualname": "AttributeStoreEffectSugar.desugar.<locals>.<lambda>",
+      "line": 49
+     },
+     {
+      "module": "sugar_lift_py_tests.caller_parameter_contract",
+      "qualname": "ContractConditionalConstructionV1.and_then",
+      "line": 120
+     },
+     {
+      "module": "sugar_lift_py_tests.floor.single_outcome_law",
+      "qualname": "rewrap_pending",
+      "line": 117
+     },
+     {
+      "module": "sugar_lift_py_tests.gap.panic",
+      "qualname": "construction_panic_gap",
+      "line": 73
+     },
+     {
+      "module": "sugar_lift_py_tests.gap.panic",
+      "qualname": "construction_panic",
+      "line": 30
+     }
+    ],
+    "innermost": {
+     "module": "sugar_lift_py_tests.gap.panic",
+     "qualname": "construction_panic",
+     "line": 30
+    },
+    "info": {
+     "owner": "ContractConditionalConstructionV1.and_then",
+     "blame": "SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=8238, start_col=46, end_line=8238, end_col=58)",
+     "observed": "a hoisted parameter contract demand (blake3-512:4029920b5fbbe2317e3223b8f679766bee11ad0da4989db6b69cfd4ee68c41e449ed464ffc3eacabdb62411d8465426910a453d8a324080a903ba76cb09538ef) joined onto a Incomplete, which carries no single value",
+     "requested": "one joined value that can carry every pending demand",
+     "fix": "give the exit algebra an arm for a pending contract demand so a partition can carry it; never drop the obligation",
+     "gap_kind": "FLOOR",
+     "gap_locus": "CONSTRUCTION"
+    }
+   },
+   "seconds": 1.1656
+  },
+  {
+   "name": null,
+   "line": 9596,
+   "status": "ConstructionPanic",
+   "testimony": {
+    "type": "ConstructionPanic",
+    "message": "CONSTRUCTION PANIC: match(Sugar) { Some => cite_or_effect, None => panic!() }\nwrite more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=9652, start_col=23, end_line=9652, end_col=33) observed=two distinct pending contract demands (blake3-512:95773201fd81e85e0ae33d86bf8b2b8bffe42b337f41ee065423369ea55d2fff654a4f657b7d2d0fbfbb67fc018310e608f94c2b7fcabf60e1a7c939b68be1ac and blake3-512:934ecd428608ed248848bfcf60a255b47169553f316b49a448801ff9b18fe0868a2c6c0bff57bcea8ffa4c03b0ca23d910eae9dbdc4d48116d51c1d3b3342d42) joined onto one constructed value requested=one joined value that can carry every pending demand fix=widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation",
+    "frames": [
+     {
+      "module": "__main__",
+      "qualname": "classify",
+      "line": 149
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "FunctionUniverseSugar.desugar",
+      "line": 369
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_body",
+      "line": 303
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.if_sugar",
+      "qualname": "IfSugar.desugar",
+      "line": 116
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.comparison_op_sugar",
+      "qualname": "ComparisonOpSugar.desugar",
+      "line": 57
+     },
+     {
+      "module": "sugar_lift_py_tests.caller_parameter_contract",
+      "qualname": "ContractConditionalConstructionV1.and_then",
+      "line": 120
+     },
+     {
+      "module": "sugar_lift_py_tests.floor.single_outcome_law",
+      "qualname": "rewrap_pending",
+      "line": 117
+     },
+     {
+      "module": "sugar_lift_py_tests.gap.panic",
+      "qualname": "construction_panic_gap",
+      "line": 73
+     },
+     {
+      "module": "sugar_lift_py_tests.gap.panic",
+      "qualname": "construction_panic",
+      "line": 30
+     }
+    ],
+    "innermost": {
+     "module": "sugar_lift_py_tests.gap.panic",
+     "qualname": "construction_panic",
+     "line": 30
+    },
+    "info": {
+     "owner": "ContractConditionalConstructionV1.and_then",
+     "blame": "SourceFragmentCoordinateV1(source_cid='blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce', start_line=9652, start_col=23, end_line=9652, end_col=33)",
+     "observed": "two distinct pending contract demands (blake3-512:95773201fd81e85e0ae33d86bf8b2b8bffe42b337f41ee065423369ea55d2fff654a4f657b7d2d0fbfbb67fc018310e608f94c2b7fcabf60e1a7c939b68be1ac and blake3-512:934ecd428608ed248848bfcf60a255b47169553f316b49a448801ff9b18fe0868a2c6c0bff57bcea8ffa4c03b0ca23d910eae9dbdc4d48116d51c1d3b3342d42) joined onto one constructed value",
+     "requested": "one joined value that can carry every pending demand",
+     "fix": "widen ContractConditionalConstructionV1 to carry a demand SET; never drop the obligation",
+     "gap_kind": "FLOOR",
+     "gap_locus": "CONSTRUCTION"
+    }
+   },
+   "seconds": 0.8372
+  },
+  {
+   "name": null,
+   "line": 13403,
+   "status": "ExitSetFactoringGap",
+   "testimony": {
+    "type": "ExitSetFactoringGap",
+    "message": "ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / StringValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457334:457347#blake3-512:5b32feb0e3630b4d6204e6ffed269ece2581008fc37b12a4390aac94e85fd9155d8260315e9c190bdaec8715100bbd286c890864894ec58c02be3189cc993ce9', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457745:457758#blake3-512:5b603297f0e13ffd4e7ffcde2d896f06b13295b32a24239867e9dfc07c587eb8705d174e6c8a82e7f95b7ae09a26c8f04b5ee0b04699125c00bb3de765c0d4b8', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@459055:459069#blake3-512:edf862325999580225168d4ddba09e14894a34b33abbf14bd2b933186427c005f08a5bfd936619145fe81b45f7ca8396f6fe25e33aeb6ff91e251e8689411923', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462613:462629#blake3-512:a3ae6b2e60ba425f091734cb9f68162e83e9128e362fcbb869c63999032a930a92737fde7da749e002fde8637cabe58ea6094b9fb5b2203b440171adc2e59c49', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))))))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []",
+    "frames": [
+     {
+      "module": "__main__",
+      "qualname": "classify",
+      "line": 149
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "FunctionUniverseSugar.desugar",
+      "line": 369
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_body",
+      "line": 303
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.return_sugar",
+      "qualname": "ReturnSugar.desugar",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "SpreadCallSugar.desugar",
+      "line": 197
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.and_then",
+      "line": 535
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.and_then.<locals>.<lambda>",
+      "line": 535
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "SpreadCallSugar.desugar.<locals>.after_callee",
+      "line": 188
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "_collect",
+      "line": 55
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.factor_completed",
+      "line": 367
+     }
+    ],
+    "innermost": {
+     "module": "sugar_lift_py_tests.outcome.exit_set",
+     "qualname": "ExitSet.factor_completed",
+     "line": 367
+    }
+   },
+   "seconds": 0.8074
+  }
+ ],
+ "file": "/usr/local/lib/python3.14/site-packages/pandas/core/generic.py",
+ "label": "main-31ca5580c",
+ "deadline_seconds": 120.0
+}

--- a/docs/ledgers/stablezero-demand-set-fix.json
+++ b/docs/ledgers/stablezero-demand-set-fix.json
@@ -1,0 +1,191 @@
+{
+ "schema": "stableZero-classify-isolated-v1",
+ "n_functions": 223,
+ "statuses": {
+  "ExitSetFactoringGap": 1,
+  "clean": 221,
+  "raised:TypeError": 1
+ },
+ "R(timeout)": 0,
+ "R(construction_panics)": 0,
+ "R(factoring_gaps)": 1,
+ "R(unnamed_exceptions)": 1,
+ "completed_denominator": 223,
+ "stableZero": false,
+ "desugar_s": 53.77,
+ "wall_s": 57.33,
+ "residuals": [
+  {
+   "name": null,
+   "line": 9596,
+   "status": "raised:TypeError",
+   "testimony": {
+    "type": "TypeError",
+    "message": "<class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>",
+    "frames": [
+     {
+      "module": "__main__",
+      "qualname": "classify",
+      "line": 148
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "FunctionUniverseSugar.desugar",
+      "line": 369
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_body",
+      "line": 303
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.store_effect_sugar",
+      "qualname": "AttributeStoreEffectSugar.desugar",
+      "line": 48
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.subscript_sugar",
+      "qualname": "SubscriptSugar.desugar",
+      "line": 43
+     },
+     {
+      "module": "sugar_lift_py_tests.caller_parameter_contract",
+      "qualname": "ContractConditionalConstructionV1.and_then",
+      "line": 159
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.subscript_sugar",
+      "qualname": "SubscriptSugar.desugar.<locals>.<lambda>",
+      "line": 44
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "SpreadCollectionSugar.desugar",
+      "line": 119
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "_collect",
+      "line": 55
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "outcome_to_exitset",
+      "line": 806
+     }
+    ],
+    "innermost": {
+     "module": "sugar_lift_py_tests.outcome.exit_set",
+     "qualname": "outcome_to_exitset",
+     "line": 806
+    }
+   },
+   "seconds": 1.3517
+  },
+  {
+   "name": null,
+   "line": 13403,
+   "status": "ExitSetFactoringGap",
+   "testimony": {
+    "type": "ExitSetFactoringGap",
+    "message": "ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / StringValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457334:457347#blake3-512:5b32feb0e3630b4d6204e6ffed269ece2581008fc37b12a4390aac94e85fd9155d8260315e9c190bdaec8715100bbd286c890864894ec58c02be3189cc993ce9', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457745:457758#blake3-512:5b603297f0e13ffd4e7ffcde2d896f06b13295b32a24239867e9dfc07c587eb8705d174e6c8a82e7f95b7ae09a26c8f04b5ee0b04699125c00bb3de765c0d4b8', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@459055:459069#blake3-512:edf862325999580225168d4ddba09e14894a34b33abbf14bd2b933186427c005f08a5bfd936619145fe81b45f7ca8396f6fe25e33aeb6ff91e251e8689411923', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462613:462629#blake3-512:a3ae6b2e60ba425f091734cb9f68162e83e9128e362fcbb869c63999032a930a92737fde7da749e002fde8637cabe58ea6094b9fb5b2203b440171adc2e59c49', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))))))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []",
+    "frames": [
+     {
+      "module": "__main__",
+      "qualname": "classify",
+      "line": 148
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "FunctionUniverseSugar.desugar",
+      "line": 369
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_body",
+      "line": 303
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset",
+      "line": 275
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
+      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
+      "line": 84
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.return_sugar",
+      "qualname": "ReturnSugar.desugar",
+      "line": 39
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "SpreadCallSugar.desugar",
+      "line": 197
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.and_then",
+      "line": 535
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.sequence",
+      "line": 522
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.and_then.<locals>.<lambda>",
+      "line": 535
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "SpreadCallSugar.desugar.<locals>.after_callee",
+      "line": 188
+     },
+     {
+      "module": "sugar_lift_py_tests.sugar.spread_sugar",
+      "qualname": "_collect",
+      "line": 55
+     },
+     {
+      "module": "sugar_lift_py_tests.outcome.exit_set",
+      "qualname": "ExitSet.factor_completed",
+      "line": 367
+     }
+    ],
+    "innermost": {
+     "module": "sugar_lift_py_tests.outcome.exit_set",
+     "qualname": "ExitSet.factor_completed",
+     "line": 367
+    }
+   },
+   "seconds": 0.7857
+  }
+ ],
+ "file": "/usr/local/lib/python3.14/site-packages/pandas/core/generic.py",
+ "label": "fix-6351",
+ "deadline_seconds": 120.0
+}

--- a/implementations/python/sugar-lift-py-tests/scripts/stablezero_classify.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/stablezero_classify.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""The `stableZero` rig: classify every function of one file, in isolation.
+
+    stableZero = completed_denominator  > 0
+               ∧ R(timeout)             == 0
+               ∧ R(construction_panics)  == 0
+               ∧ R(factoring_gaps)       == 0
+               ∧ R(unnamed_exceptions)   == 0
+
+WHY THIS SCRIPT EXISTS AT ALL. The `stableZero-classify-isolated-v1` ledgers in
+`docs/ledgers/` were produced by a rig that lived in one agent's temp directory
+and did not survive the session — its own frames record `module: "__main__"`.
+A measurement nobody else can re-take is not an instrument; it is a claim. This
+is the same rig, committed, so the number can be re-taken by anyone at any
+commit. The schema string is unchanged so old and new ledgers compare directly.
+
+WHAT "ISOLATED" MEANS. The file is copied ALONE into an empty temp directory
+and opened from there. There is no workspace contract-ref table, so a function's
+classification depends on nothing but that function, and 223 rows are 223
+independent verdicts rather than one entangled one. It also makes the rig cheap
+enough to run beside a heavy corpus job without contending for the measurement
+lease.
+
+THE STATUSES ARE THE POINT.
+
+  `clean`                 the tower reduced the function. Nothing else.
+  `ConstructionPanic`     an owner reached its `None` arm — a Floor law that
+                          does not exist yet. The panic IS the worklist row,
+                          and its `ConstructionGap` carries owner / blame /
+                          observed / requested / fix.
+  `ExitSetFactoringGap`   a completed face that a first-match-wins guarded
+                          chain cannot faithfully carry.
+  `timeout`               the per-function wall deadline. Recorded separately
+                          and never folded into the others, because a timeout
+                          ABSORBS every panic and gap row the function would
+                          have produced — that is exactly how three pandas
+                          files hid their rows behind the 300s deadline (#6324).
+  `raised:<Type>`         an UNNAMED gap: the tower stopped on a bare exception
+                          that names no owner, no observed shape and no fix.
+
+`R(unnamed_exceptions)` is a term of `stableZero` here, and that is a deliberate
+addition to the milestone as first written. A rig that gates only on panics
+reads GREEN the moment a gap stops naming itself — close three panics, let the
+carrier travel one seat further, hit a bare `raise TypeError(type(outcome))`,
+and the panic axis is zero while a function still does not lift. That is a
+false green bought by misclassification, and it is exactly the failure mode the
+whole ladder exists to prevent. A gap is a gap; wearing a bare exception
+instead of a `ConstructionGap` makes it WORSE, not absent, because it names
+neither its owner nor its replacement architecture.
+
+Every residual carries its full testimony: the gap's own `info` dict, the
+message, and the frame list with the innermost frame named. A row that cannot
+say who owns it cannot be worked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import faulthandler
+import json
+import shutil
+import signal
+import sys
+import tempfile
+import time
+import traceback
+from collections import Counter
+from pathlib import Path
+
+SCHEMA = "stableZero-classify-isolated-v1"
+
+
+class FunctionTimeout(BaseException):
+    """Per-function wall deadline. A BaseException so no `except Exception`
+    inside the tower can swallow the deadline and report a false `clean`."""
+
+
+def _alarm(signum, frame):
+    raise FunctionTimeout("function wall budget")
+
+
+def _frames(error: BaseException) -> list[dict]:
+    return [
+        {
+            "module": frame.f_globals.get("__name__"),
+            "qualname": frame.f_code.co_qualname,
+            "line": lineno,
+        }
+        for frame, lineno in traceback.walk_tb(error.__traceback__)
+    ]
+
+
+def _testimony(error: BaseException) -> dict:
+    """Full testimony for one residual. Never a summary — the row IS the fix."""
+    frames = _frames(error)
+    info = getattr(error, "info", None)
+    payload = {
+        "type": type(error).__name__,
+        "message": str(error),
+        "frames": frames,
+        "innermost": frames[-1] if frames else None,
+    }
+    if info is not None:
+        payload["info"] = {
+            "owner": getattr(info, "owner", None),
+            "blame": getattr(info, "blame", None),
+            "observed": getattr(info, "observed", None),
+            "requested": getattr(info, "requested", None),
+            "fix": getattr(info, "fix", None),
+            "gap_kind": getattr(getattr(info, "gap_kind", None), "name", None),
+            "gap_locus": getattr(getattr(info, "gap_locus", None), "name", None),
+        }
+    return payload
+
+
+def classify(path: Path, deadline: float) -> dict:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.tree import SourceFile
+
+    wall_started = time.time()
+    functions = list(SourceFile(path_source(str(path))).functions())
+
+    rows: list[dict] = []
+    desugar_seconds = 0.0
+    signal.signal(signal.SIGALRM, _alarm)
+
+    for function in functions:
+        try:
+            span = function.line_col_span()
+            line = span.start_line
+        except Exception:
+            line = None
+        try:
+            name = function.name()
+        except Exception:
+            name = None
+
+        row: dict = {"name": name, "line": line}
+        started = time.time()
+        signal.setitimer(signal.ITIMER_REAL, deadline)
+        try:
+            sugar = function.sugar()
+            if sugar is None:
+                row["status"] = "clean"
+            else:
+                sugar.desugar(None)
+                row["status"] = "clean"
+        except SugarNotWritten:
+            # The TREE door, not a Floor law. It is a construction gap on the
+            # recognition axis and is counted on its own name, never folded
+            # into the Floor panic term this rig gates on.
+            row["status"] = "SugarNotWritten"
+        except FunctionTimeout:
+            row["status"] = "timeout"
+        except ExitSetFactoringGap as gap:
+            row["status"] = "ExitSetFactoringGap"
+            row["testimony"] = _testimony(gap)
+        except ConstructionPanic as panic:
+            row["status"] = "ConstructionPanic"
+            row["testimony"] = _testimony(panic)
+        except BaseException as error:  # noqa: BLE001 — measured, never hidden
+            row["status"] = f"raised:{type(error).__name__}"
+            row["testimony"] = _testimony(error)
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+        row["seconds"] = round(time.time() - started, 4)
+        desugar_seconds += row["seconds"]
+        rows.append(row)
+
+    statuses = Counter(row["status"] for row in rows)
+    r_timeout = statuses["timeout"]
+    r_panics = statuses["ConstructionPanic"]
+    r_gaps = statuses["ExitSetFactoringGap"]
+    r_unnamed = sum(
+        count for status, count in statuses.items() if status.startswith("raised:")
+    )
+    completed = len(rows) - r_timeout
+
+    return {
+        "schema": SCHEMA,
+        "n_functions": len(rows),
+        "statuses": dict(sorted(statuses.items())),
+        "R(timeout)": r_timeout,
+        "R(construction_panics)": r_panics,
+        "R(factoring_gaps)": r_gaps,
+        "R(unnamed_exceptions)": r_unnamed,
+        "completed_denominator": completed,
+        "stableZero": bool(
+            completed > 0
+            and r_timeout == 0
+            and r_panics == 0
+            and r_gaps == 0
+            and r_unnamed == 0
+        ),
+        "desugar_s": round(desugar_seconds, 2),
+        "wall_s": round(time.time() - wall_started, 2),
+        "residuals": [row for row in rows if row["status"] != "clean"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", help="path to the single file to classify")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--deadline", type=float, default=120.0)
+    parser.add_argument("--label", default="")
+    args = parser.parse_args()
+
+    faulthandler.enable()
+    sys.setrecursionlimit(100000)
+
+    source = Path(args.source).resolve()
+    isolated = Path(tempfile.mkdtemp(prefix="sz-iso-"))
+    try:
+        copied = isolated / source.name
+        shutil.copy2(source, copied)
+        payload = classify(copied, args.deadline)
+    finally:
+        shutil.rmtree(isolated, ignore_errors=True)
+
+    payload["file"] = str(source)
+    payload["label"] = args.label
+    payload["deadline_seconds"] = args.deadline
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(payload, indent=1) + "\n", encoding="utf-8")
+
+    print(
+        f"stableZero={payload['stableZero']} "
+        f"denominator={payload['completed_denominator']} "
+        f"timeouts={payload['R(timeout)']} "
+        f"construction_panics={payload['R(construction_panics)']} "
+        f"factoring_gaps={payload['R(factoring_gaps)']} "
+        f"unnamed_exceptions={payload['R(unnamed_exceptions)']} "
+        f"statuses={payload['statuses']} out={args.out}",
+        flush=True,
+    )
+    # Red while any term is nonzero. The exit code is the gate; never read a
+    # verdict off a pipeline's last stage.
+    return 0 if payload["stableZero"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -67,12 +67,56 @@ class ParameterContractDemandV1:
         }
 
 
+def merge_demands(*groups) -> tuple[ParameterContractDemandV1, ...]:
+    """The demand SET: union by content address, ordered by content address.
+
+    `demand_cid` is the content address of the WHOLE obligation — owner source
+    identity, formal coordinate, operation site, demanded formula, candidate —
+    so equal cids are the same obligation and dedupe is not a heuristic. It is
+    the arithmetic of the obligation: a conjunction is idempotent, `F and F` IS
+    `F`, and one obligation reaching a join twice through a shared outcome DAG
+    (`p[0]` read once and consumed on both faces of a fold) is one obligation.
+
+    Ordering is by cid, never by arrival. The universe is content: a set that
+    ordered by the order two folds happened to run would make the same
+    obligations mint two different rows, and there is no RNG and no clock here
+    to justify that.
+    """
+    by_cid: dict[str, ParameterContractDemandV1] = {}
+    for group in groups:
+        for demand in group:
+            by_cid.setdefault(demand.demand_cid, demand)
+    return tuple(by_cid[cid] for cid in sorted(by_cid))
+
+
 @dataclass(frozen=True)
 class ContractConditionalConstructionV1:
+    """A constructed value together with every caller obligation it incurred.
+
+    `demands` is a SET, not one demand (#6352). One expression can incur several
+    distinct obligations — `[p[0], q[1]]` owes `python:indexable(p)` AND
+    `python:indexable(q)`, `f(p[0], q[1])` the same — and the entry used to hold
+    exactly one. Every join that met a second one panicked NAMED: `collection
+    TupleValue`, `IfExpSugar._join`, and `ContractConditionalConstructionV1
+    .and_then` each said the same sentence, "widen ... to carry a demand SET".
+    Three call sites requesting one widening is the ontology telling you it is
+    missing a kind of thing, so the thing is here now.
+
+    Two demands are NOT conjoined into one. Each carries its own
+    `formal_coordinate_cid` and `owner_source_identity_cid`; fusing their
+    formulas would mint one obligation attributed to one formal that actually
+    spans two, which is a fabricated fact, not a smaller answer.
+
+    THE WIRE SHAPE IS UNCHANGED. `contribution` splits the entry into one entry
+    per demand before anything is projected, so `to_value`, the link unit, and
+    the Rust linker still see exactly one demand per row. The set exists only
+    in flight, where the joins happen.
+    """
+
     source_node: SourceFragmentCoordinateV1
     candidate: Term
     candidate_cid: str
-    demand: ParameterContractDemandV1
+    demands: tuple[ParameterContractDemandV1, ...]
     value: FloorValue
 
     @classmethod
@@ -92,12 +136,12 @@ class ContractConditionalConstructionV1:
             demanded_formula=demand_formula,
             candidate_cid=candidate_cid,
         )
-        return cls(source_node, candidate, candidate_cid, demand, value)
+        return cls(source_node, candidate, candidate_cid, (demand,), value)
 
     def and_then(self, step):
-        """Continue with the carried value; the demand rides on the result.
+        """Continue with the carried value; every demand rides on the result.
 
-        A following ``Complete`` takes the demand back and the entry rides on
+        A following ``Complete`` takes the demands back and the entry rides on
         into the block record, where ``link_unit_projection`` enrols it and the
         linker discharges it.
 
@@ -140,14 +184,22 @@ class ContractConditionalConstructionV1:
         """
         from sugar_lift_py_tests.ir import implies
 
+        # EVERY demand weakens. Weakening only one of a set would leave the
+        # others owed unconditionally on a face that may never run, which is a
+        # stronger obligation than the source states.
         return replace(
             self,
-            demand=ParameterContractDemandV1.mint(
-                owner_source_identity_cid=self.demand.owner_source_identity_cid,
-                formal_coordinate_cid=self.demand.formal_coordinate_cid,
-                operation_site=self.demand.operation_site,
-                demanded_formula=implies(formula, self.demand.demanded_formula),
-                candidate_cid=self.demand.candidate_cid,
+            demands=merge_demands(
+                tuple(
+                    ParameterContractDemandV1.mint(
+                        owner_source_identity_cid=demand.owner_source_identity_cid,
+                        formal_coordinate_cid=demand.formal_coordinate_cid,
+                        operation_site=demand.operation_site,
+                        demanded_formula=implies(formula, demand.demanded_formula),
+                        candidate_cid=demand.candidate_cid,
+                    )
+                    for demand in self.demands
+                )
             ),
         )
 
@@ -179,7 +231,14 @@ class ContractConditionalConstructionV1:
         )
 
     def contribution(self):
-        return (self,)
+        """One row per demand: the SET collapses back to singletons HERE.
+
+        This is the boundary the wire lives behind. `to_value`, the link unit,
+        and the Rust linker each state one demand per row, and they are right
+        to -- an obligation is owned by ONE formal coordinate. The set is an
+        in-flight join carrier, not a wire shape, so it never reaches them.
+        """
+        return tuple(replace(self, demands=(demand,)) for demand in self.demands)
 
     def inv_contribution(self):
         return ()
@@ -207,6 +266,35 @@ class ContractConditionalConstructionV1:
     def extend_scope(self, ctx):
         return self.value.extend_scope(ctx)
 
+    def sole_demand(self) -> ParameterContractDemandV1:
+        """The one demand a PROJECTED row states, or a named gap.
+
+        Every projection boundary reads this. `contribution` splits the set
+        before anything is projected, so a set arriving here means a producer
+        reached the wire without going through the block record -- loud, not
+        silently first-of-set.
+        """
+        if len(self.demands) == 1:
+            return self.demands[0]
+        from sugar_lift_py_tests.gap.info import GapKind
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="ContractConditionalConstructionV1.sole_demand",
+            blame=self.source_node,
+            observed=(
+                f"a projected contract row carries {len(self.demands)} demands "
+                f"({', '.join(demand.demand_cid for demand in self.demands)})"
+            ),
+            requested="exactly one demand per projected row",
+            fix=(
+                "route the entry through `contribution`, which splits the "
+                "in-flight demand SET into one row per demand, before "
+                "projecting it to the wire"
+            ),
+            gap_kind=GapKind.FLOOR,
+        )
+
     def to_value(self) -> dict[str, Any]:
         return {
             "kind": "contract-conditional-construction",
@@ -214,7 +302,7 @@ class ContractConditionalConstructionV1:
             "sourceNode": self.source_node.wire(),
             "candidate": _json(term_to_value(self.candidate)),
             "candidateCid": self.candidate_cid,
-            "demand": self.demand.to_value(),
+            "demand": self.sole_demand().to_value(),
         }
 
 
@@ -609,7 +697,7 @@ def resume_project(universe, accepted: dict[str, dict]):
             entry.value
             if (
                 isinstance(entry, ContractConditionalConstructionV1)
-                and entry.demand.demand_cid in accepted
+                and entry.sole_demand().demand_cid in accepted
             )
             else entry
         )
@@ -644,7 +732,7 @@ def resume_apply_resolutions(link_unit, resolution_set) -> dict[str, dict]:
         )
     pending = {}
     for candidate in link_unit.candidates:
-        key = candidate.demand.demand_cid
+        key = candidate.sole_demand().demand_cid
         if key in pending:
             raise ResumeStalePanic("duplicate pending demand in link unit")
         pending[key] = candidate

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -68,58 +68,66 @@ def rewrap_pending(pending, outcome, *, owner, blame):
     """
     from dataclasses import replace
 
-    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ContractConditionalConstructionV1,
+        merge_demands,
+    )
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
 
     if pending is None:
         return outcome
+
+    # A VALUE takes the obligations back and rides on into the block record.
     if isinstance(outcome, Complete):
         return replace(pending, value=outcome.value)
-    from sugar_lift_py_tests.caller_parameter_contract import (
-        ContractConditionalConstructionV1,
-    )
+
+    # A SECOND CARRIER: union the demand sets (#6352). `demand_cid` is the
+    # content address of the whole obligation, so the union dedupes the same
+    # obligation reaching this join twice through a shared outcome DAG (`p[0]`
+    # read once, consumed on both faces of a fold) and keeps two DISTINCT
+    # obligations distinct. Nothing is conjoined into a single demand: each
+    # carries its own formal coordinate, and fusing them would attribute one
+    # obligation to a formal that does not own it.
+    if isinstance(outcome, ContractConditionalConstructionV1):
+        return replace(
+            outcome, demands=merge_demands(pending.demands, outcome.demands)
+        )
+
+    # AN EFFECT: the obligation was incurred BEFORE the effect, on the path that
+    # reached it (`o.x = p[k]` evaluates `p[k]`, then the store answers). It is
+    # owed, and `Incomplete` carries it to the block record the same way it
+    # carries branch conditions. The carried VALUE is dropped here on purpose --
+    # there is no value on this face -- but the obligation is not.
+    if isinstance(outcome, Incomplete):
+        return replace(
+            outcome,
+            pending_contracts=(*outcome.pending_contracts, pending),
+        )
+
+    # A PARTITION stays LOUD. An `ExitSet`'s faces each carry their own guard,
+    # and the entry has one value with no seam to split across them. Inventing
+    # an arm here would either attribute the obligation to every face (owing
+    # more than the source states) or pick one (dropping the rest). Neither is
+    # a smaller answer; both are wrong ones.
     from sugar_lift_py_tests.gap.info import GapKind
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
-    # Two different next architectures, named apart rather than blurred: a second
-    # PENDING entry wants the entry to carry a demand SET; a PARTITION wants the
-    # exit algebra to have an arm for a pending demand at all.
-    if isinstance(outcome, ContractConditionalConstructionV1):
-        if outcome.demand.demand_cid == pending.demand.demand_cid:
-            # NOT two demands. ``demand_cid`` is the content address of the
-            # whole obligation -- owner source identity, formal coordinate,
-            # operation site, demanded formula, candidate. Equal cids mean the
-            # SAME obligation reached this join twice through a shared outcome
-            # DAG (`p[0]` read once and consumed on both faces of a fold).
-            #
-            # Conjunction is idempotent: `F and F` IS `F`. The joined outcome
-            # already carries that exact demand, so it rides on unchanged. This
-            # discharges nothing, weakens nothing and invents nothing -- it is
-            # the arithmetic of the obligation, not a fallback. Two DISTINCT
-            # demands still need a demand SET and stay loud below.
-            return outcome
-        observed = (
-            f"two distinct pending contract demands ({pending.demand.demand_cid} "
-            f"and {outcome.demand.demand_cid}) joined onto one constructed value"
-        )
-        fix = (
-            "widen ContractConditionalConstructionV1 to carry a demand SET; "
-            "never drop the obligation"
-        )
-    else:
-        observed = (
-            f"a hoisted parameter contract demand ({pending.demand.demand_cid}) "
-            f"joined onto a {type(outcome).__name__}, which carries no single value"
-        )
-        fix = (
-            "give the exit algebra an arm for a pending contract demand so a "
-            "partition can carry it; never drop the obligation"
-        )
     construction_panic_gap(
         owner=owner,
         blame=blame,
-        observed=observed,
-        requested="one joined value that can carry every pending demand",
-        fix=fix,
+        observed=(
+            "pending parameter contract demands ("
+            + ", ".join(demand.demand_cid for demand in pending.demands)
+            + f") joined onto a {type(outcome).__name__}, whose faces each carry "
+            "their own guard and cannot share one carried value"
+        ),
+        requested="one joined outcome that can carry every pending demand",
+        fix=(
+            "give the exit algebra an arm for a pending contract demand, so each "
+            "completed face carries the demands weakened under its own guard; "
+            "never drop the obligation and never owe it on a face that does not "
+            "run"
+        ),
         gap_kind=GapKind.FLOOR,
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -80,7 +80,11 @@ class UniverseValue(FloorValue):
                 blame=self.name,
                 observed=(
                     "pending parameter contract demands "
-                    + ",".join(entry.demand.demand_cid for entry in pending)
+                    + ",".join(
+                        demand.demand_cid
+                        for entry in pending
+                        for demand in entry.demands
+                    )
                 ),
                 requested="authenticated ParameterContractResolutionV1 rows",
                 fix=(
@@ -221,11 +225,17 @@ class UniverseValue(FloorValue):
         owner_cid = coords[0].owner_source_identity_cid
         owner_locus = coords[0].owner_definition_locus
         coord_cids = {coordinate.coordinate_cid for coordinate in coords}
+        # Flatten over the entry's demand SET (#6352). `contribution` already
+        # split it into one row per demand on the way into the record, so this
+        # normally sees singletons; iterating the set keeps the reader correct
+        # for any producer that reaches the record without splitting, instead of
+        # silently owning only the first.
         owned_demands = [
-            entry.demand.demand_cid
+            demand.demand_cid
             for entry in pending
-            if entry.demand.formal_coordinate_cid in coord_cids
-            and entry.demand.owner_source_identity_cid == owner_cid
+            for demand in entry.demands
+            if demand.formal_coordinate_cid in coord_cids
+            and demand.owner_source_identity_cid == owner_cid
         ]
         owned = ParameterOwnedContractV1.mint(
             name=self.name,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -773,8 +773,11 @@ def factored_operand(outcome):
     #6319 made halting and partitioning operands LIFT instead of raising --
     correctly; that ruling drained 369 defect rows and stays. But it thereby
     put multi-arm completed faces into every one of those folds for the first
-    time. `pandas/tests/extension/test_arrow.py` measured 133,104 arms arriving
-    at ONE ``normalize`` call through ``collection_sugar._reduce_into``.
+    time. The corpus measured 133,104 arms arriving at ONE ``normalize`` call
+    through ``collection_sugar._reduce_into``; the file is named in #6324's
+    receipt, not here -- a router must not carry a vendor spelling even in
+    prose, which is what `test_routers_do_not_branch_on_keyword_vendor_or_
+    manager_spelling` is watching for.
 
     The accumulator itself cannot be factored: its completed value is the
     growing tuple the fold is building, and a ``GuardedValue`` chain over

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -7,8 +7,27 @@ from sugar_lift_py_tests.effect import Effect, effect_reason, require_effect
 
 @dataclass(frozen=True)
 class Incomplete:
+    """A typed effect, plus any caller obligation already incurred on this path.
+
+    ``pending_contracts`` is the effect face of the parameter-contract carrier
+    (#6352). `o.x = p[k]` evaluates `p[k]` -- incurring `python:indexable(p)` --
+    and THEN answers with a store effect. The obligation was incurred before
+    the effect, on the path that reached it, so it is owed. It used to have
+    nowhere to go and `rewrap_pending` panicked NAMED rather than drop it.
+
+    It rides here for exactly the reason ``branch_conditions`` does: it is
+    wrapper-level testimony ABOUT the outcome, never smashed into the effect,
+    which stays pristine. And it goes on to the block record through
+    ``contribution``, which is what enrols it for the linker to discharge.
+
+    A PARTITION is still loud. An ``ExitSet``'s faces carry their own guards
+    and the entry has no seam there, so no arm is invented for it -- see
+    ``floor/single_outcome_law.rewrap_pending``.
+    """
+
     effect: Effect
     branch_conditions: tuple = ()
+    pending_contracts: tuple = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "effect", require_effect(self.effect))
@@ -56,7 +75,19 @@ class Incomplete:
     def contribution(self):
         # An effect contributes itself to the block record; the unresolved tail rides
         # beside it via follow.
-        return (self,)
+        #
+        # Any obligation incurred BEFORE the effect contributes beside it, one
+        # row per demand, exactly as a completed carrier would (#6352). The
+        # entry's own `contribution` does the set-to-singleton split, so this
+        # never has to know the set exists.
+        return (
+            self,
+            *(
+                row
+                for entry in self.pending_contracts
+                for row in entry.contribution()
+            ),
+        )
 
     def guarded(self, formula):
         """Keep a typed effect red while recording its branch condition.
@@ -66,7 +97,14 @@ class Incomplete:
         effects, e.g. RaiseEffect, compute ``reason`` as a property with no field
         to replace), and a raise guarded by several nested ifs accumulates its
         conditions in order."""
-        return Incomplete(self.effect, (*self.branch_conditions, formula))
+        # A carried obligation weakens on the same face the effect is guarded
+        # by: a caller that never takes the branch never evaluated `p[k]` and
+        # owes nothing (#6352).
+        return Incomplete(
+            self.effect,
+            (*self.branch_conditions, formula),
+            tuple(entry.demanded_under(formula) for entry in self.pending_contracts),
+        )
 
     def extend_scope(self, ctx):
         # An effect does not rebind: the rest never runs under a new scope.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -39,6 +39,9 @@ def _reduce_into(element_sugars, ctx, build):
         pending_demand,
         rewrap_pending,
     )
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.caller_parameter_contract import merge_demands
     from sugar_lift_py_tests.outcome import true_guard
     from sugar_lift_py_tests.outcome.exit_set import factored_operand
 
@@ -52,37 +55,24 @@ def _reduce_into(element_sugars, ctx, build):
     # display has no guard of its own -- so it hoists at `true_guard`.
     pending = None
     stripped = []
-    # Two elements carrying the SAME obligation are not two obligations:
-    # ``demand_cid`` is the content address of the whole demand, so equal cids
-    # are the same formal, site, formula and candidate reached twice (`[p[0],
-    # p[0]]`, or one reduced element shared by a fold). Conjunction is
-    # idempotent, so one entry carries both. Only DISTINCT demands need a
-    # demand SET, and those stay loud.
     for outcome in reduced:
         entry, plain = pending_demand(outcome, true_guard())
-        if (
-            entry is not None
-            and pending is not None
-            and entry.demand.demand_cid != pending.demand.demand_cid
-        ):
-            from sugar_lift_py_tests.gap.info import GapKind
-            from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-            construction_panic_gap(
-                owner=owner,
-                blame=str(entry.source_node),
-                observed=(
-                    "two collection elements enrolled DISTINCT contract demands "
-                    f"({pending.demand.demand_cid} and {entry.demand.demand_cid})"
-                ),
-                requested="one pending demand per constructed value",
-                fix=(
-                    "widen ContractConditionalConstructionV1 to carry a demand SET "
-                    "before building a collection from two pending elements"
-                ),
-                gap_kind=GapKind.FLOOR,
+        if entry is not None:
+            # EVERY element's obligations accumulate into one demand SET
+            # (#6352). `[p[0], q[1]]` owes `python:indexable(p)` AND
+            # `python:indexable(q)`; this used to panic NAMED on the second
+            # distinct demand because the carrier held exactly one. The union
+            # dedupes by `demand_cid` -- the content address of the whole
+            # obligation -- so `[p[0], p[0]]` is still one obligation, and two
+            # different ones stay two.
+            pending = (
+                entry
+                if pending is None
+                else replace(
+                    pending,
+                    demands=merge_demands(pending.demands, entry.demands),
+                )
             )
-        pending = entry if entry is not None else pending
         stripped.append(plain)
 
     # An element that PARTITIONS enters the fold with at most one completed arm

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -78,25 +78,30 @@ class IfExpSugar(Sugar):
         pending = _pending(then_out), _pending(else_out)
         if any(pending):
             if all(pending):
-                # Both arms pending: one entry carries exactly one demand, so two
-                # demands on one expression have no representation here. Loud, and
-                # named -- never drop one of them.
-                from sugar_lift_py_tests.gap.info import GapKind
-                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+                # BOTH ARMS PENDING (#6352). `p[0] if c else q[1]` owes
+                # `c -> python:indexable(p)` AND `not c -> python:indexable(q)`
+                # -- two obligations, each on its own face. This used to be
+                # loud, because the carrier held exactly one demand.
+                #
+                # Each arm weakens under ITS OWN face before the union, so
+                # neither is owed where it does not run, and the sets union by
+                # content address. The then arm's value carries the joined set.
+                from dataclasses import replace
 
-                construction_panic_gap(
-                    owner="IfExpSugar._join",
-                    blame=str(self.site),
-                    observed=(
-                        "both conditional-expression arms enrolled a parameter "
-                        "contract demand"
-                    ),
-                    requested="one pending demand per constructed value",
-                    fix=(
-                        "widen ContractConditionalConstructionV1 to carry a demand "
-                        "SET before joining two pending arms"
-                    ),
-                    gap_kind=GapKind.FLOOR,
+                from sugar_lift_py_tests.caller_parameter_contract import (
+                    merge_demands,
+                )
+
+                then_entry = then_out.demanded_under(formula)
+                else_entry = else_out.demanded_under(not_formula)
+                joined = replace(
+                    then_entry,
+                    demands=merge_demands(then_entry.demands, else_entry.demands),
+                )
+                return joined.and_then(
+                    lambda value: self._join_arms(
+                        formula, Complete(value), Complete(else_entry.value)
+                    )
                 )
             if pending[0]:
                 return then_out.demanded_under(formula).and_then(

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_panic_tail_owners.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_panic_tail_owners.py
@@ -154,41 +154,45 @@ def _pending(cid: str, value):
         source_node="renamed_module.py:1:0",
         candidate=atomic("renamed_candidate", []),
         candidate_cid=f"blake3-512:{cid}",
-        demand=_RenamedDemand(f"blake3-512:{cid}"),
+        demands=(_RenamedDemand(f"blake3-512:{cid}"),),
         value=value,
     )
 
 
 def test_one_obligation_reached_twice_is_carried_once() -> None:
+    """Idempotence: `demand_cid` is content, so the same obligation unions to one."""
     from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
 
-    joined = _pending("aaaa", TermValue(2))
     result = rewrap_pending(
         _pending("aaaa", TermValue(1)),
-        joined,
+        _pending("aaaa", TermValue(2)),
         owner="renamed_join",
         blame="renamed_module.py:1:0",
     )
-    assert result is joined
-    assert result.demand.demand_cid == "blake3-512:aaaa"
+    assert result.sole_demand().demand_cid == "blake3-512:aaaa"
 
 
-def test_two_distinct_obligations_stay_loud() -> None:
-    """The discriminating face: carrying one would DROP the other."""
+def test_two_distinct_obligations_join_and_both_survive() -> None:
+    """SUPERSEDED PANIC, NOW A LAW (#6352).
+
+    This used to assert the loud refusal, because the carrier held exactly one
+    demand and carrying one would DROP the other. The panic named its own
+    replacement -- a demand SET -- and that landed. The assertion moves from
+    "it refuses" to "BOTH obligations survive the join", which is the property
+    the refusal was protecting.
+    """
     from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
 
-    with pytest.raises(ConstructionPanic) as excinfo:
-        rewrap_pending(
-            _pending("aaaa", TermValue(1)),
-            _pending("bbbb", TermValue(2)),
-            owner="renamed_join",
-            blame="renamed_module.py:1:0",
-        )
-    info = excinfo.value.info
-    assert "two distinct pending contract demands" in info.observed
-    assert "blake3-512:aaaa" in info.observed
-    assert "blake3-512:bbbb" in info.observed
-    assert "demand SET" in info.fix
+    result = rewrap_pending(
+        _pending("aaaa", TermValue(1)),
+        _pending("bbbb", TermValue(2)),
+        owner="renamed_join",
+        blame="renamed_module.py:1:0",
+    )
+    assert {demand.demand_cid for demand in result.demands} == {
+        "blake3-512:aaaa",
+        "blake3-512:bbbb",
+    }
 
 
 def test_a_partition_still_has_nowhere_to_carry_a_demand() -> None:
@@ -203,7 +207,7 @@ def test_a_partition_still_has_nowhere_to_carry_a_demand() -> None:
             owner="renamed_join",
             blame="renamed_module.py:1:0",
         )
-    assert "carries no single value" in excinfo.value.info.observed
+    assert "cannot share one carried value" in excinfo.value.info.observed
 
 
 # --------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
@@ -47,7 +47,7 @@ def _link_unit():
         owner_source_identity_cid=SRC,
         owner_definition_locus=owner_def,
         formal_coordinates=(coord,),
-        declared_demand_cids=[cand.demand.demand_cid],
+        declared_demand_cids=[cand.sole_demand().demand_cid],
     )
     unit = ParameterContractLinkUnitV1.mint(
         source_memento={"file": "vendor/b64vendor.py"},
@@ -74,7 +74,7 @@ def _resolution(
 
 
 def _good_set(unit, cand, owned):
-    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
     return (
         ParameterContractResolutionSetV1.mint(
             link_unit_cid=unit.link_unit_cid, resolutions=(res,)
@@ -87,7 +87,7 @@ def test_twin_standalone_self_declared_honored():
     unit, cand, owned = _link_unit()
     rset, res = _good_set(unit, cand, owned)
     accepted = resume_apply_resolutions(unit, rset)
-    assert accepted[cand.demand.demand_cid] == res
+    assert accepted[cand.sole_demand().demand_cid] == res
 
 
 def test_twin_missing_resolution_panics():
@@ -101,7 +101,7 @@ def test_twin_missing_resolution_panics():
 
 def test_twin_duplicate_resolution_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
     rset = ParameterContractResolutionSetV1.mint(
         link_unit_cid=unit.link_unit_cid, resolutions=(res, res)
     )
@@ -111,7 +111,7 @@ def test_twin_duplicate_resolution_panics():
 
 def test_twin_stale_resolution_cid_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
     res["resolutionCid"] = "blake3-512:" + "0" * 128
     rset = ParameterContractResolutionSetV1.mint(
         link_unit_cid=unit.link_unit_cid, resolutions=(res,)
@@ -123,7 +123,7 @@ def test_twin_stale_resolution_cid_panics():
 def test_twin_foreign_contract_panics():
     unit, cand, owned = _link_unit()
     res = _resolution(
-        cand.demand.demand_cid, cand.candidate_cid, "blake3-512:" + "f" * 128
+        cand.sole_demand().demand_cid, cand.candidate_cid, "blake3-512:" + "f" * 128
     )
     rset = ParameterContractResolutionSetV1.mint(
         link_unit_cid=unit.link_unit_cid, resolutions=(res,)
@@ -135,7 +135,7 @@ def test_twin_foreign_contract_panics():
 def test_twin_wrong_candidate_panics():
     unit, cand, owned = _link_unit()
     res = _resolution(
-        cand.demand.demand_cid, "blake3-512:" + "c" * 128, owned.contract_cid
+        cand.sole_demand().demand_cid, "blake3-512:" + "c" * 128, owned.contract_cid
     )
     rset = ParameterContractResolutionSetV1.mint(
         link_unit_cid=unit.link_unit_cid, resolutions=(res,)
@@ -146,7 +146,7 @@ def test_twin_wrong_candidate_panics():
 
 def test_twin_lost_continuation_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.demand.demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
     # a set minted for a DIFFERENT continuation key
     foreign = ParameterContractResolutionSetV1.mint(
         link_unit_cid="blake3-512:" + "9" * 128, resolutions=(res,)

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py
@@ -42,7 +42,7 @@ def _self_declared_set(unit):
     pre = {
         "kind": "parameter-contract-resolution",
         "schemaVersion": "1",
-        "demandCid": cand.demand.demand_cid,
+        "demandCid": cand.sole_demand().demand_cid,
         "candidateCid": cand.candidate_cid,
         "contractCid": unit.parameter_owned_contract.contract_cid,
         "basis": "declared-demand",
@@ -74,7 +74,7 @@ def test_twin_b_lying_candidate_is_rejected():
     pre = {
         "kind": "parameter-contract-resolution",
         "schemaVersion": "1",
-        "demandCid": cand.demand.demand_cid,
+        "demandCid": cand.sole_demand().demand_cid,
         "candidateCid": "blake3-512:" + "b" * 128,  # LIE
         "contractCid": unit.parameter_owned_contract.contract_cid,
         "basis": "declared-demand",
@@ -121,7 +121,7 @@ def test_report_declared_demand_basis_grounded():
     # #2: the ACTUAL emitted link unit carries the exact pending demand CID in
     # declaredDemandCids (that is why Rust selects DeclaredDemand).
     universe, unit = _universe_and_unit("def transform(items):\n    return items[0]\n")
-    demand_cid = unit.candidates[0].demand.demand_cid
+    demand_cid = unit.candidates[0].sole_demand().demand_cid
     declared = unit.parameter_owned_contract.declared_demand_cids
     assert demand_cid in declared, "pending demand must be self-declared"
     assert (

--- a/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
+++ b/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
@@ -95,7 +95,7 @@ class _BoundState(Sugar):
 
 def _demand_shape(entry):
     """The demanded formula's outermost connective, as wire vocabulary."""
-    return json.loads(encode_jcs(formula_to_value(entry.demand.demanded_formula)))
+    return json.loads(encode_jcs(formula_to_value(entry.sole_demand().demanded_formula)))
 
 
 # --------------------------------------------------------------------------
@@ -333,24 +333,39 @@ def test_conditional_receiver_with_one_pending_contract_arm_lifts() -> None:
     assert len(pending) == 1
 
 
-def test_two_pending_contract_arms_are_loud_and_named() -> None:
-    """DISCRIMINATING. One entry carries exactly one demand, so a join of TWO
-    pending arms has no representation. It must panic NAMING the next
-    architecture -- never silently drop one of the two obligations."""
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+def test_two_pending_contract_arms_join_and_conserve_both_demands() -> None:
+    """SUPERSEDED PANIC, NOW A LAW (#6352).
 
-    with pytest.raises(ConstructionPanic) as raised:
-        _out(
-            "def f(c, p, q):\n"
-            " if c:\n"
-            "  x = p\n"
-            " else:\n"
-            "  x = q\n"
-            " return x[0]\n"
-        )
-    message = str(raised.value)
-    assert "never drop the obligation" in message
-    assert "demand SET" in message or "carry a pending contract demand" in message
+    This used to assert the panic: one entry carried exactly one demand, so a
+    join of TWO pending arms had no representation and had to be loud. The
+    panic named its own replacement -- "widen ContractConditionalConstructionV1
+    to carry a demand SET" -- and that widening landed, so the assertion moves
+    from "it refuses" to "it joins, and conserves BOTH obligations".
+
+    The twin is rewritten rather than deleted: the obligation being conserved is
+    what the panic was protecting, and deleting the test would retire the
+    protection along with the panic. Both formals must still be owed.
+    """
+    out = _out(
+        "def f(c, p, q):\n"
+        " if c:\n"
+        "  x = p\n"
+        " else:\n"
+        "  x = q\n"
+        " return x[0]\n"
+    )
+    pending = _pending(out)
+    assert pending
+
+    formals = {
+        demand.formal_coordinate_cid
+        for entry in pending
+        for demand in entry.demands
+    }
+    assert len(formals) == 2, (
+        "a join of two pending arms conserved only one formal's obligation: the "
+        "demands were dropped or conjoined instead of unioned (#6352)"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_conditional.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_conditional.py
@@ -45,9 +45,9 @@ def test_symbolic_parameter_subscript_constructs_one_pending_candidate(
     ]
     assert len(pending) == 1
     conditional = pending[0]
-    assert conditional.demand.formal_coordinate_cid
-    assert conditional.demand.candidate_cid == conditional.candidate_cid
-    assert conditional.demand.demand_cid
+    assert conditional.sole_demand().formal_coordinate_cid
+    assert conditional.sole_demand().candidate_cid == conditional.candidate_cid
+    assert conditional.sole_demand().demand_cid
     assert calls == 1
     with pytest.raises(ConstructionPanic, match="ParameterContractResolutionV1"):
         out.value.post()

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
@@ -1,0 +1,364 @@
+"""The demand SET and the effect face: #6352's two closed construction panics.
+
+One expression can incur SEVERAL caller obligations. `[p[0], q[1]]` owes
+`python:indexable(p)` AND `python:indexable(q)`. `ContractConditionalConstructionV1`
+held exactly one demand, so every join that met a second one panicked NAMED --
+`collection TupleValue`, `IfExpSugar._join`, and
+`ContractConditionalConstructionV1.and_then` each said the same sentence in its
+own `fix` string: "widen ContractConditionalConstructionV1 to carry a demand
+SET". Three call sites asking for one widening is the ontology reporting that it
+is missing a kind of thing.
+
+The other face: `o.x = p[k]` evaluates `p[k]` -- incurring the obligation -- and
+THEN answers with a store effect. The demand was owed on the path that reached
+the effect, and `Incomplete` had nowhere to carry it.
+
+Measured on `pandas/core/generic.py` with `scripts/stablezero_classify.py`,
+223 functions, isolated:
+
+    main 31ca5580c   construction_panics = 3
+    this branch      construction_panics = 0
+
+EVERY TEST HERE IS A PAIR. A positive says the obligation survives; a
+DISCRIMINATING one says it survived *as itself*. Widening a carrier is exactly
+the change that can pass a positive while quietly losing an obligation --
+conjoin two demands into one, keep the first and drop the second, or owe a
+demand on a face that never runs. Each of those would satisfy "it lifts" and be
+a certified lie about what the caller owes, so each has its own arm below.
+
+The obligations are compared by `demand_cid`: the content address of the WHOLE
+demand (owner source identity, formal coordinate, operation site, demanded
+formula, candidate). Comparing anything less would let a test pass on a demand
+that names the wrong formal.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+    merge_demands,
+)
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _out(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _entries(out) -> tuple:
+    """Every projected contract row the function's block record enrolled.
+
+    Read off the record, not off the in-flight carrier, because the record is
+    what `link_unit_projection` hands the linker. A demand that never reaches
+    here is never discharged, so this is the only honest place to assert
+    conservation.
+
+    A function containing a STORE reduces to an `ExitSet`, not a `Complete`:
+    `o.x = v` is runtime-selected success/halt over the store's own occurrence
+    coordinate. The record lives on the completed face; the halted face carries
+    the prefix state and projects no link unit at all.
+    """
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
+
+    if isinstance(out, ExitSet):
+        completed = [e for e in out.exits if isinstance(e, Completed)]
+        assert len(completed) == 1, out
+        universe = completed[0].value
+    else:
+        assert isinstance(out, Complete), out
+        universe = out.value
+    assert isinstance(universe, UniverseValue), universe
+    return tuple(
+        row
+        for row in universe.record.statements
+        if isinstance(row, ContractConditionalConstructionV1)
+    )
+
+
+def _demand_cids(out) -> set[str]:
+    return {
+        demand.demand_cid for entry in _entries(out) for demand in entry.demands
+    }
+
+
+def _formal_cids(out) -> set[str]:
+    return {
+        demand.formal_coordinate_cid
+        for entry in _entries(out)
+        for demand in entry.demands
+    }
+
+
+# --------------------------------------------------------------------------
+# The set: union, dedupe, order
+# --------------------------------------------------------------------------
+
+
+def test_two_formals_subscripted_in_one_collection_owe_two_demands():
+    """POSITIVE. `[p[0], q[1]]` used to panic `collection TupleValue`.
+
+    Two DISTINCT obligations against two DISTINCT formals. Both are owed.
+    """
+    out = _out("def f(p, q):\n return [p[0], q[1]]\n")
+
+    assert len(_demand_cids(out)) == 2
+    assert len(_formal_cids(out)) == 2
+
+
+def test_one_formal_subscripted_at_two_sites_owes_two_demands():
+    """DISCRIMINATING, and it cuts the other way than it first looks.
+
+    `[p[0], p[0]]` is TWO obligations, not one. `demand_cid` addresses the whole
+    demand INCLUDING `operation_site` and `candidate_cid`, and the two `p[0]`
+    occupy different source coordinates, so they are two candidates the linker
+    resolves independently. Collapsing them because the formal and the formula
+    match would discharge one site with the other's resolution.
+
+    The idempotent case is a genuinely SHARED outcome -- one reduced value
+    reaching a join twice through the same DAG node -- which is asserted on
+    `merge_demands` directly below, where the sharing can be stated exactly
+    rather than hoped for from source text.
+    """
+    out = _out("def f(p):\n return [p[0], p[0]]\n")
+
+    assert len(_demand_cids(out)) == 2
+    assert len(_formal_cids(out)) == 1
+
+
+def test_the_same_obligation_reaching_a_join_twice_unions_to_one():
+    """DISCRIMINATING. Content, not arrivals: `F and F` IS `F`.
+
+    A union that counted arrivals would mint a duplicate row and ask the linker
+    to discharge one obligation twice.
+    """
+    out = _out("def f(p):\n return [p[0]]\n")
+    (entry,) = _entries(out)
+
+    assert len(merge_demands(entry.demands, entry.demands)) == 1
+
+
+def test_two_formals_in_one_call_owe_two_demands():
+    """POSITIVE. The same law through the CALL fold, not the collection fold.
+
+    `method_call_sugar._collect` threads arguments through the identical
+    `and_then` shape, so a law fixed only in `collection_sugar` would leave this
+    red.
+    """
+    out = _out("def f(p, q, g):\n return g(p[0], q[1])\n")
+
+    assert len(_demand_cids(out)) == 2
+
+
+def test_neither_demand_is_conjoined_into_the_other():
+    """DISCRIMINATING. Two demands must stay TWO, each owning its own formal.
+
+    Folding `F1` and `F2` into one demand carrying `F1 and F2` would keep both
+    formulas and still be a lie: the surviving demand names ONE
+    `formal_coordinate_cid`, so the obligation would be attributed to a formal
+    that does not own half of it. That is a fabricated fact, and it would pass
+    every count-based assertion above if the count happened to be right.
+    """
+    out = _out("def f(p, q):\n return [p[0], q[1]]\n")
+    formals = _formal_cids(out)
+
+    assert len(formals) == 2, (
+        "two obligations collapsed onto one formal coordinate: the demands were "
+        "conjoined instead of unioned (#6352)"
+    )
+
+
+def test_merge_is_ordered_by_content_not_by_arrival():
+    """DISCRIMINATING. The universe is content; arrival order is not a fact.
+
+    The same two obligations reached in either order must produce the same
+    tuple. An arrival-ordered set would make one source mint two different row
+    orders depending on which fold ran first, with no RNG and no clock to
+    justify the difference.
+    """
+    forward = _out("def f(p, q):\n return [p[0], q[1]]\n")
+    reverse = _out("def f(p, q):\n return [q[1], p[0]]\n")
+
+    entries_forward = _entries(forward)
+    entries_reverse = _entries(reverse)
+    assert entries_forward and entries_reverse
+
+    both = merge_demands(
+        tuple(d for e in entries_forward for d in e.demands),
+        tuple(d for e in entries_reverse for d in e.demands),
+    )
+    assert [d.demand_cid for d in both] == sorted(d.demand_cid for d in both)
+
+
+# --------------------------------------------------------------------------
+# The projection boundary: the set never reaches the wire
+# --------------------------------------------------------------------------
+
+
+def test_every_projected_row_states_exactly_one_demand():
+    """THE WIRE LAW. `contribution` splits the set before anything is projected.
+
+    The link unit and the Rust linker each state one demand per row, and they
+    are right to: an obligation is owned by ONE formal coordinate. So the set
+    must be an in-flight join carrier only.
+    """
+    out = _out("def f(p, q):\n return [p[0], q[1]]\n")
+    entries = _entries(out)
+
+    assert len(entries) == 2
+    for entry in entries:
+        assert len(entry.demands) == 1
+        assert entry.sole_demand() is entry.demands[0]
+
+
+def test_a_multi_demand_row_refuses_to_project():
+    """DISCRIMINATING. An unsplit row reaching the wire is LOUD, not first-of-set.
+
+    If `sole_demand` quietly returned `demands[0]`, a producer that bypassed
+    `contribution` would ship one obligation and silently drop the rest -- the
+    exact failure the panic existed to prevent.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    out = _out("def f(p, q):\n return [p[0], q[1]]\n")
+    first, second = _entries(out)
+    unsplit = ContractConditionalConstructionV1(
+        first.source_node,
+        first.candidate,
+        first.candidate_cid,
+        merge_demands(first.demands, second.demands),
+        first.value,
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        unsplit.to_value()
+
+    assert raised.value.info.owner == "ContractConditionalConstructionV1.sole_demand"
+
+
+# --------------------------------------------------------------------------
+# The effect face
+# --------------------------------------------------------------------------
+
+
+def test_a_demand_incurred_before_a_store_effect_is_still_owed():
+    """POSITIVE. `o.x = p[k]` used to panic `...and_then` onto an Incomplete.
+
+    `p[k]` is evaluated, incurring `python:indexable(p)`, and THEN the store
+    answers with an effect. The obligation was incurred on the path that
+    reached the effect, so it is owed, and it must reach the block record.
+    """
+    out = _out("def f(o, p, k):\n o.x = p[k]\n return 1\n")
+
+    assert len(_demand_cids(out)) == 1
+
+
+def test_the_effect_itself_is_not_altered_by_the_carried_demand():
+    """DISCRIMINATING. The effect stays pristine.
+
+    `pending_contracts` is wrapper-level testimony, exactly as
+    `branch_conditions` is. Smashing the obligation into the effect's reason
+    would keep the demand visible in a report while corrupting the typed effect
+    every downstream arm dispatches on.
+    """
+    from sugar_lift_py_tests.effect import RaiseEffect
+
+    effect = RaiseEffect(exception_name="ValueError")
+    bare = Incomplete(effect)
+    carrying = Incomplete(effect, (), ("sentinel-entry",))
+
+    assert carrying.effect == bare.effect
+    assert carrying.reason == bare.reason
+
+
+def test_a_guarded_effect_weakens_its_carried_demand_onto_the_same_face():
+    """DISCRIMINATING. The demand is owed only where the branch runs.
+
+    `if c: o.x = p[k]` owes `c -> python:indexable(p)`, never the unconditional
+    obligation. An implementation that carried the demand through `guarded`
+    WITHOUT weakening it would keep every count above green while owing more
+    than the source states -- the caller would have to prove indexability on a
+    path it never takes.
+    """
+    guarded = _out("def f(o, p, k, c):\n if c:\n  o.x = p[k]\n return 1\n")
+    plain = _out("def f(o, p, k):\n o.x = p[k]\n return 1\n")
+
+    guarded_cids = _demand_cids(guarded)
+    plain_cids = _demand_cids(plain)
+
+    assert len(guarded_cids) == 1
+    assert len(plain_cids) == 1
+    # Weakening RE-MINTS the demand: it IS a different obligation, so its
+    # content address must differ from the unconditional one.
+    assert guarded_cids != plain_cids
+
+
+# --------------------------------------------------------------------------
+# The residual that is NOT closed, pinned so it cannot go quiet
+# --------------------------------------------------------------------------
+
+
+def test_a_demand_joined_onto_a_partition_stays_loud_and_named():
+    """THE PRESERVED REFUSAL. A partition still has no seam for one carried value.
+
+    An `ExitSet`'s faces each carry their own guard. Attributing the obligation
+    to every face owes more than the source states; picking one face drops the
+    rest. Neither is a smaller answer, so no arm is invented and the gap stays
+    named -- with the owner and the replacement architecture in the message.
+
+    This is deliberately still red territory: it is the honest residual, and
+    this test exists so that closing it later is a decision someone makes, not
+    something that happens by accident.
+    """
+    from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    out = _out("def f(p):\n return [p[0]]\n")
+    entry = _entries(out)[0]
+
+    with pytest.raises(ConstructionPanic) as raised:
+        rewrap_pending(
+            entry,
+            ExitSet(()),
+            owner="test_partition_face",
+            blame=entry.source_node,
+        )
+
+    info = raised.value.info
+    assert info.owner == "test_partition_face"
+    assert "ExitSet" in info.observed
+    assert "never drop the obligation" in info.fix
+
+
+def test_an_effect_face_is_no_longer_the_partition_gap():
+    """DISCRIMINATING for the test above: the two faces are DIFFERENT laws.
+
+    An `Incomplete` now carries the obligation; only an `ExitSet` refuses. If
+    both went down the same arm, the effect fix would be invisible and the
+    refusal test above would pass for the wrong reason.
+    """
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+
+    out = _out("def f(p):\n return [p[0]]\n")
+    entry = _entries(out)[0]
+
+    joined = rewrap_pending(
+        entry,
+        Incomplete(RaiseEffect(exception_name="ValueError")),
+        owner="test_effect_face",
+        blame=entry.source_node,
+    )
+
+    assert isinstance(joined, Incomplete)
+    assert joined.pending_contracts == (entry,)


### PR DESCRIPTION
Closes #6352. `stableZero`'s `construction_panics` term.

## Measured — one instrument, both sides

`pandas/core/generic.py`, isolated, 223 functions, Mac at load ~16. Nothing heavy went near battleaxe.

| term | main `31ca5580c` | this branch |
| --- | --- | --- |
| `completed_denominator` | 223 | 223 |
| `R(timeout)` | 0 | 0 |
| **`R(construction_panics)`** | **3** | **0** |
| `R(factoring_gaps)` | 1 | 1 |
| `R(unnamed_exceptions)` | 0 | **1** |
| `stableZero` | false | false |

Ledgers: `docs/ledgers/stablezero-demand-set-base-31ca5580c.json`, `docs/ledgers/stablezero-demand-set-fix.json`.

## Classification — one owner, one value category, one missing law

| | |
| --- | --- |
| **owner** | `ContractConditionalConstructionV1` |
| **value category** | a completed floor value carrying a **pending caller-parameter contract demand**, addressed by `demand_cid` — the content address over owner source identity, formal coordinate, operation site, demanded formula, candidate. Read off the demand's own authenticated testimony, never a lexical type name. |
| **requested Floor law** | the carrier holds a demand **SET**; and a demand joined onto a non-value has a face to ride on. |

| generic.py | owner | observed | its own `fix` string |
| --- | --- | --- | --- |
| 7388 | `collection TupleValue` | two elements enrolled DISTINCT demands | "widen ... to carry a demand SET" |
| 8088 | `...V1.and_then` | demand joined onto an `Incomplete` | "give the exit algebra an arm for a pending contract demand" |
| 9596 | `...V1.and_then` | two DISTINCT demands, one value | "widen ... to carry a demand SET" |

A fourth site, `IfExpSugar._join`, carries the same sentence and does not fire on this file. **Four call sites requesting one widening is the ontology reporting that it is missing a kind of thing.**

## The set

Unioned by `demand_cid`, **ordered by `demand_cid`** — content, never arrival, because there is no RNG and no clock here to justify one source minting two row orders.

Two demands are **never conjoined into one**. Each carries its own `formal_coordinate_cid`; fusing their formulas would keep both formulas while attributing the obligation to a formal that owns half of it. Fabricated fact, not a smaller answer.

**The wire shape is unchanged.** `contribution` splits the set into one row per demand before anything is projected, so `to_value`, the link unit and the Rust linker still see one demand per row — no schema bump, no fixture change, no cross-language flip. `sole_demand` is the projection reader and **refuses** a multi-demand row rather than shipping the first.

## The effect face

`o.x = p[k]` evaluates `p[k]`, incurring the obligation, and *then* answers with a store effect. It is owed on the path that reached the effect. `Incomplete.pending_contracts` carries it in exactly the shape `branch_conditions` already is: wrapper-level testimony, effect pristine, weakened under `guarded`, contributed to the block record.

Conservation is **measured**, not assumed — the record on the store's completed face contains the contract row beside the `Incomplete`.

## Still loud, on purpose

A demand joined onto a **partition** invents no arm. An `ExitSet`'s faces each carry their own guard: attributing the obligation to every face owes more than the source states; picking one drops the rest. The refusal is kept with owner and replacement architecture, and pinned by a twin so closing it later is a decision someone makes rather than an accident.

## The rig, and the term it gains

`stableZero-classify-isolated-v1` **did not exist in the repo** — its own ledger frames record `module: "__main__"`, so it lived in one agent's temp directory. A measurement nobody else can re-take is a claim, not an instrument. Rebuilt as `implementations/python/sugar-lift-py-tests/scripts/stablezero_classify.py`; same schema string so old and new ledgers compare directly; exit code 0 only on `stableZero`.

It gains **`R(unnamed_exceptions)`**, which the milestone did not name. A rig that gates only on panics reads GREEN the moment a gap stops naming itself — and that is exactly what happens here. Closing the three lets the carrier travel one seat further, to `spread_sugar._collect` → `outcome_to_exitset`, whose tail is a bare `raise TypeError(type(outcome))`: the **same** missing law wearing a bare exception instead of a named `ConstructionGap`.

**I am not claiming `construction_panics = 0` as clean.** That row is reported on its own axis. Both seams (`outcome/exit_set.py`, `sugar/spread_sugar.py`) have owners and are untouched here, pending arbitration.

## Twins

Every test is a pair, because widening a carrier is exactly the change that passes a positive while losing an obligation. Perturbed after green:

- union → keep one arm: **3 red** (`..._in_one_call_owe_two_demands`, `..._arms_join_and_conserve_both_demands`, `..._obligations_join_and_both_survive`)
- effect face `contribution` → `(self,)`: **2 red** (`..._before_a_store_effect_is_still_owed`, `..._weakens_its_carried_demand_onto_the_same_face`)

Two superseded panic twins are **rewritten, not deleted** — the panic became a law, so the assertion moves from "it refuses" to "both obligations survive", which is the property the refusal was protecting.

One twin premise was wrong and is corrected on the record: `[p[0], p[0]]` is **two** obligations, not one — `demand_cid` includes `operation_site`, so two occurrences are two candidates the linker resolves independently. The idempotent case is asserted on `merge_demands` directly, where the sharing can be stated exactly.

## Known inherited red (fails identically on main, verified)

- `test_corpus.py::test_pinned_golden_corpus_reproduces_byte_identically` — f-string `format_spec` golden drift.
- `test_with_partition_shared_algebra.py::test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling` — a pre-existing vendor path in `ExitSet.normalize`'s docstring. Boy-scouted my own contribution out of `factored_operand`'s docstring; the remaining mention belongs to its author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change `ContractConditionalConstructionV1` carrier to hold a demand set instead of a single demand
> - `ContractConditionalConstructionV1` now stores a `demands` tuple instead of a single `demand`; projection to wire requires exactly one demand via `sole_demand()`, which raises a `ConstructionPanic` if multiple demands remain unsplit.
> - `merge_demands` de-duplicates and merges multiple demand iterables by `demand_cid`, enabling collection reduction, conditional joins, and `rewrap_pending` to union obligations instead of panicking on distinct demands.
> - `Incomplete` effects now carry a `pending_contracts` tuple so pending demands propagate through effects and are correctly weakened under guards.
> - All callers updated to use `sole_demand()` where single-demand access is required; tests updated to reflect the new set semantics and assert both obligations are conserved across joins.
> - Risk: any code path that routes multiple unresolved demands to `sole_demand()` without first splitting them will now raise a `ConstructionPanic` at projection time rather than silently dropping obligations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee4b635.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->