### PR TITLE
Part of #6382: construct ground class-body conditionals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -14,12 +14,20 @@ from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
 
 
 @dataclass(frozen=True)
+class ConstructedClassConditionalFieldsV1:
+    condition_fragment_cid: str
+    condition_sugar: Sugar = field(compare=False)
+    when_true: tuple[object, ...] = ()
+    when_false: tuple[object, ...] = ()
+
+
+@dataclass(frozen=True)
 class ClassDefinitionSugar(Sugar):
     class_name: str
     source_identity_cid: str
     definition_fragment_cid: str
     methods: tuple[ConstructedClassMethodV1, ...]
-    fields: tuple[ConstructedClassFieldV1, ...]
+    fields: tuple[ConstructedClassFieldV1 | ConstructedClassConditionalFieldsV1, ...]
     docstring_cid: str | None
     annotation_cids: tuple[str, ...]
     decorator_cids: tuple[str, ...]
@@ -37,6 +45,19 @@ class ClassDefinitionSugar(Sugar):
 
     @property
     def preimage(self):
+        def encode_field(item):
+            if isinstance(item, ConstructedClassFieldV1):
+                return {
+                    "name": item.name,
+                    "definitionFragmentCid": item.definition_fragment_cid,
+                }
+            return {
+                "kind": "conditional",
+                "conditionFragmentCid": item.condition_fragment_cid,
+                "whenTrue": [encode_field(child) for child in item.when_true],
+                "whenFalse": [encode_field(child) for child in item.when_false],
+            }
+
         return {
             "kind": "python-class-definition",
             "schemaVersion": "1",
@@ -50,13 +71,7 @@ class ClassDefinitionSugar(Sugar):
                 }
                 for method in self.methods
             ],
-            "fields": [
-                {
-                    "name": item.name,
-                    "definitionFragmentCid": item.definition_fragment_cid,
-                }
-                for item in self.fields
-            ],
+            "fields": [encode_field(item) for item in self.fields],
             "docstringCid": self.docstring_cid,
             "annotationCids": list(self.annotation_cids),
             "decoratorCids": list(self.decorator_cids),
@@ -89,7 +104,38 @@ class ClassDefinitionSugar(Sugar):
                     fix="keep dynamic or opaque inheritance loud",
                 )
             base_values.append(outcome.value)
-        for item in self.fields:
+        def append_field(item):
+            if isinstance(item, ConstructedClassConditionalFieldsV1):
+                condition = item.condition_sugar.desugar(ctx)
+                from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                    FalseBoolLiteralSugar,
+                )
+                from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                    TrueBoolLiteralSugar,
+                )
+
+                if not isinstance(condition, Complete) or not isinstance(
+                    condition.value, (TrueBoolLiteralSugar, FalseBoolLiteralSugar)
+                ):
+                    from sugar_source_tree.panic import SugarNotWritten
+
+                    raise SugarNotWritten(
+                        owner="ClassDefinitionSugar.desugar",
+                        observed="class conditional guard is not a ground bool literal",
+                        requested=(
+                            "one constructed TrueBoolLiteralSugar or "
+                            "FalseBoolLiteralSugar"
+                        ),
+                        fix="keep symbolic or effectful class-body control loud",
+                    )
+                selected = (
+                    item.when_true
+                    if isinstance(condition.value, TrueBoolLiteralSugar)
+                    else item.when_false
+                )
+                for child in selected:
+                    append_field(child)
+                return
             outcome = item.value_sugar.desugar(ctx)
             if not isinstance(outcome, Complete):
                 from sugar_source_tree.panic import SugarNotWritten
@@ -101,6 +147,9 @@ class ClassDefinitionSugar(Sugar):
                     fix="keep effectful or unresolved class initializers loud",
                 )
             class_fields.append(ObjectField(item.name, outcome.value))
