### PR TITLE
Receipt: core/series.py is the first true stableZero (#6356)

### DIFF
--- a/.receipts/stablezero-first-triple-zero/RECEIPT.md
+++ b/.receipts/stablezero-first-triple-zero/RECEIPT.md
@@ -1,0 +1,62 @@
+# `pandas/core/series.py` — the first true `stableZero`
+
+Every number here is read off `series-760a65540.json` in this directory. Nothing
+is inferred, and the caveat at the bottom is part of the claim, not a footnote.
+
+## The measurement
+
+```
+implementations/python/sugar-lift-py-tests/scripts/stablezero_classify.py \
+  <pandas>/core/series.py --out series-760a65540.json --deadline 60
+```
+
+Commit `760a65540`. pandas 3.0.3. Isolated — the file is copied ALONE into an
+empty temp directory, so each function's verdict depends on nothing but that
+function. Mac, load ~15; battleaxe was holding the authoritative corpus
+baseline and nothing heavy went near it.
+
+`stablezero_classify.py` exits 0 **only** on `stableZero`. This run exited 0,
+and that exit code is the claim — not a line of output someone read off a tail.
+
+## The board
+
+| term | value |
+| --- | --- |
+| `completed_denominator` | 179 |
+| `R(timeout)` | **0** |
+| `R(construction_panics)` | **0** |
+| `R(unnamed_exceptions)` | **0** |
+| `R(factoring_gaps)` | **0** |
+| `R(factoring_gaps_remaining_work)` | **0** |
+| `stableZero` | **true** |
+
+```
+statuses = {clean: 174, SugarNotWritten: 5}
+```
+
+## Why this one is worth a receipt
+
+It is the first file the board can call *done by the full definition* rather
+than by one axis. Every other file measured in the same sweep carries at least
+one residual, and for most of the session the interesting question was which
+axis was hiding the others — a timeout absorbing panics (#6324), a panic
+absorbing an unnamed exception (#6352), a scalar `factoring_gaps` absorbing the
+difference between remaining work and correct output (#6356).
+
+Four terms at zero simultaneously, on 179 functions, is the shape those splits
+were built to make visible.
+
+## THE CAVEAT, stated because a receipt that omits it is a lie
+
+**174 of 179 functions reached the floor. Five did not.**
+
+`SugarNotWritten: 5` is the TREE door refusing — a recognition gap, counted on
+its own name and deliberately not folded into the Floor terms this rig gates
+on. Those five functions never exercised the floor at all, so `stableZero` here
+means *"every function the floor saw, it handled, and none of the four gated
+terms fired"* — it does not mean 179/179 fully lifted.
+
+`stableZero` is a statement about the four terms over the completed
+denominator. Reading it as "this file is finished" would be exactly the
+misclassification the `R(unnamed_exceptions)` term was added to prevent, one
+level up.

--- a/.receipts/stablezero-first-triple-zero/series-760a65540.json
+++ b/.receipts/stablezero-first-triple-zero/series-760a65540.json
@@ -1,0 +1,54 @@
+{
+ "schema": "stableZero-classify-isolated-v1",
+ "n_functions": 179,
+ "statuses": {
+  "SugarNotWritten": 5,
+  "clean": 174
+ },
+ "R(timeout)": 0,
+ "R(construction_panics)": 0,
+ "R(factoring_gaps)": 0,
+ "R(unnamed_exceptions)": 0,
+ "R(factoring_gaps_remaining_work)": 0,
+ "factoring_gap_split": {},
+ "factoring_gap_rows": [],
+ "completed_denominator": 179,
+ "stableZero": true,
+ "desugar_s": 19.91,
+ "wall_s": 21.45,
+ "residuals": [
+  {
+   "name": null,
+   "line": 945,
+   "status": "SugarNotWritten",
+   "seconds": 0.2483
+  },
+  {
+   "name": null,
+   "line": 1070,
+   "status": "SugarNotWritten",
+   "seconds": 0.1701
+  },
+  {
+   "name": null,
+   "line": 1487,
+   "status": "SugarNotWritten",
+   "seconds": 0.0838
+  },
+  {
+   "name": null,
+   "line": 3264,
+   "status": "SugarNotWritten",
+   "seconds": 0.1673
+  },
+  {
+   "name": null,
+   "line": 6779,
+   "status": "SugarNotWritten",
+   "seconds": 0.0496
+  }
+ ],
+ "file": "/usr/local/lib/python3.14/site-packages/pandas/core/series.py",
+ "label": "core/series.py",
+ "deadline_seconds": 60.0
+}


### PR DESCRIPTION
Receipt only, zero production code. `.receipts/stablezero-first-triple-zero/`.

## The board

`pandas/core/series.py`, 179 functions, isolated, on `760a65540`:

| term | value |
| --- | --- |
| `completed_denominator` | 179 |
| `R(timeout)` | **0** |
| `R(construction_panics)` | **0** |
| `R(unnamed_exceptions)` | **0** |
| `R(factoring_gaps)` | **0** |
| `R(factoring_gaps_remaining_work)` | **0** |
| `stableZero` | **true** |

`stablezero_classify.py` exits 0 **only** on `stableZero`. This run exited 0, and that exit code is the claim — not a line someone read off a tail.

## Why it earns a receipt

The first file the board can call *done by the full definition* rather than by one axis. Four terms at zero simultaneously is exactly the shape this session's splits were built to make visible: a timeout absorbing panics (#6324), a panic absorbing an unnamed exception (#6352), a scalar `factoring_gaps` absorbing the difference between remaining work and correct output (#6356).

## The caveat is part of the claim

**174 of 179 functions reached the floor. Five did not.**

`SugarNotWritten: 5` is the TREE door refusing — a recognition gap, counted on its own name and deliberately not folded into the Floor terms this rig gates on. Those five never exercised the floor at all.

So `stableZero` here means *every function the floor saw, it handled, and none of the four gated terms fired* — **not** 179/179 fully lifted. Reading it as "this file is finished" would be the same misclassification `R(unnamed_exceptions)` was added to prevent, one level up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stableZero receipt for `pandas/core/series.py`
> Adds a receipt and JSON artifact under [.receipts/stablezero-first-triple-zero/](.receipts/stablezero-first-triple-zero/) documenting that `pandas/core/series.py` is the first file to achieve a stableZero classification. Of 179 functions, 174 are clean and 5 are marked `SugarNotWritten`; all residual R(*) counters are 0, giving `stableZero=true` against the completed denominator of 179.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b90329a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->