### PR TITLE
Disjunction intersects PARTITIONS and unions SIDES within them (#6336 algebra) — ΔR=0, 13403 still refused

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -185,13 +185,17 @@ def _complete_family(arms) -> bool:
     for origin in origins:
         sides, arity = [], None
         for arm in arms:
-            member = next(
-                (f for f in arm.faces if f.partition == origin), None
-            )
-            if member is None:
+            members = [f for f in arm.faces if f.partition == origin]
+            # A MERGED arm can carry several sides of one origin (see
+            # `_merge_faces`). It is one arm standing for several members, so
+            # it cannot be counted as the single member the arity test needs;
+            # admitting it would let two arms "cover" a three-way family. The
+            # pairwise rule below still separates it on disjoint side sets --
+            # this door just declines to call the family complete.
+            if len(members) != 1:
                 break
-            sides.append(member.side)
-            arity = member.arity
+            sides.append(members[0].side)
+            arity = members[0].arity
         else:
             if arity == len(arms) == len(set(sides)):
                 return True
@@ -218,15 +222,74 @@ def partition(owner: object) -> tuple[PartitionFace, PartitionFace]:
 _NO_FACES: frozenset[PartitionFace] = frozenset()
 
 
+def _sides_by_partition(
+    faces: frozenset[PartitionFace],
+) -> dict[object, set[object]]:
+    """Every side an arm is known to lie on, grouped by the split that named it.
+
+    An arm usually carries ONE side per partition. A MERGED arm carries several:
+    ``normalize`` disjoins two equal destinations, and the merged arm holds
+    wherever either contributor did, so it lies on one side of ``{range,
+    single}`` without saying which. That is a truthful, weaker statement, and
+    the set is how it is spelled.
+    """
+    sides: dict[object, set[object]] = {}
+    for face in faces:
+        sides.setdefault(face.partition, set()).add(face.side)
+    return sides
+
+
+def _merge_faces(
+    left: frozenset[PartitionFace], right: frozenset[PartitionFace]
+) -> frozenset[PartitionFace]:
+    """Testimony that survives a disjoining merge of two equal destinations.
+
+    THE RULE IS PER PARTITION, and it was previously a plain set intersection.
+    That answered the question "which identical faces did both carry", which is
+    the right answer only when the arms lie on the same side. Two arms on
+    DIFFERENT sides of one split still jointly testify something true and
+    useful about the merged arm -- it is on one of those two sides, and on no
+    other -- and the intersection threw that away, leaving the merged arm
+    unstamped and its refusal unclosable by any producer.
+
+    So: a split only ONE contributor named is dropped (the other claims nothing
+    there, and an unclaimed side is not an exclusion). A split BOTH named keeps
+    every side either of them could be on. That is weaker than each contributor
+    alone, which is correct -- a merged arm knows less -- and it is not nothing.
+
+    This does not let exclusivity be forged. ``_faces_exclusive`` asks for
+    DISJOINT side sets, so a merged arm covering `{range, single}` is provably
+    apart only from arms covering neither, which is exactly what the producer's
+    own mint already asserted.
+    """
+    left_sides = _sides_by_partition(left)
+    right_sides = _sides_by_partition(right)
+    shared = left_sides.keys() & right_sides.keys()
+    return frozenset(
+        face for face in (left | right) if face.partition in shared
+    )
+
+
 def _faces_exclusive(
     left: frozenset[PartitionFace], right: frozenset[PartitionFace]
 ) -> bool:
-    """Whether carried testimony alone proves the two arms cannot both hold."""
+    """Whether carried testimony alone proves the two arms cannot both hold.
+
+    DISJOINT SIDE SETS over a SHARED partition. The producer said its sides are
+    mutually exclusive when it minted them, so if everything the left arm could
+    be is something the right arm cannot be, they cannot both hold. With one
+    side each -- every face a producer mints directly -- this is exactly the
+    ``!=`` it replaces; the sets only ever grow through a merge.
+
+    Sound in the same direction as before: a False answer is "not proven",
+    never "proven to overlap".
+    """
     if not left or not right:
         return False
-    sides: dict[object, object] = {face.partition: face.side for face in left}
-    for face in right:
-        if face.partition in sides and sides[face.partition] != face.side:
+    right_sides = _sides_by_partition(right)
+    for partition_id, sides in _sides_by_partition(left).items():
+        other = right_sides.get(partition_id)
+        if other is not None and not (sides & other):
             return True
     return False
 
@@ -722,17 +785,16 @@ class ExitSet(Generic[T]):
                     # drop the arrival's, silently.
                     and _obligations(exit_) == _obligations(prior)
                 )
