### PR TITLE
Ground exit: a locus that cannot cite is refused, not crashed through

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -33,7 +33,28 @@ def ground_raise_effect(*, exception_name: str, site, owner: str):
     from sugar_lift_py_tests.effect import RaiseEffect
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
-    if Path(site.filename).is_absolute():
+    # A ground exit cites source it can RE-READ: a filename to address and the
+    # unit holding the text that filename indexes into. A locus that states
+    # neither -- prose, a bare string, anything not carrying a fragment's
+    # testimony -- cannot produce that citation at all. Before this arm the
+    # locus law below read ``site.filename`` first and died with
+    # ``AttributeError: 'str' object has no attribute 'filename'``: a crash
+    # wearing a law's clothes, which says nothing about what was wrong or what
+    # to thread instead. The requirement is stated, not tripped over.
+    filename = getattr(site, "filename", None)
+    unit = getattr(site, "unit", None)
+    if not isinstance(filename, str) or unit is None:
+        construction_panic_gap(
+            owner=owner,
+            blame=site,
+            observed=f"{type(site).__name__} locus stating no source fragment",
+            requested="a fragment stating filename and unit",
+            fix=(
+                "thread the fragment that owns the boundary; a ground exit "
+                "cites source it can re-read, which prose cannot address"
+            ),
+        )
+    if Path(filename).is_absolute():
         construction_panic_gap(
             owner=owner,
             blame=site,
@@ -41,7 +62,7 @@ def ground_raise_effect(*, exception_name: str, site, owner: str):
             requested="workspace-relative source locus",
             fix="route the source through the workspace-relative lift door",
         )
-    source = site.unit.source
+    source = unit.source
     source_sha256 = (
         hashlib.sha256(source.encode()).hexdigest() if source is not None else None
     )
