### PR TITLE
docs: stop measurement campaign — build Python from reproducers

### DIFF
--- a/docs/ledgers/python-build-not-measure-directive.md
+++ b/docs/ledgers/python-build-not-measure-directive.md
@@ -1,0 +1,59 @@
+# Python: build, do not measure (operating rule)
+
+> Stop measuring the frontier. Build it. Continue current semantic
+> implementations from concrete reproducers. Required gate is a truthful twin,
+> lying twin, focused tests, and preserved crash/timeout zeros. No new census,
+> scoreboard, receipt, classification, or pin-only work. Merge working general
+> mechanisms continuously. Re-measure only after the assertion-With milestone,
+> resource-With milestone, or final closure.
+
+**Rule:** Build the general missing mechanism from a concrete reproducer.
+Measure only afterward to attribute the gain.
+
+## Why
+
+- Unauthenticated measurement was yesterday’s mistake.
+- Solving that with more measurement was today’s.
+- Both stop. Construct Python.
+
+## Dependency order
+
+1. Authenticated partition / factoring propagation (finish; correct refusals stay loud).
+2. assertion-With over factored ExitSet.
+3. resource-With over the same algebra.
+4. Remaining desugar Floor implementations.
+5. Remaining binding/control defects.
+
+## Per implementation gate
+
+1. One real reproducer.
+2. One truthful twin.
+3. One lying twin.
+4. Focused owning-package tests.
+5. No increase in known crash/timeout axes.
+
+Merge when that evidence passes. **Do not wait for a corpus sweep.**
+
+## Census schedule (only)
+
+- After assertion-With milestone.
+- After resource-With milestone.
+- Final closure.
+
+Not between cuts.
+
+## Pins
+
+Pins are not work. A pin may accompany implemented semantics. Nobody is assigned
+merely to produce a pin.
+
+## Factoring sites
+
+Governing law is known. Finish authenticated partition propagation. If a
+concrete site is correctly refused, skip it. If the producer owns complementary
+partition evidence, wire it. No corpus-wide reconciliation first.
+
+## Supersedes
+
+Measurement-first fleet epic #6382 lanes (L0–L4 remeasure/receipt/classification)
+are **stopped**. Build lanes replace them.

--- a/docs/superpowers/HANDOFF.md
+++ b/docs/superpowers/HANDOFF.md
@@ -38,7 +38,14 @@ ToolSearch if deferred. Model is gpt-5.5 xhigh (their default).
 
 **Briefs must be COMPLETE and INLINE** (memory: `$(cat file)` does NOT survive the MCP boundary —
 paste the whole thing). Every brief contains, in order:
-- **Required sentence (every fleet brief, verbatim):**
+- 
+**Build mode (2026-07-26):** Stop measuring the frontier. Build it. Gate =
+truthful twin + lying twin + focused tests + crash/timeout zeros preserved.
+No new census/scoreboard/receipt/classification/pin-only work. Re-measure only
+after assertion-With, resource-With, or final closure. See
+`docs/ledgers/python-build-not-measure-directive.md`.
+
+**Required sentence (every fleet brief, verbatim):**
   > The objective is to eliminate authenticated residuals, not preserve today’s board. Pins protect completed laws only. A red residual is work or reattribution—never a baseline to ratify.
 - Reality sync: "PR #N merged, #issue closed" — spiky workers lose track; tell them where they are.
 - Exact worktree path + branch + "verify with git rev-parse --show-toplevel".


### PR DESCRIPTION
## Summary

Codify the operating rule change:

> Stop measuring the frontier. Build it. … Re-measure only after the assertion-With milestone, resource-With milestone, or final closure.

- `docs/ledgers/python-build-not-measure-directive.md`
- HANDOFF build-mode pointer

Supersedes measurement-first epic #6382 lanes. Construct Python.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "build, do not measure" directive for Python work
> Establishes a new operating rule that stops measurement-first workflows and requires building from reproducers instead.
>
> - [python-build-not-measure-directive.md](https://github.com/TSavo/sugar/pull/6386/files#diff-d80f13e8cd74916c4d028be1fe9c2450d0dc4bdf7598bf251c8bf2694c2476e1) defines the rule with per-implementation gates: real reproducer, truthful twin, lying twin, focused tests, and no new crash/timeout axes.
> - [HANDOFF.md](https://github.com/TSavo/sugar/pull/6386/files#diff-e7da03646196602bd11d348271adca0ad54898c6b024205c041fd3165a3417d2) adds a "Build mode (2026-07-26)" block at the top of the briefs section, listing gates and re-measurement conditions, and references the new directive.
> - The directive explicitly supersedes measurement-first lanes and includes guidance on pins, factoring, and partition propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d410d6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->