### PR TITLE
Project constructed lists through the sequence floor

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -60,6 +60,15 @@ class ListValue(FloorValue):
 
         return Complete(TermValue(len(self.elements)))
 
+    def project_sequence_with(self, operation, ctx):
+        """Unpack against the authenticated reduced members already in hand."""
+        return operation.project_tuple(self, ctx)
+
+    @property
+    def items(self) -> tuple:
+        """Member sequence for exact-arity sequence projection."""
+        return self.elements
+
     def contains(self, item, site):
         # A guarded needle is not one needle: distribute into its faces and
         # rejoin under the same guard before this receiver's own law runs.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
@@ -17,7 +17,7 @@ Which one happens is decided by the RHS.  That decision is the whole content of
 the operation, and it splits on ONE question: does the reduced value carry
 authenticated finite members?
 
-- It does (a tuple/array literal floor value): the count is lift-time
+- It does (a list/tuple/array literal floor value): the count is lift-time
   decidable.  Matching arity binds each name to the member ALREADY IN HAND --
   never a fabricated element.  A mismatch is a decidable ``ValueError`` whose
   exact exceptional exit has no floor value yet, so it stays a loud

--- a/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
+++ b/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
@@ -398,6 +398,53 @@ def test_present_finite_testimony_binds_and_a_wrong_count_stays_loud() -> None:
 
 
 # ==========================================================================
+# Category: constructed list binding -- authenticated members survive a Name
+# ==========================================================================
+
+
+def test_constructed_list_binding_projects_its_authenticated_members() -> None:
+    """TRUTHFUL. A guarded list face is still the finite list constructed."""
+    from sugar_lift_py_tests.floor.list_value import ListValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+
+    members = (TermValue(4), TermValue(5))
+    answer = _operation("left", "right").submit(ListValue(members), None)
+    assert isinstance(answer, Complete)
+    assert isinstance(answer.value, ScopeRebinds)
+    assert answer.value.bindings == (("left", members[0]), ("right", members[1]))
+
+    seen, out = _receivers(
+        "def unpack_guarded_list(choose, fallback):\n"
+        " pair = [4, 5] if choose else fallback\n"
+        " left, right = pair\n"
+        " selected = left\n"
+        " return selected\n"
+    )
+    assert seen == ["GuardedValue"], seen
+    assert isinstance(out, ExitSet)
+    assert len(out.exits) == 2
+    assert sum(
+        isinstance(exit_.effect, SequenceUnpackRuntimeEffect)
+        for exit_ in out.exits
+        if isinstance(exit_, Halted)
+    ) == 1
+
+
+def test_constructed_list_binding_does_not_lie_about_its_arity() -> None:
+    """LYING. Three authenticated members cannot satisfy two targets."""
+    seen, out = _receivers(
+        "def unpack_guarded_list(choose, fallback):\n"
+        " values = [4, 5, 6] if choose else fallback\n"
+        " left, right = values\n"
+        " selected = left\n"
+        " return selected\n"
+    )
+    assert seen == ["GuardedValue"], seen
+    assert isinstance(out, ConstructionPanic)
+    assert "too many values" in str(out)
+
+
+# ==========================================================================
 # Category: conditional value -- the unpack distributes into both faces
 # ==========================================================================
 


### PR DESCRIPTION
## What changed

- make every constructed `ListValue` answer exact-arity sequence projection from its authenticated members
- add a 4-line guarded-list reproducer that previously panicked at the missing floor arm
- add truthful and lying twins: exact members bind unchanged; wrong arity remains a loud decidable gap

## Why

Tuple and array floor values already exposed authenticated finite members to `SequenceProjectionOperation`, but constructed lists fell through the base floor panic. This made a list under a guarded binding fail construction even though its exact members were already available.

The fix is receiver-category dispatch on `ListValue`, with no package, function, or site-name recognition.

## Validation

`PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src python3 -m pytest --noconftest implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py -q`

- 19 passed
- crashes: 0
- timeouts under explicit 30-second watchdog: 0

Do not merge from this agent lane.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sequence projection support to `ListValue` through `project_sequence_with` and `items`
> - Adds `project_sequence_with` to `ListValue` in [list_value.py](https://github.com/TSavo/sugar/pull/6394/files#diff-eeacaa87aa5806ebb12e29086e825199b416c15725bb8735d0c4c86c747515bf), delegating to `operation.project_tuple(self, ctx)` so constructed lists participate in destructuring.
> - Adds an `items` property on `ListValue` that exposes `self.elements` for exact-arity sequence projection.
> - Adds tests in [test_sequence_projection_receivers.py](https://github.com/TSavo/sugar/pull/6394/files#diff-b2c0d3778513c43946e31891a4b4cac3d261530bf709648bdc78167a3b535f7c) covering successful two-member destructuring and arity mismatch (`ConstructionPanic` on too many values).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86b74b9. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->