### PR TITLE
The loop names its own exit routes: partition testimony threaded through the wire to the exit arms

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -355,6 +355,10 @@ _EXACT_FIELDS = {
         "incomingStateCid",
         "completedFaceCid",
         "projectedStateCid",
+        # The producer's declared count of exit routes for this loop occurrence
+        # (#6336 family). Part of the sealed preimage on purpose: a family size
+        # that could be attached after the fact is not testimony.
+        "exitPartitionArity",
         "postBindingObligationCid",
     },
 }
@@ -640,6 +644,27 @@ def decode_loop_construction_v1(graph: Any) -> LoopConstructionV1:
         state(post.raw["projectedStateCid"])
         if post.raw["completedFaceCid"] not in completed_by_cid:
             raise LoopWireError("post binding face is not completed")
+        # The producer's DECLARED exit-route count for this loop occurrence.
+        # It is a partition size, so it must be at least two to be a split at
+        # all, and it must never name the latch: `BodyFallthrough` is the
+        # loop-back edge, not a way out.
+        arity = post.raw.get("exitPartitionArity")
+        if not isinstance(arity, int) or isinstance(arity, bool) or arity < 1:
+            raise LoopWireError(
+                "post binding must declare exitPartitionArity: the number of "
+                "exit routes this loop occurrence owns. Without it a downstream "
+                "projection could only count the faces that happened to arrive, "
+                "and a dropped face would read as a complete partition"
+            )
+        if completed_by_cid[post.raw["completedFaceCid"]].completion_kind == (
+            "BodyFallthrough"
+        ):
+            raise LoopWireError(
+                "post binding must not project BodyFallthrough: it is the latch "
+                "input (the loop-back edge), not an exit route. Projecting it "
+                "would put the latch into the exit partition and assert an "
+                "exclusion against the real exits that nobody established"
+            )
 
     for cid in root["outwardHaltedFaceCids"]:
         halted = record(cid, "loop-outward-halted-face")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py
@@ -25,11 +25,21 @@ class LoopGuardedCompletedFace:
     completion_kind: str
     guard_formula: object
     state: BindingProjection
+    exit_partition_arity: int | None = None
 
 
 @dataclass(frozen=True)
 class LoopGuardedProjection:
     completed_faces: tuple[LoopGuardedCompletedFace, ...]
