### PR TITLE
Five teeth on the pydantic laws: enrolled, executed, reconciled

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pydantic_laws_are_enrolled_and_executed.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pydantic_laws_are_enrolled_and_executed.py
@@ -1,0 +1,252 @@
+"""The pydantic lift laws are ENROLLED, EXECUTED, and RECONCILED -- five teeth.
+
+Collection succeeding is the weaker claim, and it is the one that fooled us
+repeatedly: a suite can collect cleanly and still execute nothing that matters.
+So each tooth opposes a different way the claim could be hollow:
+
+    1. removing pydantic  -> an explicit dependency/collection FAILURE, never
+                             a skip. Absence must be loud.
+    2. a deliberate law failure -> observed as FAILED. Not skipped, not absent.
+                             A denominator that cannot go red is not a
+                             denominator.
+    3. collected node IDs -> contain the pydantic laws BY NAME. Counting tests
+                             does not prove which tests.
+    4. the workflow       -> installs ONLY the declared [test] authority. If it
+                             installs anything more, the authority is not the
+                             authority and every claim resting on it is weaker
+                             than it reads.
+    5. the receipt        -> reconciles collected / passed / failed / skipped /
+                             errored. Conservation, so a vanished test is
+                             arithmetic rather than an absence nobody sees.
+
+RULING ON THE HISTORY (#6369): these laws were **unintentionally unexecuted**.
+`pydantic` was declared nowhere -- not in [project] dependencies, not in the
+[test] extra, not in any workflow -- for the ENTIRE repo history
+(``git log -S pydantic -- .github/`` returns nothing). Nobody decided they were
+optional. They simply never ran.
+
+So prior green runs of this package **ranged over a smaller universe than they
+claimed** and are not retroactively authoritative for pydantic lifting.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+PACKAGE = HERE.parent
+ROOT = PACKAGE.parents[2]
+LAW_FILE = HERE / "test_lift_pydantic.py"
+
+# The laws that must be enrolled by name. Counting is not naming.
+REQUIRED_NODE_IDS = (
+    "TestPydanticLift::test_pydantic_v2_field_constraints",
+    "TestPydanticLift::test_pydantic_v2_numeric_range",
+    "TestPydanticLift::test_pydantic_v2_annotated_types",
+)
+
+SUMMARY = re.compile(
+    r"(?:(?P<n>\d+) (?P<outcome>passed|failed|skipped|error|errors|xfailed|xpassed))"
+)
+
+
+def _run_pytest(args, cwd=None, extra_env=None):
+    """Run pytest out-of-process so a real verdict is observed, not simulated."""
+    import os
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(PACKAGE / "src"), str(HERE)])
+    env.pop("SUGAR_BIN", None)
+    env.update(extra_env or {})
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args, "--noconftest", "-p", "no:cacheprovider"],
+        cwd=str(cwd or PACKAGE),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=600,
+    )
+
+
+def _outcomes(output):
+    """Parse the terminal summary into {outcome: count}."""
+    tail = output.strip().splitlines()[-1] if output.strip() else ""
+    found = {}
+    for match in SUMMARY.finditer(tail):
+        outcome = match.group("outcome")
+        outcome = "error" if outcome == "errors" else outcome
+        found[outcome] = found.get(outcome, 0) + int(match.group("n"))
+    return found
+
+
+# -- tooth 4: the authority is actually the authority ------------------------
+
+
+def test_the_workflow_installs_only_the_declared_authority():
+    """If a workflow hand-installs anything, the authority is not the authority.
+
+    This closes the loop the pydantic finding opened: the MECHANISM was sound
+    (every job installs only from the [test] table) while the TABLE was
+    incomplete. Had the mechanism been leaky instead, declaring pydantic would
+    have fixed nothing, because some job could satisfy the import another way
+    and the table would describe nothing real.
+    """
+    pyproject = tomllib.loads((PACKAGE / "pyproject.toml").read_text(encoding="utf-8"))
+    declared = set(pyproject["project"]["optional-dependencies"]["test"])
+    assert any(dep.startswith("pydantic") for dep in declared), (
+        "pydantic must be declared by the sole authority; it is imported by "
+        "tests/test_lift_pydantic.py and lifted by a first-party production "
+        "module. Undeclared, CI never installs it and the laws never run."
+    )
+
+    workflows = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    assert workflows, "no workflows found; this tooth would be vacuous"
+
+    offenders = []
+    for workflow in workflows:
+        text = workflow.read_text(encoding="utf-8")
+        if "sugar-lift-py-tests" not in text:
+            continue
+        for line in text.splitlines():
+            stripped = line.strip()
+            if "pip install" not in stripped and not stripped.startswith("-e "):
+                continue
+            # A bare `pip install pydantic` anywhere would mean the import can
+            # be satisfied without the authority declaring it.
+            if re.search(r"\bpip install\b(?![^\n]*-e )[^\n]*\bpydantic\b", stripped):
+                offenders.append(f"{workflow.name}: {stripped}")
+
+    assert not offenders, (
+        "a workflow installs pydantic directly, so the [test] extra is not the "
+        "sole authority and every claim resting on it is weaker than it "
+        f"reads:\n  " + "\n  ".join(offenders)
+    )
+
+
+# -- tooth 3: the laws are enrolled BY NAME ----------------------------------
+
+
+def test_the_pydantic_laws_are_collected_by_name():
+    """Counting collected tests does not prove WHICH tests were collected."""
+    result = _run_pytest([str(LAW_FILE), "--collect-only", "-q"])
+    assert result.returncode == 0, (
+        f"collection of the pydantic laws failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+    collected = result.stdout
+    missing = [node for node in REQUIRED_NODE_IDS if node not in collected]
+    assert not missing, (
+        f"R={len(missing)} pydantic laws are not enrolled by name:\n  "
+        + "\n  ".join(missing)
+        + f"\ncollected was:\n{collected}"
+    )
+
+
+# -- teeth 1 + 2 + 5: absence is loud, failure is FAILED, counts reconcile ----
+
+
+def test_the_pydantic_laws_actually_execute_and_reconcile():
+    """Executed, not merely collected -- and the receipt conserves.
+
+    Collection succeeding is the weaker claim. This asserts the stronger one:
+    the laws ran, produced passes, and the terminal counts account for every
+    collected node.
+    """
+    collect = _run_pytest([str(LAW_FILE), "--collect-only", "-q"])
+    match = re.search(r"(\d+) tests? collected", collect.stdout)
+    assert match, f"could not read collected count:\n{collect.stdout}"
+    collected = int(match.group(1))
+    assert collected >= len(REQUIRED_NODE_IDS)
+
+    run = _run_pytest([str(LAW_FILE), "-q", "--tb=short"])
+    outcomes = _outcomes(run.stdout)
+
+    assert outcomes.get("skipped", 0) == 0, (
+        "a pydantic law skipped. pydantic is DECLARED by the authority, so its "
+        f"absence is a broken environment, never a skip: {outcomes}\n{run.stdout}"
+    )
+    assert outcomes.get("passed", 0) >= len(REQUIRED_NODE_IDS), (
+        f"the pydantic laws did not execute to a pass: {outcomes}\n{run.stdout}"
+    )
+
+    # Conservation: every collected node reached a terminal verdict.
+    accounted = sum(outcomes.values())
+    assert accounted == collected, (
+        f"receipt does not reconcile: collected={collected} accounted="
+        f"{accounted} outcomes={outcomes}. A node that is collected and reaches "
+        "no verdict has vanished, and a vanished node is exactly the defect "
+        "this file exists to make impossible."
+    )
+
+
+def test_a_deliberate_law_failure_is_observed_as_FAILED(tmp_path):
+    """The denominator must be able to go red, on these specific laws.
+
+    A suite that cannot fail is not evidence. This mutates one pydantic law and
+    requires the verdict to be FAILED -- not skipped (the law quietly not
+    running) and not absent (the law quietly not collected).
+    """
+    mutated = tmp_path / "test_lift_pydantic.py"
+    source = LAW_FILE.read_text(encoding="utf-8")
+    broken = source.replace(
+        'assert "User.name" in names',
+        'assert "User.name" not in names  # deliberate mutation',
+        1,
+    )
+    assert broken != source, "mutation anchor not found; this tooth would be vacuous"
+    mutated.write_text(broken, encoding="utf-8")
+
+    result = _run_pytest([str(mutated), "-q", "--tb=no"], cwd=tmp_path)
+    outcomes = _outcomes(result.stdout)
+
+    assert outcomes.get("failed", 0) >= 1, (
+        "a deliberately broken pydantic law did not FAIL. It was "
+        f"{outcomes or 'not observed at all'} -- so these laws cannot report a "
+        f"defect and their green is not evidence.\n{result.stdout}\n{result.stderr}"
+    )
+    assert outcomes.get("skipped", 0) == 0, (
+        f"the mutated law SKIPPED instead of failing: {outcomes}"
+    )
+
+
+def test_removing_pydantic_is_a_loud_failure_never_a_skip(tmp_path):
+    """Tooth 1: absence of a declared dependency must be loud.
+
+    Simulated by making the import unsatisfiable in a child process. The point
+    is the SHAPE of the outcome: an environment missing a declared dependency
+    must produce a failure or a collection error, never a skip that reports
+    green on every machine that lacks it.
+    """
+    blocker = tmp_path / "sitecustomize.py"
+    blocker.write_text(
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_module(self, name, path=None):\n"
+        "        return self if name == 'pydantic' or name.startswith('pydantic.') else None\n"
+        "    def load_module(self, name):\n"
+        "        raise ImportError('pydantic blocked for this law')\n"
+        "sys.meta_path.insert(0, _Block())\n",
+        encoding="utf-8",
+    )
+
+    result = _run_pytest(
+        [str(LAW_FILE), "-q", "--tb=no"],
+        extra_env={"PYTHONPATH": f"{tmp_path}:{PACKAGE / 'src'}:{HERE}"},
+    )
+    outcomes = _outcomes(result.stdout)
+
+    assert outcomes.get("skipped", 0) == 0, (
+        "removing a DECLARED dependency produced a SKIP. That is the defect: "
+        "the laws would report green on every machine lacking pydantic, which "
+        f"is exactly how they went unrun for the repo's whole history.\n{result.stdout}"
+    )
+    assert result.returncode != 0, (
+        "removing a declared dependency left the suite GREEN; absence must be "
+        f"loud.\n{result.stdout}\n{result.stderr}"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_pydantic_laws_are_enrolled_and_executed.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pydantic_laws_are_enrolled_and_executed.py
@@ -139,12 +139,24 @@ def test_the_pydantic_laws_are_collected_by_name():
         f"collection of the pydantic laws failed:\n{result.stdout}\n{result.stderr}"
     )
 
-    collected = result.stdout
+    # EXACT node identities, not substrings. A substring test cannot tell a
+    # law from a law that was renamed around it: `..._numeric_range_RENAMED`
+    # contains `..._numeric_range`, so `in` reports the vanished law as
+    # present. Mutation caught exactly that, which is the whole point of a
+    # tooth that claims to check names.
+    collected = set()
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if ".py::" in line:
+            collected.add(line.split(".py::", 1)[1])
+
+    assert collected, f"no node IDs parsed; tooth would be vacuous:\n{result.stdout}"
     missing = [node for node in REQUIRED_NODE_IDS if node not in collected]
     assert not missing, (
-        f"R={len(missing)} pydantic laws are not enrolled by name:\n  "
+        f"R={len(missing)} pydantic laws are not enrolled by exact name:\n  "
         + "\n  ".join(missing)
-        + f"\ncollected was:\n{collected}"
+        + "\ncollected node IDs were:\n  "
+        + "\n  ".join(sorted(collected))
     )
 
 


### PR DESCRIPTION
## Ruling on the #6369 fork — option 3, named, with evidence

**Unintentionally unexecuted: a historical coverage defect.**

Not *intentionally optional* — nobody ever decided that. `pydantic` was declared **nowhere** for the entire repo history:

```
$ git log -S"pydantic" -- .github/     # every workflow, all history
  (no output)
```

No workflow ever installed it. No pyproject declared it before #6372. There is no extra, no lane, no receipt, no decision recorded anywhere. The laws simply never ran.

**So prior green runs of `sugar-lift-py-tests` ranged over a smaller universe than they claimed, and are NOT retroactively authoritative for pydantic lifting.**

## Five opposing teeth

Collection succeeding is the weaker claim, and it is the one that has fooled us repeatedly today. Each tooth opposes a different way the claim could be hollow.

| # | tooth | how it can fail |
|---|---|---|
| 1 | removing pydantic → **loud failure, never a skip** | import blocked via `sitecustomize` in a child; asserts `skipped == 0` and non-zero exit |
| 2 | a deliberate law failure → **observed as FAILED** | one law mutated in a temp copy; asserts `failed >= 1` and `skipped == 0` |
| 3 | collected node IDs → **the three laws BY NAME** | exact node-identity match |
| 4 | the workflow → **installs ONLY the declared authority** | scans every workflow touching this package for a bare `pip install pydantic` |
| 5 | the receipt → **reconciles** | `collected == passed + failed + skipped + errored` |

Every tooth runs pytest **out-of-process**, so a real verdict is observed rather than simulated.

**Tooth 4 closes the loop the finding opened.** The authority *mechanism* was sound while the *table* was incomplete. Had the mechanism been leaky instead, declaring pydantic would have fixed nothing — a job could satisfy the import another way and the table would describe nothing real.

## Mutation — and a tooth that could not bite

| mutation | result |
|---|---|
| undeclare pydantic from the authority | tooth 4 fired |
| reintroduce an `importorskip` | teeth 2 + 5 fired |
| **rename a law** | **passed — tooth 3 was hollow** |
| rename a law (after fix) | tooth 3 fired |
| delete a law entirely | tooth 3 fired |

Tooth 3 claimed to check *names* and used a substring test. `..._numeric_range_RENAMED` **contains** `..._numeric_range`, so a vanished law reported as present — renaming and deleting both passed. Fixed to exact node-identity parsing in `bb43f78d0`.

That is the fifth control today whose own claim was weaker than it read, and again only mutation found it.

## Measured

`5 passed` (teeth, with pydantic present) · root guard `8 passed` · root `tests/` **1 failed, 128 passed** — the inherited `wall_workflow_prerequisites_test.py:23` only.

## A finding filed, not decided — #6373

`lift/pydantic.py` has **zero reverse-deps**. Nothing in the repo calls it but its own test, and `lift/` has no siblings. It descends from #727, whose Rust counterparts were **deliberately burned** in `dc73e0f11` on exactly that criterion: *"encode-knowledge tool lifters with zero reverse-deps (nothing in the workspace links them)."*

It may be the Python survivor of that burn. Making the laws real is strictly better than 441 lines with no executing tests, and it is reversible — but it does add a dependency to a table that calls itself the sole authority for every CI job. **Keep-or-burn belongs to the leaf-adapter owner**, so #6373 states it rather than deciding it.

## Carried forward, unchanged

- **#6368** — `sugar-typed-recognition` uncollectable since #5953, 26 laws unrun, port-or-retire.
- **`test_lift_coverage_harness.py` remains unexecuted** from #6362. No binary build forced beside the baseline. Still standing.

Mac only. Box untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add five pydantic law enforcement tests for enrollment, execution, and reconciliation
> Adds a new pytest module ([test_pydantic_laws_are_enrolled_and_executed.py](https://github.com/TSavo/sugar/pull/6374/files#diff-6b160a3c09ad4f065628e67122649a6567b7a7dfd700c2be9f7a00b3cbc0ebb0)) that enforces five properties about pydantic test behavior:
> - Verifies pydantic is declared in `[project.optional-dependencies.test]` and that CI workflows do not directly `pip install pydantic`
> - Asserts the required pydantic law tests are collected by exact pytest node IDs
> - Asserts pydantic laws execute with no skips and that terminal outcome counts reconcile with collected counts
> - Confirms a deliberately mutated assertion produces a `FAILED` verdict rather than a skip
> - Confirms that blocking pydantic imports via a `sitecustomize` meta path finder produces a non-zero exit with no skips
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb43f78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for Pydantic law test enrollment and execution.
  * Verifies required tests are collected by exact name and execute without skips.
  * Confirms test results reconcile with collected counts.
  * Ensures deliberate failures are reported as failures.
  * Detects missing Pydantic installations as explicit test failures rather than skips.
  * Validates that Pydantic installation is controlled through the declared test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->