### PR TITLE
All 13 factoring gaps classified: 1 closed, 12 correct output, 0 remaining work — plus the unpinned merge half that decides 11 of them

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
@@ -180,6 +180,45 @@ def test_disjoining_merge_keeps_only_testimony_both_arms_carried():
     assert merged.exits[0].faces == frozenset()
 
 
+def test_a_merge_whose_arms_agree_KEEPS_the_face_they_share():
+    """The other half of the intersection law, and it was unpinned.
+
+    The rule is `prior.faces & exit_.faces` -- keep exactly what BOTH
+    contributors carried. The twin above pins only the case where they carry
+    DIFFERENT faces, where the intersection is empty. That case is also what
+    "clear the stamps when merging" describes, and the two readings are not the
+    same rule: `frozenset()` and `&` agree on disagreeing arms and disagree
+    here. A merge of two arms that lie on the SAME side of one split is still
+    entirely on that side, and the testimony survives.
+
+    THIS IS THE STEP `merged_arm` RESTS ON. `FactoringGapClassification`
+    declares an `UNSTAMPED` gap with `merged_arm=True` to be correct output
+    rather than remaining work, on the reasoning that a face minted by wiring
+    the producer "would be minted and then intersected away". That is true
+    exactly when the merge's contributors would receive DIFFERENT faces. This
+    arm exhibits the shape where it is false -- same face, face survives -- so
+    the reasoning is a prediction about which shape a given site has, not a
+    theorem about merges. Losing this half would make the prediction look
+    unconditional, which is why it needs its own red.
+    """
+    condition = _pred("c")
+    one_side, _other_side = partition(("merge-owner", condition))
+
+    merged = ExitSet(
+        (
+            Completed(condition, "same", frozenset({one_side})),
+            Completed(_pred("q"), "same", frozenset({one_side})),
+        )
+    ).normalize()
+
+    assert len(merged.exits) == 1
+    assert merged.exits[0].faces == frozenset({one_side}), (
+        "a merge of two arms on the SAME side of one split dropped the face "
+        "they both carried: the rule is intersection, not clearing"
+    )
+    assert getattr(merged.exits[0].guard, "kind", None) == "or"
+
+
 def test_conjoining_composition_accumulates_both_arms_testimony():
     """``sequence`` conjoins guards, so the result carries both face sets."""
     condition = _pred("c")


### PR DESCRIPTION
## RE-MEASURED FIRST

