### PR TITLE
Floor: a binary operation with an undecided operand is one law, not eight arms

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -17,6 +17,10 @@ class BytesValue(FloorValue):
 
     value: bytes
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``bytes``."""
+        return True
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -127,6 +127,20 @@ class CallSiteValue(FloorValue):
     source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
 
+    def denotes_value(self) -> bool:
+        """A call result denotes a Python runtime value."""
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        """Undecided: no citation fixes an unexecuted call's result type.
+
+        Which ``__op__``/``__rop__`` Python would select for an operation
+        over this value is undecided too, so a binary operation with it
+        constructs a symbolic coordinate rather than standing on a ground
+        field law.
+        """
+        return False
+
     def exception_type_identity(self) -> Term | None:
         return self.exception_type_coordinate
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -19,6 +19,10 @@ class ComplexValue(FloorValue):
     real: float
     imag: float
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``complex``."""
+        return True
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
@@ -28,6 +28,15 @@ class ComprehensionValue(GuardStableValue):
     term: object
     finite_elements: tuple | None = None
 
+    def denotes_value(self) -> bool:
+        """A constructed fold denotes the sequence it builds.
+
+        Its runtime TYPE is decided -- the fold constructor names whether
+        it is a list, set, or dict comprehension -- so this value alone
+        never makes a pair undecided. Only an undecided right operand does.
+        """
+        return True
+
     def to_term(self, *, owner: str):
         del owner
         return self.term

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -16,6 +16,10 @@ class DictValue(FloorValue):
 
     entries: tuple
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``dict``."""
+        return True
+
     def truth(self, site):
         """A constructed dict is truthy exactly when it has an entry."""
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -98,6 +98,28 @@ BASE_CONSTRUCTION_GAP_METHOD_NAMES = tuple(
 )
 
 
+# The term coordinate each binary-operation floor constructs when the pair is
+# undecided. These are the SAME constructor names SymbolicValue already emits;
+# the map exists so one law covers all thirteen operators instead of thirteen
+# copies of it. It is keyed by floor method name -- the dispatch surface's own
+# vocabulary -- never by a lexical spelling read off a source node.
+_BINARY_OPERATOR_COORDINATE = {
+    "add": "+",
+    "subtract": "-",
+    "multiply": "*",
+    "divide": "/",
+    "floor_divide": "//",
+    "modulo": "%",
+    "power": "**",
+    "matrix_multiply": "@",
+    "bitwise_and": "&",
+    "bitwise_or": "|",
+    "bitwise_xor": "^",
+    "left_shift": "<<",
+    "right_shift": ">>",
+}
+
+
 class FloorValue:
     def _floor_gap(
         self,
@@ -807,6 +829,78 @@ class FloorValue:
             )
         )
 
+    def denotes_value(self) -> bool:
+        """Testimony: does this floor value DENOTE a Python runtime value?
+
+        The default is the honest "no". A floor value is not automatically a
+        value: ``LambdaCallable`` and ``FunctionCallable`` denote callables,
+        ``EffectCoordinate`` denotes a pending effect, exit values denote a
+        halt. Carrying a term is NOT the discriminator -- ``FunctionCallable``
+        carries one and is never an operand. Only the class itself can say,
+        and a class that has not said stays loud.
+        """
+        return False
+
+    def runtime_type_is_decided(self) -> bool:
+        """Testimony: is this value's Python runtime TYPE known at lift time?
+
+        ``StringValue`` knows it is a ``str``; ``ComprehensionValue`` knows it
+        is the sequence its own fold constructor names. ``SymbolicValue`` and
+        ``CallSiteValue`` do not know -- an unexecuted call's result type is
+        undecided, so which ``__op__``/``__rop__`` Python would select is
+        undecided too.
+
+        The default is ``True`` (decided), which keeps a class that has not
+        spoken on the LOUD side of :meth:`_undecided_binary_law`.
+        """
+        return True
+
+    def _undecided_binary_law(self, other, site, operator):
+        """The ONE law for a binary operation with an undecided operand.
+
+        Every binary-operation floor gap measured on pandas came in the same
+        shape wearing eight operator names: a left value with no arm named for
+        THIS right operand, falling through to the pair gap. Most of those
+        pairs are not eight separate arms to write. They are one law: when at
+        least one operand's runtime TYPE is undecided, Python's own operator
+        dispatch for the pair is undecided, so the exact denotation of the
+        operation is the symbolic coordinate ``operator(left, right)`` -- the
+        same coordinate ``SymbolicValue`` already constructs, hoisted off that
+        one class and onto the law it was always stating.
+
+        Two refusals are deliberate and stay loud:
+
+        * An operand that does not DENOTE a value (a callable, a class, an
+          exit) is not an operand at all. No coordinate is invented for it.
+        * Two operands of DECIDED type are a ground question -- ``list + bool``
+          is Python's ``TypeError``, not an unknown. Constructing a coordinate
+          there would launder a ground exit into a value. That pair belongs to
+          the ground field laws, and absence there is still a gap.
+
+        Returns ``None`` when the law does not apply, so the caller falls
+        through to its own pair gap.
+        """
+        if not (self.denotes_value() and other.denotes_value()):
+            return None
+        if self.runtime_type_is_decided() and other.runtime_type_is_decided():
+            return None
+
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    operator,
+                    [
+                        self.to_term(owner=str(site)),
+                        other.to_term(owner=str(site)),
+                    ],
+                )
+            )
+        )
+
     def _binary_floor_gap(self, other, site, owner, floor):
         """The ONE None arm for every binary-operation floor.
 
