### PR TITLE
matches_raise_effect: close the identity codomain, retain the undecidable arm

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -9,29 +9,72 @@ if TYPE_CHECKING:
     from sugar_lift_py_tests.ir import Formula
 
 
-def matches_raise_effect(effect, expected) -> bool:
+def matches_raise_effect(effect, expected) -> "MessageVerdict":
     """Match by constructed exception coordinates and authenticated ancestry.
 
-    Exact identity is sufficient. When the raised type carries source-derived
-    MRO testimony, a handler coordinate may match an authenticated ancestor.
-    Missing identity is a construction gap; spelling never participates.
+    The codomain is three-valued, exactly like the message predicate below, and
+    for the same reason. Two authenticated identities settle the question here:
+    exact identity is sufficient, and when the raised type carries
+    source-derived MRO testimony a handler coordinate may match an
+    authenticated ancestor -- that is ``MatchDecided``.
+
+    When either operand's identity is NOT authenticated -- ``raise exc`` on a
+    formal, a handler type this compiler could not resolve to a class -- the
+    question is real and undecidable at lift. It is not a construction gap and
+    it is not ``False``: deciding it either way fabricates a fact about a
+    runtime type nobody testified to. It leaves as ``MatchRetained`` carrying
+    ``adt.is_python_type(raised, handler)``, the reserved tester atom the floor
+    already emits for exactly this question, so the router partitions the
+    incoming exit by it and both faces reach the emitted FOL.
+
+    Loud only where there is no question to retain: an operand that cannot even
+    produce a term has nothing to state the predicate over. Spelling never
+    participates on any arm.
     """
+    from sugar_lift_py_tests.ir import atomic
     from sugar_source_tree.panic import SugarNotWritten
 
     identity_reader = getattr(expected, "exception_type_identity", None)
     expected_identity = identity_reader() if identity_reader is not None else None
     raised_identity = getattr(effect, "exception_type_coordinate", None)
-    if expected_identity is None or raised_identity is None:
+    if expected_identity is not None and raised_identity is not None:
+        if expected_identity == raised_identity:
+            return MatchDecided(True)
+        raised_mro = getattr(effect, "exception_type_mro", None)
+        return MatchDecided(raised_mro is not None and expected_identity in raised_mro)
+
+    owner = "matches_raise_effect"
+    handler_term = expected_identity
+    if handler_term is None:
+        handler_term = _operand_term(expected, owner=owner, role="handler type")
+    raised_term = raised_identity
+    if raised_term is None:
+        raised_term = _operand_term(
+            effect.raised_value, owner=owner, role="raised exception"
+        )
+    if handler_term is None or raised_term is None:
         raise SugarNotWritten(
             owner="matches_raise_effect",
-            observed="handler or raised exception lacks authenticated identity",
-            requested="authenticated exception-type identity on both operands",
-            fix="resolve both exception classes through their lexical coordinates",
+            observed="handler or raised exception has no term to state the test over",
+            requested="an authenticated identity or an emittable operand term",
+            fix="resolve both exception operands through their lexical coordinates",
         )
-    if expected_identity == raised_identity:
-        return True
-    raised_mro = getattr(effect, "exception_type_mro", None)
-    return raised_mro is not None and expected_identity in raised_mro
+    return MatchRetained(atomic("adt.is_python_type", [raised_term, handler_term]))
+
+
+def _operand_term(operand, *, owner, role):
+    """The emitted term for a matcher operand, or ``None`` when it has none.
+
+    ``None`` is not a decision: it is the absence of anything to state the
+    predicate over, and the sole caller turns it into a loud refusal.
+    """
+    del role
+    if operand is None:
+        return None
+    to_term = getattr(operand, "to_term", None)
+    if to_term is None:
+        return None
+    return to_term(owner=owner)
 
 
 @dataclass(frozen=True)
