### PR TITLE
Rank the residual by dispatchable owner: R_desugar is 58 owed work, not 9952

### DIFF
--- a/docs/ledgers/pandas-3.0.3-control-effect-43d994888.json
+++ b/docs/ledgers/pandas-3.0.3-control-effect-43d994888.json
@@ -1,0 +1,8101 @@
+{
+  "kind": "control-effect-construction-recensus",
+  "authority": "sole authoritative Python corpus scoreboard; every other census output is non-authoritative",
+  "commit": "43d9948881df3906aa4b99977f8ab14b4fc951f5",
+  "corpus": "/home/tsavo/pandas303-audit/pandas",
+  "corpusRoot": "/home/tsavo/pandas303-audit/pandas",
+  "corpusPin": {
+    "kind": "sugar-corpus-pin/v1",
+    "distribution": "pandas",
+    "version": "3.0.3",
+    "fileCount": 1421,
+    "aggregateHash": "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c",
+    "aggregateHashConvention": "sha256 over: pin kind, distribution, version, then one '<relpath> <sha256> <sizeBytes>' line per file, sorted by relpath. Root path excluded so the same corpus pins identically on every box.",
+    "interoperableDigests": {
+      "contentOnly": "a1155ae27c10a1828ac6a02b890a8b1ee23881a5f78c3d6265f02a63065ca77d",
+      "pathBound": "04b67544e3628d25d1b20653558fb2c702a870ae3f97bc8492a9f70f854a9c31",
+      "enumerator": "SourceTree(root).paths()"
+    },
+    "root": "/home/tsavo/pandas303-audit/pandas"
+  },
+  "door": "enum:path_source\u2192SourceFile\u2192functions\u2192sugar\u2192desugar",
+  "isolation": "in-process",
+  "paths": {
+    "engineLog": "/home/tsavo/scoreboard-tree/baseline-43d994888/engine.jsonl",
+    "progress": "/home/tsavo/scoreboard-tree/baseline-43d994888/progress.log",
+    "checkpoint": "/home/tsavo/scoreboard-tree/baseline-43d994888/checkpoint.jsonl",
+    "result": "/home/tsavo/scoreboard-tree/baseline-43d994888/recensus.json"
+  },
+  "denominator": {
+    "enrolled": 1421,
+    "terminalRows": 1421,
+    "completed": 1415,
+    "corpusManifestCid": "sha256:c267d971bb2d1a3dd65769bb76ce6efec080803fea51df3964353e8c9f073c03",
+    "missingFiles": [],
+    "duplicateFiles": [],
+    "malformedRows": [],
+    "complete": true,
+    "enrolledFilesOmitted": "1421 identities; see corpus pin docs/ledgers/pins/pandas-3.0.3.pin.json"
+  },
+  "filesTotal": 1421,
+  "filesCompleted": 1415,
+  "defects": [
+    {
+      "file": "tests/io/excel/test_writers.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 55069 outside 0..27637\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    },
+    {
+      "file": "tests/io/pytables/test_store.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 30014 outside 0..27637\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    },
+    {
+      "file": "tests/io/test_compression.py",
+      "type": "SourceCallBindingGap",
+      "message": "unconsumed call actual"
+    },
+    {
+      "file": "tests/io/test_sql.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 83389 outside 0..27637\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    },
+    {
+      "file": "tests/io/test_stata.py",
+      "type": "SourceCallBindingGap",
+      "message": "unconsumed call actual"
+    },
+    {
+      "file": "tests/test_col.py",
+      "type": "BackendDefect",
+      "message": "BACKEND DEFECT [spans.LineTable.line_col]\n  observed:  offset 7085 outside 0..2671\n  requested: an offset inside the source\n  fix:       span was not minted from this source"
+    }
+  ],
+  "constructionPanics": [],
+  "R_construction_panics": 0,
+  "functionsTotal": 27425,
+  "functionsConstructClean": 22534,
+  "R": 4,
+  "R_construction": 4,
+  "families": {
+    "ConstructedValueTestimonyNotWritten": 1,
+    "ContextManagerResolutionConstructionGap": 1,
+    "SugarNotWritten": 1,
+    "UnsupportedWithBindingTarget": 1
+  },
+  "R_desugar": 9952,
+  "desugarCategories": {
+    "constructed-effect": 9894,
+    "typed-refusal": 58
+  },
+  "R_desugar_owed_work": 58,
+  "R_desugar_accounted_semantics": 9894,
+  "desugarByCategoryOwner": {
+    "constructed-effect/SubscriptStoreRuntimeEffect": 3202,
+    "constructed-effect/AttributeStoreRuntimeEffect": 2302,
+    "constructed-effect/RaiseEffect": 1787,
+    "constructed-effect/NameErrorEffect": 1398,
+    "constructed-effect/SequenceUnpackRuntimeEffect": 1094,
+    "constructed-effect/SubscriptDeleteRuntimeEffect": 37,
+    "constructed-effect/PowerRuntimeEffect": 35,
+    "typed-refusal/YieldSuspensionSugar.desugar": 29,
+    "typed-refusal/YieldFromSugar.desugar": 17,
+    "constructed-effect/BitwiseXorRuntimeEffect": 14,
+    "typed-refusal/matches_raise_effect": 11,
+    "constructed-effect/SubtractRuntimeEffect": 9,
+    "constructed-effect/UnaryPlusRuntimeEffect": 9,
+    "constructed-effect/SubscriptResultRuntimeEffect": 5,
+    "constructed-effect/TypeErrorRuntimeEffect": 2,
+    "typed-refusal/ClassDefinitionSugar.desugar": 1
+  },
+  "desugarFamilies": {
+    "SubscriptStoreRuntimeEffect": 3202,
+    "AttributeStoreRuntimeEffect": 2302,
+    "RaiseEffect": 1787,
+    "NameErrorEffect": 1398,
+    "SequenceUnpackRuntimeEffect": 1094,
+    "SubscriptDeleteRuntimeEffect": 37,
+    "PowerRuntimeEffect": 35,
+    "YieldSuspensionSugar.desugar": 29,
+    "YieldFromSugar.desugar": 17,
+    "BitwiseXorRuntimeEffect": 14,
+    "matches_raise_effect": 11,
+    "SubtractRuntimeEffect": 9,
+    "UnaryPlusRuntimeEffect": 9,
+    "SubscriptResultRuntimeEffect": 5,
+    "TypeErrorRuntimeEffect": 2,
+    "ClassDefinitionSugar.desugar": 1
+  },
+  "R_backend_defects": 6,
+  "backendDefects": {
+    "BackendDefect:unclassified": 6
+  },
+  "cmResolutions": {
+    "gap:unrecognized:opaque-call-target:func": 5727,
+    "gap:dynamic-export": 715,
+    "gap:unrecognized:opaque-call-target:cast": 709,
+    "gap:unrecognized:target-outside-binding": 24,
+    "derived-contract": 17,
+    "gap:unrecognized:non-manager-result:BlockValue": 16,
+    "gap:unrecognized:artifact-module-absent": 14,
+    "gap:unrecognized:opaque-call-target:setTZ": 9,
+    "gap:unrecognized:opaque-call-target:get_handle": 8,
+    "gap:no-derived-contract": 7,
+    "gap:unrecognized:opaque-call-target:nullcontext": 5,
+    "gap:unrecognized:force-floor:attribute:ObjectValue": 1,
+    "gap:unrecognized:opaque-call-target:available_protocols": 1
+  },
+  "R_cm_derived_contract": 17,
+  "astSitePrevalence": {
+    "site:function-def": 27751,
+    "site:with-item": 7662,
+    "site:with-statement": 7652,
+    "site:try-statement": 688
+  },
+  "desugarConstructionPanics": [
+    {
+      "where": "_testing/asserters.py:413:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=TrueBoolLiteralSugar observed=TrueBoolLiteralSugar requested=ride under a guard fix=write more Floor: implement TrueBoolLiteralSugar.guarded"
+    },
+    {
+      "where": "_testing/asserters.py:452:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "_testing/asserters.py:703:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "_testing/asserters.py:1478:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "_version.py:179:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "_version.py:459:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fbe2043bb7f3af9c5bf804411734cceb58209aa8db7e9ce9789cba64f400037d3605a644dc167a7b8431028ce7bffecce830c6b58ae6f655274c853337605e2a', start_line=476, start_col=23, end_line=476, end_col=44) observed=pending parameter contract demands (blake3-512:d81770f41f283d603bde9f2a0d4b0a7de5ff57e6f259e123ea47f5d773e9b8399632594004021c1ffe32daba8d613f5b643b69bbaa181257529fd2482a35ead3) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "_version.py:601:0",
+      "owner": "collection build",
+      "message": "write more Floor for this Construction: owner=collection build blame=collection build observed=pending parameter contract demands (blake3-512:0ce98e8e8a9de45c85ee58a3ec38c8aca498467c157d2396d396dddee99d728728ac41aa592f72b2fb53d6f483ed83a0da6578ab54e7bce57e439b4bbb0b20fb, blake3-512:819cc2f1de3a4ed36a6d260dbf74b4b62090aa7901c5d8f1bb8d9cdc901614771f2fa91b31bbdd5bf46497e57081240afbb135c3a1dfac754fb6193d3ba7c000) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/algorithms.py:1637:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/algorithms.py' [54289, 54301) node=Attribute> observed=LambdaCallable requested=stand on the attribute floor fix=write more Floor: implement LambdaCallable.attribute"
+    },
+    {
+      "where": "core/array_algos/masked_reductions.py:111:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/array_algos/replace.py:46:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=StringValue observed=StringValue requested=ride under a guard fix=write more Floor: implement StringValue.guarded"
+    },
+    {
+      "where": "core/arrays/_ranges.py:31:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/arrays/arrow/array.py:2208:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:ab7c939b8a80fcbee94adbbe4795ce68f6da84166557e9443fe5a799eb2cca1056330ce1648b25a73b1ad145c00dbcb50c93718f95b489a90270d990fb1adfba', start_line=2234, start_col=18, end_line=2234, end_col=24) observed=pending parameter contract demands (blake3-512:cf688dcc56531c5c0689200ab45341274c2e31ef8be3d864804a77f8709138e6cef446c5ac08e5c507b61f58b36660095fbbdabeb76cead7ea74639662c79273) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/arrays/arrow/extension_types.py:138:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=ClassDefinitionValue observed=ClassDefinitionValue requested=ride under a guard fix=write more Floor: implement ClassDefinitionValue.guarded"
+    },
+    {
+      "where": "core/arrays/boolean.py:178:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/boolean.py' [7418, 7428) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "core/arrays/datetimes.py:2936:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/core/arrays/datetimes.py:3004:27 observed=py.lt operand=NoneValue() requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='None', args=()) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "core/arrays/interval.py:1167:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:0fd0c7fac5ede4d863a44cbcb62cc48818c5a9a1c26e8a0575ee222ac465fbe4b9c8c9037b21d74b194b182c7b20785a04c8487826cb2a74a5ac56630ab56b9c', start_line=1193, start_col=16, end_line=1193, end_col=36) observed=pending parameter contract demands (blake3-512:51837fa5d74f4d861cedfddd85a4274478496a08c6e121df47dc6e9d8d9cb4de0a025eb14813525163e5340342e636adbce418679dfc3c2422899e1b04438593) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/arrays/interval.py:2055:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/interval.py' [69321, 69475) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for GuardedValue"
+    },
+    {
+      "where": "core/arrays/numeric.py:137:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/numeric.py' [6605, 6614) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "core/arrays/sparse/array.py:1209:4",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:60b43c9f8ecd1b902c28609633d023cfcd8065dec3d536bacffe19075f2a00973385ffea6c461575c2a516082921885357cb28ce26fd92f2a0084875a72b51d7', start_line=1210, start_col=21, end_line=1210, end_col=33) observed=a pending parameter contract carrier (blake3-512:8b009fdd66f7a06c3624725edaf971a3f12d17a028f7c4ed758cdde699570f892d25378040d49c92419ac31d8f3b4599868f40516d2e19deddefa46a97655418) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/arrays/sparse/scipy_sparse.py:40:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:908d182f0826b24d95583419afa0bd9d1a180e4499a47f26c22a829ad9b5d1a85d753e4762898d9cc626f9955143232c7b556d755731cbfa45c24d7a59924f61', start_line=71, start_col=35, end_line=71, end_col=44) observed=pending parameter contract demands (blake3-512:98d2d559e2611db34a1bdafc9fa0510771dec7ffa329df09901b04f9a75cfe0dfd7f29b6270eac3a64ae3019bf616526fb83b7310cd378ccb2ff8af352557c2e) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/arrays/string_arrow.py:383:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/arrays/string_arrow.py' [14263, 14282) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a SymbolicValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for SymbolicValue"
+    },
+    {
+      "where": "core/dtypes/concat.py:134:0",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/dtypes/concat.py' [5280, 5303) node=BinOp> observed=ComprehensionValue requested=stand on the subtraction floor for a SetValue right operand fix=write more Floor: implement ComprehensionValue.subtract for SetValue"
+    },
+    {
+      "where": "core/dtypes/dtypes.py:563:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/dtypes/missing.py:491:0",
+      "owner": "bitwise_invert",
+      "message": "write more Floor for this Construction: owner=bitwise_invert blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/dtypes/missing.py' [13763, 13768) node=UnaryOp> observed=NoneValue requested=stand on the bitwise-invert floor fix=write more Floor: implement NoneValue.bitwise_invert"
+    },
+    {
+      "where": "core/frame.py:702:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:831:32 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/frame.py:6821:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/frame.py:7041:52 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/frame.py:7859:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/frame.py:8128:4",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=8365, start_col=35, end_line=8365, end_col=40) observed=a pending parameter contract carrier (blake3-512:30f3272dd8b4a06ae1cdc5d6f51a472c1eb81e437bad7485f42ff14ad53a31be43363cdd746da307d4e79b8c68547b3376fd78f257dfece7c3c6aeb5cc6bf682, blake3-512:5d7438c229f93ad05a87cf8f98e529cf7b87e1f81e777a2d9df545bfbb929a1c8c5a0448204d945127e1df29453733e12537aa2c341ae91b175a01b707dfa5e0, blake3-512:c99687e94c811c774664d4293cc15a9e8d053604fedcc879dbc055dfe71df96c9af8c2f892a072331937780375992655cae79d371d2f2e83d43daa4ef2bc7b65) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/frame.py:11380:4",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:801f5f51a5f1d3802930c8de91770103601760b622c29baec432a3924731065e4dc00c6f6aea25e58609e7ebbd5cbef5190ee32621b66961fafddb1438ff5202', start_line=11492, start_col=24, end_line=11492, end_col=34) observed=a pending parameter contract carrier (blake3-512:e40c3b59d5b99559f57c398e02b0e5b335709d7df13c108468c389d6d2c137284688756173bcbc2fbb338ec3f1ed4f7a0ccb82f4c0bbb6e6aa454006e9e433d7) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/groupby/generic.py:314:4",
+      "owner": "ground_assertion_error",
+      "message": "write more Floor for this Construction: owner=ground_assertion_error blame=/home/tsavo/pandas303-audit/pandas/core/groupby/generic.py:467:16 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/groupby/groupby.py:5506:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/groupby/groupby.py:5645:12 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/groupby/indexing.py:158:4",
+      "owner": "bitwise_or",
+      "message": "write more Floor for this Construction: owner=bitwise_or blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/groupby/indexing.py' [5072, 5120) node=BinOp> observed=FalseBoolLiteralSugar requested=stand on the runtime bitwise or floor for a CallSiteValue right operand fix=write more Floor: implement FalseBoolLiteralSugar.bitwise_or for CallSiteValue"
+    },
+    {
+      "where": "core/groupby/indexing.py:187:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/groupby/indexing.py' [6814, 6850) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a PredicateValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for PredicateValue"
+    },
+    {
+      "where": "core/indexes/accessors.py:666:4",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/accessors.py' [19559, 19569) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "core/indexes/api.py:284:0",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/api.py' [8831, 8846) node=BinOp> observed=ComprehensionValue requested=stand on the subtraction floor for a SetValue right operand fix=write more Floor: implement ComprehensionValue.subtract for SetValue"
+    },
+    {
+      "where": "core/indexes/base.py:4147:4",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=4227, start_col=21, end_line=4227, end_col=28) observed=a pending parameter contract carrier (blake3-512:4f81128079f5fe1d465ff36487be1887d1b5410d54d2aeb6a4e203d21c0f728c19e9e418b6e8826efde066e782379ff910a5ac61fccd56c72d1f6d592fa8f7cb) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/base.py:4703:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=4744, start_col=31, end_line=4744, end_col=41) observed=pending parameter contract demands (blake3-512:4c4e5506e42023e3647a376bcdfa5630ba1e5046a67dd7e571d652afd9dd575171ca3ac7396258555c4ee69b1e43a1a5821a62d112ae6e4158573959bbec2b11) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/indexes/base.py:4717:8",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:330e874a6a8e6596e60bbd2939271e1c0ad45b6f86fa21411b6a89cb1b44aea48675b9732fe572d8bd3c4954e188d20119f14b3d30e0aaf2132a07b71a1ffc5b', start_line=4744, start_col=31, end_line=4744, end_col=41) observed=pending parameter contract demands (blake3-512:4c4e5506e42023e3647a376bcdfa5630ba1e5046a67dd7e571d652afd9dd575171ca3ac7396258555c4ee69b1e43a1a5821a62d112ae6e4158573959bbec2b11) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/indexes/interval.py:1287:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/indexes/interval.py' [49357, 49367) node=BinOp> observed=StringValue requested=stand on the multiplication floor for a TermValue right operand fix=write more Floor: implement StringValue.multiply for TermValue"
+    },
+    {
+      "where": "core/indexes/multi.py:1555:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/indexes/multi.py:1580:16 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/indexes/range.py:805:4",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:96fc5e08443810f6e42ff120ad3d5f0a7ca319ff7440997ff2a47307fdff2f663a60244cf2c4a91b7867c9765e701f461a7f94c300c4c00e52d74dd774eb6b8a', start_line=825, start_col=35, end_line=825, end_col=45) observed=a pending parameter contract carrier (blake3-512:c795744e7f2eff13c8eaf25b7e0eb83470181463d012204da083f637dbe0a22c97f799ef46e0894d2b2f350e18cf13e6b11dd63f857125c64b9717bedfafc621, blake3-512:f4876606563add34fb420a993be565d1534eb6d0b83852f60db13b298a92472de0ba58e874effa5eddeebba67d647f002dfaf037c4007dbcd0b1bee1796220d5) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/indexes/range.py:1180:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/indexes/range.py:1256:19 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/interchange/from_dataframe.py:139:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/interchange/from_dataframe.py:167:20 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/internals/blocks.py:1989:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:f5d95fb36a12e8adbf32a37e43224e397add4bafddb442b027da2fee93b8c637692a99d6ec882988bd49ccae12e88d7aab428b8f4ad50bebb7bf195fdd39c8ae', start_line=2016, start_col=26, end_line=2016, end_col=36) observed=pending parameter contract demands (blake3-512:52ea43f201cbd9ba8c6c9000c13cb5307d7c11c9eeac7632249b4bc47b23c4f6e2c9f1f79b2838f27dc2101c8aa6830cd5de4a4cf33be067d4b930819beeb6f1, blake3-512:55ec9f4b1ae368a784beca77fea9415576358d8a04189177fd4d792aacd9910370a0b99a7625f443b64c43a5ef5bef79f26221dc55aafd0044248a366a6da817, blake3-512:605798c5e6b466ba450abff72308a84348f2a2b95068a0c5749a8a966223ae77a540ac764663085bcbb7af7c732d97d6a5df1b7dc51b0780f237ee841f10e477) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/internals/construction.py:193:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/internals/construction.py' [7476, 7490) node=Attribute> observed=ComprehensionValue requested=stand on the attribute floor fix=write more Floor: implement ComprehensionValue.attribute"
+    },
+    {
+      "where": "core/internals/construction.py:605:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/internals/managers.py:552:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/methods/selectn.py:106:4",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/methods/selectn.py' [3990, 4000) node=BinOp> observed=TermValue requested=stand on the subtraction floor for a GuardedValue right operand fix=write more Floor: implement TermValue.subtract for GuardedValue"
+    },
+    {
+      "where": "core/missing.py:239:0",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:6229738eabf61c233124d0497b95f4b6abc10d056167f8aee510d760a5f66f02026d7aab34b14465a8e9b1a811f7c627a14b1a63cb065f3982a3510f2f7fd14d', start_line=264, start_col=17, end_line=264, end_col=29) observed=a pending parameter contract carrier (blake3-512:1445cab12e32196bd93e25d0a307968e551914b83e7fdbbba22f2bdf44c7a1b23de4274ed03df7e370c43e41f36194b733ca2ea7f4688a65ced7457d2b33e7bb) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/ops/missing.py:71:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/ops/missing.py' [2914, 2935) node=BinOp> observed=PredicateValue requested=stand on the runtime bitwise and floor for a CallSiteValue right operand fix=write more Floor: implement PredicateValue.bitwise_and for CallSiteValue"
+    },
+    {
+      "where": "core/resample.py:2710:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/reshape/concat.py:701:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "core/reshape/concat.py:887:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/reshape/encoding.py:43:0",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:fd80fa9c3745256a8bed021df4e8ce99abee920964f19404c72770ea0141bbda023d9063ca6383ba8cca21c1246ca76ca2f45d53fd66c976e89bb5b19cfbb491', start_line=171, start_col=29, end_line=171, end_col=42) observed=a pending parameter contract carrier (blake3-512:631dd85073d78e5fb2c9737dc5888af5762c7d0e42a25c8b6e2013772627a54dbf9db4e43a356d4ec0f102627e5fbbb182786a8027f3c2ae9b8dc1bbf8d8f401) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/melt.py:282:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/reshape/melt.py:359:33 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "core/reshape/merge.py:2043:0",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:50a78e9497b11c8e5b4a60d99c529d6eb2b812dabb425eed300c0b34ca3be1515b3934ccc217e4304ec0bc1120ea487c1be82f9f023d6e669997a80e2f612c88', start_line=2097, start_col=15, end_line=2097, end_col=27) observed=a pending parameter contract carrier (blake3-512:80b44ec643b2bc62f1c4ec9d6d396588115c5f5a7a63f5221b1bc7f8a092618cae243c7533f4fd3cf5fd1793a4ec55cf2efccf47d451454ea34c087e1aa7024e) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/merge.py:2724:0",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:50a78e9497b11c8e5b4a60d99c529d6eb2b812dabb425eed300c0b34ca3be1515b3934ccc217e4304ec0bc1120ea487c1be82f9f023d6e669997a80e2f612c88', start_line=2733, start_col=15, end_line=2733, end_col=27) observed=a pending parameter contract carrier (blake3-512:bde806f4d7211090eb89dddb455e0fefa3c88554522c0dd1f306ac8fa924abdfdcaa71c03460fb046c5f38d36206a6568b383f580b72fb711be249736b0eb311) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/reshape/pivot.py:284:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c463d3c1a1e885ac94c4d904c3d1286ba452d2a1d329b6411254165bec6c76d12bafe54b3a6b73b7084437360cf4507ecc304efb5bb9f5c47a0100de28c4303e', start_line=327, start_col=19, end_line=327, end_col=34) observed=pending parameter contract demands (blake3-512:d981648d2d10499da5ff11f6f6b9b06d28d5466ccb259d65d6c455c44ee1ca5c923db7d0daaf5b6f62a028e8d16287f15d0cdc7079ba6d68b6027debfd85eb7b) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/reshape/pivot.py:536:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c463d3c1a1e885ac94c4d904c3d1286ba452d2a1d329b6411254165bec6c76d12bafe54b3a6b73b7084437360cf4507ecc304efb5bb9f5c47a0100de28c4303e', start_line=616, start_col=12, end_line=616, end_col=31) observed=pending parameter contract demands (blake3-512:d1e35847044cedbf57ad61d2594dbd1cc040d531b9a0fcf45e2ad3c8e345000884e2bee530b341ace61142faef3091582a2efdb18c21b396f9681abb09b9bee7) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "core/reshape/pivot.py:700:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/sorting.py:599:0",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/sorting.py' [18443, 18487) node=BinOp> observed=PredicateValue requested=stand on the addition floor for a TermValue right operand fix=write more Floor: implement PredicateValue.add for TermValue"
+    },
+    {
+      "where": "core/sorting.py:675:0",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:58e844b0a5e547db5b60d088916ace4fb45806bca9373467d90857c01227f7e2c913f29abdde9b582b13ea48aeeeaca0fcb640a7d2a4558e446e8d18efa96f30', start_line=686, start_col=13, end_line=686, end_col=28) observed=a pending parameter contract carrier (blake3-512:2f21e5caa3afcde9f6c5e866043ae033480e0165235d394afe57fda9b45f8fca7794b4a7290dfe06ce3250e77e7c8b95ceb2d88059f3f20c4ed66528f4a9a42a, blake3-512:b27fa529ef1a0f21d24832fd944e00b00c85a1c540cca61e09d0d812a739c7eaeb4e47c1bfb38f057e730fde4c1b7935e95534506521541685ecc706fb6f12f0, blake3-512:fa24f90ae499e376e846cc31365d3a83ce02f37094b9bfea221f02f0ab0cb888503874b7f27f27d2107f1998f3993f217c48b2848d8e5424fa7b4db070e622f7) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "core/strings/accessor.py:81:0",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/strings/accessor.py' [3463, 3548) node=BinOp> observed=SetValue requested=stand on the subtraction floor for a CallSiteValue right operand fix=write more Floor: implement SetValue.subtract for CallSiteValue"
+    },
+    {
+      "where": "core/strings/accessor.py:1500:4",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/strings/accessor.py' [55050, 55075) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a SymbolicValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for SymbolicValue"
+    },
+    {
+      "where": "core/strings/object_array.py:339:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/strings/object_array.py:343:8",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "core/tools/numeric.py:51:0",
+      "owner": "bitwise_invert",
+      "message": "write more Floor for this Construction: owner=bitwise_invert blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/tools/numeric.py' [7871, 7880) node=UnaryOp> observed=NoneValue requested=stand on the bitwise-invert floor fix=write more Floor: implement NoneValue.bitwise_invert"
+    },
+    {
+      "where": "core/util/hashing.py:299:0",
+      "owner": "bitwise_xor",
+      "message": "write more Floor for this Construction: owner=bitwise_xor blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/core/util/hashing.py' [10101, 10119) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise xor floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_xor for GuardedValue"
+    },
+    {
+      "where": "core/window/rolling.py:444:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/core/window/rolling.py:480:23 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/formats/excel.py:690:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/excel.py' [22836, 22950) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/formats/format.py:1484:4",
+      "owner": "truth",
+      "message": "write more Floor for this Construction: owner=truth blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/format.py' [50178, 50209) node=BoolOp> observed=LambdaCallable requested=stand as a condition fix=write more Floor: implement LambdaCallable.truth"
+    },
+    {
+      "where": "io/formats/format.py:1620:0",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:3a0d67b5f29ecb800108e210a523d45920cbc26aad3b198dc4d636ab2f528215e088f02c68b2ef15a688ebf3effd3dcdc55082453ea3e41b3f01c9cd00eb0849', start_line=1622, start_col=32, end_line=1622, end_col=41) observed=pending parameter contract demands (blake3-512:06b8fc7a59969d71dc3cc6963c7eff125c5d6b8a87035eec2d2728ae589a484e6d83093172925fc04dfc51eab6eb76863a8871bbec014648bf86daa1ce77ac31) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "io/formats/html.py:147:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/html.py' [5127, 5169) node=BinOp> observed=PredicateValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement PredicateValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/formats/html.py:400:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/html.py' [14405, 14551) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/formats/style.py:2412:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [98512, 98534) node=BinOp> observed=PredicateValue requested=stand on the addition floor for a StringValue right operand fix=write more Floor: implement PredicateValue.add for StringValue"
+    },
+    {
+      "where": "io/formats/style_render.py:2239:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "io/formats/style_render.py:2648:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/formats/style_render.py:2676:9 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/formats/xml.py:226:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/xml.py' [7507, 7531) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/json/_normalize.py:72:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/json/_normalize.py:149:15 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/arrow_parser_wrapper.py:172:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/parsers/arrow_parser_wrapper.py' [6668, 6695) node=BinOp> observed=ComprehensionValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement ComprehensionValue.add for SymbolicValue"
+    },
+    {
+      "where": "io/parsers/base_parser.py:306:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "io/parsers/base_parser.py:324:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/base_parser.py:386:19 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/base_parser.py:391:4",
+      "owner": "ground_type_error",
+      "message": "write more Floor for this Construction: owner=ground_type_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/base_parser.py:427:20 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/base_parser.py:449:4",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c22b67191f3f02fec81206ff8136ff998d6d9f6fefc0d6d39b530c92716c03c976930ef63b0b8c5b0372f013b606cdc8804dce670951a2a610175e6676ae24c2', start_line=527, start_col=52, end_line=527, end_col=61) observed=a pending parameter contract carrier (blake3-512:0046d561fb7ed2f90a1ba6f52324df8a91bc0429c7451fdc03cab14c5ec60a36e33a0277d2fd99dd663946ed8666297b34a2d37d6c0f144f05477a395b743c4f, blake3-512:a5eb01a7f13252367cc13997ea7957024470e92d785172f29e90a6a153ed45dda8997c362c5b84fddd25375ca44993b2acde19ce957dcacabe3d4975f3141106, blake3-512:d085e175c2777ad16e4b63f54f918c0395358e19503cfd9d21bc58a18e79e1a1b27102c9dce9e6a37d7d1b7a7b57453b9f0e6c8b7671f0d934942fa47f0b0a17) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "io/parsers/base_parser.py:608:4",
+      "owner": "bitwise_or",
+      "message": "write more Floor for this Construction: owner=bitwise_or blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/parsers/base_parser.py' [21802, 21828) node=BinOp> observed=PredicateValue requested=stand on the runtime bitwise or floor for a CallSiteValue right operand fix=write more Floor: implement PredicateValue.bitwise_or for CallSiteValue"
+    },
+    {
+      "where": "io/parsers/python_parser.py:569:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/python_parser.py:706:36 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/parsers/python_parser.py:1266:4",
+      "owner": "ground_type_error",
+      "message": "write more Floor for this Construction: owner=ground_type_error blame=/home/tsavo/pandas303-audit/pandas/io/parsers/python_parser.py:1336:20 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "io/sas/sas_xport.py:138:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/io/sas/sas_xport.py:156:8 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='python:dict', args=()), _ConstStr(value='_', sort=PrimitiveSort(name='String')))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='python:dict', args=()), _ConstStr(value='_', sort=PrimitiveSort(name='String')))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "io/stata.py:1601:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=SymbolicValue observed=SymbolicValue requested=ride under a guard fix=write more Floor: implement SymbolicValue.guarded"
+    },
+    {
+      "where": "io/stata.py:2248:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [81635, 81665) node=BinOp> observed=BytesValue requested=stand on the multiplication floor for a SymbolicValue right operand fix=write more Floor: implement BytesValue.multiply for SymbolicValue"
+    },
+    {
+      "where": "io/stata.py:2961:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "io/stata.py:3165:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [116005, 116035) node=BinOp> observed=BytesValue requested=stand on the multiplication floor for a SymbolicValue right operand fix=write more Floor: implement BytesValue.multiply for SymbolicValue"
+    },
+    {
+      "where": "io/stata.py:3203:4",
+      "owner": "subtract",
+      "message": "write more Floor for this Construction: owner=subtract blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [118170, 118180) node=BinOp> observed=TermValue requested=stand on the subtraction floor for a GuardedValue right operand fix=write more Floor: implement TermValue.subtract for GuardedValue"
+    },
+    {
+      "where": "io/stata.py:3504:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [129665, 129693) node=BinOp> observed=BytesValue requested=stand on the addition floor for a CallSiteValue right operand fix=write more Floor: implement BytesValue.add for CallSiteValue"
+    },
+    {
+      "where": "io/stata.py:3610:4",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/io/stata.py' [131820, 131839) node=BinOp> observed=BytesValue requested=stand on the multiplication floor for a GuardedValue right operand fix=write more Floor: implement BytesValue.multiply for GuardedValue"
+    },
+    {
+      "where": "plotting/_matplotlib/boxplot.py:274:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:139:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=ComprehensionValue observed=ComprehensionValue requested=ride under a guard fix=write more Floor: implement ComprehensionValue.guarded"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:582:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=ComprehensionValue observed=ComprehensionValue requested=ride under a guard fix=write more Floor: implement ComprehensionValue.guarded"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:1119:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:d559deffd7175659afa5c03fed29ae46f40c745ed4b9a6a6454c3f0d7888d4857d8e503e0557e1458b0861ee4ebce4bee8057e9d0f4b12fa2da18e6788853537', start_line=1163, start_col=22, end_line=1163, end_col=31) observed=pending parameter contract demands (blake3-512:b9c470961e632a91e6c22c943f1fc8cd4ffe4a9c2a9a98710b0510a48cfbae3e37c0f51c24e2e5acdee914533e7a935be3e60f3a48042465ce9b7e0a2fa02860) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "plotting/_matplotlib/core.py:1462:4",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/plotting/_matplotlib/core.py' [50749, 50755) node=Attribute> observed=NoneValue requested=stand on the attribute floor fix=write more Floor: implement NoneValue.attribute"
+    },
+    {
+      "where": "plotting/_matplotlib/misc.py:345:0",
+      "owner": "outcome_to_exitset",
+      "message": "write more Floor for this Construction: owner=outcome_to_exitset blame=SourceFragmentCoordinateV1(source_cid='blake3-512:c57badfd17ed12c72652019d1f3c3bd96d9e14062d903b380bc846092a8e7c1799297814da7225a2a86ac6ac59061661c13c0beb7a0fa209eb86ff5ee6a5adfc', start_line=371, start_col=13, end_line=371, end_col=24) observed=a pending parameter contract carrier (blake3-512:007e9a5e2653abbf244cc11d2bf2ae0965c4996517559acf5befd02a588563fe20f362178bb9fe118f8117baa6ea4fbd56d24be00ef3666f451f8cbd0afe1e0a, blake3-512:043a7ecb568c05861e701d75f308f540ca02668f729ee97d0ee20b73937fd284c4fb04ee8e2b9ea63a4961ec0f786d12c84bfc21347349caddc3d3948819ad30) was converted to an exit set, which has no arm that wraps a value together with an undischarged obligation requested=a plain value or a partition fix=hoist the demands with `single_outcome_law.pending_demand` before converting, fold the carried value, and re-attach them with `rewrap_pending`; never drop the obligation"
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:707:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/apply/test_frame_apply.py:721:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/apply/test_frame_apply.py:727:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/apply/test_frame_apply.py:743:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/arithmetic/test_numeric.py:821:4",
+      "owner": "divide",
+      "message": "write more Floor for this Construction: owner=divide blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arithmetic/test_numeric.py' [29643, 29663) node=BinOp> observed=BlockValue requested=stand on the division floor for a CallSiteValue right operand fix=write more Floor: implement BlockValue.divide for CallSiteValue"
+    },
+    {
+      "where": "tests/arithmetic/test_string.py:247:0",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/arithmetic/test_string.py' [8140, 8152) node=BinOp> observed=NoneValue requested=stand on the addition floor for a CallSiteValue right operand fix=write more Floor: implement NoneValue.add for CallSiteValue"
+    },
+    {
+      "where": "tests/arithmetic/test_timedelta64.py:2254:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/computation/test_eval.py:599:4",
+      "owner": "unary_plus",
+      "message": "write more Floor for this Construction: owner=unary_plus blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/computation/test_eval.py' [21911, 21916) node=UnaryOp> observed=TrueBoolLiteralSugar requested=stand on the unary-plus floor fix=write more Floor: implement TrueBoolLiteralSugar.unary_plus"
+    },
+    {
+      "where": "tests/extension/decimal/array.py:257:4",
+      "owner": "ContractConditionalConstructionV1.and_then",
+      "message": "write more Floor for this Construction: owner=ContractConditionalConstructionV1.and_then blame=SourceFragmentCoordinateV1(source_cid='blake3-512:da81ebdfc5ee57c41adee81f7f8e00f065893e2ea5343ea369da25263c98dea18b75ba0b9b5e56d6d1c1b2354d530926ea75faf8cc70957bf27a0efff37de751', start_line=262, start_col=20, end_line=262, end_col=38) observed=pending parameter contract demands (blake3-512:fa2210033ce55acc11e9113e6810c4e55bf2dabc9e30a77779c72f1b7d19ad8a12be46b6299ad8118059a4e26f21de780f9cfc0f3c7f829e2b0c5c83166fe16f) joined onto a ExitSet, whose faces each carry their own guard and cannot share one carried value requested=one joined outcome that can carry every pending demand fix=give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard; never drop the obligation and never owe it on a face that does not run"
+    },
+    {
+      "where": "tests/frame/methods/test_map.py:172:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/frame/methods/test_map.py:184:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/frame/methods/test_quantile.py:834:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/frame/methods/test_shift.py:405:4",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/tests/frame/methods/test_shift.py:420:16 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "tests/frame/test_constructors.py:865:4",
+      "owner": "dict.subscript",
+      "message": "write more Floor for this Construction: owner=dict.subscript blame=/home/tsavo/pandas303-audit/pandas/tests/frame/test_constructors.py:883:27 observed=missing concrete key StringValue(value='z') requested=exact dictionary post-state or exceptional exit fix=carry exact dictionary provenance and intervening mutation testimony before deciding KeyError; otherwise keep the missing post-state construction loud"
+    },
+    {
+      "where": "tests/groupby/aggregate/test_aggregate.py:1342:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/methods/test_value_counts.py:283:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/methods/test_value_counts.py:868:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/test_api.py:148:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/groupby/test_api.py' [5861, 5888) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for GuardedValue"
+    },
+    {
+      "where": "tests/groupby/test_api.py:210:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/groupby/test_api.py' [8413, 8440) node=BinOp> observed=GuardedValue requested=stand on the runtime bitwise and floor for a GuardedValue right operand fix=write more Floor: implement GuardedValue.bitwise_and for GuardedValue"
+    },
+    {
+      "where": "tests/groupby/test_apply.py:147:0",
+      "owner": "RuntimeEffect",
+      "message": "write more Floor for this Construction: owner=RuntimeEffect blame=/home/tsavo/pandas303-audit/pandas/tests/groupby/test_apply.py:185:12 observed=py.delitem operand=_Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) requested=genuine runtime-dependent operand fix=RuntimeEffect requires a genuine runtime-dependent operand; _Ctor(name='python:subscript_delete_target', args=(_Ctor(name='array', args=()), _Ctor(name='py.slice', args=(_Ctor(name='None', args=()), _Ctor(name='None', args=()), _Ctor(name='None', args=()))))) is ground/decidable at lift time. Construction-gap prose and ground values cannot mint RuntimeEffect authority. replacement=construct the exact result or ConstructionPanic loudly. A decidable operand or construction-gap description must construct the exact result or panic; it cannot mint a RuntimeEffect."
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1488:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1493:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/groupby/test_groupby.py:1498:8",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/multi/test_integrity.py:268:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/multi/test_setops.py:240:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/multi/test_setops.py:285:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/period/test_period.py:116:4",
+      "owner": "BlockValue.to_term",
+      "message": "write more Floor for this Projection: owner=BlockValue.to_term blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/indexes/period/test_period.py' [3823, 3839) node=Call> observed=BlockValue requested=project this floor value to a term fix=write more Floor: implement BlockValue.to_term"
+    },
+    {
+      "where": "tests/indexes/ranges/test_range.py:535:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/test_old_base.py:310:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:719:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:784:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:797:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/indexes/test_setops.py:828:4",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/internals/test_internals.py:83:0",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/internals/test_internals.py' [2824, 2865) node=BinOp> observed=ComplexValue requested=stand on the multiplication floor for a SymbolicValue right operand fix=write more Floor: implement ComplexValue.multiply for SymbolicValue"
+    },
+    {
+      "where": "tests/io/excel/test_openpyxl.py:160:0",
+      "owner": "attribute",
+      "message": "write more Floor for this Construction: owner=attribute blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/excel/test_openpyxl.py' [5453, 5464) node=Attribute> observed=EffectCoordinate requested=stand on the attribute floor fix=write more Floor: implement EffectCoordinate.attribute"
+    },
+    {
+      "where": "tests/io/formats/style/test_bar.py:112:0",
+      "owner": "guarded",
+      "message": "write more Floor for this Construction: owner=guarded blame=BlockValue observed=BlockValue requested=ride under a guard fix=write more Floor: implement BlockValue.guarded"
+    },
+    {
+      "where": "tests/io/json/test_ujson.py:566:4",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/json/test_ujson.py' [19944, 19976) node=BinOp> observed=BytesValue requested=stand on the addition floor for a SymbolicValue right operand fix=write more Floor: implement BytesValue.add for SymbolicValue"
+    },
+    {
+      "where": "tests/io/parser/test_converters.py:111:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/tests/io/parser/test_converters.py:186:30 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "tests/io/parser/test_header.py:546:0",
+      "owner": "add",
+      "message": "write more Floor for this Construction: owner=add blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/parser/test_header.py' [15855, 15883) node=BinOp> observed=ListValue requested=stand on the addition floor for a PredicateValue right operand fix=write more Floor: implement ListValue.add for PredicateValue"
+    },
+    {
+      "where": "tests/io/pytables/test_select.py:294:0",
+      "owner": "bitwise_and",
+      "message": "write more Floor for this Construction: owner=bitwise_and blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/io/pytables/test_select.py' [10358, 10425) node=BinOp> observed=PredicateValue requested=stand on the runtime bitwise and floor for a CallSiteValue right operand fix=write more Floor: implement PredicateValue.bitwise_and for CallSiteValue"
+    },
+    {
+      "where": "tests/io/sas/test_sas7bdat.py:303:0",
+      "owner": "ground_index_error",
+      "message": "write more Floor for this Construction: owner=ground_index_error blame=/home/tsavo/pandas303-audit/pandas/tests/io/sas/test_sas7bdat.py:344:26 observed=absolute source locus requested=workspace-relative source locus fix=route the source through the workspace-relative lift door"
+    },
+    {
+      "where": "tests/reshape/merge/test_multi.py:101:12",
+      "owner": "multiply",
+      "message": "write more Floor for this Construction: owner=multiply blame=<SourceFragment '/home/tsavo/pandas303-audit/pandas/tests/reshape/merge/test_multi.py' [3248, 3266) node=BinOp> observed=BlockValue requested=stand on the multiplication floor for a TermValue right operand fix=write more Floor: implement BlockValue.multiply for TermValue"
+    }
+  ],
+  "R_desugar_construction_panics": 140,
+  "desugarDefects": [
+    {
+      "kind": "desugar-exception",
+      "where": "core/arrays/datetimelike.py:1397:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47510:47522#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47611:47663#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47737:47797#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47963:47992#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48092:48136#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48209:48271#blake3-512:db5e087706ef5b82be770d95310e52f5e77761a221ed24bcf9f1d079f5a9fe908c285a0838859242952999c39fb445d09b34350f1406bdcb36386a60e3152d9c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48331:48352#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48331:48352#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48759:48792#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48916:48944#blake3-512:93dec2e44389e5faa573b077dad22653b6fb8ad424a1fe0d9e3b465d17c86f1e648aeed35ba0acab88e5a0c2e779be0cb268e10932e131daaa4599eeb9b4c92e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@49080:49179#blake3-512:09f0c132de3e6ef493ff0b7d738720598f1af09d4c461856674ea38646c500fc96e2e89f451f3b55f74cded37e48602efeb1d20a57fcc83b22279f292d697e99', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@49298:49327#blake3-512:05110f4925fab4a851d128a6a943c61e23b1cbade1a2fe8653ecabb2a6ab15cc01485e6c490667bccb5ea67d7322b174b9b6cec38a681d77ff119ff54a533d83', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47510:47522#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47611:47663#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47737:47797#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@47963:47992#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48092:48136#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48209:48271#blake3-512:db5e087706ef5b82be770d95310e52f5e77761a221ed24bcf9f1d079f5a9fe908c285a0838859242952999c39fb445d09b34350f1406bdcb36386a60e3152d9c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48331:48352#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@48759:48792#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/arrays/datetimelike.py:1461:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50522:50534#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50623:50675#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50750:50810#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50977:51006#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51107:51151#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51224:51245#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51224:51245#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51624:51649#blake3-512:5f91653d24cc9e95fb6d47941aae54fd9d3654e2d93153abfe6ffafc78c96a5ae794325d0868755a5e9c53df581c38844c4bad9486717fb604765d1e1095fc37', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51742:51775#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51900:51928#blake3-512:93dec2e44389e5faa573b077dad22653b6fb8ad424a1fe0d9e3b465d17c86f1e648aeed35ba0acab88e5a0c2e779be0cb268e10932e131daaa4599eeb9b4c92e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52064:52163#blake3-512:09f0c132de3e6ef493ff0b7d738720598f1af09d4c461856674ea38646c500fc96e2e89f451f3b55f74cded37e48602efeb1d20a57fcc83b22279f292d697e99', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52284:52320#blake3-512:3ea6c30605e53e3c155dbca7f63de0e075eb731694fa491d8ae0e741cc2e82ebebd7aa0cc3ef20eac4bbbbf909d9f510d02e6ad44e5c808e74eb6ece4522c4a7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52410:52439#blake3-512:05110f4925fab4a851d128a6a943c61e23b1cbade1a2fe8653ecabb2a6ab15cc01485e6c490667bccb5ea67d7322b174b9b6cec38a681d77ff119ff54a533d83', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50522:50534#blake3-512:cbba9bc7a22aae410e5a7ed2341e4c5afa38ef2ed63e01dca2f6909d9e14cce2f0f40d972a37309b4dbfc585229403b6a525bb36035f4065f8050d1ec623ebaa', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50623:50675#blake3-512:f508abc4f21dd61ef97422c84524b8c4137d390bc0cd7d21c658ba08f6eec20e03f5a99a49b1eebd3d696ddfce92342371d4f3183dd1c981728a0d5badb9fb91', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50750:50810#blake3-512:7b98a0078d92fce39e9af08a13300bf806838992b43148379a2d7b8ca9c02da19de0f16f9113df2ada4a29ea0da922247c7e5fb765c62b5d273fe71daaeb6cfc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@50977:51006#blake3-512:87b6b15fbd3203fe72f5040e584138c0e7f6314babbe9755e9cce34de8571386bdaab9f25923a7f3539f0f68aeb419f0e7e266c549674dae3a075071570caffb', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51107:51151#blake3-512:da1feb8b300f6bd0404c8434a331e3161edccb2fe30785c00c5ca52a27dfb7e8e9b186e31c181d2cfb98da5980a5711fe07e0d481893ec58553ab70818298467', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51224:51245#blake3-512:58ce2393804982fe073c7e46502a5dc7fcff625c721bed7adf7c0d40a58d4ffc492ddfd1fbb53a518739b6911bc86bf9c9b758a9976b8fd57da10e46264ca482', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51624:51649#blake3-512:5f91653d24cc9e95fb6d47941aae54fd9d3654e2d93153abfe6ffafc78c96a5ae794325d0868755a5e9c53df581c38844c4bad9486717fb604765d1e1095fc37', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51624:51649#blake3-512:5f91653d24cc9e95fb6d47941aae54fd9d3654e2d93153abfe6ffafc78c96a5ae794325d0868755a5e9c53df581c38844c4bad9486717fb604765d1e1095fc37', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51742:51775#blake3-512:8d4f5a163fd47b0ceb2362f01299e6602d24b43c20e5a119a479aebbab11d3db735d306a1a31a7bb25467c8cefbcf253867b579a90b10923843f5939e9d36ca0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@51900:51928#blake3-512:93dec2e44389e5faa573b077dad22653b6fb8ad424a1fe0d9e3b465d17c86f1e648aeed35ba0acab88e5a0c2e779be0cb268e10932e131daaa4599eeb9b4c92e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52064:52163#blake3-512:09f0c132de3e6ef493ff0b7d738720598f1af09d4c461856674ea38646c500fc96e2e89f451f3b55f74cded37e48602efeb1d20a57fcc83b22279f292d697e99', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:500dad2d65a9cf450380a45d6c2e39cc5f11dceb11f2bf57818f1a862930c19f7d3e8c27e1ef81f6eeccbfc20c5d892a9c9848ab05c0053e186760754a549a2d@52284:52320#blake3-512:3ea6c30605e53e3c155dbca7f63de0e075eb731694fa491d8ae0e741cc2e82ebebd7aa0cc3ef20eac4bbbbf909d9f510d02e6ad44e5c808e74eb6ece4522c4a7', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/generic.py:13403:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / StringValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@452978:452991#blake3-512:15c08a92396272478368aacc6b07062184878af8b7a7ca44f7fdc01b18be2808b829459c7a2af4d263ff3f47dd56bab8b5bf39cdb7fa2e0a37fa9553df5a6fe4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453164:453177#blake3-512:ee1e5449e9b67547eaa7f057ba344cc3ee70d768fe60fd5fb4a6258433e44ae104cfafb59b3a03b54d5ce06ecc7f387b98bd1def38811c0724a7ac005c714cdc', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453349:453362#blake3-512:89589fdefb21b9fb2ef3dcdeb3580567d3095c97a8b8d5b8a7757d171f5206d343b354fd1ed14f39a687f8f0acd7a414228b5e7009d7dd894bb08c1264a93f3b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@453763:453776#blake3-512:02e2955c13ebf03401cf071243d5d18a2323ab5a42762d4e81c5925f83d122bdcc5dfdaca406ea320fe09377b2e881bffed96152bced7f04dd15707c14f733c1', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454178:454191#blake3-512:ecc631ede9b445725d739dab6ace711bbb802c71a6a167bd0e846a5fc461ec2970a7321f7566f3447cd404aae4b146cee4b2ccfea72367bf681fecf8f4302abf', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454517:454531#blake3-512:6bb1713d5365d94ee24c59444a40ea4632641fe549932329ac1aa06f55fbef0e10a7ea2f126ce3b03be7cc08ef8681c7b57aa181649b30ff3959fe7394b7807c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@454772:454788#blake3-512:d2c03d320a5865c1c2ddcc960258ff4f2200705ebac131492711e4acf5a3389e1ddd6d28e91ecdb74ad52f64da2fdd9733c16ccb069cfa45d74397808016420a', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@455897:455911#blake3-512:822d2c6f3671cb31e6387c45e032843ea956216c0e2e5b32ece4caa2d6454778e08cd68a9bd1beb14164af41d040e2cfab89da685b3d2d4a1b746ccb0e33ef4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457010:457023#blake3-512:cafa81e9fba102958dcc1b4389241cfa443f07d40c23d8a090305dad9002516d74ed1f18aa9c7e343e198a2080f4190d783b0579910dd7da072c39bddc3819b4', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457334:457347#blake3-512:5b32feb0e3630b4d6204e6ffed269ece2581008fc37b12a4390aac94e85fd9155d8260315e9c190bdaec8715100bbd286c890864894ec58c02be3189cc993ce9', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@457745:457758#blake3-512:5b603297f0e13ffd4e7ffcde2d896f06b13295b32a24239867e9dfc07c587eb8705d174e6c8a82e7f95b7ae09a26c8f04b5ee0b04699125c00bb3de765c0d4b8', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@459055:459069#blake3-512:edf862325999580225168d4ddba09e14894a34b33abbf14bd2b933186427c005f08a5bfd936619145fe81b45f7ca8396f6fe25e33aeb6ff91e251e8689411923', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@460354:460368#blake3-512:608f628eb0555f6785e347252bff993df50d450134c770f9c59bc0c823edaf2a080fb4d74a138f1c3fd161e00b4d11124a036106c6171933448b0ac9c14f3046', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@461810:461826#blake3-512:93d871970210cd1b3d66926e7e25a346b2aee85d74e0169ca80d4b3bfaebbcf795bdbef2358328fd504dc9ad30bf7817f972f70aa23a345b0656366b07274a0d', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462074:462091#blake3-512:e398a86a861cfdc24a60c28decee6c7d7751b2bcebd2e8a8946cc69a3c86e2676739bb9e60432ee9a65ab185155d2dfabc587bc567489e3f78280928c483efee', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462345:462361#blake3-512:7f427345347e85acb960d2200eb2db0b04f04c0267b1822f9c3dd4ba2222709e160f51da07ef55091ddab8a50dbd5b88ed9aa4d1ce65e93542b469158e702a41', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:eefd68e431e302d2bb6af4dda17ea2b18cef12eff0495e1d9fa4c01d17f1f05251b70577693883b92223bc2a49b899e5af5297ccccc1c99003798c1ed5e9a4ce@462613:462629#blake3-512:a3ae6b2e60ba425f091734cb9f68162e83e9128e362fcbb869c63999032a930a92737fde7da749e002fde8637cabe58ea6094b9fb5b2203b440171adc2e59c49', sort=PrimitiveSort(name='String')),)),))))))))))))))))))))))))))))))))))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/groupby/groupby.py:4829:8",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / GuardedValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@155833:155899#blake3-512:2dbf2bbbe2b15293fe852f0f1dbb5cd9bb5187bedf861f44bcb0019796438e42f98bfe368e150476ce4fb7f4eff66216d87a1905d31bcdd026be36ba6d476776', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@155833:155899#blake3-512:2dbf2bbbe2b15293fe852f0f1dbb5cd9bb5187bedf861f44bcb0019796438e42f98bfe368e150476ce4fb7f4eff66216d87a1905d31bcdd026be36ba6d476776', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@156023:156051#blake3-512:c7a34f63e65fe32cf3a770a985febd3ce20336b652985c636d7c88940ac1427d3becf25b78035fe520497a5609a087bece642e3b0c3ca35bd0e6634475a69c8f', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@156293:156355#blake3-512:aa034839cd487177b95b1e22ab7e1a59b053466281ab54c5f84c86957c9109599991a7c3c4a7d9273878fe32eb486887ca197a145e899bd7bc766907e8ff88c7', sort=PrimitiveSort(name='String')),)),))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@155833:155899#blake3-512:2dbf2bbbe2b15293fe852f0f1dbb5cd9bb5187bedf861f44bcb0019796438e42f98bfe368e150476ce4fb7f4eff66216d87a1905d31bcdd026be36ba6d476776', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:80c7f0dde73a793f222c3626719571f3107896c943630e46a1261a1393e28bf0191d19144b6f313c85f7272c83d366d560c79c397c3ecacebada67a6d9d0d058@156023:156051#blake3-512:c7a34f63e65fe32cf3a770a985febd3ce20336b652985c636d7c88940ac1427d3becf25b78035fe520497a5609a087bece642e3b0c3ca35bd0e6634475a69c8f', sort=PrimitiveSort(name='String')),)),))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "core/methods/selectn.py:224:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / SymbolicValue\n  arm A guard: _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:efa16f7745ca9e27dd2fd887511ed151272290d13bf49e0cd7d93f6bf63ee405ec8fb910405e929cfcc1ede8b4895ec6c9e2ea6f045db5d94dce9a34b7279331@7521:7559#blake3-512:ac796d6da6a5621d5243e380f3852f7997bd44c4a32f87e90131472362f96cad692ad87190c29326bf887a41fe437abbc6c3435bdc35b9d4d88d86b41dc70521', sort=PrimitiveSort(name='String')),)),))\n  arm B guard: _Atomic(name='python.loop.exhausted', args=(_ConstStr(value='blake3-512:524374dbac522550b29c9009f26ac3d271f23ded5ebab0602749cad7f0d780d46c551ac740b44ff30b1d98449a6bf4ca9748109d0493139ff0720c77dce4faa6', sort=PrimitiveSort(name='String')),))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/excel/_openpyxl.py:445:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13152:13212#blake3-512:b0005402b4ee2ed1cc0a6a188b922fe467f624b2b535734ead9166f1ba5fe6179bd7ddbe9154f3df9c6cfee5c6337f8dc1b48633f5d0e9b9ccb48282e31a3464', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13229:13247#blake3-512:35e2015e13c75b1a04d0dedf55999b8e1568f4e19161564364fddf60d1b717cad1a8bcefac772d71a41c58e653899e48a90e582e16d086eabac5e8e07f469700', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13268:13302#blake3-512:8a9d5093a013bbd36270d46c1e1317288e714e2a49eda68aca921c44e942525f3e23223a2f051154b66d9089a409c8d742e4f244cd14982ede3bee6fba48f72d', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13152:13212#blake3-512:b0005402b4ee2ed1cc0a6a188b922fe467f624b2b535734ead9166f1ba5fe6179bd7ddbe9154f3df9c6cfee5c6337f8dc1b48633f5d0e9b9ccb48282e31a3464', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='or', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13229:13247#blake3-512:35e2015e13c75b1a04d0dedf55999b8e1568f4e19161564364fddf60d1b717cad1a8bcefac772d71a41c58e653899e48a90e582e16d086eabac5e8e07f469700', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13229:13247#blake3-512:35e2015e13c75b1a04d0dedf55999b8e1568f4e19161564364fddf60d1b717cad1a8bcefac772d71a41c58e653899e48a90e582e16d086eabac5e8e07f469700', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13268:13302#blake3-512:8a9d5093a013bbd36270d46c1e1317288e714e2a49eda68aca921c44e942525f3e23223a2f051154b66d9089a409c8d742e4f244cd14982ede3bee6fba48f72d', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13560:13592#blake3-512:8bc4b8b9494b5419ffbb3faf47137eb13eb179eb30fb2dccb26202bb2cd04a81ab495301edb69a531dba0b42fb6e6efa5afc25a3957223d7621281d38589aa8b', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:99a25f991b7eaed1edbed8ad930fee0a86b354d5be5a79d366d1566a618f24ac8cf8eb3f6af92a2a8f0115ab50034e64b367bb4acde55b5032a25af9bedef99a@13805:13839#blake3-512:551e1dba02f569823f4e680f0b9fe826f28ee03caba16d22d05b4e84995cb983187230d6882323309efb8ab2d894e3e7893a00c1bfae1d173d6d080c3cce4e86', sort=PrimitiveSort(name='String')),)),))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/excel/_openpyxl.py:614:4",
+      "detail": "AttributeError: 'ExitSet' object has no attribute 'value'"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/formats/style.py:4259:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: CallSiteValue / CallSiteValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167797:167819#blake3-512:1239200891b25516c66e12b7641cb2926725e32a2b2cb19606d9acc2d4297502a090c7949eb1adb16e163083a7f82f482667a7efd3fca5f658e6cf77f5d73d06', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167871:167890#blake3-512:c5cc2922f13ebfdad0ef103088246e72fb7c4b3fab7de01148679f943d4382f994aeb70b8ec34169c10d22a9ee852c8daeacc76da505f2e1bae5513234548808', sort=PrimitiveSort(name='String')),)),))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)), _Connective(kind='or', operands=(_Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167797:167819#blake3-512:1239200891b25516c66e12b7641cb2926725e32a2b2cb19606d9acc2d4297502a090c7949eb1adb16e163083a7f82f482667a7efd3fca5f658e6cf77f5d73d06', sort=PrimitiveSort(name='String')),)),)))), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167726:167745#blake3-512:bdbeba8cbd9c422628b656e06876f04547251bbaaa6271c7665e5e0374be9182cf8b1fac97850f0f86d75d364c4245daaa596e458dbde351e751c305a0f5dd4f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167797:167819#blake3-512:1239200891b25516c66e12b7641cb2926725e32a2b2cb19606d9acc2d4297502a090c7949eb1adb16e163083a7f82f482667a7efd3fca5f658e6cf77f5d73d06', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167871:167890#blake3-512:c5cc2922f13ebfdad0ef103088246e72fb7c4b3fab7de01148679f943d4382f994aeb70b8ec34169c10d22a9ee852c8daeacc76da505f2e1bae5513234548808', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167942:167962#blake3-512:9db9101ff0f908c96ecc00a5492d43edf4117122870779d0bc9670071a534df483542d5f97d336fb0385a6e4cec3613995aeecd36053c15e99f8c241c1f9521a', sort=PrimitiveSort(name='String')),)),))))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: [\"PartitionFace(partition=('sugar.exit_set.partition', ('IfExpSugar', <SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [168497, 168620) node=IfExp>, _Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)))), side=True, arity=2)\"]\n  arm B faces: [\"PartitionFace(partition=('sugar.exit_set.partition', ('IfExpSugar', <SourceFragment '/home/tsavo/pandas303-audit/pandas/io/formats/style.py' [168497, 168620) node=IfExp>, _Connective(kind='not', operands=(_Connective(kind='and', operands=(_Connective(kind='implies', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='identity', args=(_Ctor(name='call:_validate_apply_axis_arg', args=(_Var(name='left'), _ConstStr(value='left', sort=PrimitiveSort(name='String')), _Ctor(name='None', args=()), _Var(name='data'))), _Ctor(name='None', args=()))))), _Connective(kind='implies', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:643af8a2583fa39f5915d56a37ba5155e014700cc8b01537502bf5be62d64f0079035e3c868f391ef68674d9d6277f72ff970062a01a761ef624cd465269e670@167427:167474#blake3-512:6cef522fe191b67e030b1c193f930f00cfe3c70091bcf235e70e7649fe019b0c9a058fbe58f3de80a54188c9a10b8085544228639c5861c755d85c0cede88ea2', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='identity', args=(_Var(name='left'), _Ctor(name='None', args=()))))))),)))), side=True, arity=2)\"]"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "io/formats/style_render.py:2579:0",
+      "detail": "AttributeError: 'ExitSet' object has no attribute 'value'"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/dtypes/cast/test_box_unbox.py:50:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: TermValue / ComplexValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1242:1257#blake3-512:efc583ae5dfeb50fa2439b74389240f61f551c7d0e2c294ff942d490122d6869e54a68cf97578a77229bfe51369c91a617e73b7edacdbf49422cb3e8a810a89c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1315:1343#blake3-512:2685c9f9a075ca577a725aabfb387149b48635579f34871cc4aefa7441fdac7b9fed313555930d1b836b2e6c768e40b0a889bf7a95db0e05e0d077839a2cab8f', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1315:1343#blake3-512:2685c9f9a075ca577a725aabfb387149b48635579f34871cc4aefa7441fdac7b9fed313555930d1b836b2e6c768e40b0a889bf7a95db0e05e0d077839a2cab8f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1396:1414#blake3-512:a04187ee9d749c146fac73de63d40494019c8ed921dbf501738cb4a0f991060ac9d09c067c00057c98ecbb8b0a07ecce5db0bcefeefa99146e83a52fe8f094c0', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1396:1414#blake3-512:a04187ee9d749c146fac73de63d40494019c8ed921dbf501738cb4a0f991060ac9d09c067c00057c98ecbb8b0a07ecce5db0bcefeefa99146e83a52fe8f094c0', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1471:1488#blake3-512:6c689285fc8445cc8062fdfc6fedee2351844799f84ad60f042fd46e316d2cc506cfff4fff3b97c530462f28639034b75193029ac6b4d266e16d4f8ef7299124', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1554:1570#blake3-512:fafd1d66b5b5ff4189a0d0d64c5f588b292d9cabab1417423ecbeecaa48635d4078251bc5b8ee4d9507e0b94201d15e80d0d83c5c2b32e464ad26cae50892245', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1627:1642#blake3-512:0d36a46b43b620b8d4d692bcaf7e64c1963051d3d0842728f7c47801946047e68f70f76bcc66eea1be5cd941c939d643bf8cc68b4a7bf1169bb7095d57252b08', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1696:1711#blake3-512:da7ff919837e44dd8af59b74e42ebe80b3dd92f0fb1ea8e84880514b8042232e77f76ea284a2f30cb403cb57ab224c3d77c26f7cad24d090bf8388bdf4f99cc5', sort=PrimitiveSort(name='String')),)),))))))))))))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1242:1257#blake3-512:efc583ae5dfeb50fa2439b74389240f61f551c7d0e2c294ff942d490122d6869e54a68cf97578a77229bfe51369c91a617e73b7edacdbf49422cb3e8a810a89c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1315:1343#blake3-512:2685c9f9a075ca577a725aabfb387149b48635579f34871cc4aefa7441fdac7b9fed313555930d1b836b2e6c768e40b0a889bf7a95db0e05e0d077839a2cab8f', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1396:1414#blake3-512:a04187ee9d749c146fac73de63d40494019c8ed921dbf501738cb4a0f991060ac9d09c067c00057c98ecbb8b0a07ecce5db0bcefeefa99146e83a52fe8f094c0', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:6f367130e72b4a178f990f1bdd58e90628a765f4d27558a7a1851a0bc9aa03a6c48e7d82a1174047f1270a4ebf452462d09ad9ffcb3b41365edb27480547b84d@1471:1488#blake3-512:6c689285fc8445cc8062fdfc6fedee2351844799f84ad60f042fd46e316d2cc506cfff4fff3b97c530462f28639034b75193029ac6b4d266e16d4f8ef7299124', sort=PrimitiveSort(name='String')),)),))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/extension/test_arrow.py:172:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: TermValue / TermValue\n  arm A guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5398:5427#blake3-512:eccb2f0c8d7cd3c2ae1f5e65d81dfa95cfe20584c1f668a80905d416292c333ab2c5d73a05832ee47247c11518a25a240831df3114ef30c8a337764117e6770e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5490:5520#blake3-512:267ce1b51ee4f295387bcf48e52658563ba279dc00a752dd2531024100146d4da62e1c2ac73f015386546af3d7ed648b7f74a0afa6282bf0f27f899ca572cb62', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5490:5520#blake3-512:267ce1b51ee4f295387bcf48e52658563ba279dc00a752dd2531024100146d4da62e1c2ac73f015386546af3d7ed648b7f74a0afa6282bf0f27f899ca572cb62', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5580:5616#blake3-512:5d4aa384a4bc682ef124f56c06530629eecf3b6b3d4492796414446d47aca4687c60093e6ec397d92428de7f077ab48e023834412f7c112194a9f00ee4d4e6ac', sort=PrimitiveSort(name='String')),)),))))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5398:5427#blake3-512:eccb2f0c8d7cd3c2ae1f5e65d81dfa95cfe20584c1f668a80905d416292c333ab2c5d73a05832ee47247c11518a25a240831df3114ef30c8a337764117e6770e', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5490:5520#blake3-512:267ce1b51ee4f295387bcf48e52658563ba279dc00a752dd2531024100146d4da62e1c2ac73f015386546af3d7ed648b7f74a0afa6282bf0f27f899ca572cb62', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5580:5616#blake3-512:5d4aa384a4bc682ef124f56c06530629eecf3b6b3d4492796414446d47aca4687c60093e6ec397d92428de7f077ab48e023834412f7c112194a9f00ee4d4e6ac', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:1d35011d09644fb842ce211045660613ae2779906f34fda74c711da88abf3f5d3dc609e9e2a2135d81e75789f5e4c5dba538530b7a0d6e255bbecd730b9ca2eb@5670:5708#blake3-512:0cb8f0c236f68703bdaaf6afcffa702ec236435f98edef04ef0ffcef1c18d839b209334498387ae9e13e4ed33a5b3747dacd070ad5a614310b9e4c7c3d3b1300', sort=PrimitiveSort(name='String')),)),))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/extension/test_masked.py:312:4",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: SymbolicValue / SymbolicValue\n  arm A guard: _Connective(kind='or', operands=(_Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),)))), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11586:11617#blake3-512:ad1b7fc9743c000da1c3158d274866625acd8acf30219abb1a24a221316e7288c76a24f14ac6ed530c926a7ba1f729f51bd89500c3ffe4856ba40f7d70b5f15c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),))))))))\n  arm B guard: _Connective(kind='or', operands=(_Connective(kind='and', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10734:10764#blake3-512:12dda3b3ab06d68648ccd07c667c8e179742dcc7e8aa9df44cec951d7b43e4f6fb93ee15ebd94e377bf8026aafdc18c16aa6549449d550a6fd17ab0430d9d5b7', sort=PrimitiveSort(name='String')),)),)))))), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11535:11554#blake3-512:6d30dac370fdf21343901866d9c5fabd223027c8bc685654c0600226d2069dd45f1b6adc4ae0cc627de39c3262a5fc71438daa1440067afd556b3bd56137885b', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@11586:11617#blake3-512:ad1b7fc9743c000da1c3158d274866625acd8acf30219abb1a24a221316e7288c76a24f14ac6ed530c926a7ba1f729f51bd89500c3ffe4856ba40f7d70b5f15c', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10644:10674#blake3-512:ca771e216e7f017c1c9d9cd802944f971df5c4d5caae0b9c608da68b136d006df1853ce74457ad863cfca2299c228c5c5b2960fd2bfcfd1ff5eae47ed82b127c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f48cd2b960d55350ede58a5855b4a30a5a9c756ab033956993ff3123db67ffa1f50678ef79ccaead3a0059a7e7d70aa8b0a8291a5cd507756f06b2d1a57a2a96@10734:10764#blake3-512:12dda3b3ab06d68648ccd07c667c8e179742dcc7e8aa9df44cec951d7b43e4f6fb93ee15ebd94e377bf8026aafdc18c16aa6549449d550a6fd17ab0430d9d5b7', sort=PrimitiveSort(name='String')),)),))))))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_categorical.py:2000:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: ListValue / ListValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67090:67111#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67090:67111#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67143:67165#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67090:67111#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67143:67165#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@67229:67250#blake3-512:dabbcf5355560bad7c44688eeafdd31219a1e12111d4a288c72a6008c967c3ff8592d449f17b268c6b7b467c099232582ff25bdc9ec068aed44ed58a7f617d1b', sort=PrimitiveSort(name='String')),)),))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_categorical.py:2036:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: ListValue / ListValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68464:68485#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68464:68485#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68517:68539#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68464:68485#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68517:68539#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@68603:68624#blake3-512:dabbcf5355560bad7c44688eeafdd31219a1e12111d4a288c72a6008c967c3ff8592d449f17b268c6b7b467c099232582ff25bdc9ec068aed44ed58a7f617d1b', sort=PrimitiveSort(name='String')),)),))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    },
+    {
+      "kind": "desugar-exception",
+      "where": "tests/groupby/test_categorical.py:2072:0",
+      "detail": "ExitSetFactoringGap: ExitSet.factor_completed cannot factor a completed face whose arms are not provably exclusive.\n  owner: ListValue / ListValue\n  arm A guard: _Connective(kind='or', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69777:69798#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69777:69798#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69830:69852#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),))))))\n  arm B guard: _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69777:69798#blake3-512:fb0bd139ec89eb87abb9dee91eb405bd950be85b1f5256d71d219f311b71556dc3372ef4d042fa862459b333462a7c0b111b118cd2452ba3f9242fc2449407e7', sort=PrimitiveSort(name='String')),)),)),)), _Connective(kind='and', operands=(_Connective(kind='not', operands=(_Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69830:69852#blake3-512:c757aab14a3988522637a3a56e59d7bf56fc19d79e86b6710dc2800d1e0108cd4aa4964d5014773ef262953183f9cd4a0ee8a027c950c3432cfa5d89f3c9bb5c', sort=PrimitiveSort(name='String')),)),)),)), _Atomic(name='py.truthy', args=(_Ctor(name='python:branch_result', args=(_ConstStr(value='branch-result:blake3-512:f2ecd27d2867bf272edfda2340d6e1a1057e028c240fbc077b928312baf9da3b66eb36388a50f5ecc4f5aac6712de05d1d10e3db9b529d139e6f92a91ab4d46f@69916:69937#blake3-512:dabbcf5355560bad7c44688eeafdd31219a1e12111d4a288c72a6008c967c3ff8592d449f17b268c6b7b467c099232582ff25bdc9ec068aed44ed58a7f617d1b', sort=PrimitiveSort(name='String')),)),))))))\n  why this is a gap: a GuardedValue chain selects ONE face, so it can only carry a partition. Overlapping arms with different values are two simultaneously reachable outcomes, and collapsing them would drop one.\n  fix: if the producing sugar OWNS a two-way split here, mint it with outcome.exit_set.partition(owner) and pass each face to .guarded(guard, face) \u2014 carried testimony survives merges and rewrites that guard shape does not. If it owns no split, these arms really are simultaneously reachable and this gap is correct: keep both at the exit level. Do NOT re-materialize the product (the m ** k blow-up #6309 removed), and do NOT widen _are_exclusive to guess exclusivity from how the formulas are spelled.\n  arm A faces: []\n  arm B faces: []"
+    }
+  ],
+  "R_desugar_defects": 15,
+  "unresolvableDispatchTargets": [],
+  "R_unresolvable_dispatch_targets": 0,
+  "elapsedSeconds": 2642.7451887130737,
+  "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+  "sourceStamp": {
+    "commit": "43d9948881df3906aa4b99977f8ab14b4fc951f5",
+    "repo": "/home/tsavo/scoreboard-checkout",
+    "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+    "platform": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
+    "host": "Battleaxe",
+    "loadAverage": [
+      15.99072265625,
+      16.060546875,
+      16.5146484375
+    ],
+    "measuredAtUnix": 1785096684.8927734
+  },
+  "floorSummary": {
+    "kind": "pandas-floor-summary-v1",
+    "floor": "control-effect",
+    "measurement": "measured",
+    "unmeasurableReasons": [],
+    "corpus": {
+      "files": [
+        "pandas/__init__.py",
+        "pandas/_config/__init__.py",
+        "pandas/_config/config.py",
+        "pandas/_config/dates.py",
+        "pandas/_config/display.py",
+        "pandas/_config/localization.py",
+        "pandas/_libs/__init__.py",
+        "pandas/_libs/tslibs/__init__.py",
+        "pandas/_libs/window/__init__.py",
+        "pandas/_testing/__init__.py",
+        "pandas/_testing/_hypothesis.py",
+        "pandas/_testing/_io.py",
+        "pandas/_testing/_warnings.py",
+        "pandas/_testing/asserters.py",
+        "pandas/_testing/compat.py",
+        "pandas/_testing/contexts.py",
+        "pandas/_typing.py",
+        "pandas/_version.py",
+        "pandas/_version_meson.py",
+        "pandas/api/__init__.py",
+        "pandas/api/executors/__init__.py",
+        "pandas/api/extensions/__init__.py",
+        "pandas/api/indexers/__init__.py",
+        "pandas/api/interchange/__init__.py",
+        "pandas/api/internals.py",
+        "pandas/api/types/__init__.py",
+        "pandas/api/typing/__init__.py",
+        "pandas/api/typing/aliases.py",
+        "pandas/arrays/__init__.py",
+        "pandas/compat/__init__.py",
+        "pandas/compat/_constants.py",
+        "pandas/compat/_optional.py",
+        "pandas/compat/numpy/__init__.py",
+        "pandas/compat/numpy/function.py",
+        "pandas/compat/pickle_compat.py",
+        "pandas/compat/pyarrow.py",
+        "pandas/conftest.py",
+        "pandas/core/__init__.py",
+        "pandas/core/_numba/__init__.py",
+        "pandas/core/_numba/executor.py",
+        "pandas/core/_numba/extensions.py",
+        "pandas/core/_numba/kernels/__init__.py",
+        "pandas/core/_numba/kernels/mean_.py",
+        "pandas/core/_numba/kernels/min_max_.py",
+        "pandas/core/_numba/kernels/shared.py",
+        "pandas/core/_numba/kernels/sum_.py",
+        "pandas/core/_numba/kernels/var_.py",
+        "pandas/core/accessor.py",
+        "pandas/core/algorithms.py",
+        "pandas/core/api.py",
+        "pandas/core/apply.py",
+        "pandas/core/array_algos/__init__.py",
+        "pandas/core/array_algos/datetimelike_accumulations.py",
+        "pandas/core/array_algos/masked_accumulations.py",
+        "pandas/core/array_algos/masked_reductions.py",
+        "pandas/core/array_algos/putmask.py",
+        "pandas/core/array_algos/quantile.py",
+        "pandas/core/array_algos/replace.py",
+        "pandas/core/array_algos/take.py",
+        "pandas/core/array_algos/transforms.py",
+        "pandas/core/arraylike.py",
+        "pandas/core/arrays/__init__.py",
+        "pandas/core/arrays/_arrow_string_mixins.py",
+        "pandas/core/arrays/_mixins.py",
+        "pandas/core/arrays/_ranges.py",
+        "pandas/core/arrays/_utils.py",
+        "pandas/core/arrays/arrow/__init__.py",
+        "pandas/core/arrays/arrow/_arrow_utils.py",
+        "pandas/core/arrays/arrow/accessors.py",
+        "pandas/core/arrays/arrow/array.py",
+        "pandas/core/arrays/arrow/extension_types.py",
+        "pandas/core/arrays/base.py",
+        "pandas/core/arrays/boolean.py",
+        "pandas/core/arrays/categorical.py",
+        "pandas/core/arrays/datetimelike.py",
+        "pandas/core/arrays/datetimes.py",
+        "pandas/core/arrays/floating.py",
+        "pandas/core/arrays/integer.py",
+        "pandas/core/arrays/interval.py",
+        "pandas/core/arrays/masked.py",
+        "pandas/core/arrays/numeric.py",
+        "pandas/core/arrays/numpy_.py",
+        "pandas/core/arrays/period.py",
+        "pandas/core/arrays/sparse/__init__.py",
+        "pandas/core/arrays/sparse/accessor.py",
+        "pandas/core/arrays/sparse/array.py",
+        "pandas/core/arrays/sparse/scipy_sparse.py",
+        "pandas/core/arrays/string_.py",
+        "pandas/core/arrays/string_arrow.py",
+        "pandas/core/arrays/timedeltas.py",
+        "pandas/core/base.py",
+        "pandas/core/col.py",
+        "pandas/core/common.py",
+        "pandas/core/computation/__init__.py",
+        "pandas/core/computation/align.py",
+        "pandas/core/computation/api.py",
+        "pandas/core/computation/check.py",
+        "pandas/core/computation/common.py",
+        "pandas/core/computation/engines.py",
+        "pandas/core/computation/eval.py",
+        "pandas/core/computation/expr.py",
+        "pandas/core/computation/expressions.py",
+        "pandas/core/computation/ops.py",
+        "pandas/core/computation/parsing.py",
+        "pandas/core/computation/pytables.py",
+        "pandas/core/computation/scope.py",
+        "pandas/core/config_init.py",
+        "pandas/core/construction.py",
+        "pandas/core/dtypes/__init__.py",
+        "pandas/core/dtypes/api.py",
+        "pandas/core/dtypes/astype.py",
+        "pandas/core/dtypes/base.py",
+        "pandas/core/dtypes/cast.py",
+        "pandas/core/dtypes/common.py",
+        "pandas/core/dtypes/concat.py",
+        "pandas/core/dtypes/dtypes.py",
+        "pandas/core/dtypes/generic.py",
+        "pandas/core/dtypes/inference.py",
+        "pandas/core/dtypes/missing.py",
+        "pandas/core/flags.py",
+        "pandas/core/frame.py",
+        "pandas/core/generic.py",
+        "pandas/core/groupby/__init__.py",
+        "pandas/core/groupby/base.py",
+        "pandas/core/groupby/categorical.py",
+        "pandas/core/groupby/generic.py",
+        "pandas/core/groupby/groupby.py",
+        "pandas/core/groupby/grouper.py",
+        "pandas/core/groupby/indexing.py",
+        "pandas/core/groupby/numba_.py",
+        "pandas/core/groupby/ops.py",
+        "pandas/core/indexers/__init__.py",
+        "pandas/core/indexers/objects.py",
+        "pandas/core/indexers/utils.py",
+        "pandas/core/indexes/__init__.py",
+        "pandas/core/indexes/accessors.py",
+        "pandas/core/indexes/api.py",
+        "pandas/core/indexes/base.py",
+        "pandas/core/indexes/category.py",
+        "pandas/core/indexes/datetimelike.py",
+        "pandas/core/indexes/datetimes.py",
+        "pandas/core/indexes/extension.py",
+        "pandas/core/indexes/frozen.py",
+        "pandas/core/indexes/interval.py",
+        "pandas/core/indexes/multi.py",
+        "pandas/core/indexes/period.py",
+        "pandas/core/indexes/range.py",
+        "pandas/core/indexes/timedeltas.py",
+        "pandas/core/indexing.py",
+        "pandas/core/interchange/__init__.py",
+        "pandas/core/interchange/buffer.py",
+        "pandas/core/interchange/column.py",
+        "pandas/core/interchange/dataframe.py",
+        "pandas/core/interchange/dataframe_protocol.py",
+        "pandas/core/interchange/from_dataframe.py",
+        "pandas/core/interchange/utils.py",
+        "pandas/core/internals/__init__.py",
+        "pandas/core/internals/api.py",
+        "pandas/core/internals/blocks.py",
+        "pandas/core/internals/concat.py",
+        "pandas/core/internals/construction.py",
+        "pandas/core/internals/managers.py",
+        "pandas/core/internals/ops.py",
+        "pandas/core/methods/__init__.py",
+        "pandas/core/methods/describe.py",
+        "pandas/core/methods/selectn.py",
+        "pandas/core/methods/to_dict.py",
+        "pandas/core/missing.py",
+        "pandas/core/nanops.py",
+        "pandas/core/ops/__init__.py",
+        "pandas/core/ops/array_ops.py",
+        "pandas/core/ops/common.py",
+        "pandas/core/ops/dispatch.py",
+        "pandas/core/ops/docstrings.py",
+        "pandas/core/ops/invalid.py",
+        "pandas/core/ops/mask_ops.py",
+        "pandas/core/ops/missing.py",
+        "pandas/core/resample.py",
+        "pandas/core/reshape/__init__.py",
+        "pandas/core/reshape/api.py",
+        "pandas/core/reshape/concat.py",
+        "pandas/core/reshape/encoding.py",
+        "pandas/core/reshape/melt.py",
+        "pandas/core/reshape/merge.py",
+        "pandas/core/reshape/pivot.py",
+        "pandas/core/reshape/reshape.py",
+        "pandas/core/reshape/tile.py",
+        "pandas/core/roperator.py",
+        "pandas/core/sample.py",
+        "pandas/core/series.py",
+        "pandas/core/shared_docs.py",
+        "pandas/core/sorting.py",
+        "pandas/core/sparse/__init__.py",
+        "pandas/core/sparse/api.py",
+        "pandas/core/strings/__init__.py",
+        "pandas/core/strings/accessor.py",
+        "pandas/core/strings/object_array.py",
+        "pandas/core/tools/__init__.py",
+        "pandas/core/tools/datetimes.py",
+        "pandas/core/tools/numeric.py",
+        "pandas/core/tools/timedeltas.py",
+        "pandas/core/tools/times.py",
+        "pandas/core/util/__init__.py",
+        "pandas/core/util/hashing.py",
+        "pandas/core/util/numba_.py",
+        "pandas/core/window/__init__.py",
+        "pandas/core/window/common.py",
+        "pandas/core/window/doc.py",
+        "pandas/core/window/ewm.py",
+        "pandas/core/window/expanding.py",
+        "pandas/core/window/numba_.py",
+        "pandas/core/window/online.py",
+        "pandas/core/window/rolling.py",
+        "pandas/errors/__init__.py",
+        "pandas/errors/cow.py",
+        "pandas/io/__init__.py",
+        "pandas/io/_util.py",
+        "pandas/io/api.py",
+        "pandas/io/clipboard/__init__.py",
+        "pandas/io/clipboards.py",
+        "pandas/io/common.py",
+        "pandas/io/excel/__init__.py",
+        "pandas/io/excel/_base.py",
+        "pandas/io/excel/_calamine.py",
+        "pandas/io/excel/_odfreader.py",
+        "pandas/io/excel/_odswriter.py",
+        "pandas/io/excel/_openpyxl.py",
+        "pandas/io/excel/_pyxlsb.py",
+        "pandas/io/excel/_util.py",
+        "pandas/io/excel/_xlrd.py",
+        "pandas/io/excel/_xlsxwriter.py",
+        "pandas/io/feather_format.py",
+        "pandas/io/formats/__init__.py",
+        "pandas/io/formats/_color_data.py",
+        "pandas/io/formats/console.py",
+        "pandas/io/formats/css.py",
+        "pandas/io/formats/csvs.py",
+        "pandas/io/formats/excel.py",
+        "pandas/io/formats/format.py",
+        "pandas/io/formats/html.py",
+        "pandas/io/formats/info.py",
+        "pandas/io/formats/printing.py",
+        "pandas/io/formats/string.py",
+        "pandas/io/formats/style.py",
+        "pandas/io/formats/style_render.py",
+        "pandas/io/formats/xml.py",
+        "pandas/io/html.py",
+        "pandas/io/iceberg.py",
+        "pandas/io/json/__init__.py",
+        "pandas/io/json/_json.py",
+        "pandas/io/json/_normalize.py",
+        "pandas/io/json/_table_schema.py",
+        "pandas/io/orc.py",
+        "pandas/io/parquet.py",
+        "pandas/io/parsers/__init__.py",
+        "pandas/io/parsers/arrow_parser_wrapper.py",
+        "pandas/io/parsers/base_parser.py",
+        "pandas/io/parsers/c_parser_wrapper.py",
+        "pandas/io/parsers/python_parser.py",
+        "pandas/io/parsers/readers.py",
+        "pandas/io/pickle.py",
+        "pandas/io/pytables.py",
+        "pandas/io/sas/__init__.py",
+        "pandas/io/sas/sas7bdat.py",
+        "pandas/io/sas/sas_constants.py",
+        "pandas/io/sas/sas_xport.py",
+        "pandas/io/sas/sasreader.py",
+        "pandas/io/spss.py",
+        "pandas/io/sql.py",
+        "pandas/io/stata.py",
+        "pandas/io/xml.py",
+        "pandas/plotting/__init__.py",
+        "pandas/plotting/_core.py",
+        "pandas/plotting/_matplotlib/__init__.py",
+        "pandas/plotting/_matplotlib/boxplot.py",
+        "pandas/plotting/_matplotlib/converter.py",
+        "pandas/plotting/_matplotlib/core.py",
+        "pandas/plotting/_matplotlib/groupby.py",
+        "pandas/plotting/_matplotlib/hist.py",
+        "pandas/plotting/_matplotlib/misc.py",
+        "pandas/plotting/_matplotlib/style.py",
+        "pandas/plotting/_matplotlib/timeseries.py",
+        "pandas/plotting/_matplotlib/tools.py",
+        "pandas/plotting/_misc.py",
+        "pandas/testing.py",
+        "pandas/tests/__init__.py",
+        "pandas/tests/api/__init__.py",
+        "pandas/tests/api/test_api.py",
+        "pandas/tests/api/test_types.py",
+        "pandas/tests/apply/__init__.py",
+        "pandas/tests/apply/common.py",
+        "pandas/tests/apply/conftest.py",
+        "pandas/tests/apply/test_frame_apply.py",
+        "pandas/tests/apply/test_frame_apply_relabeling.py",
+        "pandas/tests/apply/test_frame_transform.py",
+        "pandas/tests/apply/test_invalid_arg.py",
+        "pandas/tests/apply/test_numba.py",
+        "pandas/tests/apply/test_series_apply.py",
+        "pandas/tests/apply/test_series_apply_relabeling.py",
+        "pandas/tests/apply/test_series_transform.py",
+        "pandas/tests/apply/test_str.py",
+        "pandas/tests/arithmetic/__init__.py",
+        "pandas/tests/arithmetic/common.py",
+        "pandas/tests/arithmetic/conftest.py",
+        "pandas/tests/arithmetic/test_array_ops.py",
+        "pandas/tests/arithmetic/test_bool.py",
+        "pandas/tests/arithmetic/test_categorical.py",
+        "pandas/tests/arithmetic/test_datetime64.py",
+        "pandas/tests/arithmetic/test_interval.py",
+        "pandas/tests/arithmetic/test_numeric.py",
+        "pandas/tests/arithmetic/test_object.py",
+        "pandas/tests/arithmetic/test_period.py",
+        "pandas/tests/arithmetic/test_string.py",
+        "pandas/tests/arithmetic/test_timedelta64.py",
+        "pandas/tests/arrays/__init__.py",
+        "pandas/tests/arrays/boolean/__init__.py",
+        "pandas/tests/arrays/boolean/test_arithmetic.py",
+        "pandas/tests/arrays/boolean/test_astype.py",
+        "pandas/tests/arrays/boolean/test_comparison.py",
+        "pandas/tests/arrays/boolean/test_construction.py",
+        "pandas/tests/arrays/boolean/test_function.py",
+        "pandas/tests/arrays/boolean/test_indexing.py",
+        "pandas/tests/arrays/boolean/test_logical.py",
+        "pandas/tests/arrays/boolean/test_ops.py",
+        "pandas/tests/arrays/boolean/test_reduction.py",
+        "pandas/tests/arrays/boolean/test_repr.py",
+        "pandas/tests/arrays/categorical/__init__.py",
+        "pandas/tests/arrays/categorical/test_algos.py",
+        "pandas/tests/arrays/categorical/test_analytics.py",
+        "pandas/tests/arrays/categorical/test_api.py",
+        "pandas/tests/arrays/categorical/test_astype.py",
+        "pandas/tests/arrays/categorical/test_constructors.py",
+        "pandas/tests/arrays/categorical/test_dtypes.py",
+        "pandas/tests/arrays/categorical/test_indexing.py",
+        "pandas/tests/arrays/categorical/test_map.py",
+        "pandas/tests/arrays/categorical/test_missing.py",
+        "pandas/tests/arrays/categorical/test_operators.py",
+        "pandas/tests/arrays/categorical/test_replace.py",
+        "pandas/tests/arrays/categorical/test_repr.py",
+        "pandas/tests/arrays/categorical/test_sorting.py",
+        "pandas/tests/arrays/categorical/test_subclass.py",
+        "pandas/tests/arrays/categorical/test_take.py",
+        "pandas/tests/arrays/categorical/test_warnings.py",
+        "pandas/tests/arrays/datetimes/__init__.py",
+        "pandas/tests/arrays/datetimes/test_constructors.py",
+        "pandas/tests/arrays/datetimes/test_cumulative.py",
+        "pandas/tests/arrays/datetimes/test_reductions.py",
+        "pandas/tests/arrays/floating/__init__.py",
+        "pandas/tests/arrays/floating/conftest.py",
+        "pandas/tests/arrays/floating/test_arithmetic.py",
+        "pandas/tests/arrays/floating/test_astype.py",
+        "pandas/tests/arrays/floating/test_comparison.py",
+        "pandas/tests/arrays/floating/test_concat.py",
+        "pandas/tests/arrays/floating/test_construction.py",
+        "pandas/tests/arrays/floating/test_contains.py",
+        "pandas/tests/arrays/floating/test_function.py",
+        "pandas/tests/arrays/floating/test_repr.py",
+        "pandas/tests/arrays/floating/test_to_numpy.py",
+        "pandas/tests/arrays/integer/__init__.py",
+        "pandas/tests/arrays/integer/conftest.py",
+        "pandas/tests/arrays/integer/test_arithmetic.py",
+        "pandas/tests/arrays/integer/test_comparison.py",
+        "pandas/tests/arrays/integer/test_concat.py",
+        "pandas/tests/arrays/integer/test_construction.py",
+        "pandas/tests/arrays/integer/test_dtypes.py",
+        "pandas/tests/arrays/integer/test_function.py",
+        "pandas/tests/arrays/integer/test_indexing.py",
+        "pandas/tests/arrays/integer/test_reduction.py",
+        "pandas/tests/arrays/integer/test_repr.py",
+        "pandas/tests/arrays/interval/__init__.py",
+        "pandas/tests/arrays/interval/test_astype.py",
+        "pandas/tests/arrays/interval/test_formats.py",
+        "pandas/tests/arrays/interval/test_interval.py",
+        "pandas/tests/arrays/interval/test_interval_pyarrow.py",
+        "pandas/tests/arrays/interval/test_overlaps.py",
+        "pandas/tests/arrays/masked/__init__.py",
+        "pandas/tests/arrays/masked/test_arithmetic.py",
+        "pandas/tests/arrays/masked/test_arrow_compat.py",
+        "pandas/tests/arrays/masked/test_function.py",
+        "pandas/tests/arrays/masked/test_indexing.py",
+        "pandas/tests/arrays/masked_shared.py",
+        "pandas/tests/arrays/numpy_/__init__.py",
+        "pandas/tests/arrays/numpy_/test_indexing.py",
+        "pandas/tests/arrays/numpy_/test_numpy.py",
+        "pandas/tests/arrays/period/__init__.py",
+        "pandas/tests/arrays/period/test_arrow_compat.py",
+        "pandas/tests/arrays/period/test_astype.py",
+        "pandas/tests/arrays/period/test_constructors.py",
+        "pandas/tests/arrays/period/test_reductions.py",
+        "pandas/tests/arrays/sparse/__init__.py",
+        "pandas/tests/arrays/sparse/test_accessor.py",
+        "pandas/tests/arrays/sparse/test_arithmetics.py",
+        "pandas/tests/arrays/sparse/test_array.py",
+        "pandas/tests/arrays/sparse/test_astype.py",
+        "pandas/tests/arrays/sparse/test_combine_concat.py",
+        "pandas/tests/arrays/sparse/test_constructors.py",
+        "pandas/tests/arrays/sparse/test_dtype.py",
+        "pandas/tests/arrays/sparse/test_indexing.py",
+        "pandas/tests/arrays/sparse/test_libsparse.py",
+        "pandas/tests/arrays/sparse/test_reductions.py",
+        "pandas/tests/arrays/sparse/test_unary.py",
+        "pandas/tests/arrays/string_/__init__.py",
+        "pandas/tests/arrays/string_/test_concat.py",
+        "pandas/tests/arrays/string_/test_string.py",
+        "pandas/tests/arrays/string_/test_string_arrow.py",
+        "pandas/tests/arrays/test_array.py",
+        "pandas/tests/arrays/test_datetimelike.py",
+        "pandas/tests/arrays/test_datetimes.py",
+        "pandas/tests/arrays/test_ndarray_backed.py",
+        "pandas/tests/arrays/test_period.py",
+        "pandas/tests/arrays/test_timedeltas.py",
+        "pandas/tests/arrays/timedeltas/__init__.py",
+        "pandas/tests/arrays/timedeltas/test_constructors.py",
+        "pandas/tests/arrays/timedeltas/test_cumulative.py",
+        "pandas/tests/arrays/timedeltas/test_reductions.py",
+        "pandas/tests/base/__init__.py",
+        "pandas/tests/base/common.py",
+        "pandas/tests/base/test_constructors.py",
+        "pandas/tests/base/test_conversion.py",
+        "pandas/tests/base/test_fillna.py",
+        "pandas/tests/base/test_misc.py",
+        "pandas/tests/base/test_transpose.py",
+        "pandas/tests/base/test_unique.py",
+        "pandas/tests/base/test_value_counts.py",
+        "pandas/tests/computation/__init__.py",
+        "pandas/tests/computation/test_compat.py",
+        "pandas/tests/computation/test_eval.py",
+        "pandas/tests/config/__init__.py",
+        "pandas/tests/config/test_config.py",
+        "pandas/tests/config/test_localization.py",
+        "pandas/tests/construction/__init__.py",
+        "pandas/tests/construction/test_extract_array.py",
+        "pandas/tests/copy_view/__init__.py",
+        "pandas/tests/copy_view/index/__init__.py",
+        "pandas/tests/copy_view/index/test_datetimeindex.py",
+        "pandas/tests/copy_view/index/test_index.py",
+        "pandas/tests/copy_view/index/test_intervalindex.py",
+        "pandas/tests/copy_view/index/test_periodindex.py",
+        "pandas/tests/copy_view/index/test_timedeltaindex.py",
+        "pandas/tests/copy_view/test_array.py",
+        "pandas/tests/copy_view/test_astype.py",
+        "pandas/tests/copy_view/test_chained_assignment_deprecation.py",
+        "pandas/tests/copy_view/test_clip.py",
+        "pandas/tests/copy_view/test_constructors.py",
+        "pandas/tests/copy_view/test_copy_deprecation.py",
+        "pandas/tests/copy_view/test_core_functionalities.py",
+        "pandas/tests/copy_view/test_functions.py",
+        "pandas/tests/copy_view/test_indexing.py",
+        "pandas/tests/copy_view/test_internals.py",
+        "pandas/tests/copy_view/test_interp_fillna.py",
+        "pandas/tests/copy_view/test_methods.py",
+        "pandas/tests/copy_view/test_replace.py",
+        "pandas/tests/copy_view/test_setitem.py",
+        "pandas/tests/copy_view/test_util.py",
+        "pandas/tests/copy_view/util.py",
+        "pandas/tests/dtypes/__init__.py",
+        "pandas/tests/dtypes/cast/__init__.py",
+        "pandas/tests/dtypes/cast/test_box_unbox.py",
+        "pandas/tests/dtypes/cast/test_can_hold_element.py",
+        "pandas/tests/dtypes/cast/test_construct_from_scalar.py",
+        "pandas/tests/dtypes/cast/test_construct_ndarray.py",
+        "pandas/tests/dtypes/cast/test_construct_object_arr.py",
+        "pandas/tests/dtypes/cast/test_dict_compat.py",
+        "pandas/tests/dtypes/cast/test_downcast.py",
+        "pandas/tests/dtypes/cast/test_find_common_type.py",
+        "pandas/tests/dtypes/cast/test_infer_datetimelike.py",
+        "pandas/tests/dtypes/cast/test_infer_dtype.py",
+        "pandas/tests/dtypes/cast/test_promote.py",
+        "pandas/tests/dtypes/test_common.py",
+        "pandas/tests/dtypes/test_concat.py",
+        "pandas/tests/dtypes/test_dtypes.py",
+        "pandas/tests/dtypes/test_generic.py",
+        "pandas/tests/dtypes/test_inference.py",
+        "pandas/tests/dtypes/test_missing.py",
+        "pandas/tests/extension/__init__.py",
+        "pandas/tests/extension/array_with_attr/__init__.py",
+        "pandas/tests/extension/array_with_attr/array.py",
+        "pandas/tests/extension/array_with_attr/test_array_with_attr.py",
+        "pandas/tests/extension/base/__init__.py",
+        "pandas/tests/extension/base/accumulate.py",
+        "pandas/tests/extension/base/base.py",
+        "pandas/tests/extension/base/casting.py",
+        "pandas/tests/extension/base/constructors.py",
+        "pandas/tests/extension/base/dim2.py",
+        "pandas/tests/extension/base/dtype.py",
+        "pandas/tests/extension/base/getitem.py",
+        "pandas/tests/extension/base/groupby.py",
+        "pandas/tests/extension/base/index.py",
+        "pandas/tests/extension/base/interface.py",
+        "pandas/tests/extension/base/io.py",
+        "pandas/tests/extension/base/methods.py",
+        "pandas/tests/extension/base/missing.py",
+        "pandas/tests/extension/base/ops.py",
+        "pandas/tests/extension/base/printing.py",
+        "pandas/tests/extension/base/reduce.py",
+        "pandas/tests/extension/base/reshaping.py",
+        "pandas/tests/extension/base/setitem.py",
+        "pandas/tests/extension/conftest.py",
+        "pandas/tests/extension/date/__init__.py",
+        "pandas/tests/extension/date/array.py",
+        "pandas/tests/extension/decimal/__init__.py",
+        "pandas/tests/extension/decimal/array.py",
+        "pandas/tests/extension/decimal/test_decimal.py",
+        "pandas/tests/extension/json/__init__.py",
+        "pandas/tests/extension/json/array.py",
+        "pandas/tests/extension/json/test_json.py",
+        "pandas/tests/extension/list/__init__.py",
+        "pandas/tests/extension/list/array.py",
+        "pandas/tests/extension/list/test_list.py",
+        "pandas/tests/extension/test_arrow.py",
+        "pandas/tests/extension/test_categorical.py",
+        "pandas/tests/extension/test_common.py",
+        "pandas/tests/extension/test_datetime.py",
+        "pandas/tests/extension/test_extension.py",
+        "pandas/tests/extension/test_interval.py",
+        "pandas/tests/extension/test_masked.py",
+        "pandas/tests/extension/test_numpy.py",
+        "pandas/tests/extension/test_period.py",
+        "pandas/tests/extension/test_sparse.py",
+        "pandas/tests/extension/test_string.py",
+        "pandas/tests/extension/uuid/__init__.py",
+        "pandas/tests/extension/uuid/test_uuid.py",
+        "pandas/tests/frame/__init__.py",
+        "pandas/tests/frame/common.py",
+        "pandas/tests/frame/conftest.py",
+        "pandas/tests/frame/constructors/__init__.py",
+        "pandas/tests/frame/constructors/test_from_dict.py",
+        "pandas/tests/frame/constructors/test_from_records.py",
+        "pandas/tests/frame/indexing/__init__.py",
+        "pandas/tests/frame/indexing/test_coercion.py",
+        "pandas/tests/frame/indexing/test_delitem.py",
+        "pandas/tests/frame/indexing/test_get.py",
+        "pandas/tests/frame/indexing/test_get_value.py",
+        "pandas/tests/frame/indexing/test_getitem.py",
+        "pandas/tests/frame/indexing/test_indexing.py",
+        "pandas/tests/frame/indexing/test_insert.py",
+        "pandas/tests/frame/indexing/test_mask.py",
+        "pandas/tests/frame/indexing/test_set_value.py",
+        "pandas/tests/frame/indexing/test_setitem.py",
+        "pandas/tests/frame/indexing/test_take.py",
+        "pandas/tests/frame/indexing/test_where.py",
+        "pandas/tests/frame/indexing/test_xs.py",
+        "pandas/tests/frame/methods/__init__.py",
+        "pandas/tests/frame/methods/test_add_prefix_suffix.py",
+        "pandas/tests/frame/methods/test_align.py",
+        "pandas/tests/frame/methods/test_asfreq.py",
+        "pandas/tests/frame/methods/test_asof.py",
+        "pandas/tests/frame/methods/test_assign.py",
+        "pandas/tests/frame/methods/test_astype.py",
+        "pandas/tests/frame/methods/test_at_time.py",
+        "pandas/tests/frame/methods/test_between_time.py",
+        "pandas/tests/frame/methods/test_clip.py",
+        "pandas/tests/frame/methods/test_combine.py",
+        "pandas/tests/frame/methods/test_combine_first.py",
+        "pandas/tests/frame/methods/test_compare.py",
+        "pandas/tests/frame/methods/test_convert_dtypes.py",
+        "pandas/tests/frame/methods/test_copy.py",
+        "pandas/tests/frame/methods/test_count.py",
+        "pandas/tests/frame/methods/test_cov_corr.py",
+        "pandas/tests/frame/methods/test_describe.py",
+        "pandas/tests/frame/methods/test_diff.py",
+        "pandas/tests/frame/methods/test_dot.py",
+        "pandas/tests/frame/methods/test_drop.py",
+        "pandas/tests/frame/methods/test_drop_duplicates.py",
+        "pandas/tests/frame/methods/test_droplevel.py",
+        "pandas/tests/frame/methods/test_dropna.py",
+        "pandas/tests/frame/methods/test_dtypes.py",
+        "pandas/tests/frame/methods/test_duplicated.py",
+        "pandas/tests/frame/methods/test_equals.py",
+        "pandas/tests/frame/methods/test_explode.py",
+        "pandas/tests/frame/methods/test_fillna.py",
+        "pandas/tests/frame/methods/test_filter.py",
+        "pandas/tests/frame/methods/test_first_valid_index.py",
+        "pandas/tests/frame/methods/test_get_numeric_data.py",
+        "pandas/tests/frame/methods/test_head_tail.py",
+        "pandas/tests/frame/methods/test_infer_objects.py",
+        "pandas/tests/frame/methods/test_info.py",
+        "pandas/tests/frame/methods/test_interpolate.py",
+        "pandas/tests/frame/methods/test_is_homogeneous_dtype.py",
+        "pandas/tests/frame/methods/test_isetitem.py",
+        "pandas/tests/frame/methods/test_isin.py",
+        "pandas/tests/frame/methods/test_iterrows.py",
+        "pandas/tests/frame/methods/test_join.py",
+        "pandas/tests/frame/methods/test_map.py",
+        "pandas/tests/frame/methods/test_matmul.py",
+        "pandas/tests/frame/methods/test_nlargest.py",
+        "pandas/tests/frame/methods/test_pct_change.py",
+        "pandas/tests/frame/methods/test_pipe.py",
+        "pandas/tests/frame/methods/test_pop.py",
+        "pandas/tests/frame/methods/test_quantile.py",
+        "pandas/tests/frame/methods/test_rank.py",
+        "pandas/tests/frame/methods/test_reindex.py",
+        "pandas/tests/frame/methods/test_reindex_like.py",
+        "pandas/tests/frame/methods/test_rename.py",
+        "pandas/tests/frame/methods/test_rename_axis.py",
+        "pandas/tests/frame/methods/test_reorder_levels.py",
+        "pandas/tests/frame/methods/test_replace.py",
+        "pandas/tests/frame/methods/test_reset_index.py",
+        "pandas/tests/frame/methods/test_round.py",
+        "pandas/tests/frame/methods/test_sample.py",
+        "pandas/tests/frame/methods/test_select_dtypes.py",
+        "pandas/tests/frame/methods/test_set_axis.py",
+        "pandas/tests/frame/methods/test_set_index.py",
+        "pandas/tests/frame/methods/test_shift.py",
+        "pandas/tests/frame/methods/test_size.py",
+        "pandas/tests/frame/methods/test_sort_index.py",
+        "pandas/tests/frame/methods/test_sort_values.py",
+        "pandas/tests/frame/methods/test_swaplevel.py",
+        "pandas/tests/frame/methods/test_to_csv.py",
+        "pandas/tests/frame/methods/test_to_dict.py",
+        "pandas/tests/frame/methods/test_to_dict_of_blocks.py",
+        "pandas/tests/frame/methods/test_to_numpy.py",
+        "pandas/tests/frame/methods/test_to_period.py",
+        "pandas/tests/frame/methods/test_to_records.py",
+        "pandas/tests/frame/methods/test_to_timestamp.py",
+        "pandas/tests/frame/methods/test_transpose.py",
+        "pandas/tests/frame/methods/test_truncate.py",
+        "pandas/tests/frame/methods/test_tz_convert.py",
+        "pandas/tests/frame/methods/test_tz_localize.py",
+        "pandas/tests/frame/methods/test_update.py",
+        "pandas/tests/frame/methods/test_value_counts.py",
+        "pandas/tests/frame/methods/test_values.py",
+        "pandas/tests/frame/test_alter_axes.py",
+        "pandas/tests/frame/test_api.py",
+        "pandas/tests/frame/test_arithmetic.py",
+        "pandas/tests/frame/test_arrow_interface.py",
+        "pandas/tests/frame/test_block_internals.py",
+        "pandas/tests/frame/test_constructors.py",
+        "pandas/tests/frame/test_cumulative.py",
+        "pandas/tests/frame/test_iteration.py",
+        "pandas/tests/frame/test_logical_ops.py",
+        "pandas/tests/frame/test_nonunique_indexes.py",
+        "pandas/tests/frame/test_npfuncs.py",
+        "pandas/tests/frame/test_query_eval.py",
+        "pandas/tests/frame/test_reductions.py",
+        "pandas/tests/frame/test_repr.py",
+        "pandas/tests/frame/test_stack_unstack.py",
+        "pandas/tests/frame/test_subclass.py",
+        "pandas/tests/frame/test_ufunc.py",
+        "pandas/tests/frame/test_unary.py",
+        "pandas/tests/frame/test_validate.py",
+        "pandas/tests/generic/__init__.py",
+        "pandas/tests/generic/test_duplicate_labels.py",
+        "pandas/tests/generic/test_finalize.py",
+        "pandas/tests/generic/test_frame.py",
+        "pandas/tests/generic/test_generic.py",
+        "pandas/tests/generic/test_label_or_level_utils.py",
+        "pandas/tests/generic/test_series.py",
+        "pandas/tests/generic/test_to_xarray.py",
+        "pandas/tests/groupby/__init__.py",
+        "pandas/tests/groupby/aggregate/__init__.py",
+        "pandas/tests/groupby/aggregate/test_aggregate.py",
+        "pandas/tests/groupby/aggregate/test_cython.py",
+        "pandas/tests/groupby/aggregate/test_numba.py",
+        "pandas/tests/groupby/aggregate/test_other.py",
+        "pandas/tests/groupby/conftest.py",
+        "pandas/tests/groupby/methods/__init__.py",
+        "pandas/tests/groupby/methods/test_describe.py",
+        "pandas/tests/groupby/methods/test_groupby_shift_diff.py",
+        "pandas/tests/groupby/methods/test_is_monotonic.py",
+        "pandas/tests/groupby/methods/test_kurt.py",
+        "pandas/tests/groupby/methods/test_nlargest_nsmallest.py",
+        "pandas/tests/groupby/methods/test_nth.py",
+        "pandas/tests/groupby/methods/test_quantile.py",
+        "pandas/tests/groupby/methods/test_rank.py",
+        "pandas/tests/groupby/methods/test_sample.py",
+        "pandas/tests/groupby/methods/test_size.py",
+        "pandas/tests/groupby/methods/test_skew.py",
+        "pandas/tests/groupby/methods/test_value_counts.py",
+        "pandas/tests/groupby/test_all_methods.py",
+        "pandas/tests/groupby/test_api.py",
+        "pandas/tests/groupby/test_apply.py",
+        "pandas/tests/groupby/test_bin_groupby.py",
+        "pandas/tests/groupby/test_categorical.py",
+        "pandas/tests/groupby/test_counting.py",
+        "pandas/tests/groupby/test_cumulative.py",
+        "pandas/tests/groupby/test_filters.py",
+        "pandas/tests/groupby/test_groupby.py",
+        "pandas/tests/groupby/test_groupby_dropna.py",
+        "pandas/tests/groupby/test_groupby_subclass.py",
+        "pandas/tests/groupby/test_grouping.py",
+        "pandas/tests/groupby/test_index_as_string.py",
+        "pandas/tests/groupby/test_indexing.py",
+        "pandas/tests/groupby/test_libgroupby.py",
+        "pandas/tests/groupby/test_missing.py",
+        "pandas/tests/groupby/test_numba.py",
+        "pandas/tests/groupby/test_numeric_only.py",
+        "pandas/tests/groupby/test_pipe.py",
+        "pandas/tests/groupby/test_raises.py",
+        "pandas/tests/groupby/test_reductions.py",
+        "pandas/tests/groupby/test_timegrouper.py",
+        "pandas/tests/groupby/transform/__init__.py",
+        "pandas/tests/groupby/transform/test_numba.py",
+        "pandas/tests/groupby/transform/test_transform.py",
+        "pandas/tests/indexes/__init__.py",
+        "pandas/tests/indexes/base_class/__init__.py",
+        "pandas/tests/indexes/base_class/test_constructors.py",
+        "pandas/tests/indexes/base_class/test_formats.py",
+        "pandas/tests/indexes/base_class/test_indexing.py",
+        "pandas/tests/indexes/base_class/test_pickle.py",
+        "pandas/tests/indexes/base_class/test_reshape.py",
+        "pandas/tests/indexes/base_class/test_setops.py",
+        "pandas/tests/indexes/base_class/test_where.py",
+        "pandas/tests/indexes/categorical/__init__.py",
+        "pandas/tests/indexes/categorical/test_append.py",
+        "pandas/tests/indexes/categorical/test_astype.py",
+        "pandas/tests/indexes/categorical/test_category.py",
+        "pandas/tests/indexes/categorical/test_constructors.py",
+        "pandas/tests/indexes/categorical/test_equals.py",
+        "pandas/tests/indexes/categorical/test_fillna.py",
+        "pandas/tests/indexes/categorical/test_formats.py",
+        "pandas/tests/indexes/categorical/test_indexing.py",
+        "pandas/tests/indexes/categorical/test_map.py",
+        "pandas/tests/indexes/categorical/test_reindex.py",
+        "pandas/tests/indexes/categorical/test_setops.py",
+        "pandas/tests/indexes/conftest.py",
+        "pandas/tests/indexes/datetimelike_/__init__.py",
+        "pandas/tests/indexes/datetimelike_/test_drop_duplicates.py",
+        "pandas/tests/indexes/datetimelike_/test_equals.py",
+        "pandas/tests/indexes/datetimelike_/test_indexing.py",
+        "pandas/tests/indexes/datetimelike_/test_is_monotonic.py",
+        "pandas/tests/indexes/datetimelike_/test_nat.py",
+        "pandas/tests/indexes/datetimelike_/test_sort_values.py",
+        "pandas/tests/indexes/datetimelike_/test_value_counts.py",
+        "pandas/tests/indexes/datetimes/__init__.py",
+        "pandas/tests/indexes/datetimes/methods/__init__.py",
+        "pandas/tests/indexes/datetimes/methods/test_asof.py",
+        "pandas/tests/indexes/datetimes/methods/test_astype.py",
+        "pandas/tests/indexes/datetimes/methods/test_delete.py",
+        "pandas/tests/indexes/datetimes/methods/test_factorize.py",
+        "pandas/tests/indexes/datetimes/methods/test_fillna.py",
+        "pandas/tests/indexes/datetimes/methods/test_insert.py",
+        "pandas/tests/indexes/datetimes/methods/test_isocalendar.py",
+        "pandas/tests/indexes/datetimes/methods/test_map.py",
+        "pandas/tests/indexes/datetimes/methods/test_normalize.py",
+        "pandas/tests/indexes/datetimes/methods/test_repeat.py",
+        "pandas/tests/indexes/datetimes/methods/test_resolution.py",
+        "pandas/tests/indexes/datetimes/methods/test_round.py",
+        "pandas/tests/indexes/datetimes/methods/test_shift.py",
+        "pandas/tests/indexes/datetimes/methods/test_snap.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_frame.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_julian_date.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_period.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_pydatetime.py",
+        "pandas/tests/indexes/datetimes/methods/test_to_series.py",
+        "pandas/tests/indexes/datetimes/methods/test_tz_convert.py",
+        "pandas/tests/indexes/datetimes/methods/test_tz_localize.py",
+        "pandas/tests/indexes/datetimes/methods/test_unique.py",
+        "pandas/tests/indexes/datetimes/test_arithmetic.py",
+        "pandas/tests/indexes/datetimes/test_constructors.py",
+        "pandas/tests/indexes/datetimes/test_date_range.py",
+        "pandas/tests/indexes/datetimes/test_datetime.py",
+        "pandas/tests/indexes/datetimes/test_formats.py",
+        "pandas/tests/indexes/datetimes/test_freq_attr.py",
+        "pandas/tests/indexes/datetimes/test_indexing.py",
+        "pandas/tests/indexes/datetimes/test_iter.py",
+        "pandas/tests/indexes/datetimes/test_join.py",
+        "pandas/tests/indexes/datetimes/test_npfuncs.py",
+        "pandas/tests/indexes/datetimes/test_ops.py",
+        "pandas/tests/indexes/datetimes/test_partial_slicing.py",
+        "pandas/tests/indexes/datetimes/test_pickle.py",
+        "pandas/tests/indexes/datetimes/test_reindex.py",
+        "pandas/tests/indexes/datetimes/test_scalar_compat.py",
+        "pandas/tests/indexes/datetimes/test_setops.py",
+        "pandas/tests/indexes/datetimes/test_timezones.py",
+        "pandas/tests/indexes/interval/__init__.py",
+        "pandas/tests/indexes/interval/test_astype.py",
+        "pandas/tests/indexes/interval/test_constructors.py",
+        "pandas/tests/indexes/interval/test_equals.py",
+        "pandas/tests/indexes/interval/test_formats.py",
+        "pandas/tests/indexes/interval/test_indexing.py",
+        "pandas/tests/indexes/interval/test_interval.py",
+        "pandas/tests/indexes/interval/test_interval_range.py",
+        "pandas/tests/indexes/interval/test_interval_tree.py",
+        "pandas/tests/indexes/interval/test_join.py",
+        "pandas/tests/indexes/interval/test_pickle.py",
+        "pandas/tests/indexes/interval/test_setops.py",
+        "pandas/tests/indexes/multi/__init__.py",
+        "pandas/tests/indexes/multi/conftest.py",
+        "pandas/tests/indexes/multi/test_analytics.py",
+        "pandas/tests/indexes/multi/test_astype.py",
+        "pandas/tests/indexes/multi/test_compat.py",
+        "pandas/tests/indexes/multi/test_constructors.py",
+        "pandas/tests/indexes/multi/test_conversion.py",
+        "pandas/tests/indexes/multi/test_copy.py",
+        "pandas/tests/indexes/multi/test_drop.py",
+        "pandas/tests/indexes/multi/test_duplicates.py",
+        "pandas/tests/indexes/multi/test_equivalence.py",
+        "pandas/tests/indexes/multi/test_formats.py",
+        "pandas/tests/indexes/multi/test_get_level_values.py",
+        "pandas/tests/indexes/multi/test_get_set.py",
+        "pandas/tests/indexes/multi/test_indexing.py",
+        "pandas/tests/indexes/multi/test_integrity.py",
+        "pandas/tests/indexes/multi/test_isin.py",
+        "pandas/tests/indexes/multi/test_join.py",
+        "pandas/tests/indexes/multi/test_lexsort.py",
+        "pandas/tests/indexes/multi/test_missing.py",
+        "pandas/tests/indexes/multi/test_monotonic.py",
+        "pandas/tests/indexes/multi/test_names.py",
+        "pandas/tests/indexes/multi/test_partial_indexing.py",
+        "pandas/tests/indexes/multi/test_pickle.py",
+        "pandas/tests/indexes/multi/test_reindex.py",
+        "pandas/tests/indexes/multi/test_reshape.py",
+        "pandas/tests/indexes/multi/test_setops.py",
+        "pandas/tests/indexes/multi/test_sorting.py",
+        "pandas/tests/indexes/multi/test_take.py",
+        "pandas/tests/indexes/multi/test_util.py",
+        "pandas/tests/indexes/numeric/__init__.py",
+        "pandas/tests/indexes/numeric/test_astype.py",
+        "pandas/tests/indexes/numeric/test_indexing.py",
+        "pandas/tests/indexes/numeric/test_join.py",
+        "pandas/tests/indexes/numeric/test_numeric.py",
+        "pandas/tests/indexes/numeric/test_setops.py",
+        "pandas/tests/indexes/object/__init__.py",
+        "pandas/tests/indexes/object/test_astype.py",
+        "pandas/tests/indexes/object/test_indexing.py",
+        "pandas/tests/indexes/period/__init__.py",
+        "pandas/tests/indexes/period/methods/__init__.py",
+        "pandas/tests/indexes/period/methods/test_asfreq.py",
+        "pandas/tests/indexes/period/methods/test_astype.py",
+        "pandas/tests/indexes/period/methods/test_factorize.py",
+        "pandas/tests/indexes/period/methods/test_fillna.py",
+        "pandas/tests/indexes/period/methods/test_insert.py",
+        "pandas/tests/indexes/period/methods/test_is_full.py",
+        "pandas/tests/indexes/period/methods/test_repeat.py",
+        "pandas/tests/indexes/period/methods/test_shift.py",
+        "pandas/tests/indexes/period/methods/test_to_timestamp.py",
+        "pandas/tests/indexes/period/test_constructors.py",
+        "pandas/tests/indexes/period/test_formats.py",
+        "pandas/tests/indexes/period/test_freq_attr.py",
+        "pandas/tests/indexes/period/test_indexing.py",
+        "pandas/tests/indexes/period/test_join.py",
+        "pandas/tests/indexes/period/test_monotonic.py",
+        "pandas/tests/indexes/period/test_partial_slicing.py",
+        "pandas/tests/indexes/period/test_period.py",
+        "pandas/tests/indexes/period/test_period_range.py",
+        "pandas/tests/indexes/period/test_pickle.py",
+        "pandas/tests/indexes/period/test_resolution.py",
+        "pandas/tests/indexes/period/test_scalar_compat.py",
+        "pandas/tests/indexes/period/test_searchsorted.py",
+        "pandas/tests/indexes/period/test_setops.py",
+        "pandas/tests/indexes/period/test_tools.py",
+        "pandas/tests/indexes/ranges/__init__.py",
+        "pandas/tests/indexes/ranges/test_constructors.py",
+        "pandas/tests/indexes/ranges/test_indexing.py",
+        "pandas/tests/indexes/ranges/test_join.py",
+        "pandas/tests/indexes/ranges/test_range.py",
+        "pandas/tests/indexes/ranges/test_setops.py",
+        "pandas/tests/indexes/string/__init__.py",
+        "pandas/tests/indexes/string/test_astype.py",
+        "pandas/tests/indexes/string/test_indexing.py",
+        "pandas/tests/indexes/test_any_index.py",
+        "pandas/tests/indexes/test_base.py",
+        "pandas/tests/indexes/test_common.py",
+        "pandas/tests/indexes/test_datetimelike.py",
+        "pandas/tests/indexes/test_engines.py",
+        "pandas/tests/indexes/test_frozen.py",
+        "pandas/tests/indexes/test_index_new.py",
+        "pandas/tests/indexes/test_indexing.py",
+        "pandas/tests/indexes/test_numpy_compat.py",
+        "pandas/tests/indexes/test_old_base.py",
+        "pandas/tests/indexes/test_setops.py",
+        "pandas/tests/indexes/test_subclass.py",
+        "pandas/tests/indexes/timedeltas/__init__.py",
+        "pandas/tests/indexes/timedeltas/methods/__init__.py",
+        "pandas/tests/indexes/timedeltas/methods/test_astype.py",
+        "pandas/tests/indexes/timedeltas/methods/test_factorize.py",
+        "pandas/tests/indexes/timedeltas/methods/test_fillna.py",
+        "pandas/tests/indexes/timedeltas/methods/test_insert.py",
+        "pandas/tests/indexes/timedeltas/methods/test_repeat.py",
+        "pandas/tests/indexes/timedeltas/methods/test_shift.py",
+        "pandas/tests/indexes/timedeltas/test_arithmetic.py",
+        "pandas/tests/indexes/timedeltas/test_constructors.py",
+        "pandas/tests/indexes/timedeltas/test_delete.py",
+        "pandas/tests/indexes/timedeltas/test_formats.py",
+        "pandas/tests/indexes/timedeltas/test_freq_attr.py",
+        "pandas/tests/indexes/timedeltas/test_indexing.py",
+        "pandas/tests/indexes/timedeltas/test_join.py",
+        "pandas/tests/indexes/timedeltas/test_ops.py",
+        "pandas/tests/indexes/timedeltas/test_pickle.py",
+        "pandas/tests/indexes/timedeltas/test_scalar_compat.py",
+        "pandas/tests/indexes/timedeltas/test_searchsorted.py",
+        "pandas/tests/indexes/timedeltas/test_setops.py",
+        "pandas/tests/indexes/timedeltas/test_timedelta.py",
+        "pandas/tests/indexes/timedeltas/test_timedelta_range.py",
+        "pandas/tests/indexing/__init__.py",
+        "pandas/tests/indexing/common.py",
+        "pandas/tests/indexing/interval/__init__.py",
+        "pandas/tests/indexing/interval/test_interval.py",
+        "pandas/tests/indexing/interval/test_interval_new.py",
+        "pandas/tests/indexing/multiindex/__init__.py",
+        "pandas/tests/indexing/multiindex/test_chaining_and_caching.py",
+        "pandas/tests/indexing/multiindex/test_datetime.py",
+        "pandas/tests/indexing/multiindex/test_getitem.py",
+        "pandas/tests/indexing/multiindex/test_iloc.py",
+        "pandas/tests/indexing/multiindex/test_indexing_slow.py",
+        "pandas/tests/indexing/multiindex/test_loc.py",
+        "pandas/tests/indexing/multiindex/test_multiindex.py",
+        "pandas/tests/indexing/multiindex/test_partial.py",
+        "pandas/tests/indexing/multiindex/test_setitem.py",
+        "pandas/tests/indexing/multiindex/test_slice.py",
+        "pandas/tests/indexing/multiindex/test_sorted.py",
+        "pandas/tests/indexing/test_at.py",
+        "pandas/tests/indexing/test_categorical.py",
+        "pandas/tests/indexing/test_chaining_and_caching.py",
+        "pandas/tests/indexing/test_check_indexer.py",
+        "pandas/tests/indexing/test_coercion.py",
+        "pandas/tests/indexing/test_datetime.py",
+        "pandas/tests/indexing/test_floats.py",
+        "pandas/tests/indexing/test_iat.py",
+        "pandas/tests/indexing/test_iloc.py",
+        "pandas/tests/indexing/test_indexers.py",
+        "pandas/tests/indexing/test_indexing.py",
+        "pandas/tests/indexing/test_loc.py",
+        "pandas/tests/indexing/test_na_indexing.py",
+        "pandas/tests/indexing/test_partial.py",
+        "pandas/tests/indexing/test_scalar.py",
+        "pandas/tests/interchange/__init__.py",
+        "pandas/tests/interchange/test_impl.py",
+        "pandas/tests/interchange/test_spec_conformance.py",
+        "pandas/tests/interchange/test_utils.py",
+        "pandas/tests/internals/__init__.py",
+        "pandas/tests/internals/test_api.py",
+        "pandas/tests/internals/test_internals.py",
+        "pandas/tests/io/__init__.py",
+        "pandas/tests/io/conftest.py",
+        "pandas/tests/io/excel/__init__.py",
+        "pandas/tests/io/excel/test_odf.py",
+        "pandas/tests/io/excel/test_odswriter.py",
+        "pandas/tests/io/excel/test_openpyxl.py",
+        "pandas/tests/io/excel/test_readers.py",
+        "pandas/tests/io/excel/test_style.py",
+        "pandas/tests/io/excel/test_writers.py",
+        "pandas/tests/io/excel/test_xlrd.py",
+        "pandas/tests/io/excel/test_xlsxwriter.py",
+        "pandas/tests/io/formats/__init__.py",
+        "pandas/tests/io/formats/style/__init__.py",
+        "pandas/tests/io/formats/style/test_bar.py",
+        "pandas/tests/io/formats/style/test_exceptions.py",
+        "pandas/tests/io/formats/style/test_format.py",
+        "pandas/tests/io/formats/style/test_highlight.py",
+        "pandas/tests/io/formats/style/test_html.py",
+        "pandas/tests/io/formats/style/test_matplotlib.py",
+        "pandas/tests/io/formats/style/test_non_unique.py",
+        "pandas/tests/io/formats/style/test_style.py",
+        "pandas/tests/io/formats/style/test_to_latex.py",
+        "pandas/tests/io/formats/style/test_to_string.py",
+        "pandas/tests/io/formats/style/test_to_typst.py",
+        "pandas/tests/io/formats/style/test_tooltip.py",
+        "pandas/tests/io/formats/test_console.py",
+        "pandas/tests/io/formats/test_css.py",
+        "pandas/tests/io/formats/test_eng_formatting.py",
+        "pandas/tests/io/formats/test_format.py",
+        "pandas/tests/io/formats/test_ipython_compat.py",
+        "pandas/tests/io/formats/test_printing.py",
+        "pandas/tests/io/formats/test_to_csv.py",
+        "pandas/tests/io/formats/test_to_excel.py",
+        "pandas/tests/io/formats/test_to_html.py",
+        "pandas/tests/io/formats/test_to_latex.py",
+        "pandas/tests/io/formats/test_to_markdown.py",
+        "pandas/tests/io/formats/test_to_string.py",
+        "pandas/tests/io/generate_legacy_storage_files.py",
+        "pandas/tests/io/json/__init__.py",
+        "pandas/tests/io/json/conftest.py",
+        "pandas/tests/io/json/test_compression.py",
+        "pandas/tests/io/json/test_deprecated_kwargs.py",
+        "pandas/tests/io/json/test_json_table_schema.py",
+        "pandas/tests/io/json/test_json_table_schema_ext_dtype.py",
+        "pandas/tests/io/json/test_normalize.py",
+        "pandas/tests/io/json/test_pandas.py",
+        "pandas/tests/io/json/test_readlines.py",
+        "pandas/tests/io/json/test_ujson.py",
+        "pandas/tests/io/parser/__init__.py",
+        "pandas/tests/io/parser/common/__init__.py",
+        "pandas/tests/io/parser/common/test_chunksize.py",
+        "pandas/tests/io/parser/common/test_common_basic.py",
+        "pandas/tests/io/parser/common/test_data_list.py",
+        "pandas/tests/io/parser/common/test_decimal.py",
+        "pandas/tests/io/parser/common/test_file_buffer_url.py",
+        "pandas/tests/io/parser/common/test_float.py",
+        "pandas/tests/io/parser/common/test_index.py",
+        "pandas/tests/io/parser/common/test_inf.py",
+        "pandas/tests/io/parser/common/test_ints.py",
+        "pandas/tests/io/parser/common/test_iterator.py",
+        "pandas/tests/io/parser/common/test_read_errors.py",
+        "pandas/tests/io/parser/conftest.py",
+        "pandas/tests/io/parser/dtypes/__init__.py",
+        "pandas/tests/io/parser/dtypes/test_categorical.py",
+        "pandas/tests/io/parser/dtypes/test_dtypes_basic.py",
+        "pandas/tests/io/parser/dtypes/test_empty.py",
+        "pandas/tests/io/parser/test_c_parser_only.py",
+        "pandas/tests/io/parser/test_comment.py",
+        "pandas/tests/io/parser/test_compression.py",
+        "pandas/tests/io/parser/test_concatenate_chunks.py",
+        "pandas/tests/io/parser/test_converters.py",
+        "pandas/tests/io/parser/test_dialect.py",
+        "pandas/tests/io/parser/test_encoding.py",
+        "pandas/tests/io/parser/test_header.py",
+        "pandas/tests/io/parser/test_index_col.py",
+        "pandas/tests/io/parser/test_mangle_dupes.py",
+        "pandas/tests/io/parser/test_multi_thread.py",
+        "pandas/tests/io/parser/test_na_values.py",
+        "pandas/tests/io/parser/test_network.py",
+        "pandas/tests/io/parser/test_parse_dates.py",
+        "pandas/tests/io/parser/test_python_parser_only.py",
+        "pandas/tests/io/parser/test_quoting.py",
+        "pandas/tests/io/parser/test_read_fwf.py",
+        "pandas/tests/io/parser/test_skiprows.py",
+        "pandas/tests/io/parser/test_textreader.py",
+        "pandas/tests/io/parser/test_unsupported.py",
+        "pandas/tests/io/parser/test_upcast.py",
+        "pandas/tests/io/parser/usecols/__init__.py",
+        "pandas/tests/io/parser/usecols/test_parse_dates.py",
+        "pandas/tests/io/parser/usecols/test_strings.py",
+        "pandas/tests/io/parser/usecols/test_usecols_basic.py",
+        "pandas/tests/io/pytables/__init__.py",
+        "pandas/tests/io/pytables/common.py",
+        "pandas/tests/io/pytables/conftest.py",
+        "pandas/tests/io/pytables/test_append.py",
+        "pandas/tests/io/pytables/test_categorical.py",
+        "pandas/tests/io/pytables/test_compat.py",
+        "pandas/tests/io/pytables/test_complex.py",
+        "pandas/tests/io/pytables/test_errors.py",
+        "pandas/tests/io/pytables/test_file_handling.py",
+        "pandas/tests/io/pytables/test_keys.py",
+        "pandas/tests/io/pytables/test_put.py",
+        "pandas/tests/io/pytables/test_pytables_missing.py",
+        "pandas/tests/io/pytables/test_read.py",
+        "pandas/tests/io/pytables/test_retain_attributes.py",
+        "pandas/tests/io/pytables/test_round_trip.py",
+        "pandas/tests/io/pytables/test_select.py",
+        "pandas/tests/io/pytables/test_store.py",
+        "pandas/tests/io/pytables/test_subclass.py",
+        "pandas/tests/io/pytables/test_time_series.py",
+        "pandas/tests/io/pytables/test_timezones.py",
+        "pandas/tests/io/sas/__init__.py",
+        "pandas/tests/io/sas/test_byteswap.py",
+        "pandas/tests/io/sas/test_sas.py",
+        "pandas/tests/io/sas/test_sas7bdat.py",
+        "pandas/tests/io/sas/test_xport.py",
+        "pandas/tests/io/test_clipboard.py",
+        "pandas/tests/io/test_common.py",
+        "pandas/tests/io/test_compression.py",
+        "pandas/tests/io/test_feather.py",
+        "pandas/tests/io/test_fsspec.py",
+        "pandas/tests/io/test_gcs.py",
+        "pandas/tests/io/test_html.py",
+        "pandas/tests/io/test_http_headers.py",
+        "pandas/tests/io/test_iceberg.py",
+        "pandas/tests/io/test_orc.py",
+        "pandas/tests/io/test_parquet.py",
+        "pandas/tests/io/test_pickle.py",
+        "pandas/tests/io/test_s3.py",
+        "pandas/tests/io/test_spss.py",
+        "pandas/tests/io/test_sql.py",
+        "pandas/tests/io/test_stata.py",
+        "pandas/tests/io/test_util.py",
+        "pandas/tests/io/xml/__init__.py",
+        "pandas/tests/io/xml/conftest.py",
+        "pandas/tests/io/xml/test_to_xml.py",
+        "pandas/tests/io/xml/test_xml.py",
+        "pandas/tests/io/xml/test_xml_dtypes.py",
+        "pandas/tests/libs/__init__.py",
+        "pandas/tests/libs/test_hashtable.py",
+        "pandas/tests/libs/test_join.py",
+        "pandas/tests/libs/test_lib.py",
+        "pandas/tests/libs/test_libalgos.py",
+        "pandas/tests/plotting/__init__.py",
+        "pandas/tests/plotting/common.py",
+        "pandas/tests/plotting/conftest.py",
+        "pandas/tests/plotting/frame/__init__.py",
+        "pandas/tests/plotting/frame/test_frame.py",
+        "pandas/tests/plotting/frame/test_frame_color.py",
+        "pandas/tests/plotting/frame/test_frame_groupby.py",
+        "pandas/tests/plotting/frame/test_frame_legend.py",
+        "pandas/tests/plotting/frame/test_frame_subplots.py",
+        "pandas/tests/plotting/frame/test_hist_box_by.py",
+        "pandas/tests/plotting/test_backend.py",
+        "pandas/tests/plotting/test_boxplot_method.py",
+        "pandas/tests/plotting/test_common.py",
+        "pandas/tests/plotting/test_converter.py",
+        "pandas/tests/plotting/test_datetimelike.py",
+        "pandas/tests/plotting/test_groupby.py",
+        "pandas/tests/plotting/test_hist_method.py",
+        "pandas/tests/plotting/test_misc.py",
+        "pandas/tests/plotting/test_series.py",
+        "pandas/tests/plotting/test_style.py",
+        "pandas/tests/reductions/__init__.py",
+        "pandas/tests/reductions/test_reductions.py",
+        "pandas/tests/reductions/test_stat_reductions.py",
+        "pandas/tests/resample/__init__.py",
+        "pandas/tests/resample/conftest.py",
+        "pandas/tests/resample/test_base.py",
+        "pandas/tests/resample/test_datetime_index.py",
+        "pandas/tests/resample/test_period_index.py",
+        "pandas/tests/resample/test_resample_api.py",
+        "pandas/tests/resample/test_resampler_grouper.py",
+        "pandas/tests/resample/test_time_grouper.py",
+        "pandas/tests/resample/test_timedelta.py",
+        "pandas/tests/reshape/__init__.py",
+        "pandas/tests/reshape/concat/__init__.py",
+        "pandas/tests/reshape/concat/test_append.py",
+        "pandas/tests/reshape/concat/test_append_common.py",
+        "pandas/tests/reshape/concat/test_categorical.py",
+        "pandas/tests/reshape/concat/test_concat.py",
+        "pandas/tests/reshape/concat/test_dataframe.py",
+        "pandas/tests/reshape/concat/test_datetimes.py",
+        "pandas/tests/reshape/concat/test_empty.py",
+        "pandas/tests/reshape/concat/test_index.py",
+        "pandas/tests/reshape/concat/test_invalid.py",
+        "pandas/tests/reshape/concat/test_series.py",
+        "pandas/tests/reshape/concat/test_sort.py",
+        "pandas/tests/reshape/merge/__init__.py",
+        "pandas/tests/reshape/merge/test_join.py",
+        "pandas/tests/reshape/merge/test_merge.py",
+        "pandas/tests/reshape/merge/test_merge_antijoin.py",
+        "pandas/tests/reshape/merge/test_merge_asof.py",
+        "pandas/tests/reshape/merge/test_merge_cross.py",
+        "pandas/tests/reshape/merge/test_merge_index_as_string.py",
+        "pandas/tests/reshape/merge/test_merge_ordered.py",
+        "pandas/tests/reshape/merge/test_multi.py",
+        "pandas/tests/reshape/test_crosstab.py",
+        "pandas/tests/reshape/test_cut.py",
+        "pandas/tests/reshape/test_from_dummies.py",
+        "pandas/tests/reshape/test_get_dummies.py",
+        "pandas/tests/reshape/test_melt.py",
+        "pandas/tests/reshape/test_pivot.py",
+        "pandas/tests/reshape/test_pivot_multilevel.py",
+        "pandas/tests/reshape/test_qcut.py",
+        "pandas/tests/reshape/test_union_categoricals.py",
+        "pandas/tests/scalar/__init__.py",
+        "pandas/tests/scalar/interval/__init__.py",
+        "pandas/tests/scalar/interval/test_arithmetic.py",
+        "pandas/tests/scalar/interval/test_constructors.py",
+        "pandas/tests/scalar/interval/test_contains.py",
+        "pandas/tests/scalar/interval/test_formats.py",
+        "pandas/tests/scalar/interval/test_interval.py",
+        "pandas/tests/scalar/interval/test_overlaps.py",
+        "pandas/tests/scalar/period/__init__.py",
+        "pandas/tests/scalar/period/test_arithmetic.py",
+        "pandas/tests/scalar/period/test_asfreq.py",
+        "pandas/tests/scalar/period/test_period.py",
+        "pandas/tests/scalar/test_na_scalar.py",
+        "pandas/tests/scalar/test_nat.py",
+        "pandas/tests/scalar/timedelta/__init__.py",
+        "pandas/tests/scalar/timedelta/methods/__init__.py",
+        "pandas/tests/scalar/timedelta/methods/test_as_unit.py",
+        "pandas/tests/scalar/timedelta/methods/test_round.py",
+        "pandas/tests/scalar/timedelta/test_arithmetic.py",
+        "pandas/tests/scalar/timedelta/test_constructors.py",
+        "pandas/tests/scalar/timedelta/test_formats.py",
+        "pandas/tests/scalar/timedelta/test_timedelta.py",
+        "pandas/tests/scalar/timestamp/__init__.py",
+        "pandas/tests/scalar/timestamp/methods/__init__.py",
+        "pandas/tests/scalar/timestamp/methods/test_as_unit.py",
+        "pandas/tests/scalar/timestamp/methods/test_normalize.py",
+        "pandas/tests/scalar/timestamp/methods/test_replace.py",
+        "pandas/tests/scalar/timestamp/methods/test_round.py",
+        "pandas/tests/scalar/timestamp/methods/test_timestamp_method.py",
+        "pandas/tests/scalar/timestamp/methods/test_to_julian_date.py",
+        "pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py",
+        "pandas/tests/scalar/timestamp/methods/test_tz_convert.py",
+        "pandas/tests/scalar/timestamp/methods/test_tz_localize.py",
+        "pandas/tests/scalar/timestamp/test_arithmetic.py",
+        "pandas/tests/scalar/timestamp/test_comparisons.py",
+        "pandas/tests/scalar/timestamp/test_constructors.py",
+        "pandas/tests/scalar/timestamp/test_formats.py",
+        "pandas/tests/scalar/timestamp/test_timestamp.py",
+        "pandas/tests/scalar/timestamp/test_timezones.py",
+        "pandas/tests/series/__init__.py",
+        "pandas/tests/series/accessors/__init__.py",
+        "pandas/tests/series/accessors/test_cat_accessor.py",
+        "pandas/tests/series/accessors/test_dt_accessor.py",
+        "pandas/tests/series/accessors/test_list_accessor.py",
+        "pandas/tests/series/accessors/test_sparse_accessor.py",
+        "pandas/tests/series/accessors/test_str_accessor.py",
+        "pandas/tests/series/accessors/test_struct_accessor.py",
+        "pandas/tests/series/indexing/__init__.py",
+        "pandas/tests/series/indexing/test_datetime.py",
+        "pandas/tests/series/indexing/test_delitem.py",
+        "pandas/tests/series/indexing/test_get.py",
+        "pandas/tests/series/indexing/test_getitem.py",
+        "pandas/tests/series/indexing/test_indexing.py",
+        "pandas/tests/series/indexing/test_mask.py",
+        "pandas/tests/series/indexing/test_set_value.py",
+        "pandas/tests/series/indexing/test_setitem.py",
+        "pandas/tests/series/indexing/test_take.py",
+        "pandas/tests/series/indexing/test_where.py",
+        "pandas/tests/series/indexing/test_xs.py",
+        "pandas/tests/series/methods/__init__.py",
+        "pandas/tests/series/methods/test_add_prefix_suffix.py",
+        "pandas/tests/series/methods/test_align.py",
+        "pandas/tests/series/methods/test_argsort.py",
+        "pandas/tests/series/methods/test_asof.py",
+        "pandas/tests/series/methods/test_astype.py",
+        "pandas/tests/series/methods/test_autocorr.py",
+        "pandas/tests/series/methods/test_between.py",
+        "pandas/tests/series/methods/test_case_when.py",
+        "pandas/tests/series/methods/test_clip.py",
+        "pandas/tests/series/methods/test_combine.py",
+        "pandas/tests/series/methods/test_combine_first.py",
+        "pandas/tests/series/methods/test_compare.py",
+        "pandas/tests/series/methods/test_convert_dtypes.py",
+        "pandas/tests/series/methods/test_copy.py",
+        "pandas/tests/series/methods/test_count.py",
+        "pandas/tests/series/methods/test_cov_corr.py",
+        "pandas/tests/series/methods/test_describe.py",
+        "pandas/tests/series/methods/test_diff.py",
+        "pandas/tests/series/methods/test_drop.py",
+        "pandas/tests/series/methods/test_drop_duplicates.py",
+        "pandas/tests/series/methods/test_dropna.py",
+        "pandas/tests/series/methods/test_dtypes.py",
+        "pandas/tests/series/methods/test_duplicated.py",
+        "pandas/tests/series/methods/test_equals.py",
+        "pandas/tests/series/methods/test_explode.py",
+        "pandas/tests/series/methods/test_fillna.py",
+        "pandas/tests/series/methods/test_get_numeric_data.py",
+        "pandas/tests/series/methods/test_head_tail.py",
+        "pandas/tests/series/methods/test_infer_objects.py",
+        "pandas/tests/series/methods/test_info.py",
+        "pandas/tests/series/methods/test_interpolate.py",
+        "pandas/tests/series/methods/test_is_monotonic.py",
+        "pandas/tests/series/methods/test_is_unique.py",
+        "pandas/tests/series/methods/test_isin.py",
+        "pandas/tests/series/methods/test_isna.py",
+        "pandas/tests/series/methods/test_item.py",
+        "pandas/tests/series/methods/test_map.py",
+        "pandas/tests/series/methods/test_matmul.py",
+        "pandas/tests/series/methods/test_nlargest.py",
+        "pandas/tests/series/methods/test_nunique.py",
+        "pandas/tests/series/methods/test_pct_change.py",
+        "pandas/tests/series/methods/test_pop.py",
+        "pandas/tests/series/methods/test_quantile.py",
+        "pandas/tests/series/methods/test_rank.py",
+        "pandas/tests/series/methods/test_reindex.py",
+        "pandas/tests/series/methods/test_reindex_like.py",
+        "pandas/tests/series/methods/test_rename.py",
+        "pandas/tests/series/methods/test_rename_axis.py",
+        "pandas/tests/series/methods/test_repeat.py",
+        "pandas/tests/series/methods/test_replace.py",
+        "pandas/tests/series/methods/test_reset_index.py",
+        "pandas/tests/series/methods/test_round.py",
+        "pandas/tests/series/methods/test_searchsorted.py",
+        "pandas/tests/series/methods/test_set_name.py",
+        "pandas/tests/series/methods/test_size.py",
+        "pandas/tests/series/methods/test_sort_index.py",
+        "pandas/tests/series/methods/test_sort_values.py",
+        "pandas/tests/series/methods/test_to_csv.py",
+        "pandas/tests/series/methods/test_to_dict.py",
+        "pandas/tests/series/methods/test_to_frame.py",
+        "pandas/tests/series/methods/test_to_numpy.py",
+        "pandas/tests/series/methods/test_tolist.py",
+        "pandas/tests/series/methods/test_truncate.py",
+        "pandas/tests/series/methods/test_tz_localize.py",
+        "pandas/tests/series/methods/test_unique.py",
+        "pandas/tests/series/methods/test_unstack.py",
+        "pandas/tests/series/methods/test_update.py",
+        "pandas/tests/series/methods/test_value_counts.py",
+        "pandas/tests/series/methods/test_values.py",
+        "pandas/tests/series/test_api.py",
+        "pandas/tests/series/test_arithmetic.py",
+        "pandas/tests/series/test_arrow_interface.py",
+        "pandas/tests/series/test_constructors.py",
+        "pandas/tests/series/test_cumulative.py",
+        "pandas/tests/series/test_formats.py",
+        "pandas/tests/series/test_iteration.py",
+        "pandas/tests/series/test_logical_ops.py",
+        "pandas/tests/series/test_missing.py",
+        "pandas/tests/series/test_npfuncs.py",
+        "pandas/tests/series/test_reductions.py",
+        "pandas/tests/series/test_subclass.py",
+        "pandas/tests/series/test_ufunc.py",
+        "pandas/tests/series/test_unary.py",
+        "pandas/tests/series/test_validate.py",
+        "pandas/tests/strings/__init__.py",
+        "pandas/tests/strings/conftest.py",
+        "pandas/tests/strings/test_api.py",
+        "pandas/tests/strings/test_case_justify.py",
+        "pandas/tests/strings/test_cat.py",
+        "pandas/tests/strings/test_extract.py",
+        "pandas/tests/strings/test_find_replace.py",
+        "pandas/tests/strings/test_get_dummies.py",
+        "pandas/tests/strings/test_split_partition.py",
+        "pandas/tests/strings/test_string_array.py",
+        "pandas/tests/strings/test_strings.py",
+        "pandas/tests/test_aggregation.py",
+        "pandas/tests/test_algos.py",
+        "pandas/tests/test_col.py",
+        "pandas/tests/test_common.py",
+        "pandas/tests/test_downstream.py",
+        "pandas/tests/test_errors.py",
+        "pandas/tests/test_expressions.py",
+        "pandas/tests/test_flags.py",
+        "pandas/tests/test_multilevel.py",
+        "pandas/tests/test_nanops.py",
+        "pandas/tests/test_optional_dependency.py",
+        "pandas/tests/test_register_accessor.py",
+        "pandas/tests/test_sorting.py",
+        "pandas/tests/test_take.py",
+        "pandas/tests/tools/__init__.py",
+        "pandas/tests/tools/test_to_datetime.py",
+        "pandas/tests/tools/test_to_numeric.py",
+        "pandas/tests/tools/test_to_time.py",
+        "pandas/tests/tools/test_to_timedelta.py",
+        "pandas/tests/tseries/__init__.py",
+        "pandas/tests/tseries/frequencies/__init__.py",
+        "pandas/tests/tseries/frequencies/test_freq_code.py",
+        "pandas/tests/tseries/frequencies/test_frequencies.py",
+        "pandas/tests/tseries/frequencies/test_inference.py",
+        "pandas/tests/tseries/holiday/__init__.py",
+        "pandas/tests/tseries/holiday/test_calendar.py",
+        "pandas/tests/tseries/holiday/test_federal.py",
+        "pandas/tests/tseries/holiday/test_holiday.py",
+        "pandas/tests/tseries/holiday/test_observance.py",
+        "pandas/tests/tseries/offsets/__init__.py",
+        "pandas/tests/tseries/offsets/common.py",
+        "pandas/tests/tseries/offsets/test_business_day.py",
+        "pandas/tests/tseries/offsets/test_business_halfyear.py",
+        "pandas/tests/tseries/offsets/test_business_hour.py",
+        "pandas/tests/tseries/offsets/test_business_month.py",
+        "pandas/tests/tseries/offsets/test_business_quarter.py",
+        "pandas/tests/tseries/offsets/test_business_year.py",
+        "pandas/tests/tseries/offsets/test_common.py",
+        "pandas/tests/tseries/offsets/test_custom_business_day.py",
+        "pandas/tests/tseries/offsets/test_custom_business_hour.py",
+        "pandas/tests/tseries/offsets/test_custom_business_month.py",
+        "pandas/tests/tseries/offsets/test_dst.py",
+        "pandas/tests/tseries/offsets/test_easter.py",
+        "pandas/tests/tseries/offsets/test_fiscal.py",
+        "pandas/tests/tseries/offsets/test_halfyear.py",
+        "pandas/tests/tseries/offsets/test_index.py",
+        "pandas/tests/tseries/offsets/test_month.py",
+        "pandas/tests/tseries/offsets/test_offsets.py",
+        "pandas/tests/tseries/offsets/test_offsets_properties.py",
+        "pandas/tests/tseries/offsets/test_quarter.py",
+        "pandas/tests/tseries/offsets/test_ticks.py",
+        "pandas/tests/tseries/offsets/test_week.py",
+        "pandas/tests/tseries/offsets/test_year.py",
+        "pandas/tests/tslibs/__init__.py",
+        "pandas/tests/tslibs/test_api.py",
+        "pandas/tests/tslibs/test_array_to_datetime.py",
+        "pandas/tests/tslibs/test_ccalendar.py",
+        "pandas/tests/tslibs/test_conversion.py",
+        "pandas/tests/tslibs/test_fields.py",
+        "pandas/tests/tslibs/test_libfrequencies.py",
+        "pandas/tests/tslibs/test_liboffsets.py",
+        "pandas/tests/tslibs/test_np_datetime.py",
+        "pandas/tests/tslibs/test_npy_units.py",
+        "pandas/tests/tslibs/test_parse_iso8601.py",
+        "pandas/tests/tslibs/test_parsing.py",
+        "pandas/tests/tslibs/test_period.py",
+        "pandas/tests/tslibs/test_resolution.py",
+        "pandas/tests/tslibs/test_strptime.py",
+        "pandas/tests/tslibs/test_timedeltas.py",
+        "pandas/tests/tslibs/test_timezones.py",
+        "pandas/tests/tslibs/test_to_offset.py",
+        "pandas/tests/tslibs/test_tzconversion.py",
+        "pandas/tests/util/__init__.py",
+        "pandas/tests/util/conftest.py",
+        "pandas/tests/util/test_assert_almost_equal.py",
+        "pandas/tests/util/test_assert_attr_equal.py",
+        "pandas/tests/util/test_assert_categorical_equal.py",
+        "pandas/tests/util/test_assert_extension_array_equal.py",
+        "pandas/tests/util/test_assert_frame_equal.py",
+        "pandas/tests/util/test_assert_index_equal.py",
+        "pandas/tests/util/test_assert_interval_array_equal.py",
+        "pandas/tests/util/test_assert_numpy_array_equal.py",
+        "pandas/tests/util/test_assert_produces_warning.py",
+        "pandas/tests/util/test_assert_series_equal.py",
+        "pandas/tests/util/test_deprecate.py",
+        "pandas/tests/util/test_deprecate_kwarg.py",
+        "pandas/tests/util/test_deprecate_nonkeyword_arguments.py",
+        "pandas/tests/util/test_doc.py",
+        "pandas/tests/util/test_hashing.py",
+        "pandas/tests/util/test_numba.py",
+        "pandas/tests/util/test_rewrite_warning.py",
+        "pandas/tests/util/test_shares_memory.py",
+        "pandas/tests/util/test_show_versions.py",
+        "pandas/tests/util/test_util.py",
+        "pandas/tests/util/test_validate_args.py",
+        "pandas/tests/util/test_validate_args_and_kwargs.py",
+        "pandas/tests/util/test_validate_inclusive.py",
+        "pandas/tests/util/test_validate_kwargs.py",
+        "pandas/tests/window/__init__.py",
+        "pandas/tests/window/conftest.py",
+        "pandas/tests/window/moments/__init__.py",
+        "pandas/tests/window/moments/conftest.py",
+        "pandas/tests/window/moments/test_moments_consistency_ewm.py",
+        "pandas/tests/window/moments/test_moments_consistency_expanding.py",
+        "pandas/tests/window/moments/test_moments_consistency_rolling.py",
+        "pandas/tests/window/test_api.py",
+        "pandas/tests/window/test_apply.py",
+        "pandas/tests/window/test_base_indexer.py",
+        "pandas/tests/window/test_cython_aggregations.py",
+        "pandas/tests/window/test_dtypes.py",
+        "pandas/tests/window/test_ewm.py",
+        "pandas/tests/window/test_expanding.py",
+        "pandas/tests/window/test_groupby.py",
+        "pandas/tests/window/test_numba.py",
+        "pandas/tests/window/test_online.py",
+        "pandas/tests/window/test_pairwise.py",
+        "pandas/tests/window/test_rolling.py",
+        "pandas/tests/window/test_rolling_functions.py",
+        "pandas/tests/window/test_rolling_quantile.py",
+        "pandas/tests/window/test_rolling_skew_kurt.py",
+        "pandas/tests/window/test_timeseries_window.py",
+        "pandas/tests/window/test_win_type.py",
+        "pandas/tseries/__init__.py",
+        "pandas/tseries/api.py",
+        "pandas/tseries/frequencies.py",
+        "pandas/tseries/holiday.py",
+        "pandas/tseries/offsets.py",
+        "pandas/util/__init__.py",
+        "pandas/util/_decorators.py",
+        "pandas/util/_doctools.py",
+        "pandas/util/_exceptions.py",
+        "pandas/util/_print_versions.py",
+        "pandas/util/_test_decorators.py",
+        "pandas/util/_tester.py",
+        "pandas/util/_validators.py",
+        "pandas/util/version/__init__.py"
+      ],
+      "filesTotal": 1421,
+      "manifestCid": "sha256:c267d971bb2d1a3dd65769bb76ce6efec080803fea51df3964353e8c9f073c03"
+    },
+    "rows": [
+      {
+        "file": "pandas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/config.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/dates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/display.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_config/localization.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_libs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_libs/tslibs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_libs/window/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/_hypothesis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/_io.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/_warnings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/asserters.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_testing/contexts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_typing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_version.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/_version_meson.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/executors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/extensions/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/indexers/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/interchange/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/types/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/typing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/api/typing/aliases.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/arrays/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/_constants.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/_optional.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/numpy/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/numpy/function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/pickle_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/compat/pyarrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/executor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/extensions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/mean_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/min_max_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/shared.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/sum_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/_numba/kernels/var_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/algorithms.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/datetimelike_accumulations.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/masked_accumulations.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/masked_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/putmask.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/array_algos/transforms.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arraylike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_arrow_string_mixins.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_mixins.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_ranges.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/_arrow_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/accessors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/arrow/extension_types.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/boolean.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/floating.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/integer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/masked.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/numpy_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/sparse/scipy_sparse.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/string_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/string_arrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/arrays/timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/col.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/align.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/check.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/engines.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/eval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/expr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/expressions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/parsing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/pytables.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/computation/scope.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/config_init.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/cast.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/inference.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/dtypes/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/flags.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/grouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/numba_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/groupby/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexers/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexers/objects.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexers/utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/accessors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/category.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/extension.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/frozen.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/multi.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexes/timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/buffer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/column.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/dataframe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/dataframe_protocol.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/from_dataframe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/interchange/utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/blocks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/managers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/internals/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/selectn.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/methods/to_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/nanops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/array_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/dispatch.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/docstrings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/invalid.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/mask_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/ops/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/resample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/encoding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/melt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/merge.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/pivot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/reshape.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/reshape/tile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/roperator.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/shared_docs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sparse/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/sparse/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/strings/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/strings/accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/strings/object_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/tools/times.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/util/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/util/hashing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/util/numba_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/doc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/ewm.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/expanding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/numba_.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/online.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/core/window/rolling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/errors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/errors/cow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/clipboard/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/clipboards.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_calamine.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_odfreader.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_odswriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_openpyxl.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_pyxlsb.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_xlrd.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/excel/_xlsxwriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/feather_format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/_color_data.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/console.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/css.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/csvs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/excel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/info.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/printing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/style_render.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/formats/xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/iceberg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/_json.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/json/_table_schema.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/orc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parquet.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/arrow_parser_wrapper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/base_parser.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/c_parser_wrapper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/python_parser.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/parsers/readers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/pytables.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sas7bdat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sas_constants.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sas_xport.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sas/sasreader.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/spss.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/sql.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/stata.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/io/xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_core.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/boxplot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/converter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/core.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/hist.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/timeseries.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_matplotlib/tools.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/plotting/_misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/testing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/api/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/api/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/api/test_types.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_frame_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_frame_apply_relabeling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_frame_transform.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_invalid_arg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_series_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_series_apply_relabeling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_series_transform.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/apply/test_str.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_array_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_bool.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_datetime64.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_object.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arithmetic/test_timedelta64.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_comparison.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_logical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_reduction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/boolean/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_algos.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_analytics.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_operators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/categorical/test_warnings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/datetimes/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_comparison.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_contains.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/floating/test_to_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_comparison.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_construction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_reduction.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/integer/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_interval_pyarrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/interval/test_overlaps.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_arrow_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_function.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/masked_shared.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/numpy_/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/numpy_/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/numpy_/test_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_arrow_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/period/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_arithmetics.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_combine_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_libsparse.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/sparse/test_unary.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/test_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/string_/test_string_arrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_ndarray_backed.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/test_timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/arrays/timedeltas/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_conversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_transpose.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/base/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/computation/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/computation/test_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/computation/test_eval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/config/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/config/test_config.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/config/test_localization.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/construction/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/construction/test_extract_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_datetimeindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_intervalindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_periodindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/index/test_timedeltaindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_chained_assignment_deprecation.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_clip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_copy_deprecation.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_core_functionalities.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_functions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_interp_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_methods.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/copy_view/util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_box_unbox.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_can_hold_element.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_construct_from_scalar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_construct_ndarray.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_construct_object_arr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_dict_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_downcast.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_find_common_type.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_infer_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_infer_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/cast/test_promote.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_inference.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/dtypes/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/array_with_attr/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/array_with_attr/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/array_with_attr/test_array_with_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/accumulate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/casting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/dim2.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/interface.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/io.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/methods.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/printing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/reduce.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/reshaping.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/base/setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/date/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/date/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/decimal/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/decimal/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/decimal/test_decimal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/json/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/json/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/json/test_json.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/list/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/list/array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/list/test_list.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_arrow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_extension.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_masked.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_sparse.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/test_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/uuid/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/extension/uuid/test_uuid.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/constructors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/constructors/test_from_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/constructors/test_from_records.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_coercion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_delitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_get.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_get_value.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_mask.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_set_value.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_where.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/indexing/test_xs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_add_prefix_suffix.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_align.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_asfreq.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_assign.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_at_time.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_between_time.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_clip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_combine.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_combine_first.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_compare.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_convert_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_copy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_count.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_cov_corr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_diff.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_dot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_drop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_drop_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_droplevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_dropna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_duplicated.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_explode.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_filter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_first_valid_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_get_numeric_data.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_head_tail.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_infer_objects.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_info.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_interpolate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_is_homogeneous_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_isetitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_isin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_iterrows.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_matmul.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_nlargest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_pct_change.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_pipe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_pop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_rank.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reindex_like.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_rename.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_rename_axis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reorder_levels.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_reset_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_sample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_select_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_set_axis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_set_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_size.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_sort_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_sort_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_swaplevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_csv.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_dict_of_blocks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_records.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_to_timestamp.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_transpose.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_truncate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_tz_convert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_update.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/methods/test_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_alter_axes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_arrow_interface.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_block_internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_iteration.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_logical_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_nonunique_indexes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_npfuncs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_query_eval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_repr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_stack_unstack.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_ufunc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_unary.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/frame/test_validate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_duplicate_labels.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_finalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_generic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_label_or_level_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/generic/test_to_xarray.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_aggregate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_cython.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/aggregate/test_other.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_groupby_shift_diff.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_is_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_kurt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_nlargest_nsmallest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_nth.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_rank.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_sample.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_size.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_skew.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/methods/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_all_methods.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_bin_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_counting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_filters.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_groupby_dropna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_groupby_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_grouping.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_index_as_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_libgroupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_numeric_only.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_pipe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_raises.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/test_timegrouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/transform/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/transform/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/groupby/transform/test_transform.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_reshape.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/base_class/test_where.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_append.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_category.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/categorical/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_drop_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_is_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_nat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_sort_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimelike_/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_delete.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_factorize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_isocalendar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_resolution.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_snap.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_julian_date.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_pydatetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_to_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_tz_convert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/methods/test_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_date_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_freq_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_iter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_npfuncs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_partial_slicing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_scalar_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/datetimes/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_interval_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_interval_tree.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/interval/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_analytics.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_conversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_copy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_drop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_equivalence.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_get_level_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_get_set.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_integrity.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_isin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_lexsort.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_names.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_partial_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_reshape.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/multi/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/numeric/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/object/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/object/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/object/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_asfreq.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_factorize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_is_full.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/methods/test_to_timestamp.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_freq_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_partial_slicing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_period_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_resolution.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_scalar_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_searchsorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/period/test_tools.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/ranges/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/string/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/string/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/string/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_any_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_engines.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_frozen.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_index_new.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_numpy_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_old_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_factorize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_insert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/methods/test_shift.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_delete.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_freq_attr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_scalar_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_searchsorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_setops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexes/timedeltas/test_timedelta_range.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/interval/test_interval_new.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_chaining_and_caching.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_iloc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_indexing_slow.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_loc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_multiindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_partial.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_slice.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/multiindex/test_sorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_at.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_chaining_and_caching.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_check_indexer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_coercion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_floats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_iat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_iloc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_indexers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_loc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_na_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_partial.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/indexing/test_scalar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/test_impl.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/test_spec_conformance.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/interchange/test_utils.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/internals/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/internals/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/internals/test_internals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_odf.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_odswriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_openpyxl.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_readers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_writers.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_xlrd.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/excel/test_xlsxwriter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_bar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_exceptions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_highlight.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_matplotlib.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_non_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_to_latex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_to_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_to_typst.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/style/test_tooltip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_console.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_css.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_eng_formatting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_format.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_ipython_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_printing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_csv.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_excel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_latex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_markdown.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/formats/test_to_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/generate_legacy_storage_files.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_compression.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_deprecated_kwargs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_json_table_schema.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_json_table_schema_ext_dtype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_pandas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_readlines.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/json/test_ujson.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_chunksize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_common_basic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_data_list.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_decimal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_file_buffer_url.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_float.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_inf.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_ints.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_iterator.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/common/test_read_errors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/test_dtypes_basic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/dtypes/test_empty.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_c_parser_only.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_comment.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_compression.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_concatenate_chunks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_converters.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_dialect.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_encoding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_header.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_index_col.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_mangle_dupes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_multi_thread.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_na_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_network.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_parse_dates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_python_parser_only.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_quoting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_read_fwf.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_skiprows.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_textreader.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_unsupported.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/test_upcast.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/test_parse_dates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/test_strings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/parser/usecols/test_usecols_basic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_append.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_compat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_complex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_errors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_file_handling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_keys.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_put.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_pytables_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_read.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_retain_attributes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_round_trip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_select.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_store.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_time_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/pytables/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_byteswap.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_sas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_sas7bdat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/sas/test_xport.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_clipboard.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_compression.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/test_feather.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_fsspec.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_gcs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_html.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_http_headers.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_iceberg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_orc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_parquet.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_pickle.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_s3.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_spss.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/test_sql.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/test_stata.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/io/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/test_to_xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/test_xml.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/io/xml/test_xml_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_hashtable.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_lib.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/libs/test_libalgos.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_color.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_legend.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_frame_subplots.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/frame/test_hist_box_by.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_backend.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_boxplot_method.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_converter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_datetimelike.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_hist_method.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_misc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/plotting/test_style.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reductions/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reductions/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reductions/test_stat_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_base.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_datetime_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_period_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_resample_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_resampler_grouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_time_grouper.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/resample/test_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_append.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_append_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_categorical.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_concat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_dataframe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_datetimes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_empty.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_invalid.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_series.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/concat/test_sort.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_join.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_antijoin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_cross.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_index_as_string.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_merge_ordered.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/merge/test_multi.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_crosstab.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_cut.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_from_dummies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_get_dummies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_melt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_pivot.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_pivot_multilevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_qcut.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/reshape/test_union_categoricals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_contains.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_interval.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/interval/test_overlaps.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/test_asfreq.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/period/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/test_na_scalar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/test_nat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/methods/test_as_unit.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timedelta/test_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_as_unit.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_normalize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_timestamp_method.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_to_julian_date.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_tz_convert.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_comparisons.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_timestamp.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/scalar/timestamp/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_cat_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_dt_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_list_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_sparse_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_str_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/accessors/test_struct_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_delitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_get.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_getitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_indexing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_mask.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_set_value.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_setitem.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_where.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/indexing/test_xs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_add_prefix_suffix.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_align.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_argsort.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_asof.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_astype.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_autocorr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_between.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_case_when.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_clip.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_combine.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_combine_first.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_compare.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_convert_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_copy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_count.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_cov_corr.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_describe.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_diff.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_drop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_drop_duplicates.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_dropna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_duplicated.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_equals.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_explode.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_fillna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_get_numeric_data.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_head_tail.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_infer_objects.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_info.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_interpolate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_is_monotonic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_is_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_isin.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_isna.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_item.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_map.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_matmul.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_nlargest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_nunique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_pct_change.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_pop.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_rank.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_reindex.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_reindex_like.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_rename.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_rename_axis.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_repeat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_reset_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_round.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_searchsorted.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_set_name.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_size.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_sort_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_sort_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_csv.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_dict.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_frame.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_to_numpy.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_tolist.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_truncate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_tz_localize.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_unique.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_unstack.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_update.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_value_counts.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/methods/test_values.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_arithmetic.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_arrow_interface.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_constructors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_cumulative.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_formats.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_iteration.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_logical_ops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_missing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_npfuncs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_reductions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_subclass.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_ufunc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_unary.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/series/test_validate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_case_justify.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_cat.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_extract.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_find_replace.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_get_dummies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_split_partition.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_string_array.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/strings/test_strings.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_aggregation.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_algos.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_col.py",
+        "category": "backend-defect"
+      },
+      {
+        "file": "pandas/tests/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_downstream.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_errors.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_expressions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_flags.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_multilevel.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_nanops.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_optional_dependency.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_register_accessor.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_sorting.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/test_take.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_numeric.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_time.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tools/test_to_timedelta.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/test_freq_code.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/test_frequencies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/frequencies/test_inference.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_calendar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_federal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_holiday.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/holiday/test_observance.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_day.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_halfyear.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_hour.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_month.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_quarter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_business_year.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_common.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_custom_business_day.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_custom_business_hour.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_custom_business_month.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_dst.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_easter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_fiscal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_halfyear.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_index.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_month.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_offsets.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_offsets_properties.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_quarter.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_ticks.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_week.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tseries/offsets/test_year.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_array_to_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_ccalendar.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_conversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_fields.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_libfrequencies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_liboffsets.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_np_datetime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_npy_units.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_parse_iso8601.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_parsing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_period.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_resolution.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_strptime.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_timedeltas.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_timezones.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_to_offset.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/tslibs/test_tzconversion.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_almost_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_attr_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_categorical_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_extension_array_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_frame_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_index_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_interval_array_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_numpy_array_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_produces_warning.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_assert_series_equal.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_deprecate.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_deprecate_kwarg.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_deprecate_nonkeyword_arguments.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_doc.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_hashing.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_rewrite_warning.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_shares_memory.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_show_versions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_util.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_args.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_args_and_kwargs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_inclusive.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/util/test_validate_kwargs.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/conftest.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/test_moments_consistency_ewm.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/test_moments_consistency_expanding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/moments/test_moments_consistency_rolling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_apply.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_base_indexer.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_cython_aggregations.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_dtypes.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_ewm.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_expanding.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_groupby.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_numba.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_online.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_pairwise.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling_functions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling_quantile.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_rolling_skew_kurt.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_timeseries_window.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tests/window/test_win_type.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/api.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/frequencies.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/holiday.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/tseries/offsets.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/__init__.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_decorators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_doctools.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_exceptions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_print_versions.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_test_decorators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_tester.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/_validators.py",
+        "category": "completed"
+      },
+      {
+        "file": "pandas/util/version/__init__.py",
+        "category": "completed"
+      }
+    ],
+    "totals": {
+      "R_backend_defects": 6,
+      "R_cm_derived_contract": 17,
+      "R_control_effect": 10,
+      "R_desugar": 9952,
+      "backendDefectsOrProcessTerminals": 6,
+      "constructionPanics": 0,
+      "desugarConstructionPanics": 140,
+      "desugarDefects": 15
+    }
+  },
+  "controlEffectStableZeroTerms": {
+    "completedDenominatorPositive": true,
+    "denominatorComplete": true,
+    "timeouts": 0,
+    "constructionPanics": 0,
+    "factoringGaps": 13,
+    "unresolvableDispatchTargets": 0,
+    "backendDefectFiles": 4,
+    "desugarConstructionPanics": 140,
+    "desugarDefects": 15
+  },
+  "red": true,
+  "redReasons": [
+    "6 per-file terminal defect rows",
+    "140 desugar construction panics (construction-law None arms -- red, and never semantic R)",
+    "15 desugar defects",
+    "6 of 1421 enrolled files produced a terminal row that is not a completion (denominator is complete; the completion count is not)"
+  ],
+  "controlEffectStableZero": false
+}