@@ -821,7 +915,16 @@ class FloorValue:
 
         The category is read from the operand's own type, which is its
         authenticated construction coordinate -- never from a lexical name.
+
+        Before the gap, :meth:`_undecided_binary_law` gets to answer: a pair
+        with an undecided operand is one law, not one arm per (owner x pair).
         """
+        constructed = self._undecided_binary_law(
+            other, site, _BINARY_OPERATOR_COORDINATE[owner]
+        )
+        if constructed is not None:
+            return constructed
+
         from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
         observed = type(self).__name__
@@ -838,40 +941,40 @@ class FloorValue:
         # Default: this value does not stand on the addition floor -- it cannot answer
         # what it is to add another value. The None arm: a value that CAN implements
         # add and gives back the sum (or concat); absence here is the honest "no".
-        self._binary_floor_gap(other, site, "add", "addition")
+        return self._binary_floor_gap(other, site, "add", "addition")
 
     def subtract(self, other, site):
         # Default: this value does not stand on the subtraction floor -- it cannot
         # answer what it is minus another value. The None arm: a value that CAN
         # implements subtract and gives back a term; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "subtract", "subtraction")
+        return self._binary_floor_gap(other, site, "subtract", "subtraction")
 
     def multiply(self, other, site):
         # Default: this value does not stand on the multiplication floor -- it cannot
         # answer what it multiplies by another value to. The None arm: a value that CAN
         # implements multiply and gives back a product; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "multiply", "multiplication")
+        return self._binary_floor_gap(other, site, "multiply", "multiplication")
 
     def power(self, other, site):
-        self._binary_floor_gap(other, site, "power", "power")
+        return self._binary_floor_gap(other, site, "power", "power")
 
     def divide(self, other, site):
         # Default: this value does not stand on the division floor -- it cannot answer
         # what it divides by another value to. The None arm: a value that CAN
         # implements divide and gives back a quotient; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "divide", "division")
+        return self._binary_floor_gap(other, site, "divide", "division")
 
     def modulo(self, other, site):
         # Default: this value does not stand on the modulo floor -- it cannot answer
         # what remainder it leaves by another value. The None arm: a value that CAN
         # implements modulo and gives back a remainder; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "modulo", "modulo")
+        return self._binary_floor_gap(other, site, "modulo", "modulo")
 
     def floor_divide(self, other, site):
-        self._binary_floor_gap(other, site, "floor_divide", "floor-division")
+        return self._binary_floor_gap(other, site, "floor_divide", "floor-division")
 
     def right_shift(self, other, site):
-        self._binary_floor_gap(other, site, "right_shift", "right-shift")
+        return self._binary_floor_gap(other, site, "right_shift", "right-shift")
 
     def bitwise_and(self, other, site):
         return self._runtime_bitwise_gap(other, site, "bitwise_and", "and")
@@ -886,10 +989,12 @@ class FloorValue:
         return self._runtime_bitwise_gap(other, site, "left_shift", "left-shift")
 
     def matrix_multiply(self, other, site):
-        self._binary_floor_gap(other, site, "matrix_multiply", "matrix-multiplication")
+        return self._binary_floor_gap(
+            other, site, "matrix_multiply", "matrix-multiplication"
+        )
 
     def _runtime_bitwise_gap(self, other, site, owner, label):
-        self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
+        return self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 
     def to_term(self, *, owner: str) -> "Term":
         """The ONE None arm for floor-value projection.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -18,6 +18,10 @@ class ListValue(FloorValue):
 
     elements: tuple
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``list``."""
+        return True
+
     def attribute(self, name, site):
         # Bound methods and fields on a constructed list (``[].append``, ``xs.index``) stay the
         # py.getattr coordinate -- one law, shared with StringValue and the

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -10,6 +10,10 @@ from .floor_value import FloorValue
 class NoneValue(FloorValue):
     """The floor for the `None` literal. No fields -- the None-ness IS the type."""
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes ``None``."""
+        return True
+
     def truth(self, site):
         # None's truth IS False -- the type again.
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -36,6 +36,10 @@ class PredicateValue(FloorValue):
         default=(), compare=False
     )
 
