### PR TITLE
The delete verb carries the same authenticated loop.exit family the read verb already carries

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
@@ -12,6 +12,7 @@ from sugar_lift_py_tests.sugar.binding_projection import (
     LoopGuardedProjection,
     UnboundProjection,
 )
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import _loop_exit_faces
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 
@@ -52,11 +53,17 @@ def delete_binding(state, *, name: str, site, ctx) -> ExitSet:
         # `del` is the other verb over the SAME projection, and it simply had no
         # arm for this constructor -- which is what
         # `TypeError: LoopGuardedProjection` was.
+        partition_faces = _loop_exit_faces(state)
         exits = ExitSet(())
         for face in state.completed_faces:
             exits = exits.union(
                 delete_binding(face.state, name=name, site=site, ctx=ctx).guarded(
-                    face.guard_formula
+                    face.guard_formula,
+                    (
+                        None
+                        if partition_faces is None
+                        else partition_faces[face.completion_kind]
+                    ),
                 )
             )
         return exits.normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
@@ -54,7 +54,9 @@ from sugar_lift_py_tests.outcome.exit_set import (
 from sugar_lift_py_tests.sugar.binding_projection import (
     LoopGuardedCompletedFace,
     LoopGuardedProjection,
+    UnboundProjection,
 )
+from sugar_lift_py_tests.sugar.delete_name_sugar import delete_binding
 from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import _loop_exit_faces
 
 # The shape of `pandas/core/methods/selectn.py:224`: a name carried across a
@@ -150,6 +152,57 @@ def test_the_carrier_is_the_loop_projection_read(tmp_path):
         assert {face.partition for face in faces.values()} == {
             ("sugar.exit_set.partition", ("loop.exit", projection.target_cid))
         }
+
+
+def test_delete_uses_the_same_authenticated_loop_exit_family():
+    """The delete verb stamps the same producer-owned faces as the read verb."""
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.ir import atomic
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+    @dataclass(frozen=True)
+    class _Site:
+        filename: str = "loop-delete-twin.py"
+        line: int = 1
+        col: int = 0
+
+    class _BoundState(Sugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            raise AssertionError("delete_binding must not reduce a bound face")
+
+    site = _Site()
+    projection = _projection(
+        [
+            LoopGuardedCompletedFace(
+                "BreakExit", atomic("b", []), _BoundState(), 2
+            ),
+            LoopGuardedCompletedFace(
+                "NormalExhaustion",
+                atomic("n", []),
+                UnboundProjection("value", site),
+                2,
+            ),
+        ]
+    )
+
+    exits = delete_binding(projection, name="value", site=site, ctx=None)
+
+    assert {type(exit_).__name__ for exit_ in exits.exits} == {
+        "Completed",
+        "Halted",
+    }
+    assert {next(iter(exit_.faces)).side for exit_ in exits.exits} == {
+        "BreakExit",
+        "NormalExhaustion",
+    }
+    assert {next(iter(exit_.faces)).partition for exit_ in exits.exits} == {
+        ("sugar.exit_set.partition", ("loop.exit", projection.target_cid))
+    }
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
#6375 threaded loop-exit partition testimony through the **read** verb. `delete_name_sugar.py` was left untouched, so main carried read/delete asymmetry on exactly the projection whose original defect was `TypeError: LoopGuardedProjection` — `del` having no arm where `read` had one all along.

This closes that. `delete_binding` reuses main's `_loop_exit_faces` — one law, two callers, no reimplementation — including the `("loop.exit", target_cid)` owner, the arity admission, the `BodyFallthrough` refusal, and the no-target/no-family route.

## The tooth is load-bearing

`test_delete_uses_the_same_authenticated_loop_exit_family` asserts both arms carry faces from one authenticated family:

```python
assert {next(iter(exit_.faces)).side for exit_ in exits.exits} == {"BreakExit", "NormalExhaustion"}
assert {next(iter(exit_.faces)).partition for exit_ in exits.exits} == {
    ("sugar.exit_set.partition", ("loop.exit", projection.target_cid))
}
```

Remove the delete-side mint and `faces` is empty, so `next(iter(...))` raises `StopIteration` and the node goes red. It also asserts one `Completed` **and** one `Halted` arm, proving the testimony survives the effect conversion rather than only riding a completed face.

## This is a law, not a drain

Measured at base `78714a798`, head `2fc5919ee`, corpus `pandas 3.0.3`, instrument `scripts/stablezero_classify.py`:

| file | denom base/head | `R(factoring_gaps)` base/head | remaining work base/head |
|---|---|---|---|
| `core/indexing.py` | 83 / 83 | 0 / 0 | 0 / 0 |
| `core/methods/selectn.py` | 9 / 9 | 0 / 0 | 0 / 0 |

Both rows were **already closed by #6375** on the pinned base. Under the classification protocol they are **Category 2 — previously enrolled, improved before this branch**, not Category 5 drained by it. Claiming a `1 -> 0` here would be false and is not claimed.

Step 8: no zero axis rose. `R(timeout)`, `R(factoring_gaps)`, `R(factoring_gaps_remaining_work)`, `R(unnamed_exceptions)` all zero on both files, both sides. Existing `R(construction_panics)=1` rows stay `1 -> 1`, not hidden or reclassified.

Load during the run: `19.22 / 17.55 / 16.06` before base, `19.99 / 17.87 / 16.20` after head.

## Declared coupling

`_loop_exit_faces` is private to `guarded_binding_read_sugar` and imported across the module boundary. Promoting it to `binding_projection.py` is more than a one-line move — its partition dependencies live with the read implementation — so it is left in place and declared here rather than discovered later. The parity tooth would fail loudly on a rename.

Measured and written by Bumble; diff, tooth-failure check, and instrument provenance verified independently by Fizz.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply authenticated loop exit family to `delete_binding` over `LoopGuardedProjection`
> - Updates [`delete_name_sugar.py`](https://github.com/TSavo/sugar/pull/6384/files#diff-93a5ffbb2b078a311327a1d0598ffa094308c47fc2f9e2b741e3b64a944096f4) so that when deleting a name over a `LoopGuardedProjection`, each guarded exit passes the partition from `_loop_exit_faces` keyed by `completion_kind`, matching the behavior already present in the read verb.
> - Adds a test in [`test_loop_exit_partition_carrier.py`](https://github.com/TSavo/sugar/pull/6384/files#diff-25e0b71583cab3c158e2b837b617149bfba6c10c3b1e50901e3e21eada8b1e46) covering a `LoopGuardedProjection` with both `BreakExit` and `NormalExhaustion` faces to verify the partitioned exits align with the read behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fc5919.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->