### PR TITLE
Resource With cleanup: keep the ONE exit algebra, drop the second one (supersedes #6401)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -137,12 +137,7 @@ class WithResourceSugar(Sugar):
                         self.exit_face_id, body_exit
                     ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
-                    if _is_never_suppressing_resource(self.disposition):
-                        after = face.and_finally(lambda: exit_es)
-                    else:
-                        after = face.and_exit(
-                            exit_es, disposition=self.disposition
-                        )
+                    after = face.and_exit(exit_es, disposition=self.disposition)
                     after = prepend_facts_to_exitset(
                         after, (*mgr_facts, *enter_facts, *face_facts)
                     )
@@ -171,14 +166,3 @@ def _and_guards(left, right):
     if left == right:
         return left
     return and_([left, right])
-
-
-def _is_never_suppressing_resource(disposition) -> bool:
-    from sugar_lift_py_tests.context_manager_contract import (
-        NeverSuppresses,
-        NeverSuppressesDispositionV1,
-    )
-
-    return isinstance(
-        disposition, (NeverSuppresses, NeverSuppressesDispositionV1)
-    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -42,25 +42,36 @@ class WithResourceSugar(Sugar):
 
     @classmethod
     def witnesses(cls):
+        prefix = (
+            "class Resource:\n"
+            "    def __init__(self):\n"
+            "        self.closed = False\n"
+            "    def __enter__(self):\n"
+            "        return self\n"
+            "    def __exit__(self, effect_type, effect, traceback):\n"
+            "        self.closed = True\n"
+            "        return False\n\n"
+            "def A(halts):\n"
+            "    resource = Resource()\n"
+            "    try:\n"
+            "        with resource:\n"
+            "            if halts:\n"
+            "                raise ValueError\n"
+            "    except ValueError:\n"
+            "        pass\n"
+            "    return resource.closed\n\n"
+        )
         return _call_pair(
-            name="with_resource_structure",
+            name="with_resource_closes_completed_and_halted",
             owner_sugar="WithResourceSugar",
-            truthful=(
-                "def A(z):\n"
-                "    with contextlib.suppress(KeyError):\n"
-                "        raise KeyError\n"
-                "    return z\n\n"
-                "def test_a():\n"
-                "    assert A(5) == 5\n"
-            ),
-            lying=(
-                "def A(z):\n"
-                "    with contextlib.suppress(KeyError):\n"
-                "        raise KeyError\n"
-                "    return z\n\n"
-                "def test_a():\n"
-                "    assert A(5) == 6\n"
-            ),
+            truthful=prefix
+            + "def test_a():\n"
+            "    assert A(False)\n"
+            "    assert A(True)\n",
+            lying=prefix
+            + "def test_a():\n"
+            "    assert A(False)\n"
+            "    assert not A(True)\n",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -126,7 +137,12 @@ class WithResourceSugar(Sugar):
                         self.exit_face_id, body_exit
                     ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
-                    after = face.and_exit(exit_es, disposition=self.disposition)
+                    if _is_never_suppressing_resource(self.disposition):
+                        after = face.and_finally(lambda: exit_es)
+                    else:
+                        after = face.and_exit(
+                            exit_es, disposition=self.disposition
+                        )
                     after = prepend_facts_to_exitset(
                         after, (*mgr_facts, *enter_facts, *face_facts)
                     )
@@ -155,3 +171,14 @@ def _and_guards(left, right):
     if left == right:
         return left
     return and_([left, right])
+
+
+def _is_never_suppressing_resource(disposition) -> bool:
+    from sugar_lift_py_tests.context_manager_contract import (
+        NeverSuppresses,
+        NeverSuppressesDispositionV1,
+    )
+
+    return isinstance(
+        disposition, (NeverSuppresses, NeverSuppressesDispositionV1)
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import inspect
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_contract import (
     NeverSuppresses,
     NeverSuppressesDispositionV1,
@@ -281,6 +283,63 @@ def test_completed_body_survives_never_suppresses():
         and getattr(getattr(e, "effect", None), "exception_name", None)
     ]
     assert reds == []
+
+
+def test_resource_cleanup_uses_and_finally_on_completed_and_halted_faces(
+    monkeypatch,
+):
+    """A resource close is shared cleanup, not a normal-path-only exit."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    original = ExitSet.and_finally
+    incoming_kinds = []
+
+    def observe(incoming, cleanup, *, cleanup_restores=None):
+        incoming_kinds.append(type(incoming.exits[0]))
+        return original(
+            incoming,
+            cleanup,
+            cleanup_restores=cleanup_restores,
+        )
+
+    monkeypatch.setattr(ExitSet, "and_finally", observe)
+
+    completed = _resource(body=(_Pass(),)).desugar()
+    halted = _resource(body=(_Raise("ValueError"),)).desugar()
+
+    assert incoming_kinds == [Completed, Halted]
+    assert completed.value.can_fall_through
+    assert any(
+        isinstance(entry, Incomplete)
+        and getattr(entry.effect, "exception_name", None) == "ValueError"
+        for entry in halted.value.contribution()
+    )
+
+
+def test_lying_resource_cleanup_cannot_skip_the_halted_face(monkeypatch):
+    """BITE: a completion-only cleanup implementation changes the result."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    original = ExitSet.and_finally
+
+    def completion_only(incoming, cleanup, *, cleanup_restores=None):
+        if isinstance(incoming.exits[0], Halted):
+            return ExitSet.completed("cleanup-skipped")
+        return original(
+            incoming,
+            cleanup,
+            cleanup_restores=cleanup_restores,
+        )
+
+    monkeypatch.setattr(ExitSet, "and_finally", completion_only)
+    out = _resource(body=(_Raise("ValueError"),)).desugar()
+
+    with pytest.raises(AssertionError):
+        assert any(
+            isinstance(entry, Incomplete)
+            and getattr(entry.effect, "exception_name", None) == "ValueError"
+            for entry in out.value.contribution()
+        )
 
 
 def test_exit_face_binding_completed_is_none_triple():

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -285,24 +285,26 @@ def test_completed_body_survives_never_suppresses():
     assert reds == []
 
 
-def test_resource_cleanup_uses_and_finally_on_completed_and_halted_faces(
-    monkeypatch,
-):
-    """A resource close is shared cleanup, not a normal-path-only exit."""
+def test_resource_exit_runs_on_the_completed_and_the_halted_face(monkeypatch):
+    """LAW (E1): `__exit__` runs on EVERY outgoing body edge, not the happy one.
+
+    Pinned through `and_exit`, which is the ONE algebra that carries the
+    contract: it hands each incoming face -- completed or halted -- to the
+    disposition, and the disposition decides only whether that face leaves as a
+    completion or a halt. Observing WHICH method the router calls would pin the
+    mechanism instead of the law, so this asserts the faces that reach the
+    contract and the verdicts that come back.
+    """
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    original = ExitSet.and_finally
+    original = ExitSet.and_exit
     incoming_kinds = []
 
-    def observe(incoming, cleanup, *, cleanup_restores=None):
+    def observe(incoming, exit_es, *, disposition):
         incoming_kinds.append(type(incoming.exits[0]))
-        return original(
-            incoming,
-            cleanup,
-            cleanup_restores=cleanup_restores,
-        )
+        return original(incoming, exit_es, disposition=disposition)
 
-    monkeypatch.setattr(ExitSet, "and_finally", observe)
+    monkeypatch.setattr(ExitSet, "and_exit", observe)
 
     completed = _resource(body=(_Pass(),)).desugar()
     halted = _resource(body=(_Raise("ValueError"),)).desugar()
@@ -316,22 +318,18 @@ def test_resource_cleanup_uses_and_finally_on_completed_and_halted_faces(
     )
 
 
-def test_lying_resource_cleanup_cannot_skip_the_halted_face(monkeypatch):
-    """BITE: a completion-only cleanup implementation changes the result."""
+def test_lying_resource_exit_cannot_skip_the_halted_face(monkeypatch):
+    """BITE: a completion-only exit implementation changes the result."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    original = ExitSet.and_finally
+    original = ExitSet.and_exit
 
-    def completion_only(incoming, cleanup, *, cleanup_restores=None):
+    def completion_only(incoming, exit_es, *, disposition):
         if isinstance(incoming.exits[0], Halted):
-            return ExitSet.completed("cleanup-skipped")
-        return original(
-            incoming,
-            cleanup,
-            cleanup_restores=cleanup_restores,
-        )
+            return ExitSet.completed("exit-skipped")
+        return original(incoming, exit_es, disposition=disposition)
 
-    monkeypatch.setattr(ExitSet, "and_finally", completion_only)
+    monkeypatch.setattr(ExitSet, "and_exit", completion_only)
     out = _resource(body=(_Raise("ValueError"),)).desugar()
 
     with pytest.raises(AssertionError):
@@ -340,6 +338,56 @@ def test_lying_resource_cleanup_cannot_skip_the_halted_face(monkeypatch):
             and getattr(entry.effect, "exception_name", None) == "ValueError"
             for entry in out.value.contribution()
         )
+
+
+def test_never_suppresses_needs_no_second_cleanup_algebra():
+    """LAW: `and_exit` under NeverSuppresses IS `and_finally`, face for face.
+
+    #6401 proposed routing NeverSuppresses through `and_finally` so cleanup ran
+    on both edges. It already does: for both spellings of the contract, on a
+    completed AND a halted body face, the two produce identical exits. Routing
+    one disposition through a different algebra would therefore have changed
+    nothing except adding an asker -- a branch on WHAT KIND the disposition is,
+    which is the shape the floor exists to delete.
+
+    This twin is why that branch is not in the tree.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    exit_es = ExitSet((Completed(true_guard(), _FloorValue("exited")),))
+    faces = (
+        Completed(true_guard(), _FloorValue("body")),
+        Halted(true_guard(), RaiseEffect(exception_name="ValueError"), _FloorValue("pre")),
+    )
+    for disposition in (NeverSuppresses(), NeverSuppressesDispositionV1()):
+        for face in faces:
+            through_exit = ExitSet((face,)).and_exit(exit_es, disposition=disposition)
+            through_finally = ExitSet((face,)).and_finally(lambda: exit_es)
+            assert through_exit.exits == through_finally.exits, (
+                f"{type(disposition).__name__} / {type(face).__name__} diverged"
+            )
+
+
+def test_lying_the_equivalence_is_specific_to_never_suppresses():
+    """BITE: `and_finally` is NOT a general substitute for `and_exit`.
+
+    A suppressing contract consumes the halt; shared cleanup restores it. If
+    the equivalence above held for every disposition, routing everything
+    through `and_finally` would be safe -- it is not, and that is exactly why
+    the rejected branch needed a kind test to stay correct.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    exit_es = ExitSet((Completed(true_guard(), _FloorValue("exited")),))
+    halted = Halted(
+        true_guard(), RaiseEffect(exception_name="ValueError"), _FloorValue("pre")
+    )
+    suppressing = ExitSuppressionContract(frozenset({"ValueError"}))
+
+    through_exit = ExitSet((halted,)).and_exit(exit_es, disposition=suppressing)
+    through_finally = ExitSet((halted,)).and_finally(lambda: exit_es)
+
+    assert through_exit.exits != through_finally.exits
 
 
 def test_exit_face_binding_completed_is_none_triple():

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -295,6 +295,48 @@ def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(
     assert bound_return.value.projection == "enter-result"
 
 
+@pytest.mark.parametrize(
+    ("body", "incoming_kind"),
+    [
+        ("pass", Completed),
+        ('raise ValueError("boom")', Halted),
+    ],
+)
+def test_real_resource_reproducer_closes_every_exitset_face(
+    tmp_path, monkeypatch, body, incoming_kind
+):
+    """An authenticated provider resource closes after completion and halt."""
+    path = tmp_path / f"resource_{incoming_kind.__name__.lower()}.py"
+    path.write_text(
+        "from arbitrary_provider import acquire\n"
+        "def f():\n"
+        "    with acquire():\n"
+        f"        {body}\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+
+    resource = next(
+        statement
+        for statement in _function_sugar(path_source(str(path)), _resolved).statements
+        if isinstance(statement, WithResourceSugar)
+    )
+    original = ExitSet.and_finally
+    seen = []
+
+    def observe(incoming, cleanup, *, cleanup_restores=None):
+        seen.append(type(incoming.exits[0]))
+        return original(
+            incoming,
+            cleanup,
+            cleanup_restores=cleanup_restores,
+        )
+
+    monkeypatch.setattr(ExitSet, "and_finally", observe)
+    resource.desugar()
+
+    assert seen == [incoming_kind]
+
+
 def test_unresolved_ref_stays_typed_loud(tmp_path):
     path = tmp_path / "unresolved.py"
     path.write_text(

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -320,18 +320,17 @@ def test_real_resource_reproducer_closes_every_exitset_face(
         for statement in _function_sugar(path_source(str(path)), _resolved).statements
         if isinstance(statement, WithResourceSugar)
     )
-    original = ExitSet.and_finally
+    # Observed through `and_exit` -- the ONE algebra the resource contract
+    # routes through. Pinning `and_finally` here would pin a mechanism; the law
+    # is that every body face reaches the contract.
+    original = ExitSet.and_exit
     seen = []
 
-    def observe(incoming, cleanup, *, cleanup_restores=None):
+    def observe(incoming, exit_es, *, disposition):
         seen.append(type(incoming.exits[0]))
-        return original(
-            incoming,
-            cleanup,
-            cleanup_restores=cleanup_restores,
-        )
+        return original(incoming, exit_es, disposition=disposition)
 
-    monkeypatch.setattr(ExitSet, "and_finally", observe)
+    monkeypatch.setattr(ExitSet, "and_exit", observe)
     resource.desugar()
 
     assert seen == [incoming_kind]


### PR DESCRIPTION
**Supersedes #6401** (draft, branch `fleet/py-build-resource-with`, not authored
by me). Its witness rewrite is kept in full; its production change is dropped,
with a twin that proves why.

## Reporting ZERO for the E1 mechanism

`__exit__` on every completed and halted edge is **already carried by
`and_exit`**. #6401 proposed a second path for it:

```python
if _is_never_suppressing_resource(self.disposition):
    after = face.and_finally(lambda: exit_es)
else:
    after = face.and_exit(exit_es, disposition=self.disposition)
```

**Measured, that branch changes nothing.** For both spellings of the contract,
on a completed *and* a halted body face, `and_exit` and `and_finally` produce
identical exits. `and_exit` already hands every face to the disposition, and
`NeverSuppresses` already answers "restore" on the halted edge. #6392/#6406
landed obligation and face conservation in `and_exit`, closing the last
difference between them.

What the branch did add is an **asker** — a test of *what kind* the disposition
is, selecting a second cleanup algebra for one contract. That is the shape the
floor exists to delete, and it is a second control model for a contract whose
entire point is that one expression decides both edges.

And it could not be generalized away: **`and_finally` is not a substitute for
`and_exit`.** A suppressing contract *consumes* the halt where shared cleanup
*restores* it. The kind test was load-bearing precisely because the routing was
wrong — that is the tell.

Per the dispatch: a retired family is not a law to ratify and gets no pin. So
this is **zero new mechanism, plus the twins that prove the law is already
held.**

## Kept from #6401

The **witness rewrite**, in full. The old truthful/lying pair used
`contextlib.suppress` — a vendor manager name sitting in a witness. The
replacement is a renamed local `Resource` whose twin flips on whether `close`
ran after a halt. Strictly better, and it exercises the actual E1 law instead
of a suppression side effect.

## Retargeted, not deleted

#6401's three tests monkeypatched `and_finally` and asserted it was **called** —
pinning the mechanism, not the law. They now observe `and_exit` and keep every
real assertion they had: both faces reach the contract, the halt is restored,
and a completion-only exit changes the result.

## Added

- `test_never_suppresses_needs_no_second_cleanup_algebra` — the equivalence,
  face by face, both contract spellings. This is the evidence that deletes the
  branch.
- `test_lying_the_equivalence_is_specific_to_never_suppresses` — its bite: the
  two algebras genuinely diverge for a suppressing contract, so the equivalence
  is a fact about `NeverSuppresses`, not a fact about the algebras. Without this
  arm the first test would read as "these are interchangeable," which is false
  and dangerous.

## Gate

- **Real reproducer** — #6401's `arbitrary_provider.acquire()` site, kept and
  retargeted.
- **Truthful + lying twins** — four, two pairs.
- **Focused owning-package tests** — full `sugar-source-tree` suite:
  **699 passed, 4 failed, 5 skipped.** All 4 reproduce on `09651b50a`
  unmodified: `test_parameter_contract_demand_set` ×3 and
  `test_with_partition_shared_algebra::test_routers_do_not_branch_on_keyword_vendor_or_manager_spelling`.
  Inherited, delta 0.
- **No increase in crash/timeout axes** — no production behaviour changes at
  all; the only production edit is a deletion.

## Not run locally

`implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py`
could not be executed on this box: `bin/sugarbin` does not resolve a release
binary within its 600s timeout while peer processes hold the Rust
build-directory lock. Its edits are retargeting + two added twins, verified by
`ast.parse` only. **Not run, not green** — leaving it to CI.

## Site coverage and ΔR

- **site coverage: 0.** No new site shape constructs.
- **ΔR: 0.** No residual moves; no axis increases. This PR removes a no-op
  branch and adds evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `with` resource exit tests to verify `__exit__` runs for both completed and halted faces
> - Replaces the previous two-exit-algebra witness scenario in [`with_resource_sugar.py`](https://github.com/TSavo/sugar/pull/6417/files#diff-e157731c16f82dd84b0fbeeff14ddf0c765c34521ebda25182232c5cd85f670d) with a single scenario (`with_resource_closes_completed_and_halted`) that checks resource `__exit__` fires for both completion and halt paths.
> - Adds tests in [`test_with_resource_sugar.py`](https://github.com/TSavo/sugar/pull/6417/files#diff-2f3ef62c9f2b0c15b9f9ce067770fa40d6698321025089647c1a4db727f0aac0) that monkeypatch `ExitSet.and_exit` to assert it receives both `Completed` and `Halted` faces, and that skipping the halted face changes the outcome.
> - Adds tests proving `ExitSet.and_exit` and `ExitSet.and_finally` are equivalent for `NeverSuppresses` dispositions but not for suppressing ones.
> - Adds a parameterized integration test in [`test_with_authenticated_contract_ref.py`](https://github.com/TSavo/sugar/pull/6417/files#diff-24ed90dba7c15724cef255c1d44a25011bfd98f07aba873f4fa4de7241417552) verifying authenticated provider resources route both faces through `and_exit`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c7fb7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->