### PR TITLE
A span belongs to the source it was measured in: the cross-unit re-home behind 3 of the 5 backend defects

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -67,9 +67,18 @@ def materialize(
     *data* is memoized on the unit's ConstructionCache — slots resolve once
     per (ref, reporter, control_context) into a shared row; shells may be
     built freely over that row. Registration runs in the constructor.
+
+    ``unit`` is the unit to construct UNDER, which is the parent's for a child
+    slot. A ref that was parsed out of a specific source overrides it with that
+    source (``BackendNode.minting_unit``): a span belongs to the text it was
+    measured in, and no parent may re-home it. The unit also owns the field
+    memo, so this keeps a node's cached field data with the file it came from.
     """
     from .construction_cache import ConstructionCache
 
+    minting_unit = ref.minting_unit
+    if minting_unit is not None:
+        unit = minting_unit
     ctx = control_context or ControlConstructionContextV1()
     cache = getattr(unit, "construction_cache", None)
     if cache is None:
@@ -242,6 +251,28 @@ class BackendNode(Typeable):
 
     def describe(self) -> Description:
         raise NotImplementedError
+
+    @property
+    def minting_unit(self) -> Optional[SourceUnit]:
+        """The source this handle's span was MINTED FROM, when it has one.
+
+        A span is only meaningful against the text it was measured in, so a
+        handle parsed out of a file must say which file that was. Adapters that
+        parse answer with their unit; a handle whose span is BORROWED from an
+        origin (every shadow rewrite, every synthetic constituent) answers
+        ``None`` and correctly takes the unit it is materialized under, because
+        a borrowed span is already expressed in that source's coordinates.
+
+        This exists because a child slot used to inherit its PARENT's unit
+        unconditionally. Within one file that is free and right. Across files --
+        which is what happens the moment a caller's actual argument is bound
+        into a callee body parsed from another file -- it re-homed the child
+        onto a source its span was never measured in, and projecting it read
+        `offset 55069 outside 0..27637` (a pandas use site against contextlib.py
+        on the census's Python 3.12). The span was never wrong; the source it
+        was being read against was.
+        """
+        return None
 
     def resolve_type(self) -> type[Node]:
         """Two arms: the concrete node class for this kind, or panic."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
@@ -67,6 +67,12 @@ class _Handle(BackendNode):
         self._node = node
         self._desc: Optional[Description] = None
 
+
+    @property
+    def minting_unit(self):
+        """Parsed out of this unit's text, so its span is that unit's."""
+        return self._unit
+
     def describe(self) -> Description:
         if self._desc is None:
             self._desc = _describe(self._unit, self._node)
@@ -93,6 +99,12 @@ class _ParamHandle(BackendNode):
         self._default = default
         self._kind = param_kind
         self._desc: Optional[Description] = None
+
+
+    @property
+    def minting_unit(self):
+        """Parsed out of this unit's text, so its span is that unit's."""
+        return self._unit
 
     def describe(self) -> Description:
         if self._desc is None:
@@ -162,6 +174,12 @@ class _DictItemHandle(BackendNode):
         self._key = key
         self._value = value
         self._desc: Optional[Description] = None
+
+
+    @property
+    def minting_unit(self):
+        """Parsed out of this unit's text, so its span is that unit's."""
+        return self._unit
 
     def describe(self) -> Description:
         if self._desc is None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
@@ -110,6 +110,12 @@ class _Handle(BackendNode):
         self._node = node
         self._desc: Optional[Description] = None
 
+
+    @property
+    def minting_unit(self):
+        """Parsed out of this unit's text, so its span is that unit's."""
+        return self._unit
+
     def describe(self) -> Description:
         if self._desc is None:
             self._desc = _describe(self._unit, self._node)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
@@ -119,6 +119,12 @@ class _Handle(BackendNode):
         self._node = node
         self._desc: Optional[Description] = None
 
+
+    @property
+    def minting_unit(self):
+        """Parsed out of this unit's text, so its span is that unit's."""
+        return self._unit
+
     def describe(self) -> Description:
         if self._desc is None:
             self._desc = _describe(self._unit, self._node)

--- a/implementations/python/sugar-source-tree/tests/test_span_belongs_to_its_minting_unit.py
+++ b/implementations/python/sugar-source-tree/tests/test_span_belongs_to_its_minting_unit.py
@@ -1,0 +1,113 @@
+"""A span belongs to the source it was MEASURED IN — never to its parent's.
+
+`Child.resolve` materializes a child handle under the unit it is given, which
+for a child slot is the PARENT's unit. Within one file that is free and right:
+parent and child were parsed from the same text, so the same line table reads
+both. Across files it is not. The moment a caller's actual argument node is
+bound into a callee body parsed from another file, the child was re-homed onto
+a source its span was never measured in, and asking it to project read:
+
+    BACKEND DEFECT [spans.LineTable.line_col]
+      observed:  offset 55069 outside 0..27637
+
+Three of the pandas board's five backend-defect rows were that one bug. 27637
+is exactly `contextlib.py` on Python 3.12 — the interpreter the census ran —
+so every one of those rows was a pandas use site being read against contextlib's
+line table. The span was never wrong. The source it was read against was.
+
+`BackendNode.minting_unit` is the fix and the law: a handle that was PARSED
+out of a source says so and keeps it; a handle whose span is BORROWED from an
+origin (every shadow rewrite, every synthetic constituent) answers `None` and
+correctly takes the unit it is materialized under, because a borrowed span is
+already in that source's coordinates.
+
+Both faces are here. The truthful face is that a cross-unit child keeps its own
+source and projects to the SAME coordinates it projects to at home. The lying
+face is the discriminator: it fails if `minting_unit` is honored for shadow
+handles too, which would strand every rewrite on a unit it does not belong to.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree import SourceFile
+from sugar_source_tree.backend import Child, materialize
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.shadow import ShadowNode, _handle_of
+
+
+def _two_files(tmp_path: Path):
+    """A SHORT definer and a LONG caller, so the caller's late spans run past
+    the end of the definer's source — the `55069 > 27637` relationship."""
+    definer = tmp_path / "definer.py"
+    definer.write_text("def m(a):\n    return a\n", encoding="utf-8")
+    caller = tmp_path / "caller.py"
+    caller.write_text("# " + "pad " * 400 + "\nx = 1\ny = 2\n", encoding="utf-8")
+    return (
+        SourceFile.from_path(definer, reporter=CollectingReporter()),
+        SourceFile.from_path(caller, reporter=CollectingReporter()),
+    )
+
+
+def test_a_cross_unit_child_keeps_the_source_its_span_was_minted_from(
+    tmp_path: Path,
+) -> None:
+    definer, caller = _two_files(tmp_path)
+    # The precondition the defect needs: the caller's node lies past the end of
+    # the definer's text. Asserted, not assumed — if the fixture ever stops
+    # satisfying it this test would pass for the wrong reason.
+    late = caller.root.body[-1]
+    assert late.span.start > len(definer.unit.source)
+
+    at_home = late.line_col_span()
+    rehomed = Child(_handle_of(late)).resolve(definer.unit, definer.reporter)
+
+    assert rehomed.unit is caller.unit
+    assert rehomed.unit is not definer.unit
+    # The observable, not the number: it projects to the SAME place it does at
+    # home, because it is the same span in the same source.
+    assert rehomed.line_col_span() == at_home
+    # The fragment door reads the same table, so it must agree.
+    assert rehomed.fragment.line_col_span == at_home
+
+
+def test_lying_a_borrowed_span_must_NOT_carry_a_minting_unit(tmp_path: Path) -> None:
+    """The discriminator for the other direction.
+
+    A shadow rewrite borrows its origin's span and is materialized under that
+    origin's unit. If shadow handles also claimed a minting unit, every rewrite
+    would be pinned to whatever unit happened to mint it and substitution could
+    strand a rewritten node on a foreign source — the same defect, mirrored.
+    A handle that did not parse anything must answer `None`.
+    """
+    _definer, caller = _two_files(tmp_path)
+    late = caller.root.body[-1]
+    shadow = ShadowNode("Pass", late.span, ())
+    assert shadow.minting_unit is None
+
+    # ...and it therefore takes the unit it is materialized under, which is how
+    # a rewrite stays in its origin's source.
+    node = materialize(caller.unit, shadow, caller.reporter)
+    assert node.unit is caller.unit
+
+
+def test_a_parsed_handle_names_the_unit_it_parsed(tmp_path: Path) -> None:
+    """The source-backed side of the same law, stated directly."""
+    _definer, caller = _two_files(tmp_path)
+    late = caller.root.body[-1]
+    assert late.ref.minting_unit is caller.unit
+
+
+def test_same_file_children_are_unchanged(tmp_path: Path) -> None:
+    """The overwhelmingly common case must be byte-identical.
+
+    Parent and child from one file already agree on their unit, so honoring the
+    child's own is a no-op. This twin is what fails if the fix ever starts
+    resolving a same-file child against something other than its own source.
+    """
+    _definer, caller = _two_files(tmp_path)
+    for node in caller.root.body:
+        child = Child(_handle_of(node)).resolve(caller.unit, caller.reporter)
+        assert child.unit is caller.unit
+        assert child.line_col_span() == node.line_col_span()


### PR DESCRIPTION
## One defect, three rows

```
BACKEND DEFECT [spans.LineTable.line_col]
  observed:  offset 55069 outside 0..27637
  requested: an offset inside the source
  fix:       span was not minted from this source
```

Three of the five backend-defect rows on the pandas board, on three unrelated files — `tests/io/excel/test_writers.py`, `tests/io/pytables/test_store.py`, `tests/io/test_sql.py` — with **the same bound every time**. A constant bound across unrelated files is not three bugs.

## What 27637 is

**`contextlib.py` on Python 3.12, exactly.** That is the interpreter the census ran, per the ledger's own stamp (`"python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]"`). No file in the pandas corpus is that length — I checked all 1,421 by bytes, by codepoints, and under universal newlines. The constant is a stdlib module, so every one of those rows was a pandas **use site** being read against **contextlib's** line table. That is why the offsets were enormous and the bound never moved.

## The mechanism

`Child.resolve(unit, ...)` materializes a child handle under the unit it is handed, and for a child slot that is the **parent's** unit. Within one file this is free and correct — parent and child came from the same text, so one line table reads both.

Across files it is not. The moment a caller's actual argument is bound into a callee body parsed from another file, the child kept its own span but was re-homed onto a source that span was never measured in. **The span was never wrong. The source it was being read against was.**

## The fix is the law

`BackendNode.minting_unit` — a handle that was **parsed** out of a source names that source and keeps it through materialization; a handle whose span is **borrowed** from an origin (every shadow rewrite, every synthetic constituent) answers `None` and correctly takes the unit it is materialized under, because a borrowed span is already in that source's coordinates.

The three source-backed adapters (cpython, parso, tree-sitter) each answer for themselves rather than a base class reaching for a private name on them. The unit also owns the field memo, so this keeps a node's cached field data with the file it came from instead of interning it under a stranger.

## Reproducer

Not a description — a short definer and a long caller, the caller's late node resolved as a child under the definer's unit:

| | before | after |
|---|---|---|
| `line_col_span()` of the re-homed child | `BackendDefect … offset 1609 outside 0..23` | `LineColSpan(3, 0, 3, 5)` — identical to its projection at home |

Same owner, same message, same shape as the corpus rows.

## Tests — four twins, both faces

- **truthful** — a cross-unit child keeps its own source and agrees with itself through both the node and the fragment door. The precondition (`late.span.start > len(definer.source)`) is **asserted**, so the test cannot pass for the wrong reason if the fixture drifts.
- **lying** — a borrowed span must NOT claim a minting unit. That is the same defect mirrored: it would strand every rewrite on a foreign source.
- the parsed-handle side stated directly, and the same-file case, which is the overwhelmingly common one and must stay byte-identical.

**Perturbation — every mutation caught by a named twin:**

| mutation | twin that goes red |
|---|---|
| law removed from `materialize` | `..._keeps_the_source_its_span_was_minted_from` |
| parsed handles stop naming their unit | that one **and** `..._a_parsed_handle_names_the_unit_it_parsed` |
| a borrowed span claims a foreign unit | `test_lying_a_borrowed_span_must_NOT_carry_a_minting_unit` |

## No other axis rose

Failure-set delta over the whole `sugar-source-tree` suite — the package this changes — baseline `09651b50a` vs this head, same driver, two worktrees:

```
baseline: 502 pass / 4 fail / 14 import-fail
head:     502 pass / 4 fail / 14 import-fail
IDENTICAL RESULT SET   (same names, not just same counts)
```

The 4 + 14 are inherited and identical on both sides — they need pytest fixtures the direct-invocation driver cannot supply.

Also re-verified on this head: the two rows closed by #6411 are still clean, and the neighbouring slice/subscript shapes are still clean.

## Caveat, stated plainly

The **corpus-level** confirmation is not in this PR. Reproducing those three rows end-to-end needs a corpus-wide run with the shared `contract_refs` table, and this box could not carry one (load average ~375–515 from the rest of the fleet; the shared-table build alone ran past 25 minutes). What is proven here is the mechanism, by a reproducer that raises the identical defect from the identical owner, and its removal. **CI and the fresh baseline at `d10774abc` are the corpus-level verdict.**

The remaining 2 backend rows are `SourceCallBindingGap` (`unconsumed call actual`) and are a different owner — not touched, not claimed.

The pytest suite cannot run on this box: a session-autouse fixture resolves a Rust release binary, no cached artifact matches this tree's stamp, and the build rung waits on a lock a peer holds. The brief forbade a forced binary build, so twins were executed by direct invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix span unit provenance so each node is interpreted against the source it was parsed from
> - Adds a `minting_unit` property to `BackendNode` in [backend.py](https://github.com/TSavo/sugar/pull/6416/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8); when a ref provides a non-None `minting_unit`, `materialize` rebinds the unit before constructing the cache key and instantiating the node.
> - Implements `minting_unit` on handles in the CPython, parso, and tree-sitter adapters, returning the unit the node was originally parsed from rather than inheriting the parent's unit.
> - Adds [test_span_belongs_to_its_minting_unit.py](https://github.com/TSavo/sugar/pull/6416/files#diff-2724e4b209419df23a03b33775ae15105b1d938936a160edd91eb6e5688e129e) covering cross-unit children, borrowed (shadow) spans, and same-file children.
> - Behavioral Change: cross-unit child nodes now carry their original parsed unit for span projection instead of always inheriting the materializing parent's unit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee6ff82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->