### PR TITLE
Pin the three guards #6415 has to keep standing

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -215,6 +215,44 @@ def test_a_value_that_has_not_testified_stays_loud() -> None:
     assert raised.value.info.observed == "_Unspoken"
 
 
+def test_a_term_bearing_callable_never_enters_the_law() -> None:
+    """The trap that killed the widening in ``751142009``, pinned on the real
+    artifacts rather than a stand-in.
+
+    ``{List,Tuple}Value.contains x CallSiteValue`` was once implemented by
+    treating any TERM-BEARING operand as undecided, measured, then reverted:
+    ``FunctionCallable`` carries a term too, and two pinned refusals
+    (``test_opaque_list_member_stays_loud``, ``test_opaque_member_stays_loud``)
+    say a callable is never a member. Carrying a term is not the
+    discriminator. Denoting a value is, and these two classes state nothing,
+    so they can never enter the law from either side -- however opaque their
+    operand happens to be.
+    """
+    from sugar_lift_py_tests.floor.function_callable import FunctionCallable
+    from sugar_lift_py_tests.floor.lambda_callable import LambdaCallable
+
+    callables = (
+        FunctionCallable("f"),
+        LambdaCallable(parameters=("p",), body=None, construction_identity="lam"),
+    )
+
+    for callable_value in callables:
+        # It carries a term -- and that buys it nothing.
+        assert callable_value.to_term(owner=SITE) is not None
+        assert callable_value.denotes_value() is False
+
+        # Refused from the left...
+        with pytest.raises(ConstructionPanic) as from_left:
+            callable_value.add(_symbolic(), SITE)
+        assert from_left.value.info.observed == type(callable_value).__name__
+
+        # ...and from the right, where an undecided left operand would
+        # otherwise have carried the pair into the law.
+        with pytest.raises(ConstructionPanic) as from_right:
+            BytesValue(b"x").add(callable_value, SITE)
+        assert type(callable_value).__name__ in from_right.value.info.fix
+
+
 def test_a_non_denoting_operand_stays_loud() -> None:
     """A callable is not an operand. The law refuses it from the right too."""
     from sugar_lift_py_tests.floor.floor_value import FloorValue
@@ -233,6 +271,66 @@ def test_a_non_denoting_operand_stays_loud() -> None:
 
     assert raised.value.info.observed == "BytesValue"
     assert "_NotAValue" in raised.value.info.fix
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    (
+        (ComplexValue(0.0, 1.0), StringValue("x")),
+        (StringValue("x"), ComplexValue(0.0, 1.0)),
+    ),
+)
+def test_a_ground_type_error_never_becomes_a_coordinate(left, right) -> None:
+    """``1j + "x"`` is Python's ``TypeError``.
+
+    Both operands have decided runtime types, so the operation is not unknown
+    -- it is known to raise. A coordinate here would invent an operation that
+    never happens, which is the one way this law could launder a ground exit
+    into a value. It stays LOUD in both operand orders.
+    """
+    with pytest.raises(ConstructionPanic):
+        left.add(right, SITE)
+
+
+def test_the_field_law_is_consulted_before_the_base_law() -> None:
+    """The undecided law must not intercept ahead of a ground field law.
+
+    ``ComplexValue.add`` folds through ``complex_arithmetic`` FIRST and only
+    falls to ``super()`` on ``None``, so any refusal that law states -- an
+    overflow into the float field, a non-finite result that
+    ``ComplexValue.to_term`` has no coordinate for -- still runs and still
+    decides. Hoisting a coordinate onto the base class did not make the field
+    law's guards dead code.
+
+    Asserted by observing the field law actually being reached, including on
+    the symbolic pair that this law ultimately answers.
+    """
+    from sugar_lift_py_tests.floor import complex_arithmetic
+
+    reached: list[tuple[str, str]] = []
+    original = complex_arithmetic.complex_add
+
+    def _traced(left, right, site):
+        reached.append((type(left).__name__, type(right).__name__))
+        return original(left, right, site)
+
+    complex_arithmetic.complex_add = _traced
+    try:
+        # A pair the field law owns and folds.
+        ComplexValue(1.0, 0.0).add(ComplexValue(2.0, 0.0), SITE)
+        # A pair the field law REFUSES -- it decides, then falls through.
+        with pytest.raises(ConstructionPanic):
+            TermValue(10**400).add(ComplexValue(0.0, 1.0), SITE)
+        # The pair this law answers -- the field law still got asked first.
+        _coordinate(ComplexValue(0.0, 1.0).add(_symbolic(), SITE), "+")
+    finally:
+        complex_arithmetic.complex_add = original
+
+    assert reached == [
+        ("ComplexValue", "ComplexValue"),
+        ("TermValue", "ComplexValue"),
+        ("ComplexValue", "SymbolicValue"),
+    ]
 
 
 def test_the_law_never_converts_a_panic_into_a_refusal() -> None:


### PR DESCRIPTION
Follow-up to #6415 (merged). Tests only -- **no mechanism change**, `floor_value.py` untouched.

#6415 merged from an earlier snapshot of the branch, so the term-bearing-callable pin did not travel with it. This lands that, plus the two further guards requested on review by the owner of the complex field law (#6317).

## 1. A term-bearing callable never enters the law

`751142009` reverted a widening of `{List,Tuple}Value.contains x CallSiteValue` that keyed on **"carries a term"** -- `FunctionCallable` carries one too, and `test_opaque_list_member_stays_loud` / `test_opaque_member_stays_loud` deliberately pin that a callable is never a member. That revert named the predicate it lacked, and `denotes_value` is that predicate, so the trap now lives *inside* the law and needs an instrument rather than an argument.

`FunctionCallable` and `LambdaCallable` state no testimony and take the `False` default. Pinned on **both real classes** rather than a synthetic stand-in: each carries a term, that buys it nothing, and it is refused from the left **and from the right**, where an undecided left operand would otherwise have carried the pair in.

Both original refusals re-run green.

## 2. A ground `TypeError` never becomes a coordinate

`1j + "x"` raises in Python. Both operands have decided runtime types, so the pair is not *unknown* -- it is *known to raise*. A coordinate there would invent an operation that never happens, which is the one way this law could launder a ground exit into a value. Pinned in **both operand orders**.

## 3. The field law is consulted before the base law

The sharpest of the three: if the base-class law intercepted ahead of `ComplexValue.add`, the field law's own guards would silently become dead code -- including the non-finite refusal, which matters because `ComplexValue.to_term` projects through a canonical decimal string and would otherwise emit the text `"Infinity"` as a number.

It does not intercept. `ComplexValue.add` folds through `complex_arithmetic` first and falls to `super()` only on `None`. Asserted by **observing the field law actually being reached** -- on the folded pair, on the pair it refuses, and on the symbolic pair this law ultimately answers:

```
[("ComplexValue", "ComplexValue"),   # folded by the field law
 ("TermValue",    "ComplexValue"),   # refused by it, then falls through
 ("ComplexValue", "SymbolicValue")]  # asked first, then answered here
```

## Evidence

- **37 tests green** in `test_undecided_binary_operand_law.py`; **80 passed** across it plus `test_complex_field_arithmetic_floor.py`, `test_sequence_membership_floor.py`, `test_builtin_finite_set_floor.py`.
- **Mutation:** flipping the `denotes_value` default to `True` fails guard 1 plus two existing tests. Reverted, verified clean after.
- **Failure-set delta: zero.** Only `test_ground_non_string_in_string_is_type_error` is red, inherited at base and untouched here.

## One thing to flag, not fixed here

The concrete-concrete overflow path folds to a non-finite value at `origin/main` today:

```
ComplexValue(1e308, 0.0) + ComplexValue(1e308, 0.0)  ->  Complete(ComplexValue) real=inf imag=0.0
```

Measured identically at base and on this branch -- **not introduced by the law**, which never sees the pair. The non-finite guard that refuses it lives on `bf71d6749`, still unmerged with #6317. Guard 3 above pins that the path stays reachable, so that refusal will engage the moment it lands. Flagging so it is not mistaken for closed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin guards for callable operands, ground type errors, and field law ordering in binary addition tests
> Adds three regression tests to [test_undecided_binary_operand_law.py](https://github.com/TSavo/sugar/pull/6419/files#diff-9998d1328333d54a7b5c59ca17ab35198a7558b224afbe0df116ce7b9e33fb0b) to lock in invariants that must not regress:
> - `test_a_term_bearing_callable_never_enters_the_law`: asserts that `FunctionCallable` and `LambdaCallable` instances are rejected from both left and right operand positions in binary addition, raising `ConstructionPanic`.
> - `test_a_ground_type_error_never_becomes_a_coordinate`: asserts that mixed `ComplexValue`/`StringValue` addition raises rather than producing a coordinate, in both operand orders.
> - `test_the_field_law_is_consulted_before_the_base_law`: wraps `complex_arithmetic.complex_add` to trace invocations and verifies field-level dispatch precedes base law logic for all three operand combinations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb32c46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->