Rig: the committed `scripts/stablezero_classify.py` (#6364), isolated per file,
at `e0350dc43`, over the 10 files carrying the pinned ledger's 13
`ExitSetFactoringGap` rows. Corpus pandas 3.0.3, aggregateHash
`bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c` — identical
to `9a78828ee`'s `corpusPin`.

```
R(factoring_gaps)                13 -> 12
R(factoring_gaps_remaining_work)  0 ->  0
```

Every ledger row reproduced at its exact line and owner pair, so the isolated
rig and the corpus run agree on this slice.

## THE CLASSIFICATION

| site | kind | merged | owners | verdict |
|---|---|---|---|---|
| `core/arrays/datetimelike.py:1397` | unstamped | yes | CallSiteValue/CallSiteValue | correct output |
| `core/arrays/datetimelike.py:1461` | unstamped | yes | CallSiteValue/CallSiteValue | correct output |
| `core/generic.py:13403` | unstamped | yes | SymbolicValue/StringValue | correct output |
| `core/groupby/groupby.py:4829` | unstamped | yes | CallSiteValue/GuardedValue | correct output |
| `core/methods/selectn.py:224` | — | — | — | **CLOSED** (#6375) |
| `io/excel/_openpyxl.py:445` | unstamped | yes | CallSiteValue/CallSiteValue | correct output |
| `io/formats/style.py:4259` | **stamped-not-separating** | yes | CallSiteValue/CallSiteValue | correct output |
| `tests/dtypes/cast/test_box_unbox.py:50` | unstamped | yes | TermValue/ComplexValue | correct output |
| `tests/extension/test_arrow.py:172` | unstamped | yes | TermValue/TermValue | correct output |
| `tests/extension/test_masked.py:312` | unstamped | yes | SymbolicValue/SymbolicValue | correct output |
| `tests/groupby/test_categorical.py:2000/:2036/:2072` | unstamped | yes | ListValue/ListValue | correct output ×3 |

**Every surviving row carries `merged_arm=True`.** Not one has an unmerged arm.
The 12 are one shape, not twelve findings. The 12-file sample's 2-of-8 work
split does **not** hold here — it is 0-of-12.

`style.py:4259` is the only stamped row, and its testimony is exact: both arms
carry ONE identical `PartitionFace` from an `IfExpSugar` split, both
`side=True`. Same side is not an exclusion — the split that did testify says
nothing about how these two arms differ.

## NO AXIS ROSE

Every construction panic and unnamed exception on the 10 files is a pre-existing
ledger row at the same line: `selectn:106` (`subtract`), `groupby:5506`
(`ground_index_error`), `style:2412` (`add`), `openpyxl:614` (`AttributeError`).
`io/formats/style.py` **fell** 6 panics → 1 over the same interval, the five
closed being the `ContractConditionalConstructionV1` / `IfExpSugar._join` family
retired by #6354.

## THE WRITTEN REFUTATION, AND THE ONE TEST THIS ADDS

`FactoringGapClassification` calls an `UNSTAMPED` gap with `merged_arm=True`
correct output on the reasoning that a face minted by wiring the producer
"would be minted and then intersected away". That step decides **11 of the 12
rows**, and it rests entirely on `prior.faces & exit_.faces` in `normalize`.

Only half of that rule was pinned.
`test_disjoining_merge_keeps_only_testimony_both_arms_carried` drives arms
carrying **different** faces, where the intersection is empty — which is also
exactly what "clear the stamps when merging" (the phrasing in `normalize`'s own
comment) would produce. The two readings agree there and disagree when the
contributors carry the **same** face. Nothing tested that case.

Measured: **a merge whose arms agree KEEPS the shared face.** So "wiring cannot
help" is a prediction about which shape a given site has, not a theorem about
merges.

This changes **no row verdict** — no producer owning a split was identified at
any of the 12 — but it changes what the term means: `R(factoring_gaps_remaining_work) = 0`
reads *"no row is known to be closable"*, never *"no row is closable"*.

## PERTURBED — the two arms are complementary, not redundant

| mutation of `normalize`'s completed merge | fires |
|---|---|
| faces **cleared** instead of intersected | **only the new arm** (pre-existing stays green) |
| faces **unioned** instead of intersected | **only the pre-existing arm** |

## FILES CHANGED

- `implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py` (+1 arm)

Test only. No mechanism change. Nothing weakens `factor_completed`'s refusal,
teaches `_are_exclusive` about disjunctions, or touches #6311's identity memo.
No `remaining_work` row is pinned — there are none.

## HARNESS NOTE

This kit's conftest gates every test on a release `sugarbin` this box is not
permitted to build, so the assertions were executed through the same imports
without pytest: 12/12 partition-testimony arms, 14/14 family-admission arms
(including the mandatory `test_appending_factors_grows_linearly`), 11/11
classifier arms — 0 failed. The pytest run itself is unmeasured here, not green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test asserting face intersection semantics are preserved when merging agreeing `ExitSet` arms
> Adds a pytest test in [test_exit_set_partition_testimony.py](https://github.com/TSavo/sugar/pull/6387/files#diff-66fdebe7dc08fccb94fa2cf04a7fcb66a36df9a8489fc1420a37149a6ef87698) that verifies `ExitSet.normalize()` preserves a shared face when both arms carry the same face, rather than clearing it. The test also asserts the merged guard has `kind == 'or'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb79930.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->