### PR TITLE
An operand is not one unconditional value: the slice/subscript `.value` defect (2 desugar-defect rows to clean)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
@@ -26,18 +26,66 @@ class SliceSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
+        # A BOUND IS AN ORDINARY OPERAND, and an operand does not answer with
+        # exactly one unconditional value. `out.value` asked it to -- it read the
+        # `Complete` field off whatever came back -- so a bound that PARTITIONS
+        # (`pattern.search(s, pos).span()[0]`, whose method coordinate reduces to
+        # an ExitSet) crashed with `'ExitSet' object has no attribute 'value'`,
+        # and a bound owing a parameter contract (`xs[p[0]:]` for a formal `p`)
+        # had its demand read off and dropped.
+        #
+        # This is the shape `collection_sugar._reduce_into` already owns and
+        # names: reduce operands in source order, factor each so an arm count
+        # does not multiply through the fold (#6324), accumulate every pending
+        # demand into one set, and re-attach it to what gets built (#6352). A
+        # slice is that same fold over its present bounds, so it goes through
+        # that door rather than growing a second copy of the law.
+        from sugar_lift_py_tests.sugar.collection_sugar import _reduce_into
+
+        present = tuple(
+            bound
+            for bound in (self.lower, self.upper, self.step)
+            if bound is not None
+        )
+        omitted = tuple(
+            bound is None for bound in (self.lower, self.upper, self.step)
+        )
+        return _reduce_into(present, ctx, _slice_builder(omitted))
+
+
+def _slice_builder(omitted: tuple):
+    """The `build` the fold hands its reduced bound values.
+
+    ``omitted`` is one flag per slice position, in source order. Every position
+    is filled: a present bound contributes the next reduced value's term, an
+    omitted one contributes Python's own ``None`` -- which is a VALUE Python
+    fills in, not a missing operand, and so never reaches the fold. The two
+    sequences are consumed in lockstep, and the arity is checked rather than
+    assumed: a mismatch would silently shift a bound into a neighbouring
+    position and mint a `py.slice` that means something else.
+    """
+
+    def slice_value(values: tuple):
         from sugar_lift_py_tests.floor.none_value import NoneValue
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Incomplete
 
-        terms = []
-        for bound in (self.lower, self.upper, self.step):
-            if bound is None:
-                terms.append(NoneValue().to_term(owner="slice"))
-                continue
-            out = bound.desugar(ctx)
-            if isinstance(out, Incomplete):
-                return out
-            terms.append(out.value.to_term(owner="slice"))
-        return Complete(SymbolicValue(ctor("py.slice", terms)))
+        present = sum(1 for flag in omitted if not flag)
+        if len(values) != present:
+            raise AssertionError(
+                "LAW (a slice fills every position it declares): "
+                f"{len(values)} reduced bound(s) arrived for {present} present "
+                "position(s) of `py.slice`. Consuming them out of lockstep "
+                "would move a bound into a neighbouring position and mint a "
+                "different slice."
+            )
+        remaining = list(values)
+        terms = [
+            NoneValue().to_term(owner="slice")
+            if flag
+            else remaining.pop(0).to_term(owner="slice")
+            for flag in omitted
+        ]
+        return SymbolicValue(ctor("py.slice", terms))
+
+    return slice_value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -40,10 +40,50 @@ class SubscriptSugar(Sugar):
         )
 
     def desugar(self, ctx: Any = None) -> Outcome:
-        return self.receiver.desugar(ctx).and_then(
-            lambda receiver: self.index.desugar(ctx).and_then(
+        # THE INDEX CAN OWE A CONTRACT, and `and_then` has no arm for a carrier:
+        # a carrier wraps a value together with an obligation, which is neither a
+        # value nor a partition, so `outcome_to_exitset` panics NAMED on it
+        # (#6352). `xs[p[0]:]` and `res.append(s[pos:ps.span()[0]])` both arrive
+        # here that way -- the second is the `slice_sugar` family, whose demand
+        # now survives its own fold instead of being read off with `.value`.
+        #
+        # So hoist both operands' obligations, fold the plain values exactly as
+        # before, and re-attach the union to the result. `rewrap_pending` is the
+        # sole re-attachment door and is itself loud when the joined outcome has
+        # nowhere to carry the demand: nothing here drops an obligation quietly.
+        from dataclasses import replace
+
+        from sugar_lift_py_tests.caller_parameter_contract import merge_demands
+        from sugar_lift_py_tests.floor.single_outcome_law import (
+            pending_demand,
+            rewrap_pending,
+        )
+        from sugar_lift_py_tests.outcome import true_guard
+
+        # A subscript expression has no guard of its own, so both obligations
+        # hoist unconditionally.
+        pending = None
+        plain = []
+        for operand in (self.receiver, self.index):
+            entry, value_outcome = pending_demand(operand.desugar(ctx), true_guard())
+            if entry is not None:
+                pending = (
+                    entry
+                    if pending is None
+                    else replace(
+                        pending,
+                        demands=merge_demands(pending.demands, entry.demands),
+                    )
+                )
+            plain.append(value_outcome)
+        receiver_outcome, index_outcome = plain
+        subscripted = receiver_outcome.and_then(
+            lambda receiver: index_outcome.and_then(
                 lambda index: self._subscript(receiver, index, ctx)
             )
+        )
+        return rewrap_pending(
+            pending, subscripted, owner=type(self).__name__, blame=self.site
         )
 
     def _subscript(self, receiver, index, ctx):

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -265,3 +265,116 @@ def test_effect_without_occurrence_is_an_instrument_gap_not_a_fabricated_key() -
         "no-occurrence-coordinate:SourceOracleEffect"
     }
     assert axis.red is True
+
+
+# -- 10. a defect row carries the classification its exception already holds --
+#
+# The pandas board reported thirteen `ExitSetFactoringGap` occurrences as
+# undifferentiated `desugar-exception` rows, while the exception itself carried
+# the two refusing arms and a classifier that splits them into closable work and
+# correct output. Both twins below assert EXACT cardinality and that the row
+# stays on the defect axis: reading testimony must not move a row anywhere.
+
+
+def _factoring_gap(*, stamped: bool):
+    """One `ExitSetFactoringGap` carrying two arms, silent or testifying."""
+    from sugar_lift_py_tests.ir import atomic, make_var, not_
+    from sugar_lift_py_tests.outcome.exit_set import (
+        Completed,
+        ExitSetFactoringGap,
+        partition,
+    )
+
+    guard = atomic("g", [make_var("state")])
+    if stamped:
+        # Both arms testify to the SAME side of one producer's split — which is
+        # why the split does not separate them, and why wiring a producer
+        # cannot close this occurrence.
+        face, _other_side = partition("twin-producer")
+        left = Completed(guard, "A", frozenset({face}))
+        right = Completed(not_(guard), "B", frozenset({face}))
+    else:
+        left = Completed(guard, "A", frozenset())
+        right = Completed(not_(guard), "B", frozenset())
+    return ExitSetFactoringGap("arms are not provably exclusive", left, right)
+
+
+def test_twin_10_factoring_gap_defect_carries_its_classification() -> None:
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="gen.py:1:0")
+    row = axis.row()
+    # Still exactly one DEFECT: reading testimony moves nothing off this axis.
+    assert row["R_desugar"] == 0
+    assert row["desugarFamilies"] == {}
+    assert row["desugarConstructionPanics"] == []
+    assert len(row["desugarDefects"]) == 1
+    defect = row["desugarDefects"][0]
+    assert defect["kind"] == "desugar-exception"
+    assert defect["detail"].startswith("ExitSetFactoringGap")
+    assert defect["classification"]["kind"] == "unstamped"
+    assert defect["classification"]["isRemainingWork"] is True
+    assert axis.red is True
+
+
+def test_twin_10_discriminator_stamped_arms_are_not_reported_as_owed_work() -> None:
+    """The same row shape, the other verdict.
+
+    A classifier that answered one constant would satisfy the positive twin
+    above. Two producers that already testified and still do not separate are
+    NOT closable by wiring a producer, and the row must say so.
+    """
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=_factoring_gap(stamped=True)), where="gen.py:1:0")
+    defects = axis.row()["desugarDefects"]
+    assert len(defects) == 1
+    assert defects[0]["classification"]["kind"] == "stamped-not-separating"
+    assert defects[0]["classification"]["isRemainingWork"] is False
+
+
+def test_twin_10_discriminator_an_exception_with_no_testimony_gets_no_key() -> None:
+    """No placeholder. An ordinary exception carries no classification, and the
+    row must OMIT the key rather than carry an "unknown" a reader could read as
+    a verdict."""
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=KeyError("boom")), where="gen.py:1:0")
+    defects = axis.row()["desugarDefects"]
+    assert len(defects) == 1
+    assert "classification" not in defects[0]
+
+    # ...and neither does a factoring gap that carries no arms at all.
+    from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+
+    bare = _axis()
+    bare.measure(_FakeSugar(raises=ExitSetFactoringGap("bare")), where="gen.py:2:0")
+    bare_defects = bare.row()["desugarDefects"]
+    assert len(bare_defects) == 1
+    assert "classification" not in bare_defects[0]
+
+
+def test_twin_10_discriminator_a_merged_arm_is_not_reported_as_owed_work() -> None:
+    """Silent arms are not automatically owed work.
+
+    An equal-destination merge puts a disjunction at conjunct level, and #6336's
+    composition rule intersects faces on such a merge — so minting the producer's
+    face would only see it intersected away again (#6361 measured exactly that).
+    An `UNSTAMPED` row with a merged arm must therefore read `isRemainingWork:
+    False`, and this twin is the one that fails when the merged-arm condition is
+    dropped from `is_remaining_work`.
+    """
+    from sugar_lift_py_tests.ir import atomic, make_var, not_, or_
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSetFactoringGap
+
+    guard = atomic("g", [make_var("state")])
+    merged = or_([guard, atomic("h", [make_var("state")])])
+    gap = ExitSetFactoringGap(
+        "arms are not provably exclusive",
+        Completed(merged, "A", frozenset()),
+        Completed(not_(guard), "B", frozenset()),
+    )
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=gap), where="gen.py:1:0")
+    defects = axis.row()["desugarDefects"]
+    assert len(defects) == 1
+    assert defects[0]["classification"]["kind"] == "unstamped"
+    assert defects[0]["classification"]["mergedArm"] is True
+    assert defects[0]["classification"]["isRemainingWork"] is False