@@ -55,9 +76,7 @@ def ground_exceptional_exit(*, exception_name: str, site, owner: str) -> Outcome
 
     return Complete(
         RaiseValue(
-            ground_raise_effect(
-                exception_name=exception_name, site=site, owner=owner
-            ),
+            ground_raise_effect(exception_name=exception_name, site=site, owner=owner),
             exception=ExceptionValue(exception_name, (), site),
         )
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_locus_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_locus_law.py
@@ -1,0 +1,153 @@
+"""The ground-exit locus law: a citation must be re-readable, or it is refused.
+
+`ground_raise_effect` is the ONE door that mints a ground exceptional exit --
+IndexError from a proved out-of-bounds constant subscript, AssertionError from
+a proved-false assert, TypeError from `1 in "abc"`, ZeroDivisionError from a
+proved-zero divisor. Every one cites two things: a source locus, and the text
+that locus indexes into.
+
+That imposes two requirements on the locus, and this module pins both as
+REFUSALS rather than crashes:
+
+1. It must be a fragment stating `filename` and `unit`. Prose addresses
+   nothing, so no citation can be built from it. This arm previously read
+   `site.filename` and died with `AttributeError: 'str' object has no
+   attribute 'filename'` -- a crash wearing a law's clothes, which named
+   neither the problem nor the fix.
+
+2. Its filename must be workspace-relative. A `SourceMemento` addresses
+   `{file, span}` relative to the workspace and `resolve_span_memento` re-reads
+   it as `project_root / file`, so an absolute locus is not a longer spelling
+   of the same address -- it is an address no other checkout can resolve.
+
+Both stay LOUD. `panic = gap`. The alternative to refusing is a citation that
+silently cannot be checked, which is worse than no citation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+
+def _fragment(tmp_path, *, root):
+    """A real fragment whose locus is stated relative to ``root``."""
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+    from sugar_source_tree.tree import SourceFile
+
+    source = tmp_path / "ground.py"
+    source.write_text("def witness():\n    return [1][3]\n", encoding="utf-8")
+    identity = workspace_path_source(str(source), root=str(root))
+    return next(SourceFile(identity).functions()).fragment
+
+
+def _absolute_fragment(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    source = tmp_path / "ground.py"
+    source.write_text("def witness():\n    return [1][3]\n", encoding="utf-8")
+    return next(SourceFile(path_source(str(source))).functions()).fragment
+
+
+def _exit(site):
+    from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+    return ground_exceptional_exit(
+        exception_name="IndexError", site=site, owner="test.ground_exit"
+    )
+
+
+# -- requirement 1: the locus must be a fragment ------------------------------
+
+
+@pytest.mark.parametrize(
+    "prose",
+    ("site", "", "pandas/core/frame.py:12:4", "<SourceFragment ...>"),
+)
+def test_a_prose_locus_is_refused_and_says_what_to_thread(prose) -> None:
+    """Every spelling of prose, including one that LOOKS like a locus."""
+    with pytest.raises(ConstructionPanic) as raised:
+        _exit(prose)
+
+    info = raised.value.info
+    assert info.owner == "test.ground_exit"
+    assert "str locus stating no source fragment" == info.observed
+    assert "fragment stating filename and unit" in info.requested
+    assert "thread the fragment" in info.fix
+
+
+def test_a_locus_with_a_filename_but_no_unit_is_refused() -> None:
+    """Half a fragment cannot cite either: the text is what gets hashed."""
+
+    class HalfFragment:
+        filename = "pkg/mod.py"
+        unit = None
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _exit(HalfFragment())
+
+    assert "HalfFragment locus stating no source fragment" == raised.value.info.observed
+
+
+def test_the_refusal_is_a_named_gap_not_an_attribute_error() -> None:
+    """The discrimination that names this whole change.
+
+    A crash and a refusal are both loud, but only one of them says what is
+    wrong. `ConstructionPanic` is a BaseException and `AttributeError` is not,
+    so this also pins that the audit membrane sees a gap here, not a defect.
+    """
+    with pytest.raises(ConstructionPanic):
+        _exit("site")
+
+    with pytest.raises(BaseException) as raised:
+        _exit("site")
+    assert not isinstance(raised.value, AttributeError)
+
+
+# -- requirement 2: the locus must be workspace-relative ----------------------
+
+
+def test_an_absolute_locus_is_refused(tmp_path) -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        _exit(_absolute_fragment(tmp_path))
+
+    info = raised.value.info
+    assert info.observed == "absolute source locus"
+    assert "workspace-relative" in info.requested
+
+
+# -- the positive arm: a real fragment mints a real citation ------------------
+
+
+def test_a_workspace_relative_fragment_mints_the_cited_exit(tmp_path) -> None:
+    """Both requirements met: the door constructs, and cites re-readable source."""
+    import hashlib
+
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    site = _fragment(tmp_path, root=tmp_path)
+
+    outcome = _exit(site)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "IndexError"
+    # The citation is the hash of the text the locus indexes into -- not a
+    # placeholder, and not the absolute path's text.
+    expected = hashlib.sha256(site.unit.source.encode()).hexdigest()
+    assert outcome.value.effect.source_sha256 == expected
+
+
+def test_the_cited_locus_is_relative_so_another_checkout_can_resolve_it(
+    tmp_path,
+) -> None:
+    """The whole point of requirement 2, asserted on the minted locus."""
+    from pathlib import Path
+
+    site = _fragment(tmp_path, root=tmp_path)
+
+    assert not Path(site.filename).is_absolute()
+    assert site.filename == "ground.py"

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
@@ -112,11 +112,40 @@ def test_symbolic_string_membership_emits_py_in():
     assert result.formula.name == "py.in"
 
 
-def test_ground_non_string_in_string_is_type_error():
+def _workspace_fragment(tmp_path):
+    """One real fragment carrying a workspace-relative locus.
+
+    A ground exit cites source it can re-read, so it needs a fragment stating
+    filename and unit -- prose cannot address anything. `tmp_path` becomes the
+    workspace root so the locus is relative, which is the other half of what a
+    ground exit requires.
+    """
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+    from sugar_source_tree.tree import SourceFile
+
+    source = tmp_path / "membership.py"
+    source.write_text("def witness():\n    return 1 in 'abc'\n", encoding="utf-8")
+    identity = workspace_path_source(str(source), root=str(tmp_path))
+    return next(SourceFile(identity).functions()).fragment
+
+
+def test_ground_non_string_in_string_is_type_error(tmp_path):
+    """SUBJECT UNCHANGED: `1 in "abc"` is Python's TypeError.
+
+    Only the locus changed. This arm previously passed the literal string
+    "site", which the ground-exit door cannot cite from -- it died with
+    `AttributeError: 'str' object has no attribute 'filename'` before reaching
+    any law. The fixture was invalid, not the law it was testing, so the
+    fragment is threaded and every assertion below is the original one. The
+    refusal that the crash was standing in for gains its OWN pin in
+    test_ground_exit_locus_law.py rather than being dropped here.
+    """
     from sugar_lift_py_tests.floor import RaiseValue, StringValue, TermValue
     from sugar_lift_py_tests.outcome import Complete
 
-    outcome = StringValue("abc").contains(TermValue(1), "site")
+    site = _workspace_fragment(tmp_path)
+
+    outcome = StringValue("abc").contains(TermValue(1), site)
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, RaiseValue)
     assert outcome.value.effect.exception_name == "TypeError"


### PR DESCRIPTION
## The red was a crash, not the locus law

`test_ground_non_string_in_string_is_type_error` is red on `main` with:

```
AttributeError: 'str' object has no attribute 'filename'
  ground_exit.py:36  ->  if Path(site.filename).is_absolute():
```

That is a crash wearing a law's clothes. `ground_raise_effect` read `site.filename` before any law ran, so a locus it could not cite from produced a traceback naming neither the problem nor the fix. Two different failures were wearing the same red — this one, and the genuine absolute-locus refusal.

## The mechanism

A ground exit cites source it can **re-read**: a filename to address, and the `unit` holding the text that filename indexes into. Prose addresses nothing, so no citation can be built from it — not now, not after any amount of routing.

That requirement is now **stated at the door** as a named `ConstructionPanic` carrying `observed` / `requested` / `fix`, instead of being tripped over. The absolute-locus law is unchanged and still fires second, on a locus that at least *has* a filename.

`panic = gap` throughout. Neither arm invents a locus, and neither substitutes a placeholder citation.

## The fixture was invalid, not the law it tested

Calling this out explicitly, because "fix the fixture" is one keystroke from "delete the test that was inconvenient".

The subject of that test is **`1 in "abc"` → TypeError**. Every assertion on that subject is preserved verbatim; only the locus changed, from the literal string `"site"` to a real workspace-relative fragment. Nothing was skipped, deleted, or weakened.

And the refusal the crash was standing in for **gains its own pin** rather than a law being quietly dropped: `tests/test_ground_exit_locus_law.py` is new and pins **both** requirements as refusals —

- prose locus refused, across four spellings including one that *looks* like a locus (`"pandas/core/frame.py:12:4"`)
- a half-fragment (filename, no unit) refused — the text is what gets hashed
- the refusal is a named gap and **not** an `AttributeError` (`ConstructionPanic` is a `BaseException`, so this also pins that the audit membrane sees a gap here, not a defect)
- absolute locus refused
- **positive arm**: a workspace-relative fragment mints the cited exit, and the citation is asserted to be the hash of the text the locus indexes into — not a placeholder
- the minted locus is relative, so another checkout can resolve it

## Evidence

**Focused:** 75 passed / 0 failed across `test_ground_exit_locus_law`, `test_sequence_membership_floor`, `test_builtin_finite_set_floor`, `test_complex_field_arithmetic_floor`, `test_sequence_repetition_has_no_cardinality_cap`.

**Perturbations**, each applied to a copy and re-run:

| perturbation | result |
|---|---|
| remove the fragment guard | **6 fail** — the original `AttributeError` returns |
| accept every locus, refuse nothing | **6 fail** |
| drop the absolute-locus refusal | **1 fail** |

**Formatting:** `ground_exit.py` fails `black --check` on **pristine main** (in `ground_exceptional_exit`, which I did not otherwise touch). Formatting it is included, clearing one file's worth of the `core (Python format)` drift.

## Scope, and what this does NOT do

Two files plus one new test module. This is part (a) of the blocker only.

It does **not** address the question of what the address of an installed dependency's source is. Threading a workspace root fixes a first-party tree; an installed corpus lives outside the workspace root, where `workspace_path_source` raises a loud `SourceUnavailable` — correctly, since a vendor file has no workspace-relative name. That finding comes separately, before any implementation. `attribute × NoneValue` and `attribute × DictValue` sit behind it, not behind this.

Correcting my own earlier report: I previously stated that no workspace-relative lift door exists. It does — `source_oracle.py:167`, `workspace_path_source(path, *, root)`. I had grepped `corpus.py`, found a display-only `rel`, and stopped before checking the oracle. This PR's fixture uses that door.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse non-fragment loci in `ground_raise_effect` with a `ConstructionPanic` instead of crashing
> - `ground_raise_effect` now validates that the `site` argument has a string `filename` and a non-`None` `unit` before accessing them; invalid loci (e.g. plain strings or partial objects) raise a `ConstructionPanic` via `construction_panic_gap` with a message describing the locus type and how to fix it.
> - Previously, passing a non-fragment locus caused an unhandled `AttributeError`; the refusal is now a named gap, not a crash.
> - Tests in [test_ground_exit_locus_law.py](https://github.com/TSavo/sugar/pull/6424/files#diff-496f60a8cde0d408a9f5c284b51d4780ab07994027772a5cc21b66d1b05d0573) cover prose loci, partial objects, absolute-path fragments, and the positive workspace-relative case.
> - [test_sequence_membership_floor.py](https://github.com/TSavo/sugar/pull/6424/files#diff-ca13e5955d025c32caeacadce6de768b478805a60e5554ce8b3cdcd19b8b3e33) is updated to pass a real workspace-relative fragment instead of a string literal for its `site` argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff41b4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->