### PR TITLE
The class arm was fabricating contracts over unauthenticated callees (#6409)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -517,11 +517,26 @@ def _resolve_source_visible_frame_uncached(
                 return kind, tuple(sorted(blocked[kind]))
         return None
 
-    if isinstance(target, FunctionDef):
-        blocking = _blocking_call_targets(target)
-        if blocking is not None:
-            kind, names = blocking
-            return ManagerConstructionGapV1(kind, resolved.cid, ",".join(names))
+    # Every reachable definition is scanned, whether it is written as a
+    # module-level function or as a method of a reachable class.
+    #
+    # The class arm used to be absent, and its absence was not a reporting gap:
+    # a method calling a name with no authenticated defining source CONSTRUCTED.
+    # The unresolvable call was carried into the receiver as a `CallSiteValue`
+    # with `body=None`, `source_call_frame_cid=None` and
+    # `authenticated_target_symbol=None`, and that value was then content-addressed
+    # into `receiver_state.identity` and `manager_construction_cid` -- a
+    # manager-construction CID asserting an authenticated receiver over a call
+    # the system could not see through.  `_resolve_external_call_frame` promises
+    # it "never yields a fabricated contract"; that promise held only on the
+    # function path.  The same source written as a module-level function refused
+    # loudly, so the two faces disagreed and the silent one was wrong.
+    for definition in (target,) + tuple(definitions):
+        for scanned in _scanned_definitions(definition):
+            blocking = _blocking_call_targets(scanned)
+            if blocking is not None:
+                kind, names = blocking
+                return ManagerConstructionGapV1(kind, resolved.cid, ",".join(names))
 
     frames: dict[str, object] = {}
     reaching_classes: dict[str, ClassDef] = {}
@@ -705,6 +720,22 @@ def _classify_named_call_target(
     if builtin_floor.value_if_bound(name) is not None:
         return "builtin"
     return "free-name"
+
+
+def _scanned_definitions(definition: Node) -> tuple[FunctionDef, ...]:
+    """The frames a definition contributes to the call-target scan.
+
+    A function contributes itself.  A class contributes its methods -- each is
+    an ordinary frame with its own parameters and locals, and a called name
+    inside one is exactly as opaque as the same call written at module level.
+    Whether a body is spelled as a function or as a method is syntax; it must
+    not decide whether construction authenticates its callees.
+    """
+    if isinstance(definition, FunctionDef):
+        return (definition,)
+    if isinstance(definition, ClassDef):
+        return tuple(item for item in definition.body if isinstance(item, FunctionDef))
+    return ()
 
 
 def _frame_bound_names(function: FunctionDef) -> frozenset[str]:

--- a/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
@@ -428,3 +428,136 @@ def test_frame_bound_names_excludes_names_this_frame_does_not_bind(tmp_path):
     assert "comprehended" not in binders
     assert "nested_param" not in binders
     assert "nested_local" not in binders
+
+
+# --------------------------------------------------------------------------
+# The scan reaches METHODS, not only module-level functions
+#
+# The class arm was absent, and its absence was not a reporting gap: a method
+# calling a name with no authenticated defining source CONSTRUCTED, and the
+# unresolvable call was content-addressed into the manager-construction CID.
+# Whether a body is spelled as a function or as a method is syntax; it must not
+# decide whether construction authenticates its callees.
+# --------------------------------------------------------------------------
+
+
+_ABSENT_FROM_ARTIFACT_METHOD = (
+    "class Slot:\n"
+    "    def __init__(self, label):\n"
+    "        self.label = absent_from_artifact(label)\n"
+    "\n"
+    "def make_guard(expected):\n"
+    "    return Slot(expected)\n"
+)
+
+_CALLED_PARAMETER_METHOD = (
+    "class Slot:\n"
+    "    def __init__(self, helper):\n"
+    "        self.label = helper()\n"
+    "\n"
+    "def make_guard(expected):\n"
+    "    return Slot(expected)\n"
+)
+
+
+def test_method_calling_an_absent_symbol_refuses_instead_of_fabricating(tmp_path):
+    """LYING TWIN, and the reason this arm exists.
+
+    Before the class arm, this exact source produced a
+    ``ConstructedManagerBehaviorV1`` whose receiver field held a
+    ``CallSiteValue`` with ``body=None``, ``source_call_frame_cid=None`` and
+    ``authenticated_target_symbol=None`` -- an unauthenticated call, carried
+    into ``receiver_state.identity`` and from there into
+    ``manager_construction_cid``.  A construction CID asserting an
+    authenticated receiver over a call the system could not see through is a
+    fabricated contract, which ``_resolve_external_call_frame`` explicitly
+    promises never to yield.
+    """
+    result = _construct(tmp_path, _ABSENT_FROM_ARTIFACT_METHOD)
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "call-target-source-absent"
+    assert result.detail == "absent_from_artifact"
+
+
+def test_method_calling_a_parameter_is_a_value_call_target(tmp_path):
+    """A called parameter is higher-order dispatch inside a method too."""
+    result = _construct(tmp_path, _CALLED_PARAMETER_METHOD)
+
+    assert isinstance(result, ManagerConstructionGapV1), result
+    assert result.kind == "value-call-target"
+    assert result.detail == "helper"
+
+
+def test_method_calling_a_module_definition_still_constructs(tmp_path):
+    """TRUTHFUL TWIN: the arm refuses unauthenticated callees, not methods.
+
+    Same class, same call shape, callee authenticated in this artifact.  If
+    this went red the arm would be refusing syntax rather than opacity.
+    """
+    result = _construct(
+        tmp_path,
+        "def picked(value):\n"
+        "    return 7\n"
+        "\n"
+        "class Slot:\n"
+        "    def __init__(self, label):\n"
+        "        self.label = picked(label)\n"
+        "\n"
+        "def make_guard(expected):\n"
+        "    return Slot(expected)\n",
+    )
+
+    assert isinstance(result, ConstructedManagerBehaviorV1), result
+
+
+@pytest.mark.parametrize(
+    "spelling,source",
+    [
+        ("method", _ABSENT_FROM_ARTIFACT_METHOD),
+        (
+            "function",
+            "def make_guard(expected):\n    return absent_from_artifact(expected)\n",
+        ),
+    ],
+)
+def test_both_spellings_of_the_same_opacity_reach_the_same_kind(
+    tmp_path, spelling, source
+):
+    """DISCRIMINATION: the two faces must AGREE.
+
+    Asserting each spelling separately would still pass if one silently
+    constructed -- which is exactly what the method face used to do.  This is
+    the assertion that cannot: same condition, same kind, whichever syntax
+    carries it.
+    """
+    result = _construct(tmp_path, source)
+
+    assert isinstance(result, ManagerConstructionGapV1), (spelling, result)
+    assert result.kind == "call-target-source-absent", spelling
+
+
+def test_scanned_definitions_reaches_methods_and_nothing_else(tmp_path):
+    """The scan universe, read directly off a class and a function."""
+    from sugar_lift_python_source.manager_construction import _scanned_definitions
+    from sugar_source_tree.nodes import ClassDef
+
+    source = (
+        "class Slot:\n"
+        "    field = 1\n"
+        "    def first(self):\n"
+        "        return 1\n"
+        "    def second(self):\n"
+        "        return 2\n"
+        "\n"
+        "def loose():\n"
+        "    return 3\n"
+    )
+    tree = SourceFile((source, "scan.py", blake3_512_of(source.encode())))
+    klass = next(n for n in tree.root.body if isinstance(n, ClassDef))
+    function = next(
+        n for n in tree.root.body if isinstance(n, FunctionDef) and n.name == "loose"
+    )
+
+    assert tuple(d.name for d in _scanned_definitions(klass)) == ("first", "second")
+    assert tuple(d.name for d in _scanned_definitions(function)) == ("loose",)


### PR DESCRIPTION
> ## Correction to the brief: (C) is already merged, and probing its edge found a soundness hole
>
> This work was dispatched as "the piece you deferred — the frame-aware classifier."
> **It was not deferred.** `_named_call_is_source_opaque` no longer exists on main;
> `_classify_named_call_target(name, definition_names, builtin_floor, *, frame_binders)`
> and `_frame_bound_names` shipped in #6407 (`f8968c8c7`) and are live at `09651b50a`.
> A called parameter has already been distinguished from a missing import since that merge.
>
> So I probed where that classifier **stops** — and the boundary is not a
> misclassification. It is a fabricated contract.

## The finding

The call-target scan only ever saw module-level `FunctionDef`s:

```python
if isinstance(target, FunctionDef):
    blocking = _blocking_call_targets(target)
...
pending = [item for item in definitions if isinstance(item, FunctionDef)]
```

A `ClassDef`'s methods were **never scanned**. And a `with SomeClass(...)` manager is
the common case, so this is not a corner.

**Reproducer, on `09651b50a`, four cases, same condition in two spellings:**

```
module-level function calls a PARAMETER   -> ManagerConstructionGapV1  value-call-target
CLASS method calls a PARAMETER            -> ConstructedManagerBehaviorV1   (!)
CLASS method calls an ABSENT external     -> ConstructedManagerBehaviorV1   (!)
CLASS method calls a module definition    -> ConstructedManagerBehaviorV1   (correct)
```

The third line is the serious one. `absent_from_artifact(label)` — a callee with **no
authenticated defining source in the artifact** — constructed successfully. The
unresolvable call was carried into the receiver:

```
fields = (ObjectField(name='label', value=CallSiteValue(
    target_name='absent_from_artifact',
    body=None,                         # no authenticated source body
    source_call_frame_cid=None,        # no frame
    authenticated_target_symbol=None,  # nothing authenticated
    target_contract_cid=None, ...)),)
```

…and that value is content-addressed into `receiver_state.identity`, which is
content-addressed into `manager_construction_cid`. **A manager-construction CID
asserting an authenticated receiver over a call the system could not see through.**

`_resolve_external_call_frame`'s own docstring says `None` "keeps the call site
typed-loud … it never yields a fabricated contract." That guarantee held only on the
function path. The two faces of one condition disagreed, and the silent one was wrong.

## The fix

Whether a body is spelled as a function or as a method is **syntax**; it must not decide
whether construction authenticates its callees. `_scanned_definitions` maps a definition
to the frames it contributes — a function contributes itself, a class contributes its
methods — and every reachable definition goes through the same `_blocking_call_targets`.

No new kind, no new vocabulary, no vendor arm, no name table. The existing structural
classifier is simply reachable from every frame it should always have covered.
`parse`'s unknown-wire-kind fallthrough is untouched.

## Cost

**No CID preimage change, no wire-format change, no repin.** No preimage is edited.
Sites that were already refusing are unaffected; sites that were fabricating now refuse.

## Report this as REMOVING A FALSE GREEN, not as a drain and not as a regression

Row counts on the board may **rise**. That is the correct direction here and must not be
read as a regression: each new gap replaces a *false success*, not a real one. Equally it
is not a drain — nothing is constructed that was not constructed before.

**Site coverage and ΔR, separately:**

- **Site coverage:** the scan universe widens from module-level functions to every
  reachable frame including methods. Exact, per the direct control:
  `_scanned_definitions` on a class with two methods and a class attribute yields
  `("first", "second")`; on a function, `("loose",)`.
- **Measured ΔR: not measured.** No census, no lease, no forced binary build. **The
  corpus blast radius is genuinely unknown** — I cannot bound how many pinned-pandas
  `with` sites currently construct through a class method with an unauthenticated
  callee. Whoever runs the authoritative baseline should expect movement here and
  should attribute any rise to false-green removal before treating it as residual.

## Gate

| gate item | evidence |
|---|---|
| one real reproducer | 4-case probe above, on `09651b50a` before any edit |
| one lying twin | `test_method_calling_an_absent_symbol_refuses_instead_of_fabricating` |
| one truthful twin | `test_method_calling_a_module_definition_still_constructs` |
| discrimination | `test_both_spellings_of_the_same_opacity_reach_the_same_kind` — asserts the two faces **agree**; asserting each separately would still pass if one silently constructed, which is exactly the bug |
| focused owning-package tests | below |
| no increase in crash/timeout axes | below |

**Failure-set delta, `sugar-lift-python-source`,** baselined by reverting the source file
in-tree (not `git stash` — it is shared across worktrees):

```
baseline (clean main)  13 failed, 668 passed
head                   11 failed, 676 passed
```

Head's failure set is a strict **subset** of baseline's — **zero new failures**, no new
crash or timeout. The two absent ones are the known `test_verify_dialect` subprocess
flakes. Post-rebase: 11 failed, 676 passed, same set.

Mutation transactions, each verified present, biting, and rolled back to a clean tree:

| mutation | bitten |
|---|---|
| N1 class contributes no frames (the pre-fix hole, restored) | 4 failed, 1 passed |
| N2 scan narrowed back to the target definition only | 1 failed |

Clean after: 5 passed. Full file: 20 passed.

## Still open, still unratified

The **capability** to construct through a called value (#6409) is not implemented — this
PR widens where that condition is correctly *named*, and drains none of it. #6410 (the
export door declining an in-artifact symbol) is untouched.

Refs #6371, #6409, #6410. Does not close them.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix class arm fabricating contracts over unauthenticated callees in class methods
> - The construction path previously only validated call targets in module-level `FunctionDef` nodes, allowing class methods with unauthenticated or absent callees to fabricate contracts incorrectly.
> - Extends call-target validation in `_resolve_source_visible_frame_uncached` to scan class methods by introducing a `_scanned_definitions` helper that returns method `FunctionDef` nodes for `ClassDef` and the function itself for `FunctionDef`.
> - Returns `ManagerConstructionGapV1` with the appropriate gap kind (`call-target-source-absent`, `value-call-target`) when a blocking condition is detected in any method body.
> - Adds tests covering absent-symbol calls, parameter calls, and authenticated module-level callees from within methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65bfe60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->