+    target_cid: str | None = None
+    """The authenticated producer OCCURRENCE these faces belong to.
+
+    A partition family is minted over one origin, and this is that origin: two
+    loops in one function are two occurrences and share no exclusion. Carrying
+    the target CID is what stops a downstream mint from keying on anything
+    weaker (a name, a completion kind, a value type) -- the trap the same-type
+    partition law exists to refuse.
+    """
 
 
 BindingProjection: TypeAlias = (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -14,23 +14,75 @@ from sugar_lift_py_tests.sugar.binding_projection import (
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 
+def _loop_exit_faces(state: LoopGuardedProjection):
+    """The producer's own exit-route family for this loop, or ``None``.
+
+    A LOOP EXITS EXACTLY ONE WAY, AND THE LOOP SAYS SO. `live_loop_construction`
+    mints a post-binding record for each exit route it owns -- `BreakExit` when
+    the body can break, and always `NormalExhaustion` -- and declares how many
+    it minted. `BodyFallthrough` is not among them and must never be: it is the
+    latch input, the loop-back edge, not a way out. So this reads a family off
+    authenticated testimony; it never re-derives one from how the guards happen
+    to be spelled, from the completion kinds' names, or from the arms' types.
+
+    Returns ``None`` (leaving every arm unstamped, gap loud) unless ALL of:
+
+      - the producer declared an arity at all;
+      - the declaration is the same on every face;
+      - the faces present cover that declared arity exactly;
+      - the completion kinds are distinct, so the sides can be told apart;
+      - the occurrence is authenticated -- ``target_cid`` identifies WHICH loop.
+
+    Any one of these failing means the testimony to admit a family was not
+    earned here, and `ExitSetFactoringGap` staying loud is the correct output.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import partition_family
+
+    faces = state.completed_faces
+    if state.target_cid is None or len(faces) < 2:
+        return None
+    arities = {face.exit_partition_arity for face in faces}
+    if len(arities) != 1:
+        return None
+    arity = arities.pop()
+    if arity is None or arity != len(faces):
+        return None
+    kinds = tuple(face.completion_kind for face in faces)
+    if len(set(kinds)) != len(kinds) or "BodyFallthrough" in kinds:
+        return None
+    minted = partition_family(("loop.exit", state.target_cid), kinds)
+    return dict(zip(kinds, minted, strict=True))
+
+
+def _read_loop_projection(
+    state: LoopGuardedProjection, *, read_name: str, read_site, ctx
+) -> ExitSet:
+    by_kind = _loop_exit_faces(state)
+    exits = ExitSet(())
+    for face in state.completed_faces:
+        exits = exits.union(
+            read_binding(
+                face.state,
+                read_name=read_name,
+                read_site=read_site,
+                ctx=ctx,
+            ).guarded(
+                face.guard_formula,
+                None if by_kind is None else by_kind[face.completion_kind],
+            )
+        )
+    return exits.normalize()
+
+
 def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
     if isinstance(state, Sugar):
         return outcome_to_exitset(state.desugar(ctx))
     if isinstance(state, UnboundProjection):
         return ExitSet.halted(NameErrorEffect(name=read_name, site=read_site))
     if isinstance(state, LoopGuardedProjection):
-        exits = ExitSet(())
-        for face in state.completed_faces:
-            exits = exits.union(
-                read_binding(
-                    face.state,
-                    read_name=read_name,
-                    read_site=read_site,
-                    ctx=ctx,
-                ).guarded(face.guard_formula)
-            )
-        return exits.normalize()
+        return _read_loop_projection(
+            state, read_name=read_name, read_site=read_site, ctx=ctx
+        )
     if not isinstance(state, GuardedProjection):
         from sugar_lift_py_tests.sugar.delete_name_sugar import _unhandled_projection
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_wire.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_wire.py
@@ -239,6 +239,12 @@ def _sample_graph():
             "incomingStateCid": pre["stateCid"],
             "completedFaceCid": break_face["completedFaceCid"],
             "projectedStateCid": break_state["stateCid"],
+            # This fixture projects ONE exit route, so it declares one. The
+            # field is required (#6336 family): a post-binding that does not
+            # say how many routes its loop owns leaves a downstream projection
+            # counting arrivals, where a dropped face reads as a complete
+            # partition. A one-route declaration mints no family -- correctly.
+            "exitPartitionArity": 1,
         },
         "postBindingObligationCid",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
@@ -1,0 +1,472 @@
+"""The loop names its own exit routes, and the read stamps them. Or the gap stays loud.
+
+#6356 gave a producer the vocabulary for an n-way split. Two measured rows kept
+using it as evidence they could not reach:
+
+    core/methods/selectn.py:224   factoring_gaps=1  remaining_work=1
+    core/indexing.py:2457         factoring_gaps=1  remaining_work=1
+
+They are the SAME row twice. One arm is guarded by branch results (a `break`
+was taken), the other by `python.loop.exhausted` (the loop ran to completion),
+both are `merged=False`, and both are same-type pairs -- exactly the trap the
+same-type partition law refuses to treat as an admission.
+
+THE RULING, and this file is where it becomes executable at the CARRIER rather
+than at the algebra:
+
+  MINT A TWO-FACE PARTITION OVER `{BreakExit, NormalExhaustion}`.
+  LEAVE `BodyFallthrough` UNSTAMPED.
+
+`BodyFallthrough` is the LATCH input -- `loop_construction.py` requires the
+latch obligation's input face to be exactly that kind -- so it is the loop-back
+edge, not an exit route. Stamping it as a third exit face asserts an exclusion
+nobody established.
+
+THE CARRIER WAS MEASURED, NOT ASSUMED. The previous owner explicitly did not
+establish it: the arms reach `factor_completed` through `store_effect_sugar` /
+`method_call._collect` with NO `read_binding` frame anywhere in the stack, and
+a `loop.exhausted` guard proves the loop OWNS the guard, not that any particular
+carrier delivered it. Instrumenting every `LoopGuardedProjection` consumer while
+re-running `selectn.py:224` named the carrier outright: both refusing arms were
+minted by `read_binding`'s `LoopGuardedProjection` branch reading the name
+`indexer`, as `BreakExit` and `NormalExhaustion`. The frames are silent because
+the `ExitSet` is built at the read and only REFUSES later, downstream.
+
+`test_the_loop_exit_family_reaches_the_arms` is the end-to-end tooth: its
+fixture is the shape of `selectn.py:224` reduced to seven lines, it raised
+`ExitSetFactoringGap` with the same `SymbolicValue`/`SymbolicValue` owner pair
+at `ed686ba48`, and it desugars clean here. Everything else in this file is a
+discriminator: each one perturbs exactly one admission criterion and asserts the
+family is refused, so the end-to-end green cannot be bought by a fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    ExitSetFactoringGap,
+)
+from sugar_lift_py_tests.sugar.binding_projection import (
+    LoopGuardedCompletedFace,
+    LoopGuardedProjection,
+)
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import _loop_exit_faces
+
+# The shape of `pandas/core/methods/selectn.py:224`: a name carried across a
+# `for` loop that can `break`, then READ after the loop. The read is where the
+# two exit faces become two completed arms of one ExitSet.
+FIXTURE = """\
+def compute(columns, seed, sink):
+    indexer = seed
+    for column in columns:
+        indexer = indexer.append(column)
+        if column.done:
+            break
+    sink.result = indexer.finish()
+    return sink
+"""
+
+_CID = "blake3-512:" + "ab" * 32
+
+
+def _face(kind: str, arity: int | None, *, guard: object = None):
+    return LoopGuardedCompletedFace(kind, guard, object(), arity)
+
+
+def _projection(faces, target_cid: str | None = _CID):
+    return LoopGuardedProjection(tuple(faces), target_cid)
+
+
+def _write(tmp_path: Path, source: str) -> Path:
+    path = tmp_path / "fixture.py"
+    path.write_text(source)
+    return path
+
+
+def _desugar_all(path: Path) -> None:
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    for function in SourceFile(path_source(str(path))).functions():
+        sugar = function.sugar()
+        if sugar is not None:
+            sugar.desugar(None)
+
+
+# --------------------------------------------------------------------------
+# end to end: the producer speaks and the row closes
+# --------------------------------------------------------------------------
+
+
+def test_the_loop_exit_family_reaches_the_arms(tmp_path):
+    """POSITIVE, end to end. Red at `ed686ba48`, green here.
+
+    Nothing is stubbed: the real live loop producer mints the wire records, the
+    real decoder validates them, the real projection carries the declared family
+    size, and the real `read_binding` stamps the arms. If this goes red, the two
+    measured rows are back.
+    """
+    _desugar_all(_write(tmp_path, FIXTURE))
+
+
+def test_the_carrier_is_the_loop_projection_read(tmp_path):
+    """THE CARRIER, pinned where it was measured rather than where it raises.
+
+    The refusal's stack names `store_effect_sugar` and `method_call._collect`
+    and no `read_binding` at all, so an agent reading only the traceback would
+    wire the testimony into the wrong producer. This test asserts the mint lands
+    at `read_binding`'s `LoopGuardedProjection` branch, over the loop's own
+    target CID, with exactly the two exit routes as its sides.
+    """
+    from sugar_lift_py_tests.sugar import guarded_binding_read_sugar as module
+
+    seen: list[LoopGuardedProjection] = []
+    original = module._read_loop_projection
+
+    def spy(state, **kwargs):
+        seen.append(state)
+        return original(state, **kwargs)
+
+    module._read_loop_projection = spy
+    try:
+        _desugar_all(_write(tmp_path, FIXTURE))
+    finally:
+        module._read_loop_projection = original
+
+    assert seen, "no LoopGuardedProjection read: the carrier moved"
+    for projection in seen:
+        kinds = {face.completion_kind for face in projection.completed_faces}
+        assert kinds == {"BreakExit", "NormalExhaustion"}, kinds
+        assert "BodyFallthrough" not in kinds
+        faces = _loop_exit_faces(projection)
+        assert faces is not None
+        assert {face.side for face in faces.values()} == kinds
+        assert {face.arity for face in faces.values()} == {2}
+        assert {face.partition for face in faces.values()} == {
+            ("sugar.exit_set.partition", ("loop.exit", projection.target_cid))
+        }
+
+
+# --------------------------------------------------------------------------
+# discriminators on the mint: one criterion each, all of them required
+# --------------------------------------------------------------------------
+
+
+def test_the_latch_is_never_a_member_of_the_exit_partition():
+    """THE RULING'S OWN DISCRIMINATOR. `BodyFallthrough` is the loop-back edge.
+
+    A projection that carries the latch alongside the exits is not a producer
+    naming three exit routes; it is a projection that put the loop-back edge in
+    the exit family. Refuse the mint outright rather than assert an exclusion
+    between the latch and the routes that nobody established.
+    """
+    assert (
+        _loop_exit_faces(
+            _projection(
+                [
+                    _face("BreakExit", 3),
+                    _face("BodyFallthrough", 3),
+                    _face("NormalExhaustion", 3),
+                ]
+            )
+        )
+        is None
+    )
+
+
+def test_an_undeclared_family_size_mints_nothing():
+    """DISCRIMINATING. A producer that never said how many routes it owns.
+
+    Counting the faces that happened to arrive would read a DROPPED face as a
+    smaller complete partition. No declaration, no family, gap stays loud.
+    """
+    assert (
+        _loop_exit_faces(
+            _projection([_face("BreakExit", None), _face("NormalExhaustion", None)])
+        )
+        is None
+    )
+
+
+def test_a_family_short_of_its_declared_size_mints_nothing():
+    """DISCRIMINATING. Every face retained, or no admission.
+
+    Two declared, one present: the absent route is an outcome nobody accounted
+    for, and collapsing what is left would drop it.
+    """
+    assert _loop_exit_faces(_projection([_face("NormalExhaustion", 2)])) is None
+
+
+def test_faces_disagreeing_on_the_declared_size_mint_nothing():
+    """DISCRIMINATING. One occurrence declares ONE family size.
+
+    Two different arities on one projection means the faces did not come from
+    one statement of the split, so there is no single family to admit.
+    """
+    assert (
+        _loop_exit_faces(
+            _projection([_face("BreakExit", 2), _face("NormalExhaustion", 3)])
+        )
+        is None
+    )
+
+
+def test_an_unauthenticated_occurrence_mints_nothing():
+    """DISCRIMINATING. The origin is the loop OCCURRENCE, not the loop's shape.
+
+    Without a target CID there is nothing to key the family on, and keying on
+    anything weaker -- the name read, the completion kinds, the arms' type --
+    would let two unrelated loops share an exclusion.
+    """
+    assert (
+        _loop_exit_faces(
+            _projection(
+                [_face("BreakExit", 2), _face("NormalExhaustion", 2)],
+                target_cid=None,
+            )
+        )
+        is None
+    )
+
+
+def test_indistinguishable_routes_mint_nothing():
+    """DISCRIMINATING. Two members that cannot be told apart carry no exclusion."""
+    assert (
+        _loop_exit_faces(
+            _projection([_face("NormalExhaustion", 2), _face("NormalExhaustion", 2)])
+        )
+        is None
+    )
+
+
+def test_two_loops_are_two_origins():
+    """THE SAME-TYPE TRAP, at the carrier.
+
+    Two loops in one function agree in completion kinds, in declared arity, and
+    in the type of everything they carry. They share no origin, so their arms
+    must not factor -- and this is the criterion the two measured rows are
+    shaped to defeat.
+    """
+    other = "blake3-512:" + "cd" * 32
+    left = _loop_exit_faces(
+        _projection([_face("BreakExit", 2), _face("NormalExhaustion", 2)])
+    )
+    right = _loop_exit_faces(
+        _projection(
+            [_face("BreakExit", 2), _face("NormalExhaustion", 2)], target_cid=other
+        )
+    )
+
+    assert left is not None and right is not None
+    assert left["BreakExit"].partition != right["BreakExit"].partition
+
+    from sugar_lift_py_tests.ir import atomic, make_var
+
+    def guard(name):
+        return atomic(name, [make_var("state")])
+
+    with pytest.raises(ExitSetFactoringGap):
+        ExitSet(
+            (
+                Completed(guard("p"), "v", frozenset({left["BreakExit"]})),
+                Completed(guard("q"), "w", frozenset({right["NormalExhaustion"]})),
+            )
+        ).factor_completed()
+
+
+# --------------------------------------------------------------------------
+# the wire: the declaration is sealed testimony, not an annotation
+# --------------------------------------------------------------------------
+
+
+def _one_loop_graph(tmp_path) -> dict:
+    """A REAL sealed loop wire graph, taken from the fixture as it lifts."""
+    from sugar_source_tree import loop_recurrence as module
+
+    captured: list[dict] = []
+    original = module.project_loop_post_binding
+
+    def spy(*, construction, **kwargs):
+        captured.append(construction.wire_graph())
+        return original(construction=construction, **kwargs)
+
+    module.project_loop_post_binding = spy
+    try:
+        _desugar_all(_write(tmp_path, FIXTURE))
+    finally:
+        module.project_loop_post_binding = original
+
+    assert captured, "no loop projection ran"
+    return captured[0]
+
+
+def _post_records(graph: dict) -> list[dict]:
+    return [r for r in graph["records"] if r.get("kind") == "loop-post-binding"]
+
+
+def test_the_real_wire_declares_two_exit_routes(tmp_path):
+    """POSITIVE. The producer's own records say two, and name which two."""
+    from sugar_lift_py_tests.loop_construction import decode_loop_construction_v1
+
+    graph = _one_loop_graph(tmp_path)
+    posts = _post_records(graph)
+    assert posts
+    assert {record["exitPartitionArity"] for record in posts} == {2}
+
+    faces = {
+        record["completedFaceCid"]: record["completionKind"]
+        for record in graph["records"]
+        if record.get("kind") == "loop-completed-face"
+    }
+    assert {faces[record["completedFaceCid"]] for record in posts} == {
+        "BreakExit",
+        "NormalExhaustion",
+    }
+    decode_loop_construction_v1(graph)  # the real decoder accepts it
+
+
+def _with_producer_records(tmp_path, rewrite):
+    """Run the fixture with one rewrite applied to preimages BEFORE they seal.
+
+    Mutating a finished graph is not a way to reach these checks: every record
+    carries its own CID and the root is sealed over the CIDs it binds, so a
+    tampered graph fails on its seal long before any of the rules below get a
+    turn. The reachable defect is a PRODUCER that mints the wrong record, so
+    that is what these twins plant -- at the producer, where the result reseals
+    into a graph that is internally valid and wrong only in the way under test.
+    """
+    from sugar_source_tree import live_loop_construction as producer
+
+    original = producer._record
+    seen: dict[str, str] = {}
+
+    def rewriting_record(preimage, cid_field):
+        if preimage.get("kind") == "loop-completed-face":
+            record = original(preimage, cid_field)
+            seen[preimage["completionKind"]] = record["completedFaceCid"]
+            return record
+        preimage = rewrite(preimage, seen)
+        return original(preimage, cid_field)
+
+    producer._record = rewriting_record
+    try:
+        _desugar_all(_write(tmp_path, FIXTURE))
+    finally:
+        producer._record = original
+
+
+def test_a_post_binding_without_a_declared_arity_is_refused(tmp_path):
+    """DISCRIMINATING, at the wire. No declaration is not a small family.
+
+    A producer that mints the field but leaves it empty passes the record's
+    field-set and seal checks, so this reaches the RULE rather than a generic
+    malformed-record refusal -- which is the difference between a twin with
+    teeth and a twin that passes for someone else's reason.
+    """
+    from sugar_lift_py_tests.loop_construction import LoopWireError
+
+    def rewrite(preimage, _seen):
+        if preimage.get("kind") == "loop-post-binding":
+            return {**preimage, "exitPartitionArity": None}
+        return preimage
+
+    with pytest.raises(LoopWireError, match="must declare exitPartitionArity"):
+        _with_producer_records(tmp_path, rewrite)
+
+
+def test_a_post_binding_that_projects_the_latch_is_refused(tmp_path):
+    """DISCRIMINATING, at the wire. The latch may not enter the exit family.
+
+    THE MIS-STAMP THE RULING FORBIDS, planted at the layer that would have to
+    carry it. A producer that projected `BodyFallthrough` would hand
+    `read_binding` a family whose member is the loop-back edge, and the exits
+    would be asserting an exclusion against an edge that is not an exit at all.
+    """
+    from sugar_lift_py_tests.loop_construction import LoopWireError
+
+    def rewrite(preimage, seen):
+        if preimage.get("kind") == "loop-post-binding" and "BodyFallthrough" in seen:
+            return {**preimage, "completedFaceCid": seen["BodyFallthrough"]}
+        return preimage
+
+    with pytest.raises(LoopWireError, match="must not project BodyFallthrough"):
+        _with_producer_records(tmp_path, rewrite)
+
+
+def test_a_projection_short_of_the_declared_family_refuses(tmp_path):
+    """DISCRIMINATING, at the projection. A family short of its size is LOUD.
+
+    NOT FORGEABLE FROM OUTSIDE, AND THAT IS THE POINT. Deleting a post-binding
+    record from a finished graph cannot reach this check: the record CIDs and
+    the sealed root make a tampered graph fail the decoder first. The reachable
+    way to get here is a PRODUCER BUG -- a loop that declares more exit routes
+    than it mints post-binding records for -- so that is what this plants, by
+    raising the declared arity to three inside the producer where it is sealed.
+
+    Counting the faces that arrived would silently re-read the result as a
+    complete two-face partition. The declaration is what turns it into a gap.
+    """
+    from sugar_source_tree import live_loop_construction as producer
+    from sugar_source_tree.binding_state import BindingStateWireGap
+
+    original = producer._record
+
+    def overstating_record(preimage, cid_field):
+        if preimage.get("kind") == "loop-post-binding":
+            preimage = {**preimage, "exitPartitionArity": 3}
+        return original(preimage, cid_field)
+
+    producer._record = overstating_record
+    try:
+        with pytest.raises(BindingStateWireGap, match="short of its declared size"):
+            _desugar_all(_write(tmp_path, FIXTURE))
+    finally:
+        producer._record = original
+
+
+# --------------------------------------------------------------------------
+# the #6333 guard: an admitted family may not start multiplying again
+# --------------------------------------------------------------------------
+
+
+def test_the_loop_family_stays_linear_as_factors_are_appended(tmp_path):
+    """THE BOUND. A factored family that grows with appended factors is `m ** k`.
+
+    The admission this file adds is only worth having if the collapsed face
+    stays at one arm however many steps are sequenced after it.
+    """
+    from sugar_lift_py_tests.ir import atomic, make_var
+
+    faces = _loop_exit_faces(
+        _projection([_face("BreakExit", 2), _face("NormalExhaustion", 2)])
+    )
+    assert faces is not None
+
+    def guard(name):
+        return atomic(name, [make_var("state")])
+
+    family = ExitSet(
+        (
+            Completed(guard("broke"), "a", frozenset({faces["BreakExit"]})),
+            Completed(
+                guard("exhausted"), "b", frozenset({faces["NormalExhaustion"]})
+            ),
+        )
+    ).factor_completed()
+
+    series = []
+    for step_count in (1, 2, 3, 4, 5, 6, 7, 8):
+        exits = family
+        for index in range(step_count):
+            exits = exits.sequence(lambda value, _i=index: ExitSet.completed((value, _i)))
+        series.append(len([e for e in exits.exits if isinstance(e, Completed)]))
+
+    assert series == [1] * 8, (
+        f"completed arms by appended factors {series}: the loop exit family is "
+        "multiplying again (#6333)"
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -85,6 +85,13 @@ class LoopProjectedCompletedFace:
     guard_formula_cid: str
     state: BindingState
     guard_formula: object | None = None
+    exit_partition_arity: int | None = None
+    """How many exit routes the PRODUCER declared for this loop occurrence.
+
+    ``None`` is a face from a producer that never stated a family size. Such a
+    face can still be read; it simply cannot carry completeness downstream, in
+    the same way ``PartitionFace.arity is None`` cannot.
+    """
 
     def __post_init__(self) -> None:
         _require_runtime_cid(self.target_cid, "targetCid")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -579,11 +579,28 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         else_obligation_cid = else_obligation["elseExhaustionObligationCid"]
 
     post_records = []
+    # THE EXIT ROUTES, NAMED BY THE PRODUCER (#6336 family).
+    #
+    # A loop leaves exactly one way, and this tuple is the loop saying which
+    # ways exist. `BodyFallthrough` is deliberately absent and must stay absent:
+    # it is the LATCH input (`loop_construction.py` requires the latch
+    # obligation's input face to be exactly that kind), i.e. the loop-back edge,
+    # not an exit route. Stamping it as a third exit member would assert an
+    # exclusion between the loop-back edge and the two real exits that nobody
+    # established -- and, because a family admits only when it is COMPLETE,
+    # would cost the two genuine exit arms the admission they legitimately earn.
+    #
+    # `exitPartitionArity` is that count carried on the wire so a downstream
+    # projection reads a DECLARED family size instead of counting whatever
+    # happened to arrive. A dropped post-binding record then makes the family
+    # short of its declared size, and the projection refuses loudly rather than
+    # certifying a partial partition as exhaustive.
     completed_post_kinds = (
         ("BreakExit", "NormalExhaustion")
         if "BreakExit" in face_snapshots
         else ("NormalExhaustion",)
     )
+    exit_partition_arity = len(completed_post_kinds)
     for completion_kind in completed_post_kinds:
         face, state_record, _snapshot = (
             post_exhaustion_face
@@ -600,6 +617,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
                     "incomingStateCid": pre_state["stateCid"],
                     "completedFaceCid": face["completedFaceCid"],
                     "projectedStateCid": state_record["stateCid"],
+                    "exitPartitionArity": exit_partition_arity,
                 },
                 "postBindingObligationCid",
             )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
@@ -42,12 +42,25 @@ def project_loop_post_binding(
         for record in construction.wire_graph()["records"]
         if record.get("kind") == "loop-completed-face"
     }
-    post_face_cids = {
-        record["completedFaceCid"]
+    post_records = [
+        record
         for record in construction.wire_graph()["records"]
         if record.get("kind") == "loop-post-binding"
         and record["bindingCoordinateCid"] == binding_coordinate.cid
-    }
+    ]
+    post_face_cids = {record["completedFaceCid"] for record in post_records}
+    # The DECLARED size of this loop occurrence's exit family. Read off the
+    # producer's own records, never counted from what arrived: counting would
+    # make a dropped face silently re-read as a smaller complete partition,
+    # which is precisely the "partial partition certified exhaustive" failure
+    # the admission rule in `outcome/exit_set.py` exists to refuse.
+    declared = {record["exitPartitionArity"] for record in post_records}
+    if len(declared) > 1:
+        raise BindingStateWireGap(
+            "loop post-binding records disagree on exitPartitionArity for one "
+            f"binding coordinate: observed {sorted(declared)}"
+        )
+    exit_partition_arity = declared.pop() if declared else None
     projected_faces = []
     for face in construction.completed_faces:
         if face.cid not in post_face_cids:
@@ -83,7 +96,17 @@ def project_loop_post_binding(
                     if live_guards is None
                     else live_guards.get(record["guardFormulaCid"])
                 ),
+                exit_partition_arity=exit_partition_arity,
             )
