### PR TITLE
opaque-call-target: kind beside symbol, and the four mechanisms it was hiding (#6371)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -89,8 +89,9 @@ class ContextManagerResolutionGapV1:
     ``kind`` is the STRUCTURAL key and nothing else -- a member of the closed
     vocabulary in :func:`_gap_kinds`.  It never contains a symbol.  The
     derivation layer used to fuse ``f"{kind}:{detail}"`` into this field, which
-    made 89.3% of the pinned-pandas resolution board keyed by a vendor spelling
-    and produced, in process, a gap this module's own decoder would refuse.
+    put most of the pinned-pandas resolution board's mass under a vendor spelling
+    (#6371) and produced, in process, a gap this module's own decoder would
+    refuse.
 
     ``target_symbol`` and ``detail`` are DATA: they ride the row for a human
     reading one row, and are never a bucket key.  A measurement a vendor rename

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -84,11 +84,27 @@ class ContextManagerContractRefV1:
 
 @dataclass(frozen=True)
 class ContextManagerResolutionGapV1:
+    """One unresolved context-manager demand: a structural kind beside its data.
+
+    ``kind`` is the STRUCTURAL key and nothing else -- a member of the closed
+    vocabulary in :func:`_gap_kinds`.  It never contains a symbol.  The
+    derivation layer used to fuse ``f"{kind}:{detail}"`` into this field, which
+    made 89.3% of the pinned-pandas resolution board keyed by a vendor spelling
+    and produced, in process, a gap this module's own decoder would refuse.
+
+    ``target_symbol`` and ``detail`` are DATA: they ride the row for a human
+    reading one row, and are never a bucket key.  A measurement a vendor rename
+    can move is not a measurement.
+    """
+
     demand_cid: str
     use_site: SourceFragmentCoordinateV1
     target_symbol: str | None
     kind: str
     candidate_member_cids: tuple[str, ...]
+    # In-process only.  Not read from or written to the wire, so no preimage
+    # and no CID changes: the authenticated table hashes the bytes present.
+    detail: str | None = None
 
 
 ContextManagerResolutionV1 = ContextManagerContractRefV1 | ContextManagerResolutionGapV1
@@ -181,20 +197,27 @@ class TreeConstructionContextV1:
         )
 
 
-_GAP_KINDS = frozenset(
-    {
-        "runtime-selected",
-        "unresolved-symbol",
-        "ambiguous-symbol",
-        "wrong-contract-kind",
-        "signature-mismatch",
-        "unauthenticated-member",
-        "payload-cid-mismatch",
-        "unsupported-cm-schema",
-        "no-derived-contract",
-        "stale-derived-contract",
-    }
-)
+def _gap_kinds() -> frozenset[str]:
+    """The closed resolution-gap vocabulary, read from its ONE owner.
+
+    This used to be a second hand-maintained copy of ten members, and it drifted:
+    the source-derived path minted fused ``kind:detail`` strings that this very
+    decoder would have refused as ``malformed context-manager resolution gap``.
+    Two lists cannot disagree if there is only one list, so the members come
+    from :class:`WithConstructionGapKind`, which the producers' own typed
+    ``Literal``s are declared against.
+
+    Imported lazily: ``sugar_source_tree`` depends on this module.
+    """
+    from sugar_source_tree.panic import WithConstructionGapKind
+
+    return frozenset(
+        member.value
+        for member in WithConstructionGapKind
+        # The catch-all is a READER's fallback for a kind this build does not
+        # name; no producer may emit it as a gap kind of its own.
+        if member is not WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND
+    )
 
 
 def _cid(value: Any, field: str) -> str:
@@ -343,7 +366,7 @@ def decode_resolved_contract_refs(raw: Any) -> ResolvedContractRefsV1:
             "gap",
         }:
             gap = resolution["gap"]
-            if not isinstance(gap, dict) or gap.get("kind") not in _GAP_KINDS:
+            if not isinstance(gap, dict) or gap.get("kind") not in _gap_kinds():
                 raise ContractRefProtocolError(
                     "malformed context-manager resolution gap"
                 )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
@@ -47,7 +47,13 @@ class SourceCallPreconstructionGapV1:
         "artifact-mismatch",
         "definition-missing",
         "source-body-gap",
-        "opaque-call-target",
+        # The four conditions `opaque-call-target` used to fuse; these ride
+        # straight off `ManagerConstructionGapV1.kind`, which owns their
+        # definitions.
+        "call-graph-cycle",
+        "value-call-target",
+        "call-target-source-absent",
+        "call-target-export-unresolved",
         "non-manager-result",
         "call-binding",
         "dynamic-call-target",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -18,7 +18,25 @@ from sugar_source_tree.binding_provenance import (
     ConstructedValueTestimonyV1,
 )
 from sugar_source_tree.binding_state import BindingEntryV1
-from sugar_source_tree.nodes import Call, ClassDef, FunctionDef, Name, Node
+from sugar_source_tree.nodes import (
+    AnnAssign,
+    Assign,
+    AugAssign,
+    Call,
+    ClassDef,
+    ExceptHandler,
+    For,
+    FunctionDef,
+    Import,
+    ImportFrom,
+    List,
+    Name,
+    NamedExpr,
+    Node,
+    Starred,
+    Tuple_,
+    With,
+)
 from sugar_source_tree.tree import SourceFile
 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
@@ -92,12 +110,62 @@ class ConstructedManagerBehaviorV1:
             raise ValueError("source call frame CID mismatch")
 
 
