### PR TITLE
Execute uid-sensitive laws under a dropped identity instead of skipping them

### DIFF
--- a/tests/test_heavy_measurement_lease.py
+++ b/tests/test_heavy_measurement_lease.py
@@ -31,6 +31,12 @@ from pathlib import Path
 
 import pytest
 
+from unprivileged_identity import (
+    reachable_by_unprivileged,
+    run_unprivileged,
+    unprivileged_preexec,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 WRAPPER = ROOT / "tools" / "heavy_measurement_lease.py"
 GATE = ROOT / "tools" / "heavy_measurement_lease_gate.py"
@@ -311,15 +317,17 @@ def test_unwritable_lease_directory_refuses_by_name_and_states_the_right_path(tm
     host-shared path AND rule out /var/tmp, because that is the workaround the
     traceback teaches and it is the one that breaks the invariant."""
     module = _lease_module()
-    if os.getuid() == 0:
-        pytest.skip("root can write anywhere; this law is about an ordinary uid")
+    # Root bypasses the mode check this law is about, so under bpytest (which
+    # runs as root) this used to skip -- and a skip is not a pass. It now runs
+    # under a dropped identity instead, so the law is executed everywhere.
+    reachable_by_unprivileged(tmp_path)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o500)
     lease = module.HeavyMeasurementLease("t", str(locked / "sub" / "x.lease"), 1)
 
     with pytest.raises(module.LeaseDirectoryUnusable) as caught:
-        lease._require_usable_directory()
+        run_unprivileged(lease._require_usable_directory)
 
     message = str(caught.value)
     assert ".cache/sugar/binaries" in message, "the refusal must state the right path"
@@ -330,8 +338,11 @@ def test_unwritable_lease_directory_refuses_by_name_and_states_the_right_path(tm
 def test_an_unusable_lease_directory_never_runs_the_command(tmp_path, record):
     """The whole point: no lease, no measurement. A run that could not take the
     lease must support no claim, exactly like a timeout."""
-    if os.getuid() == 0:
-        pytest.skip("root can write anywhere; this law is about an ordinary uid")
+    # Same reason as above: the wrapper subprocess drops to an unprivileged
+    # identity so the kernel enforces the mode bits, instead of the test
+    # skipping under the root identity bpytest runs as.
+    reachable_by_unprivileged(tmp_path)
+    reachable_by_unprivileged(record.parent)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o500)
@@ -347,6 +358,7 @@ def test_an_unusable_lease_directory_never_runs_the_command(tmp_path, record):
             "--", sys.executable, "-c", f"open({str(ran)!r}, 'w').write('x')",
         ],
         capture_output=True, text=True,
+        preexec_fn=unprivileged_preexec(),
     )
 
     assert proc.returncode == 75, proc.stderr

--- a/tests/test_heavy_measurement_lease.py
+++ b/tests/test_heavy_measurement_lease.py
@@ -35,6 +35,7 @@ from unprivileged_identity import (
     reachable_by_unprivileged,
     run_unprivileged,
     unprivileged_preexec,
+    writable_by_unprivileged,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -327,7 +328,10 @@ def test_unwritable_lease_directory_refuses_by_name_and_states_the_right_path(tm
     lease = module.HeavyMeasurementLease("t", str(locked / "sub" / "x.lease"), 1)
 
     with pytest.raises(module.LeaseDirectoryUnusable) as caught:
-        run_unprivileged(lease._require_usable_directory)
+        run_unprivileged(
+            lease._require_usable_directory,
+            expected=module.LeaseDirectoryUnusable,
+        )
 
     message = str(caught.value)
     assert ".cache/sugar/binaries" in message, "the refusal must state the right path"
@@ -342,7 +346,7 @@ def test_an_unusable_lease_directory_never_runs_the_command(tmp_path, record):
     # identity so the kernel enforces the mode bits, instead of the test
     # skipping under the root identity bpytest runs as.
     reachable_by_unprivileged(tmp_path)
-    reachable_by_unprivileged(record.parent)
+    writable_by_unprivileged(record.parent)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o500)

--- a/tests/test_uid_sensitive_laws_are_executed.py
+++ b/tests/test_uid_sensitive_laws_are_executed.py
@@ -1,0 +1,134 @@
+"""A skipped law is an unrun law, and an unrun law reported as green is a lie.
+
+``bpytest`` runs as root on battleaxe. Root bypasses the DAC mode checks that
+uid-sensitive laws are about, so a test guarding on ``os.getuid() == 0`` and
+skipping is unfalsifiable there: it can never fail, no matter how broken the
+code under it becomes. Two permission laws in ``test_heavy_measurement_lease``
+skipped on the box while passing locally, and nobody noticed, because the suite
+did not go red -- it went *smaller*.
+
+That is the same defect class as a collection error that shrinks the
+denominator. The colour is not the instrument; the executed count is.
+
+These are the teeth against that class:
+
+    1. No uid-guarded test may degrade to a skip. Structural, over the whole
+       corpus, so the class cannot regrow one test at a time.
+
+    2. The privilege-drop mechanism must actually deny something HERE. A
+       mechanism that quietly no-ops under root would restore the exact
+       unfalsifiability it was written to remove -- so it is tested by
+       provoking a real EACCES, not by inspection.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from unprivileged_identity import (
+    UnprivilegedIdentityUnavailable,
+    reachable_by_unprivileged,
+    run_unprivileged,
+    unprivileged_identity,
+)
+
+TESTS = Path(__file__).resolve().parent
+SELF = Path(__file__).name
+
+
+def _uid_guarded_skips():
+    """Every test function that both consults the uid and calls ``pytest.skip``."""
+    offenders = []
+    for path in sorted(TESTS.rglob("*.py")):
+        if path.name == SELF:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            consults_uid = False
+            skips = False
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Attribute) and inner.attr in {
+                    "getuid",
+                    "geteuid",
+                }:
+                    consults_uid = True
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "skip"
+                ):
+                    skips = True
+            if consults_uid and skips:
+                offenders.append(
+                    f"{path.relative_to(TESTS.parent)}:{node.lineno}: {node.name}"
+                )
+    return offenders
+
+
+def test_no_uid_sensitive_law_degrades_to_a_skip():
+    """A uid guard that skips makes the law unfalsifiable wherever it matters.
+
+    The suite runs as root under ``bpytest``, which is precisely the identity
+    such a guard excludes -- so the law would be skipped in the one environment
+    that is supposed to run it. Run it under a dropped identity instead
+    (``tests/unprivileged_identity.py``); never skip it.
+    """
+    offenders = _uid_guarded_skips()
+    assert not offenders, (
+        f"R={len(offenders)} uid-sensitive laws degrade to a skip and are "
+        "therefore unfalsifiable under the root identity bpytest runs as:\n"
+        + "\n".join(offenders)
+        + "\nreplacement: run the law under a non-root identity with "
+        "unprivileged_identity.run_unprivileged / unprivileged_preexec, or "
+        "fail by name -- a skip reports an unrun law as green"
+    )
+
+
+def test_the_privilege_drop_actually_denies_something_here(tmp_path):
+    """The positive control: without this, the mechanism could silently no-op.
+
+    A privilege drop that failed to take effect would leave every law using it
+    passing vacuously under root -- exactly the unfalsifiability being removed,
+    now hidden one layer deeper. So provoke a real EACCES and require it.
+    """
+    reachable_by_unprivileged(tmp_path)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    target = locked / "denied.txt"
+
+    def write():
+        target.write_text("x")
+        return "wrote"
+
+    with pytest.raises(PermissionError):
+        run_unprivileged(write)
+
+    assert not target.exists(), "the write must not have landed"
+    locked.chmod(0o700)
+
+
+def test_the_dropped_identity_is_not_root():
+    """Whatever identity the law runs under, the kernel must be checking it."""
+    assert run_unprivileged(os.getuid) != 0
+    assert run_unprivileged(os.geteuid) != 0
+
+
+def test_an_unavailable_identity_refuses_by_name_rather_than_skipping():
+    """The refusal is named and is an error, never a silently smaller suite."""
+    assert issubclass(UnprivilegedIdentityUnavailable, Exception)
+    assert not issubclass(UnprivilegedIdentityUnavailable, type(pytest.skip.Exception))
+
+    identity = unprivileged_identity()
+    if identity is not None:
+        uid, _ = identity
+        assert uid != 0, "a 'dropped' identity of uid 0 would prove nothing"