+        )
+    if exit_partition_arity is not None and len(projected_faces) != (
+        exit_partition_arity
+    ):
+        raise BindingStateWireGap(
+            "loop exit partition is short of its declared size: the producer "
+            f"declared {exit_partition_arity} exit routes and this projection "
+            f"retained {len(projected_faces)}. A partition missing a face is "
+            "an outcome nobody accounted for; do not project it as complete"
         )
     return LoopProjectedBinding(target_cid, tuple(projected_faces))
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7963,9 +7963,11 @@ def _construct_binding_projection(state):
                     face.completion_kind,
                     face.guard_formula,
                     _construct_binding_projection(face.state),
+                    face.exit_partition_arity,
                 )
                 for face in state.completed_faces
-            )
+            ),
+            state.target_cid,
         )
     raise TypeError(type(state))
 


### PR DESCRIPTION
## The loop names its own exit routes, and the read stamps them

`ed686ba48` landed the same-type partition law with the latch ruling already pinned as
executable twins, and left two measured rows loud on purpose:

```
core/methods/selectn.py:224   factoring_gaps=1  remaining_work=1
core/indexing.py:2457         factoring_gaps=1  remaining_work=1
```

Both are the same row twice. One arm is guarded by branch results (a `break` was taken),
the other by `python.loop.exhausted` (the loop ran to completion), `merged=False` on both,
and both are same-type pairs — the exact trap the law refuses to treat as an admission.

