### PR TITLE
Complex field: a non-finite fold is a gap, not a value (lost in #6317 squash)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_arithmetic.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_arithmetic.py
@@ -83,7 +83,21 @@ def closed_complex_operation(
     right_coordinate = complex_field_coordinate(right)
     if left_coordinate is None or right_coordinate is None:
         return None
-    product = operate(left_coordinate, right_coordinate)
+    try:
+        product = operate(left_coordinate, right_coordinate)
+    except OverflowError:
+        return None
+    import math
+
+    if not (math.isfinite(product.real) and math.isfinite(product.imag)):
+        # Python's own answer here is an infinity or a NaN. Those are real IEEE
+        # results, but ``ComplexValue.to_term`` projects through a canonical
+        # decimal string and has no coordinate for them: it emits
+        # ``_ConstReal(value='Infinity', sort=Real)`` -- the TEXT "Infinity"
+        # standing in a Real slot, a preimage no source literal could produce
+        # and the theory cannot read back. Constructing the value would be
+        # inventing that preimage, so the pair stays loud instead.
+        return None
     return Complete(ComplexValue(product.real, product.imag))
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
@@ -162,6 +162,55 @@ def test_an_integer_too_large_for_the_float_field_stays_loud() -> None:
     assert "ComplexValue" in info.fix
 
 
+def test_a_result_that_overflows_the_float_field_stays_loud() -> None:
+    """Folding opened an edge no source literal could reach.
+
+    `(1e308+0j) * (1e308+0j)` is an infinity in Python -- a real IEEE result.
+    But ComplexValue.to_term projects through a canonical decimal string and has
+    no coordinate for it: before this guard the fold produced
+    ``_ConstReal(value='Infinity', sort=Real)``, the TEXT "Infinity" standing in
+    a Real slot, which the theory cannot read back. Constructing that is
+    inventing a preimage, so the pair stays loud.
+    """
+    huge = ComplexValue(1e308, 0.0)
+
+    with pytest.raises(ConstructionPanic) as raised:
+        huge.multiply(huge, SITE)
+
+    assert raised.value.info.owner == "multiply"
+
+
+def test_a_nan_result_stays_loud() -> None:
+    """inf * 0 is NaN in Python; NaN has no canonical decimal string either."""
+    with pytest.raises(ConstructionPanic):
+        ComplexValue(float("inf"), 0.0).multiply(ComplexValue(0.0, 0.0), SITE)
+
+
+def test_a_finite_result_at_the_edge_of_the_field_still_folds() -> None:
+    """The discrimination: the guard is about REPRESENTABILITY, not magnitude.
+
+    A guard that refused by size would be the same kind of cardinality cap this
+    floor deleted from sequence repetition. 1e308 + 1.0 is finite, so it folds.
+    """
+    outcome = ComplexValue(1e308, 0.0).add(ComplexValue(1.0, 0.0), SITE)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.real == 1e308 + 1.0
+
+
+def test_no_folded_result_ever_projects_a_non_numeric_real() -> None:
+    """The law behind the guard, stated on the term the theory actually reads."""
+    from sugar_lift_py_tests.ir import _ConstReal
+
+    outcome = ComplexValue(1e200, 0.0).multiply(ComplexValue(1e-200, 0.0), SITE)
+    term = outcome.value.to_term(owner=SITE)
+
+    for arg in term.args:
+        assert isinstance(arg, _ConstReal)
+        assert float(arg.value) == float(arg.value)  # not NaN
+        assert abs(float(arg.value)) != float("inf")
+
+
 def test_a_symbolic_operand_keeps_its_own_symbolic_door() -> None:
     """A complex plus an opaque callsite is not a field member; the complex
     floor must not swallow it into a fabricated concrete complex.


### PR DESCRIPTION
## A silent-lossy path is live on main right now

#6317 was squash-merged one commit early. The complex-field folding law landed; the guard that closes the edge that law opens did not. This is my miss to repair — the folding path is mine.

Reproduce against current `main`:

```python
ComplexValue(1e308, 0.0).multiply(ComplexValue(1e308, 0.0), site)
# -> ComplexValue(real=inf, imag=0.0)
# .to_term(...) ->
#   _ConstReal(value='Infinity', sort=PrimitiveSort(name='Real'))
```

That is the **string `"Infinity"` sitting in a Real slot of the theory** — a preimage no source literal can produce and nothing downstream can read back. Python is right that the IEEE result is an infinity; the kit has no coordinate for it, because `ComplexValue.to_term` projects through a canonical decimal string (deliberately, so a float's non-deterministic text form never reaches a CID).

No source `complex` literal can be inf or NaN, so this edge did not exist before folding. It exists now.

## The mechanism

A fold that cannot be represented is not a value. `closed_complex_operation` returns `None` on a non-finite result and on `OverflowError`, so the pair falls through to its own loud gap. `panic = gap` — no sentinel, no clamp, no "unavailable" marker.

## Gate

**Reproducer:** the `1e308 * 1e308` fold above.

**Truthful twin:** overflow-to-inf stays loud; `inf * 0` → NaN stays loud; and `test_no_folded_result_ever_projects_a_non_numeric_real` asserts the law on the term the theory actually reads, not on the Python float.

**Lying twin:** `test_a_finite_result_at_the_edge_of_the_field_still_folds`. `1e308 + 1.0` is finite and **must still fold**. This is the arm that stops the guard from drifting into a magnitude cap — the same cardinality cap this floor deleted from sequence repetition in #6317. Refusing by size would re-introduce exactly what we removed.

**Focused tests:** 65 passed / 1 failed across `test_complex_field_arithmetic_floor`, `test_sequence_repetition_has_no_cardinality_cap`, `test_sequence_membership_floor`, `test_builtin_finite_set_floor`.

**Known inherited red:** the one failure, `test_ground_non_string_in_string_is_type_error`, is **red on pristine `origin/main`** with an identical `AttributeError` in `ground_exit.py:36` (`'str' object has no attribute 'filename'` — a prose locus where a fragment is required). Verified by running the same module against a clean `origin/main` worktree. Not from this change; it is the absolute-locus provenance blocker reported separately, and `binop-floors` is seeing the same one.

## Scope

Two files. `floor/complex_arithmetic.py` (+15) and its twins (+45). `floor_value.py` untouched, per the ownership ruling giving that axis to `binop-floors`. No interaction with #6415: that law only ever constructs a symbolic coordinate and never produces a `ComplexValue`, so it cannot reach this path — concrete-concrete folding still enters through `ComplexValue.add/subtract/multiply` before the base class is consulted.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return a gap instead of a value when complex field fold produces non-finite result
> - `closed_complex_operation` in [complex_arithmetic.py](https://github.com/TSavo/sugar/pull/6418/files#diff-0df8289fccc549b145631fa9c1dd61ac8b0e67b136717200a7b6311186fe1b15) now returns `None` (a gap) when the operation overflows or produces infinite/NaN components, instead of wrapping the result in `Complete(ComplexValue(...))`.
> - Adds four tests covering overflow, NaN (inf × 0), edge-case finite results, and representability of folded real arguments.
> - Behavioral Change: operations that previously folded to a `Complete` value on overflow or NaN now raise `ConstructionPanic`, leaving the result loud rather than silently producing a non-finite complex value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e68687f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->