### PR TITLE
Conserve obligations across the effect->halted conversion, and name the arm (#6352)

### DIFF
--- a/docs/ledgers/stablezero-demand-set-fix.json
+++ b/docs/ledgers/stablezero-demand-set-fix.json
@@ -3,100 +3,17 @@
  "n_functions": 223,
  "statuses": {
   "ExitSetFactoringGap": 1,
-  "clean": 221,
-  "raised:TypeError": 1
+  "clean": 222
  },
  "R(timeout)": 0,
  "R(construction_panics)": 0,
  "R(factoring_gaps)": 1,
- "R(unnamed_exceptions)": 1,
+ "R(unnamed_exceptions)": 0,
  "completed_denominator": 223,
  "stableZero": false,
- "desugar_s": 53.77,
- "wall_s": 57.33,
+ "desugar_s": 35.12,
+ "wall_s": 37.85,
  "residuals": [
-  {
-   "name": null,
-   "line": 9596,
-   "status": "raised:TypeError",
-   "testimony": {
-    "type": "TypeError",
-    "message": "<class 'sugar_lift_py_tests.caller_parameter_contract.ContractConditionalConstructionV1'>",
-    "frames": [
-     {
-      "module": "__main__",
-      "qualname": "classify",
-      "line": 148
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
-      "qualname": "FunctionUniverseSugar.desugar",
-      "line": 369
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
-      "qualname": "reduce_body",
-      "line": 303
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
-      "qualname": "reduce_block_to_exitset",
-      "line": 275
-     },
-     {
-      "module": "sugar_lift_py_tests.outcome.exit_set",
-      "qualname": "ExitSet.sequence",
-      "line": 522
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
-      "qualname": "reduce_block_to_exitset.<locals>.reduce_next",
-      "line": 84
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.store_effect_sugar",
-      "qualname": "AttributeStoreEffectSugar.desugar",
-      "line": 48
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.subscript_sugar",
-      "qualname": "SubscriptSugar.desugar",
-      "line": 43
-     },
-     {
-      "module": "sugar_lift_py_tests.caller_parameter_contract",
-      "qualname": "ContractConditionalConstructionV1.and_then",
-      "line": 159
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.subscript_sugar",
-      "qualname": "SubscriptSugar.desugar.<locals>.<lambda>",
-      "line": 44
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.spread_sugar",
-      "qualname": "SpreadCollectionSugar.desugar",
-      "line": 119
-     },
-     {
-      "module": "sugar_lift_py_tests.sugar.spread_sugar",
-      "qualname": "_collect",
-      "line": 55
-     },
-     {
-      "module": "sugar_lift_py_tests.outcome.exit_set",
-      "qualname": "outcome_to_exitset",
-      "line": 806
-     }
-    ],
-    "innermost": {
-     "module": "sugar_lift_py_tests.outcome.exit_set",
-     "qualname": "outcome_to_exitset",
-     "line": 806
-    }
-   },
-   "seconds": 1.3517
-  },
   {
    "name": null,
    "line": 13403,
@@ -108,7 +25,7 @@
      {
       "module": "__main__",
       "qualname": "classify",
-      "line": 148
+      "line": 149
      },
      {
       "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
@@ -128,7 +45,7 @@
      {
       "module": "sugar_lift_py_tests.outcome.exit_set",
       "qualname": "ExitSet.sequence",
-      "line": 522
+      "line": 567
      },
      {
       "module": "sugar_lift_py_tests.sugar.function_universe_sugar",
@@ -143,49 +60,49 @@
      {
       "module": "sugar_lift_py_tests.sugar.spread_sugar",
       "qualname": "SpreadCallSugar.desugar",
-      "line": 197
+      "line": 233
      },
      {
       "module": "sugar_lift_py_tests.outcome.exit_set",
       "qualname": "ExitSet.and_then",
-      "line": 535
+      "line": 580
      },
      {
       "module": "sugar_lift_py_tests.outcome.exit_set",
       "qualname": "ExitSet.sequence",
-      "line": 522
+      "line": 567
      },
      {
       "module": "sugar_lift_py_tests.outcome.exit_set",
       "qualname": "ExitSet.and_then.<locals>.<lambda>",
-      "line": 535
+      "line": 580
      },
      {
       "module": "sugar_lift_py_tests.sugar.spread_sugar",
       "qualname": "SpreadCallSugar.desugar.<locals>.after_callee",
-      "line": 188
+      "line": 224
      },
      {
       "module": "sugar_lift_py_tests.sugar.spread_sugar",
       "qualname": "_collect",
-      "line": 55
+      "line": 81
      },
      {
       "module": "sugar_lift_py_tests.outcome.exit_set",
       "qualname": "ExitSet.factor_completed",
-      "line": 367
+      "line": 404
      }
     ],
     "innermost": {
      "module": "sugar_lift_py_tests.outcome.exit_set",
      "qualname": "ExitSet.factor_completed",
-     "line": 367
+     "line": 404
     }
    },
-   "seconds": 0.7857
+   "seconds": 0.9488
   }
  ],
  "file": "/usr/local/lib/python3.14/site-packages/pandas/core/generic.py",
- "label": "fix-6351",
+ "label": "fix-6352-v3",
  "deadline_seconds": 120.0
 }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -210,6 +210,21 @@ def _unhashable_destination_count() -> int:
     return len(_UNHASHABLE_DESTINATIONS)
 
 
