### PR TITLE
Yield ownership tests both constructors of the suspension boundary (yield-family owed-work classification)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2051,10 +2051,21 @@ class FunctionDef(Statement):
 
     @staticmethod
     def _owns_yield(body) -> bool:
+        """Does this body own a suspension boundary of its own?
+
+        `Yield` and `YieldFrom` are the two constructors of that boundary, so
+        ownership tests BOTH. Recognizing only `Yield` made a `yield from`-only
+        function construct an ordinary eager call frame: the call completed as
+        a plain `CallSiteValue` instead of allocating a generator, and the
+        boundary's refusal only surfaced later if the body happened to be
+        forced. One constructor recognized and the other not is what let a
+        suspension escape as an ordinary value.
+        """
+
         def visit(node) -> bool:
             if isinstance(node, (FunctionDef, AsyncFunctionDef, Lambda)):
                 return False
-            if isinstance(node, Yield):
+            if isinstance(node, (Yield, YieldFrom)):
                 return True
             for field in getattr(node, "_child_fields", ()):
                 value = getattr(node, field)
@@ -2067,7 +2078,8 @@ class FunctionDef(Statement):
             return False
 
         return any(
-            isinstance(statement, Yield) or visit(statement) for statement in body
+            isinstance(statement, (Yield, YieldFrom)) or visit(statement)
+            for statement in body
         )
 
     def _make_coordinate_ref(self, param: "Param", coordinate) -> "Node":

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -17,6 +17,7 @@ from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.generator_construction import (
     GeneratorConstructionV1,
     GeneratorTerminationV1,
+    GeneratorTransitionGapV1,
     YieldEffect,
 )
 from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
@@ -215,3 +216,93 @@ def test_class_body_assign_of_free_call_is_opaque_dig_cue() -> None:
     field = next(f for f in value.class_fields if f.name == "state")
     assert field.value.term.name == "call:make_state"
     assert field.value.body is None
+
+
+def test_yield_from_only_function_allocates_a_generator_not_an_eager_call() -> None:
+    """TRUTHFUL FACE: `yield from` owns the suspension boundary just as `yield` does.
+
+    Ownership recognized only `Yield`, so a `yield from`-only function built an
+    ordinary eager call frame: the call completed as a plain `CallSiteValue`
+    and the boundary escaped as an ordinary value. Both constructors of the
+    boundary must make the function a generator.
+    """
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "def arbitrarily_renamed():\n"
+        "    yield from (1, 2)\n"
+        "    return 9\n\n"
+        "arbitrarily_renamed()\n",
+        context=context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    frame = function.source_visible_call_frame()
+    context.source_call_frames[_coordinate(call)] = frame
+
+    assert frame.generator_steps is not None
+
+    outcome = call.sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, GeneratorConstructionV1)
+    assert not isinstance(outcome.value, CallSiteValue)
+
+
+def test_yield_from_delegation_stays_a_typed_gap_and_is_never_invented() -> None:
+    """LYING FACE: recognizing the boundary must not fabricate delegated iteration.
+
+    Owning the boundary is exactly what the recognition fix buys; it does NOT
+    buy `yield from`'s delegation protocol. Resuming names
+    `GeneratorConstructionV1.transition` as the owner that still owes it, so
+    the debt is loud and attributed rather than silently discharged as a
+    yielded value or a termination.
+    """
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "def arbitrarily_renamed():\n"
+        "    yield from (1, 2)\n"
+        "    return 9\n\n"
+        "arbitrarily_renamed()\n",
+        context=context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
+
+    machine = call.sugar().desugar().value
+    transition = machine.resume()
+
+    assert isinstance(transition, GeneratorTransitionGapV1)
+    assert transition.owner == "GeneratorConstructionV1.transition"
+    assert transition.requested == "resume"
+    assert not isinstance(transition, YieldEffect)
+    assert not isinstance(transition, GeneratorTerminationV1)
+
+
+def test_census_door_refuses_both_yield_constructors_with_no_call_site() -> None:
+    """CLASSIFICATION PIN: the census door's yield refusals are accounted semantics.
+
+    `functions() -> sugar -> desugar` reduces a function body with no call, so
+    no call frame and therefore no generator instance can exist. Only
+    `GeneratorConstructionV1` may consume a suspension boundary, so BOTH
+    constructors must refuse here — permanently, for every implementation of
+    the generator machine. These occurrences are correct output, not owed work,
+    and no fix at any layer drains them.
+    """
+    from sugar_source_tree.panic import SugarNotWritten
+
+    for body, owner in (
+        ("    yield 7\n    return 9\n", "YieldSuspensionSugar.desugar"),
+        ("    yield from (1, 2)\n    return 9\n", "YieldFromSugar.desugar"),
+    ):
+        source = _source_file("def arbitrarily_renamed():\n" + body)
+        function = next(
+            node for node in source.nodes() if isinstance(node, FunctionDef)
+        )
+        sugar = function.sugar()
+        try:
+            sugar.desugar(None)
+        except SugarNotWritten as refusal:
+            assert refusal.owner == owner
+        else:
+            raise AssertionError(f"{owner} must refuse under the census door")


### PR DESCRIPTION
## Verdict first: 46 of the 48 targeted rows are **not** owed work

The brief targeted `YieldSuspensionSugar.desugar` and `YieldFromSugar.desugar` as **category 2 (explicit incomplete obligations)**. They are **category 1 (accounted semantics)**, and no fix at any layer drains them.

At the pin (`9a78828ee`, `docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json`) the counts reproduce as `YieldSuspensionSugar.desugar` **29** and `YieldFromSugar.desugar` **17** (the brief said 31/17; the suspension figure is 29).