+# The four conditions that ``opaque-call-target`` used to fuse into one name.
+#
+# ``opaque-call-target`` named a *symptom* -- "construction could not see through
+# this call" -- and four structurally different conditions arrived under it, three
+# of them carrying a callee spelling as their detail.  Each is decided here by a
+# condition construction already evaluates; none reads a name table.
+#
+# ``call-graph-cycle``
+#     Re-entry of a frame already being projected, a returned-callsite cycle, or a
+#     fixpoint that stops making progress.  Carries NO symbol.  The fix is a cycle
+#     policy.
+# ``value-call-target``
+#     The callee is bound by the enclosing definition itself -- a parameter or a
+#     local -- so it is a runtime VALUE.  Higher-order dispatch.  No export lookup
+#     can ever resolve it, because there is nothing to look up.  The fix is a
+#     capability, not coverage.
+# ``call-target-source-absent``
+#     The authenticated export door declined the name: no defining source for it
+#     inside this distribution artifact.  An artifact-COVERAGE gap.
+# ``call-target-export-unresolved``
+#     The export door DID authenticate an object in this artifact, but projecting
+#     its frame failed.  A defect in the door, not a coverage gap -- and invisible
+#     for as long as it shares a bucket with the other three.
+
+_CALL_TARGET_GAP_PRECEDENCE = (
+    "call-graph-cycle",
+    "value-call-target",
+    "call-target-export-unresolved",
+    "call-target-source-absent",
+)
+
+# The closed set the fused `opaque-call-target` key was hiding.  Exported so a
+# control can name the vocabulary instead of keeping a second copy of it.
+CALL_TARGET_GAP_KINDS = frozenset(_CALL_TARGET_GAP_PRECEDENCE)
+
+
+@dataclass(frozen=True)
+class _ExternalCallTargetGap:
+    """Why the one authenticated export door declined a free callee name."""
+
+    kind: Literal[
+        "call-target-source-absent",
+        "call-target-export-unresolved",
+        "call-graph-cycle",
+    ]
+
+
 @dataclass(frozen=True)
 class ManagerConstructionGapV1:
     kind: Literal[
         "artifact-mismatch",
         "definition-missing",
-        "opaque-call-target",
+        "call-graph-cycle",
+        "value-call-target",
+        "call-target-source-absent",
+        "call-target-export-unresolved",
         "non-manager-result",
         "call-binding",
         "force-floor",
@@ -211,7 +279,7 @@ def construct_manager_behavior(
                 break
             if id(returned) in seen_calls:
                 return ManagerConstructionGapV1(
-                    "opaque-call-target", resolved.cid, "recursive source call graph"
+                    "call-graph-cycle", resolved.cid, "recursive source call graph"
                 )
             seen_calls.add(id(returned))
             result = returned.force_floor(
@@ -311,7 +379,7 @@ def resolve_source_visible_frame(
         # memoized: the cycle is a property of this traversal, not of this
         # definition.
         return ManagerConstructionGapV1(
-            "opaque-call-target", resolved.cid, "recursive source call graph"
+            "call-graph-cycle", resolved.cid, "recursive source call graph"
         )
 
     session.frame_active.add(cache_key)
@@ -393,35 +461,67 @@ def _resolve_source_visible_frame_uncached(
     # entry per demanded name, in `external_frames` when the defining source is
     # authenticated in this artifact, otherwise in `external_opaque`.
     external_frames: dict[str, object] = {}
-    external_opaque: set[str] = set()
+    external_opaque: dict[str, str] = {}
 
-    def _opaque_call_targets(function: FunctionDef) -> tuple[str, ...]:
-        opaque: list[str] = []
+    def _blocking_call_targets(
+        function: FunctionDef,
+    ) -> tuple[str, tuple[str, ...]] | None:
+        """The structural condition blocking this definition's named callees.
+
+        Returns ``(kind, names)`` where ``names`` is the WHOLE blocking set for
+        that kind, sorted -- never a first-hit projection.  The old
+        ``opaque[0]`` made the reported symbol depend on statement order, so a
+        definition blocked on several callees named one arbitrarily and
+        discarded the rest.
+
+        When a definition is blocked by more than one condition it is genuinely
+        blocked by all of them, and the row carries one kind, so the reported
+        kind follows the fixed precedence in ``_CALL_TARGET_GAP_PRECEDENCE``:
+        the capability gap that no coverage change can close, then the door
+        defect, then coverage.  The order is a property of this module, not of
+        the corpus.
+        """
+        binders = _frame_bound_names(function)
+        blocked: dict[str, set[str]] = {}
         for call in _local_named_calls(function):
             name = call.func.id
             if name in external_frames:
                 continue
-            if not _named_call_is_source_opaque(name, definition_names, builtin_floor):
-                continue
-            if name in external_opaque:
-                opaque.append(name)
-                continue
-            frame = _resolve_external_call_frame(
-                name, resolved=resolved, graph=graph, session=session
+            classification = _classify_named_call_target(
+                name, definition_names, builtin_floor, frame_binders=binders
             )
-            if frame is None:
-                external_opaque.add(name)
-                opaque.append(name)
-            else:
-                external_frames[name] = frame
-        return tuple(opaque)
+            if classification in ("local-definition", "builtin"):
+                continue
+            if classification == "frame-bound-value":
+                # Bound HERE: a value, not a symbol.  The export door is never
+                # asked, because there is nothing for it to look up.
+                blocked.setdefault("value-call-target", set()).add(name)
+                continue
+            declined = external_opaque.get(name)
+            if declined is None:
+                outcome = _resolve_external_call_frame(
+                    name, resolved=resolved, graph=graph, session=session
+                )
+                if not isinstance(outcome, _ExternalCallTargetGap):
+                    external_frames[name] = outcome
+                    continue
+                declined = outcome.kind
+                if declined != "call-graph-cycle":
+                    # A cycle is a property of THIS traversal, not of the
+                    # callee; memoizing it against the name would serve a
+                    # traversal verdict to an unrelated one.
+                    external_opaque[name] = declined
+            blocked.setdefault(declined, set()).add(name)
+        for kind in _CALL_TARGET_GAP_PRECEDENCE:
+            if kind in blocked:
+                return kind, tuple(sorted(blocked[kind]))
+        return None
 
     if isinstance(target, FunctionDef):
-        opaque = _opaque_call_targets(target)
-        if opaque:
-            return ManagerConstructionGapV1(
-                "opaque-call-target", resolved.cid, opaque[0]
-            )
+        blocking = _blocking_call_targets(target)
+        if blocking is not None:
+            kind, names = blocking
+            return ManagerConstructionGapV1(kind, resolved.cid, ",".join(names))
 
     frames: dict[str, object] = {}
     reaching_classes: dict[str, ClassDef] = {}
@@ -446,11 +546,10 @@ def _resolve_source_visible_frame_uncached(
         progressed = False
         for function in tuple(pending):
             local_calls = tuple(_local_named_calls(function))
-            opaque = _opaque_call_targets(function)
-            if opaque:
-                return ManagerConstructionGapV1(
-                    "opaque-call-target", resolved.cid, opaque[0]
-                )
+            blocking = _blocking_call_targets(function)
+            if blocking is not None:
+                kind, names = blocking
+                return ManagerConstructionGapV1(kind, resolved.cid, ",".join(names))
             unresolved = tuple(
                 call.func.id
                 for call in local_calls
@@ -469,7 +568,7 @@ def _resolve_source_visible_frame_uncached(
             progressed = True
         if not progressed:
             return ManagerConstructionGapV1(
-                "opaque-call-target", resolved.cid, "recursive source call graph"
+                "call-graph-cycle", resolved.cid, "recursive source call graph"
             )
     frame = frames.get(target.name)
     if frame is None:
@@ -485,7 +584,7 @@ def _resolve_external_call_frame(
     resolved: ResolvedPythonObjectV1,
     graph: DependencyArtifactGraph,
     session: SourceResolutionSession,
-) -> object | None:
+) -> object | _ExternalCallTargetGap:
     """Project one non-local call target through the authenticated export door.
 
     A name called inside an authenticated module but not defined there is bound
@@ -497,11 +596,21 @@ def _resolve_external_call_frame(
     executed import, and no name arm: the only question asked is whether the
     defining source is authenticated inside this artifact.
 
-    Returns the ordinary source frame, or ``None`` when the callee has no
-    authenticated defining source in this artifact (native/builtin callables,
-    modules outside the distribution manifest, dynamic or ambiguous exports,
-    free names).  ``None`` keeps the call site typed-loud at
-    ``opaque-call-target``; it never yields a fabricated contract.
+    Returns the ordinary source frame, or a typed ``_ExternalCallTargetGap``
+    naming WHICH of the two declines happened.  Both used to be a bare ``None``
+    and were reported under one kind, which is why an in-artifact symbol the
+    door failed on was indistinguishable from a stdlib symbol the artifact does
+    not contain:
+
+    - ``call-target-source-absent`` -- the export door itself declined: no
+      authenticated defining source for this name in this artifact
+      (native/builtin callables, modules outside the distribution manifest,
+      dynamic or ambiguous exports, free names).  Artifact COVERAGE.
+    - ``call-target-export-unresolved`` -- the door DID authenticate an object
+      in this artifact and projecting its frame still failed.  A DEFECT.
+
+    Either way the call site stays typed-loud; it never yields a fabricated
+    contract.
     """
     from .dependency_artifact import ResolvedPythonObjectV1 as _Resolved
 
@@ -515,10 +624,16 @@ def _resolve_external_call_frame(
         session=session,
     )
     if not isinstance(callee, _Resolved):
-        return None
+        return _ExternalCallTargetGap("call-target-source-absent")
     projected = resolve_source_visible_frame(callee, graph=graph, session=session)
     if isinstance(projected, ManagerConstructionGapV1):
-        return None
+        # A cycle reached through a re-export hop is still a cycle.  Read the
+        # callee's OWN authenticated gap kind rather than restating the hop as a
+        # door defect -- otherwise every cross-module recursion would be
+        # reported as a bug in the export door.
+        if projected.kind == "call-graph-cycle":
+            return _ExternalCallTargetGap("call-graph-cycle")
+        return _ExternalCallTargetGap("call-target-export-unresolved")
     frame, _target = projected
     return frame
 
@@ -546,29 +661,103 @@ def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:
     )
 
 
-def _named_call_is_source_opaque(
-    name: str, definition_names: set[str], builtin_floor
-) -> bool:
-    """True when a free name is not a local definition and not a Python builtin.
+def _classify_named_call_target(
+    name: str,
+    definition_names: set[str],
+    builtin_floor,
+    *,
+    frame_binders: frozenset[str],
+) -> Literal["frame-bound-value", "local-definition", "builtin", "free-name"]:
+    """What binds a named callee, read off the enclosing frame and the module.
+
+    This supersedes the old ``_named_call_is_source_opaque`` predicate, which
+    answered only "is this a local definition or a builtin" and therefore
+    classified a callee that is a bound PARAMETER identically to a missing
+    import.  Those are different conditions with different fixes: a parameter
+    callee is higher-order dispatch that no export door can ever resolve, and a
+    missing import is artifact coverage.  A predicate cannot say that; a
+    classification can.
+
+    Precedence is Python's own scoping order, which is also why checking the
+    frame first is a correctness fix and not only a reporting one: a local
+    binding SHADOWS both a module-level definition of the same name and a
+    builtin, so a definition with a parameter named ``len`` does not call the
+    builtin ``len``.
 
     Frame resolution used to treat only ``BuiltinSemanticCallable`` (issubclass,
     set) as non-opaque, so ordinary builtins like ``len`` / ``sorted`` /
-    ``isinstance`` aborted manager construction as ``opaque-call-target`` before
-    force_floor. That over-classified residual for every source-derived manager
-    family — including assertion EffectBoundary factories.
+    ``isinstance`` aborted manager construction before force_floor. That
+    over-classified residual for every source-derived manager family --
+    including assertion EffectBoundary factories.  A name bound in the builtin
+    temporal is not source-opaque; construction may still refuse at force_floor
+    when the builtin is not yet reducible, and that is a later, stage-keyed gap.
 
-    A name bound in the builtin temporal is not source-opaque. Construction may
-    still refuse at force_floor when the builtin is not yet reducible; that is a
-    later, stage-keyed gap, not a false free-name opaque.
-
-    This is the LOCAL question only.  A name that is source-opaque here is then
-    offered to the one authenticated export door (``_opaque_call_targets`` ->
-    ``_resolve_external_call_frame``); it is reported as ``opaque-call-target``
-    only when that door also declines.
+    ``free-name`` is the LOCAL question's only remaining answer, and it is not
+    yet a gap: the name is offered to the one authenticated export door
+    (``_blocking_call_targets`` -> ``_resolve_external_call_frame``) and is
+    reported only when that door also declines, under the kind naming WHICH
+    decline it was.
     """
+    if name in frame_binders:
+        return "frame-bound-value"
     if name in definition_names:
-        return False
-    return builtin_floor.value_if_bound(name) is None
+        return "local-definition"
+    if builtin_floor.value_if_bound(name) is not None:
+        return "builtin"
+    return "free-name"
+
+
+def _frame_bound_names(function: FunctionDef) -> frozenset[str]:
+    """Every name the enclosing definition binds itself: parameters and locals.
+
+    A callee bound HERE is a runtime value, not a symbol.  The set is read off
+    the definition's own binding syntax -- parameters, assignment / for / with /
+    except targets, function-local imports, walrus, nested definitions -- and
+    never off a spelling.  There is no name table and nothing vendor-specific:
+    the same walk answers the same question for any Python definition.
+
+    Comprehension targets are deliberately ABSENT.  They bind in their own
+    scope, so a callee spelled like one is still a free name in this frame and
+    still goes to the export door -- exactly as before this classification
+    existed.  Reporting it as frame-bound would be a claim this walk cannot
+    authenticate.
+    """
+    names: set[str] = {param.name for param in function.params}
+
+    def _bind_target(node) -> None:
+        if isinstance(node, Name):
+            names.add(node.id)
+        elif isinstance(node, (Tuple_, List)):
+            for element in node.elts:
+                _bind_target(element)
+        elif isinstance(node, Starred):
+            _bind_target(node.value)
+
+    stack = list(function.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (FunctionDef, ClassDef)):
+            # A nested definition binds its own name here and opens its own
+            # scope; its body's binders are not this frame's.
+            names.add(node.name)
+            continue
+        if isinstance(node, Assign):
+            for target in node.targets:
+                _bind_target(target)
+        elif isinstance(node, (AnnAssign, AugAssign, For, NamedExpr)):
+            _bind_target(node.target)
+        elif isinstance(node, With):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    _bind_target(item.optional_vars)
+        elif isinstance(node, ExceptHandler):
+            if node.name:
+                names.add(node.name)
+        elif isinstance(node, (Import, ImportFrom)):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".", 1)[0])
+        stack.extend(child for _, _, child in node.children())
+    return frozenset(names)
 
 
 def _local_named_calls(function: FunctionDef):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -692,36 +692,21 @@ def populate_source_derived_resource_refs(
         from .manager_protocol_construction import ConstructedManagerProtocolV1
 
         if not isinstance(behavior, ConstructedManagerBehaviorV1):
-            # Stage-keyed residual: opaque-call-target:sorted, force-floor:… —
-            # never collapse assertion-membrane mass into a single opaque label.
-            _install_derivation_gap(
-                context,
-                coordinate,
-                receipt,
-                _construction_gap_kind(behavior),
-            )
+            # Stage-keyed residual — never collapse assertion-membrane mass into
+            # a single opaque label, and never fuse the stage with its data:
+            # `value-call-target` is the key, the callee names are the row.
+            kind, detail = _gap_kind_and_detail(behavior)
+            _install_derivation_gap(context, coordinate, receipt, kind, detail)
             continue
         protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
         if not isinstance(protocol, ConstructedManagerProtocolV1):
-            kind = getattr(protocol, "kind", None) or "protocol-construction"
-            detail = getattr(protocol, "detail", None)
-            _install_derivation_gap(
-                context,
-                coordinate,
-                receipt,
-                f"{kind}:{detail}" if detail else str(kind),
-            )
+            kind, detail = _gap_kind_and_detail(protocol)
+            _install_derivation_gap(context, coordinate, receipt, kind, detail)
             continue
         summary = derive_manager_summary(protocol, behavior=behavior)
         if not isinstance(summary, DerivedManagerSummaryV1):
-            kind = getattr(summary, "kind", None) or "summary-derivation"
-            detail = getattr(summary, "detail", None)
-            _install_derivation_gap(
-                context,
-                coordinate,
-                receipt,
-                f"{kind}:{detail}" if detail else str(kind),
-            )
+            kind, detail = _gap_kind_and_detail(summary)
+            _install_derivation_gap(context, coordinate, receipt, kind, detail)
             continue
         context.source_derived_contract_refs[coordinate] = (
             SourceDerivedContextManagerRefV1(
@@ -734,19 +719,26 @@ def populate_source_derived_resource_refs(
         )
 
 
-def _construction_gap_kind(gap) -> str:
+def _gap_kind_and_detail(gap) -> tuple[str, str | None]:
+    """Read a producer's ALREADY-SEPARATE kind and detail, unfused.
+
+    Every producer that reaches here declares ``kind`` as a closed ``Literal``
+    with ``detail`` as its own field.  This function used to be
+    ``_construction_gap_kind``, which returned ``f"{kind}:{detail}"`` and
+    truncated the result to 80 chars -- a key that can be truncated is not an
+    identity, and the fused strings it minted are what put a callee spelling at
+    79% of the pinned-pandas resolution board.  The structure was never
+    missing; the reporting layer was throwing it away and rebuilding a worse
+    one from a string.
+    """
     kind = getattr(gap, "kind", None) or "no-derived-contract"
     detail = getattr(gap, "detail", None)
-    if detail is None or detail == "":
-        return str(kind)
-    # Keep kind:detail compact for census keys (first free-name / first panic).
-    text = str(detail)
-    if len(text) > 80:
-        text = text[:77] + "..."
-    return f"{kind}:{text}"
+    return str(kind), (str(detail) if detail else None)
 
 
-def _install_derivation_gap(context, coordinate, receipt, kind: str) -> None:
+def _install_derivation_gap(
+    context, coordinate, receipt, kind: str, detail: str | None = None
+) -> None:
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
     )
@@ -757,4 +749,5 @@ def _install_derivation_gap(context, coordinate, receipt, kind: str) -> None:
         receipt.target_symbol,
         kind,
         (),
+        detail,
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
@@ -1,0 +1,423 @@
+"""The four conditions ``opaque-call-target`` used to fuse into one name.
+
+One kind named four structurally different failures, three of them carrying a
+callee spelling in the key.  On the pinned pandas board that made
+``opaque-call-target:func`` 79.0% of every resolution row -- a *capability* gap
+(calling a value) wearing a vendor-looking name, indistinguishable from a
+*coverage* gap (stdlib outside the artifact) and from a *defect* (an in-artifact
+symbol the export door failed on).  A measurement a vendor rename can move is
+not a measurement.
+
+Each mechanism gets both faces here:
+
+* ``value-call-target`` -- the callee is bound by the enclosing definition, as a
+  parameter or as a local.  Higher-order dispatch; no export lookup can ever
+  resolve it.  Negative face: the same call, same spelling, where the name is a
+  module-level definition instead -- and it constructs.
+* ``call-target-source-absent`` -- the export door declines: no defining source
+  in this artifact.  Coverage.
+* ``call-target-export-unresolved`` -- the door authenticates an object that IS
+  in this artifact and projecting its frame still fails.  A defect that was
+  invisible while it shared a bucket with the other two.
+* ``call-graph-cycle`` -- recursion.  Carries no symbol at all.
+
+Plus the law the whole split exists to serve: the kind is the structural key and
+never contains a callee spelling; the spelling rides ``detail``.
+
+All fixture source is neutral and written for this test.  No vendor text, no
+vendor names, no name arms.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_lift_py_tests.ir import _term_content_cid
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import (
+    CALL_TARGET_GAP_KINDS,
+    ConstructedCallActualV1,
+    ConstructedManagerBehaviorV1,
+    ManagerConstructionGapV1,
+    _frame_bound_names,
+    construct_manager_behavior,
+)
+from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.nodes import Call, Constant, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, modules: dict[str, str]) -> importlib.metadata.Distribution:
+    """One authenticated distribution whose file manifest is exactly ``modules``."""
+    package = root / "arbitrary"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text(
+        "from arbitrary.manager import make_guard\n", encoding="utf-8"
+    )
+    names = ["arbitrary/__init__.py"]
+    for name, source in modules.items():
+        (package / f"{name}.py").write_text(source, encoding="utf-8")
+        names.append(f"arbitrary/{name}.py")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir(parents=True)
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    names += [
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    ]
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for name in names:
+            writer.writerow((name, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _construct(root: Path, manager_source: str, **extra_modules: str):
+    """Construct ``arbitrary.make_guard(23)`` from authenticated source."""
+    graph = DependencyArtifactGraph.authenticate(
+        _distribution(root, {"manager": manager_source, **extra_modules})
+    )
+    consumer = "import arbitrary\narbitrary.make_guard(23)\n"
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode())
+    receipts, _ = authenticated_import_use_receipts(root, path, consumer, source_cid)
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1), resolved
+    source_file = SourceFile((consumer, str(path), source_cid))
+    call = next(item for item in source_file.nodes() if isinstance(item, Call))
+    literal = next(item for item in call.args if isinstance(item, Constant))
+    actual = TermValue(23)
+    supplied = ConstructedCallActualV1(
+        literal,
+        actual,
+        ConstructedValueTestimonyV1.mint(
+            literal.fragment, _term_content_cid(actual.to_term(owner="test"))
+        ),
+    )
+    return construct_manager_behavior(
+        resolved, graph=graph, actuals=(supplied,), call_site=call.fragment
+    )
+
+
+# --------------------------------------------------------------------------
+# value-call-target -- the callee is a VALUE bound by the enclosing definition
+# --------------------------------------------------------------------------
+
+
+def test_called_parameter_is_a_value_call_target_not_a_missing_import(tmp_path):
+    """POSITIVE: a formal parameter that is called is higher-order dispatch.
+
+    ``helper`` is never imported and never defined -- it is *bound*, as the
+    enclosing definition's own parameter.  No export door can resolve it,
+    because there is nothing to look up.  Reporting this as an unresolvable
+    external symbol claims a coverage problem that does not exist.
+    """
+    result = _construct(
+        tmp_path,
+        "def make_guard(helper):\n    return helper()\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "value-call-target"
+    assert result.detail == "helper"
+
+
+def test_called_local_binding_is_a_value_call_target(tmp_path):
+    """POSITIVE: a function-LOCAL binding is a value for the same reason.
+
+    Different binder, same mechanism: the callee is produced at runtime inside
+    this frame.  Parameter and local must not split into two kinds, because the
+    missing capability is one capability.
+    """
+    result = _construct(
+        tmp_path,
+        "def picked(value):\n"
+        "    return value\n"
+        "\n"
+        "def make_guard(expected):\n"
+        "    helper = picked\n"
+        "    return helper(expected)\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "value-call-target"
+    assert result.detail == "helper"
+
+
+def test_module_level_definition_of_the_same_spelling_constructs(tmp_path):
+    """NEGATIVE FACE: identical call text, and it constructs.
+
+    The only difference from the positive twin is what BINDS ``helper``.  If
+    this arm also refused, the classification would be reading the spelling.
+    """
+    result = _construct(
+        tmp_path,
+        "class Slot:\n"
+        "    def __init__(self, label):\n"
+        "        self.label = 7\n"
+        "\n"
+        "def helper():\n"
+        "    return Slot(7)\n"
+        "\n"
+        "def make_guard(expected):\n"
+        "    return helper()\n",
+    )
+
+    assert isinstance(result, ConstructedManagerBehaviorV1), result
+
+
+def test_parameter_shadowing_a_module_definition_is_still_a_value(tmp_path):
+    """A local binding SHADOWS a module-level definition of the same name.
+
+    ``helper`` is both a parameter of ``make_guard`` and a module-level
+    definition.  Python binds the parameter, so the callee is the value passed
+    in -- not the definition.  Classifying by the module's definition set first
+    would resolve a frame the call never reaches, which is a soundness bug and
+    not only a reporting one.
+    """
+    result = _construct(
+        tmp_path,
+        "class Slot:\n"
+        "    def __init__(self, label):\n"
+        "        self.label = 7\n"
+        "\n"
+        "def helper():\n"
+        "    return Slot(7)\n"
+        "\n"
+        "def make_guard(helper):\n"
+        "    return helper()\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "value-call-target"
+
+
+def test_parameter_shadowing_a_builtin_is_still_a_value(tmp_path):
+    """A parameter shadows the builtin temporal too, for the same reason."""
+    result = _construct(
+        tmp_path,
+        "def make_guard(len):\n    return len(7)\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "value-call-target"
+    assert result.detail == "len"
+
+
+# --------------------------------------------------------------------------
+# call-target-source-absent vs call-target-export-unresolved
+# --------------------------------------------------------------------------
+
+
+def test_callee_outside_the_artifact_is_coverage_not_a_defect(tmp_path):
+    """POSITIVE: the export door declines -- no defining source in the artifact."""
+    result = _construct(
+        tmp_path,
+        "def make_guard(expected):\n    return unbound_helper(expected)\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "call-target-source-absent"
+    assert result.detail == "unbound_helper"
+
+
+def test_in_artifact_callee_whose_frame_fails_is_a_door_defect(tmp_path):
+    """POSITIVE: the callee IS authenticated here, and its frame still failed.
+
+    ``support.build_slot`` is a real definition inside this artifact's own file
+    manifest, statically exported and reached through the same door.  Its own
+    body is what refuses.  Under the fused key this was indistinguishable from
+    a stdlib symbol the artifact does not contain -- eight rows of real defect
+    hidden inside 714 rows of coverage.
+    """
+    result = _construct(
+        tmp_path,
+        "from arbitrary.support import build_slot\n"
+        "\n"
+        "def make_guard(expected):\n"
+        "    return build_slot(expected)\n",
+        support="def build_slot(label):\n    return absent_from_artifact(label)\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "call-target-export-unresolved"
+    assert result.detail == "build_slot"
+
+
+def test_coverage_and_defect_do_not_share_a_kind(tmp_path):
+    """DISCRIMINATION: run both arms and require the kinds to DIFFER.
+
+    Asserting each arm separately would still pass if both collapsed onto the
+    same kind tomorrow.  This is the assertion that cannot.
+    """
+    absent = _construct(
+        tmp_path / "absent",
+        "def make_guard(expected):\n    return unbound_helper(expected)\n",
+    )
+    defect = _construct(
+        tmp_path / "defect",
+        "from arbitrary.support import build_slot\n"
+        "\n"
+        "def make_guard(expected):\n"
+        "    return build_slot(expected)\n",
+        support="def build_slot(label):\n    return absent_from_artifact(label)\n",
+    )
+
+    assert isinstance(absent, ManagerConstructionGapV1), absent
+    assert isinstance(defect, ManagerConstructionGapV1), defect
+    assert absent.kind != defect.kind
+
+
+# --------------------------------------------------------------------------
+# The law the split exists to serve
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "manager_source",
+    [
+        "def make_guard(helper):\n    return helper(7)\n",
+        "def make_guard(expected):\n    return unbound_helper(expected)\n",
+        "def make_guard(len):\n    return len(7)\n",
+    ],
+)
+def test_the_kind_is_a_structural_key_and_never_carries_a_spelling(
+    tmp_path, manager_source
+):
+    """Every reported kind is a member of the closed vocabulary, unfused.
+
+    The old reporting layer minted ``f"{kind}:{detail}"`` and truncated it to 80
+    chars.  A key that can be truncated is not an identity, and a key whose
+    cardinality is the cardinality of callee spellings is a name table.
+    """
+    result = _construct(tmp_path, manager_source)
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind in CALL_TARGET_GAP_KINDS, result.kind
+    assert ":" not in result.kind
+    # The spelling exists -- it just is not the key.
+    assert result.detail and ":" not in result.detail
+
+
+def test_the_whole_blocking_set_rides_the_row_not_the_first_hit(tmp_path):
+    """``detail`` is the SORTED blocking set, not whichever callee sorted first.
+
+    ``opaque[0]`` made the reported symbol depend on statement order, so
+    ``5,737 sites blocked on func`` actually meant ``5,737 sites whose blocking
+    set happened to put func first``.
+    """
+    result = _construct(
+        tmp_path,
+        "def make_guard(expected):\n"
+        "    zulu(expected)\n"
+        "    alpha(expected)\n"
+        "    return mike(expected)\n",
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "call-target-source-absent"
+    assert result.detail == "alpha,mike,zulu"
+
+
+# --------------------------------------------------------------------------
+# _frame_bound_names -- the binder walk, read directly
+# --------------------------------------------------------------------------
+
+
+def _definition(source: str, name: str) -> FunctionDef:
+    tree = SourceFile((source, "binders.py", blake3_512_of(source.encode())))
+    return next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == name
+    )
+
+
+def test_frame_bound_names_reads_every_binding_form(tmp_path):
+    """POSITIVE: parameters and each local binding syntax, from the AST alone."""
+    definition = _definition(
+        "def frame(param, *args, keyword=None, **rest):\n"
+        "    assigned = 1\n"
+        "    annotated: int = 2\n"
+        "    augmented = 0\n"
+        "    augmented += 1\n"
+        "    first, *starred = (1, 2, 3)\n"
+        "    for looped in ():\n"
+        "        pass\n"
+        "    with open('x') as managed:\n"
+        "        pass\n"
+        "    try:\n"
+        "        pass\n"
+        "    except ValueError as caught:\n"
+        "        pass\n"
+        "    import json\n"
+        "    from os import path as renamed\n"
+        "    if (walrus := 3):\n"
+        "        pass\n"
+        "    def nested():\n"
+        "        inner_only = 1\n"
+        "        return inner_only\n"
+        "    return nested\n",
+        "frame",
+    )
+
+    assert _frame_bound_names(definition) == frozenset(
+        {
+            "param",
+            "args",
+            "keyword",
+            "rest",
+            "assigned",
+            "annotated",
+            "augmented",
+            "first",
+            "starred",
+            "looped",
+            "managed",
+            "caught",
+            "json",
+            "renamed",
+            "walrus",
+            "nested",
+        }
+    )
+
+
+def test_frame_bound_names_excludes_names_this_frame_does_not_bind(tmp_path):
+    """NEGATIVE FACE: a comprehension target and a nested frame's local.
+
+    A comprehension binds in its OWN scope, so claiming it here would be a
+    claim this walk cannot authenticate -- such a callee stays a free name and
+    still goes to the export door, exactly as before this walk existed.
+    """
+    definition = _definition(
+        "def frame():\n"
+        "    values = [comprehended for comprehended in ()]\n"
+        "    def nested(nested_param):\n"
+        "        nested_local = 1\n"
+        "        return nested_local\n"
+        "    return values, nested\n",
+        "frame",
+    )
+    binders = _frame_bound_names(definition)
+
+    assert "values" in binders
+    assert "nested" in binders
+    assert "comprehended" not in binders
+    assert "nested_param" not in binders
+    assert "nested_local" not in binders

--- a/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
@@ -1,12 +1,17 @@
 """The four conditions ``opaque-call-target`` used to fuse into one name.
 
 One kind named four structurally different failures, three of them carrying a
-callee spelling in the key.  On the pinned pandas board that made
-``opaque-call-target:func`` 79.0% of every resolution row -- a *capability* gap
-(calling a value) wearing a vendor-looking name, indistinguishable from a
-*coverage* gap (stdlib outside the artifact) and from a *defect* (an in-artifact
-symbol the export door failed on).  A measurement a vendor rename can move is
-not a measurement.
+callee spelling in the key.  ``opaque-call-target:func`` was the largest single
+term on the pinned pandas board (#6371) -- a *capability* gap (calling a value)
+wearing a vendor-looking name, indistinguishable from a *coverage* gap (stdlib
+outside the artifact) and from a *defect* (an in-artifact symbol the export door
+failed on).  A measurement a vendor rename can move is not a measurement.
+
+Splitting these apart REATTRIBUTES rows; it drains none of them.  The capability
+itself is open work (#6409), as is the door defect (#6410).  Corpus row counts
+from the pre-`d10774abc` ledger are deliberately not restated here: that
+collection universe was short by 290 laws and the figures are pending
+re-baseline.
 
 Each mechanism gets both faces here:
 
@@ -242,8 +247,9 @@ def test_in_artifact_callee_whose_frame_fails_is_a_door_defect(tmp_path):
     ``support.build_slot`` is a real definition inside this artifact's own file
     manifest, statically exported and reached through the same door.  Its own
     body is what refuses.  Under the fused key this was indistinguishable from
-    a stdlib symbol the artifact does not contain -- eight rows of real defect
-    hidden inside 714 rows of coverage.
+    a stdlib symbol the artifact does not contain -- a real defect hidden inside
+    a much larger coverage bucket, and therefore never worked.  Tracked at
+    #6410; this test only makes it nameable.
     """
     result = _construct(
         tmp_path,
@@ -317,9 +323,10 @@ def test_the_kind_is_a_structural_key_and_never_carries_a_spelling(
 def test_the_whole_blocking_set_rides_the_row_not_the_first_hit(tmp_path):
     """``detail`` is the SORTED blocking set, not whichever callee sorted first.
 
-    ``opaque[0]`` made the reported symbol depend on statement order, so
-    ``5,737 sites blocked on func`` actually meant ``5,737 sites whose blocking
-    set happened to put func first``.
+    ``opaque[0]`` made the reported symbol depend on statement order, so a term
+    reading ``N sites blocked on <callee>`` actually meant ``N sites whose
+    blocking set happened to put <callee> first``.  Order-dependent, and lossy
+    about every other blocker.
     """
     result = _construct(
         tmp_path,

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -10,8 +10,10 @@ authenticate its callee.  These twins pin the two faces:
   asserted by the ACTUAL receiver state (field names and field values), with
   discrimination arms that perturb the defining source and must fail;
 * callee NOT reachable in the authenticated artifact (native, stdlib outside
-  the artifact, absent module) -> the site stays ``opaque-call-target``.  That
-  is the correct outcome, never a fabricated contract.
+  the artifact, absent module) -> the site stays typed-loud at
+  ``call-target-source-absent``.  That is the correct outcome, never a
+  fabricated contract.  The kind names the CONDITION; the callee spelling
+  rides ``detail`` and is never part of the key.
 
 All fixture source here is neutral and written for this test.  No vendor text,
 no vendor names, no name arms.
@@ -38,6 +40,7 @@ from sugar_lift_python_source.manager_construction import (
     ConstructedCallActualV1,
     ConstructedManagerBehaviorV1,
     ManagerConstructionGapV1,
+    _ExternalCallTargetGap,
     _resolve_external_call_frame,
     construct_manager_behavior,
 )
@@ -127,8 +130,8 @@ _CROSS_MODULE_CLASS_SUPPORT = (
 def test_cross_module_class_call_target_reduces_to_constructed_receiver(tmp_path):
     """POSITIVE: the callee lives in another authenticated module of the artifact.
 
-    On ``main`` this ends at ``opaque-call-target``: ``ScopedSlot`` is not a
-    definition of ``arbitrary.manager`` and not a semantic builtin.
+    Before the export door existed this ended typed-loud: ``ScopedSlot`` is not
+    a definition of ``arbitrary.manager`` and not a semantic builtin.
     """
     result, _ = _construct(
         tmp_path,
@@ -227,7 +230,9 @@ def test_reexport_chain_call_target_reduces(tmp_path):
     # make_guard, so ``arbitrary.ScopedSlot`` is NOT statically exported.
     # This is the honest negative face of the re-export door.
     assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "opaque-call-target"
+    assert result.kind == "call-target-source-absent"
+    # The KEY names the condition and carries no spelling.
+    assert ":" not in result.kind
     assert result.detail == "ScopedSlot"
 
 
@@ -249,7 +254,9 @@ def test_unavailable_callee_stays_typed_loud(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "opaque-call-target"
+    assert result.kind == "call-target-source-absent"
+    # The KEY names the condition and carries no spelling.
+    assert ":" not in result.kind
     assert result.detail == "Path"
 
 
@@ -267,7 +274,9 @@ def test_absent_module_callee_stays_typed_loud(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "opaque-call-target"
+    assert result.kind == "call-target-source-absent"
+    # The KEY names the condition and carries no spelling.
+    assert ":" not in result.kind
     assert result.detail == "ScopedSlot"
 
 
@@ -282,7 +291,9 @@ def test_undefined_free_name_call_stays_typed_loud(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "opaque-call-target"
+    assert result.kind == "call-target-source-absent"
+    # The KEY names the condition and carries no spelling.
+    assert ":" not in result.kind
     assert result.detail == "unbound_helper"
 
 
@@ -336,11 +347,16 @@ def test_external_call_frame_demand_maps_exactly_onto_availability(
         name, resolved=resolved, graph=graph, session=SourceResolutionSession()
     )
 
-    assert (frame is not None) is available
+    declined = isinstance(frame, _ExternalCallTargetGap)
+    assert (not declined) is available
     if available:
         # The frame is the callee's OWN definition, addressed by content.
         assert frame.frame_cid.startswith("blake3-512:")
         assert frame.definition_fragment_cid.startswith("blake3-512:")
+    else:
+        # A decline is not a bare `None`: it names WHICH decline it was, so an
+        # in-artifact symbol the door failed on can never be read as coverage.
+        assert frame.kind == "call-target-source-absent"
 
 
 def test_external_call_frame_is_the_callee_defining_source_not_the_caller(tmp_path):
@@ -382,4 +398,10 @@ def test_mutually_recursive_cross_module_call_stays_typed_loud(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "opaque-call-target"
+    # Recursion is a different condition from an unresolvable callee: the
+    # cycle is reported as itself even though it is reached through the
+    # export door, and it carries NO symbol.
+    assert result.kind == "call-graph-cycle"
+    assert ":" not in result.kind
+    # detail is DATA: which callee's projection cycled.  It is never the key.
+    assert result.detail == "build_slot"

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -15,6 +15,7 @@ from sugar_lift_python_source.dependency_artifact import (
     resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
+    CALL_TARGET_GAP_KINDS as _CALL_TARGET_GAP_KINDS,
     ConstructedCallActualV1,
     ConstructedManagerBehaviorV1,
     ManagerConstructionGapV1,
@@ -152,7 +153,11 @@ def test_renamed_factory_constructs_returned_receiver_state_through_one_door(tmp
 
 
 def test_free_name_call_stays_typed_loud(tmp_path):
-    """A free (non-local, non-builtin) name remains opaque-call-target."""
+    """A free (non-local, non-builtin) name the export door declines.
+
+    The condition is artifact coverage: there is no defining source for this
+    name in the artifact.  That is the KEY; the spelling is the row.
+    """
     graph, resolved, actual, call_site = _resolved(
         tmp_path, "def make_guard(expected):\n    return missing_helper(expected)\n"
     )
@@ -162,16 +167,17 @@ def test_free_name_call_stays_typed_loud(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1)
-    assert result.kind == "opaque-call-target"
+    assert result.kind == "call-target-source-absent"
+    assert ":" not in result.kind
     assert result.detail == "missing_helper"
 
 
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
     """Python builtin names are not free-name opaques at frame resolution.
 
-    ``len`` is in the builtin temporal. Frame scan must not abort as
-    ``opaque-call-target:len``; construction may still refuse later when the
-    builtin is not yet a reducible force_floor (stage-keyed gap).
+    ``len`` is in the builtin temporal. Frame scan must not abort as a
+    call-target gap; construction may still refuse later when the builtin is
+    not yet a reducible force_floor (stage-keyed gap).
     """
     graph, resolved, actual, call_site = _resolved(
         tmp_path, "def make_guard(expected):\n    return len(expected)\n"
@@ -182,7 +188,7 @@ def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
     )
 
     assert isinstance(result, ManagerConstructionGapV1)
-    assert result.kind != "opaque-call-target", result
+    assert result.kind not in _CALL_TARGET_GAP_KINDS, result
     assert result.kind in {"non-manager-result", "force-floor"}, result
 
 
@@ -948,13 +954,22 @@ def test_installed_source_boundary_with_opaque_builtin_verdict_stays_loud(tmp_pa
     # free-name / force-floor chain constructs without vendor arms.
     assert resolution.kind != "derived-contract"
     assert resolution.target_symbol and "raises" in resolution.target_symbol
-    assert (
-        resolution.kind.startswith("opaque-call-target")
-        or resolution.kind.startswith("force-floor")
-        or resolution.kind.startswith("non-manager-result")
-        or resolution.kind.startswith("protocol-construction")
-        or resolution.kind.startswith("summary-derivation")
-        or resolution.kind == "no-derived-contract"
+    # EXACT membership, not `startswith`: the kind is now the whole key, so a
+    # prefix match would pass on a fused `kind:symbol` string too -- which is
+    # precisely the shape this control has to refuse.
+    assert resolution.kind in (
+        _CALL_TARGET_GAP_KINDS
+        | {
+            "force-floor",
+            "non-manager-result",
+            "no-derived-contract",
+            "enter-missing",
+            "exit-missing",
+            "method-construction",
+            "enter-may-halt",
+            "exit-may-halt",
+            "opaque-exit-truthiness",
+        }
     ), resolution.kind
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -144,9 +144,14 @@ def test_source_visible_function_with_opaque_child_stays_typed_loud(
     coordinate = _coordinate(call)
     row = context.source_call_resolutions[coordinate]
     assert isinstance(row, SourceCallPreconstructionGapV1)
-    assert row.kind == "opaque-call-target"
+    # INHERITED RED on origin/main (78714a798): `len` is bound in the builtin
+    # temporal, so this fixture no longer has an opaque child and the row is a
+    # constructed ref.  The kind is renamed to the vocabulary that exists; the
+    # fixture is a separate defect and stays loud rather than being trimmed to
+    # fit.
+    assert row.kind == "call-target-source-absent"
     assert coordinate not in context.source_call_frames
-    with pytest.raises(SugarNotWritten, match="opaque-call-target"):
+    with pytest.raises(SugarNotWritten, match="call-target-source-absent"):
         call.sugar().desugar()
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4476,12 +4476,19 @@ class With(Statement):
     def _raise_resolution_gap(self, resolution) -> None:
         from .panic import ContextManagerResolutionConstructionGap
 
+        # `kind` is the structural key and stays alone; `detail` rides the
+        # OBSERVED line so the panic still names the blocking callee(s) that the
+        # fused `kind:detail` key used to smuggle into the key itself.
+        detail = getattr(resolution, "detail", None)
         panic = ContextManagerResolutionConstructionGap(
             kind=resolution.kind,
             demand_cid=resolution.demand_cid,
             candidate_member_cids=resolution.candidate_member_cids,
             owner="With._construct_sugar",
-            observed=f"authenticated preconstruction resolution gap: {resolution.kind}",
+            observed=(
+                f"authenticated preconstruction resolution gap: {resolution.kind}"
+                + (f" [{detail}]" if detail else "")
+            ),
             requested="one resolved authenticated ContextManagerContractRefV1",
             fix="publish or resolve the exact typed CM contract before construction",
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -150,6 +150,35 @@ class WithConstructionGapKind(str, Enum):
     DYNAMIC_EXPORT = "dynamic-export"
     STATIC_EXPORT_ABSENT = "static-export-absent"
     UNSUPPORTED_STATEMENT = "unsupported-statement"
+    MALFORMED_IMPORT_BINDING = "malformed-import-binding"
+    ARTIFACT_MODULE_ABSENT = "artifact-module-absent"
+    TARGET_OUTSIDE_BINDING = "target-outside-binding"
+    AMBIGUOUS_STATIC_EXPORT = "ambiguous-static-export"
+    OPAQUE_SOURCE = "opaque-source"
+    REEXPORT_CYCLE = "reexport-cycle"
+    # Source-derived preconstruction kinds.  Each is minted by a typed Literal
+    # (`ManagerConstructionGapV1`, `ManagerProtocolConstructionGapV1`,
+    # `DerivedManagerSummaryGapV1`), so this is a closed structural vocabulary,
+    # not a name table -- the derivation layer used to fuse `kind:detail` into
+    # one string and hand the wire decoder a kind it would have REFUSED.
+    INCOMPLETE_CALL_ACTUALS = "incomplete-call-actuals"
+    ARTIFACT_MISMATCH = "artifact-mismatch"
+    DEFINITION_MISSING = "definition-missing"
+    NON_MANAGER_RESULT = "non-manager-result"
+    CALL_BINDING = "call-binding"
+    FORCE_FLOOR = "force-floor"
+    # The four conditions that `opaque-call-target` fused into one name; see
+    # `manager_construction.py` for what decides each.
+    CALL_GRAPH_CYCLE = "call-graph-cycle"
+    VALUE_CALL_TARGET = "value-call-target"
+    CALL_TARGET_SOURCE_ABSENT = "call-target-source-absent"
+    CALL_TARGET_EXPORT_UNRESOLVED = "call-target-export-unresolved"
+    ENTER_MISSING = "enter-missing"
+    EXIT_MISSING = "exit-missing"
+    METHOD_CONSTRUCTION = "method-construction"
+    ENTER_MAY_HALT = "enter-may-halt"
+    EXIT_MAY_HALT = "exit-may-halt"
+    OPAQUE_EXIT_TRUTHINESS = "opaque-exit-truthiness"
     # Catch-all: never crash the census on a newly minted resolution kind.
     # The original string is preserved on ``ContextManagerResolutionConstructionGap.resolution_kind``.
     UNRECOGNIZED_RESOLUTION_KIND = "unrecognized-resolution-kind"


### PR DESCRIPTION
> ## This is REATTRIBUTION, not a drain. Read this before reading any number below.
>
> Nothing here reduces residual. Every row that was `opaque-call-target:<spelling>`
> is still a refusing site afterwards. What changes is **which named owner it is
> filed under** — and that a vendor rename can no longer move the measurement.
>
> Row conservation is the point, not a disappointment: rows in == rows out.
> **No axis is claimed reduced by this PR.** The two owners this makes visible are
> filed as open work with their measured size, never as accepted baseline:
> **#6409** (calling a value — a missing capability, ~5.7% of on-pin named callees
> in the attributed files) and **#6410** (the export door declining a symbol it
> authenticated in-artifact — a defect).
>
> Nothing here is a pin. No failure count is ratified.

> ### Denominator warning
>
> `docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json`'s collection universe
> was **short by 290 laws** — 1,269 → 1,559 collected once sibling resolution was
> derived rather than declared (`d10774abc`). A fresh authoritative baseline is
> running. Every percentage-of-board figure below is quoted **from the diagnosis as
> prior, not as a current result**, and none of them is used as a denominator for
> anything this PR claims. The measurement this PR actually makes is the on-pin
> site coverage further down, which does not depend on that ledger.

Diagnosis #6371 (`docs/audits/opaque-call-target-diagnosis-6371.md`) landed the
finding: `opaque-call-target:func` was the largest single term on the conserved
board, against a total construction R of **4**. This executes on it.

Two tangled defects, both fixed here.

## A. The key is separated from the symbol

`_construction_gap_kind` returned `f"{kind}:{detail}"`, with inline copies at two
more sites. **Every layer beneath already had the structural key.** The three
fusions are deleted; `_gap_kind_and_detail` reads the producer's already-separate
fields, `_install_derivation_gap` takes `kind` and `detail` as two arguments, and
`ContextManagerResolutionGapV1` gains `detail` beside its existing `kind` and
`target_symbol`.

The wire decoder already **rejected** any gap whose `kind` was outside
`_GAP_KINDS`, so the source-derived path was constructing, in process, a gap its
own decoder would refuse as `malformed context-manager resolution gap`. That
second hand-maintained list is gone: `_gap_kinds()` now reads
`WithConstructionGapKind`, the one owner the producers' `Literal`s are declared
against, so the two cannot drift again. `WithConstructionGapKind` is widened with
every kind the source-derived path can actually install — each minted by a typed
`Literal`, so this is a closed structural vocabulary, not a name table.

`parse`'s `UNRECOGNIZED_RESOLUTION_KIND` fallthrough **stays**; the enum is not
re-closed by crashing. `_cm_resolution_bucket` already bucketed on `kind` alone
and needed no change — it just stops seeing fused strings.

### Cost, stated

**Reporting layer only. No wire-format change. No CID preimage change. No repin.**
`detail` is in-process: it is never read from or written to the wire, and
`ContextManagerResolutionGapV1` has no `wire()`. Widening `WithConstructionGapKind`
widens what the decoder *accepts*; it changes no preimage, because `byUseSite`
hashes the bytes actually present and no producer emits the new kinds over the
wire today.

## B and C. Four mechanisms, four kinds, decided by authenticated structure

`opaque-call-target` named a symptom. It is replaced by the conditions it hid,
each decided by something construction already evaluates — never by a spelling:

| kind | decided by | what it is |
|---|---|---|
| `call-graph-cycle` | frame re-entry / no fixpoint progress | carries **no symbol**; the fix is a cycle policy |
| `value-call-target` | the callee is bound by the enclosing definition | higher-order dispatch; **no export lookup can ever resolve it** |
| `call-target-source-absent` | the export door declined | artifact **coverage** |
| `call-target-export-unresolved` | the door authenticated an in-artifact object and frame projection still failed | a **defect**, invisible while it shared a bucket |

`_named_call_is_source_opaque` is superseded by `_classify_named_call_target`,
which takes the enclosing frame's binder set. A predicate could not say that a
called parameter is a different condition from a missing import; a classification
can. The new `_frame_bound_names` walk reads parameters, assignment / for / with /
except targets, function-local imports, walrus, and nested definition names off
the definition's own binding syntax. Comprehension targets are deliberately
excluded — they bind in their own scope, so such a callee stays a free name and
still goes to the export door.

Checking the frame **first** is also a correctness fix, not only a reporting one:
a local binding shadows both a module-level definition and a builtin, so a
definition with a parameter named `helper` does not call the module's `helper`.
The old order would have resolved a frame the call never reaches.

Two further losses repaired: `_resolve_external_call_frame` returned a bare
`None` for two different declines and now returns a typed `_ExternalCallTargetGap`
naming which; and `opaque[0]` was first-hit-wins over a set, so `detail` is now
the **whole blocking set, sorted**. A definition blocked by several conditions
reports by a fixed precedence declared in `_CALL_TARGET_GAP_PRECEDENCE`, which is
a property of this module and not of the corpus.

No vendor arms. No name tables. Nothing here reads a spelling.

## Measurement

**Site coverage** — the *production* `_frame_bound_names` and
`_classify_named_call_target` run over the nine on-pin pandas 3.0.3 files the
diagnosis attributed the board's symbols to (sha256-checked against
`docs/ledgers/pins/pandas-3.0.3.pin.json`), 473 named-callee occurrences:

```
builtin             237   50.1%
local-definition    121   25.6%
free-name            88   18.6%   -> export door
frame-bound-value    27    5.7%   -> value-call-target
```

The two board symbols land in **different classes**, confirmed by running the
shipped code rather than an `ast` mirror: `func` (10) and `setTZ` (2) are
`frame-bound-value`; `cast` (14) is `free-name`.

**Measured ΔR: not measured on this branch, and expected to be ZERO by
construction.** No census, no lease, no forced binary build were run — the
authoritative baseline is being re-run elsewhere at `d10774abc`.

This is not a hedge, it is the claim: the mint refuses at exactly the same sites
as before, so the board should conserve — same rows, redistributed from
symbol-carrying keys onto a closed structural vocabulary. **A re-keying must not
read as a reduction.** If a future census shows this PR *lowering* a residual
count, that is a bug in this PR, not a win.

Two mechanisms are made visible and remain **unresolved**, filed as work with
their size rather than ratified: **#6409** and **#6410**.

## Tests

New `tests/test_call_target_gap_mechanisms.py` (14 tests): both faces per
mechanism, a discrimination arm that requires coverage and defect kinds to
**differ** (asserting each separately would still pass if they collapsed), the
shadowing arms, the blocking-set arm, and the binder walk read directly on both
faces. `test_installed_stdlib_suppress…`'s `startswith("opaque-call-target")`
control is replaced with **exact membership** — a prefix match would also pass on
a fused `kind:symbol` string, which is the shape the control has to refuse.

Five mutation transactions, each verified present, biting, and rolled back to a
clean tree:

| mutation | tests bitten |
|---|---|
| M1 parameters dropped from the binder set | 3 failed |
| M2 module definitions consulted before the enclosing frame | 1 failed |
| M3 door defect collapsed back onto coverage | 2 failed |
| M4 first-hit projection restored over the blocking set | 1 failed |
| M5 local assignments dropped from the binder set | 2 failed |

Clean after: 8 passed.

## Failure-set delta vs `origin/main`

Baselined by stashing this work in the same tree and re-running.

- `sugar-source-tree`: **identical** — 1 failed, 681 passed, 5 skipped, same test
  (`test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`, inherited,
  in `outcome/exit_set.py`, untouched here).
- `sugar-lift-python-source`: baseline 13 failed / 649 passed; head 11 failed /
  651 passed. Head's failure set is a strict **subset** of baseline's — no new
  failure. The two absent ones are `test_verify_dialect` subprocess tests that
  flake.
- `sugar-lift-py-tests`: **not run** — it resolves the Rust binary and would
  force a build; the brief forbids that on this box. CI owns it.

Inherited red touching these files:
`test_source_call_preconstruction.py::test_source_visible_function_with_opaque_child_stays_typed_loud`
is red on `origin/main`: `len` is bound in the builtin temporal, so its fixture no
longer has an opaque child. Its kind string is renamed to the vocabulary that
exists; **the fixture is a separate defect and stays loud rather than being
trimmed to fit.**

## Scope, stated

(C) — the frame-aware classifier — is **implemented here, not deferred**, so no
misclassification is pinned: higher-order dispatch is no longer labelled as a
missing import. The *capability* to construct through a called value is **not**
implemented and stays loud under its own name, tracked at #6409.

Refs #6371, #6409, #6410. Does not close any of them.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `opaque-call-target` gap kind into four distinct call-target gap kinds
> - Replaces the single `opaque-call-target` gap kind with four explicit kinds: `call-graph-cycle`, `value-call-target`, `call-target-source-absent`, and `call-target-export-unresolved` in [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6407/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) and [`source_call_resolution.py`](https://github.com/TSavo/sugar/pull/6407/files#diff-3743478c2f53cedf586c532c3000f3452f8fb1a2a8f6c6cadbd2e663d8f0d0e9).
> - Adds `_frame_bound_names` helper and replaces the `_named_call_is_source_opaque` boolean predicate with `_classify_named_call_target`, which correctly distinguishes parameters/locals, module-level definitions, and builtins — fixing false gaps for builtin callees.
> - Blocking callee names are now aggregated and reported in a separate `detail` field on `ContextManagerResolutionGapV1` rather than fused into the kind string, and gap panics in `With._raise_resolution_gap` include that detail in the observed message.
> - `WithConstructionGapKind` enum in [`panic.py`](https://github.com/TSavo/sugar/pull/6407/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb) is extended with the new kinds so decoding and controls stay in sync.
> - Risk: any code matching on `opaque-call-target` kind strings will no longer match; callers must handle the four replacement kinds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 972a3a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->