--- a/tests/test_uid_sensitive_laws_are_executed.py
+++ b/tests/test_uid_sensitive_laws_are_executed.py
@@ -126,7 +126,9 @@ def test_the_dropped_identity_is_not_root():
 def test_an_unavailable_identity_refuses_by_name_rather_than_skipping():
     """The refusal is named and is an error, never a silently smaller suite."""
     assert issubclass(UnprivilegedIdentityUnavailable, Exception)
-    assert not issubclass(UnprivilegedIdentityUnavailable, type(pytest.skip.Exception))
+    assert not issubclass(UnprivilegedIdentityUnavailable, pytest.skip.Exception), (
+        "an unavailable identity must fail, never register as a skip"
+    )
 
     identity = unprivileged_identity()
     if identity is not None:

--- a/tests/unprivileged_identity.py
+++ b/tests/unprivileged_identity.py
@@ -92,14 +92,37 @@ def reachable_by_unprivileged(path):
     return path
 
 
-def run_unprivileged(law):
+def writable_by_unprivileged(directory):
+    """Let a dropped identity WRITE into ``directory``, not merely reach it.
+
+    A law whose subject writes a receipt needs somewhere to write it. Without
+    this the receipt is missing and the test fails on the wrong thing, which
+    proves nothing about the law.
+    """
+    directory = reachable_by_unprivileged(directory)
+    try:
+        mode = directory.stat().st_mode
+        directory.chmod(mode | stat.S_IRWXO)
+    except OSError:
+        pass
+    return directory
+
+
+def run_unprivileged(law, expected=()):
     """Run ``law()`` under an unprivileged identity and return its result.
 
     When the caller is already unprivileged the law runs inline. Otherwise it
     runs in a forked child that has irrevocably dropped to a non-root uid, so
-    the kernel enforces mode bits against it. An exception raised inside the
-    child is transported back and re-raised in the parent, so ``pytest.raises``
-    around this call behaves exactly as it does for an ordinary caller.
+    the kernel enforces mode bits against it.
+
+    An exception raised inside the child is transported back and re-raised, so
+    ``pytest.raises`` around this call behaves as it does for an ordinary
+    caller. Exception *classes* do not always survive a fork boundary: a module
+    loaded by file location (as the lease wrapper is, freshly per call) defines
+    classes that are unpicklable and whose identity differs between parent and
+    child. So the caller names the classes it expects in ``expected`` and they
+    are matched by name and re-raised as the parent's own class. Anything
+    unexpected is still raised, never swallowed.
     """
     identity = unprivileged_identity()
     if identity is None:
@@ -110,7 +133,6 @@ def run_unprivileged(law):
     pid = os.fork()
 
     if pid == 0:  # child
-        status = 1
         try:
             os.close(read_fd)
             os.setgroups([])
@@ -121,20 +143,24 @@ def run_unprivileged(law):
                     "privilege drop did not take effect; the law would have "
                     "run as root and proved nothing"
                 )
-            payload = ("value", law())
+            value = law()
+            try:
+                payload = pickle.dumps(("value", None, None, pickle.dumps(value)))
+            except Exception:
+                payload = pickle.dumps(("value", None, repr(value), None))
         except BaseException as error:  # transported to the parent, not swallowed
             try:
-                payload = ("error", error)
-                pickle.dumps(payload)
+                blob = pickle.dumps(error)
             except Exception:
-                payload = ("error", RuntimeError(f"{type(error).__name__}: {error}"))
+                blob = None
+            payload = pickle.dumps(
+                ("error", type(error).__name__, str(error), blob)
+            )
         try:
-            blob = pickle.dumps(payload)
-            os.write(write_fd, blob)
-            status = 0
+            os.write(write_fd, payload)
         finally:
             os.close(write_fd)
-            os._exit(status)
+            os._exit(0)
 
     # parent
     os.close(write_fd)
@@ -153,10 +179,19 @@ def run_unprivileged(law):
             f"result (wait status {wait_status}); the law did not execute"
         )
 