@@ -100,25 +143,42 @@ def _message_term(effect, *, owner):
 def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
     """Authenticated identity match, then the contract's optional message predicate.
 
-    The identity half is ``matches_raise_effect`` -- the one matcher, and it is
-    total: a missing identity is loud there, never a quiet ``False``.
+    The identity half is ``matches_raise_effect`` -- the one matcher. BOTH
+    halves have THREE outcomes, and this function is their conjunction, so it
+    is the conjunction of two three-valued verdicts and nothing here may
+    collapse one. A contract that states no pattern asserts nothing about the
+    message (``MatchDecided(True)``). Two ground strings settle the message
+    predicate here. Anything else -- a symbolic message, a computed pattern --
+    leaves as ``MatchRetained`` carrying ``py.re_search(pattern, message)``,
+    the vendor's own predicate spelled on the membrane.
 
-    The message half has THREE outcomes, not two. A contract that states no
-    pattern asserts nothing about the message (``MatchDecided(True)``). Two
-    ground strings settle the predicate here. Anything else -- a symbolic
-    message, a computed pattern -- is a predicate this compiler cannot decide,
-    and deciding it either way would be a fabricated fact. It leaves as
-    ``MatchRetained`` carrying ``py.re_search(pattern, message)``, which is the
-    vendor's own predicate spelled on the membrane.
+    A ``False`` on either half is ``False`` outright: a conjunct that is
+    decidably false settles the conjunction without deciding the other half.
+    Two open halves leave as one conjoined obligation.
     """
     import re
 
-    from sugar_lift_py_tests.ir import atomic
+    from sugar_lift_py_tests.ir import and_, atomic
 
-    if not matches_raise_effect(effect, expected):
+    identity = matches_raise_effect(effect, expected)
+    if isinstance(identity, MatchDecided) and not identity.value:
         return MatchDecided(False)
+    retained_identity = (
+        identity.obligation if isinstance(identity, MatchRetained) else None
+    )
+
+    def _conjoin(verdict):
+        """Fold the open identity half, if any, into a settled message half."""
+        if retained_identity is None:
+            return verdict
+        if isinstance(verdict, MatchDecided):
+            if not verdict.value:
+                return MatchDecided(False)
+            return MatchRetained(retained_identity)
+        return MatchRetained(and_([retained_identity, verdict.obligation]))
+
     if pattern is None:
-        return MatchDecided(True)
+        return _conjoin(MatchDecided(True))
 
     owner = "authenticated_exception_matching.raise_effect_message_verdict"
     pattern_term = pattern.to_term(owner=owner)
@@ -127,6 +187,10 @@ def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
     ground_pattern = _ground_string(pattern_term)
     ground_message = _ground_string(message_term)
     if ground_pattern is not None and ground_message is not None:
-        return MatchDecided(re.search(ground_pattern, ground_message) is not None)
+        return _conjoin(
+            MatchDecided(re.search(ground_pattern, ground_message) is not None)
+        )
 
