### PR TITLE
Exit algebra: give a pending caller obligation an arm on the completed face

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -89,6 +89,49 @@ def merge_demands(*groups) -> tuple[ParameterContractDemandV1, ...]:
     return tuple(by_cid[cid] for cid in sorted(by_cid))
 
 
+def merge_pending(*groups) -> tuple:
+    """Union pending CARRIERS by candidate content address (#6352 family).
+
+    The carrier set is the exit-level counterpart of ``merge_demands``. Two
+    carriers are the same pending construction exactly when their
+    ``candidate_cid`` agrees -- that address is taken over the source node AND
+    the candidate term, so equal addresses are the same construction at the
+    same site, and dedupe is arithmetic rather than a heuristic.
+
+    Same candidate reaching a join twice: ONE carrier, demand sets unioned by
+    ``merge_demands`` -- which is idempotent, so a shared outcome DAG that
+    delivers the same obligation on two faces still owes it once. Different
+    candidates: two carriers, both kept, nothing conjoined.
+
+    Ordering is by ``candidate_cid``, never by arrival, for the reason
+    ``merge_demands`` orders by ``demand_cid``: the universe is content, and
+    two folds that happened to run in a different order must not mint two
+    different rows.
+    """
+    by_candidate: dict[str, "ContractConditionalConstructionV1"] = {}
+    for group in groups:
+        for entry in group:
+            prior = by_candidate.get(entry.candidate_cid)
+            by_candidate[entry.candidate_cid] = (
+                entry
+                if prior is None
+                else replace(
+                    prior, demands=merge_demands(prior.demands, entry.demands)
+                )
+            )
+    return tuple(by_candidate[cid] for cid in sorted(by_candidate))
+
+
+def weaken_pending(entries, formula) -> tuple:
+    """Every carrier in a group weakened to one guarded face.
+
+    Weakening only some of a group would leave the rest owed unconditionally on
+    a face that may never run, which is a STRONGER obligation than the source
+    states -- the same reason ``demanded_under`` weakens every demand in a set.
+    """
+    return merge_pending(tuple(entry.demanded_under(formula) for entry in entries))
+
+
 @dataclass(frozen=True)
 class ContractConditionalConstructionV1:
     """A constructed value together with every caller obligation it incurred.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -28,6 +28,11 @@ value and not one effect, and they are different obligations, not one blob:
   face is not a value and the join has no seam to put it on. That is a real
   construction gap, and `require_single_value` panics with it NAMED, so it is
   loud and counted rather than an empty `AssertionError`.
+
+  A pending OBLIGATION meeting a partition is a different question and is no
+  longer a gap: it asks where the demand is owed, not which value the join
+  takes. Every face is downstream of the construction that incurred it, so
+  `rewrap_pending` puts it on every face, weakened under that face's own guard.
 """
 
 from __future__ import annotations
@@ -60,11 +65,12 @@ def pending_demand(outcome, guard):
 def rewrap_pending(pending, outcome, *, owner, blame):
     """Re-attach a hoisted demand to a joined result, or be loud.
 
-    A joined ``Complete`` takes the demand back and the entry rides on into the
-    block record. A joined partition or effect has nowhere to carry it: one entry
-    holds exactly one value, so the demand would have to be dropped. Dropping a
-    pending obligation silently would let a caller discharge nothing and still
-    look resolved, so it panics NAMED instead.
+    Four arms, each conserving the obligation somewhere it is honestly owed: a
+    ``Complete`` takes it back; a second carrier unions demand SETS by content
+    address; an ``Incomplete`` carries it beside the effect it was incurred
+    before; an ``ExitSet`` puts it on every face, weakened under that face's own
+    guard. Any other outcome kind stays LOUD -- dropping a pending obligation
+    silently would let a caller discharge nothing and still look resolved.
     """
     from dataclasses import replace
 
@@ -104,11 +110,44 @@ def rewrap_pending(pending, outcome, *, owner, blame):
             pending_contracts=(*outcome.pending_contracts, pending),
         )
 
-    # A PARTITION stays LOUD. An `ExitSet`'s faces each carry their own guard,
-    # and the entry has one value with no seam to split across them. Inventing
-    # an arm here would either attribute the obligation to every face (owing
-    # more than the source states) or pick one (dropping the rest). Neither is
-    # a smaller answer; both are wrong ones.
+    # A PARTITION. Every face of the partition is downstream of this obligation:
+    # the carried value was constructed, incurring the demand, and only THEN did
+    # the following step split. So the demand is owed on EVERY face -- owing it
+    # on one only would drop it on the others.
+    #
+    # It attaches AS INCURRED. Each arm's own `guard` states the face it is owed
+    # on, and `guard -> D` is minted once, at the block boundary that enrols it
+    # (`function_universe_sugar._enrol_exit_obligations`). Weakening per face
+    # here instead would re-mint a `demand_cid` per arm, and since a re-minted
+    # obligation is a different destination, the same obligation reaching this
+    # join twice through a shared outcome DAG would stop deduping -- `F and F`
+    # would stop being `F`.
+    #
+    # This was the last LOUD category here, and the panic it replaces asked for
+    # precisely this arm. `Completed.pending_contracts` is it (`Halted` has had
+    # its twin since #6352), so the request is answered rather than re-raised.
+    from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+
+    if isinstance(outcome, ExitSet):
+        exits = []
+        for exit_ in outcome.exits:
+            owed = merge_pending(exit_.pending_contracts, (pending,))
+            if isinstance(exit_, Completed):
+                exits.append(
+                    Completed(exit_.guard, exit_.value, exit_.faces, owed)
+                )
+            else:
+                exits.append(
+                    Halted(
+                        exit_.guard, exit_.effect, exit_.state, exit_.faces, owed
+                    )
+                )
+        return ExitSet(tuple(exits)).normalize()
+
+    # ANYTHING ELSE stays LOUD: an outcome kind this law has never seen has no
+    # arm here by construction, and inventing one would be a guess about where
+    # an obligation belongs.
     from sugar_lift_py_tests.gap.info import GapKind
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
@@ -118,15 +157,14 @@ def rewrap_pending(pending, outcome, *, owner, blame):
         observed=(
             "pending parameter contract demands ("
             + ", ".join(demand.demand_cid for demand in pending.demands)
-            + f") joined onto a {type(outcome).__name__}, whose faces each carry "
-            "their own guard and cannot share one carried value"
+            + f") joined onto a {type(outcome).__name__}, which is not a value, "
+            "an effect, a second carrier, or a partition"
         ),
         requested="one joined outcome that can carry every pending demand",
         fix=(
-            "give the exit algebra an arm for a pending contract demand, so each "
-            "completed face carries the demands weakened under its own guard; "
-            "never drop the obligation and never owe it on a face that does not "
-            "run"
+            "give this outcome kind an arm that states where the obligation is "
+            "owed; never drop the obligation and never owe it on a face that "
+            "does not run"
         ),
         gap_kind=GapKind.FLOOR,
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -321,11 +321,12 @@ def _unhashable_destination_count() -> int:
     return len(_UNHASHABLE_DESTINATIONS)
 
 
