### PR TITLE
With store-target binding: the as-clause IS an assignment, so Assign owns it

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1095,6 +1095,24 @@ class Node(Typed):
             self.unit, ShadowNode("Call", self.span, slots), self.reporter
         )
 
+    def _make_assign(self, target: "Node", value: "Node") -> "Node":
+        """Construct ``<target> = <value>`` as a shadow borrowing this span.
+
+        The one door for synthesizing a store: callers hand over a real target
+        node and a real value node, and ``Assign`` supplies target totality.
+        Nobody synthesizing a binding needs to learn target shapes.
+        """
+        from .backend import Child, Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (
+            ("targets", Children((_handle_of(target),))),
+            ("value", Child(_handle_of(value))),
+        )
+        return materialize(
+            self.unit, ShadowNode("Assign", self.span, slots), self.reporter
+        )
+
     def _make_attribute(self, value: "Node", attr: str) -> "Node":
         """Construct ``<value>.<attr>`` as a shadow borrowing this node's span."""
         from .backend import Child, Leaf, materialize
@@ -4605,6 +4623,72 @@ class With(Statement):
         inner = rewrite(self, items=tuple(self.items[1:]), body=tuple(self.body))
         return rewrite(self, items=(self.items[0],), body=(inner,))
 
+    def _bind_store_target(self, item) -> "With":
+        """``with M() as <store target>:`` IS ``<target> = enter_result`` first.
+
+        Python's as-clause is an ASSIGNMENT, not a name declaration. A simple
+        ``as <Name>`` is discharged by substitution (stated, no store effect,
+        the stronger discharge) and is left alone. Every OTHER target -- an
+        attribute, a subscript, a tuple, a nested or starred destructure -- is a
+        real store, and ``Assign`` is already total over exactly that target
+        set. So this node does not grow one arm per target shape: it rewrites
+        into the form ``Assign`` already owns and inherits the totality.
+
+        The store rides as the FIRST body statement, which is where Python runs
+        it: after ``__enter__`` completed, inside the block, so a store that
+        halts is a body edge and the contract's ``__exit__`` still runs over it.
+        Nothing about exit routing is special-cased -- the store is simply the
+        first thing the body does.
+
+        Restricted to ProtocolResource semantics on purpose. The EffectBoundary
+        contract refuses an as-binding outright (its projection is not
+        authenticated), and that refusal stays total; injecting a store there
+        would route a binding its contract has not admitted.
+
+        Idempotent: the rewrite only fires on a target this node did not already
+        rewrite, detected structurally by the injected store's own value being
+        this item's enter-result ObservationRef.
+        """
+        from sugar_lift_py_tests.context_manager_contract import (
+            ENTER_RESULT,
+            ProtocolResourceSemanticsV1,
+        )
+        from sugar_lift_py_tests.context_manager_resolution import (
+            ContextManagerContractRefV1,
+            SourceDerivedContextManagerRefV1,
+        )
+        from .shadow import rewrite
+
+        target = item.optional_vars
+        if target is None or target.kind == "Name":
+            return self
+        if self._generator_manager_frame(item) is not None:
+            return self
+        resolution = self._prebound_manager_resolution(item)
+        if not isinstance(
+            resolution,
+            (ContextManagerContractRefV1, SourceDerivedContextManagerRefV1),
+        ) or not isinstance(resolution.semantics, ProtocolResourceSemanticsV1):
+            return self
+
+        enter_slot = f"{item._manager_slot_id()}#enter_result"
+        if self._already_bound_store(enter_slot):
+            return self
+        store = self._make_assign(
+            target, item._make_observation_ref(enter_slot, ENTER_RESULT)
+        )
+        return rewrite(self, body=(store, *self.body))
+
+    def _already_bound_store(self, enter_slot: str) -> bool:
+        """True when this With's body already opens with its own enter store."""
+        if not self.body:
+            return False
+        head = self.body[0]
+        if head.kind != "Assign":
+            return False
+        value = head.value
+        return value.kind == "ObservationRef" and value.slot_id == enter_slot
+
     def _construct_sugar(self):
         """Build only from the pre-resolved authenticated CM contract ref.
 
@@ -4615,21 +4699,21 @@ class With(Statement):
         if len(self.items) != 1:
             return self._nest_items()._construct_sugar()
         item = self.items[0]
+        # The as-clause is Python's own ASSIGNMENT, not a name declaration, so
+        # this node does not enumerate target shapes at all:
+        #
+        # - a simple ``as <Name>`` is discharged by SUBSTITUTION -- `substitute`
+        #   rewrote the body's loads to ObservationRef(slot). Stated, no store
+        #   effect, and that is the stronger discharge, so it stays.
+        # - any other target is a real store, and `_bind_store_target` already
+        #   rewrote it into the body as `<target> = ObservationRef(slot)`, where
+        #   `Assign` supplies attribute/subscript/tuple/nested/starred totality.
+        #
+        # Either way the enter-result slot must be BOUND whenever the site names
+        # a target, which is what `binds_enter_result` (not `as_name`) decides.
         as_name = None
-        if item.optional_vars is not None:
-            # ``as <Name>`` only: substitute already rewrote loads to
-            # ObservationRef(slot). Non-Name targets stay loud.
-            if item.optional_vars.kind != "Name":
-                from .panic import UnsupportedWithBindingTarget
-
-                panic = UnsupportedWithBindingTarget(
-                    owner="With._construct_sugar",
-                    observed=f"unsupported with binding target {item.optional_vars.kind}",
-                    requested="no target or one simple Name target",
-                    fix="leave destructuring and attribute targets loud",
-                )
-                self.reporter.report_gap(self, panic)
-                raise panic
+        binds_enter_result = item.optional_vars is not None
+        if binds_enter_result and item.optional_vars.kind == "Name":
             as_name = item.optional_vars.id
 
         generator_manager = self._generator_manager_sugar(item)
@@ -4640,7 +4724,7 @@ class With(Statement):
 
             enter_slot = (
                 f"{item._manager_slot_id()}#enter_result"
-                if as_name is not None
+                if binds_enter_result
                 else None
             )
             return GeneratorWithSugar(
@@ -4672,7 +4756,7 @@ class With(Statement):
 
                 manager_slot = item._manager_slot_id()
                 enter_slot = (
-                    f"{manager_slot}#enter_result" if as_name is not None else None
+                    f"{manager_slot}#enter_result" if binds_enter_result else None
                 )
                 return WithSourceResourceSugar(
                     manager=item.context_expr.sugar(),
@@ -4699,6 +4783,31 @@ class With(Statement):
                     observation_slot = self._effect_boundary_observation_slot(
                         item, resolved_ref
                     )
+                elif binds_enter_result:
+                    # A STORE target on an EffectBoundary. #6391 authenticated an
+                    # observation slot for a NAME; it did not authenticate a
+                    # store, and `_bind_store_target` deliberately declines to
+                    # rewrite this contract. Without this arm the binding would
+                    # silently become `observation_slot = None` -- the site would
+                    # construct while dropping the binding the source wrote.
+                    # Stay loud instead; a dropped binding is the one outcome
+                    # neither contract admits.
+                    from .panic import UnsupportedWithBindingTarget
+
+                    panic = UnsupportedWithBindingTarget(
+                        owner="With._construct_sugar",
+                        observed=(
+                            "EffectBoundary as-binding to a "
+                            f"{item.optional_vars.kind} store target"
+                        ),
+                        requested="an EffectBoundary manager bound to a simple Name, or no target",
+                        fix=(
+                            "authenticate a store projection for this contract, or "
+                            "keep the store target loud -- never drop the binding"
+                        ),
+                    )
+                    self.reporter.report_gap(self, panic)
+                    raise panic
                 manager_sugar = item.context_expr.sugar()
                 manager_sugar = self._authenticate_expected_exception_type(
                     item.context_expr, manager_sugar, resolved_ref
@@ -4728,7 +4837,9 @@ class With(Statement):
                 )
 
             manager_slot = item._manager_slot_id()
-            enter_slot = f"{manager_slot}#enter_result" if as_name is not None else None
+            enter_slot = (
+                f"{manager_slot}#enter_result" if binds_enter_result else None
+            )
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
@@ -4846,6 +4957,17 @@ class With(Statement):
             if len(items) != 1:
                 return self if not changed else rewrite(self, **changed)
             item = items[0]
+            if item.optional_vars is not None and item.optional_vars.kind != "Name":
+                # A store target is normalized into `<target> = enter_result` as
+                # the first body statement BEFORE the body is substituted, so
+                # the store threads its own bindings to the rest of the block
+                # through the ordinary assignment seam. Substituting first and
+                # injecting after would resolve the block's loads against the
+                # OUTER scope and silently shadow the names this site binds.
+                current = self if not changed else rewrite(self, **changed)
+                bound = current._bind_store_target(item)
+                if bound is not current:
+                    return bound.substitute(scope)
             if item.optional_vars is not None and item.optional_vars.kind == "Name":
                 if self._generator_manager_frame(item) is None:
                     self._require_narrow_cm_ref(item)

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -384,13 +384,22 @@ def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
         next(source.functions()).sugar()
 
 
-def test_multiple_items_nest_and_non_name_binding_stays_typed_loud(tmp_path):
+def test_multiple_items_nest_and_store_binding_target_constructs(tmp_path):
     """Multi-item With is no longer a gap: it nests into single-item Withs.
 
     ``MultipleContextManagerItems`` was the shell that watched this; it is
     deleted, because the illegal shape (a multi-manager With reaching the
     resource router) is now unconstructable — construction rewrites it into
