### PR TITLE
Split R(factoring_gaps) into remaining work and correct output (#6356)

### DIFF
--- a/docs/ledgers/factoring-gap-split-660cb7c77.json
+++ b/docs/ledgers/factoring-gap-split-660cb7c77.json
@@ -1,0 +1,236 @@
+{
+ "schema": "factoringGap-split-v1",
+ "commit": "660cb7c77",
+ "corpus": "pandas 3.0.3",
+ "files": [
+  {
+   "file": "core/arrays/arrow/array.py",
+   "n_functions": 155,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 1,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 0,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {},
+   "factoring_gap_rows": []
+  },
+  {
+   "file": "core/arrays/datetimelike.py",
+   "n_functions": 112,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 0,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 2,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {
+    "unstamped": 2
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "unstamped",
+     "mergedArm": true,
+     "leftOwner": "CallSiteValue",
+     "rightOwner": "CallSiteValue",
+     "isRemainingWork": false
+    },
+    {
+     "kind": "unstamped",
+     "mergedArm": true,
+     "leftOwner": "CallSiteValue",
+     "rightOwner": "CallSiteValue",
+     "isRemainingWork": false
+    }
+   ]
+  },
+  {
+   "file": "core/frame.py",
+   "n_functions": 293,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 5,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 0,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {},
+   "factoring_gap_rows": []
+  },
+  {
+   "file": "core/generic.py",
+   "n_functions": 223,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 0,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 1,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {
+    "unstamped": 1
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "unstamped",
+     "mergedArm": true,
+     "leftOwner": "SymbolicValue",
+     "rightOwner": "StringValue",
+     "isRemainingWork": false
+    }
+   ]
+  },
+  {
+   "file": "core/groupby/groupby.py",
+   "n_functions": 102,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 1,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 1,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {
+    "unstamped": 1
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "unstamped",
+     "mergedArm": true,
+     "leftOwner": "CallSiteValue",
+     "rightOwner": "GuardedValue",
+     "isRemainingWork": false
+    }
+   ]
+  },
+  {
+   "file": "core/indexes/base.py",
+   "n_functions": 235,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 3,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 0,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {},
+   "factoring_gap_rows": []
+  },
+  {
+   "file": "core/indexing.py",
+   "n_functions": 83,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 1,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 1,
+   "R(factoring_gaps_remaining_work)": 1,
+   "factoring_gap_split": {
+    "unstamped": 1
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "unstamped",
+     "mergedArm": false,
+     "leftOwner": "PredicateValue",
+     "rightOwner": "PredicateValue",
+     "isRemainingWork": true
+    }
+   ]
+  },
+  {
+   "file": "core/methods/selectn.py",
+   "n_functions": 9,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 1,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 1,
+   "R(factoring_gaps_remaining_work)": 1,
+   "factoring_gap_split": {
+    "unstamped": 1
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "unstamped",
+     "mergedArm": false,
+     "leftOwner": "SymbolicValue",
+     "rightOwner": "SymbolicValue",
+     "isRemainingWork": true
+    }
+   ]
+  },
+  {
+   "file": "core/reshape/pivot.py",
+   "n_functions": 14,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 3,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 0,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {},
+   "factoring_gap_rows": []
+  },
+  {
+   "file": "core/series.py",
+   "n_functions": 179,
+   "stableZero": true,
+   "R(timeout)": 0,
+   "R(construction_panics)": 0,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 0,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {},
+   "factoring_gap_rows": []
+  },
+  {
+   "file": "io/excel/_openpyxl.py",
+   "n_functions": 23,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 0,
+   "R(unnamed_exceptions)": 1,
+   "R(factoring_gaps)": 1,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {
+    "unstamped": 1
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "unstamped",
+     "mergedArm": true,
+     "leftOwner": "CallSiteValue",
+     "rightOwner": "CallSiteValue",
+     "isRemainingWork": false
+    }
+   ]
+  },
+  {
+   "file": "io/formats/style.py",
+   "n_functions": 64,
+   "stableZero": false,
+   "R(timeout)": 0,
+   "R(construction_panics)": 1,
+   "R(unnamed_exceptions)": 0,
+   "R(factoring_gaps)": 1,
+   "R(factoring_gaps_remaining_work)": 0,
+   "factoring_gap_split": {
+    "stamped-not-separating": 1
+   },
+   "factoring_gap_rows": [
+    {
+     "kind": "stamped-not-separating",
+     "mergedArm": true,
+     "leftOwner": "CallSiteValue",
+     "rightOwner": "CallSiteValue",
+     "isRemainingWork": false
+    }
+   ]
+  }
+ ],
+ "totals": {
+  "gaps": 8,
+  "work": 2,
+  "kinds": {
+   "unstamped": 7,
+   "stamped-not-separating": 1
+  }
+ }
+}