-def _obligations(exit_: "Halted") -> tuple:
-    """A halted arm's obligations by content address, order-free (#6352).
+def _obligations(exit_: "Exit[T]") -> tuple:
+    """An arm's obligations by content address, order-free (#6352).
 
     Keyed by ``demand_cid`` -- the obligation's own content address -- never by
-    hashing the carrier, which holds a floor value and a term.
+    hashing the carrier, which holds a floor value and a term. Both arm kinds
+    answer here: a completed face owes exactly the way a halted face does.
     """
     return tuple(
         sorted(
@@ -345,7 +346,9 @@ def _destination_key(exit_: "Exit[T]") -> object:
     """
     try:
         if isinstance(exit_, Completed):
-            return ("completed", hash(exit_.value))
+            # Obligations are part of the destination on this face too: two
+            # completed arms owing different things are different destinations.
+            return ("completed", hash(exit_.value), _obligations(exit_))
         return (
             "halted",
             hash(exit_.effect),
@@ -358,6 +361,38 @@ def _destination_key(exit_: "Exit[T]") -> object:
 
 @dataclass(frozen=True)
 class Completed(Generic[T]):
+    """Control left with this value, under this guard.
+
+    ``pending_contracts`` is the COMPLETED face of the parameter-contract
+    carrier, the twin of the field ``Halted`` has carried since #6352. An
+    operation distributed onto a value that already owed a caller obligation
+    can answer with a partition -- `(a if c else b)[i]` where the subscript
+    enrolled `python:indexable(b)` and the following step contained a store --
+    and until this field existed the exit algebra had no arm that held a value
+    together with an undischarged obligation. That was the ONE remaining LOUD
+    category in ``single_outcome_law.rewrap_pending``, and the panic said so:
+    "give the exit algebra an arm for a pending contract demand, so each
+    completed face carries the demands weakened under its own guard".
+
+    ENTRIES ARE CARRIED AS INCURRED, NOT PRE-WEAKENED. The arm's own ``guard``
+    already states the face it is owed on, so `g -> D` is minted exactly once,
+    at the block boundary that enrols it
+    (``function_universe_sugar._enrol_exit_obligations``), under the guard the
+    arm finally holds. Weakening at every restriction instead re-mints a
+    ``demand_cid`` -- a blake3 over the JCS of the formula -- on every
+    ``guarded``, ``sequence`` and ``and_exit`` step, and since a re-minted
+    obligation is a DIFFERENT destination, it also stops arms merging in
+    ``normalize``. Measured on pandas `core/reshape/merge.py`: minting per
+    restriction did not finish the file in 13 minutes at 600MB resident, with
+    the sample dominated by blake3 and JCS encoding; minting once does. Same
+    obligation, same face, one mint.
+
+    Like ``Halted.pending_contracts`` it is part of the DESTINATION, not
+    testimony: two arms owing different things are different destinations and
+    must not merge under a disjunction. Obligations are therefore compared,
+    unlike ``faces``.
+    """
+
     guard: Formula
     value: T
     # Testimony ABOUT this arm, never part of what it denotes: two arms with the
@@ -367,6 +402,7 @@ class Completed(Generic[T]):
     faces: frozenset[PartitionFace] = _dataclass_field(
         default=_NO_FACES, compare=False, repr=False
     )
+    pending_contracts: tuple = ()
 
 
 @dataclass(frozen=True)
@@ -441,15 +477,26 @@ class ExitSet(Generic[T]):
         exit so that a later ``factor_completed`` can read the exclusion off the
         arms instead of trying to re-prove it from guard shape. Omitting it is
         the honest default for a restriction that is not a partition face.
+
+        Obligations RIDE ALONG unchanged and narrow with the arm's guard, which
+        is the whole point of carrying them on the arm: ``combined`` is the face
+        they are owed on, and `combined -> D` is minted once at enrolment. This
+        method used to rebuild each arm from its guard, effect and state alone,
+        so ``Halted.pending_contracts`` was dropped here outright -- conserved
+        across the `Incomplete` -> halted conversion by #6352, then lost one
+        call later.
         """
         exits: list[Exit[T]] = []
         for exit_ in self.exits:
             combined = _and_guards(guard, exit_.guard)
             faces = exit_.faces if face is None else exit_.faces | {face}
+            owed = exit_.pending_contracts
             if isinstance(exit_, Completed):
-                exits.append(Completed(combined, exit_.value, faces))
+                exits.append(Completed(combined, exit_.value, faces, owed))
             else:
-                exits.append(Halted(combined, exit_.effect, exit_.state, faces))
+                exits.append(
+                    Halted(combined, exit_.effect, exit_.state, faces, owed)
+                )
         return ExitSet(tuple(exits)).normalize()
 
     def with_partition_face(self, partition_id: str, face: int) -> "ExitSet[T]":
@@ -580,7 +627,19 @@ class ExitSet(Generic[T]):
         for arm in completed[1:]:
             factored_faces = factored_faces & arm.faces
 
-        factored = Completed(face_guard, chain, factored_faces)
+        # Obligations UNION rather than intersect. `faces` is testimony -- a
+        # claim true of one arm says nothing about the merged face, so only
+        # what every arm carried survives. An obligation is the opposite: it
+        # was really incurred on the arm that carries it, that arm is still
+        # reachable inside the factored face, and each entry is already
+        # weakened under its own arm's guard, so `g_i -> D` remains exactly as
+        # true of the disjunction. Intersecting here would DROP every
+        # obligation any single arm owed, which is the silent-drop this whole
+        # field exists to stop.
+        from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+
+        factored_owed = merge_pending(*(arm.pending_contracts for arm in completed))
+        factored = Completed(face_guard, chain, factored_faces, factored_owed)
         exits: list[Exit[T]] = []
         placed = False
         for exit_ in self.exits:
@@ -648,6 +707,10 @@ class ExitSet(Generic[T]):
                     isinstance(exit_, Completed)
                     and isinstance(prior, Completed)
                     and exit_.value == prior.value
+                    # #6352: arms owing different obligations are different
+                    # destinations on THIS face too. Merging them would keep
+                    # the prior's and drop the arrival's, silently.
+                    and _obligations(exit_) == _obligations(prior)
                 )
                 same_halted = (
                     isinstance(exit_, Halted)
@@ -670,6 +733,9 @@ class ExitSet(Generic[T]):
                         _or_guards(prior.guard, exit_.guard),
                         prior.value,
                         prior.faces & exit_.faces,
+                        # Equal by `same_completed`; stated explicitly so the
+                        # field cannot be dropped by a later edit here.
+                        prior.pending_contracts,
                     )
                     break
                 if same_halted:
@@ -695,7 +761,18 @@ class ExitSet(Generic[T]):
         return ExitSet(tuple(merged))
 
     def sequence(self, step: Callable[[T], "ExitSet[U]"]) -> "ExitSet[U]":
-        """Map ``step`` over completed exits; halted exits bypass the tail."""
+        """Map ``step`` over completed exits; halted exits bypass the tail.
+
+        The prefix arm's obligations ride onto EVERY exit the tail produced
+        under it. They were incurred before the tail ran, on the path that
+        reached it, so every continuation of that path owes them -- the same
+        argument that puts an obligation on ``Incomplete`` when the effect
+        answers after the demand was incurred. Conjoined guards, so union:
+        each side is already weakened under its own face and `g -> D` still
+        holds under `g and h`. Nothing is conjoined into a single demand.
+        """
+        from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+
         exits: list[Exit[U]] = []
         for exit_ in self.exits:
             if isinstance(exit_, Halted):
@@ -705,11 +782,16 @@ class ExitSet(Generic[T]):
                 guard = _and_guards(exit_.guard, following.guard)
                 # Conjoined guard: both sets of testimony hold of the result.
                 faces = exit_.faces | following.faces
+                owed = merge_pending(
+                    exit_.pending_contracts, following.pending_contracts
+                )
                 if isinstance(following, Completed):
-                    exits.append(Completed(guard, following.value, faces))
+                    exits.append(Completed(guard, following.value, faces, owed))
                 else:
                     exits.append(
-                        Halted(guard, following.effect, following.state, faces)
+                        Halted(
+                            guard, following.effect, following.state, faces, owed
+                        )
                     )
         return ExitSet(tuple(exits)).normalize()
 
@@ -739,24 +821,37 @@ class ExitSet(Generic[T]):
         # Construct cleanup ExitSet once; fan the same exits across every
         # incoming exit (cleanup runs on every path, not once per path).
         cleanup_exits = cleanup().exits
+        # Obligations from BOTH sides ride onto every outgoing arm. The body
+        # ran and the cleanup ran, so both incurred what they incurred; which
+        # of the two decides the outgoing SHAPE says nothing about who owes.
+        # Superseding is a choice about the exit, never a discharge.
+        from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+
         exits: list[Exit[object]] = []
         for incoming in self.exits:
             for clean in cleanup_exits:
                 guard = _and_guards(incoming.guard, clean.guard)
                 faces = incoming.faces | clean.faces
+                owed = merge_pending(
+                    incoming.pending_contracts, clean.pending_contracts
+                )
                 if isinstance(clean, Halted):
-                    exits.append(Halted(guard, clean.effect, clean.state, faces))
+                    exits.append(
+                        Halted(guard, clean.effect, clean.state, faces, owed)
+                    )
                     continue
                 if restores(clean.value):
                     if isinstance(incoming, Completed):
-                        exits.append(Completed(guard, incoming.value, faces))
+                        exits.append(Completed(guard, incoming.value, faces, owed))
                     else:
                         exits.append(
-                            Halted(guard, incoming.effect, incoming.state, faces)
+                            Halted(
+                                guard, incoming.effect, incoming.state, faces, owed
+                            )
                         )
                 else:
                     # Terminal cleanup completion supersedes (return in finally).
-                    exits.append(Completed(guard, clean.value, faces))
+                    exits.append(Completed(guard, clean.value, faces, owed))
         return ExitSet(tuple(exits)).normalize()
 
     def and_exit(
@@ -790,14 +885,21 @@ class ExitSet(Generic[T]):
             exit_disposition_effect,
         )
 
+        from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+
         exit_exits = exit_es.exits
         exits: list[Exit[object]] = []
         for incoming in self.exits:
             for ex in exit_exits:
                 guard = _and_guards(incoming.guard, ex.guard)
                 faces = incoming.faces | ex.faces
+                # The body ran and the exit expression ran; both sides'
+                # obligations are owed on the outgoing arm. A contract decides
+                # the SHAPE of the exit, never who owes what was incurred
+                # reaching it -- suppression is not discharge.
+                owed = merge_pending(incoming.pending_contracts, ex.pending_contracts)
                 if isinstance(ex, Halted):
-                    exits.append(Halted(guard, ex.effect, ex.state, faces))
+                    exits.append(Halted(guard, ex.effect, ex.state, faces, owed))
                     continue
                 carried = (
                     incoming.value
@@ -834,17 +936,24 @@ class ExitSet(Generic[T]):
                         ),
                     ):
                         sub_faces = faces | {sub_face}
+                        # The retention narrows this arm's guard; `sub_guard`
+                        # IS that narrowing, and the obligation is minted
+                        # against it once, at enrolment.
                         if sub_verdict is None:
-                            exits.append(Completed(sub_guard, carried, sub_faces))
+                            exits.append(
+                                Completed(sub_guard, carried, sub_faces, owed)
+                            )
                         else:
                             exits.append(
-                                Halted(sub_guard, sub_verdict, carried, sub_faces)
+                                Halted(
+                                    sub_guard, sub_verdict, carried, sub_faces, owed
+                                )
                             )
                     continue
                 if verdict is None:
-                    exits.append(Completed(guard, carried, faces))
+                    exits.append(Completed(guard, carried, faces, owed))
                 else:
-                    exits.append(Halted(guard, verdict, carried, faces))
+                    exits.append(Halted(guard, verdict, carried, faces, owed))
         return ExitSet(tuple(exits)).normalize()
 
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
@@ -856,6 +965,7 @@ class ExitSet(Generic[T]):
         the effect and falsity restores that exact effect; neither face is
         discarded.
         """
+        from sugar_lift_py_tests.caller_parameter_contract import merge_pending
         from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
         exits: list[Exit[object]] = []
@@ -863,11 +973,12 @@ class ExitSet(Generic[T]):
             for ex in exit_es.exits:
                 guard = _and_guards(incoming.guard, ex.guard)
                 faces = incoming.faces | ex.faces
+                owed = merge_pending(incoming.pending_contracts, ex.pending_contracts)
                 if isinstance(ex, Halted):
-                    exits.append(Halted(guard, ex.effect, ex.state, faces))
+                    exits.append(Halted(guard, ex.effect, ex.state, faces, owed))
                     continue
                 if isinstance(incoming, Completed):
-                    exits.append(Completed(guard, incoming.value, faces))
+                    exits.append(Completed(guard, incoming.value, faces, owed))
                     continue
                 from sugar_lift_py_tests.floor import TermValue
 
@@ -891,6 +1002,7 @@ class ExitSet(Generic[T]):
                         _and_guards(guard, truth),
                         incoming.state,
                         faces | {truth_face},
+                        owed,
                     )
                 )
                 exits.append(
@@ -899,19 +1011,47 @@ class ExitSet(Generic[T]):
                         incoming.effect,
                         incoming.state,
                         faces | {falsity_face},
+                        owed,
                     )
                 )
         return ExitSet(tuple(exits)).normalize()
 
     def collapse(self):
