### PR TITLE
EffectBoundary: bind the observed effect from the routed occurrence (#6298)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -85,6 +85,12 @@ class EffectBoundaryDisposition:
 
     matcher: AuthenticatedRaiseMatcher
     unmet: object = None
+    # The ``as`` slot this boundary authenticates, or None when the source
+    # binds no name. A slot is authenticated ONLY on the arm whose halt this
+    # boundary actually consumed -- never on the restored arm and never on a
+    # body that completed, because on those arms no occurrence exists to
+    # project and inventing one is the forbidden ``E()``.
+    observation_slot_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -45,6 +45,22 @@ class RetainedObligation:
     failed: object
 
 
+@dataclass(frozen=True)
+class ConsumedObservation:
+    """The boundary consumed this halt AND authenticated its observation slot.
+
+    ``None`` already means "consumed"; this says the same thing and carries the
+    testimony that authenticates the ``as`` slot. The facts are built from the
+    ROUTED occurrence -- the exact effect this boundary matched -- so the slot
+    is authenticated by the thing that actually happened and never by an
+    ``E()`` the router invented. It is a separate shape rather than a flag
+    because a consumed-without-binding face must remain unable to carry
+    testimony at all.
+    """
+
+    facts: tuple
+
+
 def exit_disposition_effect(disposition: object, incoming: object):
     """The verdict for one body exit: an ``Effect``, ``None``, or a retention.
 
@@ -106,17 +122,39 @@ def _boundary_halted_edge(disposition, incoming):
             fix="repair the block reducer; never fabricate a continuation state",
         )
     if isinstance(verdict, MatchDecided):
-        return None
+        return _consumed(disposition, incoming)
     if isinstance(verdict, MatchRetained):
         # The identity matched; only the message predicate is open. Under it
         # the boundary consumes, under its complement the ORIGINAL halt stands.
         return RetainedObligation(
-            obligation=verdict.obligation, held=None, failed=incoming.effect
+            obligation=verdict.obligation,
+            held=_consumed(disposition, incoming),
+            failed=incoming.effect,
         )
     raise TypeError(
         "message verdict must be MatchDecided or MatchRetained; "
         f"got {type(verdict).__name__}"
     )
+
+
+def _consumed(disposition, incoming):
+    """Consume, carrying observation testimony only when a slot was declared.
+
+    No slot -> plain ``None``. A declared slot is authenticated from
+    ``incoming.effect``, the occurrence the matcher just decided on.
+    """
+    from sugar_lift_py_tests.effect_router import EffectBinding
+
+    slot_id = getattr(disposition, "observation_slot_id", None)
+    if slot_id is None:
+        return None
+    binding = EffectBinding(
+        slot_id=slot_id,
+        kind="raise",
+        type_name=getattr(incoming.effect, "exception_name", None),
+        effect=incoming.effect,
+    )
+    return ConsumedObservation(binding.to_facts(site=getattr(incoming, "site", None)))
 
 
 def _authenticate(disposition: object) -> None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -881,11 +881,32 @@ class ExitSet(Generic[T]):
         expression.
         """
         from sugar_lift_py_tests.outcome.exit_disposition import (
+            ConsumedObservation,
             RetainedObligation,
             exit_disposition_effect,
         )
 
         from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+
+        def _place(target: list, guard, verdict, carried, arm_faces, owed):
+            """One outgoing arm per verdict shape. Conserves the incoming arm.
+
+            ``owed`` is the pending caller obligation this arm carries (#6392),
+            threaded unchanged: authenticating an observation slot neither
+            discharges an obligation nor incurs one.
+            """
+            if verdict is None:
+                target.append(Completed(guard, carried, arm_faces, owed))
+            elif isinstance(verdict, ConsumedObservation):
+                # Consumed AND authenticating a slot: the testimony rides the
+                # completed arm it belongs to, never a sibling arm.
+                target.append(
+                    Completed(
+                        guard, _carry_facts(carried, verdict.facts), arm_faces, owed
+                    )
+                )
+            else:
+                target.append(Halted(guard, verdict, carried, arm_faces, owed))
 
         exit_exits = exit_es.exits
         exits: list[Exit[object]] = []
@@ -935,26 +956,21 @@ class ExitSet(Generic[T]):
                             failed_face,
                         ),
                     ):
