### PR TITLE
docs: re-measure/pin ruling + Python frontier drain directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -845,3 +845,48 @@ the failing instrument should identify every illegal resident and describe the
 boundary, abstraction, visitor, typed result, deletion, or migration that will
 remove it. Fly by that red compiler/test signal until stable zero makes it
 silent.
+
+### Re-measurement and pins (decision of record)
+
+> Re-measurement may prove an owner already drained. It may not replace
+> unresolved semantic work with a pin.
+
+A pin is allowed only when it protects a **verified law** whose truthful and
+lying faces are already implemented. It must never accept a current failure
+count, preserve an incomplete result, or convert newly visible red into
+baseline debt.
+
+**Baseline receipt classification.** Every node is exactly one category:
+
+1. Previously enrolled, unchanged verdict.
+2. Previously enrolled, improved.
+3. Previously enrolled, **regressed**.
+4. Newly enrolled, passing.
+5. Newly enrolled, failing due to a **product semantic gap**.
+6. Newly enrolled, failing due to an **instrument/environment defect**.
+
+Act as follows:
+
+- **Category 3:** stop and fix forward immediately.
+- **Category 5:** enter the semantic drain ranked by authenticated owner mass.
+- **Category 6:** repair the instrument only far enough to expose the semantic
+  verdict, then return it to classification.
+- **Categories 1, 2, and 4:** no implementation.
+- **Never pin Categories 3, 5, or 6 as accepted red.**
+
+**Per ranked owner:**
+
+1. Reproduce its current occurrence count at the pinned commit.
+2. Determine whether the general law already exists.
+3. If it exists, prove all occurrences now construct/desugar correctly; add a
+   missing discrimination twin only if it can fail when the law is removed.
+4. If it does not exist, implement the general mechanism—not a name/site arm.
+5. Run truthful and lying twins.
+6. Re-measure the same owner.
+7. Accept the cut only if its residual reaches zero or every survivor is
+   reattributed to a different named owner.
+8. Confirm no other zero axis increases.
+
+Do not infer closure from shared ancestry. Re-measure. Historical mass already
+retired by a later law is recorded as `ΔR=0 at current baseline; historical N
+already retired by #PR`, not as another drain.

--- a/docs/ledgers/python-frontier-drain-directive-78714a798.md
+++ b/docs/ledgers/python-frontier-drain-directive-78714a798.md
@@ -1,0 +1,63 @@
+# Python frontier drain directive
+
+> The objective is to eliminate authenticated residuals, not preserve today’s board. Pins protect completed laws only. A red residual is work or reattribution—never a baseline to ratify.
+
+**Authority:** sole control-effect board
+`docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json` (commit `9a78828ee`,
+`R_desugar_construction_panics=502`) is a **historical receipt**. It is not a
+live work list. #6352/#6354 (demand SET) and #6381 (IfExp face twin) landed
+**after** that board.
+
+**Ruling (AGENTS.md — Re-measurement and pins):**
+
+- Re-measurement may prove an owner already drained. It may not replace
+  unresolved semantic work with a pin.
+- Pins protect completed laws (truthful + lying faces implemented) only.
+- Never pin Categories 3 / 5 / 6 as accepted red.
+- Baseline receipt: every node is exactly one of categories 1–6.
+
+## Historical owner mass (stale board — remeasure before drain)
+
+| N | owner | default disposition |
+|---|-------|---------------------|
+| 283 | `ContractConditionalConstructionV1.and_then` | **Re-measure.** Same law as #6354 demand SET. Do not infer closure from ancestry; do not pin survivors. |
+| 46 | `IfExpSugar._join` | **ΔR=0 at current baseline; historical 46 already retired by #6354.** Twin #6381 protects the face law. Not a drain. |
+| 41 | `collection ListValue` | Re-measure (demand SET family). |
+| 26 | `collection build` | Re-measure (demand SET family). |
+| 25 | `guarded` | Re-measure → drain general guarded law if live. |
+| 15 | `ground_index_error` | Re-measure → drain if live. |
+| 11 | `add` | Re-measure → drain operator floor if live. |
+| 8 | `bitwise_and` | Re-measure → drain if live. |
+| 7 | `GuardedValue._map(subscript)` | Re-measure → drain if live. |
+| 6 | `attribute` / `RuntimeEffect` / `multiply` | Re-measure → drain if live. |
+| 5 | `subtract` / `collection TupleValue` | Re-measure (TupleValue: demand SET family). |
+| ≤2 | bitwise_* / ground_* / truth / divide / unary_plus / dict.subscript / BlockValue.to_term | Re-measure → drain if live. |
+
+## Fleet lanes (non-overlapping)
+
+| Lane | Mission | Do not |
+|------|---------|--------|
+| **L0** | Live remeasure of all 502 historical desugarConstructionPanic sites at HEAD. Emit `docs/ledgers/python-desugar-panic-remeasure-<commit>.json` with per-row category 1–6. Rank live Category-5 owners by mass. | Do not implement product fixes. Do not pin red. |
+| **L1** | Demand-SET family confirmation only: `and_then` + collection ListValue/build/TupleValue. Report zeros or survivor list. | Do not re-widen the carrier if live residual is a different owner. |
+| **L2** | IfExp close-out receipt only: record `ΔR=0; historical 46 retired by #6354`; verify #6381 twins; no drain PR. | Do not open a "drain IfExp" PR. |
+| **L3** | First live Category-5 owner after L0 rank (expected candidates: `guarded`, `ground_index_error`, or arithmetic). General law + truthful/lying twins + remeasure to zero. | No name/site arms. No pin of residual. |
+| **L4** | Second live Category-5 owner (same bar as L3). | Same. |
+
+After L0 lands, re-rank and redispatch L3/L4 if the live mass differs from historical.
+
+## Per-owner cut (when draining)
+
+1. Reproduce occurrence count at the pin commit.
+2. Does the general law already exist?
+3. If yes: prove all occurrences construct/desugar; discrimination twin only if removing the law fails it.
+4. If no: implement the general mechanism—not a name/site arm.
+5. Truthful + lying twins.
+6. Re-measure the same owner.
+7. Accept only if residual is zero or every survivor is reattributed to a **different named owner**.
+8. Confirm no other zero axis increases.
+
+## Out of scope for this directive
+
+- Full 1,421-file timeout census (separate hangsafe track).
+- Assertion/resource With drain until desugar-panic stableZero terms for enrolled axes are honest.
+- Pinning any live Category-5 count as “baseline debt.”