--- a/implementations/python/sugar-lift-py-tests/scripts/stablezero_classify.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/stablezero_classify.py
@@ -158,6 +158,13 @@ def classify(path: Path, deadline: float) -> dict:
         except ExitSetFactoringGap as gap:
             row["status"] = "ExitSetFactoringGap"
             row["testimony"] = _testimony(gap)
+            # #6356: the term is not a scalar. Each refusal says whether a
+            # producer failed to testify (possibly closable) or no exclusion
+            # was available to this prover (correct output). Read off the arms
+            # the refusal carries, never re-derived from its message.
+            classification = gap.classification()
+            if classification is not None:
+                row["factoringGap"] = classification.row()
         except ConstructionPanic as panic:
             row["status"] = "ConstructionPanic"
             row["testimony"] = _testimony(panic)
@@ -177,6 +184,9 @@ def classify(path: Path, deadline: float) -> dict:
     r_unnamed = sum(
         count for status, count in statuses.items() if status.startswith("raised:")
     )
+    gap_rows = [row.get("factoringGap") for row in rows if row.get("factoringGap")]
+    gap_split = Counter(row["kind"] for row in gap_rows)
+    gap_work = sum(1 for row in gap_rows if row["isRemainingWork"])
     completed = len(rows) - r_timeout
 
     return {
@@ -187,6 +197,13 @@ def classify(path: Path, deadline: float) -> dict:
         "R(construction_panics)": r_panics,
         "R(factoring_gaps)": r_gaps,
         "R(unnamed_exceptions)": r_unnamed,
+        # The (a)/(b) split. `R(factoring_gaps)` counts every refusal;
+        # `R(factoring_gaps_remaining_work)` counts only those a producer could
+        # plausibly close by testifying. The rest are the gate working, and a
+        # term that mixes them overstates the board.
+        "R(factoring_gaps_remaining_work)": gap_work,
+        "factoring_gap_split": dict(sorted(gap_split.items())),
+        "factoring_gap_rows": gap_rows,
         "completed_denominator": completed,
         "stableZero": bool(
             completed > 0
@@ -233,6 +250,8 @@ def main() -> int:
         f"timeouts={payload['R(timeout)']} "
         f"construction_panics={payload['R(construction_panics)']} "
         f"factoring_gaps={payload['R(factoring_gaps)']} "
+        f"(remaining_work={payload['R(factoring_gaps_remaining_work)']} "
+        f"split={payload['factoring_gap_split']}) "
         f"unnamed_exceptions={payload['R(unnamed_exceptions)']} "
         f"statuses={payload['statuses']} out={args.out}",
         flush=True,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -62,7 +62,28 @@ class ExitSetFactoringGap(ValueError):
 
     Loud on contact, in the same shape as ``SourceCallBindingGap``: the message
     names the two guards, why the collapse would lose an outcome, and the fix.
+
+    Carries the two refusing ARMS as well as the prose (#6356). A census that
+    has to re-derive them from the message is parsing a repr, and the split
+    between "a producer failed to testify" and "no exclusion is available"
+    is read off carried testimony -- see `outcome/factoring_gap_kind.py`.
+    This is data on the exception, not a change to when it is raised.
     """
+
+    def __init__(self, message: str, left=None, right=None) -> None:
+        super().__init__(message)
+        self.left = left
+        self.right = right
+
+    def classification(self):
+        """The (a)/(b) split for this occurrence, or None if arms are absent."""
+        if self.left is None or self.right is None:
+            return None
+        from sugar_lift_py_tests.outcome.factoring_gap_kind import (
+            classify_factoring_gap,
+        )
+
+        return classify_factoring_gap(self.left, self.right)
 
 
 @dataclass(frozen=True)
@@ -423,7 +444,9 @@ class ExitSet(Generic[T]):
                         "widen _are_exclusive to guess exclusivity from how the "
                         "formulas are spelled.\n"
                         f"  arm A faces: {sorted(str(f) for f in arm.faces)}\n"
-                        f"  arm B faces: {sorted(str(f) for f in other.faces)}"
+                        f"  arm B faces: {sorted(str(f) for f in other.faces)}",
+                        arm,
+                        other,
                     )
 
         from sugar_lift_py_tests.floor import GuardedValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py
@@ -1,0 +1,162 @@
+"""Split `R(factoring_gaps)` into remaining work and correct output (#6356).
+
+`factoring_gaps` is one number covering two different things:
+
+  (a) a producer OWNED a partition and failed to carry the testimony -- real,
+      closable work, exactly what #6336 was built for;
+  (b) a refusal of arms with no exclusion available -- correct output, and
+      `factor_completed` doing its job.
+
+Nothing separated them, so the term could not be read either way: under a
+"wire the producers" plan you need (a) to size the design, under an "accept the
+residual" plan you need it to name an owner, and under a "stop counting correct
+refusals" plan you need it to define what stops being counted. The split is
+common to all three.
+
+This is the same move that made `R_desugar` legible. That figure was a mixed
+number until it was split off the authenticated occurrence-key prefix, and the
+owed work turned out to be a fraction of the total. A term that mixes correct
+output with remaining work overstates the board.
+
+THE CHANNEL IS CARRIED TESTIMONY, NOT GUARD SHAPE. `PartitionFace` is what a
+producer SAID when it split; guard spelling is a downstream artefact that a
+conjunction, a merge or a rewrite can change without changing the meaning.
+#6356 established the hard way that shape is the wrong channel here: a
+conjunctive prefix does not hide an exclusion (`_conjuncts` flattens), and the
+shape that does hide one -- a disjunction from an equal-destination merge -- is
+exactly where #6336's rule has already intersected the testimony away.
+
+NAMING IS LOAD-BEARING. `_are_exclusive` is SOUND-ONLY: `False` means "not
+proven", never "proven false". So no classification here may be called
+"overlapping". `NO_EXCLUSION_AVAILABLE` says precisely what was observed --
+this prover, on this evidence, has nothing to separate these arms -- and
+claims nothing about whether they can actually both hold.
+
+This module CHANGES NO BEHAVIOUR. The refusal fires identically in every class.
+It only reads the arms a refusal already carries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class FactoringGapKind(Enum):
+    """Why one refusal happened, read off the arms' carried testimony."""
+
+    UNSTAMPED = "unstamped"
+    """Neither arm carries a face. NO producer testified at all.
+
+    Remaining work IF a producer here owns a split -- and that is a real IF,
+    not a promise. #6361 measured one occurrence where wiring the producer
+    changed nothing, because an arm was merged and the testimony would have
+    been intersected away before it arrived. `merged_arm` below is what
+    separates the hopeful case from that one.
+    """
+
+    STAMPED_NOT_SEPARATING = "stamped-not-separating"
+    """Both arms carry faces and share a partition, never on opposite sides.
+
+    Testimony WAS offered and does not separate these two. Wiring more
+    producers cannot help: the producers that own these arms have already
+    spoken.
+    """
+
+    STAMPED_DISJOINT = "stamped-disjoint"
+    """Both arms carry faces, sharing no partition at all.
+
+    They come from unrelated splits, so neither producer ever claimed anything
+    about the other. Not a wiring omission and not a lie -- simply two arms
+    about which nothing exclusive was ever said.
+    """
+
+    PARTLY_STAMPED = "partly-stamped"
+    """One arm testifies, the other does not. The silent side is the lead."""
+
+
+@dataclass(frozen=True)
+class FactoringGapClassification:
+    kind: FactoringGapKind
+    merged_arm: bool
+    """At least one arm's guard carries a disjunction at conjunct level.
+
+    STRUCTURAL, and named apart from `kind` on purpose: this is the one thing
+    here read off guard SHAPE rather than testimony, and it is not used to
+    decide exclusivity. It detects that an equal-destination merge happened,
+    because `_or_guards` is the only thing that puts a disjunction there.
+
+    It matters because #6336's composition rule INTERSECTS faces on such a
+    merge -- correctly, since a merged arm holds under a disjunction and may
+    only keep what every contributing arm carried. So an `UNSTAMPED` gap with
+    `merged_arm=True` will NOT be closed by wiring its producer: the face would
+    be minted and then intersected away. #6361 measured exactly that.
+
+    `UNSTAMPED` and not merged is the shape actually worth trying.
+    """
+
+    left_owner: str
+    right_owner: str
+
+    @property
+    def is_remaining_work(self) -> bool:
+        """Whether wiring a producer could plausibly close this occurrence.
+
+        Deliberately narrow. A stamped gap has already heard from its
+        producers, and a merged arm cannot keep a new face. Everything else is
+        `NO_EXCLUSION_AVAILABLE` for this prover -- which is NOT a claim that
+        the arms overlap.
+        """
+        return (
+            self.kind in (FactoringGapKind.UNSTAMPED, FactoringGapKind.PARTLY_STAMPED)
+            and not self.merged_arm
+        )
+
+    def row(self) -> dict:
+        return {
+            "kind": self.kind.value,
+            "mergedArm": self.merged_arm,
+            "leftOwner": self.left_owner,
+            "rightOwner": self.right_owner,
+            "isRemainingWork": self.is_remaining_work,
+        }
+
+
+def _has_disjunct(guard) -> bool:
+    from sugar_lift_py_tests.outcome.exit_set import _conjuncts
+
+    return any(getattr(lit, "kind", None) == "or" for lit in _conjuncts(guard))
+
+
+def classify_factoring_gap(left, right) -> FactoringGapClassification:
+    """Classify ONE refusing pair of completed arms. Reads, never decides."""
+    left_faces = frozenset(getattr(left, "faces", ()) or ())
+    right_faces = frozenset(getattr(right, "faces", ()) or ())
+
+    if not left_faces and not right_faces:
+        kind = FactoringGapKind.UNSTAMPED
+    elif not left_faces or not right_faces:
+        kind = FactoringGapKind.PARTLY_STAMPED
+    else:
+        shared = {face.partition for face in left_faces} & {
+            face.partition for face in right_faces
+        }
+        kind = (
+            FactoringGapKind.STAMPED_NOT_SEPARATING
+            if shared
+            else FactoringGapKind.STAMPED_DISJOINT
+        )
+
+    return FactoringGapClassification(
+        kind=kind,
+        merged_arm=_has_disjunct(left.guard) or _has_disjunct(right.guard),
+        left_owner=type(left.value).__name__,
+        right_owner=type(right.value).__name__,
+    )
+
+
+__all__ = [
+    "FactoringGapClassification",
+    "FactoringGapKind",
+    "classify_factoring_gap",
+]

--- a/implementations/python/sugar-lift-py-tests/tests/test_factoring_gap_kind.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factoring_gap_kind.py
@@ -1,0 +1,208 @@
+"""The `factoring_gaps` discriminator: remaining work vs correct output (#6356).
+
+One number covered two different things — a producer that owned a partition and
+failed to carry the testimony, and a refusal of arms with no exclusion
+available. The first is closable work; the second is `factor_completed` doing
+its job. A term that mixes correct output with remaining work overstates the
+board, so it is split here, off CARRIED TESTIMONY rather than guard shape.
+
+EVERY TEST IS A PAIR, because a classifier is exactly the kind of code that can
+look right while calling everything one class. Each positive is followed by a
+discriminator that would pass if the classifier had collapsed two kinds
+together.
+
+The naming caveat is load-bearing and is asserted, not just documented:
+`_are_exclusive` is SOUND-ONLY, so `False` means "not proven", never "proven
+false". No classification may claim the arms overlap, and
+`test_no_classification_claims_the_arms_overlap` holds that line by name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.ir import and_, atomic, make_var, not_, or_
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    ExitSetFactoringGap,
+    partition,
+)
+from sugar_lift_py_tests.outcome.factoring_gap_kind import (
+    FactoringGapKind,
+    classify_factoring_gap,
+)
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def _arm(guard, value, faces=frozenset()):
+    return Completed(guard, value, faces)
+
+
+# --------------------------------------------------------------------------
+# The four kinds
+# --------------------------------------------------------------------------
+
+
+def test_two_silent_arms_are_unstamped():
+    """POSITIVE. No producer testified, so nothing was offered to separate them."""
+    left = _arm(_guard("a"), "one")
+    right = _arm(_guard("b"), "two")
+
+    assert classify_factoring_gap(left, right).kind is FactoringGapKind.UNSTAMPED
+
+
+def test_one_silent_arm_is_partly_stamped_not_unstamped():
+    """DISCRIMINATING. The silent SIDE is the lead, so it must not read as
+    'nobody testified' — one producer did, and the other is the one to look at.
+    """
+    face, _ = partition("owner")
+    left = _arm(_guard("a"), "one", frozenset({face}))
+    right = _arm(_guard("b"), "two")
+
+    assert (
+        classify_factoring_gap(left, right).kind is FactoringGapKind.PARTLY_STAMPED
+    )
+
+
+def test_shared_partition_same_side_is_stamped_not_separating():
+    """POSITIVE. Testimony WAS offered and does not separate these two.
+
+    Wiring more producers cannot help here: the producers that own these arms
+    have already spoken.
+    """
+    face, _ = partition("owner")
+    left = _arm(_guard("a"), "one", frozenset({face}))
+    right = _arm(_guard("b"), "two", frozenset({face}))
+
+    classification = classify_factoring_gap(left, right)
+
+    assert classification.kind is FactoringGapKind.STAMPED_NOT_SEPARATING
+    assert not classification.is_remaining_work
+
+
+def test_unrelated_partitions_are_stamped_disjoint():
+    """DISCRIMINATING. Sharing NO partition is a different fact from sharing one
+    and agreeing on the side. Collapsing them would hide that these arms come
+    from unrelated splits whose producers never claimed anything about each
+    other."""
+    left_face, _ = partition("owner-a")
+    right_face, _ = partition("owner-b")
+    left = _arm(_guard("a"), "one", frozenset({left_face}))
+    right = _arm(_guard("b"), "two", frozenset({right_face}))
+
+    assert (
+        classify_factoring_gap(left, right).kind is FactoringGapKind.STAMPED_DISJOINT
+    )
+
+
+def test_opposed_faces_never_reach_a_gap_at_all():
+    """DISCRIMINATING for the whole file: a separating pair FACTORS.
+
+    If this ever raised, the classifier would be describing refusals that
+    should not exist, and every count above would be measuring the wrong set.
+    """
+    true_face, false_face = partition("owner")
+    guard = _guard("a")
+
+    factored = ExitSet(
+        (
+            _arm(and_([_guard("p"), guard]), "one", frozenset({true_face})),
+            _arm(and_([_guard("q"), not_(guard)]), "two", frozenset({false_face})),
+        )
+    ).factor_completed()
+
+    assert sum(isinstance(e, Completed) for e in factored.exits) == 1
+
+
+# --------------------------------------------------------------------------
+# The merged-arm flag: why "unstamped" is not the same as "closable"
+# --------------------------------------------------------------------------
+
+
+def test_an_unstamped_pair_is_remaining_work():
+    """POSITIVE. Nobody testified and no arm was merged: worth wiring."""
+    classification = classify_factoring_gap(
+        _arm(_guard("a"), "one"), _arm(_guard("b"), "two")
+    )
+
+    assert classification.is_remaining_work
+    assert not classification.merged_arm
+
+
+def test_an_unstamped_pair_with_a_merged_arm_is_not_remaining_work():
+    """DISCRIMINATING, and it is the whole reason the flag exists.
+
+    #6361 MEASURED an occurrence where wiring the producer changed nothing: the
+    face would be minted and then intersected away, because #6336's rule keeps
+    only testimony every contributing arm carried when an equal-destination
+    merge disjoins guards. Calling that "remaining work" would send the next
+    agent down the afternoon that produced the refutation.
+    """
+    merged = and_([_guard("p"), or_([_guard("a"), _guard("x")])])
+    classification = classify_factoring_gap(
+        _arm(merged, "one"), _arm(_guard("b"), "two")
+    )
+
+    assert classification.kind is FactoringGapKind.UNSTAMPED
+    assert classification.merged_arm
+    assert not classification.is_remaining_work
+
+
+def test_the_flag_reads_either_arm():
+    """DISCRIMINATING. A merge on the RIGHT arm is the same obstacle.
+
+    Checking only the left would classify half the real occurrences as work.
+    """
+    merged = and_([_guard("p"), or_([_guard("a"), _guard("x")])])
+
+    assert classify_factoring_gap(_arm(_guard("b"), "two"), _arm(merged, "one")).merged_arm
+
+
+# --------------------------------------------------------------------------
+# The honesty line
+# --------------------------------------------------------------------------
+
+
+def test_no_classification_claims_the_arms_overlap():
+    """THE NAMING LAW. `_are_exclusive` is sound-only.
+
+    `False` means "not proven", never "proven false". A classification that
+    said "overlapping" would be a claim about reachability that nothing here
+    measured. Every kind name must describe the EVIDENCE, not the world.
+    """
+    forbidden = ("overlap", "simultaneous", "reachable", "proven-false")
+
+    for kind in FactoringGapKind:
+        assert not any(word in kind.value for word in forbidden), (
+            f"{kind.value!r} claims something about the world; _are_exclusive "
+            "returning False only means no exclusion was proven (#6356)"
+        )
+
+
+def test_the_refusal_carries_its_arms_so_a_census_never_parses_the_message():
+    """The census reads arms, not a repr.
+
+    Re-deriving the pair by parsing the exception's prose is how a measurement
+    starts depending on message formatting.
+    """
+    with pytest.raises(ExitSetFactoringGap) as raised:
+        ExitSet(
+            (_arm(_guard("a"), "one"), _arm(_guard("b"), "two"))
+        ).factor_completed()
+
+    gap = raised.value
+    assert gap.left is not None and gap.right is not None
+    assert gap.classification().kind is FactoringGapKind.UNSTAMPED
+
+
+def test_a_gap_without_arms_classifies_as_nothing_rather_than_guessing():
+    """DISCRIMINATING. An occurrence with no arms must not default into a kind.
+
+    A classifier that guessed would put uncounted rows into whichever bucket it
+    defaulted to, which is exactly how a mixed number is born.
+    """
+    assert ExitSetFactoringGap("bare message").classification() is None


### PR DESCRIPTION
`factoring_gaps` was one number covering two different things. **The term overstated the owed work fourfold.**

## Measured — 12 pandas files, 1,492 functions, on `660cb7c77`

| | |
|---|---|
| `R(factoring_gaps)` | **8** |
| `R(factoring_gaps_remaining_work)` | **2** — 25% |
| split | `unstamped` 7, `stamped-not-separating` 1 |

Same shape as the `R_desugar` split: a term that mixes correct output with remaining work overstates the board.

**The two rows that ARE work, named and owned:**

| file:line | owners |
|---|---|
| `core/indexing.py:2457` | `PredicateValue / PredicateValue` |
| `core/methods/selectn.py:224` | `SymbolicValue / SymbolicValue` |

Ledger: `docs/ledgers/factoring-gap-split-660cb7c77.json`.

## The channel is carried testimony, not guard shape

`PartitionFace` is what a producer *said* when it split; guard spelling is a downstream artefact a conjunction, a merge or a rewrite can change without changing meaning. #6356 established the hard way that shape is the wrong channel here.

Four kinds off the arms' faces:

- **`UNSTAMPED`** — nobody testified.
- **`PARTLY_STAMPED`** — one side silent, and that side is the lead.
- **`STAMPED_NOT_SEPARATING`** — testimony offered and does not separate; more wiring cannot help.
- **`STAMPED_DISJOINT`** — unrelated splits; nothing was ever claimed either way.

## `merged_arm` — why `is_remaining_work` is narrower than "unstamped"

Named **apart** from the kind, and it is the one thing read off guard shape — structurally, to detect that an equal-destination merge happened, never to decide exclusivity.

An unstamped gap on a merged arm will **not** close by wiring its producer: the face would be minted and then intersected away, because #6336's rule keeps only testimony every contributing arm carried. #6361 measured that over an afternoon. **The classifier now reproduces it mechanically** — it is what makes `generic.py:13403` read as 0 work rather than 1.

## The naming law, asserted rather than documented

`_are_exclusive` is **sound-only**: `False` means *"not proven"*, never *"proven false"*. So no kind may claim the arms overlap, and `test_no_classification_claims_the_arms_overlap` holds that line by name across the whole enum. A `(b)` classification is *"no exclusion available to this prover"*, which is what was observed, not a claim about the world.

## No production behaviour change

The refusal fires identically in every class. `factor_completed` is untouched except that the gap now **carries its two arms**, so a census reads arms instead of parsing a repr. #6311's identity memo and #6336's composition algebra are untouched. `factor_completed`'s refusal is not weakened and `_are_exclusive` is not taught about disjunctions — both were explicitly out.

**12 twins**, each positive paired with a discriminator that would pass if two kinds had been collapsed — including that a separating pair *factors* and never reaches a gap at all, so the counts are over the right set. 57 passed with the exit-set, partition-testimony and arm-growth suites.

## Two findings the sample surfaced — reported, not fixed

- **`core/series.py` reads `stableZero=TRUE`.** 179 functions, every term zero. First true triple zero on the board.
- **`io/excel/_openpyxl.py:614` is a new `raised:AttributeError`** — an unnamed gap outside `generic.py`, which `R(unnamed_exceptions)` now catches.

## UNMEASURED

`make test-python` has no verdict — battleaxe holds the authoritative baseline and this was Mac-only as instructed. Do not read the focused passes as a full-suite result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `R(factoring_gaps)` into remaining work count and gap-kind breakdown
> - Adds `FactoringGapKind` enum and `FactoringGapClassification` dataclass in [`factoring_gap_kind.py`](https://github.com/TSavo/sugar/pull/6364/files#diff-6e40ebefa2df95de56c81010e90f9e3f5d390e1ee077eecb25e2791ca9b5379d) to classify refusing arm pairs into four kinds: `UNSTAMPED`, `STAMPED_NOT_SEPARATING`, `STAMPED_DISJOINT`, and `PARTLY_STAMPED`.
> - `ExitSetFactoringGap` now stores the left/right `Completed` arms and exposes a `classification()` method, so callers can retrieve per-gap metadata without re-inspecting the exception site.
> - `classify()` in [`stablezero_classify.py`](https://github.com/TSavo/sugar/pull/6364/files#diff-1af6ce12396de7b87fad8d3bb068b230530e3925356c0e9054019f9a424ec8fa) now emits `R(factoring_gaps_remaining_work)`, `factoring_gap_split` (a kind → count map), and `factoring_gap_rows` (per-gap detail) in its payload; the CLI prints remaining_work and split in its summary.
> - New tests in [`test_factoring_gap_kind.py`](https://github.com/TSavo/sugar/pull/6364/files#diff-45ce7877ad8c4cc7c7a43f35493faba3ecbd4b8913ccc515443eb983a17ec4ab) cover all four kinds, merged-arm detection, and the arm-carrying behavior of `ExitSetFactoringGap`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51dc2e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->