The census door is `enum:path_source→SourceFile→functions→sugar→desugar`. It desugars each function's **own** sugar. There is no call, therefore no `SourceVisibleCallFrameV1`, therefore no generator instance can exist — and only `GeneratorConstructionV1` may consume a suspension boundary. So under this door both constructors **must** refuse, permanently, for every possible implementation of the generator machine. Measured directly, with no call site:

```
plain yield generator, census door   -> SugarNotWritten YieldSuspensionSugar.desugar
yield from generator, census door    -> SugarNotWritten YieldFromSugar.desugar
```

This is correct output at the owner that holds the meaning. Reattribution: **category 2 → category 1**, 46 rows. `control_effect_recensus.py`'s own docstring already states this (#6243); it was the drain target that had drifted, not the code. **ΔR = 0 and must be 0.** The third twin below pins the classification so it cannot silently drift back.

## The real defect the drain target was hiding

Chasing the classification surfaced a genuine bug the census door **cannot see**, because it lives at the call door.

`FunctionDef._owns_yield` recognized `Yield` but not `YieldFrom`. A `yield from`-only function was therefore **not a generator at all**:

```
yield from only   generator_steps: None    outcome: Complete CallSiteValue   <- silent wrong answer
```

Calling it built an ordinary eager call frame and completed as a plain `CallSiteValue`. The suspension escaped as an ordinary value; the boundary's refusal surfaced only later, and only if the body happened to be forced. Meanwhile the *mixed* case (`yield` beside `yield from`) was recognized correctly — so one constructor of the boundary was recognized and the other was not, and the two shapes disagreed.

Ownership now tests both constructors. After:

```
yield from only   generator_steps: (OpaqueStepV1('Expr'), ReturnStepV1(...))
                  outcome: Complete GeneratorConstructionV1
                  resume() -> GeneratorTransitionGapV1(owner='GeneratorConstructionV1.transition')
```

**This buys ownership, not delegation.** Step construction stays deliberately narrow — only a bare `yield v` statement becomes a `YieldStepV1` — so a `yield from` step lands as `OpaqueStepV1` and resuming returns a typed `GeneratorTransitionGapV1` naming `GeneratorConstructionV1.transition` as the owner that still owes the delegation protocol. Widening the step builder would have invented generator-protocol behaviour at the wrong layer, which is exactly what the refusal exists to prevent. A silent wrong answer becomes a loud, attributed debt.

General mechanism, not a name arm: the change is to the structural ownership predicate over node types, and all three tree backends (parso, libcst, tree-sitter) already emit `YieldFrom` distinctly, so recognition is backend-uniform.

## Twins

| test | face | mutation it bites |
|---|---|---|
| `test_yield_from_only_function_allocates_a_generator_not_an_eager_call` | truthful | ownership reverted to `(Yield,)` |
| `test_yield_from_delegation_stays_a_typed_gap_and_is_never_invented` | lying | ownership reverted to `(Yield,)` |
| `test_census_door_refuses_both_yield_constructors_with_no_call_site` | classification pin | `YieldFromSugar.desugar` discharging instead of refusing |

Both mutations run as transactions: clean before, mutation verified present, test bites, revert verified, clean after.

- **Mutation 1** (ownership → `(Yield,)`): `2 failed, 7 passed`. The classification pin correctly survives — it pins a different law.
- **Mutation 2** (`YieldFromSugar.desugar` returns `Complete(self.value)` instead of refusing): `1 failed, 8 passed` — only the classification pin bites.
- Rollback verified after each; suite clean again at `9 passed`.

## Measurement

Baseline and head both at base `e0350dc43`, `sugar-source-tree` suite:

```
baseline: 1 failed, 681 passed, 5 skipped
head:     1 failed, 684 passed, 5 skipped
```

Failure sets are **identical**: `test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling` (`test_with_partition_shared_algebra.py:795`) fails on both sides — inherited red in the With/router area, untouched by this change. Head is +3 passed, exactly the three new twins. No new failures.

`R_generator_construction = 0 (discovered=4, completed=4)` — unchanged, no other zero axis increases.

**Site coverage and ΔR, reported separately:**
- **ΔR on the pandas board: 0**, and correctly so — the 46 rows are accounted semantics, reattributed from category 2 to category 1, not drained.
- **Site coverage:** the `yield from` ownership defect is fixed at the general predicate, so it covers every `yield from`-only function in any corpus on any backend. This defect never appeared on the board at all, because the census door cannot reach it.

## Not done / next owner

`yield from`'s delegation protocol is still owed, and is now loud and attributed: `GeneratorConstructionV1.transition`. Same for `received = yield v` (`OpaqueStepV1('Assign')`). Both were already gaps before this change; this PR does not widen or narrow them, it only stops a `yield from`-only function from bypassing the machine entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify `YieldFrom` as a suspension boundary in `FunctionDef._owns_yield`
> - `FunctionDef._owns_yield` previously only recognized `Yield` nodes; functions with only `yield from` in their body were incorrectly treated as eager calls instead of generators.
> - Both the AST visitor and the top-level body scan in [nodes.py](https://github.com/TSavo/sugar/pull/6385/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now return `True` for `YieldFrom` nodes.
> - New tests cover: generator frame allocation for `yield from`-only functions, delegation producing `GeneratorTransitionGapV1`, and census-door rejection of both `yield` and `yield from` without a call site.
> - Behavioral Change: functions whose bodies contain only `yield from` now produce a `GeneratorConstructionV1` outcome instead of a `CallSiteValue`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d1af4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->