### PR TITLE
Partition the Cargo build root by identity; refuse an unusable one by name

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -688,6 +688,58 @@ cache_dir() {
   printf '%s\n' "${SUGAR_BINARY_CACHE_DIR:-$HOME/.cache/sugar/binaries}"
 }
 
+# The cache is ONE host directory reached under two names: HOME is
+# /home/runner inside a runner container, the owning user's home on the host,
+# and the bind mount joins them (#6355 established this for the lease path).
+# Its artifact cells earn that sharing -- content-addressed, written once,
+# world-readable, and never rewritten once complete. Every identity reads the
+# same bytes under a name derived from those bytes.
+#
+# A Cargo target directory is not that shape. Cargo rewrites .rustc_info.json,
+# the build and artifact locks, every fingerprint and .d file, and the
+# executables themselves on each invocation. Those land at 644 under the
+# writer's umask, and every writer we have -- root under bpytest, uid 1001 in
+# a runner container, uid 1000 interactive over ssh -- defaults to umask 022.
+# Measured on battleaxe: .build children are 755 owned by root:root and
+# 1001:docker with 644 contents. So the first identity to touch a build family
+# owns it permanently and every other identity dies inside Cargo on
+# .cargo-build-lock with a bare EACCES.
+#
+# Group-writable plus setgid does not rescue it. setgid governs the group of
+# new entries, not the mode a foreign umask writes; sharing a mutable Cargo
+# tree would require umask 002 from every writer, including writers inside
+# images we do not own. So the scratch tree is partitioned by identity and the
+# artifact cells stay shared. Sharing is kept exactly where sharing is sound.
+build_identity_key() {
+  local uid
+  uid="$(id -u 2>/dev/null)" || uid=""
+  if [[ -z "$uid" ]]; then
+    log "crime=unnameable-build-identity owner=bin/sugarbin illegal shape=id -u yielded no uid so the per-identity build root under $(cache_dir)/.build cannot be named replacement=run where id(1) works, or set SUGAR_BINARY_BUILD_ROOT to a directory this identity owns"
+    return 1
+  fi
+  printf 'uid-%s\n' "$uid"
+}
+
+# An unusable build root refuses by name and states the correct remedy. It must
+# never suggest repointing SUGAR_BINARY_CACHE_DIR: that is the workaround that
+# discards the shared artifact cells the cache exists to serve.
+require_writable_build_root() {
+  local root="$1" probe owner
+  if ! mkdir -p "$root" 2>/dev/null; then
+    log "crime=uncreatable-build-root owner=bin/sugarbin path=$root current-uid=$(id -u) illegal shape=the per-identity Cargo build root under the host-shared cache could not be created replacement=make $(dirname "$root") creatable by this identity, or set SUGAR_BINARY_BUILD_ROOT to a directory this identity owns -- do NOT repoint SUGAR_BINARY_CACHE_DIR, that abandons every shared artifact cell"
+    return 1
+  fi
+  probe="$root/.sugarbin-write-probe.$$"
+  if ! : >"$probe" 2>/dev/null; then
+    owner="$(stat -c '%u:%g mode=%a' "$root" 2>/dev/null \
+      || stat -f '%u:%g mode=%Lp' "$root" 2>/dev/null \
+      || printf 'unknown')"
+    log "crime=foreign-owned-build-root owner=bin/sugarbin path=$root owned=$owner current-uid=$(id -u) illegal shape=a Cargo target directory owned by another identity cannot be rewritten, and Cargo would otherwise die on .cargo-build-lock with a bare EACCES replacement=remove $root, or set SUGAR_BINARY_BUILD_ROOT to a directory this identity owns -- do NOT repoint SUGAR_BINARY_CACHE_DIR, that abandons every shared artifact cell"
+    return 1
+  fi
+  rm -f "$probe"
+}
+
 shelf_tag_for_stamp() {
   local stamp="$1"
   if [[ -n "${SUGAR_BINARY_SHELF_TAG:-}" ]]; then
@@ -986,11 +1038,18 @@ build_from_source() {
     return 1
   }
   local target_root="${SUGAR_BINARY_TARGET_ROOT:-$rust_workspace/target}"
-  local build_base="${SUGAR_BINARY_BUILD_ROOT:-$(cache_dir)/.build}"
+  local build_base
+  if [[ -n "${SUGAR_BINARY_BUILD_ROOT:-}" ]]; then
+    build_base="$SUGAR_BINARY_BUILD_ROOT"
+  else
+    local identity_key
+    identity_key="$(build_identity_key)" || return 1
+    build_base="$(cache_dir)/.build/$identity_key"
+  fi
   local family_identity
   family_identity="$(build_family_identity "$stamp")" || return $?
   local build_root="$build_base/$(stamp_for_filename "$family_identity")"
-  mkdir -p "$build_root"
+  require_writable_build_root "$build_root" || return 1
   local built="$build_root/$profile/$bin_name"
   # SUGAR_BUILD_STAMP is the authenticated sourceStamp (source matter only).
   # SUGAR_BUILD_GIT_HEAD remains a version/attestation label, not a shelf key.

--- a/implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs
+++ b/implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs
@@ -170,6 +170,20 @@ fn sugarbin_build_identity_target_contract() {
 }
 
 #[test]
+fn sugarbin_build_root_identity_contract() {
+    let root = repo_root();
+    let status = Command::new("bash")
+        .arg(root.join("tests/sugarbin_build_root_identity.sh"))
+        .arg(&root)
+        .status()
+        .expect("run build root identity contract");
+    assert!(
+        status.success(),
+        "build root identity contract failed: {status}"
+    );
+}
+
+#[test]
 fn remote_execution_provisioning_has_one_owner() {
     let root = repo_root();
     let offenders = duplicate_remote_ownership(&root);

--- a/tests/sugarbin_build_root_identity.sh
+++ b/tests/sugarbin_build_root_identity.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# The shared binary cache is one host directory reached under two names, and it
+# is written by several identities: root under bpytest, uid 1001 inside a runner
+# container, uid 1000 interactively over ssh. Its artifact cells earn that
+# sharing -- content-addressed, written once, never rewritten. Its Cargo build
+# tree does not: Cargo rewrites 644 files on every invocation, so whichever
+# identity touches a build family first owns it forever and the next one dies
+# inside Cargo on .cargo-build-lock with a bare EACCES.
+#
+# So the Cargo scratch tree is partitioned by identity while the artifact cells
+# stay shared, and a build root this identity cannot use refuses BY NAME rather
+# than surfacing as a Cargo traceback.
+set -euo pipefail
+
+repo="${1:?usage: sugarbin_build_root_identity.sh REPO_ROOT}"
+tmp_root="${SUGARBIN_EXEC_TMPDIR:-$repo/.sugar/test-tmp}"
+mkdir -p "$tmp_root"
+tmp="$(mktemp -d "$tmp_root/sugarbin-build-root.XXXXXX")"
+trap 'chmod -R u+rwX "$tmp" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/target/release" "$tmp/cache"
+: >"$tmp/cargo.log"
+
+cat >"$tmp/bin/rustc" <<'SH'
+#!/usr/bin/env bash
+cat <<'EOF'
+rustc 1.96.0 (fake 2026-01-01)
+binary: rustc
+commit-hash: fake
+host: x86_64-unknown-linux-gnu
+release: 1.96.0
+LLVM version: 22.0.0
+EOF
+SH
+cat >"$tmp/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == -vV ]]; then
+  cat <<'EOF'
+cargo 1.96.0 (fake 2026-01-01)
+release: 1.96.0
+commit-hash: fake
+commit-date: 2026-01-01
+host: x86_64-unknown-linux-gnu
+libgit2: 1.9.0
+libcurl: 8.12.0
+ssl: OpenSSL 3.5.0
+os: Linux 6.1.0 [64-bit]
+EOF
+  exit 0
+fi
+target="${CARGO_TARGET_DIR:?sugarbin must isolate Cargo output by build identity}"
+printf '%s\n' "$target" >>"$SUGARBIN_FAKE_CARGO_LOG"
+binary=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == --bin ]]; then binary="$2"; shift 2; else shift; fi
+done
+mkdir -p "$target/release"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "fresh:%s"\n' "$binary" >"$target/release/$binary"
+chmod +x "$target/release/$binary"
+SH
+cat >"$tmp/bin/git" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *"rev-parse HEAD"* ]]; then
+  printf '%s\n' "fake-head"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+SH
+chmod +x "$tmp/bin/rustc" "$tmp/bin/cargo" "$tmp/bin/git"
+
+export PATH="$tmp/bin:$PATH"
+export SUGARBIN_FAKE_CARGO_LOG="$tmp/cargo.log"
+export SUGAR_BINARY_CARGO="$tmp/bin/cargo"
+export SUGAR_BINARY_TARGET_ROOT="$tmp/target"
+export SUGAR_BINARY_CACHE_DIR="$tmp/cache"
+export SUGAR_BINARY_SOURCE_STAMP="blake3-512_$(printf '7%.0s' {1..128})"
+export SUGAR_BINARY_NO_SHELF=1 SUGAR_BINARY_PUBLISH=0
+
+uid="$(id -u)"
+
+# --- The Cargo scratch tree is partitioned by identity ------------------------
+# Two identities on one host share the cache and must not share the target dir.
+"$repo/bin/sugarbin" --bin sugar >/dev/null
+target_used="$(head -n 1 "$tmp/cargo.log")"
+[[ "$target_used" == "$tmp/cache/.build/uid-$uid/"* ]] || {
+  echo "build root is not partitioned by identity: $target_used" >&2
+  echo "expected a prefix of $tmp/cache/.build/uid-$uid/" >&2
+  exit 1
+}
+
+# --- The artifact cells stay shared ------------------------------------------
+# Partitioning scratch must not partition the cache itself. Nothing outside
+# .build may acquire a per-identity segment, or the shared cache is defeated.
+while IFS= read -r entry; do
+  [[ "$entry" == "$tmp/cache/.build" ]] && continue
+  case "$(basename "$entry")" in
+    uid-*)
+      echo "artifact cell was partitioned by identity, defeating the shared cache: $entry" >&2
+      exit 1
+      ;;
+  esac
+done < <(find "$tmp/cache" -maxdepth 1 -mindepth 1)
+
+# --- An unusable build root refuses by name ----------------------------------
+# Not a Cargo EACCES traceback, and never a silent fallback to a private cache.
+rm -f "$tmp/target/release/sugar" "$tmp/target/release/sugar.sugarbin.json"
+cargo_calls_before="$(wc -l <"$tmp/cargo.log" | tr -d ' ')"
+blocked_cache="$tmp/blocked-cache"
+mkdir -p "$blocked_cache/.build"
+# The per-identity build root cannot be created: its own path is a regular
+# file. This is uid-agnostic -- ENOTDIR refuses root exactly as it refuses
+# anyone else -- so this law is executed under every caller, including the
+# root identity bpytest runs as.
+: >"$blocked_cache/.build/uid-$uid"
+set +e
+refusal="$(SUGAR_BINARY_CACHE_DIR="$blocked_cache" "$repo/bin/sugarbin" --bin sugar 2>&1 >/dev/null)"
+status=$?
+set -e
+[[ $status -ne 0 ]] || { echo 'an uncreatable build root did not refuse' >&2; exit 1; }
+grep -Fq 'crime=uncreatable-build-root' <<<"$refusal" || {
+  echo 'refusal was not named; the caller sees an anonymous failure' >&2
+  printf '%s\n' "$refusal" >&2
+  exit 1
+}
+grep -Fq "$blocked_cache/.build/uid-$uid" <<<"$refusal" || {
+  echo 'refusal did not name the unusable path' >&2; printf '%s\n' "$refusal" >&2; exit 1;
+}
+grep -Fq 'do NOT repoint SUGAR_BINARY_CACHE_DIR' <<<"$refusal" || {
+  echo 'refusal failed to rule out the workaround that abandons the shared cache' >&2
+  printf '%s\n' "$refusal" >&2
+  exit 1
+}
+[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == "$cargo_calls_before" ]] || {
+  echo 'sugarbin invoked Cargo against an unusable build root instead of refusing first' >&2
+  exit 1
+}
+
+echo 'PASS: Cargo scratch is partitioned by identity, artifact cells stay shared, unusable build roots refuse by name'