-    kind, payload = pickle.loads(b"".join(chunks))
-    if kind == "error":
-        raise payload
-    return payload
+    kind, name, text, blob = pickle.loads(b"".join(chunks))
+
+    if kind == "value":
+        return pickle.loads(blob) if blob is not None else text
+
+    if isinstance(expected, type):
+        expected = (expected,)
+    for candidate in expected:
+        if candidate.__name__ == name:
+            raise candidate(text)
+    if blob is not None:
+        raise pickle.loads(blob)
+    raise RuntimeError(f"{name}: {text}")
 
 
 def unprivileged_preexec():

--- a/tests/unprivileged_identity.py
+++ b/tests/unprivileged_identity.py
@@ -1,0 +1,179 @@
+"""Run a uid-sensitive law under an identity that the kernel actually checks.
+
+``bpytest`` runs as root on battleaxe. Root bypasses DAC mode checks, so every
+test guarding on ``os.getuid() == 0`` skipped there while passing locally --
+and a skip is not a pass. The suite did not go red, it went *smaller*, which is
+the same defect class as a collection error that shrinks the denominator:
+nobody notices, because a skipped test reports green.
+
+The honest fix is not a louder skip. It is to stop needing one: fork, drop to
+an unprivileged identity, and run the law there, so the permission bits the
+law is about are enforced by the kernel exactly as they are for an ordinary
+caller. The law then executes under root and non-root alike.
+
+When no unprivileged identity can be reached, this refuses BY NAME with
+``UnprivilegedIdentityUnavailable``. It never degrades to a skip. An
+environment that is supposed to run these laws and cannot must say so out
+loud, as a failure.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import stat
+from pathlib import Path
+
+# nobody(65534) is the conventional unprivileged identity on Linux and macOS
+# alike. The candidates are tried in order and the first that resolves wins.
+_CANDIDATE_USERS = ("nobody", "nfsnobody", "daemon")
+
+
+class UnprivilegedIdentityUnavailable(RuntimeError):
+    """No identity was available under which a uid-sensitive law could run.
+
+    Raised, never skipped. A uid-sensitive law that cannot be executed is an
+    unrun law, and an unrun law reported as green is the defect this module
+    exists to close.
+    """
+
+
+def unprivileged_identity():
+    """Return ``(uid, gid)`` of an identity with no special privileges.
+
+    Returns ``None`` when the caller is already unprivileged: there is nothing
+    to drop to, because the kernel already enforces mode bits against it.
+    """
+    if os.getuid() != 0:
+        return None
+
+    import pwd
+
+    for name in _CANDIDATE_USERS:
+        try:
+            entry = pwd.getpwnam(name)
+        except KeyError:
+            continue
+        if entry.pw_uid != 0:
+            return (entry.pw_uid, entry.pw_gid)
+
+    raise UnprivilegedIdentityUnavailable(
+        "running as root and no unprivileged identity "
+        f"({', '.join(_CANDIDATE_USERS)}) exists on this host, so a "
+        "uid-sensitive law cannot be executed here. This is reported as a "
+        "failure and never as a skip: root bypasses the DAC mode checks the "
+        "law is about, so skipping would report an unrun law as green. "
+        "replacement: provide an unprivileged account in the image that runs "
+        "the suite (bpytest runs as root), or run the suite as a non-root uid."
+    )
+
+
+def reachable_by_unprivileged(path):
+    """Open the ancestor chain of ``path`` so a dropped identity can reach it.
+
+    ``tmp_path`` lives under ``/tmp/pytest-of-root/...`` at mode 700 when the
+    suite runs as root. Traversal, not the law under test, would otherwise
+    decide the outcome -- and a law that fails for the wrong reason is no
+    better than one that never ran.
+    """
+    path = Path(path).resolve()
+    for ancestor in [path, *path.parents]:
+        try:
+            mode = ancestor.stat().st_mode
+        except OSError:
+            continue
+        if mode & stat.S_IXOTH and mode & stat.S_IROTH:
+            # Already world-traversable; every ancestor above it is too.
+            break
+        try:
+            ancestor.chmod(mode | stat.S_IROTH | stat.S_IXOTH)
+        except OSError:
+            continue
+    return path
+
+
+def run_unprivileged(law):
+    """Run ``law()`` under an unprivileged identity and return its result.
+
+    When the caller is already unprivileged the law runs inline. Otherwise it
+    runs in a forked child that has irrevocably dropped to a non-root uid, so
+    the kernel enforces mode bits against it. An exception raised inside the
+    child is transported back and re-raised in the parent, so ``pytest.raises``
+    around this call behaves exactly as it does for an ordinary caller.
+    """
+    identity = unprivileged_identity()
+    if identity is None:
+        return law()
+
+    uid, gid = identity
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+
+    if pid == 0:  # child
+        status = 1
+        try:
+            os.close(read_fd)
+            os.setgroups([])
+            os.setgid(gid)
+            os.setuid(uid)
+            if os.getuid() == 0 or os.geteuid() == 0:
+                raise UnprivilegedIdentityUnavailable(
+                    "privilege drop did not take effect; the law would have "
+                    "run as root and proved nothing"
+                )
+            payload = ("value", law())
+        except BaseException as error:  # transported to the parent, not swallowed
+            try:
+                payload = ("error", error)
+                pickle.dumps(payload)
+            except Exception:
+                payload = ("error", RuntimeError(f"{type(error).__name__}: {error}"))
+        try:
+            blob = pickle.dumps(payload)
+            os.write(write_fd, blob)
+            status = 0
+        finally:
+            os.close(write_fd)
+            os._exit(status)
+
+    # parent
+    os.close(write_fd)
+    chunks = []
+    while True:
+        chunk = os.read(read_fd, 65536)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    os.close(read_fd)
+    _, wait_status = os.waitpid(pid, 0)
+
+    if not chunks:
+        raise UnprivilegedIdentityUnavailable(
+            f"the unprivileged child (uid {uid}) died without reporting a "
+            f"result (wait status {wait_status}); the law did not execute"
+        )
+
+    kind, payload = pickle.loads(b"".join(chunks))
+    if kind == "error":
+        raise payload
+    return payload
+
+
+def unprivileged_preexec():
+    """A ``subprocess`` ``preexec_fn`` that drops to an unprivileged identity.
+
+    Returns ``None`` when the caller is already unprivileged, which is exactly
+    what ``subprocess`` expects for "do nothing extra".
+    """
+    identity = unprivileged_identity()
+    if identity is None:
+        return None
+
+    uid, gid = identity
+
+    def drop():
+        os.setgroups([])
+        os.setgid(gid)
+        os.setuid(uid)
+
+    return drop

--- a/tests/unprivileged_identity.py
+++ b/tests/unprivileged_identity.py
@@ -77,6 +77,10 @@ def reachable_by_unprivileged(path):
     better than one that never ran.
     """
     path = Path(path).resolve()
