### PR TITLE
Derive sibling resolution instead of declaring it: 30 collection errors to 0

### DIFF
--- a/tests/checkout_resolution.py
+++ b/tests/checkout_resolution.py
@@ -30,7 +30,9 @@ about the wrong thing.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import pathlib
 import os
 import sys
 
@@ -132,6 +134,74 @@ def require_local_resolution(module_name, root):
     return resolved
 
 
+def _imported_roots(path):
+    """Top-level module names imported by one file, at any scope.
+
+    Module scope is where an undeclared import aborts collection for the whole
+    package, but a function-scope import of a sibling escapes to the wrong tree
+    just as silently at runtime. Both are collected.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return ()
+    roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return tuple(roots)
+
+
+def _module_owners(packages_dir):
+    """Map every top-level module this repo provides to the package shipping it."""
+    owners = {}
+    if not os.path.isdir(packages_dir):
+        return owners
+    for entry in sorted(os.listdir(packages_dir)):
+        src = os.path.join(packages_dir, entry, "src")
+        for module_name in local_modules_under(src):
+            owners.setdefault(module_name, entry)
+    return owners
+
+
+def derive_required_siblings(package_dir, packages_dir):
+    """Which sibling packages this one's code actually imports.
+
+    DERIVED, never declared. A hand-maintained sibling list is a declaration
+    that drifts from reality with nothing to notice -- which is exactly how
+    ``siblings=()`` sat beside two real sibling imports while the guard stayed
+    green and 30 test modules resolved a stale worktree.
+
+    Transitive: a sibling's own sibling must be on the path too, or the import
+    that reaches it escapes just the same.
+    """
+    owners = _module_owners(packages_dir)
+    own_name = os.path.basename(package_dir)
+    required = {}
+    pending = [package_dir]
+    seen = {own_name}
+
+    while pending:
+        current = pending.pop()
+        for sub in ("tests", "src"):
+            root = os.path.join(current, sub)
+            if not os.path.isdir(root):
+                continue
+            for path in pathlib.Path(root).rglob("*.py"):
+                if any(part in {"__pycache__", ".venv", "build"} for part in path.parts):
+                    continue
+                for imported in _imported_roots(path):
+                    owner = owners.get(imported)
+                    if owner is None or owner in seen:
+                        continue
+                    seen.add(owner)
+                    required[owner] = imported
+                    pending.append(os.path.join(packages_dir, owner))
+    return required
+
+
 def pin_checkout(conftest_file, siblings=()):
     """Pin this package's sources (and declared siblings) to THIS checkout.
 
@@ -144,8 +214,12 @@ def pin_checkout(conftest_file, siblings=()):
     root = repo_root_from(conftest_file)
     packages_dir = os.path.dirname(package_dir)
 
+    # Derived first, so nothing depends on a declaration staying true.
+    # `siblings` remains only as an additive escape hatch for an import no
+    # static scan can see; it can no longer HIDE a sibling by being empty.
+    required = derive_required_siblings(package_dir, packages_dir)
     src_dirs = [os.path.join(package_dir, "src")]
-    for sibling in siblings:
+    for sibling in sorted(set(required) | set(siblings)):
         src_dirs.append(os.path.join(packages_dir, sibling, "src"))
 
     for entry in reversed(src_dirs):
@@ -156,4 +230,9 @@ def pin_checkout(conftest_file, siblings=()):
 
     for module_name in local_modules_under(src_dirs[0]):
         require_local_resolution(module_name, root)
+    # The positive assertion applies to siblings too. Importing one without an
+    # ImportError proves nothing when the defect is a SUCCESSFUL import of the
+    # wrong tree -- which is precisely what these 30 collection errors were.
+    for imported in sorted(required.values()):
+        require_local_resolution(imported, root)
     return root

--- a/tests/test_no_law_goes_unrun.py
+++ b/tests/test_no_law_goes_unrun.py
@@ -20,6 +20,12 @@ These are the teeth against that class:
        unfalsifiability it was written to remove -- so it is tested by
        provoking a real EACCES, not by inspection.
 
+    5. A package's SIBLINGS must be derived and proven too. A hand-written
+       sibling list is a declaration that drifts with nothing to notice:
+       ``siblings=()`` sat beside two real sibling imports while the
+       structural guard stayed green and 30 test modules resolved a stale
+       worktree. Derived, or it rots.
+
     4. Every package under test must PIN this checkout, and prove it. A
        package resolving to an editable install elsewhere does not fail -- it
        passes, reports coverage, and describes a tree nobody is editing. That
@@ -363,3 +369,90 @@ def test_the_resolution_guard_can_actually_fail():
 
     assert "resolved OUTSIDE this checkout" in message
     assert "fabricates" in message