### PR DESCRIPTION
## The row

`'ExitSet' object has no attribute 'value'` — the 2-row desugar-defect family of the conserved 1,421/1,421 board at `docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json`.

#6319's finding held. It is code asking an operation for exactly one unconditional answer.

## What was wrong

`SliceSugar.desugar` read `out.value` off each bound's outcome. A bound that PARTITIONS crashed. Reduced to a **minimal non-vendor shape** — a `while ps:` loop over `pattern.search`, whose `ps.span()[0]` reduces through a method coordinate to an ExitSet — it reproduces in seconds without pandas installed.

The fold now goes through `collection_sugar._reduce_into`, the door that already owns this law and **names this exact defect in its own docstring**: factor each operand so arm counts do not multiply (#6324), accumulate every pending demand into one set, re-attach it to what gets built (#6352). Omitted bounds never enter the fold — Python fills them with a value, they are not missing operands — and the builder checks its arity rather than assuming lockstep, because a shifted bound would mint a `py.slice` that quietly means something else.

`SubscriptSugar.desugar` then met the obligation the slice fold had correctly stopped dropping, and `and_then` has no arm for a carrier. It now hoists both operands' demands with `pending_demand`, folds the plain values exactly as before, and re-attaches the union with `rewrap_pending` — the sole re-attachment door, itself loud when the join has nowhere to carry a demand.

## Measured ΔR, not predicted

Same two ledger coordinates, same corpus (pandas 3.0.3, file count matching the pin), **baseline `a6dfd2303` vs this head**, run through the same door in two worktrees:

| coordinate | baseline `a6dfd2303` | head |
|---|---|---|
| `io/excel/_openpyxl.py:614` | DEFECT `AttributeError` | **clean** |
| `io/formats/style_render.py:2579` | DEFECT `AttributeError` | **clean** |

**ΔR(desugar defects) = −2. No other axis rose** — both land on CLEAN, not on a refusal and not on a panic. Two neighbouring shapes that were already clean stayed clean.

Site coverage is separate from ΔR: the change touches every `SliceSugar` and `SubscriptSugar` site in the corpus; the two rows above are the occurrences the board recorded.

## What the other 38 rows turned out to be

Re-measured at head before implementing, which the ledger's staleness required (`9a78828ee` → main is ~two dozen merges):

- **25 rows — `TypeError: ContractConditionalConstructionV1`.** Already rehomed by #6352. That `raise TypeError(type(outcome))` is gone from `outcome_to_exitset`; it is now a named construction panic with an owner, an observed shape and a fix. Those rows are on the **panic** axis at head, not the defect axis. Not work on this branch.
- **13 rows — `ExitSetFactoringGap`.** One is now clean (`core/methods/selectn.py:224`). Re-measured, the other twelve classify — through `outcome/factoring_gap_kind`, off carried testimony — as **`isRemainingWork: False`, every one of them, all with `mergedArm: True`**. That is `factor_completed` doing its job by the module's own definition, not closable by wiring a producer. **Caveat, stated because it matters:** that reading came through the file-local construction door, not the corpus-wide one the census uses, so it is indicative and not authoritative. It wants confirmation from the battleaxe baseline before anyone plans against it.
- **5 backend defects.** See below — not closed, and not closable here.

## Tests

Five twins on the census's defect row, both faces, exact cardinality, in `test_desugar_axis_twins.py`. Every one is perturbation-tested against the mechanism it *names* (carried testimony), not the code it touches:

| mutation | twin that goes red |
|---|---|
| classifier ignores carried testimony | `..._stamped_arms_are_not_reported_as_owed_work` |
| `is_remaining_work` drops the merged-arm condition | `..._a_merged_arm_is_not_reported_as_owed_work` |
| reader silently drops the classification | the positive twin + both discriminators |
| absent testimony mints an `"unknown"` placeholder | `..._an_exception_with_no_testimony_gets_no_key` |

The merged-arm twin exists **because** perturbation found it: mutating `is_remaining_work` passed every test that existed until that twin was written.

The census-side reader turned out to be #6364, which landed on main while this branch was open and reads the same classification off the same exception. Its implementation is kept — mine was dropped in the rebase. The twins here are additional teeth for it.

## Known inherited red / blockers

- **The pytest suite cannot run on this box.** `tests/conftest.py` has a session-autouse fixture that resolves a Rust release binary; there is no cached artifact for this tree's stamp and the build rung waits on a build-directory lock a peer process holds. The brief forbade a forced binary build, so the twins were executed by direct invocation instead (15/15 green, and green against main's implementation after rebase). **CI is the real verdict on this PR.**
- **The 3 `spans.LineTable.line_col` backend defects are NOT closed.** They are one bug and one fix, but reproducing them requires the corpus-wide *shared* `contract_refs` table — a single-file run passes `contract_refs=None` and cannot show them. That reading did not complete on this box (load average ~375 from the rest of the fleet; the shared-table build alone ran past 25 minutes). What was established: `LineTable` is per-`SourceUnit` and the only two projection sites are `nodes.py:1481` and `fragment.py:91`, so the defect is a span minted from one unit projected through another's table — and the shared demand/gap table is the only thing in the census that crosses files. The `0..27637` bound is identical across all three rows and matches no file in the wheel corpus, which points at the audit corpus rather than a pandas module. **Next owner needs a multi-file run with a shared table.**
- The remaining 2 `SourceCallBindingGap` backend rows were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slice and subscript desugaring to handle operands with obligations or partitions
> - [`SliceSugar.desugar`](https://github.com/TSavo/sugar/pull/6411/files#diff-08eabbce095d4b39634073e53c0dedc4ec4b414c3421ed45c56e88c8e3b7e632) now delegates bound reduction to `collection_sugar._reduce_into`, preserving partitions and re-attaching pending parameter-contract demands instead of assuming a single unconditional value per bound.
> - A new `_slice_builder` factory fills omitted slice positions with `NoneValue` and enforces an arity check between present bounds and reduced values.
> - [`SubscriptSugar.desugar`](https://github.com/TSavo/sugar/pull/6411/files#diff-0a35660414dc62dca7c8656f2f0c64e6e5547d02aa7e1017e20304426061fb05) hoists and merges pending demands from both receiver and index, then re-attaches accumulated obligations to the resulting outcome.
> - New tests in [`test_desugar_axis_twins.py`](https://github.com/TSavo/sugar/pull/6411/files#diff-10eb5ea731ca9e1a69546a25149a6b1aa4e7925e67769c5d2970fd46b1cb7155) validate defect-row classification for `ExitSetFactoringGap` across unstamped, stamped, and merged-arm cases.
> - Risk: `_slice_builder` raises `AssertionError` on arity mismatch between present bounds and reduced values, which is a new failure mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc37d17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->