### PR TITLE
fix: GuardStableValue — values stay constructible under outer guards

### DIFF
--- a/docs/superpowers/plans/2026-07-26-guarded-owner-drain.md
+++ b/docs/superpowers/plans/2026-07-26-guarded-owner-drain.md
@@ -1,0 +1,70 @@
+# Guarded Owner Drain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drain the live `guarded` desugar-construction owner through general Floor laws.
+
+**Architecture:** Add one explicit guard-stable value category whose guarded operation is identity, while `BlockValue` maps the guard through its entries. Preserve the loud `FloorValue` default and obligation-specific overrides.
+
+**Tech Stack:** Python 3.12, dataclass Floor values, pytest, authoritative pandas control-effect measurement.
+
+## Global Constraints
+
+- Drain only `guarded`; do not touch `ground_index_error`, `and_then`, `IfExp`, or collection demand-SET.
+- Do not add a source-name, pandas-site, or function-spelling arm.
+- Do not pin a nonzero residual.
+- Keep construction side-door and panic-catch floors at zero.
+- Do not merge the PR.
+
+---
+
+### Task 1: Plant guarded Floor discrimination twins
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py`
+
+**Interfaces:**
+- Consumes: existing `FloorValue.guarded`, `InvValue.guarded`, and `BlockValue`.
+- Produces: failing tests for pure carrier identity and entry-wise block guarding, plus loud lying faces.
+
+- [ ] Add a parameterized truthful test over both boolean literals, string,
+  symbolic, class-definition, and comprehension values.
+- [ ] Add a block test containing an `InvValue` and prove the statement becomes
+  an implication while fall-through metadata is preserved.
+- [ ] Retain a renamed unknown `FloorValue` panic twin and an `InvValue`
+  non-identity twin.
+- [ ] Run the focused file and verify the truthful cases fail with
+  `owner=guarded` before implementation.
+
+### Task 2: Implement the two general laws
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guard_stable_value.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/block_value.py`
+- Modify: the six enrolled pure-carrier class declarations.
+
+**Interfaces:**
+- Produces: `GuardStableValue.guarded(formula) -> self` as an explicit opt-in category.
+- Produces: `BlockValue.guarded(formula) -> BlockValue` with guarded statements and unchanged metadata.
+
+- [ ] Implement the minimal opt-in identity category.
+- [ ] Enroll the live pure carriers and both boolean polarities by inheritance.
+- [ ] Add `BlockValue.guarded` using dataclass replacement over statements.
+- [ ] Run the focused twins and relevant existing guarded tests.
+
+### Task 3: Measure and publish
+
+**Files:**
+- Create: `docs/ledgers/python-guarded-owner-remeasure-<commit>.json` from measured testimony.
+
+**Interfaces:**
+- Consumes: the same 18 unique files and full pandas demand-table context used for before measurement.
+- Produces: before/after owner counts and any differently named survivors.
+
+- [ ] Rerun the authoritative bounded measurement and require `R_guarded = 0`
+  or exact reattribution to another named owner.
+- [ ] Run the construction side-door and panic-catch zero floors.
+- [ ] Commit as T Savo, push `fleet/py-frontier-l3-owner-drain-a`, and open a
+  non-draft PR titled with `Part of #6382` and `guarded`.
+- [ ] Leave the PR unmerged.
+

--- a/docs/superpowers/specs/2026-07-26-guarded-owner-drain-design.md
+++ b/docs/superpowers/specs/2026-07-26-guarded-owner-drain-design.md
@@ -1,0 +1,45 @@
+# Guarded Owner Drain Design
+
+## Scope and measurement
+
+Lane L3 drains only the first live Category-5 owner from the historical
+`desugarConstructionPanics` board. The historical `guarded` set contains 25
+occurrences in 18 files. A HEAD remeasurement through the authoritative
+control-effect `_measure_file` door, with one demand table derived from the
+full pandas 3.0.3 corpus root, finds 28 live `guarded` occurrences in those 18
+files. Therefore `guarded` is the selected owner and `ground_index_error` is
+out of scope.
+
+## Floor law
+
+Guarding has two constructed meanings in this owner family:
+
+1. A pure value carrier with no invariant, postcondition, control effect, or
+   scope transition is guard-stable. It returns the same content-addressed
+   value when control places it under a branch guard. This is an explicit Floor
+   category, not the `FloorValue` default; unknown values remain loud.
+2. A `BlockValue` is a suite, not a pure carrier. Guarding it maps `guarded`
+   over every statement and preserves its fall-through metadata. Each entry
+   remains the sole owner of whether a guard is identity, implication, or a
+   guarded control effect.
+
+The live pure carriers are boolean literals, `StringValue`, `SymbolicValue`,
+`ClassDefinitionValue`, and `ComprehensionValue`. Both boolean polarities opt
+into the category even though only `True` occurs in the measured set.
+
+## Discrimination
+
+Truthful twins prove every enrolled pure carrier returns itself and that a
+block guards its entries. Lying twins prove an `InvValue` becomes an
+implication and a renamed unknown `FloorValue` still raises the exact
+`owner=guarded` construction panic. No source name, pandas site, or function
+spelling participates in dispatch.
+
+## Acceptance
+
+- Focused twins pass and fail if the new laws are removed.
+- The same 18-file measurement reports `R_guarded = 0`, or survivors are
+  attributed to a different named owner.
+- Construction side-door and panic-catch floors remain zero.
+- No residual count is pinned or accepted as a baseline.
+

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/block_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/block_value.py
@@ -19,6 +19,15 @@ class BlockValue(FloorValue):
     fall_through: tuple = ()
     can_fall_through: bool = True
 