+
+
+def test_sibling_requirements_are_derived_not_declared():
+    """A package that declares NO siblings must still have them derived.
+
+    This is the exact case that hid the defect: `pin_checkout(__file__,
+    siblings=())` satisfied the structural guard while two sibling packages
+    resolved ambiently, one of them to another worktree entirely. If derivation
+    ever stops seeing them, an empty declaration hides them again.
+    """
+    from checkout_resolution import derive_required_siblings
+
+    packages_dir = ROOT / "implementations" / "python"
+    package = packages_dir / "sugar-lift-py-tests"
+    conftest = (package / "tests" / "conftest.py").read_text(encoding="utf-8")
+    assert "siblings=()" in conftest, (
+        "this control is pinned to the package that declares NO siblings; if "
+        "that changed, point it at another empty-declaration package or the "
+        "regression it guards becomes invisible again"
+    )
+
+    derived = derive_required_siblings(str(package), str(packages_dir))
+    assert set(derived) >= {"sugar-lift-python-source", "sugar-source-tree"}, (
+        "derivation stopped seeing siblings this package imports; an empty "
+        f"`siblings=()` would hide them again. derived={derived}"
+    )
+
+
+def test_a_sibling_resolving_outside_the_checkout_FAILS(tmp_path):
+    """The positive assertion extended to siblings, and it must FAIL.
+
+    Absence of an ImportError proves nothing when the defect is a SUCCESSFUL
+    import of the wrong tree -- which is what those 30 errors were: one of them
+    named a source_oracle.py in another worktree. So the refusal is provoked,
+    and a degraded skip is caught explicitly rather than trusted.
+    """
+    from checkout_resolution import CheckoutResolutionEscaped, require_local_resolution
+
+    assert issubclass(CheckoutResolutionEscaped, AssertionError)
+    assert not issubclass(CheckoutResolutionEscaped, pytest.skip.Exception)
+
+    try:
+        # `json` stands for any sibling resolving outside the checkout root.
+        require_local_resolution("json", str(tmp_path))
+    except pytest.skip.Exception as skipped:
+        raise AssertionError(
+            f"sibling resolution degraded into a SKIP ({skipped!r}); a package "
+            "measuring another checkout would then report green"
+        ) from None
+    except CheckoutResolutionEscaped as refusal:
+        message = str(refusal)
+    else:
+        raise AssertionError(
+            "a module resolving OUTSIDE the root was accepted; the guard "
+            "cannot catch the defect it exists for"
+        )
+
+    assert "resolved OUTSIDE this checkout" in message
+
+
+def test_every_package_proves_its_derived_siblings_resolve_locally():
+    """Derivation must be wired into the pin, not merely available beside it."""
+    from checkout_resolution import derive_required_siblings
+
+    packages_dir = ROOT / "implementations" / "python"
+    packages = _packages_under_test()
+    assert packages, "no packages under test; this guard would be vacuous"
+
+    source = (TESTS / "checkout_resolution.py").read_text(encoding="utf-8")
+    assert "derive_required_siblings(package_dir, packages_dir)" in source, (
+        "pin_checkout no longer derives its siblings; an empty declaration "
+        "would silently stop pinning them again"
+    )
+
+    covered = 0
+    for package in packages:
+        derived = derive_required_siblings(str(package), str(packages_dir))
+        for sibling in derived:
+            assert (packages_dir / sibling / "src").is_dir(), (
+                f"{_rel(package)} derives sibling {sibling!r}, which has no "
+                "src/ in this checkout -- it could only resolve from elsewhere"
+            )
+            covered += 1
+    assert covered, (
+        "no package derived any sibling; either the repo genuinely has none "
+        "or derivation is broken, and this guard cannot tell the difference"
+    )

--- a/tests/test_no_law_goes_unrun.py
+++ b/tests/test_no_law_goes_unrun.py
@@ -47,6 +47,8 @@ from __future__ import annotations
 
 import ast
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -437,10 +439,31 @@ def test_every_package_proves_its_derived_siblings_resolve_locally():
     packages = _packages_under_test()
     assert packages, "no packages under test; this guard would be vacuous"
 
-    source = (TESTS / "checkout_resolution.py").read_text(encoding="utf-8")
-    assert "derive_required_siblings(package_dir, packages_dir)" in source, (
-        "pin_checkout no longer derives its siblings; an empty declaration "
-        "would silently stop pinning them again"
+    # BEHAVIOURAL, not a text match. An earlier version of this control
+    # asserted the source contained "derive_required_siblings(package_dir,
+    # packages_dir)" -- which also matches the function DEFINITION, so deleting
+    # the CALL left it green. Mutation caught it. Text presence is not evidence
+    # that a thing runs; run it.
+    package = packages_dir / "sugar-lift-py-tests"
+    sibling_src = str((packages_dir / "sugar-source-tree" / "src").resolve())
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, runpy;"
+            f"runpy.run_path({str(package / 'tests' / 'conftest.py')!r});"
+            "print(chr(10).join(sys.path))",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={**os.environ, "PYTHONPATH": ""},
+    )
+    assert probe.returncode == 0, f"conftest failed to load:\n{probe.stderr}"
+    assert sibling_src in probe.stdout.splitlines(), (
+        "loading a conftest that declares `siblings=()` did NOT put its derived "
+        f"sibling {sibling_src} on sys.path, so those imports resolve whatever "
+        f"install the machine has.\nsys.path was:\n{probe.stdout}"
     )
 
     covered = 0