### PR DESCRIPTION
The shared binary cache could not be built into by an interactive caller:

```
error: failed to open: /home/tsavo/.cache/sugar/binaries/.build/blake3-512_.../debug/.cargo-build-lock
Caused by: Permission denied (os error 13)
```

`~/.cache/sugar/binaries` is ONE host directory under two names: HOME is `/home/runner` inside a runner container, the owning user's home on the host, joined by a bind mount. #6355 landed `expanduser` as the correct resolution for the **lease path** on that same directory. The same directory was correct for the lease and unusable for builds. That asymmetry is the defect.

## Measured first, on battleaxe, as the interactive uid 1000

```
blake3-512_0e1a94655370a owner=root:root      mode=755 -> EACCES
blake3-512_42695093d046b owner=1001:docker    mode=755 -> EACCES
blake3-512_9531d43c8a519 owner=1001:docker    mode=755 -> EACCES
```

Contents inside those trees are **644** files owned by `1001:docker`. And the artifact cells: **299 of 302** top-level entries under `binaries/` are `1001:docker` 755.

Three writers, one tree: root under `bpytest`, uid 1001 in a runner container, uid 1000 interactive over ssh.

## The two trees do not have the same nature

The **artifact cells earn sharing**: content-addressed, written once, world-readable, never rewritten once complete. Every identity reads the same bytes under a name derived from those bytes.

