### PR TITLE
Thread assertion With through reduction context

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -52,7 +52,6 @@ class WithEffectBoundarySugar(Sugar):
         )
         from sugar_source_tree.panic import SugarNotWritten
 
-        del ctx
         semantics = self.semantics
         if (
             not isinstance(semantics, EffectBoundarySemanticsV1)
@@ -66,7 +65,7 @@ class WithEffectBoundarySugar(Sugar):
                 fix="keep other effect-boundary variants loud until their typed router exists",
             )
 
-        manager_es = sugar_outcome_to_exitset(self.manager.desugar())
+        manager_es = sugar_outcome_to_exitset(self.manager.desugar(ctx))
         routed = []
         for manager_exit in manager_es.exits:
             if isinstance(manager_exit, Halted):
@@ -99,9 +98,9 @@ class WithEffectBoundarySugar(Sugar):
                     variadic_keyword_actuals={},
                 )
 
-            body_es = promote_raise_halts(reduce_block_to_exitset(self.body)).guarded(
-                manager_exit.guard
-            )
+            body_es = promote_raise_halts(
+                reduce_block_to_exitset(self.body, ctx)
+            ).guarded(manager_exit.guard)
 
             # One typed contract, both edges. ``unmet`` is what makes this an
             # assertion boundary rather than a resource ``__exit__``: under

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -840,6 +840,47 @@ def test_the_assertion_with_routes_through_the_shared_exitset_algebra(
     assert routed == incoming.and_exit(exit_es, disposition=disposition)
 
 
+def test_assertion_with_threads_the_reduction_context_through_manager_and_body(
+    tmp_path, monkeypatch
+):
+    """A real assertion-With is a statement in its enclosing reduction.
+
+    Manager operands and body statements must therefore see the same context
+    as their enclosing block. Dropping it makes the boundary work only for
+    already-ground fixtures, not for general source-derived bindings.
+    """
+    _resource, boundary = _both_arms(tmp_path, stem="context")
+    from sugar_lift_py_tests.claim import SugarCatalog
+    from sugar_lift_py_tests.context import FactoryBuildContext
+
+    marker = FactoryBuildContext("context.py", SugarCatalog())
+    observed = []
+
+    manager_type = type(boundary.manager)
+    manager_desugar = manager_type.desugar
+
+    def manager_probe(self, ctx=None):
+        if self is boundary.manager:
+            observed.append(("manager", ctx))
+        return manager_desugar(self, ctx)
+
+    body_type = type(boundary.body[0])
+    body_desugar = body_type.desugar
+
+    def body_probe(self, ctx=None):
+        if self is boundary.body[0]:
+            observed.append(("body", ctx))
+        return body_desugar(self, ctx)
+
+    monkeypatch.setattr(manager_type, "desugar", manager_probe)
+    monkeypatch.setattr(body_type, "desugar", body_probe)
+
+    boundary.desugar(marker)
+
+    assert ("manager", marker) in observed
+    assert ("body", marker) in observed
+
+
 def test_discrimination_the_routing_probe_observes_a_real_call(tmp_path, monkeypatch):
     """The probe is armed: it sees the resource router too, under a resource contract.
 


### PR DESCRIPTION
## Summary

Thread the enclosing reduction context through authenticated assertion-style `With` manager operands and body reduction.

`WithEffectBoundarySugar` previously discarded `ctx`, so the shared `ExitSet.and_exit` route worked only when manager operands and body statements were already ground. The boundary now evaluates both through the caller context while preserving authenticated contract projection and completed/halted routing.

The regression uses one real neutral assertion-manager source and proves both manager and body receive the exact enclosing context. Existing truthful, mismatched, and contract-swap lying twins remain the semantic discrimination gate.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | +1 | assertion-With can construct context-dependent manager/body reductions |
| `mandatory_panics` | -1 | removes the context-loss failure at this construction seam |
| `suppressed_descendants` | 0 | no catch, fallback, or suppression path added |
| `typed_effects` | 0 | existing typed effect routing is unchanged |
| `silent` | 0 | floor: must stay 0 |

No corpus census, scoreboard, receipt, or classification was run for this lane.

## Validation

Focused assertion-With package gate: `6 passed in 9.54s`; crash count `0`; timeout count `0`.

Covered the shared `ExitSet.and_exit` route, exact context threading, truthful matching halt, mismatched halt, contract-swap lying twin, and the lying-twin setup tooth.

## Floors preserved

- `data_loss=0`
- no secret committed
- no test deleted for green
- `silent=0`
- unmatched effects remain typed and loud
- manager authority and expected-effect identity remain contract-authenticated


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread reduction context through `WithEffectBoundarySugar.desugar` manager and body calls
> Previously, `WithEffectBoundarySugar.desugar` discarded the `ctx` parameter before calling into the manager and body reduction. Now it forwards `ctx` to both `self.manager.desugar(ctx)` and `reduce_block_to_exitset(self.body, ctx)`, enabling context-aware behavior in those components. A new test in [test_with_partition_shared_algebra.py](https://github.com/TSavo/sugar/pull/6408/files#diff-4c2dc084662d16aaa82b994deee4c8e6f1a999e1d2e90bfbc1c64be73b88e1b5) verifies that both the manager and body receive the same context marker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3dbf25.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->