### PR TITLE
Propagate guarded binding partition faces

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
@@ -12,7 +12,10 @@ from sugar_lift_py_tests.sugar.binding_projection import (
     LoopGuardedProjection,
     UnboundProjection,
 )
-from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import _loop_exit_faces
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+    _guarded_projection_faces,
+    _loop_exit_faces,
+)
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 
@@ -70,12 +73,13 @@ def delete_binding(state, *, name: str, site, ctx) -> ExitSet:
     if not isinstance(state, GuardedProjection):
         _unhandled_projection(state, verb="delete", name=name, site=site)
     guard = branch_result_guard(state.slot, site)
+    true_face, false_face = _guarded_projection_faces(state)
     return (
         delete_binding(state.when_true, name=name, site=site, ctx=ctx)
-        .guarded(guard)
+        .guarded(guard, true_face)
         .union(
             delete_binding(state.when_false, name=name, site=site, ctx=ctx).guarded(
-                not_(guard)
+                not_(guard), false_face
             )
         )
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -14,6 +14,13 @@ from sugar_lift_py_tests.sugar.binding_projection import (
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 
+def _guarded_projection_faces(state: GuardedProjection):
+    """The two faces owned by this authenticated branch-result projection."""
+    from sugar_lift_py_tests.outcome.exit_set import partition
+
+    return partition(("binding.projection", state.slot.slot_id))
+
+
 def _loop_exit_faces(state: LoopGuardedProjection):
     """The producer's own exit-route family for this loop, or ``None``.
 
@@ -89,6 +96,7 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
         _unhandled_projection(state, verb="read", name=read_name, site=read_site)
 
     guard = branch_result_guard(state.slot, read_site)
+    true_face, false_face = _guarded_projection_faces(state)
     return (
         read_binding(
             state.when_true,
@@ -96,14 +104,14 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
             read_site=read_site,
             ctx=ctx,
         )
-        .guarded(guard)
+        .guarded(guard, true_face)
         .union(
             read_binding(
                 state.when_false,
                 read_name=read_name,
                 read_site=read_site,
                 ctx=ctx,
-            ).guarded(not_(guard))
+            ).guarded(not_(guard), false_face)
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py
@@ -1,0 +1,124 @@
+"""Authenticated partition testimony from nested guarded binding reads."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import StringValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+from sugar_lift_py_tests.sugar.binding_projection import GuardedProjection
+from sugar_lift_py_tests.sugar.binding_projection import UnboundProjection
+from sugar_lift_py_tests.sugar.delete_name_sugar import delete_binding
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import read_binding
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_source_tree.binding_state import BranchResultSlot
+
+
+@dataclass(frozen=True)
+class _Value(Sugar):
+    text: str
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        return Complete(StringValue(self.text))
+
+
+def _slot(name: str) -> BranchResultSlot:
+    return BranchResultSlot(f"branch-result:blake3-512:{name}")
+
+
+@dataclass(frozen=True)
+class _Site:
+    filename: str = "guarded-binding-partition.py"
+    line: int = 1
+    col: int = 0
+
+
+def _read(state):
+    return read_binding(
+        state,
+        read_name="value",
+        read_site=_Site(),
+        ctx=None,
+    )
+
+
+def test_nested_projection_keeps_ancestor_face_when_equal_leaves_merge():
+    """Truthful twin: the outer producer still excludes the distinct sibling."""
+    outer = _slot("outer")
+    inner = _slot("inner")
+    state = GuardedProjection(
+        outer,
+        GuardedProjection(inner, _Value("same"), _Value("same")),
+        _Value("different"),
+    )
+
+    exits = _read(state)
+    same = next(exit_ for exit_ in exits.exits if exit_.value == StringValue("same"))
+    different = next(
+        exit_ for exit_ in exits.exits if exit_.value == StringValue("different")
+    )
+
+    assert len(exits.exits) == 2
+    assert any(
+        left.partition == right.partition and left.side != right.side
+        for left in same.faces
+        for right in different.faces
+    )
+    exits.factor_completed()
+
+
+def test_nested_projection_does_not_keep_a_face_the_merged_leaves_disagree_on():
+    """Lying twin: a merge spanning both outer sides cannot claim either side."""
+    outer = _slot("outer")
+    inner = _slot("inner")
+    state = GuardedProjection(
+        outer,
+        GuardedProjection(inner, _Value("same"), _Value("different")),
+        _Value("same"),
+    )
+
+    exits = _read(state)
+    same = next(exit_ for exit_ in exits.exits if exit_.value == StringValue("same"))
+
+    assert not any(face.partition[-1] == outer.slot_id for face in same.faces)
+
+
+def test_unrelated_projection_arms_still_refuse_without_shared_testimony():
+    """Lying twin: two independently owned splits do not buy exclusivity."""
+    left = _read(GuardedProjection(_slot("left"), _Value("a"), _Value("b")))
+    right = _read(GuardedProjection(_slot("right"), _Value("c"), _Value("d")))
+
+    left_arm = left.exits[0]
+    right_arm = right.exits[0]
+
+    with pytest.raises(ExitSetFactoringGap):
+        type(left)((left_arm, right_arm)).factor_completed()
+
+
+def test_delete_stamps_the_same_authenticated_guarded_projection_faces():
+    """The other verb over the closed projection union preserves the split."""
+    state = GuardedProjection(
+        _slot("delete"),
+        _Value("bound"),
+        UnboundProjection("value", "deleted earlier"),
+    )
+
+    exits = delete_binding(
+        state,
+        name="value",
+        site=_Site(),
+        ctx=None,
+    )
+
+    assert len(exits.exits) == 2
+    left, right = exits.exits
+    assert any(
+        a.partition == b.partition and a.side != b.side
+        for a in left.faces
+        for b in right.faces
+    )


### PR DESCRIPTION
Closes the producer-wiring portion of #6356 and advances #6344 with the existing authenticated PartitionFace/factor_completed law.

What changed:
- mint one reproducible two-face partition for each authenticated BranchResultSlot projection;
- stamp the true/false faces after recursive read/delete reduction, so nested composition accumulates ancestor testimony and equal-destination merges retain only testimony shared by every contributor;
- keep unrelated owners, same-side arms, and merges spanning both sides loud;
- add the smallest nested projection reproducer plus truthful and lying twins.

Why:
A nested GuardedProjection can merge equal inner leaves before a distinct sibling reaches factor_completed. The projection owns the complementary branch faces, but read_binding/delete_binding previously discarded that testimony. This wires the existing general mechanism without widening _are_exclusive or weakening ExitSetFactoringGap.

Validation:
- PYTHONPATH=../sugar-lift-python-source/src:src:../sugar-lift-py-tests/src python3 -m pytest --noconftest -q ../sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py ../sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py ../sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py ../sugar-source-tree/tests/test_branch_result_exclusion_is_already_provable.py ../sugar-source-tree/tests/test_desugar_defect_family_twins.py ../sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py tests/test_parameter_contract_demand_set.py ../sugar-lift-py-tests/tests/test_desugar_repro.py
- 86 passed

Crash/timeout floors remain covered at zero by the focused floor tests. No census, scoreboard, receipt, classification, or pin was added or run.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate authenticated partition faces through guarded binding read and delete operations
> - Adds `_guarded_projection_faces` helper in [`guarded_binding_read_sugar.py`](https://github.com/TSavo/sugar/pull/6393/files#diff-aad969d839fe75c16270bb867782bac3ed239fda15da4f1faa74b3ba8b570d27) to retrieve the true/false partition faces for a `GuardedProjection` keyed by its branch-result slot.
> - Updates `read_binding` and `delete_binding` to pass the appropriate authenticated face to each `.guarded(...)` call on the true and false arms.
> - Adds [`test_guarded_binding_partition_carrier.py`](https://github.com/TSavo/sugar/pull/6393/files#diff-8fcafde426d9d1a215545d98b239446e4922d1347a185777f09146c6e295e5e2) with four tests covering ancestor face retention, disagreeing-leaf exclusion, unrelated-projection refusal, and delete stamping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d535a4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->