### PR TITLE
Wire the conditional binding read's own split, and let a merge keep what both arms could be (#6336 family)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -185,13 +185,17 @@ def _complete_family(arms) -> bool:
     for origin in origins:
         sides, arity = [], None
         for arm in arms:
-            member = next(
-                (f for f in arm.faces if f.partition == origin), None
-            )
-            if member is None:
+            members = [f for f in arm.faces if f.partition == origin]
+            # A MERGED arm can carry several sides of one origin (see
+            # `_merge_faces`). It is one arm standing for several members, so
+            # it cannot be counted as the single member the arity test needs;
+            # admitting it would let two arms "cover" a three-way family. The
+            # pairwise rule below still separates it on disjoint side sets --
+            # this door just declines to call the family complete.
+            if len(members) != 1:
                 break
-            sides.append(member.side)
-            arity = member.arity
+            sides.append(members[0].side)
+            arity = members[0].arity
         else:
             if arity == len(arms) == len(set(sides)):
                 return True
@@ -218,15 +222,74 @@ def partition(owner: object) -> tuple[PartitionFace, PartitionFace]:
 _NO_FACES: frozenset[PartitionFace] = frozenset()
 
 
+def _sides_by_partition(
+    faces: frozenset[PartitionFace],
+) -> dict[object, set[object]]:
+    """Every side an arm is known to lie on, grouped by the split that named it.
+
+    An arm usually carries ONE side per partition. A MERGED arm carries several:
+    ``normalize`` disjoins two equal destinations, and the merged arm holds
+    wherever either contributor did, so it lies on one side of ``{range,
+    single}`` without saying which. That is a truthful, weaker statement, and
+    the set is how it is spelled.
+    """
+    sides: dict[object, set[object]] = {}
+    for face in faces:
+        sides.setdefault(face.partition, set()).add(face.side)
+    return sides
+
+
+def _merge_faces(
+    left: frozenset[PartitionFace], right: frozenset[PartitionFace]
+) -> frozenset[PartitionFace]:
+    """Testimony that survives a disjoining merge of two equal destinations.
+
+    THE RULE IS PER PARTITION, and it was previously a plain set intersection.
+    That answered the question "which identical faces did both carry", which is
+    the right answer only when the arms lie on the same side. Two arms on
+    DIFFERENT sides of one split still jointly testify something true and
+    useful about the merged arm -- it is on one of those two sides, and on no
+    other -- and the intersection threw that away, leaving the merged arm
+    unstamped and its refusal unclosable by any producer.
+
+    So: a split only ONE contributor named is dropped (the other claims nothing
+    there, and an unclaimed side is not an exclusion). A split BOTH named keeps
+    every side either of them could be on. That is weaker than each contributor
+    alone, which is correct -- a merged arm knows less -- and it is not nothing.
+
+    This does not let exclusivity be forged. ``_faces_exclusive`` asks for
+    DISJOINT side sets, so a merged arm covering `{range, single}` is provably
+    apart only from arms covering neither, which is exactly what the producer's
+    own mint already asserted.
+    """
+    left_sides = _sides_by_partition(left)
+    right_sides = _sides_by_partition(right)
+    shared = left_sides.keys() & right_sides.keys()
+    return frozenset(
+        face for face in (left | right) if face.partition in shared
+    )
+
+
 def _faces_exclusive(
     left: frozenset[PartitionFace], right: frozenset[PartitionFace]
 ) -> bool:
-    """Whether carried testimony alone proves the two arms cannot both hold."""
+    """Whether carried testimony alone proves the two arms cannot both hold.
+
+    DISJOINT SIDE SETS over a SHARED partition. The producer said its sides are
+    mutually exclusive when it minted them, so if everything the left arm could
+    be is something the right arm cannot be, they cannot both hold. With one
+    side each -- every face a producer mints directly -- this is exactly the
+    ``!=`` it replaces; the sets only ever grow through a merge.
+
+    Sound in the same direction as before: a False answer is "not proven",
+    never "proven to overlap".
+    """
     if not left or not right:
         return False
-    sides: dict[object, object] = {face.partition: face.side for face in left}
-    for face in right:
-        if face.partition in sides and sides[face.partition] != face.side:
+    right_sides = _sides_by_partition(right)
+    for partition_id, sides in _sides_by_partition(left).items():
+        other = right_sides.get(partition_id)
+        if other is not None and not (sides & other):
             return True
     return False
 