+def _obligations(exit_: "Halted") -> tuple:
+    """A halted arm's obligations by content address, order-free (#6352).
+
+    Keyed by ``demand_cid`` -- the obligation's own content address -- never by
+    hashing the carrier, which holds a floor value and a term.
+    """
+    return tuple(
+        sorted(
+            demand.demand_cid
+            for entry in exit_.pending_contracts
+            for demand in entry.demands
+        )
+    )
+
+
 def _destination_key(exit_: "Exit[T]") -> object:
     """Bucket key for an exit's DESTINATION, ignoring its guard.
 
@@ -220,7 +235,12 @@ def _destination_key(exit_: "Exit[T]") -> object:
     try:
         if isinstance(exit_, Completed):
             return ("completed", hash(exit_.value))
-        return ("halted", hash(exit_.effect), hash(exit_.state))
+        return (
+            "halted",
+            hash(exit_.effect),
+            hash(exit_.state),
+            _obligations(exit_),
+        )
     except TypeError:
         return _UNHASHABLE
 
@@ -240,12 +260,29 @@ class Completed(Generic[T]):
 
 @dataclass(frozen=True)
 class Halted:
+    """Control left with this effect, under this guard, from this state.
+
+    ``pending_contracts`` conserves obligations incurred BEFORE the effect
+    across the ``Incomplete`` -> halted conversion (#6352). Each is already
+    weakened under this arm's own guard by ``outcome_to_exitset``, so the arm
+    carries ``g -> D`` rather than a bare ``D``.
+
+    It is deliberately NOT routed like ``faces``. A merged arm holds under a
+    DISJUNCTION, so partition testimony may only keep what every contributing
+    arm carried -- intersecting is what stops a merged arm claiming a face it
+    held on one side only. Obligations must not be intersected (that drops one)
+    and must not be unioned (that owes one on a face that never runs), so they
+    take neither route: they are part of the DESTINATION, and two arms owing
+    different things are different destinations that never merge at all.
+    """
+
     guard: Formula
     effect: Effect
     state: object | None = None
     faces: frozenset[PartitionFace] = _dataclass_field(
         default=_NO_FACES, compare=False, repr=False
     )
+    pending_contracts: tuple = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "effect", require_effect(self.effect))
@@ -480,6 +517,10 @@ class ExitSet(Generic[T]):
                     and isinstance(prior, Halted)
                     and exit_.effect == prior.effect
                     and exit_.state == prior.state
+                    # #6352: arms owing different obligations are different
+                    # destinations. Merging them would keep the prior's and
+                    # drop the arrival's, silently.
+                    and _obligations(exit_) == _obligations(prior)
                 )
                 # Same destination under a DISJOINED guard: only testimony both
                 # arms carried survives the merge, for the same reason as in
@@ -500,6 +541,10 @@ class ExitSet(Generic[T]):
                         prior.effect,
                         prior.state,
                         prior.faces & exit_.faces,
+                        # Equal by `same_halted`, so this conserves rather than
+                        # chooses; stated explicitly so the field cannot be
+                        # dropped by a later edit to this constructor.
+                        prior.pending_contracts,
                     )
                     break
             else:
@@ -803,10 +848,89 @@ def outcome_to_exitset(outcome) -> ExitSet:
     if isinstance(outcome, Complete):
         return ExitSet.completed(outcome.value)
     if isinstance(outcome, Incomplete):
+        # CONSERVATION AT THE CONVERSION BOUNDARY (#6352). An `Incomplete` can
+        # carry obligations incurred BEFORE its effect (`o.x = p[k]` evaluates
+        # `p[k]`, then the store answers). This conversion used to build the
+        # halted arm from `effect` alone, so those obligations vanished HERE --
+        # silently, on a boundary, where nothing downstream could report them.
+        # A demand that disappears at an effect -> halted conversion is
+        # unattributable afterward: no caller owes it and no instrument knows.
+        #
+        # They are weakened under the arm's own guard on the way across, so the
+        # arm carries `g -> D` rather than `D`. That weakening is what makes the
+        # later merge sound (see `_destination_key` / `normalize`).
+        contracts = tuple(getattr(outcome, "pending_contracts", ()))
         if outcome.branch_conditions:
-            return ExitSet.halted(outcome.effect, and_(list(outcome.branch_conditions)))
-        return ExitSet.halted(outcome.effect)
-    raise TypeError(type(outcome))
+            guard = and_(list(outcome.branch_conditions))
+            return ExitSet(
+                (
+                    Halted(
+                        guard,
+                        outcome.effect,
+                        None,
+                        pending_contracts=tuple(
+                            entry.demanded_under(guard) for entry in contracts
+                        ),
+                    ),
+                )
+            ).normalize()
+        return ExitSet(
+            (
+                Halted(
+                    true_guard(),
+                    outcome.effect,
+                    None,
+                    pending_contracts=contracts,
+                ),
+            )
+        ).normalize()
+
+    # A PENDING PARAMETER-CONTRACT CARRIER (#6352). This used to be
+    # `raise TypeError(type(outcome))` -- a gap that named no owner, no observed
+    # shape and no fix, which is strictly worse than a panic, not absent.
+    #
+    # The carrier is not a value and not a partition: it WRAPS a value together
+    # with obligations the linker has not discharged. The exit algebra has no
+    # arm for it because an ExitSet's faces each carry their own guard and the
+    # carrier has one value with no seam to split across them. The producer must
+    # hoist the obligations before converting, exactly as
+    # `collection_sugar._reduce_into` and `spread_sugar._collect` do.
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        ContractConditionalConstructionV1,
+    )
+    from sugar_lift_py_tests.gap.info import GapKind
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    if isinstance(outcome, ContractConditionalConstructionV1):
+        construction_panic_gap(
+            owner="outcome_to_exitset",
+            blame=outcome.source_node,
+            observed=(
+                "a pending parameter contract carrier ("
+                + ", ".join(demand.demand_cid for demand in outcome.demands)
+                + ") was converted to an exit set, which has no arm that wraps "
+                "a value together with an undischarged obligation"
+            ),
+            requested="a plain value or a partition",
+            fix=(
+                "hoist the demands with `single_outcome_law.pending_demand` "
+                "before converting, fold the carried value, and re-attach them "
+                "with `rewrap_pending`; never drop the obligation"
+            ),
+            gap_kind=GapKind.FLOOR,
+        )
+
+    construction_panic_gap(
+        owner="outcome_to_exitset",
+        blame=type(outcome).__name__,
+        observed=f"{type(outcome).__name__} is not an Outcome the exit algebra knows",
+        requested="Complete, Incomplete or ExitSet",
+        fix=(
+            "give this outcome variant an arm in `outcome_to_exitset`, or stop "
+            "producing it upstream of the exit algebra"
+        ),
+        gap_kind=GapKind.FLOOR,
+    )
 
 
 __all__ = [

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass, field as dataclass_field, replace as _replace
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -47,12 +47,38 @@ def _collect(sugars: tuple, ctx, done: tuple, finish):
         true_guard,
     )
 
+    from sugar_lift_py_tests.caller_parameter_contract import merge_demands
+    from sugar_lift_py_tests.floor.single_outcome_law import (
+        pending_demand,
+        rewrap_pending,
+    )
+
     prefix_guard = true_guard()
     values = list(done)
     halted: list = []
+    pending = None
 
     for sugar in sugars:
-        factors = outcome_to_exitset(sugar.desugar(ctx)).factor_completed()
+        # An operand that owes a parameter contract (`[*p[0]]`, `[*xs, p[0]]`
+        # for a formal `p`) WRAPS its value rather than being one, and the exit
+        # algebra has no arm for a value carried together with an undischarged
+        # obligation. Hoisting is the same door `collection_sugar._reduce_into`
+        # uses; without it this reached `outcome_to_exitset` and stopped on a
+        # bare `TypeError` that named no owner and no fix (#6352).
+        #
+        # The operand hoists at `true_guard`: a spread display has no guard of
+        # its own, and the prefix guard already rides on the arms below.
+        entry, operand = pending_demand(sugar.desugar(ctx), true_guard())
+        if entry is not None:
+            pending = (
+                entry
+                if pending is None
+                else _replace(
+                    pending,
+                    demands=merge_demands(pending.demands, entry.demands),
+                )
+            )
+        factors = outcome_to_exitset(operand).factor_completed()
         completed = None
         for exit_ in factors.exits:
             if isinstance(exit_, Halted):
@@ -68,8 +94,14 @@ def _collect(sugars: tuple, ctx, done: tuple, finish):
         if completed is None:
             # Every path through this operand halts: there is no completed
             # continuation to hand to ``finish``, and the halted face is the
-            # whole meaning.
-            return ExitSet(tuple(halted)).normalize().collapse()
+            # whole meaning. Any obligation already incurred rides on the halted
+            # arms, which `outcome_to_exitset` conserved across the conversion.
+            return rewrap_pending(
+                pending,
+                ExitSet(tuple(halted)).normalize().collapse(),
+                owner="spread operand",
+                blame=str(getattr(sugar, "site", sugar)),
+            )
         prefix_guard = _and_guards(prefix_guard, completed.guard)
         values.append(completed.value)
 
@@ -78,7 +110,11 @@ def _collect(sugars: tuple, ctx, done: tuple, finish):
         tail = tail.guarded(prefix_guard)
     # ``collapse`` restores the linear ``Outcome`` for the unconditional case, so
     # a spread with no guarded operand desugars to exactly what it did before.
-    return ExitSet((*halted, *tail.exits)).normalize().collapse()
+    built = ExitSet((*halted, *tail.exits)).normalize().collapse()
+    # Re-attach every hoisted obligation to the finished display, or be loud.
+    return rewrap_pending(
+        pending, built, owner="spread display", blame=str(finish)
+    )
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
@@ -362,3 +362,169 @@ def test_an_effect_face_is_no_longer_the_partition_gap():
 
     assert isinstance(joined, Incomplete)
     assert joined.pending_contracts == (entry,)
+
+
+# --------------------------------------------------------------------------
+# The conversion boundary: an obligation must not vanish becoming a halted arm
+#
+# This is its own named thing, not a side effect of the arm below. A demand
+# that disappears at an `Incomplete` -> `Halted` conversion is unattributable
+# afterward: no caller owes it, no linker discharges it, and NOTHING reports
+# it. A silent loss on a conversion boundary is the worst shape a bug can
+# take here, which is why it gets its own twins rather than riding on the
+# tests for the arm that exposed it.
+# --------------------------------------------------------------------------
+
+
+def _halted_carrier(guard=None):
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.outcome.exit_set import Halted, outcome_to_exitset
+
+    out = _out("def f(p):\n return [p[0]]\n")
+    (entry,) = _entries(out)
+    effect = RaiseEffect(exception_name="ValueError")
+    incomplete = Incomplete(effect, (guard,) if guard is not None else (), (entry,))
+    exits = outcome_to_exitset(incomplete)
+    (arm,) = exits.exits
+    assert isinstance(arm, Halted)
+    return entry, arm
+
+
+def test_an_obligation_survives_the_effect_to_halted_conversion():
+    """POSITIVE. `outcome_to_exitset` used to build the arm from `effect` alone.
+
+    Everything else on the `Incomplete` -- the obligations it had already
+    incurred -- was dropped on the floor at the conversion, with no panic, no
+    row and no way to notice.
+    """
+    entry, arm = _halted_carrier()
+
+    assert arm.pending_contracts == (entry,)
+
+
+def test_the_conversion_weakens_the_obligation_under_the_arms_own_guard():
+    """DISCRIMINATING. Carrying it UNCONDITIONALLY would also pass the test above.
+
+    The arm holds only under its guard, so the obligation it carries is
+    `g -> D`, never the bare `D`. Carrying the bare demand would make a caller
+    prove indexability on a path where control never reached the subscript.
+    """
+    from sugar_lift_py_tests.ir import atomic, make_var
+
+    guard = atomic("branch", [make_var("state")])
+    entry, arm = _halted_carrier(guard)
+
+    (carried,) = arm.pending_contracts
+    assert carried.demands[0].demand_cid != entry.demands[0].demand_cid, (
+        "the obligation crossed the conversion unweakened: it is owed on a face "
+        "that may never run (#6352)"
+    )
+
+
+def test_halted_arms_owing_different_things_are_different_destinations():
+    """DISCRIMINATING. `normalize` merges equal destinations by DISJOINING guards.
+
+    If obligations were not part of the destination, two halted arms with the
+    same effect and state but different demands would merge, and the merge
+    keeps the PRIOR's payload -- silently dropping the arrival's obligation.
+
+    They are not intersected either: intersecting drops one, unioning owes one
+    on a face that never runs. Neither route is taken, so the arms simply do
+    not merge.
+    """
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.ir import atomic, make_var
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+
+    first = _entries(_out("def f(p):\n return [p[0]]\n"))[0]
+    second = _entries(_out("def f(q):\n return [q[1]]\n"))[0]
+    effect = RaiseEffect(exception_name="ValueError")
+
+    merged = ExitSet(
+        (
+            Halted(
+                atomic("a", [make_var("s")]), effect, None, pending_contracts=(first,)
+            ),
+            Halted(
+                atomic("b", [make_var("s")]), effect, None, pending_contracts=(second,)
+            ),
+        )
+    ).normalize()
+
+    assert len(merged.exits) == 2
+    carried = {
+        demand.demand_cid
+        for arm in merged.exits
+        for entry in arm.pending_contracts
+        for demand in entry.demands
+    }
+    assert len(carried) == 2
+
+
+def test_halted_arms_owing_the_same_thing_still_merge():
+    """DISCRIMINATING for the test above: the destination key must not over-split.
+
+    Making every halted arm unique would also make the merge "never drop"
+    anything, and would give back the arm growth #6333 removed. Arms with the
+    SAME obligations are the same destination and still merge to one.
+    """
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.ir import atomic, make_var
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+
+    (entry,) = _entries(_out("def f(p):\n return [p[0]]\n"))
+    effect = RaiseEffect(exception_name="ValueError")
+
+    merged = ExitSet(
+        (
+            Halted(
+                atomic("a", [make_var("s")]), effect, None, pending_contracts=(entry,)
+            ),
+            Halted(
+                atomic("b", [make_var("s")]), effect, None, pending_contracts=(entry,)
+            ),
+        )
+    ).normalize()
+
+    assert len(merged.exits) == 1
+    assert merged.exits[0].pending_contracts == (entry,)
+
+
+# --------------------------------------------------------------------------
+# The arm: a carrier reaching the exit algebra names its owner
+# --------------------------------------------------------------------------
+
+
+def test_a_spread_operand_owing_a_contract_lifts_and_keeps_its_demand():
+    """POSITIVE. `[*xs, p[0]]` stopped on a bare `TypeError(type(outcome))`.
+
+    `spread_sugar._collect` never hoisted the way `collection_sugar` does, so
+    the carrier reached `outcome_to_exitset` and the tower stopped on an
+    exception that named no owner, no observed shape and no fix.
+    """
+    out = _out("def f(xs, p):\n return [*xs, p[0]]\n")
+
+    assert len(_demand_cids(out)) == 1
+
+
+def test_a_carrier_reaching_the_exit_algebra_names_its_owner_and_its_fix():
+    """DISCRIMINATING. The refusal must be a NAMED gap, never a bare exception.
+
+    A producer that forgets to hoist has to be handed the fix, not a
+    `TypeError` whose whole content is a type name. An unnamed row is worse
+    than the panic it replaced, because it names neither owner nor replacement
+    architecture.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+    (entry,) = _entries(_out("def f(p):\n return [p[0]]\n"))
+
+    with pytest.raises(ConstructionPanic) as raised:
+        outcome_to_exitset(entry)
+
+    info = raised.value.info
+    assert info.owner == "outcome_to_exitset"
+    assert "pending parameter contract carrier" in info.observed
+    assert "rewrap_pending" in info.fix
+    assert "never drop the obligation" in info.fix


### PR DESCRIPTION
**Recovers the second half of #6354.** I merged that PR while its author was still pushing, so `d2c2b46c2` carries only the demand-set commit. This is `593d410f5` rebased onto current main — same content, no re-derivation.

## The conservation hole, as its own thing

`outcome_to_exitset` built the halted arm from `effect` alone, so an `Incomplete`'s already-incurred obligations **died at the conversion** — no panic, no row, nothing downstream able to report it. `Halted.pending_contracts` now carries them, **weakened under the arm's own guard** on the way across, so an arm holds `g -> D` and never a bare `D`.

## The merge is where it could still lie, and it takes neither of #6336's routes

A merged arm holds under a **disjunction**, so it may only keep what every contributing arm carried — which is why `faces` **intersect**. Obligations can do neither:

- **intersect** would drop one
- **union** would owe one on a face that never runs

So obligations are part of the **destination**, keyed by `demand_cid`: **arms owing different things are different destinations and never merge.** Arms owing the *same* things still merge, so #6333's arm bound is not given back — and that discriminator has its own twin, because **"never merge anything" would have passed the conservation test and quietly restored the arm growth.**

## The arm

`raise TypeError(type(outcome))` is now a named `ConstructionGap` handing the producer its fix, and the residual non-`Outcome` arm is named rather than left bare. `spread_sugar._collect` was the producer not hoisting; it now uses the same door `collection_sugar._reduce_into` does.

## Measured — same rig both sides

```
term                     main 31ca5580c   branch
R(timeout)                     0            0
R(construction_panics)         3            0
R(unnamed_exceptions)          0            0    (was 1 mid-branch)
R(factoring_gaps)              1            1    <- #6356, not this PR's
clean                     219/223      222/223
```

## Boundaries verified, not asserted

- `factor_completed`'s refusal untouched; its lying twins still pass.
- **#6311's identity memo untouched** — grepping the diff for `__eq__`, `__hash__`, `_term_cycle_key` and the weak coordinate memo returns **empty**.
- #6336's algebra untouched: conjunction unions faces, disjunction intersects.

159 passed across exit-set, partition-testimony, arm-growth, destination-hash, floor-panic and parameter-contract suites. **Perturbed after green three ways:** conversion drops obligations → 2 red; obligations leave the destination key → 1 red; spread stops hoisting → 1 red.

## Not measured

`make test-python` never produced a verdict — three attempts died on battleaxe's cargo build lock held by the authoritative baseline, and the author stopped rather than contend. What exists is the 159 focused + 662 source-tree passes and the rig.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Conserve pending obligations across the `Incomplete`-to-`Halted` conversion and name the arm
> - `Halted` exits now carry a `pending_contracts` field; `outcome_to_exitset` attaches obligations from `Incomplete` outcomes to the resulting `Halted` arm and weakens them under the arm's own guard.
> - `ExitSet.normalize` no longer merges `Halted` arms that owe different obligations, using a new `_obligations` key derived from sorted `demand_cid` values.
> - Spread operands in [`spread_sugar.py`](https://github.com/TSavo/sugar/pull/6358/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945) now hoist parameter-contract demands and reattach them via `rewrap_pending` instead of silently dropping them.
> - Passing a `ContractConditionalConstructionV1` carrier directly to `outcome_to_exitset` now raises a `ConstructionPanic` with owner and fix info instead of a generic `TypeError`.
> - New tests in [`test_parameter_contract_demand_set.py`](https://github.com/TSavo/sugar/pull/6358/files#diff-3966764b652b28cda5f8839b625c2467e4c00e1613121d850936711d9e7f55ef) cover obligation survival, guard weakening, destination separation, merging, and the panic diagnostic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a7b23c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->