This PR does not change the law or the algebra. It lets the PRODUCER speak the testimony
the law already requires, and the two rows close because the evidence arrived, not because
the door widened.

### The carrier was measured, not assumed

The previous owner explicitly did not establish it, and flagged that so nobody would repeat
the wrong call: the refusing arms reach `factor_completed` through `store_effect_sugar` /
`method_call._collect`, with **no `read_binding` frame anywhere in the stack**. A
`loop.exhausted` guard proves the loop OWNS the guard, not that any particular carrier
delivered it.

So the carrier was instrumented first. Every `LoopGuardedProjection` consumer was wrapped
and `selectn.py:224` re-run. Both refusing arms were minted by `read_binding`'s
`LoopGuardedProjection` branch, reading the name `indexer`, as `BreakExit` and
`NormalExhaustion` over one loop target CID. The frames are silent because the `ExitSet` is
built at the read and only refuses later, downstream.

### The ruling, unchanged

Mint a TWO-face partition over `{BreakExit, NormalExhaustion}`. Leave `BodyFallthrough`
UNSTAMPED — it is the latch input (`loop_construction.py` requires the latch obligation's
input face to be exactly that kind), the loop-back edge, not an exit route.

The producer already agreed: `live_loop_construction` mints post-binding records only for
`("BreakExit", "NormalExhaustion")` (or `("NormalExhaustion",)` with no break). The latch
was never in that list. This PR carries that list's SIZE to the read.