--- a/docs/superpowers/HANDOFF.md
+++ b/docs/superpowers/HANDOFF.md
@@ -38,6 +38,8 @@ ToolSearch if deferred. Model is gpt-5.5 xhigh (their default).
 
 **Briefs must be COMPLETE and INLINE** (memory: `$(cat file)` does NOT survive the MCP boundary —
 paste the whole thing). Every brief contains, in order:
+- **Required sentence (every fleet brief, verbatim):**
+  > The objective is to eliminate authenticated residuals, not preserve today’s board. Pins protect completed laws only. A red residual is work or reattribution—never a baseline to ratify.
 - Reality sync: "PR #N merged, #issue closed" — spiky workers lose track; tell them where they are.
 - Exact worktree path + branch + "verify with git rev-parse --show-toplevel".
 - The doctrine (why this is a crime, one paragraph) — orientation they can't be assumed to hold.
@@ -49,6 +51,11 @@ paste the whole thing). Every brief contains, in order:
 - A "Do NOT" list fencing scope (workers wander into adjacent files and other agents' worktrees).
 - The recurring gotchas: "never touch files you did not edit in /Users/tsavo/provekit (it holds
   T's pre-existing dirty state); gh 403 = wait ~10min, retry, don't spin."
+- **Pin law:** re-measurement may prove an owner already drained; it may not replace unresolved
+  semantic work with a pin. Pins protect verified laws (truthful + lying faces already
+  implemented) only. Never pin Categories 3/5/6 (regressed / product gap / instrument defect)
+  as accepted red. Full classification + per-owner drain steps: repo-root `AGENTS.md`
+  ("Re-measurement and pins").
 
 **Worktrees**: one per issue, `git worktree add ~/provekit-wt/<name> origin/main -b codex/<name>`.
 Workers self-PR now (they own commit/push/gh pr create). You merge + delete worktree + redispatch.


### PR DESCRIPTION
## Summary

Codify T's re-measurement / pin ruling and stand up the Python desugar-panic frontier drain under it.

- **AGENTS.md:** six-category baseline classification; pins only for completed laws; per-owner cut steps.
- **HANDOFF:** every fleet brief must include the objective sentence.
- **Directive ledger:** historical 502-owner mass from `9a78828ee`, remeasure-first lanes L0–L4.
- **Epic:** #6382

## Hard law

> The objective is to eliminate authenticated residuals, not preserve today’s board. Pins protect completed laws only. A red residual is work or reattribution—never a baseline to ratify.

## Notes

- IfExp historical 46: record as `ΔR=0 at current baseline; historical 46 already retired by #6354` — not a drain (#6381 twin).
- Suspected 283 `and_then`: remeasure; never pin; never infer from ancestry.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add re-measurement and pin ruling docs for the Python frontier drain directive
> - Adds a 'Re-measurement and pins' section to [AGENTS.md](https://github.com/TSavo/sugar/pull/6383/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) that defines when pins are allowed (only to protect a verified law with truthful and lying faces), introduces a six-category baseline receipt classification, and prescribes a per-owner 8-step drain process.
> - Adds [docs/ledgers/python-frontier-drain-directive-78714a798.md](https://github.com/TSavo/sugar/pull/6383/files#diff-096061de09e0720cd57dd32ccccce12272d97309d974463060a25d81167cc527) as the canonical directive for eliminating authenticated Python residuals, including a historical owner mass table, fleet lanes L0–L4, and the per-owner cut process.
> - Updates [docs/superpowers/HANDOFF.md](https://github.com/TSavo/sugar/pull/6383/files#diff-e7da03646196602bd11d348271adca0ad54898c6b024205c041fd3165a3417d2) to require a verbatim pin-policy sentence in every fleet brief and adds a 'Pin law' bullet prohibiting pins for Categories 3/5/6.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63c30cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for classifying baseline measurement results and handling regressions, newly detected failures, and environmental issues.
  - Documented when measurements may be pinned or re-measured, including requirements for verifying both truthful and lying cases.
  - Added operational procedures for tracking residual issues, assigning ownership, and recording historical results.
  - Updated handoff instructions with required briefing language and pinning constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->