-    Python's own nested spelling first. Non-Name binding targets stay loud.
+    Python's own nested spelling first.
+
+    The non-Name binding half of this test used to assert
+    ``UnsupportedWithBindingTarget``. That refusal is retired for authenticated
+    ProtocolResource sites: the as-clause is Python's own assignment, so
+    ``With._bind_store_target`` rewrites a store target into
+    ``<target> = ObservationRef(enter_slot)`` as the first body statement and
+    inherits ``Assign``'s target totality. The law is now owned in full by
+    ``test_with_store_binding_target.py``; this arm keeps the nesting law and
+    pins that the two rewrites compose.
     """
     from sugar_lift_python_source.source_oracle import path_source
 
@@ -428,13 +437,30 @@ def test_multiple_items_nest_and_non_name_binding_stays_typed_loud(tmp_path):
     assert len(chain) == 2
     assert chain[1] in chain[0].body
 
+    # Both rewrites compose: two managers nest, and the inner one's store
+    # target becomes an ordinary assignment at the head of its body.
     target = tmp_path / "target.py"
     target.write_text(
         "from dependency import manager\n"
         "def f():\n"
-        "    with manager() as (left, right):\n"
+        "    with manager(), manager() as (left, right):\n"
         "        pass\n"
     )
-    with pytest.raises(SugarNotWritten) as caught:
-        _function_sugar(path_source(str(target)), _resolved)
-    assert type(caught.value).__name__ == "UnsupportedWithBindingTarget"
+    probe = SourceFile(path_source(str(target)))
+    node = next(n for n in probe.nodes() if n.kind == "With")
+    rows = {
+        _coordinate(item.context_expr): _resolved(_coordinate(item.context_expr))
+        for item in node.items
+    }
+    composed = SourceFile(
+        path_source(str(target)),
+        construction_context=TreeConstructionContextV1(
+            ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+        ),
+    )
+    chain = []
+    _walk(next(composed.functions()).sugar())
+    outer, inner = chain[0], chain[1]
+    assert inner in outer.body
+    assert outer.enter_slot_id is None, "the outer manager names no target"
+    assert inner.enter_slot_id == f"{inner.manager_slot_id}#enter_result"

--- a/implementations/python/sugar-source-tree/tests/test_with_store_binding_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_store_binding_target.py
@@ -1,0 +1,366 @@
+"""``with M() as <store target>:`` — the as-clause is Python's own assignment.
+
+Two shapes, both taken from real corpus sites and renamed:
+
+    with get_handle(...) as self.handles:          # Attribute store target
+    with builder.if_else(cond) as (yes, no):       # Tuple destructure target
+
+Both used to be one hard `UnsupportedWithBindingTarget` refusal whose fix line
+read "leave destructuring and attribute targets loud". They are not a second
+binding mechanism: Python's as-clause IS an assignment, and `Assign` is already
+total over attribute / subscript / tuple / nested / starred targets. So the
+capability is a REWRITE, not a new arm — `With._bind_store_target` normalizes
+the site into `<target> = ObservationRef(enter_slot)` as the first body
+statement and inherits `Assign`'s totality. The With node stops knowing about
+target shapes entirely.
+
+What deliberately did NOT change:
+
+- ``as <Name>`` still discharges by SUBSTITUTION (loads rewritten to
+  ObservationRef), which is the stronger stated discharge. It is not routed
+  through a store.
+- The EffectBoundary contract still refuses ANY as-binding. Its projection is
+  not authenticated, and the refusal is now total over every target shape
+  rather than over Name targets only.
+- A site whose manager never resolved to a ProtocolResource contract is not
+  rewritten and stays exactly as loud as it was.
+
+Each law carries a truthful twin and a lying twin.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    EnterResultContractV1,
+    ExceptionInfoBindingV1,
+    ExitContractV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    NeverSuppressesDispositionV1,
+    NoDefaultV1,
+    OptionalFormalArgumentProjectionV1,
+    PositionalOrKeywordV1,
+    ProtocolResourceSemanticsV1,
+    RaiseEffectKindV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ImportSignatureV2,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import UnsupportedWithBindingTarget
+from sugar_source_tree.tree import SourceFile
+
+# ---------------------------------------------------------------- tree fixture
+
+
+def _cid(char: str) -> str:
+    return "blake3-512:" + char * 128
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _base_ref(use_site, *, signature, semantics) -> ContextManagerContractRefV1:
+    return ContextManagerContractRefV1(
+        resolution_cid=_cid("r"),
+        demand_cid=_cid("d"),
+        use_site=use_site,
+        use_site_cid=_hash_json(use_site.wire()),
+        authenticated_import_use_cid=_cid("u"),
+        import_binding_cid=_cid("i"),
+        construction_context_generation_cid=_cid("g"),
+        contract_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        provenance_cid=_cid("v"),
+        distribution_artifact_cid=_cid("a"),
+        dependency_artifact_graph_cid=_cid("b"),
+        module_source_cid=_cid("s"),
+        resolved_definition_cid=_cid("f"),
+        manager_construction_cid=_cid("n"),
+        enter_testimony_cid=_cid("1"),
+        exit_testimony_cid=_cid("2"),
+        import_signature=signature,
+        semantics=semantics,
+    )
+
+
+def _resource_ref(use_site) -> ContextManagerContractRefV1:
+    return _base_ref(
+        use_site,
+        signature=ImportSignatureV2(()),
+        semantics=ProtocolResourceSemanticsV1(
+            enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+            exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+        ),
+    )
+
+
+def _boundary_ref(use_site) -> ContextManagerContractRefV1:
+    return _base_ref(
+        use_site,
+        signature=ImportSignatureV2(
+            (
+                CallParameterV1(
+                    "expected_exception",
+                    PrimitiveSort("Value"),
+                    PositionalOrKeywordV1(),
+                    True,
+                    NoDefaultV1(),
+                ),
+            )
+        ),
+        semantics=EffectBoundarySemanticsV1(
+            ExpectsModeV1(),
+            RaiseEffectKindV1(),
+            FormalArgumentProjectionV1(0),
+            OptionalFormalArgumentProjectionV1(0),
+            ExceptionInfoBindingV1(),
+        ),
+    )
+
+
+def _function_sugar(tmp_path, source: str, *, ref=_resource_ref, name="f"):
+    path = tmp_path / "store_target.py"
+    path.write_text(source, encoding="utf-8")
+    identity = path_source(str(path))
+    probe = SourceFile(identity)
+    rows = {}
+    for node in probe.nodes():
+        if node.kind != "With":
+            continue
+        for item in node.items:
+            coordinate = _coordinate(item.context_expr)
+            rows[coordinate] = ref(coordinate)
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+    )
+    source_file = SourceFile(identity, construction_context=context)
+    for fn in source_file.functions():
+        if fn.name == name:
+            return fn.sugar()
+    raise AssertionError(f"no function {name}")
+
+
+def _resource_of(sugar):
+    found = []
+
+    def walk(node):
+        if isinstance(node, WithResourceSugar):
+            found.append(node)
+        for field in ("body", "statements", "entries"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return found
+
+
+HEADER = "from dependency import manager\n"
+
+# Renamed from the real corpus attribute-target site.
+ATTRIBUTE_TARGET = HEADER + (
+    "def f(self):\n"
+    "    with manager() as self.handles:\n"
+    "        return self.handles\n"
+)
+
+# Renamed from the real corpus tuple-destructure site.
+TUPLE_TARGET = HEADER + (
+    "def f():\n"
+    "    with manager() as (yes, no):\n"
+    "        return yes\n"
+)
+
+NAME_TARGET = HEADER + (
+    "def f():\n"
+    "    with manager() as entered:\n"
+    "        return entered\n"
+)
+
+NO_TARGET = HEADER + ("def f():\n    with manager():\n        return 1\n")
+
+
+# ------------------------------------------------- LAW: attribute store target
+
+
+def test_attribute_target_constructs_instead_of_refusing(tmp_path):
+    """TRUTHFUL: the real `as self.handles` shape now constructs."""
+    resources = _resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))
+    assert len(resources) == 1, f"expected one resource with, got {len(resources)}"
+
+
+def test_lying_attribute_target_is_not_silently_dropped(tmp_path):
+    """LYING: constructing must not mean the store vanished.
+
+    The enter-result slot MUST be bound — an attribute store whose RHS is an
+    unbound slot would be a fabricated binding. Assert the slot is absent and
+    show that fails.
+    """
+    resource = _resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))[0]
+    with pytest.raises(AssertionError):
+        assert resource.enter_slot_id is None, "a bound target must bind its slot"
+
+
+def test_attribute_target_binds_the_enter_result_slot(tmp_path):
+    """LAW: the store's RHS is the authenticated enter-result projection."""
+    resource = _resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))[0]
+    assert resource.enter_slot_id == f"{resource.manager_slot_id}#enter_result"
+
+
+# ---------------------------------------------------- LAW: tuple destructure
+
+
+def test_tuple_target_constructs_instead_of_refusing(tmp_path):
+    """TRUTHFUL: the real `as (yes, no)` shape now constructs."""
+    resources = _resource_of(_function_sugar(tmp_path, TUPLE_TARGET))
+    assert len(resources) == 1, f"expected one resource with, got {len(resources)}"
+
+
+def test_tuple_target_binds_the_enter_result_slot(tmp_path):
+    """LAW: a destructure binds the same one slot; elements project from it."""
+    resource = _resource_of(_function_sugar(tmp_path, TUPLE_TARGET))[0]
+    assert resource.enter_slot_id == f"{resource.manager_slot_id}#enter_result"
+
+
+def test_lying_tuple_target_does_not_bind_a_second_manager(tmp_path):
+    """LYING: a destructure is ONE manager, not one per element.
+
+    A rewrite that treated the tuple as multiple items would build two
+    resources. Exact cardinality — `!= 1` is satisfied by 0 and by 2.
+    """
+    resources = _resource_of(_function_sugar(tmp_path, TUPLE_TARGET))
+    with pytest.raises(AssertionError):
+        assert len(resources) == 2, "a destructure must not multiply the manager"
+
+
+# ------------------------------ LAW: the store is the FIRST body statement
+
+
+def test_store_runs_inside_the_block_as_the_first_body_statement(tmp_path):
+    """LAW: the store lands where Python runs it — after `__enter__`, inside
+    the block — so a halting store is a body edge the contract's `__exit__`
+    still covers. The body is therefore LONGER than the source body."""
+    stored = _resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))[0]
+    plain = _resource_of(_function_sugar(tmp_path, NAME_TARGET))[0]
+    assert len(stored.body) == len(plain.body) + 1
+
+
+def test_lying_store_is_not_hoisted_out_of_the_block(tmp_path):
+    """LYING: hoisting the store outside the With would leave the body the same
+    length as the substituted Name case. Assert that and show it fails."""
+    stored = _resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))[0]
+    plain = _resource_of(_function_sugar(tmp_path, NAME_TARGET))[0]
+    with pytest.raises(AssertionError):
+        assert len(stored.body) == len(plain.body)
+
+
+# --------------------------------- LAW: the Name path is NOT routed to a store
+
+
+def test_name_target_still_discharges_by_substitution(tmp_path):
+    """LAW: `as <Name>` keeps the STRONGER stated discharge — no store injected.
+
+    This is the non-regression that matters most: the overwhelming majority of
+    corpus as-bindings are simple names, and routing them through a store would
+    trade a stated binding for a derived one.
+    """
+    plain = _resource_of(_function_sugar(tmp_path, NAME_TARGET))[0]
+    bare = _resource_of(_function_sugar(tmp_path, NO_TARGET))[0]
+    assert len(plain.body) == len(bare.body), "a Name target must inject no store"
+    assert plain.enter_slot_id is not None
+    assert bare.enter_slot_id is None
+
+
+def test_lying_name_path_is_not_vacuous(tmp_path):
+    """LYING: the equality above would fail against a shape that DOES store."""
+    stored = _resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))[0]
+    bare = _resource_of(_function_sugar(tmp_path, NO_TARGET))[0]
+    with pytest.raises(AssertionError):
+        assert len(stored.body) == len(bare.body)
+
+
+# ------------------------- LAW: the EffectBoundary refusal stays TOTAL
+
+
+def test_effect_boundary_refuses_a_store_target(tmp_path):
+    """LAW: widening the resource arm must not widen the assertion arm.
+
+    #6391 authenticated an EffectBoundary observation slot for a NAME binding.
+    It did not authenticate a STORE, and `_bind_store_target` deliberately
+    declines to rewrite this contract. So a store target here must stay loud.
+
+    Without the paired production arm this is exactly where a binding would be
+    silently DROPPED: `as_name` is None for a store target, so the slot would
+    quietly resolve to None and the site would construct having thrown away the
+    binding the source wrote. A dropped binding is the one outcome neither
+    contract admits.
+    """
+    with pytest.raises(UnsupportedWithBindingTarget):
+        _function_sugar(tmp_path, ATTRIBUTE_TARGET, ref=_boundary_ref)
+
+
+def test_effect_boundary_admits_a_name_target_through_its_observation_slot(tmp_path):
+    """LAW (#6391, milestone #2's): a NAME binding IS admitted here.
+
+    This arm used to assert a refusal. That refusal was retired when the
+    contract's observation projection became authenticated, so the twin is
+    retargeted rather than deleted — it now pins that the resource-side change
+    did NOT regress the assertion side's new capability.
+    """
+    _function_sugar(tmp_path, NAME_TARGET, ref=_boundary_ref)
+
+
+def test_lying_effect_boundary_refusal_is_not_unconditional(tmp_path):
+    """LYING: the refusal above is caused by the STORE TARGET, not the contract.
+
+    Same boundary contract, no as-clause, constructs fine.
+    """
+    _function_sugar(tmp_path, NO_TARGET, ref=_boundary_ref)
+
+
+# --------------------------------------- LAW: unresolved managers stay loud
+
+
+def test_unresolved_store_target_is_not_admitted_by_the_rewrite(tmp_path):
+    """LAW: the rewrite is not an admission door.
+
+    With no resolution table row, the site must stay typed-loud exactly as it
+    did before — the rewrite fires only for an authenticated ProtocolResource.
+    """
+    path = tmp_path / "unresolved.py"
+    path.write_text(ATTRIBUTE_TARGET, encoding="utf-8")
+    identity = path_source(str(path))
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType({}))
+    )
+    source_file = SourceFile(identity, construction_context=context)
+    from sugar_source_tree.panic import SourceTreePanic
+
+    with pytest.raises(SourceTreePanic):
+        next(fn for fn in source_file.functions() if fn.name == "f").sugar()
+
+
+def test_lying_unresolved_case_is_not_failing_for_an_unrelated_reason(tmp_path):
+    """LYING: the same source WITH a resolution row constructs."""
+    assert len(_resource_of(_function_sugar(tmp_path, ATTRIBUTE_TARGET))) == 1


