### PR TITLE
Route resource With cleanup through ExitSet

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -42,25 +42,36 @@ class WithResourceSugar(Sugar):
 
     @classmethod
     def witnesses(cls):
+        prefix = (
+            "class Resource:\n"
+            "    def __init__(self):\n"
+            "        self.closed = False\n"
+            "    def __enter__(self):\n"
+            "        return self\n"
+            "    def __exit__(self, effect_type, effect, traceback):\n"
+            "        self.closed = True\n"
+            "        return False\n\n"
+            "def A(halts):\n"
+            "    resource = Resource()\n"
+            "    try:\n"
+            "        with resource:\n"
+            "            if halts:\n"
+            "                raise ValueError\n"
+            "    except ValueError:\n"
+            "        pass\n"
+            "    return resource.closed\n\n"
+        )
         return _call_pair(
-            name="with_resource_structure",
+            name="with_resource_closes_completed_and_halted",
             owner_sugar="WithResourceSugar",
-            truthful=(
-                "def A(z):\n"
-                "    with contextlib.suppress(KeyError):\n"
-                "        raise KeyError\n"
-                "    return z\n\n"
-                "def test_a():\n"
-                "    assert A(5) == 5\n"
-            ),
-            lying=(
-                "def A(z):\n"
-                "    with contextlib.suppress(KeyError):\n"
-                "        raise KeyError\n"
-                "    return z\n\n"
-                "def test_a():\n"
-                "    assert A(5) == 6\n"
-            ),
+            truthful=prefix
+            + "def test_a():\n"
+            "    assert A(False)\n"
+            "    assert A(True)\n",
+            lying=prefix
+            + "def test_a():\n"
+            "    assert A(False)\n"
+            "    assert not A(True)\n",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -126,7 +137,12 @@ class WithResourceSugar(Sugar):
                         self.exit_face_id, body_exit
                     ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
-                    after = face.and_exit(exit_es, disposition=self.disposition)
+                    if _is_never_suppressing_resource(self.disposition):
+                        after = face.and_finally(lambda: exit_es)
+                    else:
+                        after = face.and_exit(
+                            exit_es, disposition=self.disposition
+                        )
                     after = prepend_facts_to_exitset(
                         after, (*mgr_facts, *enter_facts, *face_facts)
                     )
@@ -155,3 +171,14 @@ def _and_guards(left, right):
     if left == right:
         return left
     return and_([left, right])
+
+
+def _is_never_suppressing_resource(disposition) -> bool:
+    from sugar_lift_py_tests.context_manager_contract import (
+        NeverSuppresses,
+        NeverSuppressesDispositionV1,
+    )
+
+    return isinstance(
+        disposition, (NeverSuppresses, NeverSuppressesDispositionV1)
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import inspect
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_contract import (
     NeverSuppresses,
     NeverSuppressesDispositionV1,
@@ -281,6 +283,63 @@ def test_completed_body_survives_never_suppresses():
         and getattr(getattr(e, "effect", None), "exception_name", None)
     ]
     assert reds == []
+
+
+def test_resource_cleanup_uses_and_finally_on_completed_and_halted_faces(
+    monkeypatch,
+):
+    """A resource close is shared cleanup, not a normal-path-only exit."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    original = ExitSet.and_finally
+    incoming_kinds = []
+
+    def observe(incoming, cleanup, *, cleanup_restores=None):
+        incoming_kinds.append(type(incoming.exits[0]))
+        return original(
+            incoming,
+            cleanup,
+            cleanup_restores=cleanup_restores,
+        )
+
+    monkeypatch.setattr(ExitSet, "and_finally", observe)
+
+    completed = _resource(body=(_Pass(),)).desugar()
+    halted = _resource(body=(_Raise("ValueError"),)).desugar()
+
+    assert incoming_kinds == [Completed, Halted]
+    assert completed.value.can_fall_through
+    assert any(
+        isinstance(entry, Incomplete)
+        and getattr(entry.effect, "exception_name", None) == "ValueError"
+        for entry in halted.value.contribution()
+    )
+
+
+def test_lying_resource_cleanup_cannot_skip_the_halted_face(monkeypatch):
+    """BITE: a completion-only cleanup implementation changes the result."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    original = ExitSet.and_finally
+
+    def completion_only(incoming, cleanup, *, cleanup_restores=None):
+        if isinstance(incoming.exits[0], Halted):
+            return ExitSet.completed("cleanup-skipped")
+        return original(
+            incoming,
+            cleanup,
+            cleanup_restores=cleanup_restores,
+        )
+
+    monkeypatch.setattr(ExitSet, "and_finally", completion_only)
+    out = _resource(body=(_Raise("ValueError"),)).desugar()
+
+    with pytest.raises(AssertionError):
+        assert any(
+            isinstance(entry, Incomplete)
+            and getattr(entry.effect, "exception_name", None) == "ValueError"
+            for entry in out.value.contribution()
+        )
 
 
 def test_exit_face_binding_completed_is_none_triple():

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -295,6 +295,48 @@ def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(
     assert bound_return.value.projection == "enter-result"
 
 
+@pytest.mark.parametrize(
+    ("body", "incoming_kind"),
+    [
+        ("pass", Completed),
+        ('raise ValueError("boom")', Halted),
+    ],
+)
+def test_real_resource_reproducer_closes_every_exitset_face(
+    tmp_path, monkeypatch, body, incoming_kind
+):
+    """An authenticated provider resource closes after completion and halt."""
+    path = tmp_path / f"resource_{incoming_kind.__name__.lower()}.py"
+    path.write_text(
+        "from arbitrary_provider import acquire\n"
+        "def f():\n"
+        "    with acquire():\n"
+        f"        {body}\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+
+    resource = next(
+        statement
+        for statement in _function_sugar(path_source(str(path)), _resolved).statements
+        if isinstance(statement, WithResourceSugar)
+    )
+    original = ExitSet.and_finally
+    seen = []
+
+    def observe(incoming, cleanup, *, cleanup_restores=None):
+        seen.append(type(incoming.exits[0]))
+        return original(
+            incoming,
+            cleanup,
+            cleanup_restores=cleanup_restores,
+        )
+
+    monkeypatch.setattr(ExitSet, "and_finally", observe)
+    resource.desugar()
+
+    assert seen == [incoming_kind]
+
+
 def test_unresolved_ref_stays_typed_loud(tmp_path):
     path = tmp_path / "unresolved.py"
     path.write_text(


### PR DESCRIPTION
## Summary

Route authenticated never-suppressing resource `With` cleanup through the shared `ExitSet.and_finally` fold. The constructed close operation now runs on both completed and halted body faces. A cleanup halt supersedes the incoming face; completed cleanup restores it.

Typed suppressing dispositions remain on `and_exit`. No manager, package, or vendor spelling grants authority.

Adds one real arbitrary-provider source reproducer, a truthful close-on-both-faces witness, a lying completion-only witness, and a mutation-sensitive focused test.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | existing authenticated admission; cleanup algebra fixed |
| `mandatory_panics` | 0 | no admission or panic suppression |
| `suppressed_descendants` | 0 | no descendant suppression |
| `typed_effects` | 0 | halted effects remain typed and restored |
| `silent` | 0 | floor |

No census or corpus sweep was run, per the build-not-measure directive.

## Validation

- Focused owning-package tests: 47 passed in 20.55s
- Bounded subprocess: timeout=0, crash=0
- Witness execution: truthful passed; lying raised `AssertionError`
- `git diff --check origin/main...HEAD`

## Floors preserved

- data loss = 0
- crash = 0
- timeout = 0
- silent = 0
- no test deleted for green
- no census, scoreboard, receipt, classification, or pin-only artifact added

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `WithResourceSugar` cleanup through `ExitSet.and_finally` for non-suppressing dispositions
> - `WithResourceSugar.desugar` now uses `ExitSet.and_finally` instead of `ExitSet.and_exit` when the disposition is a `NeverSuppresses` or `NeverSuppressesDispositionV1` instance, ensuring cleanup runs on both `Completed` and `Halted` faces.
> - A helper `_is_never_suppressing_resource` checks the disposition type to select the correct path.
> - New tests in [test_with_resource_sugar.py](https://github.com/TSavo/sugar/pull/6401/files#diff-2f3ef62c9f2b0c15b9f9ce067770fa40d6698321025089647c1a4db727f0aac0) monkeypatch `and_finally` to verify it is called for both faces and that skipping the `Halted` face produces incorrect results.
> - A parametrized integration test in [test_with_authenticated_contract_ref.py](https://github.com/TSavo/sugar/pull/6401/files#diff-24ed90dba7c15724cef255c1d44a25011bfd98f07aba873f4fa4de7241417552) confirms the behavior against a real authenticated provider resource.
> - Behavioral Change: for `NeverSuppresses`/`NeverSuppressesDispositionV1` dispositions, cleanup is now applied to both `Completed` and `Halted` faces rather than only as a dispositioned exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f403dad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->