-        """Return the old linear Outcome only for one unconditional exit."""
+        """Return the old linear Outcome only for one unconditional exit.
+
+        An arm that OWES something collapses to the linear shape that carries
+        the obligation, never to the one that does not: a completed arm becomes
+        the pending carrier it came from, a halted arm becomes an ``Incomplete``
+        holding the same obligations. ``Complete(value)`` and
+        ``Incomplete(effect)`` have no field for a demand, so returning them
+        here would discharge nothing and look resolved -- the exact drop
+        ``rewrap_pending`` refuses.
+        """
         normalized = self.normalize()
         if len(normalized.exits) != 1 or not _is_true(normalized.exits[0].guard):
             return self if normalized == self else normalized
         exit_ = normalized.exits[0]
         if isinstance(exit_, Completed):
+            if len(exit_.pending_contracts) == 1:
+                # ONE pending construction: that IS the linear carrier, holding
+                # this arm's value. Its demand set rides across unchanged.
+                from dataclasses import replace as _replace
+
+                return _replace(exit_.pending_contracts[0], value=exit_.value)
+            if exit_.pending_contracts:
+                # SEVERAL distinct pending constructions. The linear carrier
+                # holds one candidate and every demand in it carries that same
+                # candidate address, so two candidates have no single linear
+                # shape -- fusing them would attribute one construction's
+                # demands to another construction's candidate. The exit algebra
+                # IS the shape that holds several, so the arm stays here. This
+                # is not a gap and not a drop: collapse already answers with the
+                # ExitSet whenever no linear shape denotes it.
+                return normalized
             return Complete(exit_.value)