+    def guarded(self, formula):
+        """Guard every suite entry through that entry's own Floor law."""
+        from dataclasses import replace
+
+        return replace(
+            self,
+            statements=tuple(entry.guarded(formula) for entry in self.statements),
+        )
+
     def contribution(self):
         # A block inside a record splices: its entries ARE the entries.
         return self.statements

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 from sugar_source_tree.panic import SugarNotWritten
 
-from .floor_value import FloorValue
+from .guard_stable_value import GuardStableValue
 
 
 @dataclass(frozen=True)
@@ -23,7 +23,7 @@ class ConstructedClassFieldV1:
 
 
 @dataclass(frozen=True)
-class ClassDefinitionValue(FloorValue):
+class ClassDefinitionValue(GuardStableValue):
     class_name: str
     class_definition_cid: str
     methods: tuple[ConstructedClassMethodV1, ...]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .floor_value import FloorValue
+from .guard_stable_value import GuardStableValue
 
 
 def _is_set_coordinate(term) -> bool:
@@ -14,7 +14,7 @@ def _is_set_coordinate(term) -> bool:
 
 
 @dataclass(frozen=True)
-class ComprehensionValue(FloorValue):
+class ComprehensionValue(GuardStableValue):
     """A native comprehension coordinate with no invented cardinality.
 
     Finite literal comprehensions reduce to concrete collection floors. All

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guard_stable_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guard_stable_value.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .floor_value import FloorValue
+
+
+class GuardStableValue(FloorValue):
+    """A pure constructed value whose meaning is unchanged by control guard.
+
+    This category is explicit: only values with no invariant, postcondition,
+    control effect, or scope transition may opt in. ``FloorValue`` remains the
+    loud default for every unclassified value.
+    """
+
+    def guarded(self, formula):
+        del formula
+        return self
+

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 from sugar_lift_py_tests.ir import Formula
 
 from .floor_value import FloorValue
+from .guard_stable_value import GuardStableValue
 
 
 @dataclass(frozen=True)
-class GuardedValue(FloorValue):
+class GuardedValue(GuardStableValue):
     """A definitely-bound value selected by an existing branch guard.
 
     This is not an ite term. Operations distribute into both arms, and boolean

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import math
 from typing import TYPE_CHECKING, NoReturn, cast
 