@@ -722,17 +785,16 @@ class ExitSet(Generic[T]):
                     # drop the arrival's, silently.
                     and _obligations(exit_) == _obligations(prior)
                 )
-                # Same destination under a DISJOINED guard: only testimony both
-                # arms carried survives the merge, for the same reason as in
-                # factor_completed. Intersecting here is what keeps a merged
-                # arm from claiming a face it only held on one side.
+                # Same destination under a DISJOINED guard. Only a split BOTH
+                # contributors spoke about survives -- a partition one of them
+                # never mentioned tells you nothing about where the merged arm
+                # lies. For a split they both named, the merged arm lies on one
+                # of their sides, so the sides UNION.
                 if same_completed:
-                    # OR of guards is not a partition; clear stamps when merging
-                    # equal destinations so exclusivity cannot be forged.
                     merged[index] = Completed(
                         _or_guards(prior.guard, exit_.guard),
                         prior.value,
-                        prior.faces & exit_.faces,
+                        _merge_faces(prior.faces, exit_.faces),
                         # Equal by `same_completed`; stated explicitly so the
                         # field cannot be dropped by a later edit here.
                         prior.pending_contracts,
@@ -743,7 +805,7 @@ class ExitSet(Generic[T]):
                         _or_guards(prior.guard, exit_.guard),
                         prior.effect,
                         prior.state,
-                        prior.faces & exit_.faces,
+                        _merge_faces(prior.faces, exit_.faces),
                         # Equal by `same_halted`, so this conserves rather than
                         # chooses; stated explicitly so the field cannot be
                         # dropped by a later edit to this constructor.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -6,6 +6,7 @@ from sugar_lift_py_tests.effect import NameErrorEffect
 from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
 from sugar_lift_py_tests.ir import not_
 from sugar_lift_py_tests.outcome import ExitSet, Outcome, outcome_to_exitset
+from sugar_lift_py_tests.outcome.exit_set import partition as _partition
 from sugar_lift_py_tests.sugar.binding_projection import (
     GuardedProjection,
     LoopGuardedProjection,
@@ -89,6 +90,23 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
         _unhandled_projection(state, verb="read", name=read_name, site=read_site)
 
     guard = branch_result_guard(state.slot, read_site)
+    # THE READ OWNS THIS SPLIT, AND NOW SAYS SO.
+    #
+    # A conditionally-bound name is one value under the branch result and
+    # another under its negation. That is a two-way partition this producer
+    # decides, and it used to guard both arms with no face at all -- so every
+    # downstream `factor_completed` had nothing but guard SHAPE to go on, and
+    # any rewrite or merge that moved the shape made a real partition
+    # unprovable. Same shape as the loop before #6375: the producer already
+    # named its routes (`when_true` / `when_false` over an authenticated slot)
+    # and simply never minted the testimony.
+    #
+    # The owner is `state.slot`, the branch-result identity itself, NOT the
+    # read site: two reads of the same conditional binding are governed by the
+    # SAME branch outcome, so they must mint the same partition or arms that
+    # genuinely exclude each other would look unrelated. `partition` addresses
+    # by content, so this is reproducible rather than allocation-based.
+    then_face, else_face = _partition(("binding.read", state.slot))
     return (
         read_binding(
             state.when_true,
@@ -96,14 +114,14 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
             read_site=read_site,
             ctx=ctx,
         )
-        .guarded(guard)
+        .guarded(guard, then_face)
         .union(
             read_binding(
                 state.when_false,
                 read_name=read_name,
                 read_site=read_site,
                 ctx=ctx,
-            ).guarded(not_(guard))
+            ).guarded(not_(guard), else_face)
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_binding_read_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binding_read_partition_carrier.py
@@ -1,0 +1,216 @@
+"""The conditional binding read names its own split, and the merge keeps it.
+
+THE PRODUCER OWNED EVIDENCE AND DID NOT SPEAK. `read_binding`'s
+`GuardedProjection` branch is the reader for every conditionally-bound name: the
+value is one thing under an authenticated branch result and another under its
+negation. That is a two-way partition this producer DECIDES, and it guarded both
+arms with `.guarded(guard)` / `.guarded(not_(guard))` carrying no face at all.
+Downstream `factor_completed` therefore had nothing but guard SHAPE, and shape
+decays -- the moment a prefix conjoins or a sibling merges, a real partition
+stops being provable.
+
+Same shape as the loop before #6375: the producer already named its routes
+(`when_true` / `when_false` over `state.slot`) and simply never minted. Wiring
+it is a mint and two face arguments; no admission rule changes, and
+`factor_completed` refuses exactly when it refused before.
+
+WHY THE MINT IS OWNED BY THE SLOT AND NOT THE READ SITE. Two reads of the same
+conditional binding are governed by the SAME branch outcome. Keying the
+partition by read site would mint two unrelated tokens for one decision, and
+arms that genuinely exclude each other would look like arms from different
+splits -- the `STAMPED_DISJOINT` shape, which proves nothing. `partition`
+addresses by content, so slot-keyed tokens are reproducible across reads rather
+than allocation-based.
+
+EVERY TRUTHFUL ARM HERE HAS A LYING ONE. A carrier that mints faces is exactly
+the change that can buy a green by handing out testimony nobody earned, so each
+arm that says "this factors now" is paired with one that says "and this still
+does not".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.ir import and_, atomic, not_, or_
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    ExitSetFactoringGap,
+    _are_exclusive,
+    _faces_exclusive,
+)
+from sugar_lift_py_tests.sugar.binding_projection import GuardedProjection
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import read_binding
+from sugar_source_tree.binding_state import BranchResultSlot
+
+
+class _Value:
+    """A leaf binding state that desugars to one completed arm.
+
+    `read_binding` treats a `Sugar` state as "already reduced", so this is the
+    smallest thing that can sit on a branch without dragging a source file in.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(self.value)
+
+
+# `read_binding` dispatches on `Sugar`, so the leaf must register as one.
+from sugar_lift_py_tests.sugar.sugar_base import Sugar  # noqa: E402
+
+Sugar.register(_Value)
+
+
+def _read(slot_id: str, *, site="site-1", then="then-value", other="else-value"):
+    """Drive the carrier directly, the way #6375's file drives the loop one.
+
+    `site` is a real parameter, not a placeholder: the arm below that pins the
+    mint to the SLOT is only able to see a read-site-keyed mint if two reads
+    differ in it. Holding it constant made that control silent -- measured, not
+    supposed: keying the partition by `read_site` fired nothing at all until
+    this argument existed.
+    """
+    return read_binding(
+        GuardedProjection(
+            BranchResultSlot(slot_id), _Value(then), _Value(other)
+        ),
+        read_name="chosen",
+        read_site=site,
+        ctx=None,
+    )
+
+
+def _completed(exits):
+    return [e for e in exits.exits if isinstance(e, Completed)]
+
+
+def _faces_of(exit_):
+    return exit_.faces
+
+
+def test_the_read_stamps_both_arms_of_the_binding_it_split():
+    """POSITIVE, and the whole point: the arms arrive carrying testimony.
+
+    Before the wiring every arm here had `faces == frozenset()`, so the split
+    the reader owns was invisible to anything downstream.
+    """
+    arms = _completed(_read("slot-a"))
+
+    assert len(arms) == 2
+    assert all(_faces_of(arm) for arm in arms), (
+        "the conditional binding read minted no partition testimony: the "
+        "producer owns this split and must say so"
+    )
+
+
+def test_the_two_arms_are_opposite_sides_of_ONE_split():
+    """POSITIVE. One partition, two sides -- not two unrelated tokens.
+
+    Two tokens would classify as STAMPED_DISJOINT downstream, which proves
+    nothing at all, and would still read as "the producer testified".
+    """
+    left, right = (_faces_of(a) for a in _completed(_read("slot-a")))
+
+    assert {f.partition for f in left} == {f.partition for f in right}
+    assert _faces_exclusive(left, right), (
+        "the two arms of one conditional binding must be provably exclusive "
+        "from carried testimony alone"
+    )
+
+
+def test_the_stamped_arms_factor_when_a_MERGE_has_hidden_the_exclusion():
+    """THE TOOTH, and the live condition is a merge, not a prefix.
+
+    A conjunctive prefix does NOT hide anything -- `_conjuncts` flattens, so
+    `_are_exclusive` still sees `g` against `not g` one literal deep. That was
+    measured here rather than assumed, and the first draft of this arm asserted
+    the opposite and failed.
+
+    The shape that genuinely hides an exclusion is the DISJUNCTION `normalize`
+    writes when it merges two equal destinations: `g` against `or(not g, q)`
+    really can hold together as far as shape is concerned. That is the arm the
+    corpus rows are shaped like, and the reason a wired producer is worth
+    anything -- carried testimony reads through it.
+    """
+    arms = _completed(_read("slot-a"))
+    merged_guard = or_([arms[1].guard, atomic("sibling", [])])
+
+    hidden = ExitSet(
+        (
+            Completed(arms[0].guard, arms[0].value, _faces_of(arms[0])),
+            Completed(merged_guard, arms[1].value, _faces_of(arms[1])),
+        )
+    )
+    # Shape alone cannot separate these...
+    assert not _are_exclusive(hidden.exits[0].guard, hidden.exits[1].guard)
+    # ...and the producer's own testimony can.
+    assert len(_completed(hidden.factor_completed())) == 1
+
+
+def test_the_same_slot_read_twice_mints_the_SAME_partition():
+    """POSITIVE. The mint is owned by the branch decision, not by the read.
+
+    Two reads of one conditional binding are governed by the same outcome. If
+    the token were keyed by read site, arms from the two reads would look like
+    arms of unrelated splits and prove nothing about each other.
+    """
+    first = _completed(_read("slot-a", site="read-here"))
+    again = _completed(_read("slot-a", site="read-somewhere-else"))
+
+    assert _faces_exclusive(_faces_of(first[0]), _faces_of(again[1])), (
+        "two reads of ONE conditional binding minted unrelated partitions: the "
+        "mint is keyed by the read site instead of the branch slot"
+    )
+
+
+def test_two_unrelated_conditional_bindings_do_not_exclude_each_other():
+    """LYING TWIN. Different slots are different splits.
+
+    This fires if the mint is keyed by anything coarser than the slot -- a
+    per-function or per-file token would make every conditional binding in a
+    function look mutually exclusive.
+    """
+    first = _completed(_read("slot-a"))
+    second = _completed(_read("slot-b"))
+
+    assert not _faces_exclusive(_faces_of(first[0]), _faces_of(second[1]))
+    assert not _faces_exclusive(_faces_of(first[1]), _faces_of(second[0]))
+
+
+def test_arms_on_the_SAME_side_are_still_refused():
+    """LYING TWIN. A partition token is not exclusivity; the SIDE carries it.
+
+    Reusing one arm's face for both arms is the cheapest way to fake a green,
+    and it is what `factor_completed` must keep refusing.
+    """
+    arms = _completed(_read("slot-a"))
+    one_side = _faces_of(arms[0])
+
+    with pytest.raises(ExitSetFactoringGap):
+        ExitSet(
+            tuple(
+                Completed(atomic(f"g{i}", []), arm.value, one_side)
+                for i, arm in enumerate(arms)
+            )
+        ).factor_completed()
+
+
+def test_the_refusal_still_fires_for_a_producer_that_owns_no_split():
+    """LYING TWIN. The door did not widen.
+
+    Nothing in this change touches when `factor_completed` refuses. Two arms
+    nobody testified about still cannot be factored, whatever their shape.
+    """
+    left = atomic("p", [])
+    right = or_([not_(left), atomic("q", [])])
+
+    with pytest.raises(ExitSetFactoringGap):
+        ExitSet(
+            (Completed(left, "a"), Completed(right, "b"))
+        ).factor_completed()

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
@@ -30,9 +30,10 @@ from sugar_lift_py_tests.outcome.exit_set import (
     ExitSet,
     ExitSetFactoringGap,
     partition,
+    partition_family,
     true_guard,
 )
-from sugar_lift_py_tests.outcome.exit_set import _are_exclusive
+from sugar_lift_py_tests.outcome.exit_set import _are_exclusive, _faces_exclusive
 
 
 def _pred(name: str):
@@ -159,12 +160,25 @@ def test_guarded_stamps_the_face_it_is_given_and_nothing_else():
     assert len([e for e in factored.exits if isinstance(e, Completed)]) == 1
 
 
-def test_disjoining_merge_keeps_only_testimony_both_arms_carried():
-    """A merged arm holds under a DISJUNCTION, so faces intersect, never union.
+def test_a_disjoining_merge_keeps_every_side_either_contributor_could_be_on():
+    """A merged arm holds under a DISJUNCTION, so its SIDES union.
 
-    If the merge unioned faces, an arm reachable on either side of a split would
-    claim to be on one named side of it — an exclusion the producer never gave,
-    and the exact way carried testimony could start lying.
+    LAW CHANGED ON THE RECORD. This arm used to assert
+    `merged.exits[0].faces == frozenset()`: a merge of two arms on different
+    sides of one split kept nothing. That was a conservative approximation, not
+    the truth. The merged arm holds wherever either contributor did, so what is
+    actually known is "on one of these two sides, and no other" — a weaker
+    statement than either contributor made, and a strictly stronger one than
+    silence.
+
+    Dropping it had a measured cost: it is why wiring a producer could not close
+    a merged-arm refusal. The producer would mint `range` and `single`, the
+    merge would erase both, and the arm would arrive unstamped no matter how
+    well the producer testified. Testimony that cannot survive the wire is not
+    propagation.
+
+    The reason the old assertion existed is preserved exactly, and is pinned by
+    the arm below: a merged arm must never claim to be on ONE named side.
     """
     condition = _pred("c")
     left_face, right_face = partition(("merge-owner", condition))
@@ -177,6 +191,53 @@ def test_disjoining_merge_keeps_only_testimony_both_arms_carried():
     ).normalize()
 
     assert len(merged.exits) == 1
+    assert merged.exits[0].faces == frozenset({left_face, right_face})
+
+
+def test_a_merged_arm_is_not_exclusive_with_either_side_it_came_from():
+    """THE LYING TWIN for the union, and the reason the old rule was written.
+
+    The danger the intersection was guarding against is that an arm reachable on
+    EITHER side of a split ends up claiming one named side, forging an exclusion
+    the producer never gave. Carrying both sides does not forge it, because
+    `_faces_exclusive` asks for DISJOINT side sets: `{c, not c}` overlaps `{c}`
+    and overlaps `{not c}`, so the merged arm is provably apart from neither.
+
+    Without this arm, a union looks like a free upgrade. With it, the union is
+    only sound because the prover reads sets.
+    """
+    condition = _pred("c")
+    left_face, right_face = partition(("merge-owner", condition))
+    both = frozenset({left_face, right_face})
+
+    assert not _faces_exclusive(both, frozenset({left_face}))
+    assert not _faces_exclusive(both, frozenset({right_face}))
+    assert not _faces_exclusive(both, both)
+    # ...and it still separates from a side of the SAME split it cannot be on.
+    a, b, c = partition_family(("three", "way"), ("a", "b", "c"))
+    assert _faces_exclusive(frozenset({a, b}), frozenset({c}))
+    assert not _faces_exclusive(frozenset({a, b}), frozenset({b, c}))
+
+
+def test_a_merge_drops_a_split_only_one_contributor_named():
+    """DISCRIMINATING. Union is per SHARED partition, never across all faces.
+
+    A plain `left | right` would let an arm inherit a face from a split the
+    other contributor never mentioned — the merged arm would claim to lie on a
+    side of a partition it may be entirely outside. Only splits both arms spoke
+    about survive.
+    """
+    condition = _pred("c")
+    mine, _other = partition(("mine", condition))
+    theirs, _ = partition(("theirs", condition))
+
+    merged = ExitSet(
+        (
+            Completed(condition, "same", frozenset({mine})),
+            Completed(not_(condition), "same", frozenset({theirs})),
+        )
+    ).normalize()
+
     assert merged.exits[0].faces == frozenset()
 
 


### PR DESCRIPTION
## THE PRODUCER OWNED EVIDENCE AND DID NOT SPEAK

`read_binding`'s `GuardedProjection` branch is the reader for **every**
conditionally-bound name: one value under an authenticated branch result,
another under its negation. It guarded both arms with `.guarded(guard)` /
`.guarded(not_(guard))` carrying **no face at all**, so downstream
`factor_completed` had nothing but guard SHAPE — and shape decays.

Same shape as the loop before #6375: the producer already names its routes
(`when_true` / `when_false` over `state.slot`) and simply never minted.

## WIRING IT ALONE WAS NOT ENOUGH — MEASURED, NOT ASSUMED

With the mint in place the testimony still died on the wire. `normalize` merges
two equal destinations and **intersected** their faces, so a merged arm arrived
unstamped no matter how well its producer testified. I simulated the whole path
end to end before writing either change.

So the merge rule is **completed**, not weakened:

- a split only **one** contributor named is dropped (unchanged — the other
  claims nothing there);
- a split **both** named keeps every side either could be on.

A merged arm holds wherever either contributor did, so *"on one of these sides,
and no other"* is exactly what is true. `_faces_exclusive` now asks for
**disjoint side sets** over a shared partition. With one side each — every face
a producer mints directly — that is precisely the `!=` it replaces; sets only
ever grow through a merge.

### The old assertion's reason is preserved, and now has its own arm

The law I changed said a merged arm must never claim ONE named side. It still
cannot: `{c, ¬c}` overlaps `{c}` and overlaps `{¬c}`, so it is provably apart
from **neither** contributor. That is
`test_a_merged_arm_is_not_exclusive_with_either_side_it_came_from` — without it
the union looks like a free upgrade.

`_complete_family` declines an arm carrying several sides of one origin: it is
one arm standing for several members, so it cannot fill the single member slot
the arity test counts. Family admission is unchanged for every arm a producer mints.

## MEASURED — 10 files, 900 functions, isolated rig, the ledger's own corpus pin

```
R(factoring_gaps)        12 -> 11     io/excel/_openpyxl.py:445 CLOSED
R(construction_panics)    3 ->  3
R(unnamed_exceptions)     1 ->  1
R(timeout)                0 ->  0
completed_denominator   900 -> 900
```

Every one of the 11 survivors moved `unstamped` → `stamped-not-separating`: the
testimony now **arrives at every site** and does not separate those particular
pairs. Propagation advanced everywhere; it closed where the arms were genuinely
two sides of one split.

## PERTURBED — six mutations, each firing a distinct named arm

| mutation | fires |
|---|---|
| P1 merge unions ALL faces, no shared filter | drops-a-split-only-one-named |
| P2 merge reverts to plain intersection | keeps-every-side |
| P3 exclusivity from a shared partition alone | not-exclusive-with-either-side **+** same-side-is-not-an-exclusion |
| P4 mint keyed by read site, not slot | same-slot-mints-same-partition |
| P5 both arms stamped the SAME side | opposite-sides **+** the tooth |
| P6 then arm left unstamped | stamps-both-arms **+** the tooth |

**P4 fired nothing on the first pass.** The fixture passed one `read_site` to
both reads, so the control could not see the mutation it names; `_read` takes a
real `site` now. Two further claims of mine were wrong and were corrected
against measurement rather than argued: a conjunctive prefix does **not** hide
an exclusion (`_conjuncts` flattens), and the flat 3-way family in my first
simulation is not what nested `elif` builds.

## CONSTRAINTS HELD

Nothing weakens `factor_completed`'s refusal — the three lying twins for a
producer owning no split all still pass. `_are_exclusive` is untouched and knows
nothing about disjunctions. #6311's identity memo is untouched. The mandatory
linear-growth twin passes.

Rebased onto #6392, which added `pending_contracts` to the same merge site; both
are kept.

## HARNESS

This kit's conftest gates every test on a release `sugarbin` this box may not
build, so the arms were executed through the same imports without pytest: 7/7
new, 14/14 partition testimony, 14/14 family admission, 11/11 classifier — 0
failed. The pytest run itself is unmeasured here, not green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire partition faces onto conditional binding read arms and fix merge to union sides across shared partitions
> - `read_binding` in [guarded_binding_read_sugar.py](https://github.com/TSavo/sugar/pull/6403/files#diff-aad969d839fe75c16270bb867782bac3ed239fda15da4f1faa74b3ba8b570d27) now stamps both arms of a `GuardedProjection` with partition faces keyed by the binding slot, making the two arms provably exclusive via `_faces_exclusive`.
> - A new `_merge_faces` helper in [exit_set.py](https://github.com/TSavo/sugar/pull/6403/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716) replaces the previous strict face-set intersection during same-destination merges: it retains testimony only for partitions both arms named, but unions their sides within those partitions.
> - `_faces_exclusive` is updated to treat arms as exclusive when they share a partition but carry disjoint side sets, handling multi-sided partitions correctly.
> - `_complete_family` now rejects arms that carry multiple faces for the same origin instead of silently picking one arbitrarily.
> - Behavioral Change: merged arms no longer drop testimony from shared partitions due to strict intersection; sides are unioned instead, so a merged arm carrying both sides of a partition is no longer treated as exclusive with itself.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81419e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->