-                        sub_faces = faces | {sub_face}
                         # The retention narrows this arm's guard; `sub_guard`
                         # IS that narrowing, and the obligation is minted
                         # against it once, at enrolment.
-                        if sub_verdict is None:
-                            exits.append(
-                                Completed(sub_guard, carried, sub_faces, owed)
-                            )
-                        else:
-                            exits.append(
-                                Halted(
-                                    sub_guard, sub_verdict, carried, sub_faces, owed
-                                )
-                            )
+                        _place(
+                            exits,
+                            sub_guard,
+                            sub_verdict,
+                            carried,
+                            faces | {sub_face},
+                            owed,
+                        )
                     continue
-                if verdict is None:
-                    exits.append(Completed(guard, carried, faces, owed))
-                else:
-                    exits.append(Halted(guard, verdict, carried, faces, owed))
+                _place(exits, guard, verdict, carried, faces, owed)
         return ExitSet(tuple(exits)).normalize()
+
 
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
         """Run a source-constructed ``__exit__`` and retain both truth faces.
@@ -1231,3 +1247,25 @@ __all__ = [
     "true_guard",
     "outcome_to_exitset",
 ]
+
+
+def _carry_facts(carried, facts: tuple):
+    """Splice authenticated facts into the state the outgoing arm carries.
+
+    Same shape as the Try handler's binding deposit: a reduced block gets the
+    facts spliced into its entries, anything else is wrapped once so the
+    testimony has somewhere to live. No arm is added and none is dropped.
+    """
+    from dataclasses import replace as _replace
+
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    if not facts:
+        return carried
+    if isinstance(carried, _ReducedBlock):
+        return _replace(carried, entries=(*facts, *carried.entries))
+    return _ReducedBlock(
+        entries=(*facts, carried) if carried is not None else facts,
+        can_fall_through=True,
+        fall_through=(),
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -15,6 +15,7 @@ class WithEffectBoundarySugar(Sugar):
     semantics: object
     contract_ref: object
     context_manager_edge: object
+    observation_slot_id: str | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
@@ -109,6 +110,7 @@ class WithEffectBoundarySugar(Sugar):
                 matcher=AuthenticatedRaiseMatcher(
                     expected=expected, message_pattern=pattern
                 ),
+                observation_slot_id=self.observation_slot_id,
                 unmet=(
                     ExpectationNotMetEffect("raise", self.site)
                     if isinstance(semantics.mode, ExpectsModeV1)

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1381,3 +1381,163 @@ def test_boundary_consumes_authenticated_builtin_ancestry_only_in_one_direction(
 
     face = outcome_to_exitset(boundary.desugar()).exits[0]
     assert type(face).__name__.lower() == expected_face
+
+
+# --- bind-observed-effect: `with <boundary> as info:` -------------------------
+#
+# The binding projects the ROUTED OCCURRENCE COORDINATE and never fabricates
+# `E()`. So the slot is authenticated on exactly one arm -- the one whose halt
+# this boundary actually consumed. On a restored halt there is an occurrence
+# but it is not this boundary's, and on a completed body there is no occurrence
+# at all; both must carry zero binding facts.
+
+
+_BOUNDARY_IMPLEMENTATION = (
+    "class Boundary:\n"
+    "    def __init__(self, expected):\n"
+    "        self.expected = expected\n"
+    "    def __enter__(self):\n"
+    "        return self\n"
+    "    def __exit__(self, effect_type, effect, traceback):\n"
+    "        if effect_type is None:\n"
+    "            raise RuntimeError()\n"
+    "        return effect_type is self.expected\n\n"
+    "def boundary(expected):\n"
+    "    return Boundary(expected)\n"
+)
+
+
+def _route_boundary_with_binding(tmp_path, *, body: str, as_clause: str = " as info"):
+    distribution = _distribution(tmp_path, _BOUNDARY_IMPLEMENTATION, exported="boundary")
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        f"    with arbitrary.boundary(ValueError){as_clause}:\n"
+        f"        {body}\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+    return outcome_to_exitset(
+        next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
+    )
+
+
+def _effect_slot_facts(face) -> tuple:
+    """Every `effect_slot_*` row this arm carries. Exact, not `>= 1`."""
+    from sugar_lift_py_tests.floor.inv_value import InvValue
+    from sugar_lift_py_tests.outcome import Completed
+
+    state = face.value if isinstance(face, Completed) else face.state
+    return tuple(
+        entry
+        for entry in (getattr(state, "entries", ()) or ())
+        if isinstance(entry, InvValue) and "effect_slot" in str(entry.formula)
+    )
+
+
+def test_boundary_as_binding_authenticates_the_slot_it_consumed(tmp_path):
+    """Truthful twin: the consumed halt authenticates the observation slot."""
+    from sugar_lift_py_tests.outcome import Completed
+
+    exits = _route_boundary_with_binding(tmp_path, body='raise ValueError("boom")')
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Completed)
+    # kind, type, origin -- exactly the three rows EffectBinding.to_facts owes.
+    assert len(_effect_slot_facts(face)) == 3
+
+
+def test_boundary_as_binding_is_absent_when_the_halt_was_restored(tmp_path):
+    """Lying twin: a nonmatching halt stays halted AND authenticates nothing."""
+    from sugar_lift_py_tests.outcome import Halted
+
+    exits = _route_boundary_with_binding(tmp_path, body='raise TypeError("boom")')
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Halted)
+    assert _effect_slot_facts(face) == ()
+
+
+def test_boundary_as_binding_is_absent_when_the_body_completed(tmp_path):
+    """Lying twin: no occurrence exists, so no `E()` may be invented for it."""
+    from sugar_lift_py_tests.outcome import Halted
+
+    exits = _route_boundary_with_binding(tmp_path, body="pass")
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Halted)
+    assert type(face.effect).__name__ == "ExpectationNotMetEffect"
+    assert _effect_slot_facts(face) == ()
+
+
+def test_boundary_without_as_clause_authenticates_no_slot(tmp_path):
+    """No `as` name, no slot: the consumed arm carries no binding testimony."""
+    from sugar_lift_py_tests.outcome import Completed
+
+    exits = _route_boundary_with_binding(
+        tmp_path, body='raise ValueError("boom")', as_clause=""
+    )
+    face = exits.exits[0]
+    assert isinstance(face, Completed)
+    assert _effect_slot_facts(face) == ()
+
+
+def test_as_binding_requires_a_contract_that_declares_one(tmp_path):
+    """A slot is granted by the CONTRACT, never by the `as` spelling.
+
+    The same source with the same name stays loud when the authenticated
+    semantics carry `NoBindingV1` -- otherwise syntax would be handing the
+    body a projection the manager never agreed to provide.
+    """
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.context_manager_contract import NoBindingV1
+    from sugar_source_tree.panic import UnsupportedWithBindingTarget
+
+    distribution = _distribution(
+        tmp_path, _BOUNDARY_IMPLEMENTATION, exported="boundary"
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        "    with arbitrary.boundary(ValueError) as info:\n"
+        '        raise ValueError("boom")\n'
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    refs = context.source_derived_contract_refs
+    coordinate, reference = next(iter(refs.items()))
+    refs[coordinate] = replace(
+        reference, semantics=replace(reference.semantics, binding=NoBindingV1())
+    )
+
+    with pytest.raises(UnsupportedWithBindingTarget):
+        next(node for node in tree.nodes() if node.kind == "With").sugar()

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4686,17 +4686,15 @@ class With(Statement):
                     WithEffectBoundarySugar,
                 )
 
+                observation_slot = None
                 if as_name is not None:
-                    from .panic import UnsupportedWithBindingTarget
-
-                    panic = UnsupportedWithBindingTarget(
-                        owner="With._construct_sugar",
-                        observed="EffectBoundary as-binding projection is not yet authenticated",
-                        requested="an EffectBoundary manager without optional_vars",
-                        fix="keep exception-info/warning observation binding loud until its projection slot is authenticated",
+                    # The slot exists because the CONTRACT declares a binding,
+                    # never because the source spelled `as`. A manager that
+                    # binds nothing cannot acquire a slot by being written with
+                    # a name next to it.
+                    observation_slot = self._effect_boundary_observation_slot(
+                        item, resolved_ref
                     )
-                    self.reporter.report_gap(self, panic)
-                    raise panic
                 manager_sugar = item.context_expr.sugar()
                 manager_sugar = self._authenticate_expected_exception_type(
                     item.context_expr, manager_sugar, resolved_ref
@@ -4713,6 +4711,7 @@ class With(Statement):
                             resolved_ref, resolved_ref.use_site
                         )
                     ),
+                    observation_slot_id=observation_slot,
                     site=self.fragment,
                 )
 
@@ -4864,6 +4863,47 @@ class With(Statement):
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
 
+    def _effect_boundary_binding(self, item, resolved_ref):
+        """(slot_id, projection) the CONTRACT declares for this ``as`` name.
+
+        The projection is read off the authenticated semantics' ``binding``
+        field -- exception-info or warning-observation -- so a manager name
+        never selects it. ``NoBindingV1`` means the contract states this
+        manager hands the body nothing, and a source that binds a name anyway
+        is a real disagreement between contract and use site: it stays loud
+        rather than acquiring a slot by syntax.
+        """
+        from sugar_lift_py_tests.context_manager_contract import (
+            EXCEPTION_INFO,
+            ExceptionInfoBindingV1,
+            WARNING_OBSERVATION,
+            WarningObservationBindingV1,
+        )
+
+        binding = resolved_ref.semantics.binding
+        if isinstance(binding, ExceptionInfoBindingV1):
+            projection = EXCEPTION_INFO
+        elif isinstance(binding, WarningObservationBindingV1):
+            projection = WARNING_OBSERVATION
+        else:
+            from .panic import UnsupportedWithBindingTarget
+
+            panic = UnsupportedWithBindingTarget(
+                owner="With._construct_sugar",
+                observed=(
+                    "source binds an EffectBoundary result the authenticated "
+                    f"contract declares no binding for ({type(binding).__name__})"
+                ),
+                requested="a contract carrying exception-info or warning-observation binding",
+                fix="never grant an observation slot from the `as` spelling alone",
+            )
+            self.reporter.report_gap(self, panic)
+            raise panic
+        return f"{item._manager_slot_id()}#observation", projection
+
+    def _effect_boundary_observation_slot(self, item, resolved_ref):
+        return self._effect_boundary_binding(item, resolved_ref)[0]
+
     def substitution_binding(self, scope):
         """Export ObservationRef for resolved resource enter-result as-names."""
         from sugar_lift_py_tests.context_manager_contract import (
@@ -4877,8 +4917,23 @@ class With(Statement):
             item = self.items[0]
             if item.optional_vars is None or item.optional_vars.kind != "Name":
                 return None
+            resolved_ref = None
             if self._generator_manager_frame(item) is None:
-                self._require_narrow_cm_ref(item)
+                resolved_ref = self._require_narrow_cm_ref(item)
+            from sugar_lift_py_tests.context_manager_contract import (
+                EffectBoundarySemanticsV1,
+            )
+
+            if resolved_ref is not None and isinstance(
+                getattr(resolved_ref, "semantics", None), EffectBoundarySemanticsV1
+            ):
+                # An effect boundary hands the body its OBSERVATION slot, not
+                # an enter result. Exporting enter-result here would have made
+                # the body read a projection the contract never declared.
+                slot, projection = self._effect_boundary_binding(item, resolved_ref)
+                return {
+                    item.optional_vars.id: item._make_observation_ref(slot, projection)
+                }
             enter_slot = f"{item._manager_slot_id()}#enter_result"
             return {
                 item.optional_vars.id: item._make_observation_ref(


### PR DESCRIPTION
## The reproducer

Same manager, same body. Only the `as` clause differs:

```
no as-clause    : ['Completed']
with `as info`  : LOUD UnsupportedWithBindingTarget
                  "EffectBoundary as-binding projection is not yet authenticated"
```

`with <effect boundary> as info:` did not construct.

## The mechanism — bind-observed-effect

The law it owes: **effect binding projects the routed occurrence coordinate; never fabricates `E()`.** So the slot is authenticated on exactly one arm — the one whose halt this boundary actually consumed. On a restored halt there *is* an occurrence but it is not this boundary's; on a completed body there is no occurrence at all.

Three pieces, each extending existing substrate rather than adding a parallel one:

- **`ConsumedObservation`** — a fourth verdict shape beside `Effect` / `None` / `RetainedObligation`. `None` already means "consumed"; this says the same thing and carries testimony built from `incoming.effect`, the occurrence the matcher just decided on. It is a separate shape rather than a flag on `None` so that a consumed-**without**-binding arm is structurally unable to carry testimony. It rides the `RetainedObligation.held` face too, so an open message predicate still authenticates the slot only under its own guard.
- **`and_exit._place`** — one outgoing arm per verdict shape, with #6336 partition faces threaded through. No arm added, none dropped; the three prior call sites collapse into it.
- **`substitution_binding`** — an effect boundary now exports its **observation** slot instead of an enter result. This was a live defect independent of the panic: the body was being handed `ObservationRef(slot#enter_result, "enter-result")`, a projection the boundary contract never declares.

The slot comes from the **contract's** `binding` field (`ExceptionInfoBindingV1` / `WarningObservationBindingV1`), never from the `as` spelling. `NoBindingV1` with a name beside it stays loud. No manager name is read anywhere.

## Gate

**Truthful twin** — matching raise consumed: one `Completed` arm carrying **exactly 3** `effect_slot` rows (kind, type, origin — what `EffectBinding.to_facts` owes).

**Lying twins** — exact cardinality `== ()`, not `>= 0`:

| case | arm | binding rows |
| --- | --- | --- |
| `raise ValueError` (matches) | `Completed` | **3** |
| `raise TypeError` (restored) | `Halted` | **0** |
| body completes (unmet) | `Halted(ExpectationNotMetEffect)` | **0** |
| no `as` clause | `Completed` | **0** |
| `NoBindingV1` contract + `as` | loud | — |

**Mutations** — each one mutates the mechanism the twin *names*, run as a transaction (clean before → mutation verified present → test bites → revert → mutation count 0):

| mutation | bites |
| --- | --- |
| `_consumed` ignores the declared slot | `..._authenticates_the_slot_it_consumed` |
| authenticate the slot on a restored halt too | `..._absent_when_the_halt_was_restored` |
| grant a slot from the `as` spelling regardless of contract | `..._requires_a_contract_that_declares_one` |
| invent an occurrence for a body that never raised | `..._absent_when_the_body_completed` |

Four mutations, four bites, one test each, clean before and after — `5 passed` both times.

## Crash/timeout axes

No new panic path and no new loop. `ConsumedObservation` is constructed only where `None` was already returned, so every previously-consumed arm stays consumed; the only difference is what the arm carries. `ExitSetFactoringGap` and `factor_completed` are untouched.

## Not in this PR, named rather than shipped

`completed_observed` for the **warning** kind still has no producer: nothing in production emits `WarningObservationValue`, so a router for it would be a door with nothing walking through. The contract vocabulary (`WarningEffectKindV1`, `WarningObservationBindingV1`) and this PR's projection path are both ready for it, and `substitution_binding` already routes `WARNING_OBSERVATION` — what is missing is the evidence, not the door.

## Measurement

None claimed. Per the milestone rule this is build-first; attribution comes after, against the repaired scoreboard, and I am not quoting any pre-`9a78828ee` number.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind the observed effect from a routed `EffectBoundary` occurrence when an `as` clause is present
> - `with SomeBoundary() as x` now binds `x` to the authenticated observation (exception info or warning) rather than raising `UnsupportedWithBindingTarget`, when the contract declares a binding.
> - `EffectBoundaryDisposition` gains an `observation_slot_id` field, threaded through `WithEffectBoundarySugar.desugar` into the exit-disposition logic.
> - On a consumed halt, a new `ConsumedObservation` value carries `EffectBinding` facts into the carried state; on a retained (non-matching) halt, those facts travel with the held branch.
> - `nodes.With` gains `_effect_boundary_binding` and `_effect_boundary_observation_slot` helpers that validate the contract's declared binding and derive the correct observation projection (`EXCEPTION_INFO` or `WARNING_OBSERVATION`); `substitution_binding` now returns an `ObservationRef` for effect-boundary managers instead of an enter-result ref.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 727f7d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->