+    def denotes_value(self) -> bool:
+        """A carried boolean formula denotes a Python ``bool``."""
+        return True
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import _Atomic, _Connective, ctor
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -16,6 +16,10 @@ class SetValue(FloorValue):
 
     elements: tuple
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``set``."""
+        return True
+
     def attribute(self, name, site):
         # Bound methods and fields on a constructed set (``set().add``, ``s.union``) stay the
         # py.getattr coordinate -- one law, shared with StringValue and the

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
 class StringValue(GuardStableValue):
     value: str
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``str``."""
+        return True
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -46,6 +46,20 @@ class SymbolicValue(GuardStableValue):
     term: Term
     formal_coordinate: object | None = None
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a Python runtime value."""
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        """Undecided: this is an unresolved term: nothing names its Python type.
+
+        Which ``__op__``/``__rop__`` Python would select for an
+        operation over this value is therefore undecided too, so a
+        binary operation with it constructs a symbolic coordinate
+        rather than standing on a ground field law.
+        """
+        return False
+
     def python_isinstance(self, type_name: str, type_term, site):
         """Fold ground ``python:*`` data ctors against a named builtin type.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -12,6 +12,10 @@ class TermValue(FloorValue):
     # their calculus sort: int -> Int and float -> Real. There is no Number sort.
     value: int | float
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a Python scalar it carries as its own payload."""
+        return True
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -16,6 +16,10 @@ class TupleValue(FloorValue):
 
     elements: tuple
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``tuple``."""
+        return True
+
     def attribute(self, name, site):
         # Bound methods and fields on a constructed tuple (``().count``, ``t.index``) stay the
         # py.getattr coordinate -- one law, shared with StringValue and the

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
@@ -128,6 +128,10 @@ class FalseBoolLiteralSugar(Sugar, GuardStableValue):
     def callsites(self):
         return ()
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes ``False``."""
+        return True
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import bool_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
@@ -125,6 +125,10 @@ class TrueBoolLiteralSugar(Sugar, GuardStableValue):
     def callsites(self):
         return ()
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes ``True``."""
+        return True
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import bool_const

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
@@ -164,15 +164,29 @@ def test_an_integer_too_large_for_the_float_field_stays_loud() -> None:
 
 def test_a_symbolic_operand_keeps_its_own_symbolic_door() -> None:
     """A complex plus an opaque callsite is not a field member; the complex
-    floor must not swallow it into a fabricated concrete complex."""
+    floor must not swallow it into a fabricated concrete complex.
+
+    What this arm pinned was the REFUSAL to fabricate a complex, and that is
+    unchanged: the outcome below is not a ``ComplexValue``. What it also
+    asserted -- that the pair panics -- was the state before the undecided
+    binary-operand law existed, and is superseded by it. An unexecuted call's
+    result type is undecided, so Python's own operator dispatch for the pair is
+    undecided, and the exact denotation is the symbolic coordinate. This is the
+    SAME answer ``test_an_integer_plus_a_symbolic_operand_is_still_symbolic``
+    below already pinned for ``int + symbolic``; the law states it once for
+    every field member instead of once per left class.
+
+    See ``tests/test_undecided_binary_operand_law.py``.
+    """
     opaque = CallSiteValue("vendor.op", (), (), ctor("call:vendor.op", []), None)
 
     assert complex_field_coordinate(opaque) is None
-    with pytest.raises(ConstructionPanic) as raised:
-        ComplexValue(0.0, 1.0).add(opaque, SITE)
 
-    assert raised.value.info.owner == "add"
-    assert "CallSiteValue" in raised.value.info.fix
+    outcome = ComplexValue(0.0, 1.0).add(opaque, SITE)
+
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is SymbolicValue
+    assert outcome.value.term.name == "+"
 
 
 def test_an_integer_plus_a_symbolic_operand_is_still_symbolic() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -1,0 +1,281 @@
+"""One law, not eight arms: a binary operation with an undecided operand.
+
+The binary-operation floor gaps measured on the pinned pandas tree
+(``docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json``) came in eight
+operator names -- ``add``, ``subtract``, ``multiply``, ``divide``,
+``bitwise_and``/``or``/``xor`` -- wearing one shape: a left value with no arm
+named for THIS right operand, falling to the (owner x pair) gap.
+
+Most of those pairs are not eight arms to write. When at least one operand's
+runtime TYPE is undecided, Python's own operator dispatch for the pair is
+undecided, so the exact denotation is the symbolic coordinate
+``operator(left, right)`` -- the coordinate ``SymbolicValue`` already
+constructed, hoisted off that one class onto the law it was always stating.
+
+The category is read from each value's own testimony (``denotes_value`` /
+``runtime_type_is_decided``), never from a lexical type name.
+
+Every positive arm below carries its discriminating arm: the law admits the
+undecided pair and stays LOUD everywhere else.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.bytes_value import BytesValue
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.complex_value import ComplexValue
+from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+from sugar_lift_py_tests.floor.list_value import ListValue
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+from sugar_lift_py_tests.floor.set_value import SetValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, _Lambda, ctor, make_var
+from sugar_lift_py_tests.outcome import Complete
+
+SITE = "undecided-binary-site"
+
+
+def _symbolic() -> SymbolicValue:
+    return SymbolicValue(make_var("s"))
+
+
+def _callsite() -> CallSiteValue:
+    return CallSiteValue("vendor.op", (), (), ctor("call:vendor.op", []), None)
+
+
+def _predicate() -> PredicateValue:
+    return PredicateValue(_Atomic("py.gt", (make_var("a"), make_var("b"))), SITE)
+
+
+def _comprehension() -> ComprehensionValue:
+    return ComprehensionValue(
+        ctor(
+            "py.listcomp",
+            [
+                make_var("xs"),
+                _Lambda("p", PrimitiveSort("Value"), make_var("p")),
+                ctor("python:loop.exhaustion", []),
+            ],
+        )
+    )
+
+
+def _coordinate(outcome, operator: str):
+    assert isinstance(outcome, Complete), outcome
+    assert type(outcome.value) is SymbolicValue
+    term = outcome.value.term
+    assert term.name == operator
+    assert len(term.args) == 2
+    return term
+
+
+# -- positive arm: the pairs the pinned census actually found -----------------
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "method", "operator"),
+    (
+        # pandas/io/formats/{excel,html,xml}.py, io/parsers/arrow_parser_wrapper.py
+        (_comprehension(), _symbolic(), "add", "+"),
+        # pandas/io/formats/html.py, io/formats/style.py
+        (_predicate(), _symbolic(), "add", "+"),
+        # pandas/core/ops/missing.py, tests/io/pytables/test_select.py
+        (_predicate(), _callsite(), "bitwise_and", "&"),
+        # pandas/core/strings/accessor.py
+        (SetValue((TermValue(1),)), _callsite(), "subtract", "-"),
+        # pandas/io/stata.py, tests/io/json/test_ujson.py
+        (BytesValue(b"x"), _symbolic(), "multiply", "*"),
+        (BytesValue(b"x"), _symbolic(), "add", "+"),
+        (BytesValue(b"x"), _callsite(), "add", "+"),
+        # pandas/tests/internals/test_internals.py
+        (ComplexValue(1.0, 2.0), _symbolic(), "multiply", "*"),
+        # pandas/tests/arithmetic/test_string.py
+        (NoneValue(), _callsite(), "add", "+"),
+    ),
+)
+def test_an_undecided_operand_constructs_the_symbolic_coordinate(
+    left, right, method, operator
+) -> None:
+    _coordinate(getattr(left, method)(right, SITE), operator)
+
+
+def test_the_law_covers_every_operator_it_names_from_one_place() -> None:
+    """Eight operator names, one law -- so a ninth costs no new arm."""
+    for method, operator in (
+        ("add", "+"),
+        ("subtract", "-"),
+        ("multiply", "*"),
+        ("divide", "/"),
+        ("floor_divide", "//"),
+        ("modulo", "%"),
+        ("power", "**"),
+        ("matrix_multiply", "@"),
+        ("bitwise_and", "&"),
+        ("bitwise_or", "|"),
+        ("bitwise_xor", "^"),
+        ("left_shift", "<<"),
+        ("right_shift", ">>"),
+    ):
+        _coordinate(getattr(BytesValue(b"x"), method)(_symbolic(), SITE), operator)
+
+
+def test_both_operands_are_conserved_in_the_coordinate() -> None:
+    """One output arm conserves exactly its two input arms, in order."""
+    left = BytesValue(b"ab")
+    right = _symbolic()
+
+    term = _coordinate(left.add(right, SITE), "+")
+
+    assert term.args[0] == left.to_term(owner=SITE)
+    assert term.args[1] == right.to_term(owner=SITE)
+
+
+# -- the real reproducers: whole functions, lifted from source ---------------
+
+
+@pytest.mark.parametrize(
+    ("name", "source"),
+    (
+        # pandas/io/stata.py: `b"\x00" * (n - len(name))`
+        ("bytes_times_param", 'def f(n):\n    return b"x" * n\n'),
+        # pandas/tests/arithmetic/test_string.py
+        ("none_plus_call", "def f(g):\n    return None + g()\n"),
+        # pandas/io/formats/{excel,html,xml}.py
+        ("comp_plus_param", "def f(xs, y):\n    return [x for x in xs] + y\n"),
+        # pandas/io/stata.py: `self.sep + want_bytes(x)`
+        ("bytes_plus_call", 'def f(g):\n    return b"x" + g()\n'),
+        # pandas/core/strings/accessor.py
+        ("set_minus_call", "def f(g):\n    return {1, 2} - g()\n"),
+    ),
+)
+def test_the_whole_function_lifts_where_it_construction_panicked(
+    tmp_path, name, source
+) -> None:
+    """Each of these construction_panicked on the tree before the law: a
+    snippet flip is not the acceptance, the whole function is."""
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path / f"{name}.py"
+    path.write_text(source, encoding="utf-8")
+
+    fn = next(SourceFile(path_source(str(path))).functions())
+    outcome = fn.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is UniverseValue
+
+
+# -- discriminating arm: the law refuses, loudly, everywhere else -------------
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "method"),
+    (
+        # Two DECIDED types are a ground question, not an unknown:
+        # `list + bool` is Python's TypeError. Constructing a coordinate here
+        # would launder a ground exit into a value.
+        (ListValue((TermValue(1),)), _predicate(), "add"),
+        (_predicate(), TermValue(1), "add"),
+        (_predicate(), StringValue("x"), "add"),
+        (_comprehension(), SetValue((TermValue(1),)), "subtract"),
+    ),
+)
+def test_two_decided_operands_stay_loud(left, right, method) -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        getattr(left, method)(right, SITE)
+
+    info = raised.value.info
+    assert info.owner == method
+    assert info.observed == type(left).__name__
+    assert type(right).__name__ in info.fix
+
+
+def test_a_value_that_has_not_testified_stays_loud() -> None:
+    """``denotes_value`` defaults to the honest "no": carrying a term is not
+    the discriminator, so a class that has not spoken never enters the law."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    class _Unspoken(FloorValue):
+        def to_term(self, *, owner: str):
+            return make_var("unspoken")
+
+    assert _Unspoken().denotes_value() is False
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _Unspoken().add(_symbolic(), SITE)
+
+    assert raised.value.info.observed == "_Unspoken"
+
+
+def test_a_non_denoting_operand_stays_loud() -> None:
+    """A callable is not an operand. The law refuses it from the right too."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    class _NotAValue(FloorValue):
+        def runtime_type_is_decided(self) -> bool:
+            return False
+
+        def to_term(self, *, owner: str):
+            return make_var("callable")
+
+    assert _NotAValue().denotes_value() is False
+
+    with pytest.raises(ConstructionPanic) as raised:
+        BytesValue(b"x").add(_NotAValue(), SITE)
+
+    assert raised.value.info.observed == "BytesValue"
+    assert "_NotAValue" in raised.value.info.fix
+
+
+def test_the_law_never_converts_a_panic_into_a_refusal() -> None:
+    """The loud arm is still a ConstructionPanic -- never an Incomplete, never
+    a refusal value that a caller could mistake for an answer."""
+    with pytest.raises(ConstructionPanic):
+        ListValue((TermValue(1),)).add(_predicate(), SITE)
+
+
+# -- the testimony is the value's own, never a lexical name ------------------
+
+
+@pytest.mark.parametrize(
+    "undecided",
+    (
+        SymbolicValue(make_var("s")),
+        CallSiteValue("f", (), (), ctor("call:f", []), None),
+    ),
+)
+def test_undecided_values_testify_to_their_own_category(undecided) -> None:
+    assert undecided.denotes_value() is True
+    assert undecided.runtime_type_is_decided() is False
+
+
+@pytest.mark.parametrize(
+    "ground",
+    (
+        TermValue(1),
+        StringValue("x"),
+        BytesValue(b"x"),
+        NoneValue(),
+        ListValue(()),
+        SetValue(()),
+        ComplexValue(0.0, 1.0),
+    ),
+)
+def test_ground_values_testify_that_their_type_is_decided(ground) -> None:
+    assert ground.denotes_value() is True
+    assert ground.runtime_type_is_decided() is True
+
+
+def test_a_fold_knows_its_own_sequence_type() -> None:
+    """A comprehension's constructor names the sequence it builds, so the fold
+    alone never makes a pair undecided -- only its operand can."""
+    assert _comprehension().denotes_value() is True
+    assert _comprehension().runtime_type_is_decided() is True