### PR DESCRIPTION
Closes #6376. Finishes #6370.

#6370 proved a package's **own** modules resolve under this checkout and **never its siblings**, and `test_every_package_pins_its_own_checkout` could not tell `siblings=()` from a correct list — **a call that pins nothing satisfied it.**

`sugar-lift-py-tests` declared no siblings while importing two, so both resolved ambiently. Seventeen of the thirty errors named `/Users/tsavo/provekit-wt/fresh-main-20260701`: **the stale worktree survived the PR written to close it.**

## Derived, because a list rots

A hand-maintained sibling list is a declaration that drifts from reality with nothing to notice — the `cmMembranes` shape. So the set is **derived from the imports themselves**: both `tests/` and `src/`, at any scope, transitively, mapped against the top-level modules each in-repo package ships.

`siblings=` survives only as an additive escape hatch for an import no static scan can see. **It can no longer hide a sibling by being empty.**

```
derived for sugar-lift-py-tests:
  {"sugar-lift-python-source": "sugar_lift_python_source",
   "sugar-source-tree": "sugar_source_tree"}
```

The **positive assertion now covers siblings too**: each derived sibling must resolve *under this repo root*. Absence of an ImportError proves nothing when the defect is a successful import of the wrong tree — which is exactly what these errors were.

## Measured

| `sugar-lift-py-tests` | before | after |
|---|---|---|
| collection errors | **30** | **0** |
| tests collected | 1269 | **1559** (+290) |

**All 30 had one cause**, so nothing unrelated was folded in to make the number fall:

- 17 × `ImportError: cannot import name 'path_source' from 'sugar_lift_python_source.source_oracle'` — resolved from the stale worktree
- 13 × `ModuleNotFoundError: No module named 'sugar_source_tree'` — sibling never on the path

Every other package still collects. `sugar-typed-recognition`'s 2 errors are **unchanged and out of scope** — it imports `sugar_node_membrane`, deleted in #5953 (#6368, ruled retire).

## Mutation — each verified applied, then reverted, clean state confirmed

| mutation | result |
|---|---|
| derivation returns nothing (the `siblings=()` hiding case) | 2 controls fired |
| `pin_checkout` stops deriving, declaration only | **silent** → fixed, now fires |
| a sibling resolving outside the root is accepted | escape control fired |
| the escape raises a `pytest.skip` instead of failing | escape control fired |

### The second row is the finding

`test_every_package_proves_its_derived_siblings_resolve_locally` asserted the source contained `derive_required_siblings(package_dir, packages_dir)` — **a string that also matches the function definition.** Deleting the *call* left the control green, so a `pin_checkout` that had stopped deriving entirely would have passed.

It now **loads a conftest declaring `siblings=()` in a subprocess and asserts the derived sibling's `src` is actually on that process's `sys.path`.` Text presence is not evidence that a thing runs; run it.

That is the sixth control today whose claim was weaker than it read, and the sixth found only by mutating the mechanism it names rather than the code it touches.

## A measurement hazard worth recording

One mutation run hit a 2-minute timeout **between applying a mutation and reverting it**, leaving the tree mutated. The next run's "baseline" was silently that mutation, and reported a failure I briefly took for a real bug. Every mutation above is now verified present after applying and absent after reverting, with `git status` clean on both sides. **A stale mutation is indistinguishable from a discovery if you do not check.**

## Carried, still not absorbed

- **#6368** — typed-recognition, 26 laws unrun since #5953; ruled retire, separate brief.
- **`test_lift_coverage_harness.py`** — still unexecuted from #6362, needs a built `sugar` binary. **Different failure from these 30**, which needed only resolution.

Mac only. No binary build forced. Box untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive sibling package dependencies automatically instead of requiring manual declarations
> - Adds `derive_required_siblings()` in [checkout_resolution.py](https://github.com/TSavo/sugar/pull/6380/files#diff-e1f0dbba80697a5e9628c0973635f56ca4bd5f48de8fde59374821d04a9ca645) which walks a package's `src/` and `tests/` trees, extracts imported module roots via AST parsing, and resolves them transitively to sibling packages using a module-owner map.
> - Updates `pin_checkout` to use `derive_required_siblings()` to build `sys.path`, superseding empty manual `siblings=()` declarations, and asserts that all derived sibling modules resolve within the repo root.
> - Adds tests in [test_no_law_goes_unrun.py](https://github.com/TSavo/sugar/pull/6380/files#diff-a01ec47ab6fdebc36b330e163b3d816bb01a361378f13a4b033eec3b4d4d0fec) covering: derivation detects siblings despite `siblings=()`, out-of-repo resolution raises `CheckoutResolutionEscaped`, and conftest wiring uses derivation at runtime.
> - Behavioral Change: an empty `siblings=()` declaration no longer suppresses required siblings — derivation runs regardless and will fail hard if a sibling resolves outside the repo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 401ff1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->