### PR TITLE
The guarded law, exercised from Python source instead of by hand (#6352 tail)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_law_from_source.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_law_from_source.py
@@ -1,0 +1,203 @@
+"""The guard-stable Floor law, exercised from Python source rather than by hand.
+
+`test_guarded_floor_value_law.py` pins the law over floor values built
+directly in the test. That proves the law; it cannot prove the corpus reaches
+it. The 25 `owner=guarded` rows in the pinned pandas ledger are source sites,
+and every one of the six categories they name is reproducible from ordinary
+Python: a bare expression statement under an `if` rides its value under the
+branch guard.
+
+Three faces.
+
+TRUTHFUL: each category constructs. At `78714a798` every function in
+`GUARDED_CATEGORIES` raised the ledger's exact panic
+(`owner=guarded ... requested=ride under a guard`); each now completes.
+
+REACHED: the six categories are actually dispatched through `guarded`. Without
+this face the truthful one passes vacuously — a change that stops routing these
+values under the guard at all would leave every construction green while the
+law it is supposed to exercise goes untested. That is the shape of a control
+that asserts something weaker than it reads.
+
+CONSERVED: the guard is not dropped. Guard-stable means *this category's
+meaning* is unchanged by the guard, never that `guarded` became a no-op. An
+obligation under the same source shape must still weaken to an implication.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.floor.inv_value import InvValue
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.outcome import Complete
+
+CORPUS = '''\
+def bare_string(flag):
+    if flag:
+        "a string statement"
+    return 1
+
+
+def bare_true(flag):
+    if flag:
+        True
+    return 2
+
+
+def bare_false(flag):
+    if flag:
+        False
+    return 3
+
+
+def bare_comprehension(flag, xs):
+    if flag:
+        [x for x in xs]
+    return 4
+
+
+def bare_symbolic(flag, series):
+    if flag:
+        series
+    return 5
+
+
+def guarded_class_definition(flag):
+    if flag:
+        class Inner:
+            pass
+        keep = Inner
+    return 6
+
+
+def guarded_obligation(flag, claim):
+    if flag:
+        assert claim
+    return 7
+'''
+
+# Each function names the Floor category its guarded entry rides as. The six
+# categories are exactly the non-BlockValue owners the ledger records.
+GUARDED_CATEGORIES = {
+    "bare_string": "StringValue",
+    "bare_true": "TrueBoolLiteralSugar",
+    "bare_false": "FalseBoolLiteralSugar",
+    "bare_comprehension": "ComprehensionValue",
+    "bare_symbolic": "SymbolicValue",
+    "guarded_class_definition": "ClassDefinitionValue",
+}
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "guarded_categories.py").write_text(CORPUS, encoding="utf-8")
+    return root
+
+
+def _functions(root: Path):
+    source_file = open_source_file_for_construction(
+        root / "guarded_categories.py", root=root, populate_derived=True
+    )
+    return {function.name: function for function in source_file.functions()}
+
+
+@pytest.fixture
+def guarded_dispatch(monkeypatch):
+    """Record the concrete category riding through every `guarded` arm.
+
+    Patches each Floor class that defines `guarded`, so the recording sees the
+    concrete arm that runs rather than a base-class wrapper the subclasses
+    shadow.
+    """
+    import sugar_lift_py_tests.floor as floor_package
+
+    ridden: list[str] = []
+    patched: set[type] = set()
+    for module_info in pkgutil.iter_modules(floor_package.__path__):
+        module = importlib.import_module(
+            f"sugar_lift_py_tests.floor.{module_info.name}"
+        )
+        for value in vars(module).values():
+            if not inspect.isclass(value) or value in patched:
+                continue
+            arm = value.__dict__.get("guarded")
+            if arm is None:
+                continue
+            patched.add(value)
+
+            def record(original):
+                def guarded(self, formula):
+                    ridden.append(type(self).__name__)
+                    return original(self, formula)
+
+                return guarded
+
+            monkeypatch.setattr(value, "guarded", record(arm))
+    assert patched, "no Floor class defines `guarded` -- nothing was instrumented"
+    return ridden
+
+
+@pytest.mark.parametrize("name", sorted(GUARDED_CATEGORIES))
+def test_guarded_category_constructs_from_source(corpus: Path, name: str) -> None:
+    """TRUTHFUL: the ledger's guarded categories complete instead of panicking."""
+    outcome = _functions(corpus)[name].sugar().desugar(None)
+    assert isinstance(outcome, Complete), f"{name} did not construct: {outcome!r}"
+
+
+def test_every_category_actually_rides_under_the_guard(
+    corpus: Path, guarded_dispatch: list[str]
+) -> None:
+    """REACHED: each construction really dispatches the category it names.
+
+    Without this the truthful face is satisfied by source that never reaches
+    `guarded` at all.
+    """
+    functions = _functions(corpus)
+    for name, category in sorted(GUARDED_CATEGORIES.items()):
+        before = len(guarded_dispatch)
+        functions[name].sugar().desugar(None)
+        rode = guarded_dispatch[before:]
+        assert category in rode, (
+            f"{name} constructed without riding a {category} under its guard; "
+            f"categories seen: {rode or 'none'}"
+        )
+
+
+def test_the_guard_is_not_dropped_by_the_stable_category(corpus: Path) -> None:
+    """CONSERVED: an obligation under the same shape still weakens.
+
+    Guard-stable is a claim about a category's meaning, not a licence for
+    `guarded` to return its input. `assert claim` under `if flag` must come
+    back as an implication, never as the bare claim.
+    """
+    from sugar_lift_py_tests.ir import implies
+
+    outcome = _functions(corpus)["guarded_obligation"].sugar().desugar(None)
+    assert isinstance(outcome, Complete)
+    obligations = [
+        statement
+        for statement in outcome.value.record.statements
+        if isinstance(statement, InvValue)
+    ]
+    assert len(obligations) == 1, (
+        f"expected exactly one obligation, saw {len(obligations)}"
+    )
+    formula = obligations[0].formula
+    assert getattr(formula, "kind", None) == "implies", (
+        f"the guarded obligation is `{formula}`, not an implication -- the "
+        f"branch guard was dropped"
+    )
+    guard, claim = formula.operands
+    # And it is the branch's own guard, reconstructed from the parts rather
+    # than trusted from the shape: an implication over the wrong antecedent
+    # would satisfy the kind check alone.
+    assert formula == implies(guard, claim)
+    assert guard != claim, "the obligation implies itself -- no guard was carried"


### PR DESCRIPTION
## Re-measure first: the `guarded` 25 is **already drained** on main

`eee759947` (Construct values under control guards) and `df14f0cc9` (Keep guarded values stable under outer guards) landed while I was reading the family. Both mechanisms the ledger implies are there — `BlockValue.guarded` distributes over its entries, and `GuardStableValue` carries the pure-value category. So: **zero, no pin.** #6398 closed as implemented.

That would normally be the whole report. It isn't, because of *how* the law is pinned.

## The gap re-measurement found

`test_guarded_floor_value_law.py` builds its floor values in the test:

```python
StringValue("renamed-value").guarded(GUARD) is value
```

That proves the law. It cannot prove the **corpus reaches it** — and the 25 ledger rows are source sites, not hand-built values. Site coverage and law coverage are different measurements, and only one of them was taken.

Six of the categories turn out to be reproducible from ordinary Python. A bare expression statement under an `if` rides its value under the branch guard:

```python
def bare_string(flag):
    if flag:
        "a string statement"
    return 1
```

### Baseline vs head, from source, at the pinned commit

| function | category | `78714a798` | main |
|---|---|---|---|
| `bare_string` | `StringValue` | ConstructionPanic | Complete |
| `bare_true` | `TrueBoolLiteralSugar` | ConstructionPanic | Complete |
| `bare_false` | `FalseBoolLiteralSugar` | ConstructionPanic | Complete |
| `bare_comprehension` | `ComprehensionValue` | ConstructionPanic | Complete |
| `bare_symbolic` | `SymbolicValue` | ConstructionPanic | Complete |
| `guarded_class_definition` | `ClassDefinitionValue` | ConstructionPanic | Complete |

Every baseline panic carried the ledger's exact message — `owner=guarded ... requested=ride under a guard fix=write more Floor: implement <X>.guarded` — so these are the ledger's own rows reproduced, not a lookalike that happens to panic.

## The face that earns its place

Six green constructions prove less than they look like they prove. **A change that stops routing values under the branch guard at all leaves every one of them `Complete` while the law goes completely untested.** So the twin instruments the dispatch and asserts each category actually rides:

- **TRUTHFUL** — each category constructs.
- **REACHED** — each construction really dispatches the category it names, recorded by wrapping every Floor class that defines `guarded` (per-class, because subclasses shadow a base-class wrapper).
- **CONSERVED** — the guard is not dropped. Guard-stable is a claim about a category's *meaning*, not a licence for `guarded` to return its input; an obligation under the same source shape must still weaken to an implication over the branch's own guard, reconstructed from its parts rather than trusted from its shape.

## Mutations

Each: clean before, mutation verified present, test bites, revert verified, clean after.

| mutation | result |
|---|---|
| **M1** delete the guard-stable arm — the loud base default returns | 5 truthful faces + REACHED fail |
| **M2** `InvValue.guarded` drops the guard and rides unchanged | CONSERVED alone fails |
| **M3** the if-router stops carrying its entries under the branch guard | **REACHED + CONSERVED fail; all six constructions stay green** |

M3 is the demonstration. It is the exact shape a truthful-only control cannot see — and the shape the brief warns about, where a control claims something weaker than it reads.

An earlier M3 attempt against `predicate_value.py:245` did **not** bite; tracing the dispatch showed the owner is `if_sugar.py:147`. Recording that because it is the useful part: the guarded entries come from the if-router over `exit_.value.entries`, not from the predicate branch-entry path.

## Not claimed: `BlockValue`, 15 of the 25

**No Python source shape I could construct routes a `BlockValue` through `guarded`.** Tried and traced: nested `if`, `if/elif/else`, `for`, `for/else`, `while`, `try/except`, `try/finally`, `match`, nested `def` with each of those bodies, bare/multiple expression statements, `assert`, `del`, augmented assign, and branches returning out of loops. Every one dispatches something else (`BranchResultAuthentication`, `ReturnValue`, `GuardedReturn`, `InvValue`, `UniverseValue`, `CallSiteValue`) or nothing.

The unit law for `BlockValue.guarded` exists and is pinned by the peer's test. What is missing is evidence that the corpus reaches it. The lead is `if_sugar.py:147` — a `BlockValue` among `exit_.value.entries` is the shape still to be found. Whoever picks that up should also check the lead's misnaming hypothesis: it is possible the 15 rows are not `BlockValue` in the sense the arm now handles.

## Terminal record

```
branch/head:  panic-tail-drain @ 5790847ea (rebased on origin/main)
PR:           this one. #6389 and #6402 previously merged.
files changed: implementations/python/sugar-lift-py-tests/tests/
               test_guarded_law_from_source.py (new, tests only — no src change)
focused evidence: 8 passed. With the two neighbouring guarded/ground-exit
               modules: 22 passed.
baseline-vs-head failure-set delta: none — this PR adds a test file and
               changes no source, so no existing failure can move.
measured ΔR:  the guarded family measures 0 for the six categories covered,
               by source reproduction at the pinned commit. BlockValue (15)
               UNMEASURED from source. No census run.
known inherited red: test_kit_rpc_dtos::test_python_dtos_emit_rpc_report_shapes
               and test_assert_sugar_from_node::test_unbuilt_condition_child_
               preserves_its_own_gap, both red at origin/main, both unrelated.
remaining blocker/next owner: BlockValue x guarded source reproducer (above).
               Binary-operation floors (~48) belong to the second owner per
               dispatch; this PR touches no floor/ arm.
```

Does not close #6352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automated tests for the guarded law exercised from Python source
> - Adds [test_guarded_law_from_source.py](https://github.com/TSavo/sugar/pull/6422/files#diff-14c5a23a00c89e3abd6527a37636847b0e86d9f6b0e81d3f5a8e3d20ef7d54eb) with a corpus fixture that writes a temporary Python source file containing seven guarded-category functions and parses it via `open_source_file_for_construction`.
> - Parametrizes `test_guarded_category_constructs_from_source` over six expected Floor categories, asserting each `sugar().desugar(None)` call returns `Complete`.
> - Adds `guarded_dispatch` fixture that monkeypatches `guarded` methods on all Floor subclasses in `sugar_lift_py_tests.floor.*` to record which class handled each call, enabling `test_every_category_actually_rides_under_the_guard`.
> - Adds `test_the_guard_is_not_dropped_by_the_stable_category`, which verifies that an assertion under a branch guard desugars to a single `InvValue` whose formula is `implies(guard, claim)` with `guard != claim`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5790847.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->