### PR TITLE
A ground exit must cite a locus another checkout can resolve (#6352 tail)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/function_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/function_callable.py
@@ -426,22 +426,14 @@ class FunctionCallable(FloorValue):
                 )
             )
             if static_type_error:
-                import hashlib
-
-                from sugar_lift_py_tests.effect import RaiseEffect
-                from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-
-                source_sha256 = (
-                    hashlib.sha256(site.source.encode()).hexdigest()
-                    if site.source is not None
-                    else None
+                from sugar_lift_py_tests.floor.ground_exit import (
+                    ground_exceptional_exit,
                 )
-                exception = ExceptionValue("TypeError", (), site)
-                return Complete(
-                    RaiseValue(
-                        RaiseEffect("TypeError", str(site), source_sha256),
-                        exception=exception,
-                    )
+
+                return ground_exceptional_exit(
+                    exception_name="TypeError",
+                    site=site,
+                    owner="FunctionCallable.call",
                 )
             construction_panic_gap(
                 owner="FunctionCallable",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_assertion_error.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_assertion_error.py
@@ -8,37 +8,17 @@ if TYPE_CHECKING:
 
 def assertion_raise_effect(*, site):
     """Construct source-cited ``AssertionError`` testimony for one assert."""
-    import hashlib
-    from pathlib import Path
+    from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
 
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-    if Path(site.filename).is_absolute():
-        construction_panic_gap(
-            owner="ground_assertion_error",
-            blame=site,
-            observed="absolute source locus",
-            requested="workspace-relative source locus",
-            fix="route the source through the workspace-relative lift door",
-        )
-    source_sha256 = (
-        hashlib.sha256(site.source.encode()).hexdigest()
-        if site.source is not None
-        else None
+    return ground_raise_effect(
+        exception_name="AssertionError", site=site, owner="ground_assertion_error"
     )
-    return RaiseEffect("AssertionError", str(site), source_sha256)
 
 
 def ground_assertion_error(*, site) -> Outcome:
     """Construct the exact exceptional exit from a proved-false assertion."""
-    from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-    exception = ExceptionValue("AssertionError", (), site)
-    return Complete(
-        RaiseValue(
-            assertion_raise_effect(site=site),
-            exception=exception,
-        )
+    return ground_exceptional_exit(
+        exception_name="AssertionError", site=site, owner="ground_assertion_error"
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exception_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exception_exit.py
@@ -8,31 +8,8 @@ if TYPE_CHECKING:
 
 def ground_exception_exit(*, exception_name: str, site) -> Outcome:
     """Construct an exceptional exit whose triggering operands are proved ground."""
-    import hashlib
-    from pathlib import Path
+    from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
-    from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-    from sugar_lift_py_tests.outcome import Complete
-
-    if Path(site.filename).is_absolute():
-        construction_panic_gap(
-            owner="ground_exception_exit",
-            blame=site,
-            observed="absolute source locus",
-            requested="workspace-relative source locus",
-            fix="route the source through the workspace-relative lift door",
-        )
-    source_sha256 = (
-        hashlib.sha256(site.source.encode()).hexdigest()
-        if site.source is not None
-        else None
-    )
-    exception = ExceptionValue(exception_name, (), site)
-    return Complete(
-        RaiseValue(
-            RaiseEffect(exception_name, str(site), source_sha256),
-            exception=exception,
-        )
+    return ground_exceptional_exit(
+        exception_name=exception_name, site=site, owner="ground_exception_exit"
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sugar_lift_py_tests.outcome import Outcome
+
+
+def ground_raise_effect(*, exception_name: str, site, owner: str):
+    """The ONE door that mints a ground exceptional exit's `RaiseEffect`.
+
+    Every ground exit -- IndexError from a proved out-of-bounds constant
+    subscript, AssertionError from a proved-false assert, TypeError from
+    ``None[...]``, ZeroDivisionError from a proved-zero divisor -- cites the
+    same two things: a source locus and the text that locus indexes into.
+    They were five copies of one block, which is why they also carried five
+    copies of one bug: each read ``site.source``, and a ``SourceFragment``
+    has no ``source``. The read was dead because the locus law below always
+    fired first on the corpus, so the broken citation never ran. The text
+    lives on the fragment's ``unit`` (as ``RaiseSugar`` already reads it).
+
+    The locus law: a ground exit's blame must be workspace-relative. A
+    ``SourceMemento`` addresses ``{file, span}`` relative to the workspace and
+    ``resolve_span_memento`` re-reads it as ``project_root / file``, so an
+    absolute locus is not a longer spelling of the same address -- it is an
+    address no other checkout can resolve. An absolute locus means the source
+    did not come through ``workspace_path_source``; that stays LOUD, because
+    the alternative is a citation that silently cannot be checked.
+    """
+    import hashlib
+    from pathlib import Path
+
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    if Path(site.filename).is_absolute():
+        construction_panic_gap(
+            owner=owner,
+            blame=site,
+            observed="absolute source locus",
+            requested="workspace-relative source locus",
+            fix="route the source through the workspace-relative lift door",
+        )
+    source = site.unit.source
+    source_sha256 = (
+        hashlib.sha256(source.encode()).hexdigest() if source is not None else None
+    )
+    return RaiseEffect(exception_name, str(site), source_sha256)
+
+
+def ground_exceptional_exit(*, exception_name: str, site, owner: str) -> Outcome:
+    """The whole ground exit: the cited effect plus its exception value."""
+    from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    return Complete(
+        RaiseValue(
+            ground_raise_effect(
+                exception_name=exception_name, site=site, owner=owner
+            ),
+            exception=ExceptionValue(exception_name, (), site),
+        )
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_index_error.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_index_error.py
@@ -15,32 +15,9 @@ def ground_index_error(
     site,
 ) -> Outcome:
     """Construct the exact exceptional exit from a proved-failing bounds check."""
-    import hashlib
-    from pathlib import Path
-
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
-    from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
     del owner, operation, index, length
-    if Path(site.filename).is_absolute():
-        construction_panic_gap(
-            owner="ground_index_error",
-            blame=site,
-            observed="absolute source locus",
-            requested="workspace-relative source locus",
-            fix="route the source through the workspace-relative lift door",
-        )
-    source_sha256 = (
-        hashlib.sha256(site.source.encode()).hexdigest()
-        if site.source is not None
-        else None
-    )
-    exception = ExceptionValue("IndexError", (), site)
-    return Complete(
-        RaiseValue(
-            RaiseEffect("IndexError", str(site), source_sha256),
-            exception=exception,
-        )
+    return ground_exceptional_exit(
+        exception_name="IndexError", site=site, owner="ground_index_error"
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_zero_division_error.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_zero_division_error.py
@@ -8,31 +8,10 @@ if TYPE_CHECKING:
 
 def ground_zero_division_error(*, site) -> Outcome:
     """Construct the exact exceptional exit from a proved-zero divisor."""
-    import hashlib
-    from pathlib import Path
+    from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
-    from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-    from sugar_lift_py_tests.outcome import Complete
-
-    if Path(site.filename).is_absolute():
-        construction_panic_gap(
-            owner="ground_zero_division_error",
-            blame=site,
-            observed="absolute source locus",
-            requested="workspace-relative source locus",
-            fix="route the source through the workspace-relative lift door",
-        )
-    source_sha256 = (
-        hashlib.sha256(site.source.encode()).hexdigest()
-        if site.source is not None
-        else None
-    )
-    exception = ExceptionValue("ZeroDivisionError", (), site)
-    return Complete(
-        RaiseValue(
-            RaiseEffect("ZeroDivisionError", str(site), source_sha256),
-            exception=exception,
-        )
+    return ground_exceptional_exit(
+        exception_name="ZeroDivisionError",
+        site=site,
+        owner="ground_zero_division_error",
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -21,34 +21,11 @@ class NoneValue(FloorValue):
 
     def subscript(self, index, site):
         """Construct Python's exact ground ``None[...]`` exceptional exit."""
-        import hashlib
-        from pathlib import Path
-
-        from sugar_lift_py_tests.effect import RaiseEffect
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-        from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
         del index
-        if Path(site.filename).is_absolute():
-            construction_panic_gap(
-                owner="ground_type_error",
-                blame=site,
-                observed="absolute source locus",
-                requested="workspace-relative source locus",
-                fix="route the source through the workspace-relative lift door",
-            )
-        source_sha256 = (
-            hashlib.sha256(site.source.encode()).hexdigest()
-            if site.source is not None
-            else None
-        )
-        exception = ExceptionValue("TypeError", (), site)
-        return Complete(
-            RaiseValue(
-                RaiseEffect("TypeError", str(site), source_sha256),
-                exception=exception,
-            )
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ground_type_error"
         )
 
     def less_than(self, other, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -218,24 +218,12 @@ class StringValue(FloorValue):
             # Python raises TypeError for non-str needles in a str. Both sides
             # are lift-time decidable, so construct the exact exceptional exit —
             # never mint RuntimeEffect authority over ground operands.
-            import hashlib
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-            from sugar_lift_py_tests.effect import RaiseEffect
-            from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
-            from sugar_lift_py_tests.outcome import Complete
-
-            source = getattr(site, "source", None)
-            source_sha256 = (
-                hashlib.sha256(source.encode()).hexdigest()
-                if source is not None
-                else None
-            )
-            exception = ExceptionValue("TypeError", (), site)
-            return Complete(
-                RaiseValue(
-                    RaiseEffect("TypeError", str(site), source_sha256),
-                    exception=exception,
-                )
+            return ground_exceptional_exit(
+                exception_name="TypeError",
+                site=site,
+                owner="StringValue.contains",
             )
         from sugar_lift_py_tests.gap.panic import construction_panic_gap
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -205,7 +205,7 @@ def open_source_file_for_construction(
     freezes source-derived manager refs at exact use-sites. Callers that already
     hold a frozen context (shared demand table across a census) may pass it.
     """
-    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_python_source.source_oracle import workspace_path_source
     from sugar_source_tree.reporter import NULL_REPORTER
     from sugar_source_tree.tree import SourceFile
 
@@ -218,7 +218,7 @@ def open_source_file_for_construction(
             call_contract_refs=call_contract_refs,
         )
     source_file = SourceFile(
-        path_source(str(path)),
+        workspace_path_source(str(path), root=str(root)),
         reporter=reporter,
         construction_context=construction_context,
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_workspace_locus.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_workspace_locus.py
@@ -1,0 +1,165 @@
+"""Ground exceptional exits carry a workspace-relative, source-cited locus.
+
+Three faces of one law.
+
+TRUTHFUL: a corpus opened by absolute path through the construction door
+mints a workspace-relative locus, and every ground exit (IndexError from a
+proved out-of-bounds constant subscript, TypeError from ``None[...]``,
+AssertionError from a proved-false assert, ZeroDivisionError from a
+proved-zero divisor) CONSTRUCTS -- it does not panic.
+
+CITED: the constructed exit pins the text its locus indexes into. The five
+ground-exit copies each read ``site.source``, which a ``SourceFragment`` does
+not have; the read was dead because the locus law below fired first, so a
+green board never exercised it. A citation that is silently absent is the
+elision this face forbids.
+
+LYING: the locus law is SATISFIED, not deleted. A ``SourceFile`` built from
+the bare ``path_source`` door still carries an absolute locus, and a ground
+exit over it must still panic with the workspace-relative demand. A
+``SourceMemento`` addresses ``{file, span}`` relative to a workspace and
+``resolve_span_memento`` re-reads it as ``project_root / file``; an absolute
+locus is an address no other checkout can resolve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import RaiseValue
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.outcome import Complete
+
+CORPUS = """\
+def ground_index():
+    xs = [1, 2, 3]
+    return xs[5]
+
+
+def ground_type():
+    n = None
+    return n[0]
+
+
+def ground_assert():
+    assert False
+    return 1
+
+
+def ground_zero_div():
+    return 1 / 0
+
+
+def ground_str_index():
+    s = "ab"
+    return s[9]
+
+
+def ground_tuple_index():
+    t = (1, 2)
+    return t[7]
+"""
+
+EXPECTED_EXCEPTIONS = {
+    "ground_index": "IndexError",
+    "ground_type": "TypeError",
+    "ground_assert": "AssertionError",
+    "ground_zero_div": "ZeroDivisionError",
+    "ground_str_index": "IndexError",
+    "ground_tuple_index": "IndexError",
+}
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "ground_exits.py").write_text(CORPUS, encoding="utf-8")
+    return root
+
+
+def _raise_effects(root: Path) -> dict[str, RaiseEffect]:
+    """Desugar every function through the production construction door.
+
+    The path handed in is ABSOLUTE -- that is the corpus shape the census
+    lifts, and the shape that used to panic.
+    """
+    path = root / "ground_exits.py"
+    assert path.is_absolute()
+    source_file = open_source_file_for_construction(
+        path, root=root, populate_derived=True
+    )
+    effects: dict[str, RaiseEffect] = {}
+    for function in source_file.functions():
+        outcome = function.sugar().desugar(None)
+        assert isinstance(outcome, Complete), (
+            f"{function.name} did not construct: {outcome!r}"
+        )
+        value = outcome.value
+        assert isinstance(value, RaiseValue), (
+            f"{function.name} constructed {type(value).__name__}, not a RaiseValue"
+        )
+        effects[function.name] = value.effect
+    return effects
+
+
+def test_ground_exits_construct_under_an_absolute_corpus_path(corpus: Path) -> None:
+    """TRUTHFUL: every ground exit constructs; none panics on its own locus."""
+    effects = _raise_effects(corpus)
+    assert {
+        name: effect.exception_name for name, effect in effects.items()
+    } == EXPECTED_EXCEPTIONS
+
+
+def test_ground_exit_blame_is_workspace_relative(corpus: Path) -> None:
+    """TRUTHFUL: the blame names the file by its workspace-relative locus."""
+    effects = _raise_effects(corpus)
+    assert effects, "no ground exit was constructed -- nothing was measured"
+    for name, effect in effects.items():
+        blame = effect.blame
+        assert blame is not None, f"{name} exit carries no blame locus"
+        assert blame.startswith("ground_exits.py:"), (
+            f"{name} blame `{blame}` is not the workspace-relative locus"
+        )
+        assert not Path(blame.split(":")[0]).is_absolute()
+
+
+def test_ground_exit_cites_the_source_it_locates(corpus: Path) -> None:
+    """CITED: the exit pins the exact text of the file its locus indexes."""
+    expected = hashlib.sha256(CORPUS.encode()).hexdigest()
+    effects = _raise_effects(corpus)
+    for name, effect in effects.items():
+        assert effect.source_sha256 == expected, (
+            f"{name} exit cites {effect.source_sha256!r}, not the source text "
+            f"its locus indexes into"
+        )
+
+
+def test_absolute_locus_still_refuses_to_construct_a_ground_exit(
+    corpus: Path,
+) -> None:
+    """LYING: the law is satisfied, not deleted.
+
+    Built through the bare ``path_source`` door the locus is absolute again,
+    and the ground exit must stay LOUD rather than mint an unresolvable
+    citation. Deleting the locus check makes this test pass a construction it
+    must refuse.
+    """
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_source_tree.tree import SourceFile
+
+    path = corpus / "ground_exits.py"
+    source_file = SourceFile(path_source(str(path)))
+    function = next(
+        fn for fn in source_file.functions() if fn.name == "ground_index"
+    )
+    with pytest.raises(ConstructionPanic) as raised:
+        function.sugar().desugar(None)
+    message = str(raised.value)
+    assert "absolute source locus" in message
+    assert "workspace-relative source locus" in message

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -164,6 +164,32 @@ def path_source(path: str) -> tuple[str, str, str]:
     return (source, str(path), blake3_512_of(source.encode("utf-8")))
 
 
+def workspace_path_source(path: str, *, root: str) -> tuple[str, str, str]:
+    """The workspace-relative half of `path_source` — the construction door.
+
+    `path_source` mints the locus from the read path, so a corpus opened by
+    absolute path carries an absolute locus. Every ground exceptional exit
+    (`ground_index_error` and its siblings) refuses an absolute locus, because
+    a `SourceMemento` addresses `{file, span}` workspace-relative and
+    `resolve_span_memento` re-reads it as `project_root / file`. An absolute
+    locus is therefore not a longer spelling of the same address: it is an
+    address that cannot be resolved against any other checkout.
+
+    This door reads through the same minting path — one read, one CID — and
+    states the locus relative to the workspace `root`. A path outside `root`
+    has no workspace-relative name at all; that is a LOUD `SourceUnavailable`,
+    never a silent fall back to the absolute spelling.
+    """
+    source, _absolute, source_cid = path_source(path)
+    try:
+        relative = Path(path).resolve().relative_to(Path(root).resolve())
+    except ValueError as exc:
+        raise SourceUnavailable(
+            f"source `{path}` lies outside workspace root `{root}`: {exc}"
+        ) from exc
+    return (source, relative.as_posix(), source_cid)
+
+
 def dependency_artifact_file(path: str) -> tuple[bytes, str, str]:
     """Mint one recorded dependency file as ``(bytes, seat, content CID)``.
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2354,11 +2354,18 @@ class FunctionDef(Statement):
                 ):
                     from pathlib import Path
 
-                    relative = (
-                        Path(self.unit.filename)
-                        .resolve()
-                        .relative_to(Path(workspace_root).resolve())
-                    )
+                    # The construction door already mints the locus
+                    # workspace-relative (`workspace_path_source`). Re-deriving
+                    # it here would be a second answer to a question already
+                    # resolved; an absolute filename means the unit did NOT come
+                    # through that door, and that stays LOUD.
+                    relative = Path(self.unit.filename)
+                    if relative.is_absolute():
+                        raise SugarNotWritten(
+                            f"module-level bridge symbol needs a workspace-relative "
+                            f"locus; `{self.unit.filename}` is absolute -- route the "
+                            f"source through the workspace-relative lift door"
+                        )
                     module_parts = list(relative.with_suffix("").parts)
                     if module_parts and module_parts[-1] == "__init__":
                         module_parts.pop()


### PR DESCRIPTION
## The tail, named

The brief asked first for the 173 desugar construction panics that are neither `ContractConditionalConstructionV1.and_then` (283) nor `IfExpSugar._join` (46). Extracted from `docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json` and ranked by **(owner x value category)**:

| count | family | status at `78714a798` |
|---|---|---|
| 79 | `two ... DISTINCT contract demands` — `collection ListValue` 41, `collection build` 26, `GuardedValue._map(subscript)` 7, `collection TupleValue` 5 | **already drained.** The message does not exist in `implementations/` any more; `git log -S` puts its removal in #6354 (the parameter-contract carrier holds a demand SET). Zero, no pin — a retired family is not a law to ratify. |
| 18 | **absolute source locus** — `ground_index_error` 15, `ground_type_error` 2, `ground_assertion_error` 1 | **this PR** |
| 25 | `guarded` — `BlockValue` 15, `SymbolicValue` 6, plus `TrueBoolLiteralSugar`/`StringValue`/`ClassDefinitionValue`/`ComprehensionValue` | live, not attempted (see below) |
| ~48 | binary-operation floors — `add`/`multiply`/`subtract`/`divide`/`bitwise_*`/`unary_plus`/`truth`/`attribute` x operand category | live, not attempted |
| 7 | `RuntimeEffect` minted over a ground operand (`py.delitem`, `py.lt`) | live, not attempted |
| 2 | `dict.subscript` missing concrete key; `BlockValue.to_term` | live, not attempted |

## The cut

The 18 absolute-locus rows were one owner family refusing with `observed=absolute source locus requested=workspace-relative source locus`.

**The refusal is right.** A `SourceMemento` addresses `{file, span}` relative to a workspace and `resolve_span_memento` re-reads it as `project_root / file`. An absolute locus is not a longer spelling of the same address — it is an address no other checkout can resolve.

**The defect was upstream.** `open_source_file_for_construction` already holds the workspace `root`, and minted the locus from the read path anyway. So a corpus opened by absolute path — the shape the census lifts — could never satisfy the law it was being measured against.

`workspace_path_source` is the workspace-relative half of `path_source`: one read, one CID, locus stated relative to the root. A path outside the root has no workspace-relative name at all and stays a LOUD `SourceUnavailable`, never a silent fall back to the absolute spelling. The module-level bridge symbol in `nodes.py` stopped re-deriving the same relative path and now consumes the one the door resolved; an absolute filename there means the unit did not come through the door, and that stays loud.

## What the panic was hiding

Five copies of one ground-exit block each cited the source as `hashlib.sha256(site.source)` — and a `SourceFragment` has no `source`. The read never ran, because the locus law fired first on every corpus row. **Satisfying the law turned it into an `AttributeError` on contact.**

`floor/ground_exit.py` is now the ONE door those five route through, reading the text where it lives (`site.unit.source`, as `RaiseSugar` already did). Two further copies of the same defect — `StringValue.contains` and `FunctionCallable` — route there too; both had degraded to `getattr(site, "source", None)`, i.e. citing nothing at all, silently.

## Faces

`tests/test_ground_exit_workspace_locus.py`:

- **truthful** — six ground exits (IndexError from list/str/tuple, TypeError from `None[...]`, AssertionError, ZeroDivisionError) lifted from an **absolute** corpus path all construct, and their blame is `ground_exits.py:...`.
- **cited** — each exit pins the sha256 of the exact file text its locus indexes into. This is the face the dead `site.source` read could not have passed.
- **lying** — a `SourceFile` built through the bare `path_source` door still carries an absolute locus, and the ground exit **still panics** with the workspace-relative demand. The law is satisfied, not deleted; deleting the check makes this test pass a construction it must refuse.

Baseline check at `78714a798`, before the change, on the same six functions: 6/6 `ConstructionPanic: observed=absolute source locus`. After: 6/6 `Complete`.

## Flag: memento `file` becomes workspace-relative

`SourceFragment.memento()` sets `file=self.filename`. Sources opened through the construction door now mint that field relative to the workspace. That is what makes a memento portable across checkouts and what `resolve_span_memento` already expects — but it **changes contract-row content, and any CID over it, for path-lifted sources**. Reviewers should read this as intended, not incidental.

## Measurement

- **Site coverage**: 18 of 18 ledger rows in this family are the absolute-locus refusal, and the door they name is the one this PR changes. Every ground-exit constructor in the kit now routes through the single door.
- **ΔR: unmeasured.** No census was run — battleaxe is re-running the authoritative baseline and the brief forbade a local census. The predicted ε is −18 on `R_desugar_construction_panics`, contingent on the recensus.
- **Known inherited red**: the local suite result is reported in a follow-up comment; the box was at load average 200 with six agents' pytest runs when this was opened.

Does not close #6352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize ground exit construction to enforce workspace-relative loci
> - Adds `ground_raise_effect` and `ground_exceptional_exit` helpers in [`ground_exit.py`](https://github.com/TSavo/sugar/pull/6389/files#diff-a7f3cb4fd67eabedbf1a0720f9bcc32bcf2bc01ec14036c4dd92a52e68dd6bd9) that panic on absolute `site.filename`, hash source via `site.unit.source`, and construct `RaiseEffect`/`Complete` exits in one place.
> - Refactors all floor exception constructors (`ground_assertion_error`, `ground_exception_exit`, `ground_index_error`, `ground_zero_division_error`, `NoneValue.subscript`, `StringValue.contains`, `FunctionCallable.call`) to delegate to these helpers instead of building exits inline.
> - Adds `workspace_path_source` in [`source_oracle.py`](https://github.com/TSavo/sugar/pull/6389/files#diff-46c211dd48cf8b40814f36939afc72cfd9d8d750d36f6572af9c9e02ba22ea6f) to produce workspace-root-relative seats for `SourceFile` construction, and switches `open_source_file_for_construction` in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/6389/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to use it.
> - `FunctionDef.source_visible_call_frame` now raises `SugarNotWritten` if `unit.filename` is absolute rather than attempting to derive a relative path.
> - Risk: any call site that passes an absolute `site.filename` to a ground exit constructor will now panic at construction time instead of producing a potentially invalid exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89a4b2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->