-        return Incomplete(exit_.effect)
+        return Incomplete(
+            exit_.effect, pending_contracts=exit_.pending_contracts
+        )
 
 
 def sole_completed_outcome(outcome):
@@ -938,7 +1078,23 @@ def sole_completed_outcome(outcome):
             "A body with several completed faces has no single success path to "
             "project onto — reason over the ExitSet arms directly."
         )
-    return Complete(completed[0].value)
+    sole = completed[0]
+    if len(sole.pending_contracts) == 1:
+        # The success path still OWES what it incurred. `Complete` has no field
+        # for it, so project onto the carrier instead of dropping it.
+        from dataclasses import replace as _replace
+
+        return _replace(sole.pending_contracts[0], value=sole.value)
+    if sole.pending_contracts:
+        raise ValueError(
+            "sole_completed_outcome cannot project a completed arm owing "
+            f"{len(sole.pending_contracts)} distinct pending constructions onto "
+            "one linear outcome: a carrier holds ONE candidate and every demand "
+            "in it carries that candidate's address, so fusing two would "
+            "attribute one construction's obligations to another's candidate. "
+            "Reason over the ExitSet arm directly."
+        )
+    return Complete(sole.value)
 
 
 def factored_operand(outcome):
@@ -993,9 +1149,11 @@ def outcome_to_exitset(outcome) -> ExitSet:
         # A demand that disappears at an effect -> halted conversion is
         # unattributable afterward: no caller owes it and no instrument knows.
         #
-        # They are weakened under the arm's own guard on the way across, so the
-        # arm carries `g -> D` rather than `D`. That weakening is what makes the
-        # later merge sound (see `_destination_key` / `normalize`).
+        # They cross AS INCURRED. The arm's own guard is the face they are owed
+        # on, and `guard -> D` is minted once, at the block boundary that enrols
+        # them. Weakening here as well would mint the same implication twice
+        # over -- and every re-mint is a new `demand_cid`, which is a new
+        # destination, which stops the arm merging in `normalize`.
         contracts = tuple(getattr(outcome, "pending_contracts", ()))
         if outcome.branch_conditions:
             guard = and_(list(outcome.branch_conditions))
@@ -1005,9 +1163,7 @@ def outcome_to_exitset(outcome) -> ExitSet:
                         guard,
                         outcome.effect,
                         None,
-                        pending_contracts=tuple(
-                            entry.demanded_under(guard) for entry in contracts
-                        ),
+                        pending_contracts=contracts,
                     ),
                 )
             ).normalize()
@@ -1022,16 +1178,15 @@ def outcome_to_exitset(outcome) -> ExitSet:
             )
         ).normalize()
 
-    # A PENDING PARAMETER-CONTRACT CARRIER (#6352). This used to be
-    # `raise TypeError(type(outcome))` -- a gap that named no owner, no observed
-    # shape and no fix, which is strictly worse than a panic, not absent.
+    # A PENDING PARAMETER-CONTRACT CARRIER (#6352). This USED to panic: the exit
+    # algebra had no arm that wrapped a value together with an undischarged
+    # obligation, so the only honest answer was a named gap.
     #