### Four layers

| layer | change |
| --- | --- |
| `live_loop_construction.py` | the `loop-post-binding` record declares `exitPartitionArity` |
| `loop_construction.py` | the decoder requires the declaration and refuses a post-binding that projects `BodyFallthrough` |
| `loop_recurrence.py` | the projection carries the declared size and refuses a family short of it |
| `binding_state.py` / `nodes.py` / `binding_projection.py` | the face and the projection carry arity and the occurrence CID |
| `guarded_binding_read_sugar.py` | `_loop_exit_faces` mints `partition_family(("loop.exit", target_cid), kinds)` and stamps each exit arm |

**CID REPIN, stated explicitly.** `exitPartitionArity` is inside the sealed
`loop-post-binding` preimage, so every loop-construction graph containing a post-binding
record gets a new record CID and a new root CID. That is deliberate: a family size that
could be attached after the fact is not testimony. The one checked-in wire fixture
(`test_loop_construction_wire.py`) declares the one route it projects.

Why declare it rather than count the faces that arrive: counting makes a DROPPED face read
as a smaller complete partition. The declaration is what turns that into a loud gap.

### Admission criteria, all required, none inferable

`_loop_exit_faces` returns `None` — leaving every arm unstamped and the gap loud — unless
all of: the producer declared an arity; every face agrees on it; the faces cover it exactly;
the completion kinds are distinct; `BodyFallthrough` is absent; and the occurrence is
authenticated by target CID. No fallback, no default-success arm, no lexical inference, no
solver guess.