+
+        for item in self.fields:
+            append_field(item)
         initializer = next(
             (method for method in self.methods if method.name == "__init__"), None
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_small_family_batch.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_small_family_batch.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.class_definition_sugar import ClassDefinitionSugar
 from sugar_lift_py_tests.sugar.named_expr_sugar import NamedExprSugar
@@ -47,14 +49,46 @@ def test_classdef_constant_and_method_still_construct(tmp_path: Path) -> None:
     assert any(method.name == "m" for method in sugar.methods)
 
 
-def test_classdef_if_body_stays_loud(tmp_path: Path) -> None:
-    sf = _file(tmp_path, "class C:\n    if True:\n        x = 1\n")
+def test_classdef_ground_true_body_constructs_its_field(tmp_path: Path) -> None:
+    sf = _file(
+        tmp_path,
+        "class C:\n    if True:\n        x = 1\n    else:\n        invented = 2\n",
+    )
     class_def = next(n for n in sf.nodes() if type(n).__name__ == "ClassDef")
-    try:
-        class_def.sugar()
-        raise AssertionError("expected unsupported If member to stay loud")
-    except SugarNotWritten as gap:
-        assert "If" in str(gap) or "unsupported class member" in str(gap)
+    sugar = class_def.sugar()
+    value = sugar.desugar().value
+    assert [field.name for field in value.class_fields] == ["x"]
+
+
+def test_classdef_ground_false_body_does_not_invent_its_field(tmp_path: Path) -> None:
+    sf = _file(
+        tmp_path,
+        "class C:\n    if False:\n        invented = 1\n    else:\n        y = 2\n",
+    )
+    class_def = next(n for n in sf.nodes() if type(n).__name__ == "ClassDef")
+    sugar = class_def.sugar()
+    value = sugar.desugar().value
+    assert [field.name for field in value.class_fields] == ["y"]
+
+
+def test_classdef_conditional_fields_preserve_source_override_order(
+    tmp_path: Path,
+) -> None:
+    sf = _file(
+        tmp_path,
+        "class C:\n    if True:\n        x = 1\n    x = 2\n",
+    )
+    class_def = next(n for n in sf.nodes() if type(n).__name__ == "ClassDef")
+    value = class_def.sugar().desugar().value
+    assert [field.name for field in value.class_fields] == ["x", "x"]
+    assert value.class_fields[-1].value.value == 2
+
+
+def test_classdef_symbolic_body_stays_loud(tmp_path: Path) -> None:
+    sf = _file(tmp_path, "class C:\n    if choose:\n        x = 1\n")
+    class_def = next(n for n in sf.nodes() if type(n).__name__ == "ClassDef")
+    with pytest.raises(SugarNotWritten, match="class conditional"):
+        class_def.sugar().desugar()
 
 
 # --- NamedExpr ---

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2479,13 +2479,6 @@ class ClassDef(Statement):
         # residual ClassDef mass is non-constant body assigns; Constant-only
         # was an over-narrow partition that left honest source-visible fields
         # as unsupported-member gaps.
-        class_assignments = tuple(
-            (item.targets[0].id, item.value, item.fragment)
-            for item in self.body
-            if isinstance(item, Assign)
-            and len(item.targets) == 1
-            and isinstance(item.targets[0], Name)
-        )
         annotated_assignments = tuple(
             item
             for item in self.body
@@ -2494,7 +2487,7 @@ class ClassDef(Statement):
         unsupported = tuple(
             item
             for index, item in enumerate(self.body)
-            if not isinstance(item, (FunctionDef, ClassDef, Pass))
+            if not isinstance(item, (FunctionDef, ClassDef, If, Pass))
             and not (
                 index == 0
                 and isinstance(item, Expr)
@@ -2523,7 +2516,65 @@ class ClassDef(Statement):
         )
         from sugar_lift_py_tests.sugar.class_definition_sugar import (
             ClassDefinitionSugar,
+            ConstructedClassConditionalFieldsV1,
         )
+
+        def conditional_fields(statements):
+            fields = []
+            for item in statements:
+                if (
+                    isinstance(item, Assign)
+                    and len(item.targets) == 1
+                    and isinstance(item.targets[0], Name)
+                ):
+                    fields.append(
+                        ConstructedClassFieldV1(
+                            item.targets[0].id,
+                            item.fragment.seal().cid,
+                            item.value.sugar(),
+                        )
+                    )
+                    continue
+                if isinstance(item, AnnAssign) and isinstance(item.target, Name):
+                    if item.value is not None:
+                        fields.append(
+                            ConstructedClassFieldV1(
+                                item.target.id,
+                                item.fragment.seal().cid,
+                                item.value.sugar(),
+                            )
+                        )
+                    continue
+                if isinstance(item, ClassDef):
+                    fields.append(
+                        ConstructedClassFieldV1(
+                            item.name,
+                            item.fragment.seal().cid,
+                            item.sugar(),
+                        )
+                    )
+                    continue
+                if isinstance(item, If):
+                    fields.append(
+                        ConstructedClassConditionalFieldsV1(
+                            condition_fragment_cid=item.test.fragment.seal().cid,
+                            condition_sugar=item.test.sugar(),
+                            when_true=conditional_fields(item.body),
+                            when_false=conditional_fields(item.orelse),
+                        )
+                    )
+                    continue
+                if isinstance(item, Pass):
+                    continue
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="ClassDef._construct_sugar",
+                    observed=f"unsupported conditional class member {item.kind}",
+                    requested="a constructed field assignment or pass",
+                    fix="add the member's ordinary class-control arm or keep it loud",
+                )
+            return tuple(fields)
 
         constructed = tuple(
             ConstructedClassMethodV1(
@@ -2534,32 +2585,17 @@ class ClassDef(Statement):
             )
             for method in methods
         )
-        fields = (
+        fields = conditional_fields(
             tuple(
-                ConstructedClassFieldV1(
-                    name,
-                    fragment.seal().cid,
-                    value.sugar(),
+                item
+                for index, item in enumerate(self.body)
+                if not isinstance(item, (FunctionDef, Pass))
+                and not (
+                    index == 0
+                    and isinstance(item, Expr)
+                    and isinstance(item.value, Constant)
+                    and isinstance(item.value.value, str)
                 )
-                for name, value, fragment in class_assignments
-            )
-            + tuple(
-                ConstructedClassFieldV1(
-                    item.target.id,
-                    item.fragment.seal().cid,
-                    item.value.sugar(),
-                )
-                for item in annotated_assignments
-                if item.value is not None
-            )
-            + tuple(
-                ConstructedClassFieldV1(
-                    item.name,
-                    item.fragment.seal().cid,
-                    item.sugar(),
-                )
-                for item in self.body
-                if isinstance(item, ClassDef)
             )
         )
         base_sugars = ()


### PR DESCRIPTION
Part of #6382.

## What changed
- carry class-body `if` fields as an authenticated, source-ordered conditional field construction
- select only constructed `TrueBoolLiteralSugar` / `FalseBoolLiteralSugar` faces during class desugaring
- keep symbolic/effectful guards and unsupported conditional members typed-loud
- preserve ordinary class-definition CIDs when no conditional field is present

## Truthful / lying twins
- literal true selects only the true field
- literal false selects only the else field and does not invent the true field
- source-order override remains exact
- symbolic guard stays loud

## Validation
`env PYTHONPATH="$PWD/implementations/python/sugar-source-tree/src:$PWD/implementations/python/sugar-lift-python-source/src:$PWD/implementations/python/sugar-lift-py-tests/src" python3 -m pytest -q --noconftest implementations/python/sugar-lift-py-tests/tests/test_small_family_batch.py implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py`

Result: 35 passed. Crash and timeout zero-tolerance floors remain green.

No census, scoreboard, receipt, classification, or pin was added. Not merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct ground class-body conditionals by evaluating `if True/False` guards during desugaring
> - Adds `ConstructedClassConditionalFieldsV1` to represent conditional field groups in class sugar, carrying a guard expression and `when_true`/`when_false` field branches.
> - Updates `ClassDef._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6412/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to treat `If` statements as supported class members, recursively building conditional field structures instead of rejecting them.
> - Updates `ClassDefinitionSugar.desugar` in [class_definition_sugar.py](https://github.com/TSavo/sugar/pull/6412/files#diff-680148569a4f6d44547c05b43a6ab5f0648d25c1a98876e2f42fef6273e7efe1) to evaluate ground boolean guards and include only the selected branch's fields; symbolic (non-ground) guards raise `SugarNotWritten`.
> - The preimage serialization now emits a nested structure with explicit `conditional` nodes instead of a flat field list.
> - Behavioral Change: `If` statements in class bodies that previously caused loud failure during construction now succeed; only non-ground guards during desugaring remain loud.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3538c7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->