-    # The carrier is not a value and not a partition: it WRAPS a value together
-    # with obligations the linker has not discharged. The exit algebra has no
-    # arm for it because an ExitSet's faces each carry their own guard and the
-    # carrier has one value with no seam to split across them. The producer must
-    # hoist the obligations before converting, exactly as
-    # `collection_sugar._reduce_into` and `spread_sugar._collect` do.
+    # `Completed.pending_contracts` is that arm. The carrier converts to one
+    # unconditional completed exit holding the carried value and owing exactly
+    # what the carrier owed -- the same conversion `Incomplete` gets, on the
+    # other face. Nothing is hoisted, nothing is dropped, and the round trip
+    # back through `collapse` returns the carrier.
     from sugar_lift_py_tests.caller_parameter_contract import (
         ContractConditionalConstructionV1,
     )
@@ -1039,23 +1194,15 @@ def outcome_to_exitset(outcome) -> ExitSet:
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
     if isinstance(outcome, ContractConditionalConstructionV1):
-        construction_panic_gap(
-            owner="outcome_to_exitset",
-            blame=outcome.source_node,
-            observed=(
-                "a pending parameter contract carrier ("
-                + ", ".join(demand.demand_cid for demand in outcome.demands)
-                + ") was converted to an exit set, which has no arm that wraps "
-                "a value together with an undischarged obligation"
-            ),
-            requested="a plain value or a partition",
-            fix=(
-                "hoist the demands with `single_outcome_law.pending_demand` "
-                "before converting, fold the carried value, and re-attach them "
-                "with `rewrap_pending`; never drop the obligation"
-            ),
-            gap_kind=GapKind.FLOOR,
-        )
+        return ExitSet(
+            (
+                Completed(
+                    true_guard(),
+                    outcome.value,
+                    pending_contracts=(outcome,),
+                ),
+            )
+        ).normalize()
 
     construction_panic_gap(
         owner="outcome_to_exitset",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -20,9 +20,10 @@ class Incomplete:
     which stays pristine. And it goes on to the block record through
     ``contribution``, which is what enrols it for the linker to discharge.
 
-    A PARTITION is still loud. An ``ExitSet``'s faces carry their own guards
-    and the entry has no seam there, so no arm is invented for it -- see
-    ``floor/single_outcome_law.rewrap_pending``.
+    A PARTITION now has its own arm rather than being loud: every face of an
+    ``ExitSet`` carries the obligation weakened under that face's own guard,
+    on ``Completed.pending_contracts`` and ``Halted.pending_contracts`` alike.
+    See ``floor/single_outcome_law.rewrap_pending``.
     """
 
     effect: Effect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -42,6 +42,87 @@ class _ReducedBlock:
     transforms: tuple = ()
 
 
+def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
+    """Move every arm's pending obligations INTO that arm's block record.
+
+    THE NAMED CONSUMPTION. ``Completed.pending_contracts`` and
+    ``Halted.pending_contracts`` are in-flight carriers: they conserve an
+    obligation through the exit algebra, but nothing downstream of the algebra
+    reads them, so an arm that still owed something when the block finished had
+    its obligation vanish at this boundary -- conserved for the whole flight and
+    dropped on landing. Enrolment is what makes it discharged rather than
+    forgotten: ``entry.contribution()`` is the same one-row-per-demand split a
+    completed carrier goes through, and the rows join the block's entries, where
+    ``link_unit_projection`` enrols them for the linker.
+
+    The field is CLEARED as the rows are appended. That is what makes this a
+    consumption and not a duplication: the obligation exists in exactly one
+    place afterwards.
+
+    THIS IS ALSO THE ONE MINT. An arm carries its obligations as they were
+    incurred; the arm's ``guard`` is the face they are owed on, so `guard -> D`
+    is minted here, once, against the guard the arm finally holds. An arm under
+    the true guard owes the bare obligation and is not re-minted at all.
+
+    An arm with no block to enrol into (a halted arm whose state is ``None``)
+    stays LOUD -- there is no record to owe on, and inventing one would
+    attribute the obligation to a block that never ran.
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import weaken_pending
+    from sugar_lift_py_tests.gap.info import GapKind
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    from sugar_lift_py_tests.outcome.exit_set import _is_true
+
+    enrolled: list[object] = []
+    for exit_ in exits.exits:
+        if not exit_.pending_contracts:
+            enrolled.append(exit_)
+            continue
+        owed = (
+            exit_.pending_contracts
+            if _is_true(exit_.guard)
+            else weaken_pending(exit_.pending_contracts, exit_.guard)
+        )
+        rows = tuple(row for entry in owed for row in entry.contribution())
+        block = exit_.value if isinstance(exit_, Completed) else exit_.state
+        if not isinstance(block, _ReducedBlock):
+            construction_panic_gap(
+                owner="reduce_block_to_exitset.enrol_exit_obligations",
+                blame=exit_.pending_contracts[0].source_node,
+                observed=(
+                    "a block exit owing "
+                    + ", ".join(
+                        demand.demand_cid
+                        for entry in exit_.pending_contracts
+                        for demand in entry.demands
+                    )
+                    + f" carries {type(block).__name__} where its reduced block "
+                    "record should be, so there is nothing to enrol the "
+                    "obligation into"
+                ),
+                requested="a reduced block record on every exit that owes",
+                fix=(
+                    "carry the reduced block on this arm, or hand the obligation "
+                    "to the producer that does; never drop it and never enrol it "
+                    "on a block that did not run"
+                ),
+                gap_kind=GapKind.FLOOR,
+            )
+        widened = _ReducedBlock(
+            (*block.entries, *rows),
+            block.can_fall_through,
+            block.fall_through,
+            block.transforms,
+        )
+        if isinstance(exit_, Completed):
+            enrolled.append(Completed(exit_.guard, widened, exit_.faces, ()))
+        else:
+            enrolled.append(
+                Halted(exit_.guard, exit_.effect, widened, exit_.faces, ())
+            )
+    return ExitSet(tuple(enrolled)).normalize()
+
+
 def _prefixed(state: _ReducedBlock, inner: object) -> object:
     """The temporal state of a halt INSIDE a nested statement, read from outside.
 
@@ -274,7 +355,11 @@ def reduce_block_to_exitset(
 
         exits = exits.sequence(reduce_next)
 
-    return exits
+    # The block boundary is where an obligation stops being in flight, so it is
+    # the one door that consumes the carriers. Doing it here rather than per
+    # statement keeps a single owner and lets `sequence` compose obligations
+    # across statements first.
+    return _enrol_exit_obligations(exits)
 
 
 def reduce_statements(statements: tuple, ctx: object = None):

--- a/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
@@ -1,0 +1,386 @@
+"""The exit-algebra arm for a pending caller-parameter obligation.
+
+``rewrap_pending`` had four categories and answered three: a value took the
+demands back, a second carrier unioned demand sets, an effect carried them
+beside itself. A PARTITION panicked -- ``ContractConditionalConstructionV1
+.and_then`` joined onto an ``ExitSet`` and had nowhere to put the obligation.
+
+The arm is ``Completed.pending_contracts``, the twin of the field ``Halted``
+has carried since #6352. Each law below has a TRUTHFUL twin (the mechanism does
+what it claims) and a LYING twin (a plausible weaker mechanism that would still
+pass a looser reading), and each names the mechanism it mutates.
+"""
+
+import types
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+    merge_demands,
+    merge_pending,
+    weaken_pending,
+)
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, atomic, ctor, make_var, num
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import (
+    outcome_to_exitset,
+    sole_completed_outcome,
+    true_guard,
+)
+
+SRC = "blake3-512:" + "a" * 128
+
+
+def _coordinate(name: str, ordinal: int):
+    owner_def = SourceFragmentCoordinateV1(SRC, 1, 0, 10, 4)
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=SRC,
+        owner_definition_locus=owner_def,
+        declaration_locus=SourceFragmentCoordinateV1(SRC, 1, 17 + ordinal, 1, 22),
+        ordinal=ordinal,
+        parameter_kind="positional-or-keyword",
+        declared_name=name,
+        sort=PrimitiveSort("Value"),
+    )
+
+
+def _carrier(name="value", *, ordinal=0, line=3, value="carried"):
+    """One pending construction: `<name>[0]`, owing `python:indexable(<name>)`."""
+    span = types.SimpleNamespace(
+        start_line=line, start_col=9, end_line=line, end_col=17
+    )
+    site = types.SimpleNamespace(source_cid=SRC, line_col_span=span)
+    return ContractConditionalConstructionV1.mint(
+        site=site,
+        candidate=ctor("py.subscript", [make_var(name), num(0)]),
+        demand_formula=atomic("python:indexable", [make_var(name)]),
+        value=value,
+        coordinate=_coordinate(name, ordinal),
+    )
+
+
+def _guard(name="g"):
+    return atomic(f"test:{name}", [make_var("x")])
+
+
+def _cids(entries):
+    return sorted(d.demand_cid for e in entries for d in e.demands)
+
+
+# ---------------------------------------------------------------- the arm ----
+
+
+def test_partition_join_puts_the_obligation_on_every_face():
+    """TRUTHFUL. Every face of the partition is downstream of the demand."""
+    pending = _carrier()
+    partitioned = ExitSet(
+        (
+            Completed(_guard("hot"), "then-value"),
+            Halted(_guard("cold"), RaiseEffect("ValueError", "boom")),
+        )
+    )
+
+    joined = rewrap_pending(
+        pending, partitioned, owner="test", blame=pending.source_node
+    )
+
+    assert isinstance(joined, ExitSet)
+    assert len(joined.exits) == 2
+    for exit_ in joined.exits:
+        assert _cids(exit_.pending_contracts) == _cids((pending,))
+
+
+def test_partition_join_does_not_pick_one_face():
+    """LYING TWIN. A mechanism that attached the demand to the completed face
+    only would satisfy "the obligation survived the join" and still drop it on
+    every halted path. Exact cardinality per face: not `>= 1` over the set."""
+    pending = _carrier()
+    partitioned = ExitSet(
+        (
+            Completed(_guard("hot"), "then-value"),
+            Halted(_guard("cold"), RaiseEffect("ValueError", "boom")),
+        )
+    )
+
+    joined = rewrap_pending(
+        pending, partitioned, owner="test", blame=pending.source_node
+    )
+
+    halted = [e for e in joined.exits if isinstance(e, Halted)]
+    completed = [e for e in joined.exits if isinstance(e, Completed)]
+    assert len(halted) == 1 and len(completed) == 1
+    assert len(halted[0].pending_contracts) == 1
+    assert len(completed[0].pending_contracts) == 1
+
+
+def test_partition_join_conserves_an_obligation_the_face_already_owed():
+    """TRUTHFUL. A face that already owed something keeps it AND takes the new
+    one: two distinct constructions, two carriers, nothing conjoined."""
+    already = _carrier("other", ordinal=1, line=7)
+    pending = _carrier()
+    partitioned = ExitSet(
+        (Completed(true_guard(), "v", frozenset(), (already,)),)
+    )
+
+    joined = rewrap_pending(
+        pending, partitioned, owner="test", blame=pending.source_node
+    )
+
+    (arm,) = joined.exits
+    assert len(arm.pending_contracts) == 2
+    assert _cids(arm.pending_contracts) == sorted(
+        _cids((already,)) + _cids((pending,))
+    )
+
+
+def test_partition_join_is_idempotent_on_the_same_construction():
+    """TRUTHFUL. The same obligation reaching a join twice through a shared
+    outcome DAG is ONE obligation -- `F and F` IS `F`. Exact cardinality: `!= 1`
+    would be satisfied by the 2 this is meant to exclude."""
+    pending = _carrier()
+    partitioned = ExitSet(
+        (Completed(true_guard(), "v", frozenset(), (pending,)),)
+    )
+
+    joined = rewrap_pending(
+        pending, partitioned, owner="test", blame=pending.source_node
+    )
+
+    (arm,) = joined.exits
+    assert len(arm.pending_contracts) == 1
+    assert len(arm.pending_contracts[0].demands) == 1
+
+
+def test_an_unknown_outcome_kind_is_still_loud():
+    """TRUTHFUL. Draining the partition category must not drain the refusal:
+    a kind this law has never seen has no arm, and guessing one would invent a
+    place for an obligation to be owed."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    pending = _carrier()
+    with pytest.raises(ConstructionPanic):
+        rewrap_pending(
+            pending, object(), owner="test", blame=pending.source_node
+        )
+
+
+# ------------------------------------------------------ conservation laws ----
+
+
+def test_exitset_guarded_conserves_what_each_arm_owes():
+    """TRUTHFUL. `ExitSet.guarded` used to rebuild every arm from guard, effect
+    and state alone, dropping `Halted.pending_contracts` one call after #6352
+    conserved it across the effect -> halted conversion."""
+    pending = _carrier()
+    before = ExitSet(
+        (
+            Halted(
+                true_guard(),
+                RaiseEffect("ValueError", "boom"),
+                None,
+                frozenset(),
+                (pending,),
+            ),
+        )
+    )
+
+    after = before.guarded(_guard("branch"))
+
+    (arm,) = after.exits
+    assert _cids(arm.pending_contracts) == _cids((pending,))
+
+
+def test_sequence_carries_the_prefix_obligation_onto_every_tail_exit():
+    """TRUTHFUL. The prefix incurred it before the tail ran, so every
+    continuation of that path owes it."""
+    pending = _carrier()
+    prefix = ExitSet((Completed(true_guard(), "v", frozenset(), (pending,)),))
+
+    def step(_value):
+        return ExitSet(
+            (
+                Completed(_guard("ok"), "tail"),
+                Halted(_guard("bad"), RaiseEffect("KeyError", "k")),
+            )
+        )
+
+    after = prefix.sequence(step)
+
+    assert len(after.exits) == 2
+    for exit_ in after.exits:
+        assert _cids(exit_.pending_contracts) == _cids((pending,))
+
+
+def test_factoring_unions_obligations_rather_than_intersecting_them():
+    """LYING TWIN of the `faces` rule. Partition testimony INTERSECTS on a
+    factored arm -- a claim true of one arm says nothing about the merged face.
+    Copying that rule to obligations would drop every obligation any single arm
+    owed, which is exactly backwards: the arm that owes is still reachable
+    inside the factored face."""
+    left = _carrier("left", ordinal=0, line=3)
+    right = _carrier("right", ordinal=1, line=4)
+    g = _guard("pick")
+    before = ExitSet(
+        (
+            Completed(g, "a", frozenset(), (left,)),
+            Completed(
+                __import__(
+                    "sugar_lift_py_tests.ir", fromlist=["not_"]
+                ).not_(g),
+                "b",
+                frozenset(),
+                (right,),
+            ),
+        )
+    )
+
+    after = before.factor_completed()
+
+    (arm,) = [e for e in after.exits if isinstance(e, Completed)]
+    assert _cids(arm.pending_contracts) == sorted(
+        _cids((left,)) + _cids((right,))
+    )
+
+
+def test_arms_owing_different_things_do_not_merge():
+    """TRUTHFUL. Obligations are part of the DESTINATION. Two completed arms
+    with the same value but different debts are different destinations; merging
+    them would keep one debt and drop the other, silently."""
+    left = _carrier("left", ordinal=0, line=3)
+    right = _carrier("right", ordinal=1, line=4)
+    merged = ExitSet(
+        (
+            Completed(_guard("p"), "same-value", frozenset(), (left,)),
+            Completed(_guard("q"), "same-value", frozenset(), (right,)),
+        )
+    ).normalize()
+
+    assert len(merged.exits) == 2
+
+
+def test_arms_owing_the_same_thing_still_merge():
+    """LYING TWIN of the law above. A mechanism that simply refused to merge any
+    arm carrying obligations would pass the previous test while abandoning the
+    merge that keeps arm counts linear. Equal debts are one destination."""
+    same = _carrier()
+    merged = ExitSet(
+        (
+            Completed(_guard("p"), "same-value", frozenset(), (same,)),
+            Completed(_guard("q"), "same-value", frozenset(), (same,)),
+        )
+    ).normalize()
+
+    assert len(merged.exits) == 1
+    assert _cids(merged.exits[0].pending_contracts) == _cids((same,))
+
+
+# ------------------------------------------------------ the round trip -------
+
+
+def test_carrier_converts_to_an_exit_set_and_back():
+    """TRUTHFUL. `outcome_to_exitset` panicked on a carrier because the algebra
+    had no arm for it. With the arm, the conversion is total and the round trip
+    through `collapse` returns the same carrier."""
+    pending = _carrier()
+
+    exits = outcome_to_exitset(pending)
+
+    (arm,) = exits.exits
+    assert isinstance(arm, Completed)
+    assert arm.pending_contracts == (pending,)
+    assert exits.collapse() == pending
+
+
+def test_collapse_of_a_clean_arm_is_still_a_bare_complete():
+    """LYING TWIN. A mechanism that routed EVERY completed arm through the
+    carrier would satisfy the round trip above and change the shape of every
+    ordinary block. An arm owing nothing collapses to `Complete`."""
+    assert ExitSet.completed("v").collapse() == Complete("v")
+
+
+def test_collapse_of_a_halted_arm_carries_its_obligations():
+    """TRUTHFUL. `Incomplete(effect)` has a field for the debt; using the
+    one-argument form here would drop it at the exit of the algebra."""
+    pending = _carrier()
+    effect = RaiseEffect("ValueError", "boom")
+    exits = ExitSet((Halted(true_guard(), effect, None, frozenset(), (pending,)),))
+
+    collapsed = exits.collapse()
+
+    assert isinstance(collapsed, Incomplete)
+    assert _cids(collapsed.pending_contracts) == _cids((pending,))
+
+
+def test_sole_completed_outcome_projects_onto_the_carrier():
+    """TRUTHFUL. The success path still owes what it incurred; `Complete` has
+    no field for it."""
+    pending = _carrier()
+    exits = ExitSet((Completed(true_guard(), "v", frozenset(), (pending,)),))
+
+    projected = sole_completed_outcome(exits)
+
+    assert isinstance(projected, ContractConditionalConstructionV1)
+    assert projected.value == "v"
+    assert _cids((projected,)) == _cids((pending,))
+
+
+def test_sole_completed_outcome_refuses_two_distinct_constructions():
+    """TRUTHFUL. A linear carrier holds ONE candidate and every demand in it
+    carries that candidate's address, so fusing two would attribute one
+    construction's obligations to another's candidate."""
+    exits = ExitSet(
+        (
+            Completed(
+                true_guard(),
+                "v",
+                frozenset(),
+                (_carrier("left", ordinal=0, line=3), _carrier("right", ordinal=1, line=4)),
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match="distinct pending constructions"):
+        sole_completed_outcome(exits)
+
+
+# ------------------------------------------------------------- the union -----
+
+
+def test_merge_pending_keys_on_candidate_not_arrival():
+    """TRUTHFUL. Ordering is by content address so two folds that ran in a
+    different order mint the same rows."""
+    left = _carrier("left", ordinal=0, line=3)
+    right = _carrier("right", ordinal=1, line=4)
+
+    assert merge_pending((left,), (right,)) == merge_pending((right,), (left,))
+
+
+def test_merge_pending_unions_demand_sets_of_one_candidate():
+    """TRUTHFUL. Same candidate reaching a join twice under different guards is
+    ONE carrier owing BOTH obligations -- never two carriers, never one
+    conjoined demand."""
+    base = _carrier()
+    a = base.demanded_under(_guard("p"))
+    b = base.demanded_under(_guard("q"))
+
+    (fused,) = merge_pending((a,), (b,))
+
+    assert len(fused.demands) == 2
+    assert fused.demands == merge_demands(a.demands, b.demands)
+
+
+def test_weaken_pending_weakens_every_carrier():
+    """LYING TWIN. Weakening only the first entry would still 'weaken the
+    group'; the rest would then be owed unconditionally on a face that may
+    never run, which is STRONGER than the source states."""
+    group = (_carrier("left", ordinal=0, line=3), _carrier("right", ordinal=1, line=4))
+
+    weakened = weaken_pending(group, _guard("branch"))
+
+    assert len(weakened) == 2
+    assert set(_cids(weakened)).isdisjoint(_cids(group))


### PR DESCRIPTION
## The category

`floor/single_outcome_law.rewrap_pending` has four outcome categories and answered three. A `Complete` took the demands back; a second `ContractConditionalConstructionV1` unioned demand SETS by content address (#6352); an `Incomplete` carried them beside the effect they were incurred before. A **partition** panicked NAMED, and the panic asked for exactly one thing:

> give the exit algebra an arm for a pending contract demand, so each completed face carries the demands weakened under its own guard

That panic is `ContractConditionalConstructionV1.and_then` meeting an `ExitSet`. `outcome_to_exitset` said the same sentence from the other side. This PR answers the request rather than re-raising it.

## The arm

`Completed.pending_contracts` — the twin of the field `Halted` has carried since #6352. Every face of a partition is downstream of the construction that incurred the obligation (the value was built, THEN the following step split), so the demand rides on every face, and each face's own `guard` states where it is owed.

## Conservation, per operation

- **`ExitSet.guarded`** rebuilt each arm from guard, effect and state alone, so `Halted.pending_contracts` was **dropped there outright** — conserved across the effect→halted conversion by #6352, then lost one call later. Fixed.
- **`sequence`** carries the prefix arm's obligations onto every exit the tail produced under it.
- **`and_finally` / `and_exit` / `and_exit_truthiness`** union both sides. A contract decides the SHAPE of an exit; suppression is not discharge.
- **`factor_completed` UNIONS, it does not intersect.** Partition testimony intersects because a claim true of one arm says nothing about the merged face. An obligation is the opposite: the arm that owes is still reachable inside the factored face, so intersecting would drop every obligation any single arm owed.
- **`normalize`** treats obligations as part of the DESTINATION on this face too, so two arms owing different things do not merge — and equal debts still merge, so arm counts stay linear.
- **`collapse` / `sole_completed_outcome`** project onto the carrier, never a bare `Complete`, which has no field for a debt.

## One mint, at the block boundary

Entries are carried **as incurred**; `guard -> D` is minted **once**, in `function_universe_sugar._enrol_exit_obligations`, against the guard the arm finally holds.

Weakening at every restriction instead re-mints a `demand_cid` — a blake3 over the JCS of a formula — on every `guarded`, `sequence` and `and_exit` step, and a re-minted obligation is a *different destination*, so arms stop merging and the same obligation stops deduping (`F and F` stops being `F`). Measured on pandas `core/reshape/merge.py`: minting per restriction did not finish the file in 13 minutes at 600MB resident, with the `sample` dominated by blake3 and JCS encoding. Minting once does not do that.

## The named consumption

Nothing downstream of the exit algebra read `pending_contracts`. An arm that still owed something when the block finished had its obligation **vanish on landing** — conserved for the whole flight, dropped at the record. `_enrol_exit_obligations` appends `entry.contribution()` rows to the block's entries and **clears the field**, so the obligation exists in exactly one place afterwards. An arm with no block to enrol into stays LOUD.

## The refusal is not drained with the category

An outcome kind this law has never seen still panics NAMED. Guessing where an obligation is owed is worse than saying you do not know.

## Evidence

- `test_pending_contract_partition_arm.py`: 18 twins, truthful and lying per mechanism, exact cardinality (`== 1`, never `!= 1`), renamed non-vendor fixtures. **18/18 green.**
- **Perturbation battery, 10 mutations, each mutating the mechanism its twin NAMES: 10/10 caught.** Two mechanisms (the bucket key and the equality check) cooperate to carry the no-merge law and each alone enforces it, so they are mutated together — mutating either alone is masked by the other, which is stated in the battery.
- Adjacent suites green: `test_exit_set*` (6 files), `test_caller_parameter_contract`, `test_parameter_contract_resume_twins`, `test_parameter_contract_value_correctness`, `test_store_outcome_composition`, `test_assign_unpack_store_outcome_composition`, `test_spread_exit_factoring`, `test_factoring_gap_kind` — **191 passed**.
- Measured ΔR over a bounded pandas 3.0.3 slice is reported on the PR thread, not predicted here.

## Not touched

`factor_completed`'s refusal, `_are_exclusive`, the partition algebra, #6311's identity memo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Give pending caller obligations an arm on completed exits in partition handling
> - Adds a `pending_contracts` field to `Completed` exits so that pending parameter-contract obligations can travel alongside completed values, mirroring the existing support on `Halted` arms.
> - Extends `rewrap_pending` in [single_outcome_law.py](https://github.com/TSavo/sugar/pull/6392/files#diff-83138b0992d2a78091fde1db7a22872748a9537647d3184f281c55ddda192acb) to distribute a pending carrier onto every face of an `ExitSet` partition instead of panicking.
> - Updates `ExitSet` operations (`guarded`, `factor_completed`, `normalize`, `sequence`) to preserve, merge, and compose obligations across all arms rather than silently dropping them.
> - Adds `_enrol_exit_obligations` in [function_universe_sugar.py](https://github.com/TSavo/sugar/pull/6392/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) to consume and enrol pending obligations into block records at the exit boundary, weakening by guard as needed.
> - Risk: `normalize` no longer merges `Completed` arms with the same value but different obligations; arms that previously collapsed into one are now kept distinct.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5afbf18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->