### PR DESCRIPTION
## The reproducer

`with M() as <target>:` refused every non-Name target with
`UnsupportedWithBindingTarget`, whose own fix line read *"leave destructuring
and attribute targets loud"*. Both real corpus shapes were sitting behind it —
these are the only two non-Name as-targets in pandas 3.0.3:

```
io/stata.py:2885             with get_handle(...) as self.handles:
core/_numba/extensions.py:358  with builder.if_else(c) as (has_parent, otherwise):
```

## The general mechanism

Python's as-clause is an **assignment**, not a name declaration. `Assign` is
already total over attribute / subscript / tuple / nested / starred targets. So
this is a **rewrite, not a new arm**: `With._bind_store_target` normalizes the
site into `<target> = ObservationRef(enter_slot)` as the first body statement
and inherits that totality. The With node stops knowing about target shapes
entirely — it does not gain one arm per shape.

The door did not widen. The evidence moved to where the law already was.

The store lands as the **first body statement** because that is where Python
runs it — after `__enter__` completed, inside the block — so a store that halts
is an ordinary body edge and the contract's `__exit__` still runs over it. Exit
routing is untouched; `and_exit` never learns this happened.

Injection happens at **substitute time, before the body is substituted**, so the
store threads its bindings through the ordinary assignment seam. Injecting after
substitution would resolve the block's loads against the outer scope and
silently shadow the names the site binds.

