### PR TITLE
Exit obligations: pay nothing on the arms that owe nothing (#6392 follow-up)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -108,6 +108,18 @@ def merge_pending(*groups) -> tuple:
     two folds that happened to run in a different order must not mint two
     different rows.
     """
+    # THE EMPTY AND SINGLETON CASES COST NOTHING. This is called once per exit
+    # pair in `ExitSet.sequence` -- the innermost loop of every k-operand fold
+    # in the lift -- and almost every arm owes nothing at all, so building a
+    # dict, sorting it and rebuilding a tuple to answer `()` is work done per
+    # arm per fold step for no result. A group of at most one carrier is
+    # already sorted and already deduped, so it is returned as it stands.
+    populated = [group for group in groups if group]
+    if not populated:
+        return ()
+    if len(populated) == 1 and len(populated[0]) <= 1:
+        return tuple(populated[0])
+
     by_candidate: dict[str, "ContractConditionalConstructionV1"] = {}
     for group in groups:
         for entry in group:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -327,7 +327,13 @@ def _obligations(exit_: "Exit[T]") -> tuple:
     Keyed by ``demand_cid`` -- the obligation's own content address -- never by
     hashing the carrier, which holds a floor value and a term. Both arm kinds
     answer here: a completed face owes exactly the way a halted face does.
+
+    The empty case is the overwhelmingly common one and is answered without
+    building anything: this runs once per arm per ``normalize``, and
+    ``normalize`` is the hottest call in the reducer.
     """
+    if not exit_.pending_contracts:
+        return ()
     return tuple(
         sorted(
             demand.demand_cid
@@ -382,10 +388,11 @@ class Completed(Generic[T]):
     ``demand_cid`` -- a blake3 over the JCS of the formula -- on every
     ``guarded``, ``sequence`` and ``and_exit`` step, and since a re-minted
     obligation is a DIFFERENT destination, it also stops arms merging in
-    ``normalize``. Measured on pandas `core/reshape/merge.py`: minting per
-    restriction did not finish the file in 13 minutes at 600MB resident, with
-    the sample dominated by blake3 and JCS encoding; minting once does. Same
-    obligation, same face, one mint.
+    ``normalize`` and stops the same obligation deduping when it reaches a join
+    twice -- `F and F` would stop being `F`. Observed on pandas
+    `core/reshape/merge.py`, where a `sample` of the per-restriction spelling
+    was dominated by blake3 and JCS encoding. Same obligation, same face, one
+    mint.
 
     Like ``Halted.pending_contracts`` it is part of the DESTINATION, not
     testimony: two arms owing different things are different destinations and

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -68,6 +68,13 @@ def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
     stays LOUD -- there is no record to owe on, and inventing one would
     attribute the obligation to a block that never ran.
     """
+    if not any(exit_.pending_contracts for exit_ in exits.exits):
+        # The overwhelmingly common case, and it must cost nothing: this runs at
+        # the end of EVERY block reduction, nested ones included, and rebuilding
+        # the set would pay for a second `normalize` over every arm of every
+        # block that never owed anything.
+        return exits
+
     from sugar_lift_py_tests.caller_parameter_contract import weaken_pending
     from sugar_lift_py_tests.gap.info import GapKind
     from sugar_lift_py_tests.gap.panic import construction_panic_gap


### PR DESCRIPTION
Follow-up to #6392, which gave a pending caller obligation an arm on the completed face. That PR is merged; this is the cost side of it, and it is three fast paths on the empty case — no cap, no threshold, no behaviour change.

- **`merge_pending`** is called once per exit pair in `ExitSet.sequence`, the innermost loop of every k-operand fold in the lift, and almost every arm owes nothing. Building a dict, sorting it and rebuilding a tuple in order to answer `()` is work done per arm per fold step for no result. A group of at most one carrier is already sorted and already deduped, so it is returned as it stands.
- **`_obligations`** answers `()` without building anything when an arm owes nothing. It runs once per arm per `normalize`, the hottest call in the reducer.
- **`_enrol_exit_obligations`** returns the exit set untouched when no arm owes, rather than rebuilding it and paying for a second `normalize` over every arm of every block. It runs at the end of every block reduction, nested ones included.

## Evidence

- `test_pending_contract_partition_arm.py` and the adjacent exit-set / parameter-contract suites: **194 passed** on the rebased tree.
- **Perturbation battery re-run on the rebased tree: 10 mutations, 10 caught**, each mutating the mechanism its named twin covers. The fast paths do not blunt a single control — in particular `merge_pending keeps the LAST arrival instead of unioning demand sets` and `weaken_pending weakens only the first carrier` still go red.

## What this does not claim

No wall-clock number. This box ran at load average ~500 throughout (fleet load plus a concurrent Rust build), which confounded three separate elapsed comparisons badly enough that I retracted a "2.8× slowdown" reading drawn from it. The justification above is the mechanism — work per arm per fold step for an empty result — not a timing I can stand behind from this box. A quiet-box reading is still owed.

## Still open from #6392

`pandas 3.0.3 core/reshape/merge.py` does not finish at head (17+ min, 371MB resident and climbing, `sample` dominated by `tuple_hash` under `ExitSet.normalize`) where it completed at `74d7bb1d3` with 2 `outcome_to_exitset` panics. Arms owing different obligations correctly do not merge, so arm counts grow where they previously collapsed, and the relief — `factor_completed`, which unions obligations onto one arm — only applies in the folds that call `factored_operand`. These fast paths do **not** address that; it is the #6324 factoring surface. Detail in https://github.com/TSavo/sugar/pull/6392#issuecomment-5085640265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip exit obligation processing when no arms have pending contracts
> Adds fast-path short-circuits across three files to avoid unnecessary work when exit obligations are empty.
>
> - [`_enrol_exit_obligations`](https://github.com/TSavo/sugar/pull/6423/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) returns the original `ExitSet` immediately if no arm has `pending_contracts`, skipping rebuild and normalization.
> - [`_obligations`](https://github.com/TSavo/sugar/pull/6423/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716) returns an empty tuple early when `exit_.pending_contracts` is falsy.
> - [`merge_pending`](https://github.com/TSavo/sugar/pull/6423/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) skips dict construction and sorting for empty or singleton inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 488cc50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->