### Twins

`tests/test_loop_exit_partition_carrier.py`, 14 tests. The end-to-end tooth is a seven-line
fixture with the shape of `selectn.py:224`: it raised `ExitSetFactoringGap` with the same
`SymbolicValue`/`SymbolicValue` owner pair at `ed686ba48` and desugars clean here.

Seven perturbations were run against the file; each fired its intended twin and nothing
else:

| perturbation | fired |
| --- | --- |
| latch admitted into the family | `test_the_latch_is_never_a_member_of_the_exit_partition` |
| family size counted from arrivals | `test_an_undeclared_family_size_mints_nothing` |
| family keyed on completion kinds, not the occurrence | `test_the_carrier_is_the_loop_projection_read`, `test_two_loops_are_two_origins` |
| decoder stops requiring the declaration | `test_a_post_binding_without_a_declared_arity_is_refused` |
| decoder stops refusing the latch | `test_a_post_binding_that_projects_the_latch_is_refused` |
| projection stops refusing a short family | `test_a_projection_short_of_the_declared_family_refuses` |
| the mint removed entirely (base behaviour) | the three end-to-end / wire positives |

Two twins bind hardest and are both present: same-type faces from different origins do NOT
factor (`test_two_loops_are_two_origins`), and growth stays linear as factors are appended
(`test_the_loop_family_stays_linear_as_factors_are_appended`) — a factored family that
grows with appended factors is #6333's `m ** k` bound returning under a new name.