### PR DESCRIPTION
## The shape

The binary-operation floor set was the largest unowned shape in the #6389 panic tail: **43 rows** in `docs/ledgers/pandas-3.0.3-control-effect-9a78828ee.json` wearing eight operator names -- `add` / `subtract` / `multiply` / `divide` / `bitwise_and` / `bitwise_or` / `bitwise_xor` -- over one shape: a left value with no arm named for *this* right operand, falling to the `(owner x pair)` gap.

**#6317 found `add x TermValue` was misnamed once.** It is misnamed again here. These are not eight arms to write, and they are not 43 pairs to enumerate.

## The law

When at least one operand's runtime **type** is undecided, Python's own operator dispatch for the pair is undecided, so the exact denotation of the operation is the symbolic coordinate `operator(left, right)`. That is the coordinate `SymbolicValue` already constructed on its own. The law hoists it off that one class onto `FloorValue`, keyed by the dispatch surface's method vocabulary, covering all thirteen operators from one place.

The discriminator is **each value's own testimony** -- never a lexical type name, and never "carries a term" (`FunctionCallable` carries one and is never an operand):

| testimony | question | default |
|---|---|---|
| `denotes_value()` | does this floor value DENOTE a Python value? | `False` -- the honest "no". A class that has not spoken stays LOUD. |
| `runtime_type_is_decided()` | is its Python type known at lift time? | `True` -- which keeps a silent class on the LOUD side. |