--- a/docs/ledgers/pandas-3.0.3-ranked-residual-owners-43d994888.md
+++ b/docs/ledgers/pandas-3.0.3-ranked-residual-owners-43d994888.md
@@ -1,0 +1,113 @@
+# Ranked residual owners — pandas 3.0.3
+
+Commit `43d9948881df3906aa4b99977f8ab14b4fc951f5`, corpus pin `bbb70a76f4032eda…`, 1421 files.
+
+> **What this ranks, and what it refuses to.** Ranked by the dispatchable unit
+> — `(owner × category)` — off one pinned baseline at one commit. Nothing is
+> extrapolated from a sample and nothing is compared against the 1,415-file
+> ledger, which is a different pandas.
+>
+> **The factoring-gap term is UNCLASSIFIED here and that is not a zero.** The
+> `#6364` classifier produces its verdict as data on the exception; this census
+> was stringifying the message and discarding it, so all 13 occurrences reached
+> the ledger unclassified. The wiring is committed (`27e9e9a92`) and the split
+> will be measured on the next run. It is reported as unmeasured rather than
+> guessed.
+
+
+## Denominator
+
+```
+enrolled                 1421
+terminalRows             1421
+completed                1415
+corpusManifestCid        sha256:c267d971bb2d1a3dd65769bb76ce6efec080803fea51df3964353e8c9f073c03
+missingFiles             []
+duplicateFiles           []
+malformedRows            []
+complete                 True
+```
+
+## stableZero vector
+
+`controlEffectStableZero` = **False**, `red` = **True**
+
+```
+completedDenominatorPositive     True
+denominatorComplete              True
+timeouts                         0
+constructionPanics               0
+factoringGaps                    13
+unresolvableDispatchTargets      0
+backendDefectFiles               4
+desugarConstructionPanics        140
+desugarDefects                   15
+```
+
+- 6 per-file terminal defect rows
+- 140 desugar construction panics (construction-law None arms -- red, and never semantic R)
+- 15 desugar defects
+- 6 of 1421 enrolled files produced a terminal row that is not a completion (denominator is complete; the completion count is not)
+
+## R_desugar is two numbers
+
+Total 9952 = **58 owed work** + 9894 accounted semantics. Publishing the total as work overstates it by **171.6x**.
+
+### Owed work, by owner
+
+```
+    29  YieldSuspensionSugar.desugar
+    17  YieldFromSugar.desugar
+    11  matches_raise_effect
+     1  ClassDefinitionSugar.desugar
+```
+
+## Desugar construction panics, by (owner × files)
+
+```
+    44  in   30 files  guarded
+    15  in   14 files  ground_index_error
+    12  in   10 files  ContractConditionalConstructionV1.and_then
+    12  in   10 files  outcome_to_exitset
+    11  in   10 files  add
+     8  in    7 files  bitwise_and
+     7  in    7 files  attribute
+     6  in    5 files  RuntimeEffect
+     6  in    4 files  multiply
+     5  in    5 files  subtract
+     2  in    2 files  bitwise_invert
+     2  in    2 files  bitwise_or
+     2  in    2 files  ground_type_error
+     1  in    1 files  collection build
+     1  in    1 files  ground_assertion_error
+     1  in    1 files  bitwise_xor
+     1  in    1 files  truth
+     1  in    1 files  divide
+     1  in    1 files  unary_plus
+     1  in    1 files  dict.subscript
+```
+
+## Factoring gaps
+
+```
+    13  UNCLASSIFIED (ledger predates #6364 classifier)
+```
+
+## Backend defects, by shape (not by file)
+
+```
+     4  spans.LineTable.line_col
+     2  SourceCallBindingGap
+```
+
+## Site prevalence — a DENOMINATOR, never R
+
+```
+ 27751  site:function-def
+  7662  site:with-item
+  7652  site:with-statement
+   688  site:try-statement
+```
+
+Construction R over the whole corpus: **4**.
+

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -614,6 +614,8 @@ def main() -> int:
     floor_rows: list[dict[str, Any]] = []
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
+    desugar_categories: Counter[str] = Counter()
+    desugar_by_category_owner: Counter[str] = Counter()
     backend_defects: Counter[str] = Counter()
     cm_resolutions: Counter[str] = Counter()
     ast_sites: Counter[str] = Counter()