The two wire twins plant their defect at the PRODUCER, not in a finished graph: record CIDs
and the sealed root make a tampered graph fail on its seal long before the rule under test
gets a turn, so a graph-level perturbation would pass for someone else's reason. That was
caught by the perturbation sweep and fixed.

### What this does NOT do

No change to `factor_completed`, `_complete_family`, `_are_exclusive`, `partition_family`,
or any admission rule. No twin from `ed686ba48` weakened. No shell retired yet — the family
admission is still an algebra rule enforced by tests, and it retires when a completed exit
arm's partition membership becomes a type the constructor demands rather than a frozenset it
may omit.

### Epsilon R

`R(factoring_gaps_remaining_work)` on `core/methods/selectn.py` and `core/indexing.py`:
1 → 0 each. No other axis predicted to move.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread exit partition arity through loop wire records and sugar projection
> - Loop post-binding records now include `exitPartitionArity`, declaring the number of exit routes (e.g. `BreakExit` + `NormalExhaustion`, or just `NormalExhaustion`) emitted by `construct_live_loop_recurrence` in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6375/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094).
> - The decoder in [loop_construction.py](https://github.com/TSavo/sugar/pull/6375/files#diff-82ae08e844ec0a3ad333125f7e4a0609af140be5e2413837fe63ad5a63de3bbc) now rejects post-binding records missing a valid `exitPartitionArity` (must be int ≥ 1, not bool) and rejects `BodyFallthrough` as a completed face.
> - `project_loop_post_binding` in [loop_recurrence.py](https://github.com/TSavo/sugar/pull/6375/files#diff-afe55c723729e17a85608133e5f131be4afde1ab9414bb2eedbd2f61a3de4b4a) raises `BindingStateWireGap` if records disagree on arity or if retained faces are fewer than the declared family size.
> - `_loop_exit_faces` in [guarded_binding_read_sugar.py](https://github.com/TSavo/sugar/pull/6375/files#diff-aad969d839fe75c16270bb867782bac3ed239fda15da4f1faa74b3ba8b570d27) mints an exit partition family keyed by `('loop.exit', target_cid)` when faces agree on arity, are distinct, and exclude `BodyFallthrough`; the family sides are attached per arm during projection.
> - Risk: existing loop wire graphs without `exitPartitionArity` on post-binding records will now fail to decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aeb09f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->