`set_value.py` already named this exact missing mechanism in a comment: *"the discriminator has to be the value's own testimony about whether it DENOTES a value, which no floor states yet. Left loud until it does."* It states it now.

## Two refusals stay LOUD, deliberately

- A **non-denoting** operand (callable, class, exit) is not an operand at all. No coordinate is invented for it.
- Two operands of **decided** type are a ground question, not an unknown. `list + bool` is Python's `TypeError`; constructing a coordinate there would launder a ground exit into a value. That pair belongs to the ground field laws, where absence is still a gap.

No size cap, no sentinel, no placeholder, no fallback, and **no panic converted into a refusal** -- the loud arm is still a `ConstructionPanic`, pinned as such.

## Evidence

`implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py` -- **33 focused tests, all green**, including:

- **Real reproducers, whole-function source lifts.** Five functions that `construction_panic`ed at `origin/main` and lift to `Complete(UniverseValue)` here: `b"x" * n`, `None + g()`, `[x for x in xs] + y`, `b"x" + g()`, `{1, 2} - g()`. Verified panicking at base by stashing and re-running the same probe.
- **Both arms of the discriminator, run.** Positive: the nine `(left x right)` pairs the pinned census found. Negative: four decided-pair shapes that must stay loud, plus a class that has not testified and a non-denoting right operand.
- **Conservation.** `term.args[0] == left.to_term(...)`, `term.args[1] == right.to_term(...)` -- one output arm conserving exactly its two input arms, in order.