@@ -892,6 +894,8 @@ def main() -> int:
         functions_clean += int(row.get("functionsClean") or 0)
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
+        desugar_categories.update(row.get("desugarCategories") or {})
+        desugar_by_category_owner.update(row.get("desugarByCategoryOwner") or {})
         backend_defects.update(row.get("backendDefects") or {})
         cm_resolutions.update(row.get("cmResolutions") or {})
         ast_sites.update(row.get("astSites") or {})
@@ -999,7 +1003,24 @@ def main() -> int:
             sorted(families.items(), key=lambda item: (-item[1], item[0]))
         ),
         # Axis 2 — desugar refusals + typed red (#6243). Separate quantity.
+        # R_desugar is MIXED. Read the split, never the total: a typed refusal
+        # owes work, a constructed effect IS the correct output of a reduction
+        # that succeeded. Publishing the sum as work remaining overstated the
+        # earlier board 7.6x.
         "R_desugar": r_desugar,
+        "desugarCategories": dict(
+            sorted(desugar_categories.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "R_desugar_owed_work": int(desugar_categories.get("typed-refusal", 0)),
+        "R_desugar_accounted_semantics": int(
+            desugar_categories.get("constructed-effect", 0)
+        ),
+        "desugarByCategoryOwner": dict(
+            sorted(
+                desugar_by_category_owner.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ),
         "desugarFamilies": dict(
             sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
         ),

--- a/implementations/python/sugar-lift-py-tests/scripts/rank_residual_owners.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/rank_residual_owners.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Rank the residual by DISPATCHABLE OWNER, off one pinned baseline.
+
+    python3 rank_residual_owners.py <recensus.json> [--markdown]
+
+A board is a pile of counters. A worklist is a ranking by the unit someone can
+actually be handed. This turns the first into the second, and refuses three
+ways of lying while doing it.
+
+**Never rank by a mixed total.** ``R_desugar`` is two different things sharing a
+counter: typed refusals (owed work) and constructed effects (the correct output
+of a reduction that succeeded). Quoted whole it overstated the earlier board by
+7.6x. This ranks the parts, and prints the accounted-semantics share beside
+them so the total can never be mistaken for a backlog.
+
+**Never rank by raw occurrence.** A panic owner with 283 occurrences across 40
+files is one dispatchable row, not 283. The unit is ``(owner x category)``.
+
+**Never merge axes.** Construction R, desugar owed work, desugar constructed
+effects, panics, defects, backend defects and factoring gaps have different
+denominators and different owners. They are ranked separately and never summed
+into a single "R_total" here -- that number belongs to
+``reconcile_pandas_floors.py``, which is the corpus authority.
+
+Site prevalence is printed for scale and is labelled as a denominator. It is
+never R.
+"""
+
+from __future__ import annotations
+
+# Not the board. This module ranks an existing board's rows; the sole
+# authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def _owner_of_panic(row: dict[str, Any]) -> str:
+    owner = row.get("owner")
+    if isinstance(owner, str) and owner:
+        return owner
+    # No owner on the row is itself a defect worth seeing, not a silent "other".
+    return "UNNAMED-OWNER (panic row carries no owner)"
+
+
+def _factoring_rows(defects: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [row for row in defects if "FactoringGap" in json.dumps(row)]
+
+
+def _classify_factoring(row: dict[str, Any]) -> str:
+    """Read the merged classifier's verdict off the defect text.
+
+    ``#6364`` split ``factoring_gaps`` into remaining work and correct refusal.
+    When the run that produced this ledger carried that classifier, its verdict
+    is in the detail; when it did not, say so rather than guessing a split.
+    """
+    detail = str(row.get("detail", ""))
+    match = re.search(r"isRemainingWork[\"']?\s*[:=]\s*(True|true|False|false)", detail)
+    if match:
+        return (
+            "remaining-work"
+            if match.group(1).lower() == "true"
+            else "correct-refusal"
+        )
+    match = re.search(r"\b(unstamped|stamped-not-separating|stamped-disjoint|partly-stamped)\b", detail)
+    if match:
+        return f"kind:{match.group(1)}"
+    return "UNCLASSIFIED (ledger predates #6364 classifier)"
+
+
+def _owner_from_detail(row: dict[str, Any]) -> str:
+    detail = str(row.get("detail", ""))
+    match = re.search(r"owner:\s*([^\n]+)", detail)
+    return match.group(1).strip() if match else "unnamed"
+
+
+def rank(board: dict[str, Any]) -> dict[str, Any]:
+    desugar_by_owner = board.get("desugarByCategoryOwner") or {}
+    owed = Counter()
+    accounted = Counter()
+    for key, count in desugar_by_owner.items():
+        category, _, owner = key.partition("/")
+        (owed if category == "typed-refusal" else accounted)[owner] += count
+
+    panics = board.get("desugarConstructionPanics") or []
+    panic_owners = Counter(_owner_of_panic(row) for row in panics)
+    panic_files = {}
+    for row in panics:
+        where = str(row.get("where", ""))
+        panic_files.setdefault(_owner_of_panic(row), set()).add(where.split(":")[0])
+
+    defects = board.get("desugarDefects") or []
+    factoring = _factoring_rows(defects)
+    other_defects = [row for row in defects if row not in factoring]
+
+    backend = board.get("defects") or []
+    backend_by_shape = Counter()
+    for row in backend:
+        message = str(row.get("message", ""))
+        # Group by the defect's own owner line, not by file: three files
+        # reporting one LineTable bug are ONE defect, not three.
+        match = re.search(r"BACKEND DEFECT \[([^\]]+)\]", message)
+        backend_by_shape[match.group(1) if match else str(row.get("type", "?"))] += 1
+
+    return {
+        "commit": board.get("commit"),
+        "corpusPin": board.get("corpusPin", {}),
+        "denominator": {
+            k: v
+            for k, v in (board.get("denominator") or {}).items()
+            if k not in ("enrolledFiles", "enrolledFilesOmitted")
+        },
+        "red": board.get("red"),
+        "redReasons": board.get("redReasons"),
+        "stableZeroTerms": board.get("controlEffectStableZeroTerms"),
+        "controlEffectStableZero": board.get("controlEffectStableZero"),
+        "axes": {
+            "R_construction": board.get("R_construction"),
+            "R_desugar_total_DO_NOT_PUBLISH_RAW": board.get("R_desugar"),
+            "R_desugar_owed_work": board.get("R_desugar_owed_work"),
+            "R_desugar_accounted_semantics": board.get(
+                "R_desugar_accounted_semantics"
+            ),
+            "R_construction_panics": board.get("R_construction_panics"),
+            "R_desugar_construction_panics": board.get(
+                "R_desugar_construction_panics"
+            ),
+            "R_desugar_defects": board.get("R_desugar_defects"),
+            "R_backend_defects": board.get("R_backend_defects"),
+            "R_unresolvable_dispatch_targets": board.get(
+                "R_unresolvable_dispatch_targets"
+            ),
+        },
+        "sitePrevalence_NOT_R": board.get("astSitePrevalence"),
+        "rankings": {
+            "constructionFamilies": board.get("families"),
+            "desugarOwedWorkByOwner": dict(owed.most_common()),
+            "desugarAccountedSemanticsByOwner": dict(accounted.most_common()),
+            "desugarConstructionPanicsByOwner": [
+                {
+                    "owner": owner,
+                    "occurrences": count,
+                    "files": len(panic_files.get(owner, ())),
+                }
+                for owner, count in panic_owners.most_common()
+            ],
+            "factoringGaps": [
+                {
+                    "where": row.get("where"),
+                    "owner": _owner_from_detail(row),
+                    "classification": _classify_factoring(row),
+                }
+                for row in factoring
+            ],
+            "factoringGapSplit": dict(
+                Counter(_classify_factoring(row) for row in factoring).most_common()
+            ),
+            "otherDesugarDefects": len(other_defects),
+            "backendDefectsByShape": dict(backend_by_shape.most_common()),
+            "withResolutionKinds": board.get("cmResolutions"),
+        },
+    }
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    axes = report["axes"]
+    rank_ = report["rankings"]
+    out: list[str] = []
+    add = out.append
+    pin = report["corpusPin"]
+    add(f"# Ranked residual owners — {pin.get('distribution')} {pin.get('version')}\n")
+    add(f"Commit `{report['commit']}`, corpus pin `{pin.get('aggregateHash','')[:16]}…`, "
+        f"{pin.get('fileCount')} files.\n")
+
+    denominator = report["denominator"]
+    add("## Denominator\n")
+    add("```")
+    for key, value in denominator.items():
+        add(f"{key:24} {value}")
+    add("```\n")
+
+    add("## stableZero vector\n")
+    add(f"`controlEffectStableZero` = **{report['controlEffectStableZero']}**, "
+        f"`red` = **{report['red']}**\n")
+    add("```")
+    for key, value in (report["stableZeroTerms"] or {}).items():
+        add(f"{key:32} {value}")
+    add("```\n")
+    for reason in report["redReasons"] or []:
+        add(f"- {reason}")
+    add("")
+
+    add("## R_desugar is two numbers\n")
+    total = axes["R_desugar_total_DO_NOT_PUBLISH_RAW"] or 0
+    work = axes["R_desugar_owed_work"]
+    semantics = axes["R_desugar_accounted_semantics"]
+    if work is None or semantics is None:
+        # An ABSENT split is not a split of zero. Saying "0 accounted
+        # semantics" here would be a fabricated measurement -- the same
+        # misleading-zero shape this instrument exists to refuse.
+        add(f"Total {total}. **SPLIT UNAVAILABLE** — this ledger predates the "
+            "occurrence-key split, so the owed-work share is unmeasured, not "
+            "zero. Re-run to obtain it; do not publish the total as work.\n")
+    elif work:
+        add(f"Total {total} = **{work} owed work** + {semantics} accounted "
+            f"semantics. Publishing the total as work overstates it by "
+            f"**{total / work:.1f}x**.\n")
+    else:
+        add(f"Total {total} = **0 owed work** + {semantics} accounted "
+            "semantics. Every row is the correct output of a reduction that "
+            "succeeded; none of it is a backlog.\n")
+    add("### Owed work, by owner\n")
+    add("```")
+    for owner, count in list(rank_["desugarOwedWorkByOwner"].items())[:20]:
+        add(f"{count:6d}  {owner}")
+    add("```\n")
+
+    add("## Desugar construction panics, by (owner × files)\n")
+    add("```")
+    for row in rank_["desugarConstructionPanicsByOwner"][:20]:
+        add(f"{row['occurrences']:6d}  in {row['files']:4d} files  {row['owner']}")
+    add("```\n")
+
+    add("## Factoring gaps\n")
+    add("```")
+    for key, count in rank_["factoringGapSplit"].items():
+        add(f"{count:6d}  {key}")
+    add("```\n")
+
+    add("## Backend defects, by shape (not by file)\n")
+    add("```")
+    for shape, count in rank_["backendDefectsByShape"].items():
+        add(f"{count:6d}  {shape}")
+    add("```\n")
+
+    add("## Site prevalence — a DENOMINATOR, never R\n")
+    add("```")
+    for site, count in (report["sitePrevalence_NOT_R"] or {}).items():
+        add(f"{count:6d}  {site}")
+    add("```\n")
+    add(f"Construction R over the whole corpus: **{axes['R_construction']}**.\n")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("board", type=Path)
+    parser.add_argument("--markdown", action="store_true")
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    report = rank(json.loads(args.board.read_text(encoding="utf-8")))
+    rendered = _markdown(report) if args.markdown else json.dumps(report, indent=2)
+    if args.out:
+        args.out.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/rank_residual_owners.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/rank_residual_owners.py
@@ -60,21 +60,26 @@ def _classify_factoring(row: dict[str, Any]) -> str:
     When the run that produced this ledger carried that classifier, its verdict
     is in the detail; when it did not, say so rather than guessing a split.
     """
-    detail = str(row.get("detail", ""))
-    match = re.search(r"isRemainingWork[\"']?\s*[:=]\s*(True|true|False|false)", detail)
-    if match:
-        return (
-            "remaining-work"
-            if match.group(1).lower() == "true"
-            else "correct-refusal"
+    # Structured verdict, carried on the row by the census. Never parse the
+    # prose message: a repr is not an interface, and the classifier already
+    # produced a typed answer.
+    verdict = row.get("classification")
+    if isinstance(verdict, dict):
+        kind = verdict.get("kind", "?")
+        merged = " merged-arm" if verdict.get("mergedArm") else ""
+        head = (
+            "remaining-work" if verdict.get("isRemainingWork") else "correct-refusal"
         )
-    match = re.search(r"\b(unstamped|stamped-not-separating|stamped-disjoint|partly-stamped)\b", detail)
-    if match:
-        return f"kind:{match.group(1)}"
+        return f"{head} ({kind}{merged})"
     return "UNCLASSIFIED (ledger predates #6364 classifier)"
 
 
 def _owner_from_detail(row: dict[str, Any]) -> str:
+    verdict = row.get("classification")
+    if isinstance(verdict, dict):
+        left, right = verdict.get("leftOwner"), verdict.get("rightOwner")
+        if left or right:
+            return f"{left} / {right}"
     detail = str(row.get("detail", ""))
     match = re.search(r"owner:\s*([^\n]+)", detail)
     return match.group(1).strip() if match else "unnamed"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -262,8 +262,25 @@ class DesugarAxis:
         self.categories[category] += 1
         self.by_category_owner[f"{category}/{owner}"] += 1
 
-    def _defect(self, kind: str, where: str, detail: str) -> None:
-        self.defects.append({"kind": kind, "where": where, "detail": detail})
+    def _defect(
+        self, kind: str, where: str, detail: str, *, exc: object | None = None
+    ) -> None:
+        row: dict[str, Any] = {"kind": kind, "where": where, "detail": detail}
+        # If the exception carries a classifier verdict, RECORD IT. #6364 built
+        # the remaining-work vs correct-refusal split as data on the exception
+        # (ExitSetFactoringGap.classification), and this census was
+        # stringifying the message and throwing that data away -- so every
+        # factoring gap reached the ledger UNCLASSIFIED and the split could not
+        # be read at corpus scale. Never re-derive it by parsing a repr.
+        classify = getattr(exc, "classification", None)
+        if callable(classify):
+            try:
+                verdict = classify()
+            except Exception:  # noqa: BLE001 -- a classifier defect is not R
+                verdict = None
+            if verdict is not None and hasattr(verdict, "row"):
+                row["classification"] = verdict.row()
+        self.defects.append(row)
 
     # -- the one door -------------------------------------------------------
 
@@ -311,7 +328,9 @@ class DesugarAxis:
             return
         if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == "defect":
             exc = outcome[1]
-            self._defect("desugar-exception", where, f"{type(exc).__name__}: {exc}")
+            self._defect(
+                "desugar-exception", where, f"{type(exc).__name__}: {exc}", exc=exc
+            )
             return
 
         walk = OutcomeWalk().walk(outcome)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -231,6 +231,9 @@ class DesugarAxis:
 
     def __init__(self) -> None:
         self.families: Counter[str] = Counter()
+        # The disjoint split of R_desugar, read off the occurrence-key prefix.
+        self.categories: Counter[str] = Counter()
+        self.by_category_owner: Counter[str] = Counter()
         self.construction_panics: list[dict[str, Any]] = []
         self.defects: list[dict[str, Any]] = []
         # Row identity: (owner, authenticated effect-occurrence coordinate).
@@ -244,6 +247,20 @@ class DesugarAxis:
             return
         self._seen.add(key)
         self.families[owner] += 1
+        # R_desugar is a MIXED number and must never be published raw. The
+        # occurrence key already says which kind of row this is: a
+        # ``desugar-call:`` key is a typed refusal (the reduction stopped and
+        # owes work), anything else is an authenticated effect occurrence --
+        # the correct OUTPUT of a reduction that succeeded. Publishing the sum
+        # as "work remaining" overstated the earlier board by 7.6x, because
+        # 7483 of 8624 rows were accounted semantics.
+        category = (
+            "typed-refusal"
+            if occurrence.startswith("desugar-call:")
+            else "constructed-effect"
+        )
+        self.categories[category] += 1
+        self.by_category_owner[f"{category}/{owner}"] += 1
 
     def _defect(self, kind: str, where: str, detail: str) -> None:
         self.defects.append({"kind": kind, "where": where, "detail": detail})
@@ -317,6 +334,8 @@ class DesugarAxis:
 
     def merge(self, other: "DesugarAxis") -> None:
         self.families.update(other.families)
+        self.categories.update(other.categories)
+        self.by_category_owner.update(other.by_category_owner)
         self.construction_panics.extend(other.construction_panics)
         self.defects.extend(other.defects)
         self._seen |= other._seen
@@ -325,6 +344,13 @@ class DesugarAxis:
         return {
             "desugarFamilies": dict(self.families),
             "R_desugar": sum(self.families.values()),
+            # Disjoint and summing to R_desugar. Read these, not the total.
+            "desugarCategories": dict(self.categories),
+            "desugarByCategoryOwner": dict(self.by_category_owner),
+            "R_desugar_owed_work": int(self.categories.get("typed-refusal", 0)),
+            "R_desugar_accounted_semantics": int(
+                self.categories.get("constructed-effect", 0)
+            ),
             "desugarConstructionPanics": list(self.construction_panics),
             "desugarDefects": list(self.defects),
         }

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_r_is_never_one_number.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_r_is_never_one_number.py
@@ -1,0 +1,87 @@
+"""``R_desugar`` is a mixed number. Publishing the total is a 7.6x overstatement.
+
+The rows behind ``R_desugar`` are two different things sharing one counter:
+
+* a **typed refusal** — the reduction stopped and owes work;
+* a **constructed effect** — the authenticated output of a reduction that
+  *succeeded*. Accounted semantics, not a backlog.
+
+On the earlier board 7,483 of 8,624 rows were the second kind. Quoted whole,
+``R_desugar`` read as remaining work and was wrong by 7.6x.
+
+The split is not a heuristic and not a name table: the occurrence key already
+records which kind each row is, because a refusal is keyed by the desugar CALL
+(``desugar-call:<where>``) while an effect is keyed by its own authenticated
+occurrence coordinate. This test pins that the axis reports the split, that the
+parts are disjoint and sum to the total, and — the discriminating face — that
+the two kinds actually land in different buckets.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.desugar_axis import DesugarAxis
+
+
+def test_the_split_is_disjoint_and_conserves_the_total() -> None:
+    axis = DesugarAxis()
+    axis._tally("SomeSugar", "desugar-call:pkg/m.py:10:4")
+    axis._tally("SomeSugar", "desugar-call:pkg/m.py:20:4")
+    axis._tally("SubscriptStoreRuntimeEffect", "pkg/m.py:11:8#store")
+    axis._tally("RaiseEffect", "pkg/m.py:12:8#raise")
+    axis._tally("RaiseEffect", "pkg/m.py:13:8#raise")
+
+    row = axis.row()
+    assert row["R_desugar"] == 5
+    assert row["R_desugar_owed_work"] == 2
+    assert row["R_desugar_accounted_semantics"] == 3
+    # Disjoint, and conserving: the parts are the whole, with nothing dropped
+    # into an unnamed remainder.
+    assert row["R_desugar_owed_work"] + row["R_desugar_accounted_semantics"] == (
+        row["R_desugar"]
+    )
+    assert sum(row["desugarCategories"].values()) == row["R_desugar"]
+
+
+def test_the_two_kinds_do_not_land_in_the_same_bucket() -> None:
+    """Discriminating face: if both landed together the split proves nothing."""
+    refusals = DesugarAxis()
+    refusals._tally("SomeSugar", "desugar-call:pkg/m.py:1:0")
+    assert refusals.row()["desugarCategories"] == {"typed-refusal": 1}
+
+    effects = DesugarAxis()
+    effects._tally("RaiseEffect", "pkg/m.py:1:0#raise")
+    assert effects.row()["desugarCategories"] == {"constructed-effect": 1}
+
+
+def test_owner_is_kept_within_its_category() -> None:
+    """One owner can produce both kinds; the ranking must not merge them.
+
+    Ranking by owner alone would put a refusal and its own successful effects
+    in one row and make the owner look like more work than it is.
+    """
+    axis = DesugarAxis()
+    axis._tally("YieldSuspensionSugar", "desugar-call:pkg/m.py:1:0")
+    axis._tally("YieldSuspensionSugar", "pkg/m.py:2:0#effect")
+
+    by_owner = axis.row()["desugarByCategoryOwner"]
+    assert by_owner == {
+        "typed-refusal/YieldSuspensionSugar": 1,
+        "constructed-effect/YieldSuspensionSugar": 1,
+    }
+    # And the flat family count still sees one owner with two rows, which is
+    # exactly the number that must never be published as owed work.
+    assert axis.row()["desugarFamilies"] == {"YieldSuspensionSugar": 2}
+
+
+def test_merge_carries_the_split() -> None:
+    """A per-file axis folded into the run total must not lose its categories."""
+    whole = DesugarAxis()
+    part = DesugarAxis()
+    part._tally("SomeSugar", "desugar-call:pkg/m.py:1:0")
+    part._tally("RaiseEffect", "pkg/m.py:2:0#raise")
+    whole.merge(part)
+
+    row = whole.row()
+    assert row["R_desugar_owed_work"] == 1
+    assert row["R_desugar_accounted_semantics"] == 1
+    assert row["R_desugar"] == 2


### PR DESCRIPTION
Step 2 off the conserved baseline. Ranked by `(owner × category)` at one commit, `43d994888`, pinned pandas 3.0.3, 1421 enrolled / 1421 terminal rows.

## The number that changes the picture

```
R_desugar 9952 = 58 owed work + 9894 accounted semantics
```

Publishing the total as remaining work overstates it by **171.6x**. The earlier board's 7.6x was the same disease at a fifth the severity.

The split needed no new classifier — **the occurrence key already recorded which kind each row was and the axis simply never reported it.** A typed refusal is keyed by the desugar CALL, a constructed effect by its own authenticated occurrence coordinate.

Owed work is four owners: `YieldSuspensionSugar.desugar` 29, `YieldFromSugar.desugar` 17, `matches_raise_effect` 11, `ClassDefinitionSugar.desugar` 1.

## What the ranker refuses

- **a mixed total** — the parts are ranked, never the sum;
- **raw occurrence** — 44 occurrences of `guarded` across 30 files is one dispatchable row; both numbers shown;
- **merged axes** — no `R_total` here; that belongs to `reconcile_pandas_floors.py`;
- **a fabricated zero** — a ledger with no split prints `SPLIT UNAVAILABLE — unmeasured, not zero`. It caught itself on first run printing "0 accounted semantics" for the merged ledger.

Backend defects group by the defect's own owner line, so four files reporting one `spans.LineTable.line_col` bug read as **one** defect.

## Two quantities, still separate

Construction R over the whole corpus is **4**, against **7663** with-statement sites. Prevalence is printed as a denominator and never as R.

## Honest gap

The factoring term is published **UNCLASSIFIED, which is not a zero**. #6364 produces its verdict as data on the exception; this census stringified the message and discarded it, so all 13 reached the ledger unclassified. Wiring committed here (`27e9e9a92`); the split will be measured on the next run.

Also filed: **#6371** — `WithConstructionGapKind`'s closed vocabulary names ~750 of ~7250 live gap rows, and `opaque-call-target:<name>` embeds a vendor symbol inside the structural key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `R_desugar` into owed work vs accounted semantics ranked by owner
> - `DesugarAxis` now classifies each desugar occurrence as either `typed-refusal` (owed work) or `constructed-effect` (accounted semantics), tracking counts per category and per (category × owner).
> - The scoreboard JSON emitted by `control_effect_recensus.py` gains `desugarCategories`, `desugarByCategoryOwner`, `R_desugar_owed_work`, and `R_desugar_accounted_semantics` fields derived from these counters.
> - A new `rank_residual_owners.py` CLI consumes the scoreboard and produces a ranked report (JSON or Markdown) showing owed work by owner, construction panics, factoring gaps, and backend defect shapes.
> - The pandas 3.0.3 ledger artifacts in `docs/ledgers/` capture the first run of this recensus, showing `R_desugar` owed work is 58, not the raw total of 9952.
> - Four new tests in `test_desugar_r_is_never_one_number.py` verify disjointness, conservation, per-owner attribution, and correct merge behavior of the split.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4b66c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->