-                # Same destination under a DISJOINED guard: only testimony both
-                # arms carried survives the merge, for the same reason as in
-                # factor_completed. Intersecting here is what keeps a merged
-                # arm from claiming a face it only held on one side.
+                # Same destination under a DISJOINED guard. Only a split BOTH
+                # contributors spoke about survives -- a partition one of them
+                # never mentioned tells you nothing about where the merged arm
+                # lies. For a split they both named, the merged arm lies on one
+                # of their sides, so the sides UNION.
                 if same_completed:
-                    # OR of guards is not a partition; clear stamps when merging
-                    # equal destinations so exclusivity cannot be forged.
                     merged[index] = Completed(
                         _or_guards(prior.guard, exit_.guard),
                         prior.value,
-                        prior.faces & exit_.faces,
+                        _merge_faces(prior.faces, exit_.faces),
                         # Equal by `same_completed`; stated explicitly so the
                         # field cannot be dropped by a later edit here.
                         prior.pending_contracts,
@@ -743,7 +805,7 @@ class ExitSet(Generic[T]):
                         _or_guards(prior.guard, exit_.guard),
                         prior.effect,
                         prior.state,
-                        prior.faces & exit_.faces,
+                        _merge_faces(prior.faces, exit_.faces),
                         # Equal by `same_halted`, so this conserves rather than
                         # chooses; stated explicitly so the field cannot be
                         # dropped by a later edit to this constructor.

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
@@ -30,9 +30,10 @@ from sugar_lift_py_tests.outcome.exit_set import (
     ExitSet,
     ExitSetFactoringGap,
     partition,
+    partition_family,
     true_guard,
 )
-from sugar_lift_py_tests.outcome.exit_set import _are_exclusive
+from sugar_lift_py_tests.outcome.exit_set import _are_exclusive, _faces_exclusive
 
 
 def _pred(name: str):
@@ -159,12 +160,25 @@ def test_guarded_stamps_the_face_it_is_given_and_nothing_else():
     assert len([e for e in factored.exits if isinstance(e, Completed)]) == 1
 
 
-def test_disjoining_merge_keeps_only_testimony_both_arms_carried():
-    """A merged arm holds under a DISJUNCTION, so faces intersect, never union.
+def test_a_disjoining_merge_keeps_every_side_either_contributor_could_be_on():
+    """A merged arm holds under a DISJUNCTION, so its SIDES union.
 
-    If the merge unioned faces, an arm reachable on either side of a split would
-    claim to be on one named side of it — an exclusion the producer never gave,
-    and the exact way carried testimony could start lying.
+    LAW CHANGED ON THE RECORD. This arm used to assert
+    `merged.exits[0].faces == frozenset()`: a merge of two arms on different
+    sides of one split kept nothing. That was a conservative approximation, not
+    the truth. The merged arm holds wherever either contributor did, so what is
+    actually known is "on one of these two sides, and no other" — a weaker
+    statement than either contributor made, and a strictly stronger one than
+    silence.
+
+    Dropping it had a measured cost: it is why wiring a producer could not close
+    a merged-arm refusal. The producer would mint `range` and `single`, the
+    merge would erase both, and the arm would arrive unstamped no matter how
+    well the producer testified. Testimony that cannot survive the wire is not
+    propagation.
+
+    The reason the old assertion existed is preserved exactly, and is pinned by
+    the arm below: a merged arm must never claim to be on ONE named side.
     """
     condition = _pred("c")
     left_face, right_face = partition(("merge-owner", condition))
@@ -177,6 +191,53 @@ def test_disjoining_merge_keeps_only_testimony_both_arms_carried():
     ).normalize()
 
     assert len(merged.exits) == 1
+    assert merged.exits[0].faces == frozenset({left_face, right_face})
+
+
+def test_a_merged_arm_is_not_exclusive_with_either_side_it_came_from():
+    """THE LYING TWIN for the union, and the reason the old rule was written.
+
+    The danger the intersection was guarding against is that an arm reachable on
+    EITHER side of a split ends up claiming one named side, forging an exclusion
+    the producer never gave. Carrying both sides does not forge it, because
+    `_faces_exclusive` asks for DISJOINT side sets: `{c, not c}` overlaps `{c}`
+    and overlaps `{not c}`, so the merged arm is provably apart from neither.
+
+    Without this arm, a union looks like a free upgrade. With it, the union is
+    only sound because the prover reads sets.
+    """
+    condition = _pred("c")
+    left_face, right_face = partition(("merge-owner", condition))
+    both = frozenset({left_face, right_face})
+
+    assert not _faces_exclusive(both, frozenset({left_face}))
+    assert not _faces_exclusive(both, frozenset({right_face}))
+    assert not _faces_exclusive(both, both)
+    # ...and it still separates from a side of the SAME split it cannot be on.
+    a, b, c = partition_family(("three", "way"), ("a", "b", "c"))
+    assert _faces_exclusive(frozenset({a, b}), frozenset({c}))
+    assert not _faces_exclusive(frozenset({a, b}), frozenset({b, c}))
+
+
+def test_a_merge_drops_a_split_only_one_contributor_named():
+    """DISCRIMINATING. Union is per SHARED partition, never across all faces.
+
+    A plain `left | right` would let an arm inherit a face from a split the
+    other contributor never mentioned — the merged arm would claim to lie on a
+    side of a partition it may be entirely outside. Only splits both arms spoke
+    about survive.
+    """
+    condition = _pred("c")
+    mine, _other = partition(("mine", condition))
+    theirs, _ = partition(("theirs", condition))
+
+    merged = ExitSet(
+        (
+            Completed(condition, "same", frozenset({mine})),
+            Completed(not_(condition), "same", frozenset({theirs})),
+        )
+    ).normalize()
+
     assert merged.exits[0].faces == frozenset()
 
 


### PR DESCRIPTION
## READ THE ZERO FIRST

On current main this measures **ΔR = 0** over the 10-file slice: `gaps 12→12`,
`panics 3→3`, `unnamed 1→1`, `timeouts 0→0`, `denominator 900→900`. **It buys
nothing today.** It is a generalization of the composition algebra, offered on
that basis and not as a drain. My earlier 12→11 was against `e0350dc43` and does
not reproduce: #6392 changed which arms satisfy `same_completed`, so
`_openpyxl.py:445` now arrives `stamped-not-separating` either way.

**The #6393 half is dropped.** Main already keys the mint by `state.slot.slot_id`
— exactly what my comment argued for; only the label differed. **Zero for that
half, no pin, not re-landed under another name.**

## (1) WHAT THE MERGED ARM KEEPS, PRECISELY

Per partition `P` that **both** contributors named, the merged arm keeps the
**set of sides** `S = S_left ∪ S_right`, and asserts:

> this arm holds only where `P` took some side in `S`

The old rule intersected the set of **faces**, which conflates two questions —
*which partition is known about* and *which side of it*. This separates them:

```
conjunction (sequence)   UNIONS     the partitions; each keeps its one side
disjunction (merge)      INTERSECTS the partitions; within a survivor,
                         UNIONS the sides
```

A partition only one contributor named is **still dropped entirely** — the
intersect rule, intact, at the level where it is the true one. `left | right` is
a different and wrong thing and has its own lying twin
(`test_a_merge_drops_a_split_only_one_contributor_named`).

**Weaker than "holds on side s", without being union.** A singleton `S` is the
old point claim. Every side added makes the statement say *less*; when `S` covers
all of `P`'s sides it says nothing and can exclude nothing. Exclusivity is
`S_A ∩ S_B = ∅` over a shared `P` — with singletons, exactly the `!=` it
replaces. **Sets only ever grow through a merge, never through a mint.**

**Soundness.** If A holds, `P` took a side in `S_A`; if B holds, a side in `S_B`;
`P`'s sides are mutually exclusive *because the producer said so when it minted
them*. Disjoint `S` ⇒ they cannot both hold. `_are_exclusive` is untouched and
still knows nothing about disjunctions — this is the testimony channel only.

**Why it cannot lie the way intersect was written to prevent.** The danger was a
merged arm claiming ONE named side. Carrying `{c, ¬c}` claims neither: it
overlaps `{c}` and overlaps `{¬c}`, so it is provably apart from **neither
contributor**. It excludes only arms confined to sides outside `S` — precisely
what the producer asserted at mint time, and nothing more.
(`test_a_merged_arm_is_not_exclusive_with_either_side_it_came_from`)

## (2) `core/generic.py:13403` — MEASURED, NOT REASONED

```
main 417aa16f1   gaps=1  13403  stamped-not-separating  merged=True  isRemainingWork=False
this branch      gaps=1  13403  stamped-not-separating  merged=True  isRemainingWork=False
```

**Identical. It does NOT become factorable.** It remains a correct refusal, and
`is_remaining_work` stays narrower than "unstamped". 223 functions, 0 panics, 0
timeouts, same denominator both sides. Re-measured after the rebase onto
`417aa16f1`, not carried over from the earlier base.

## (3) LINEAR GROWTH — mandatory, passing

`test_appending_factors_grows_linearly` and
`test_bounded_expansion_is_extensionally_identical_before_and_after`. No factored
family grows as factors are appended; #6333's `m ** k` does not return.

## (4) THE LYING TWINS THAT MUST STILL BITE — all passing

```
test_unowned_arms_still_hit_the_refusal
test_faces_from_two_different_owners_are_not_complementary
test_same_partition_same_side_is_not_an_exclusion
test_overlapping_guards_do_not_factor
test_same_type_faces_from_different_origins_do_not_factor
```

`_complete_family` declines an arm carrying several sides of one origin: one arm
standing for several members cannot fill the single member slot the arity test
counts. Family admission is unchanged for every minted arm.

The old `test_disjoining_merge_keeps_only_testimony_both_arms_carried` asserted
`faces == frozenset()` and is **changed on the record**, its reason preserved as
its own arm.

## HARNESS

The kit's conftest gates every test on a release `sugarbin` this box may not
build, so arms ran through the same imports without pytest: 16/16 partition
testimony, 14/14 family admission, 11/11 classifier, 4/4 guarded-binding carrier.
The pytest run itself is unmeasured here, not green.

Related: #6413 repairs a vacuous lying twin in `test_guarded_binding_partition_carrier.py`
(independent of this change; green under both merge rules).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix disjunction merge in `ExitSet` to union sides per partition instead of intersecting faces
> - `_merge_faces` now identifies partitions present in both arms and returns all faces from either arm whose partition is shared, giving a per-partition union of sides rather than a plain face intersection.
> - `_faces_exclusive` is rewritten to use disjoint side-set semantics per shared partition, so arms carrying multiple sides of a partition are non-exclusive unless those side sets are disjoint.
> - `_complete_family` now rejects any arm that carries more than one face for the same partition (e.g. a merged arm covering both sides), requiring exactly one face per partition per arm.
> - New and updated tests in [`test_exit_set_partition_testimony.py`](https://github.com/TSavo/sugar/pull/6420/files#diff-66fdebe7dc08fccb94fa2cf04a7fcb66a36df9a8489fc1420a37149a6ef87698) cover union merge, dropped partitions, and disjoint-set exclusivity.
> - Behavioral Change: merging two equal-destination exits now produces faces covering both sides of shared partitions; previously the intersection could produce an empty face set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 161fe0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->