### PR TITLE
#6356's premise was wrong: pin the refutation, do not ship the no-op

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_branch_result_exclusion_is_already_provable.py
+++ b/implementations/python/sugar-source-tree/tests/test_branch_result_exclusion_is_already_provable.py
@@ -1,0 +1,120 @@
+"""#6356's premise was WRONG, and this file is why nobody should retry it.
+
+The theory, from the diagnosis I wrote on the last measurement: the residual
+`ExitSetFactoringGap` on `pandas/core/generic.py:13403` survives because
+`guarded_binding_read_sugar.read_binding` owns a genuine two-way split
+(`GuardedProjection` under `branch_result_guard`) and joins it with a bare
+`.guarded(g)` / `.guarded(not g)` union, minting no `PartitionFace` where
+`IfSugar` and `IfExpSugar` do. Wire it up, the theory said, and the last
+`stableZero` term closes.
+
+I wired it — `read_binding` and `delete_binding`, both verbs, faces keyed by
+`slot_id` — and MEASURED. `R(factoring_gaps)` read 1 before and 1 after. The
+theory was wrong twice over, and both refutations are pinned below so the next
+agent reaches them in seconds instead of an afternoon.
+
+REFUTATION 1: there is nothing for the testimony to add.
+`_conjuncts` FLATTENS nested conjunctions, so conjoining a branch-result guard
+with any prefix leaves `g` and `not g` as top-level literals and
+`_are_exclusive` still sees the complement. The "guards stop spelling the
+exclusion once conjoined with a prefix" story — which is true of #6336's
+motivating case — is NOT true of a conjunctive prefix. Faces on this producer
+would be evidence for something already proven.
+
+REFUTATION 2: the shape that DOES hide it cannot carry testimony either.
+The corpus arms that actually refuse are opposed at a slot, but one of them is
+a MERGED arm whose conjunct there is a DISJUNCTION (`g or X`, built by
+`_or_guards` when `normalize` merged two equal destinations). `complement_guard`
+of `g or X` is not `not g`, so the shape test correctly fails — and #6336's
+composition rule has ALREADY intersected the faces away on that merge, on
+purpose: a merged arm holds under a disjunction, so it may only keep testimony
+every contributing arm carried.
+
+Both of those are correct behaviour. The refusal on `generic.py:13403` is
+`factor_completed` doing its job: `¬g1 ∧ ¬g2 ∧ (g3 or X)` and
+`¬g1 ∧ ¬g2 ∧ ¬g3 ∧ … ∧ g9` can both hold whenever `X` does, so the completed
+face there is a SET of simultaneously reachable outcomes, not a selection, and
+a first-match-wins `GuardedValue` chain cannot carry it.
+
+So the last `stableZero` term is not a wiring omission. It is either an arm
+whose guard is under-constrained upstream of the merge, or a genuinely
+non-exclusive face — and the fix belongs to whoever produces that arm, before
+it merges. Do not close it by minting faces, by widening `_are_exclusive` to
+reason about disjunctions, or by weakening the refusal.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
+from sugar_lift_py_tests.ir import and_, not_, or_
+from sugar_lift_py_tests.outcome.exit_set import _are_exclusive, _conjuncts
+from sugar_source_tree.binding_state import BranchResultSlot
+
+
+def _slot(name: str) -> BranchResultSlot:
+    return BranchResultSlot(f"branch-result:{name}")
+
+
+def _guard():
+    return branch_result_guard(_slot("a"), site=None)
+
+
+def _prefix(index: int):
+    from sugar_lift_py_tests.ir import atomic, make_var
+
+    return atomic(f"prefix{index}", [make_var("state")])
+
+
+def test_a_conjoined_prefix_does_not_hide_the_branch_result_exclusion():
+    """REFUTATION 1. Faces on `read_binding` would be evidence for the proven.
+
+    If this ever goes red, a conjunctive prefix HAS started hiding the
+    exclusion, and minting faces at the branch-result producers becomes worth
+    doing after all. Until then it is a no-op and must not be shipped as a fix.
+    """
+    guard = _guard()
+    left = and_([_prefix(0), guard])
+    right = and_([_prefix(1), not_(guard)])
+
+    assert _are_exclusive(left, right)
+
+
+def test_conjuncts_flattens_nested_conjunctions_which_is_why():
+    """The mechanism behind refutation 1, asserted directly.
+
+    `_are_exclusive` is one literal deep, and this is what makes that enough
+    for every conjunctive nesting the tower builds.
+    """
+    guard = _guard()
+    nested = and_([and_([_prefix(0), _prefix(1)]), and_([guard])])
+
+    assert guard in frozenset(_conjuncts(nested))
+
+
+def test_a_disjoined_guard_is_not_provably_exclusive_and_must_not_be():
+    """REFUTATION 2, and the correctness claim under it.
+
+    A merged arm's conjunct is `g or X`. It genuinely overlaps `not g` whenever
+    `X` holds, so the shape test answering False is RIGHT, not shallow. Any
+    future attempt to make this pair exclusive is a request to collapse two
+    simultaneously reachable outcomes into one.
+    """
+    guard = _guard()
+    merged = and_([_prefix(0), or_([guard, _prefix(9)])])
+    sibling = and_([_prefix(0), not_(guard)])
+
+    assert not _are_exclusive(merged, sibling)
+
+
+def test_the_unmerged_pair_the_disjunction_came_from_is_exclusive():
+    """DISCRIMINATING for the test above: the loss happens AT the merge.
+
+    Before `_or_guards` disjoins them the two contributing arms are exclusive
+    against the sibling. That is what makes the merge the interesting event and
+    the producer the right owner — not the prover, and not the refusal.
+    """
+    guard = _guard()
+    contributing = and_([_prefix(0), guard])
+    sibling = and_([_prefix(0), not_(guard)])
+
+    assert _are_exclusive(contributing, sibling)


### PR DESCRIPTION
**Zero production code.** One test file, 120 lines, four assertions. #6356 asked me to wire `read_binding` to `partition(...)` and close the last `stableZero` term. I did, measured, and it closed nothing — so the wiring is reverted and the refutation ships in its place.

## Measured

```
main 90aa0badf   timeouts=0 panics=0 unnamed=0 factoring_gaps=1   clean=222/223
wired            timeouts=0 panics=0 unnamed=0 factoring_gaps=1   clean=222/223
```

A change that closes no row and whose twins cannot discriminate it is ceremony, not a fix.

## Refutation 1 — nothing for the testimony to add

`_conjuncts` **flattens** nested conjunctions, so conjoining a branch-result guard with any prefix still leaves `g` and `not g` as top-level literals and `_are_exclusive` sees the complement. The "guards stop spelling the exclusion once conjoined with a prefix" story is true of #6336's motivating case and **not** of a conjunctive prefix.

## Refutation 2 — the shape that *does* hide it cannot carry testimony either

Instrumenting `factor_completed` on `generic.py:13403`, the first non-exclusive pair is:

```
arm2   ¬g1 ∧ ¬g2 ∧ (g3 ∨ X)              faces=2
arm3   ¬g1 ∧ ¬g2 ∧ ¬g3 ∧ ¬g4…¬g8 ∧ g9    faces=8
```

`arm2` is a **merged** arm — `_or_guards` disjoined two equal destinations — so `complement_guard(g3 ∨ X)` is not `¬g3` and #6336's rule has already intersected its faces away, correctly: a merged arm holds under a disjunction and may only keep testimony every contributing arm carried.

Both arms hold whenever `X` does. That completed face is a **set of simultaneously reachable outcomes, not a selection**, so the refusal is right.

## What this file is

Four assertions so the next agent reaches the refutation in seconds instead of an afternoon:

1. the conjoined prefix is still provable — the wiring would be evidence for the proven;
2. the flattening that makes it so;
3. the disjoined pair is not provable **and must not be**;
4. the unmerged pair it came from **is** — which makes the merge the interesting event and the producer the right owner.

**Retirement path**, stated in the docstring: if assertion 1 ever goes red, a conjunctive prefix *has* started hiding the exclusion and wiring those producers becomes worth doing after all.

## Floors

`factor_completed`'s refusal, #6311's identity memo and #6336's composition algebra are all untouched. `R` is unchanged by construction — no production code.

## Known inherited red and what is UNMEASURED

- `test_corpus` golden f-string drift and the router vendor-spelling auditor fail identically on main. 666 passed in `sugar-source-tree`.
- **`make test-python` has no verdict.** Battleaxe holds the authoritative baseline; I ran Mac-only focused runs as instructed. Do not read the 666 as a full-suite result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests to refute the premise of #6356 by pinning proof that branch-result exclusion is already provable
> Adds [test_branch_result_exclusion_is_already_provable.py](https://github.com/TSavo/sugar/pull/6361/files#diff-4242fc7f782d34adedb1c7264acd1a32309132146c925b1e191a4092ef43802c) to document and verify that the change proposed in #6356 was unnecessary. The tests prove that: conjunctive prefixes do not hide exclusivity between a guard and its complement; `_conjuncts` correctly flattens nested conjunctions so the guard literal is visible at the top level; a disjunction `(g or X)` is correctly identified as non-exclusive with `not g`; and the pre-merge pair is exclusive, confirming the disjunction case is the only problematic one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c0a303.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->