A **Cargo target directory does not**. Cargo rewrites `.rustc_info.json`, the build and artifact locks, every fingerprint and `.d` file, and the executables themselves on every invocation. Those land at 644 under the writer's umask, and every writer we have defaults to umask 022. So the first identity to touch a build family owns it permanently.

**Group-writable plus setgid does not rescue this.** setgid governs the group of new entries, not the mode a foreign umask writes. Sharing a mutable Cargo tree would require umask 002 from every writer, including writers inside images we do not own. That is a permission model that genuinely cannot be shared.

## Resolution

Partition the scratch tree by identity (`.build/uid-<uid>/<family>`); leave the artifact cells shared. Sharing is kept exactly where sharing is sound, and **no caller is asked to repoint `SUGAR_BINARY_CACHE_DIR`** — that is the workaround already in use, and it abandons every shared cell.

After, same box, same uid: `/home/tsavo/.cache/sugar/binaries/.build/uid-1000 -> WRITABLE`.

## Refusal by name, not a Cargo traceback

An unusable build root now refuses as `crime=uncreatable-build-root` / `crime=foreign-owned-build-root`, naming the path, the owning uid, the current uid, and the remedy — and explicitly ruling out the cache-repointing workaround, exactly as #6355 rules out `/var/tmp`. Cargo is never invoked against a root it cannot use. No silent fallback.