### Deliberately unchanged

- **`as <Name>` still discharges by substitution.** Stated beats derived, and
  686 of the 688 corpus as-bindings are simple names. They are not routed
  through a store, and a twin pins that they inject nothing.
- **EffectBoundary still refuses ANY as-binding.** Its projection is
  unauthenticated. The guard moved from `as_name is not None` to
  `binds_enter_result`, so the refusal is now total over the non-Name shapes
  too — without that edit, killing `as_name` for those shapes would have let
  them slip past milestone #2's refusal. Two twins pin both faces.
- **An unresolved manager is not rewritten.** The rewrite fires only for an
  authenticated `ProtocolResource`, so it is not an admission door. No manager
  name, vendor spelling, or contract kind reaches production.

## Gate

**Real reproducer** — two, both from corpus, measured below.

**Truthful + lying twins** — new `test_with_store_binding_target.py`, 15 tests.
**10 of them go red at `e0350dc43`** with the exact
`UnsupportedWithBindingTarget` refusal; the 5 that pass both sides are the
non-regression guards (Name path, EffectBoundary refusal), which is what they
are for.

**Focused owning-package tests** — full `sugar-source-tree` suite:
**696 passed, 1 failed, 5 skipped.** The one failure,
`test_with_partition_shared_algebra::test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`,
is inherited — verified red at `e0350dc43` with this change stashed.

