### PR TITLE
The ground-exit twins read the shape the door actually constructs (#6389 follow-up)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_workspace_locus.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_workspace_locus.py
@@ -99,11 +99,16 @@ def _raise_effects(root: Path) -> dict[str, RaiseEffect]:
         assert isinstance(outcome, Complete), (
             f"{function.name} did not construct: {outcome!r}"
         )
-        value = outcome.value
-        assert isinstance(value, RaiseValue), (
-            f"{function.name} constructed {type(value).__name__}, not a RaiseValue"
+        raises = [
+            statement
+            for statement in outcome.value.record.statements
+            if isinstance(statement, RaiseValue)
+        ]
+        assert len(raises) == 1, (
+            f"{function.name} constructed {len(raises)} raise exits, not the "
+            f"one ground exit its body proves"
         )
-        effects[function.name] = value.effect
+        effects[function.name] = raises[0].effect
     return effects
 
 
@@ -122,10 +127,15 @@ def test_ground_exit_blame_is_workspace_relative(corpus: Path) -> None:
     for name, effect in effects.items():
         blame = effect.blame
         assert blame is not None, f"{name} exit carries no blame locus"
-        assert blame.startswith("ground_exits.py:"), (
-            f"{name} blame `{blame}` is not the workspace-relative locus"
+        # The blame renders the fragment, which names the file it cites. That
+        # name must be the workspace-relative one -- an absolute spelling is
+        # the address no other checkout can resolve.
+        assert "'ground_exits.py'" in blame, (
+            f"{name} blame `{blame}` does not name the workspace-relative locus"
         )
-        assert not Path(blame.split(":")[0]).is_absolute()
+        assert str(corpus) not in blame, (
+            f"{name} blame `{blame}` leaks the absolute workspace path"
+        )
 
 
 def test_ground_exit_cites_the_source_it_locates(corpus: Path) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2362,9 +2362,13 @@ class FunctionDef(Statement):
                     relative = Path(self.unit.filename)
                     if relative.is_absolute():
                         raise SugarNotWritten(
-                            f"module-level bridge symbol needs a workspace-relative "
-                            f"locus; `{self.unit.filename}` is absolute -- route the "
-                            f"source through the workspace-relative lift door"
+                            owner="FunctionDef.bridge_source_symbol",
+                            observed=f"absolute source locus `{self.unit.filename}`",
+                            requested="workspace-relative source locus",
+                            fix=(
+                                "route the source through the workspace-relative "
+                                "lift door (`workspace_path_source`)"
+                            ),
                         )
                     module_parts = list(relative.with_suffix("").parts)
                     if module_parts and module_parts[-1] == "__init__":


### PR DESCRIPTION
**#6389 merged as `248bc1305` while the follow-up commit was still local.** Main is carrying a red test file I authored and a loud arm that crashes on the way to being loud. Fix-forward.

## 1. The twins asserted a shape the door does not construct

`test_ground_exit_workspace_locus.py` in main fails 3 of its 4 faces:

```
FAILED test_ground_exits_construct_under_an_absolute_corpus_path
FAILED test_ground_exit_blame_is_workspace_relative
FAILED test_ground_exit_cites_the_source_it_locates
1 passed
```

Both mistakes were the test's assumption, not the door's behaviour:

- a function desugars to a `UniverseValue` whose `record` holds the ground exit, so `isinstance(outcome.value, RaiseValue)` was never going to hold. The twin now reaches into the record and asserts exactly one raise exit — a count, so a body that grows a second exit is caught rather than silently indexed past.
- `RaiseEffect.blame` renders the fragment (`<SourceFragment 'ground_exits.py' [50, 55) node=Subscript>`), not `file:line:col`. The twin now asserts the fragment names the workspace-relative file **and** that the absolute workspace path does not appear anywhere in the blame — which is the property the law is actually about.

## 2. The loud arm crashed instead of being loud

`SourceTreePanic.__init__` takes `owner/observed/requested/fix`; the arm added to `bridge_source_symbol` passed a single string. On an absolute locus it raised `TypeError: SourceTreePanic.__init__() missing 3 required positional arguments` instead of the `SugarNotWritten` it names.

On the unmutated tree that arm is unreachable, so no test could have found it. **The M1 mutation did** — reverting the construction door to the absolute-locus `path_source` routes straight through it. This is the case for perturbing after green: the bug lived in the only code path a green board can never execute.

## Evidence

`4 passed` at this head, `SUGAR_BIN` pinned to a cached release artifact (`SUGAR_BINARY_ALLOW_BUILD=0`, no binary built).

Mutation transactions re-run against the corrected twins — clean before, mutation verified present, test bites, revert verified, clean after:

| mutation | result |
|---|---|
| M1 construction door reverts to `path_source` | 3 truthful faces fail, lying face still passes |
| M2 delete the `is_absolute` law from `floor/ground_exit.py` | lying face alone fails |
| M3 citation reverts to `getattr(site, "source", None)` | cited face alone fails |

Does not close #6352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ground-exit tests to read the shape the door actually constructs
> - Updates `_raise_effects` helper in [test_ground_exit_workspace_locus.py](https://github.com/TSavo/sugar/pull/6402/files#diff-202bab7dcda9bffee6b5a445fab2c219294a2e89ceb6a28b7b003aa1a70f19ac) to search `outcome.value.record.statements` for `RaiseValue` instances rather than assuming the entire constructed value is a `RaiseValue`, asserting exactly one raise exit exists.
> - Updates `test_ground_exit_blame_is_workspace_relative` to check that the blame string contains the quoted filename `ground_exits.py` and does not contain the absolute corpus path, replacing the previous prefix and `is_absolute()` checks.
> - Fixes `FunctionDef.source_visible_call_frame` in [nodes.py](https://github.com/TSavo/sugar/pull/6402/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to raise `SugarNotWritten` with structured keyword arguments (`owner`, `observed`, `requested`, `fix`) instead of a single formatted message string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4084e7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->