**Mutation transactions** (clean before, mutant verified present, revert verified, clean after):

| mutation | bites |
|---|---|
| drop the decided-pair refusal | 5 tests fail |
| flip `denotes_value` default to `True` | 2 tests fail |

## Failure-set delta

Baseline (`origin/main`, same venv, same focused set) and head both red on exactly:

- `test_sequence_membership_floor.py::test_ground_non_string_in_string_is_type_error`
- `test_floor_panic_tail_owners.py::test_a_partition_still_has_nowhere_to_carry_a_demand`

**Delta: zero new failures.** Both are inherited red at base and untouched by this branch.

## Supersession -- flagged, not silent

One assertion in `test_a_symbolic_operand_keeps_its_own_symbolic_door` (#6317, `floor-pairs-a`) changed. The refusal it pinned -- *do not fabricate a concrete complex* -- is **unchanged and still asserted**. Its second assertion, that the pair panics, was the state before this law; the pair now yields the symbolic coordinate the adjacent `int + symbolic` arm in the same file already pinned. The docstring records the supersession in place.

## Scope

- `GuardedValue` is untouched -- `denotes_value()` defaults to `False` there, so every `guarded` row falls exactly where it did. That owner is unaffected.
- `BlockValue.to_term` and `RuntimeEffect` rows are sibling shapes, not touched.
- `StringValue.multiply for TermValue` was **already closed** before this branch. Re-measured, reported zero, no arm, no pin.
- Nothing touched in `outcome/exit_set.py`, `sugar/spread_sugar.py`, `ir.py`, `canonicalizer.py`, or #6311's identity memo.

## Site coverage vs ΔR

Reported separately, as required.

- **Site coverage at the pin: 13 of 43 rows** retired by one law (comprehension+symbolic x4, predicate+symbolic, predicate&callsite x2, set-callsite, bytes x symbolic/callsite x4, complex*symbolic, none+callsite). The remainder are correctly-loud decided pairs, `guarded` rows belonging to another owner, and sibling shapes.
- **ΔR: explicitly unmeasured.** No corpus sweep was run; merging on the focused evidence per the brief.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate binary operations with an undecided operand into a single `_undecided_binary_law` in `FloorValue`
> - Adds `denotes_value()` and `runtime_type_is_decided()` virtual methods to `FloorValue`, letting each value subclass declare whether it represents a runtime value and whether its type is decided.
> - Introduces `_undecided_binary_law()` in `FloorValue`: when at least one operand has an undecided runtime type, binary operations now return a symbolic operator coordinate instead of panicking.
> - All binary operator methods (`add`, `subtract`, `multiply`, etc.) now return the result of `_binary_floor_gap`, which tries `_undecided_binary_law` before falling back to the panic path.
> - Concrete value types (`SymbolicValue`, `CallSiteValue`, `BytesValue`, `ListValue`, etc.) each add `denotes_value`/`runtime_type_is_decided` overrides to participate in the new law.
> - A new test suite in [test_undecided_binary_operand_law.py](https://github.com/TSavo/sugar/pull/6415/files#diff-9998d1328333d54a7b5c59ca17ab35198a7558b224afbe0df116ce7b9e33fb0b) covers all supported operators, operand ordering, end-to-end lifting, and loud failure when both operands are decided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bde8b1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->