**No increase in crash/timeout axes** — measured, below.

## Site coverage and ΔR, separately

Both real files run through `control_effect_recensus.py` at `e0350dc43` and at
this commit (`--corpus-version 3.0.3`):

| axis | baseline | head |
|---|---:|---:|
| `R_construction` | 5 | **5** |
| `R_construction_panics` | 0 | **0** |
| `R_desugar_defects` | 0 | **0** |
| `R_backend_defects` | 0 | **0** |
| `R_desugar` | 196 | **196** |
| `functionsConstructClean` | 177 / 183 | **177 / 183** |

```
families  base: {ContextManagerResolutionConstructionGap: 2, SugarNotWritten: 2, UnsupportedWithBindingTarget: 1}
families  head: {ContextManagerResolutionConstructionGap: 3, SugarNotWritten: 2}
```

- **site coverage: +2.** Both non-Name as-target shapes in pandas now construct
  when their manager is authenticated. That is the whole non-Name as-target
  population of the corpus.
- **ΔR: 0.** No residual disappeared, and **no axis increased**.

The honest reading is in the families line: `UnsupportedWithBindingTarget` **1 →
0**, `ContextManagerResolutionConstructionGap` **2 → 3**. The site did not go
green — it moved from *"we refuse this shape"* to *"this manager was never
authenticated"*, which is the correct classification and puts it behind the same
single wall as every other With in the corpus. A shape-refusal became an
evidence-gap.