-    return MatchRetained(atomic("py.re_search", [pattern_term, message_term]))
+    return _conjoin(
+        MatchRetained(atomic("py.re_search", [pattern_term, message_term]))
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -50,11 +50,18 @@ class EffectBinding:
         The **witness identity is the slot itself** (effect-slot(S) on returns).
         Type is separate testimony. Origin links the slot to a deterministic
         raise-effect occurrence when available — never identity-from-type-alone.
+
+        Each projection is a TERM, not a predicate. ``=`` relates two terms, so
+        ``effect_slot_kind(S)`` must be built with ``ctor``; building it with
+        ``atomic`` put a Formula in a term position, and a fact that cannot be
+        content addressed is a fact that cannot be compared, normalized, or
+        pinned. It stayed latent only because a decided handler scan never
+        emitted two fact-carrying arms that had to normalize together.
         """
         slot = str_const(self.slot_id)
         facts = [
             InvValue(
-                eq(atomic("effect_slot_kind", [slot]), str_const(self.kind)),
+                eq(ctor("effect_slot_kind", [slot]), str_const(self.kind)),
                 site=site,
             ),
         ]
@@ -62,7 +69,7 @@ class EffectBinding:
             facts.append(
                 InvValue(
                     eq(
-                        atomic("effect_slot_type", [slot]),
+                        ctor("effect_slot_type", [slot]),
                         str_const(self.type_name),
                     ),
                     site=site,
@@ -74,7 +81,7 @@ class EffectBinding:
             facts.append(
                 InvValue(
                     eq(
-                        atomic("effect_slot_origin", [slot]),
+                        ctor("effect_slot_origin", [slot]),
                         ctor(
                             "python:raise_effect_occurrence",
                             [str_const(occurrence)],

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -124,8 +124,11 @@ def _boundary_halted_edge(disposition, incoming):
     if isinstance(verdict, MatchDecided):
         return _consumed(disposition, incoming)
     if isinstance(verdict, MatchRetained):
-        # The identity matched; only the message predicate is open. Under it
-        # the boundary consumes, under its complement the ORIGINAL halt stands.
+        # Some conjunct of the boundary's predicate is open -- the identity
+        # test, the message test, or both conjoined. Under the obligation the
+        # boundary consumes, under its complement the ORIGINAL halt stands.
+        # Which conjunct is open is not this edge's business: the verdict is
+        # one predicate and it is routed as one.
         return RetainedObligation(
             obligation=verdict.obligation,
             held=_consumed(disposition, incoming),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -89,19 +89,26 @@ class TrySugar(Sugar):
         return exitset_to_outcome(after)
 
 
-def _effect_matches(effect, matcher, ctx=None) -> bool:
-    """Bare except matches any raise; typed arms use constructed identity."""
+def _effect_match_verdict(effect, matcher, ctx=None):
+    """Bare except matches any raise; typed arms use constructed identity.
+
+    The codomain is the shared matcher's: ``MatchDecided`` when the arm settles
+    at lift, ``MatchRetained`` when the identity test is real and open. The
+    caller must route BOTH faces of a retention -- never treat it as a match
+    and never as a miss.
+    """
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.authenticated_exception_matching import (
+        MatchDecided,
         matches_raise_effect,
     )
     from sugar_lift_py_tests.outcome import Complete
     from sugar_source_tree.panic import SugarNotWritten
 
     if not isinstance(effect, RaiseEffect):
-        return False
+        return MatchDecided(False)
     if matcher is None:
-        return True
+        return MatchDecided(True)
     expected = matcher.desugar(ctx)
     if not isinstance(expected, Complete):
         raise SugarNotWritten(
@@ -149,24 +156,7 @@ def _route_handlers_over_exits(
     parts: list = []
     for exit_ in body_es.exits:
         if isinstance(exit_, Halted):
-            matched = False
-            for matcher, handler_body, slot_id in handlers:
-                if not _effect_matches(exit_.effect, matcher, ctx):
-                    continue
-                from sugar_lift_py_tests.in_flight_effect import (
-                    bind_in_flight_effect,
-                )
-
-                handler_ctx = bind_in_flight_effect(ctx, slot_id, exit_.effect)
-                handler_es = reduce_block_to_exitset(handler_body, handler_ctx)
-                facts = _binding_facts_for(slot_id, exit_.effect, site)
-                if facts:
-                    handler_es = _prepend_facts(handler_es, facts)
-                parts.append(handler_es.guarded(exit_.guard))
-                matched = True
-                break
-            if not matched:
-                parts.append(ExitSet((exit_,)))
+            parts.extend(_route_one_halt(exit_, handlers, site=site, ctx=ctx))
             continue
 
         if orelse:
@@ -199,6 +189,69 @@ def _route_handlers_over_exits(
     for part in parts[1:]:
         result = result.union(part)
     return result
+
+
+def _route_one_halt(exit_, handlers: tuple, *, site, ctx) -> list:
+    """Route ONE halted body exit through the handler list, in source order.
+
+    Walks the arms carrying a residual: the exit as it still stands after every
+    arm considered so far declined it. A settled match takes the whole residual
+    and the walk is over. A settled miss leaves the residual untouched.
+
+    A ``MatchRetained`` arm is the third case and the reason this is a walk
+    rather than a scan. The arm owns a genuine two-way split, so it mints one,
+    routes the residual into the handler under the obligation, and narrows the
+    residual to the complement for the arms that follow. Nothing is admitted
+    and nothing is dropped: whatever residual survives every arm leaves as the
+    halt it always was, still red, under the conjunction of every complement.
+    """
+    from sugar_lift_py_tests.authenticated_exception_matching import (
+        MatchDecided,
+        MatchRetained,
+    )
+    from sugar_lift_py_tests.ir import not_
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, partition
+
+    def handler_exits(handler_body, slot_id):
+        from sugar_lift_py_tests.in_flight_effect import bind_in_flight_effect
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        handler_ctx = bind_in_flight_effect(ctx, slot_id, exit_.effect)
+        handler_es = reduce_block_to_exitset(handler_body, handler_ctx)
+        facts = _binding_facts_for(slot_id, exit_.effect, site)
+        return _prepend_facts(handler_es, facts) if facts else handler_es
+
+    parts: list = []
+    residual = ExitSet((exit_,))
+    for index, (matcher, handler_body, slot_id) in enumerate(handlers):
+        if not residual.exits:
+            return parts
+        residual_guard = residual.exits[0].guard
+        verdict = _effect_match_verdict(exit_.effect, matcher, ctx)
+        if isinstance(verdict, MatchDecided):
+            if not verdict.value:
+                continue
+            parts.append(handler_exits(handler_body, slot_id).guarded(residual_guard))
+            return parts
+        if not isinstance(verdict, MatchRetained):
+            raise TypeError(
+                "except-arm verdict must be MatchDecided or MatchRetained; "
+                f"got {type(verdict).__name__}"
+            )
+        # This arm owns the split, so it mints the faces rather than leaving the
+        # exclusion legible only in the ``not_`` spelling of the two guards.
+        caught_face, missed_face = partition(("try.except-identity", site, index))
+        parts.append(
+            handler_exits(handler_body, slot_id)
+            .guarded(verdict.obligation, caught_face)
+            .guarded(residual_guard)
+        )
+        residual = residual.guarded(not_(verdict.obligation), missed_face)
+    if residual.exits:
+        parts.append(residual)
+    return parts
 
 
 def _prepend_facts(exits, facts: tuple):

--- a/implementations/python/sugar-lift-py-tests/tests/test_retained_exception_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_retained_exception_identity.py
@@ -1,0 +1,191 @@
+"""An undecidable handler match is RETAINED, never decided, never loud.
+
+`matches_raise_effect` is the one matcher shared by Try and With, so every
+assertion boundary depends on its codomain being honest. Its message half was
+closed to three outcomes once already, after a `bool` codomain let
+`with hold(ValueError, match="boom")` restore a halt *as if* the pattern had
+been checked -- a fabricated fact in the emitted FOL. Its identity half was
+still two-valued plus a panic:
+
+    def f(exc):
+        try:
+            raise exc
+        except ValueError:
+            return 1
+
+Nobody can decide at lift whether the runtime type of the formal `exc` is a
+`ValueError`. That is not a construction gap -- both operands produce perfectly
+good terms -- and it is emphatically not `False`. It is a real predicate this
+compiler cannot settle, so it leaves as `adt.is_python_type(exc, ValueError)`,
+the reserved tester atom the floor already emits for exactly this question, and
+the router partitions the incoming exit by it.
+
+Both faces are pinned here, because each alone is a distinct lie:
+
+- **Never admitted.** The raise must still be on the wall. A router that
+  routed the retained arm into the handler and stopped would have silently
+  claimed the exception was caught.
+- **Never dropped.** The obligation must appear in the emitted FOL. A router
+  that propagated the halt and forgot the predicate would have silently
+  claimed the handler is unreachable.
+
+And the decided arms must stay decided: an obligation emitted where the
+compiler *could* answer is its own fabrication, so the ground cases assert the
+tester atom does not appear at all.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.outcome import Incomplete, outcome_to_exitset
+from sugar_source_tree.tree import SourceFile
+
+TESTER_ATOM = "adt.is_python_type"
+
+
+def _universe(source: str):
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    source_file = SourceFile(
+        (source, "/tmp/retained_identity.py", blake3_512_of(source.encode()))
+    )
+    return list(source_file.functions())[-1].sugar().desugar()
+
+
+def _residual_raises(source: str) -> tuple[str, ...]:
+    """Every raise that survived the `try` -- the effects still on the wall."""
+    exit_set = outcome_to_exitset(_universe(source))
+    names: list[str] = []
+    seen: set[int] = set()
+
+    def walk(value: object) -> None:
+        if value is None or isinstance(value, (str, int, bool, float, bytes)):
+            return
+        key = id(value)
+        if key in seen:
+            return
+        seen.add(key)
+        if isinstance(value, Incomplete) and isinstance(value.effect, RaiseEffect):
+            names.append(value.effect.exception_name)
+        effect = getattr(value, "effect", None)
+        if isinstance(effect, RaiseEffect):
+            names.append(effect.exception_name)
+        for attribute in ("statements", "record", "value", "exits", "entries"):
+            child = getattr(value, attribute, None)
+            if isinstance(child, tuple):
+                for item in child:
+                    walk(item)
+            else:
+                walk(child)
+
+    for face in exit_set.exits:
+        walk(face)
+    return tuple(sorted(set(names)))
+
+
+def _tester_atom_count(source: str) -> int:
+    """How many times the reserved type-tester atom reaches the emitted FOL."""
+    return repr(_universe(source)).count(TESTER_ATOM)
+
+
+_FORMAL_ONE_ARM = (
+    "def f(exc):\n"
+    "    try:\n"
+    "        raise exc\n"
+    "    except ValueError:\n"
+    "        return 1\n"
+    "    return 3\n"
+)
+
+_FORMAL_TWO_ARMS = (
+    "def f(exc):\n"
+    "    try:\n"
+    "        raise exc\n"
+    "    except ValueError:\n"
+    "        return 1\n"
+    "    except KeyError:\n"
+    "        return 2\n"
+    "    return 3\n"
+)
+
+
+# --- the undecidable arm: retained, both faces alive -------------------------
+
+
+def test_formal_raise_is_not_swallowed_by_a_typed_handler():
+    # NEVER ADMITTED: the handler did not prove it catches this, so the halt
+    # stands. `exc` on the wall is the whole point -- a router that consumed it
+    # would have decided a runtime type question at lift.
+    assert _residual_raises(_FORMAL_ONE_ARM) == ("exc",)
+
+
+def test_formal_raise_emits_the_handler_obligation():
+    # NEVER DROPPED: the handler face is real and reachable, and the predicate
+    # under which it is reachable is stated rather than assumed away.
+    assert _tester_atom_count(_FORMAL_ONE_ARM) > 0
+
+
+def test_every_arm_after_a_retained_arm_still_gets_its_own_obligation():
+    # A retained arm narrows the residual to its complement instead of ending
+    # the walk, so a later arm is considered under `not(first)` and states its
+    # own predicate. Collapsing the walk at the first retention would leave the
+    # second handler unreachable by silence.
+    assert _tester_atom_count(_FORMAL_TWO_ARMS) > _tester_atom_count(_FORMAL_ONE_ARM)
+    assert _residual_raises(_FORMAL_TWO_ARMS) == ("exc",)
+
+
+def test_bare_except_over_a_formal_raise_is_decided_not_retained():
+    # A bare `except` catches every raise by the language's own rule -- there is
+    # no type question, so there is no obligation to state and nothing survives.
+    source = (
+        "def f(exc):\n"
+        "    try:\n"
+        "        raise exc\n"
+        "    except:\n"
+        "        return 1\n"
+        "    return 3\n"
+    )
+    assert _residual_raises(source) == ()
+    assert _tester_atom_count(source) == 0
+
+
+# --- the decided arms must stay decided --------------------------------------
+
+
+def test_authenticated_exact_match_states_no_obligation():
+    source = (
+        "def f():\n"
+        "    try:\n"
+        "        raise ValueError('b')\n"
+        "    except ValueError:\n"
+        "        return 1\n"
+        "    return 3\n"
+    )
+    assert _residual_raises(source) == ()
+    assert _tester_atom_count(source) == 0
+
+
+def test_authenticated_miss_stays_red_and_states_no_obligation():
+    source = (
+        "def f():\n"
+        "    try:\n"
+        "        raise ValueError('b')\n"
+        "    except KeyError:\n"
+        "        return 1\n"
+        "    return 3\n"
+    )
+    assert _residual_raises(source) == ("ValueError",)
+    assert _tester_atom_count(source) == 0
+
+
+def test_authenticated_ancestor_match_states_no_obligation():
+    source = (
+        "def f():\n"
+        "    try:\n"
+        "        raise ValueError('b')\n"
+        "    except Exception:\n"
+        "        return 1\n"
+        "    return 3\n"
+    )
+    assert _residual_raises(source) == ()
+    assert _tester_atom_count(source) == 0


### PR DESCRIPTION
## The defect class, for the third time

`matches_raise_effect` is the one matcher shared by Try and With, so every assertion boundary depends on its codomain being honest. It has produced a silent-fabrication bug twice already, and both times the shape was **a decided `False` standing in for testimony nobody authenticated**:

- `matches_raise_effect_with_message` returned `bool`, so an undecidable message predicate restored the halt *as if* the pattern had been checked and had not matched. Fixed by closing that codomain to `MatchDecided | MatchRetained`.
- Builtin exception ancestry was `bases=()` — the positive claim that a class has no ancestors — so `try: raise ValueError / except Exception:` did not catch. Fixed by vendoring `BUILTIN_EXCEPTION_BASES`.

The **identity** half was still two-valued plus a panic. Concrete reproducer:

```python
def f(exc):
    try:
        raise exc
    except ValueError:
        return 1
```

Nobody can decide at lift whether the runtime type of the formal `exc` is a `ValueError`. Both operands produce perfectly good terms, so this is **not** a construction gap — and it is emphatically not `False`. It is a real predicate this compiler cannot settle, and the only honest disposition is to state it.

## The mechanism

`matches_raise_effect` now returns `MatchDecided | MatchRetained`.

Two authenticated identities still settle here exactly as before — exact match, or authenticated MRO ancestry. When either operand's identity is not authenticated, the verdict leaves as `adt.is_python_type(raised, handler)`: **the reserved tester atom the floor already emits for exactly this question.** No new vocabulary, no name table, no spelling arm, no vendor arm. Category comes from authenticated value testimony throughout.

It stays loud only where there is no question to retain — an operand with no term to state the predicate over.

Both consumers honour the third outcome:

- **`TrySugar` routing becomes a walk over a residual rather than a scan.** A retained arm owns a genuine two-way split, so it mints one, routes the residual into the handler under the obligation, and narrows the residual to the complement for the arms that follow. Whatever residual survives every arm leaves as the halt it always was, still red, under the conjunction of every complement.
- **`raise_effect_message_verdict` is now the conjunction of two three-valued verdicts.** A decidably false conjunct settles the conjunction without deciding the other half; two open conjuncts leave as one conjoined obligation. Neither half is collapsed.

## The latent malformation the residual walk exposed

`effect_router.to_facts` built `effect_slot_kind` / `_type` / `_origin` with `atomic`, putting a **Formula in a term position** of `=`. A fact that cannot be content addressed cannot be compared, normalized, or pinned — `term_to_value` raises `TypeError: unknown Term: _Atomic`.

It stayed latent only because a decided handler scan never emitted two fact-carrying arms that had to normalize together. The residual walk does. Repaired to `ctor`, which is what a term-valued projection compared by `=` always was. No golden carries these symbols.

## Evidence

Both faces are pinned in `tests/test_retained_exception_identity.py`, because each alone is a distinct lie:

- **Never admitted** — the raise must still be on the wall. A router that routed the retained arm in and stopped would have silently claimed the exception was caught.
- **Never dropped** — the obligation must reach the emitted FOL. A router that propagated the halt and forgot the predicate would have silently claimed the handler is unreachable.

And the decided arms assert the tester atom **does not appear at all** — an obligation emitted where the compiler could answer is its own fabrication. Exact match, MRO-ancestor match, authenticated miss, and bare `except` are all pinned as decided with zero obligations.

### Mutation transactions (clean before, verified present, bites, reverted, clean after)

| mutation | bites |
|---|---|
| retained arm routed as a **match** | `never_admitted`, `never_dropped`, both `second_arm` checks |
| retained arm routed as a **miss** | `never_dropped`, `second_arm_gets_obligation` |
| matcher **decides `False`** instead of retaining (the historical defect class verbatim) | `never_dropped`, `second_arm_gets_obligation` |

The two router mutations bite on **complementary** checks — that is the discriminator pair. Every decided-arm check stays green under all three, so the twins are not merely sensitive to any edit.

### Site coverage (a denominator, reported separately from ΔR)

Every raised-value category that previously panicked now retains, across every handler category:

| raised value | handler | before | after |
|---|---|---|---|
| `SymbolicValue` (`raise exc`, `raise o.err`) | builtin / tuple / user class | **panic** | `MatchRetained` |
| unauthenticated `CallSiteValue` (`raise cls('b')`, `raise o[k]`) | builtin | **panic** | `MatchRetained` |
| authenticated `CallSiteValue` (`raise ValueError('b')`) | builtin | `MatchDecided` | `MatchDecided` (unchanged) |
| `AuthenticatedExceptionTypeValue` (`raise ValueError`) | builtin | `MatchDecided` | `MatchDecided` (unchanged) |

### ΔR — explicitly unmeasured

The pandas 3.0.3 corpus is not on this box, so the 11 owed `matches_raise_effect` rows at `43d994888` were **not** re-measured here and no ΔR is claimed. Per the drain brief this merges on the twin gate, not on a corpus sweep. Attribution belongs to the next census run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain undecidable exception identity checks as obligations instead of raising in except-arm routing
> - `matches_raise_effect` now returns a `MessageVerdict` union: decided true/false for resolvable identities, or `MatchRetained` with an `adt.is_python_type` obligation when identity cannot be determined synchronously.
> - `_route_one_halt` in [try_sugar.py](https://github.com/TSavo/sugar/pull/6414/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) splits a single halted raise into caught/missed faces per handler when a match is retained, emitting the obligation and its negation into guards.
> - `raise_effect_message_verdict` composes retained identity obligations with the message-pattern verdict using `and_`, preserving both conjuncts in the emitted obligation.
> - A new test module [test_retained_exception_identity.py](https://github.com/TSavo/sugar/pull/6414/files#diff-baf2964beb243b318cc684c594b462a27136e820bfeaeae8c6c3529152190555) asserts that retained obligations are emitted, later arms still fire after a retained arm, and bare/exact/ancestor matches are decided with no obligations.
> - Behavioral Change: except-arm routing can now split one halted exit into multiple guarded faces rather than consuming or passing it unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ca1591.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

---

## Second finding: the retained path exposed a message-operand fabrication

`CallSiteValue.arg_values[0]` is the first **actual** only when the call's exception class was authenticated. For `raise cls(msg)` on a formal the unresolved callee occupies that position — the emitted term is `py.call(cls, msg)` with `arg_values = (cls, msg)` — so a boundary stating `match="boom"` over that raise emitted:

```
py.re_search("boom", cls)
```

The vendor's pattern asserted over the exception **class** instead of its message. That is this module's own forbidden shape, and closing the identity codomain is what made it reachable.

`_message_term` now demands the same authenticated identity the matcher decides on before reading any operand position. Absent it, there is no authenticated message operand and the refusal is loud — not a positional guess, and not a name check on the callee spelling.

Every authenticated path is unchanged and pinned:

| raise | pattern | verdict |
|---|---|---|
| `raise ValueError('boom')` | `"boom"` | `MatchDecided(True)` |
| `raise ValueError('boom')` | `"nope"` | `MatchDecided(False)` |
| `raise ValueError(msg)` | `"boom"` | `MatchRetained(py.re_search)` |
| `raise cls(msg)` | none | `MatchRetained(adt.is_python_type)` |
| `raise cls(msg)` | `"boom"` | **loud refusal** |

Ten pinned tests total in `tests/test_retained_exception_identity.py`, all green.

### Upstream note for the next owner

The `arg_values` conflation itself is not repaired here — for an opaque callee it still carries the callee in position 0 alongside the actuals. Every consumer that reads a positional actual off a call site with an unauthenticated target has the same exposure. This PR closes it at the one consumer the drain made reachable and leaves the general repair to whoever owns `CallSiteValue` construction.
