### PR TITLE
Part of #6382 — guarded owner remeasure: 28 to 0

### DIFF
--- a/docs/ledgers/python-guarded-owner-remeasure-b06290a69.json
+++ b/docs/ledgers/python-guarded-owner-remeasure-b06290a69.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "1",
+  "issue": 6382,
+  "lane": "L3",
+  "owner": "guarded",
+  "historicalBoard": "docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json",
+  "historicalBoardCommit": "9a78828ee",
+  "historicalR": 25,
+  "historicalUniqueFiles": 18,
+  "corpus": {
+    "distribution": "pandas",
+    "version": "3.0.3",
+    "root": "/home/tsavo/pandas303-audit/pandas",
+    "pin": "docs/ledgers/pins/pandas-3.0.3.pin.json"
+  },
+  "measurement": {
+    "door": "control_effect_recensus._measure_file",
+    "context": "one provisional contract-ref table derived from the full corpus root; one fresh construction context per measured file",
+    "selection": "unique files containing the historical guarded occurrences",
+    "files": [
+      "_testing/asserters.py",
+      "core/array_algos/masked_reductions.py",
+      "core/array_algos/replace.py",
+      "core/arrays/_ranges.py",
+      "core/arrays/arrow/extension_types.py",
+      "core/dtypes/dtypes.py",
+      "core/internals/construction.py",
+      "core/reshape/concat.py",
+      "core/strings/object_array.py",
+      "io/formats/style_render.py",
+      "io/parsers/base_parser.py",
+      "io/stata.py",
+      "plotting/_matplotlib/core.py",
+      "tests/frame/methods/test_quantile.py",
+      "tests/groupby/methods/test_value_counts.py",
+      "tests/groupby/test_groupby.py",
+      "tests/indexes/multi/test_integrity.py",
+      "tests/indexes/test_old_base.py"
+    ]
+  },
+  "before": {
+    "commit": "fb853d301",
+    "R_guarded": 28,
+    "note": "Live whole-file owner rows over the 18 unique historical-candidate files; three additional live occurrences were present beyond the stale 25-row board."
+  },
+  "intermediate": {
+    "commit": "2cb33f88a",
+    "R_guarded": 1,
+    "survivor": {
+      "where": "tests/groupby/methods/test_value_counts.py:283:0",
+      "observed": "GuardedValue"
+    }
+  },
+  "after": {
+    "commit": "b06290a69",
+    "R_guarded": 0,
+    "liveRows": [],
+    "allOwnerCountsInCandidateFiles": {
+      "add": 2,
+      "attribute": 2,
+      "bitwise_or": 1,
+      "RaiseValue.to_term": 1,
+      "multiply": 3,
+      "subtract": 1,
+      "truth": 1
+    },
+    "reattributedHistoricalCoordinates": [
+      {
+        "where": "core/arrays/_ranges.py:31:0",
+        "owner": "add",
+        "observed": "NoneValue",
+        "requested": "stand on the addition floor for a CallSiteValue right operand"
+      }
+    ]
+  },
+  "deltaR_guarded": -28,
+  "epsilonR_guarded": 0,
+  "constructionFloors": {
+    "sideDoor": {
+      "R": 0,
+      "auditorErrors": 0
+    },
+    "panicCatch": {
+      "originMainR": 4,
+      "headR": 4,
+      "deltaR": 0,
+      "auditorErrors": 0,
+      "inheritedLoci": [
+        "scripts/desugar_repro.py:44",
+        "scripts/exit_set_arm_census.py:348",
+        "scripts/stablezero_classify.py:168",
+        "scripts/stablezero_classify.py:171"
+      ]
+    }
+  },
+  "residualPinned": false
+}


### PR DESCRIPTION
## Part of #6382 — Lane L3 (`guarded`)

This PR banks the authenticated owner-only measurement after the general Floor law and twins landed in #6390. #6390 was merged externally while the final measurement was running; this follow-up contains only the measured receipt and is intentionally left unmerged.

## Measured owner delta

- Historical board candidate: `guarded = 25` across 18 unique files.
- Live before at HEAD, same 18-file denominator: `R_guarded = 28`.
- Intermediate after pure carriers and `BlockValue`: `R_guarded = 1`, exposing `GuardedValue`.
- Final on current merged main: `R_guarded = 0`.
- Honest `Delta R_guarded = -28`; `Epsilon R_guarded = 0`.
- One historical coordinate reattributes to the different named owner `add`; it is not pinned or drained here.

The receipt uses the authoritative control-effect `_measure_file` door with one provisional contract-ref table derived from the full pandas 3.0.3 corpus root and a fresh construction context per file. No residual count is accepted as baseline.

## General law already landed in #6390

- Explicit `GuardStableValue` opt-in category for pure constructed carriers.
- `BlockValue.guarded` maps the guard through each statement owner.
- Unknown Floor values remain loud; `InvValue` still weakens obligations to implications.
- Truthful and lying twins cover identity, block mapping, obligation weakening, and unknown-value panic.

## Verification

- Same-owner remeasure: `R_guarded = 0` over 18/18 unique candidate files.
- Guarded-related focused suite: `132 passed, 1 deselected`.
- The deselected test is an inherited stale #6392 expectation that still expects the now-implemented pending-demand ExitSet arm to panic; this branch changes only the JSON receipt.
- Construction side-door: `R = 0`, auditor errors 0.
- Construction panic-catch: inherited `origin/main 4 -> head 4`, `Delta R = 0`, auditor errors 0; all four untouched loci are named in the receipt.

## Scope

Receipt only. No `ground_index_error`, `and_then`, `IfExp`, collection demand-SET, site/name arm, or pin. Do not merge automatically.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guarded-owner remeasure ledger reducing `R_guarded` from 28 to 0
> Adds a JSON ledger file at [python-guarded-owner-remeasure-b06290a69.json](https://github.com/TSavo/sugar/pull/6405/files#diff-f7c70d165fc057ba7ebe6f8805cf7532ff42a0c6eae243ac3a0804656c72ed46) documenting the elimination of all 28 guarded-owner occurrences across three commits, ending at zero residual with a reattributed coordinate in `core/arrays/_ranges.py`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10db7a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a ledger record documenting a guarded ownership re-measurement for issue 6382.
  * Captured measurement inputs, historical ownership counts, intermediate survivor results, attribution deltas, and construction-floor outcomes.
  * Recorded the final result showing guarded ownership reduced from 28 to 0, including any remaining pinned state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->