### PR TITLE
#6393's lying twin could not fail: repair the one control over "a merged arm may not claim a side"

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py
@@ -6,11 +6,17 @@ import pytest
 
 from sugar_lift_py_tests.floor import StringValue
 from sugar_lift_py_tests.outcome import Complete
-from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+from sugar_lift_py_tests.outcome.exit_set import (
+    ExitSetFactoringGap,
+    _faces_exclusive,
+)
 from sugar_lift_py_tests.sugar.binding_projection import GuardedProjection
 from sugar_lift_py_tests.sugar.binding_projection import UnboundProjection
 from sugar_lift_py_tests.sugar.delete_name_sugar import delete_binding
-from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import read_binding
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+    _guarded_projection_faces,
+    read_binding,
+)
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_source_tree.binding_state import BranchResultSlot
 
@@ -72,8 +78,27 @@ def test_nested_projection_keeps_ancestor_face_when_equal_leaves_merge():
     exits.factor_completed()
 
 
-def test_nested_projection_does_not_keep_a_face_the_merged_leaves_disagree_on():
-    """Lying twin: a merge spanning both outer sides cannot claim either side."""
+def test_a_merge_spanning_both_outer_sides_claims_NEITHER_of_them():
+    """Lying twin: a merge spanning both outer sides cannot claim either side.
+
+    THIS ARM WAS VACUOUS AND IS REPAIRED HERE. It asserted
+
+        not any(face.partition[-1] == outer.slot_id for face in same.faces)
+
+    and `face.partition[-1]` is the tuple `("binding.projection", slot_id)`,
+    never the bare `slot_id` string. The comparison is False for every face
+    that has ever existed, so `not any(...)` was true no matter what the merge
+    did — the one control standing over this law could not fail.
+
+    The law it MEANT to state is about what the merged arm may claim, and that
+    is what is asserted now: an arm reachable on both sides of the outer split
+    must not be provably apart from anything on either side. Stated through
+    `_faces_exclusive`, because claiming a side is only observable as an
+    exclusion — which is also the only way it could ever hurt anything.
+
+    Carrying both sides is how the arm says "one of these, I am not saying
+    which", and it is exactly why it excludes neither.
+    """
     outer = _slot("outer")
     inner = _slot("inner")
     state = GuardedProjection(
@@ -84,8 +109,18 @@ def test_nested_projection_does_not_keep_a_face_the_merged_leaves_disagree_on():
 
     exits = _read(state)
     same = next(exit_ for exit_ in exits.exits if exit_.value == StringValue("same"))
+    outer_true, outer_false = _guarded_projection_faces(GuardedProjection(
+        outer, _Value("x"), _Value("y")
+    ))
 
-    assert not any(face.partition[-1] == outer.slot_id for face in same.faces)
+    assert not _faces_exclusive(same.faces, frozenset({outer_true}))
+    assert not _faces_exclusive(same.faces, frozenset({outer_false}))
+    # ...and the discrimination the vacuous form never had: an arm on ONE side
+    # of that same split IS provably apart from the other side.
+    different = next(
+        exit_ for exit_ in exits.exits if exit_.value == StringValue("different")
+    )
+    assert _faces_exclusive(different.faces, frozenset({outer_false}))
 
 
 def test_unrelated_projection_arms_still_refuse_without_shared_testimony():


### PR DESCRIPTION
## THE ASSERTION COMPARED A TUPLE TO A STRING

```python
assert not any(face.partition[-1] == outer.slot_id for face in same.faces)
```

`face.partition` is `("sugar.exit_set.partition", ("binding.projection", slot_id))`,
so `face.partition[-1]` is the **tuple** `("binding.projection", slot_id)` — never
the bare `slot_id` string. The comparison is `False` for every face that has ever
existed, so `not any(...)` was **vacuously true**. The only control standing over
*"a merge spanning both outer sides may not claim either side"* could not fail,
whatever the merge did.

**Measured, not argued.** It passes identically against the shipped intersection
rule *and* against a candidate union rule that gives the merged arm both sides —
two rules with opposite behaviour, one green test. A control that cannot
distinguish a law from its negation is evidence for neither.

## REPAIRED TO THE LAW IT MEANT

Claiming a side is only ever observable as an **exclusion** — that is the only way
it could hurt anything — so the arm states it through `_faces_exclusive`: an arm
reachable on both sides of the outer split is provably apart from **neither**.

Plus the discrimination the vacuous form never had: an arm on **one** side **is**
provably apart from the other. Without it the test could be satisfied by testimony
simply going missing.

## PERTURBED

| mutation | vacuous form | repaired |
|---|---|---|
| stamp both read arms with the SAME side | silent | **fails** (this arm + the truthful twin beside it) |

That mutation is the exact lie "may not claim a side" exists to catch.

## SCOPE

Test only. No mechanism change — #6393's wiring and #6336's merge algebra are
untouched, and every other arm in the file passes unchanged.

## HARNESS

The kit's conftest gates every test on a release `sugarbin` this box may not build,
so the arms were executed through the same imports without pytest: 4/4 in this file,
green on unmodified main. The pytest run itself is unmeasured here, not green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vacuous assertion in merge-spanning-both-sides test for guarded binding partition
> The previous test (`test_nested_projection_does_not_keep_a_face_the_merged_disagree_on`) compared a face partition entry to a bare slot ID, making the assertion trivially pass without validating actual exclusivity logic.
>
> - Renames the test to `test_a_merge_spanning_both_outer_sides_claims_NEITHER_of_them` and adds a docstring explaining the intent.
> - Computes `outer_true` and `outer_false` via `_guarded_projection_faces` and asserts that the 'same' (merged) exit is not exclusive with either outer face.
> - Adds a new assertion that the 'different' exit *is* exclusive with `outer_false`, providing the discriminating case that was previously untested.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a40289.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->