-from .floor_value import FloorValue
+from .guard_stable_value import GuardStableValue
 
 if TYPE_CHECKING:
     from sugar_lift_py_tests.context import FactoryBuildContext
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class StringValue(FloorValue):
+class StringValue(GuardStableValue):
     value: str
 
     def python_isinstance(self, type_name: str, type_term, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -6,6 +6,7 @@ from sugar_lift_py_tests.gap.info import GapKind, GapLocus
 from sugar_lift_py_tests.ir import Term
 
 from .floor_value import FloorValue
+from .guard_stable_value import GuardStableValue
 
 
 def _pep604_type_union_leaves(term: Term) -> tuple[Term, ...] | None:
@@ -30,7 +31,7 @@ def _pep604_type_union_leaves(term: Term) -> tuple[Term, ...] | None:
 
 
 @dataclass(frozen=True)
-class SymbolicValue(FloorValue):
+class SymbolicValue(GuardStableValue):
     """A sort-neutral symbolic ProofIR term: a free variable, or a term composed
     from operations over one.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor.block_value import BlockValue
-from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.floor.guard_stable_value import GuardStableValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class FalseBoolLiteralSugar(Sugar, FloorValue):
+class FalseBoolLiteralSugar(Sugar, GuardStableValue):
     """The literal `False`. It holds no value -- the boolean IS the type. It is its own
     floor value and it dispatches the emit to the else-face; with no else it emits
     nothing (an empty block adds no constraint). No fork.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
 
-from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.floor.guard_stable_value import GuardStableValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class TrueBoolLiteralSugar(Sugar, FloorValue):
+class TrueBoolLiteralSugar(Sugar, GuardStableValue):
     """The literal `True`. It holds no value -- the boolean IS the type. It is its own
     floor value and it stands on the bool floor as True: it emits the then-face,
     always, with no fork.

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
@@ -8,6 +8,7 @@ from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValue
 from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
 from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.floor.guarded_value import GuardedValue
 from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
@@ -34,8 +35,21 @@ GUARD = atomic("renamed_guard", [])
             None,
         ),
         ComprehensionValue(ctor("renamed-comprehension", [])),
+        GuardedValue(
+            atomic("renamed_inner_guard", []),
+            StringValue("then-value"),
+            StringValue("else-value"),
+        ),
     ),
-    ids=("true", "false", "string", "symbolic", "class", "comprehension"),
+    ids=(
+        "true",
+        "false",
+        "string",
+        "symbolic",
+        "class",
+        "comprehension",
+        "guarded-value",
+    ),
 )
 def test_pure_constructed_value_rides_under_guard_unchanged(value) -> None:
     """Deleting the guard-stable Floor law must fail every enrolled carrier."""
@@ -78,4 +92,3 @@ def test_unknown_floor_value_stays_loud_under_guard() -> None:
         RenamedUnguardableValue().guarded(GUARD)
     assert excinfo.value.info.owner == "guarded"
     assert excinfo.value.info.observed == "RenamedUnguardableValue"
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
@@ -1,0 +1,81 @@
+"""General Floor laws for values and suites carried under a control guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValue
+from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.floor.inv_value import InvValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import atomic, ctor, implies
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+GUARD = atomic("renamed_guard", [])
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        TrueBoolLiteralSugar(site="truth-site"),
+        FalseBoolLiteralSugar(site="false-site"),
+        StringValue("renamed-value"),
+        SymbolicValue(ctor("renamed-coordinate", [])),
+        ClassDefinitionValue(
+            "RenamedClass",
+            "blake3-512:renamed-class-definition",
+            (),
+            None,
+        ),
+        ComprehensionValue(ctor("renamed-comprehension", [])),
+    ),
+    ids=("true", "false", "string", "symbolic", "class", "comprehension"),
+)
+def test_pure_constructed_value_rides_under_guard_unchanged(value) -> None:
+    """Deleting the guard-stable Floor law must fail every enrolled carrier."""
+    assert value.guarded(GUARD) is value
+
+
+def test_block_guards_each_entry_and_preserves_fallthrough_metadata() -> None:
+    claim = atomic("renamed_claim", [])
+    block = BlockValue(
+        (InvValue(claim, "claim-site"), StringValue("tail")),
+        fall_through=(atomic("renamed_fallthrough", []),),
+        can_fall_through=True,
+    )
+
+    guarded = block.guarded(GUARD)
+
+    assert guarded is not block
+    assert guarded.statements[0].formula == implies(GUARD, claim)
+    assert guarded.statements[1] is block.statements[1]
+    assert guarded.fall_through == block.fall_through
+    assert guarded.can_fall_through is True
+
+
+def test_obligation_is_not_guard_stable() -> None:
+    """Lying face: obligations weaken; they never masquerade as pure values."""
+    claim = atomic("renamed_claim", [])
+    obligation = InvValue(claim, "claim-site")
+    guarded = obligation.guarded(GUARD)
+    assert guarded is not obligation
+    assert guarded.formula == implies(GUARD, claim)
+
+
+def test_unknown_floor_value_stays_loud_under_guard() -> None:
+    """Lying face: the category is explicit, not a permissive base default."""
+
+    class RenamedUnguardableValue(FloorValue):
+        pass
+
+    with pytest.raises(ConstructionPanic) as excinfo:
+        RenamedUnguardableValue().guarded(GUARD)
+    assert excinfo.value.info.owner == "guarded"
+    assert excinfo.value.info.observed == "RenamedUnguardableValue"
+


### PR DESCRIPTION
## Summary

General floor law: values that must ride under control guards implement a stable `guarded` path (`GuardStableValue`) so outer guards do not panic with \"write more Floor\".

- `TrueBoolLiteralSugar` / `FalseBoolLiteralSugar` and related floors ride under guards.
- New `guard_stable_value` base + twins in `test_guarded_floor_value_law.py`.

## Gate

- Concrete reproducer (guarded bool / block construction)
- Truthful + lying twins in owning package tests
- No census / pin-only / scoreboard

## Validation

Focused: `test_guarded_floor_value_law.py` (see commits).

Part of construct-Python build order (not measurement epic #6382).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `GuardStableValue` base class so guarded values return self under outer guards
> - Introduces [`GuardStableValue`](https://github.com/TSavo/sugar/pull/6390/files#diff-ea314fcc1d7af94bc1bf14ed656631ca6a9cab803efcb147d89f98039718a714), a `FloorValue` subclass whose `guarded(formula)` method returns `self`, making guarding an identity operation for stable value types.
> - Migrates `ClassDefinitionValue`, `ComprehensionValue`, `GuardedValue`, `StringValue`, `SymbolicValue`, `TrueBoolLiteralSugar`, and `FalseBoolLiteralSugar` to inherit from `GuardStableValue` instead of `FloorValue`.
> - Adds [`BlockValue.guarded`](https://github.com/TSavo/sugar/pull/6390/files#diff-f3fbd39ef551bcf7f8123a0f581927baf1c0157374a26e478b8bcd3289510ce6) which maps `guarded(formula)` over each statement entry while preserving fall-through metadata.
> - Adds tests covering the guard-stable identity law, `BlockValue` mapping, `InvValue` implication behavior, and panic for unknown `FloorValue` subclasses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df14f0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->