### PR TITLE
Lease default resolves from both sides of the bind mount, and refuses by name

### DIFF
--- a/tests/test_heavy_measurement_lease.py
+++ b/tests/test_heavy_measurement_lease.py
@@ -282,6 +282,81 @@ def test_outside_a_container_one_filesystem_really_is_one_machine(monkeypatch, t
     lease._require_machine_wide()  # must not raise
 
 
+# -- the default path, and the refusal that must replace a bare traceback ---
+#
+# A hardcoded /home/runner default is correct inside a runner container and
+# wrong everywhere else, and it failed OPAQUELY: every interactive caller died
+# in os.makedirs with a bare PermissionError. The workaround that traceback
+# invites is --lease /var/tmp/..., which is per-container here and has already
+# produced two heavy jobs overlapping with a 0.0007s wait. So the default must
+# resolve from both sides of the bind mount, and an unusable directory must
+# REFUSE BY NAME while stating the correct path.
+
+
+def test_default_lease_path_resolves_under_the_callers_home_not_a_hardcoded_runner():
+    """`~/.cache/sugar/binaries` is one host directory under two names: HOME is
+    /home/runner inside a runner, the owning user's home on the host. The
+    default has to be right from both sides, so it may not hardcode either."""
+    module = _lease_module()
+    assert module.DEFAULT_LEASE_PATH == os.path.expanduser(
+        "~/.cache/sugar/binaries/.sugar-heavy-measurement.lease"
+    )
+    assert not module.DEFAULT_LEASE_PATH.startswith("/home/runner/"), (
+        "a hardcoded /home/runner default is unusable off-runner"
+    )
+
+
+def test_unwritable_lease_directory_refuses_by_name_and_states_the_right_path(tmp_path):
+    """The bare PermissionError is the defect. The refusal must name the
+    host-shared path AND rule out /var/tmp, because that is the workaround the
+    traceback teaches and it is the one that breaks the invariant."""
+    module = _lease_module()
+    if os.getuid() == 0:
+        pytest.skip("root can write anywhere; this law is about an ordinary uid")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    lease = module.HeavyMeasurementLease("t", str(locked / "sub" / "x.lease"), 1)
+
+    with pytest.raises(module.LeaseDirectoryUnusable) as caught:
+        lease._require_usable_directory()
+
+    message = str(caught.value)
+    assert ".cache/sugar/binaries" in message, "the refusal must state the right path"
+    assert "/var/tmp" in message, "the refusal must rule out the tempting workaround"
+    locked.chmod(0o700)
+
+
+def test_an_unusable_lease_directory_never_runs_the_command(tmp_path, record):
+    """The whole point: no lease, no measurement. A run that could not take the
+    lease must support no claim, exactly like a timeout."""
+    if os.getuid() == 0:
+        pytest.skip("root can write anywhere; this law is about an ordinary uid")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    ran = tmp_path / "ran.txt"
+
+    proc = subprocess.run(
+        [
+            sys.executable, str(WRAPPER),
+            "--class", "t",
+            "--lease", str(locked / "sub" / "x.lease"),
+            "--record", str(record),
+            "--timeout", "1",
+            "--", sys.executable, "-c", f"open({str(ran)!r}, 'w').write('x')",
+        ],
+        capture_output=True, text=True,
+    )
+
+    assert proc.returncode == 75, proc.stderr
+    assert not ran.exists(), "the command must NOT run without a lease"
+    payload = json.loads(record.read_text())
+    assert payload["measurementStatus"] == "cancelled-before-measurement"
+    assert payload["supportsZeroClaim"] is False
+    locked.chmod(0o700)
+
+
 # -- the status vocabulary: silence is never a clean floor ------------------
 #
 #   queued -> lease-waiting -> measuring -> completed/{findings,zero-findings}

--- a/tools/heavy_measurement_lease.py
+++ b/tools/heavy_measurement_lease.py
@@ -62,8 +62,12 @@ Usage::
         --class python-package-suite \\
         --record "$GITHUB_WORKSPACE/lease-record.json" \\
         [--embed-into suite-report.json] [--timeout 14400] \\
-        [--lease /var/tmp/sugar-heavy-measurement.lease] \\
+        [--lease ~/.cache/sugar/binaries/.sugar-heavy-measurement.lease] \\
         -- <command> [args...]
+
+The default lease path already resolves correctly from both sides of the bind
+mount, so `--lease` is normally unnecessary. NEVER point it at /var/tmp: that
+path is per-container on battleaxe and a lease there serializes nothing.
 
 Exit status: the command's own status, or 75 if the lease was never acquired.
 """
@@ -120,12 +124,34 @@ ZERO_CLAIM_STATUS = STATUS_COMPLETED_ZERO_FINDINGS
 # Same kernel, different inode: a lease that serialized nothing. The receipts
 # caught it on day one, which is exactly why they record bootId and dev/ino.
 #
-# `/home/runner/.cache/sugar/binaries` is bind-mounted from the SAME host
-# directory into every runner container (verified across all twelve live
-# containers), so a lock file there is one lock for the whole machine.
+# `~/.cache/sugar/binaries` is bind-mounted from the SAME host directory into
+# every runner container (verified across all twelve live containers), so a lock
+# file there is one lock for the whole machine.
+#
+# THE DEFAULT IS `~`, NOT A HARDCODED `/home/runner`, AND THAT MATTERS.
+#
+# The bind mount joins two names for one directory: inside a runner container
+# HOME is `/home/runner`, on the host it is the owning user's home, and both
+# resolve to the same host inode. A hardcoded `/home/runner` is therefore
+# correct in exactly one of the two places a caller can stand. Off-runner it
+# does not exist and is not writable, so every interactive caller died in
+# `os.makedirs` with a bare `PermissionError` traceback -- no named refusal, no
+# statement of the right path.
+#
+# That failure mode has already cost a real overlap. Faced with the traceback,
+# the obvious workaround is `--lease /var/tmp/...`, which is per-container on
+# battleaxe and is precisely how two heavy jobs took the lease 0.0007s apart and
+# ran side by side. A default that fails opaquely teaches the one workaround
+# that breaks the invariant.
+#
+# `expanduser` resolves correctly from both sides of the mount. It is not
+# trusted blindly: `_require_machine_wide` still proves the resolved path is not
+# container-private before any measurement runs, and `_require_usable_directory`
+# turns an unusable directory into a named refusal that states the correct path
+# instead of a traceback.
 DEFAULT_LEASE_PATH = os.environ.get(
     "SUGAR_HEAVY_LEASE_PATH",
-    "/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease",
+    os.path.expanduser("~/.cache/sugar/binaries/.sugar-heavy-measurement.lease"),
 )
 DEFAULT_TIMEOUT_SECONDS = float(
     os.environ.get("SUGAR_HEAVY_LEASE_TIMEOUT_SECONDS", "14400")
@@ -160,6 +186,18 @@ class LeaseNotMachineWide(Exception):
     saying `acquired` while two censuses run side by side. That is the exact
     shape of dishonesty this mechanism exists to remove, so it is a REFUSAL,
     not a warning.
+    """
+
+
+class LeaseDirectoryUnusable(Exception):
+    """The lease file's directory cannot be created or written.
+
+    Raised INSTEAD of letting `os.makedirs`/`open` surface a bare `OSError`
+    traceback. The distinction is not cosmetic: the traceback names a path and
+    an errno, and the obvious workaround it invites is `--lease /var/tmp/...`,
+    which is per-container on battleaxe and has already produced two heavy jobs
+    overlapping with a 0.0007s wait. So the refusal has to carry the correct
+    path, not merely the failure.
     """
 
 
@@ -219,8 +257,40 @@ class HeavyMeasurementLease:
 
     # -- acquisition --------------------------------------------------------
 
+    def _require_usable_directory(self):
+        """The lease directory must exist and be writable, or REFUSE by name.
+
+        A bare `PermissionError` from `os.makedirs` states an errno and invites
+        `--lease /var/tmp/...` as the fix -- the one workaround that silently
+        destroys the invariant, because /var/tmp is per-container here. So this
+        names the correct path in the refusal itself.
+        """
+        directory = os.path.dirname(self.lease_path) or "."
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except OSError as exc:
+            raise LeaseDirectoryUnusable(
+                f"cannot create the lease directory {directory}: {exc}. "
+                f"The lease must live on the ONE host-shared directory every "
+                f"runner container bind-mounts, which is `~/.cache/sugar/"
+                f"binaries` from whichever side you are standing on: "
+                f"/home/runner/... inside a runner, the owning user's home on "
+                f"the host. Point SUGAR_HEAVY_LEASE_PATH (or --lease) at that "
+                f"directory. Do NOT use /var/tmp: it is per-container on "
+                f"battleaxe, and a lease there reports `acquired` while a "
+                f"second census runs beside you."
+            ) from exc
+        if not os.access(directory, os.W_OK):
+            raise LeaseDirectoryUnusable(
+                f"the lease directory {directory} exists but is not writable by "
+                f"uid {os.getuid()}. A lease you cannot take is not a lease. "
+                f"Point SUGAR_HEAVY_LEASE_PATH (or --lease) at a host-shared "
+                f"directory you own -- never /var/tmp, which is per-container "
+                f"here and serializes nothing."
+            )
+
     def acquire(self, interrupted=None):
-        os.makedirs(os.path.dirname(self.lease_path) or ".", exist_ok=True)
+        self._require_usable_directory()
         self.requested_at = time.time()
         self.set_status(STATUS_LEASE_WAITING)
         _log(
@@ -508,8 +578,18 @@ def main(argv=None):
     # the wait.
     try:
         lease.acquire(interrupted=lambda: state["pending"] is not None)
-    except (LeaseTimeout, LeaseCancelled, LeaseNotMachineWide) as exc:
+    except (
+        LeaseTimeout,
+        LeaseCancelled,
+        LeaseNotMachineWide,
+        LeaseDirectoryUnusable,
+    ) as exc:
         _log(str(exc))
+        if isinstance(exc, LeaseDirectoryUnusable):
+            _log("REFUSING to measure without a lease that serializes.")
+            lease.set_status(STATUS_CANCELLED_BEFORE)
+            lease.released_at = time.time()
+            lease.stale_owner = str(exc)
         if isinstance(exc, LeaseNotMachineWide):
             _log("REFUSING to measure behind a lease that serializes nothing.")
             lease.set_status(STATUS_CANCELLED_BEFORE)


### PR DESCRIPTION
## The defect

`DEFAULT_LEASE_PATH` was hardcoded `/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease` — correct inside a runner container, wrong everywhere else. Off-runner that path does not exist and is not writable, so every interactive caller died inside `os.makedirs`:

```
PermissionError: [Errno 13] Permission denied: '/home/runner/.cache'
```

A bare traceback, no named refusal, no statement of the correct path. I hit it launching a showcase receipt; a prior agent hit it and worked around it with `/var/tmp`.

**That workaround is the thing this file exists to prevent.** `/var/tmp` is per-container on battleaxe, and it is precisely how two heavy jobs took the lease 0.0007s apart and ran side by side — the incident already documented in this module's own header. So the default's failure mode was actively teaching the one workaround that destroys the invariant.

## The fix

`~/.cache/sugar/binaries` is **one host directory under two names**: HOME is `/home/runner` inside a runner, the owning user's home on the host, and the bind mount joins them to the same inode. `expanduser` is therefore correct from *both* sides, where either hardcoded absolute path is correct from only one.

This is not trusted blindly, and the existing guard is untouched:

- `_require_machine_wide` still proves the resolved path is not container-private before any measurement runs. It remains the authority — this change only makes the *default* portable enough to reach it.
- New `_require_usable_directory` turns an uncreatable or unwritable lease directory into a named `LeaseDirectoryUnusable` refusal that **states the host-shared path and rules out `/var/tmp` explicitly**, then exits 75 with `cancelled-before-measurement`. No lease, no measurement, no claim.
- The usage docstring recommended `--lease /var/tmp/sugar-heavy-measurement.lease`. That is where the folklore came from, so it now shows the shared path and says never `/var/tmp`.

**No silent fallback.** An unusable directory refuses; it never quietly relocates the lease somewhere private, because a lease that serializes nothing while reporting `acquired` is the worst available outcome.

## Validation

```
tests/test_heavy_measurement_lease.py   14 passed, 12 failed, 2 skipped   (battleaxe)
```

**The 12 failures are inherited.** I stashed the change and re-ran the same file at baseline rather than assuming:

```
baseline: 12 failed, 13 passed
head:     12 failed, 14 passed, 2 skipped
introduced by my change: (none)
```

**The 2 skips are not passes, and I did not let them stand.** Both new permission tests guard on `os.getuid() == 0`, and `bpytest` runs as root on battleaxe, so they skipped there — vacuous. Re-run locally as an ordinary uid (501):

```
3 passed, 25 deselected
```

## Discrimination — both laws can actually fail

**Mutation A** — put the hardcoded `/home/runner` default back:

```
FAILED test_default_lease_path_resolves_under_the_callers_home_not_a_hardcoded_runner
1 failed, 2 passed
```

**Mutation B** — swallow the unusable-directory error and continue:

```
FAILED test_unwritable_lease_directory_refuses_by_name_and_states_the_right_path
FAILED test_an_unusable_lease_directory_never_runs_the_command
2 failed, 1 passed
```

The second failure in B is the load-bearing one: with the refusal swallowed, the wrapper **ran the measured command with no lease at all**. That is the overlap defect reproduced on demand, and the test now catches it.

Both mutations reverted; working tree byte-identical to HEAD; re-confirmed green.

## Shot accounting

- **Floors preserved:** no detector weakened, no test skipped or deleted, no gate loosened. `_require_machine_wide` is unchanged. The refusal surface got strictly larger, not smaller.
- **Shell deleted:** none. This raises the rung of an existing guard rather than retiring one — the honest ceiling here is a runtime refusal, because whether a path is host-shared is a property of the machine, not of the program.

## Related

Adjacent infrastructure defect found while taking receipts, **not fixed here** and worth its own owner: the shared binary cache's `.build` subdirectories are owned by `1001:docker` and `root:root` at mode 755, so `sugarbin` cannot build there as an interactive uid —

```
error: failed to open: /home/tsavo/.cache/sugar/binaries/.build/blake3-512_.../debug/.cargo-build-lock
Caused by: Permission denied (os error 13)
```

Same directory, same class of host-vs-container uid mismatch, different mechanism. Workaround for now is a private `SUGAR_BINARY_CACHE_DIR` with the lease still on the shared path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve `DEFAULT_LEASE_PATH` from the caller's home and refuse by name when the lease directory is unusable
> - Changes `DEFAULT_LEASE_PATH` in [heavy_measurement_lease.py](https://github.com/TSavo/sugar/pull/6355/files#diff-9fa7fb069e55d839f17153320511f689f1c8cf57016ae314dae01dea7bdaaefc) from a hardcoded `/home/runner/...` path to `os.path.expanduser('~/.cache/sugar/binaries/.sugar-heavy-measurement.lease')`.
> - Adds `HeavyMeasurementLease._require_usable_directory()`, which checks that the lease directory can be created and is writable, raising a new `LeaseDirectoryUnusable` exception (with a message naming the path and warning against `/var/tmp`) if not.
> - The CLI catches `LeaseDirectoryUnusable` and records `cancelled-before-measurement` with exit code 75 instead of crashing with a raw `PermissionError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9abd6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->