*Caveat, stated because it bit me before:* this is a 2-file directory corpus, so
`workspace_root` is that directory and the demand table is built from those two
files, not from pandas. The **paired** reading is valid (identical harness both
sides); the **absolutes** are not comparable to a full-corpus run and must not be
differenced against one.

## Which shell this deletes

`UnsupportedWithBindingTarget` is now unreachable from the resource arm — it
survives only as milestone #2's EffectBoundary refusal. It cannot be deleted
outright until that contract authenticates its binding projection; when it does,
the class goes with it. Named, not done.

The rung climbed is better than a test: the With node no longer branches on
target kind at all, so "a target shape With forgot to handle" stopped being a
thing that can exist. New target shapes are `Assign`'s problem, and `Assign`
already has a compiler-shaped answer for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow non-Name `as`-clause targets in `with` statements by injecting a leading `Assign` in the body
> - For `ProtocolResource` semantics, non-Name `as`-clause targets (attributes, subscripts, tuples, destructures) now construct successfully by injecting an `Assign` as the first statement in the `with` body, storing the authenticated `enter_result` into the original target.
> - `Name` targets continue to discharge by substitution with no injected store.
> - `EffectBoundary` semantics still reject non-Name `as`-bindings with `UnsupportedWithBindingTarget`.
> - A new `Node._make_assign` helper synthesizes single-target `Assign` nodes, and idempotency guards prevent duplicate injection on repeated sugar construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e264952.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->