## Evidence

`tests/sugarbin_build_root_identity.sh`, wired into `sugarbin_execution_contract.rs` so it actually runs. Three laws: scratch is partitioned by identity; artifact cells are **not** partitioned (a guard against "fixing" this by shattering the shared cache); an unusable root refuses by name before Cargo is called.

The refusal arm is provoked via **ENOTDIR**, which refuses root exactly as it refuses anyone else — so this law executes under every caller including the root identity `bpytest` runs as, rather than skipping there. (The EACCES arm is genuinely uid-sensitive and belongs to the companion PR on unfalsifiable uid-guarded tests.)

Discrimination, each mutation reverted and re-confirmed green:

| mutation | assertion that fired | neighbour test |
|---|---|---|
| drop the `uid-<uid>` segment | `build root is not partitioned by identity` | green |
| `mkdir -p` instead of the named refusal | `refusal was not named` | green |
| soften the refusal to "try a different cache dir" | `refusal failed to rule out the workaround` | green |

Nothing else fired in any arm.

## Verified

- New contract test: green on macOS (uid 501) and on battleaxe (uid 1000).
- Neighbouring `sugarbin_build_identity_target.sh`: green throughout.
- No heavy work run beside the authoritative baseline — the contract test uses a fake Cargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Partition Cargo build root by uid and refuse unusable build roots with named errors
> - Default `CARGO_TARGET_DIR` in `build_from_source` now includes a uid-specific segment (`uid-<uid>`) under `<cache>/.build/`, so concurrent builds by different users share the cache without colliding on the build root.
> - Adds `build_identity_key` to resolve the current uid via `id -u`, logging `crime=unnameable-build-identity` and returning non-zero on failure.
> - Adds `require_writable_build_root` to validate the build root is creatable and writable before invoking Cargo; logs `crime=uncreatable-build-root` or `crime=foreign-owned-build-root` with ownership details on failure.
> - Explicit `SUGAR_BINARY_BUILD_ROOT` overrides the uid-partitioned default and bypasses the new guards.
> - A new contract test in [`tests/sugarbin_build_root_identity.sh`](https://github.com/TSavo/sugar/pull/6357/files#diff-4e8b3673d32b11f61bfcc12b75f96119fad9cfbf5d9bc0c65c0e3980d731da44) verifies partitioning and refusal behavior end-to-end.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32bf0d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->