+    if unprivileged_identity() is None:
+        # Nothing will be dropped to, so nothing needs opening. Loosening modes
+        # anyway would weaken a developer's private temp tree for no reason.
+        return path
     for ancestor in [path, *path.parents]:
         try:
             mode = ancestor.stat().st_mode
@@ -100,6 +104,8 @@ def writable_by_unprivileged(directory):
     proves nothing about the law.
     """
     directory = reachable_by_unprivileged(directory)
+    if unprivileged_identity() is None:
+        return directory
     try:
         mode = directory.stat().st_mode
         directory.chmod(mode | stat.S_IRWXO)


### PR DESCRIPTION
`bpytest` runs as **root** on battleaxe. Root bypasses the DAC mode checks that uid-sensitive laws are about, so a test guarding on `os.getuid() == 0` and skipping is **unfalsifiable there**: it cannot fail no matter how broken the code beneath it becomes.

Two permission laws in `tests/test_heavy_measurement_lease.py` skipped on the box while passing locally as uid 501. Nobody noticed, because the suite did not go red — **it went smaller**. Same defect class as a collection error that shrinks the denominator. The colour is not the instrument; the executed count is.

## The census

Those two are the entire census: they are the only `os.getuid()` guards in the Python corpus. But the general problem is that **any** uid-sensitive test was unfalsifiable under `bpytest`, so this is a mechanism plus a structural guard, not two edits.

## The fix, in the brief's preference order

**Run them under a non-root identity** — the first-preference option, not a louder skip.

`tests/unprivileged_identity.py` forks, drops irrevocably to a non-root uid, and runs the law there, so the kernel enforces the permission bits exactly as it does for an ordinary caller. The law then executes under root and non-root alike. `unprivileged_preexec()` does the same for subprocess-shaped laws.

When no unprivileged identity exists, it refuses **by name** with `UnprivilegedIdentityUnavailable` and never degrades to a skip.

## Keeping the class from regrowing

`tests/test_uid_sensitive_laws_are_executed.py`:

- **AST scan over the whole corpus** fails any test that both consults the uid and calls `pytest.skip`, reporting `R=` and naming each offender. Structural, so the class cannot regrow one test at a time.
- **A positive control** provokes a real `EACCES` under the drop. Without it, a privilege drop that silently no-opped under root would restore the exact unfalsifiability being removed, one layer deeper.

## Two harness defects the root run exposed

Both were only visible **because the laws now execute there**, which is itself the point:

1. The lease module is loaded by file location, freshly per call, so its exception classes are unpicklable and differ in identity between parent and child. `LeaseDirectoryUnusable` arrived as a bare `RuntimeError` and `pytest.raises` did not match — even though the child raised the right refusal with the right message. Callers now name expected classes and the parent re-raises **its own** class.
2. The dropped wrapper subprocess could not write its receipt into a 700 `tmp_path` owned by root, so the test failed on a missing file rather than on the law.

## Measured, as root on battleaxe (`sudo python3 -m pytest tests/`)

| | baseline `e5a7a77cc` | head |
|---|---|---|
| passed | 118 | **124** |
| skipped | **2** | **0** |
| failed | 1 | 1 |

**Failure sets IDENTICAL.** The one failure, `tests/wall_workflow_prerequisites_test.py:23`, is inherited red present on `origin/main`, untouched by this PR.

`+6` executed: `+2` the previously-skipped laws now actually run, `+4` the new guard file. The denominator grew; nothing went green by shrinking.

## Discrimination, as root, each mutation reverted and re-confirmed

| mutation | result |
|---|---|
| neuter the privilege drop to a no-op | **4 failed** — both lease laws and both mechanism controls, instead of silently green |
| reintroduce a uid-guarded `pytest.skip` in the corpus | `R=1 uid-sensitive laws degrade to a skip`, offender named |

Before this PR, the first mutation was invisible as root. That is the property being bought.

## Verified

- As root on battleaxe (the `bpytest` identity): 32 passed, **0 skipped**.
- Locally as uid 501: 32 passed.
- No heavy work run beside the authoritative baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute uid-sensitive tests under a dropped identity instead of skipping when running as root
> - Adds [unprivileged_identity.py](https://github.com/TSavo/sugar/pull/6360/files#diff-925d8c62e65b82cd346f1f8d2e0d8ce5477067caf64a1caa8dc6cf1915a2216c) with utilities to drop privileges in tests: `run_unprivileged` forks, drops to a non-root uid/gid, runs a callable, and transports results or exceptions back over a pipe; `unprivileged_preexec` returns a `preexec_fn` for subprocess calls.
> - Removes `pytest.skip` guards gated on root uid from lease directory tests, replacing them with `run_unprivileged` and `unprivileged_preexec` so those tests always execute.
> - Adds [test_uid_sensitive_laws_are_executed.py](https://github.com/TSavo/sugar/pull/6360/files#diff-a18d08b21ac7b7f19531532f38afa1d3f80f019eed738a61c57ba3aff3e412af), which AST-scans all test files and fails the suite if any test both checks uid/euid and calls `pytest.skip`, enforcing the new pattern going forward.
> - Raises `UnprivilegedIdentityUnavailable` (a named exception, not a skip) when no non-root candidate identity can be found on the host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b057b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->