### PR TITLE
Floor: None.foo stands on the getattr coordinate, not on a fabricated exit

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -23,6 +23,24 @@ class NoneValue(FloorValue):
 
         return Complete(FalseBoolLiteralSugar(site=site))
 
+    def attribute(self, name, site):
+        # ``None.foo`` stands where every other constructed value stands: the
+        # py.getattr coordinate. None owns no field the lift knows and its
+        # methods have no body here, which is exactly the position
+        # StringValue and the constructed containers already occupy.
+        #
+        # NOT a ground AttributeError. `None.foo` raises, but `None.__class__`
+        # and `None.__doc__` do not, so a blanket exit here would be wrong for
+        # every real member -- and deciding which is which would need a
+        # NoneType member table, i.e. a name table read off spelling. The
+        # coordinate is not a claim that the attribute EXISTS; it is an opaque
+        # symbol over the receiver's term and the name, so it stays exact for
+        # both cases and invents neither a field nor an exit.
+        del site
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+
+        return getattr_coordinate(self, name, owner="NoneValue.attribute")
+
     def subscript(self, index, site):
         """Construct Python's exact ground ``None[...]`` exceptional exit."""
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/tests/test_none_attribute_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_none_attribute_floor.py
@@ -1,0 +1,147 @@
+"""``None.foo`` stands on the getattr coordinate, like every constructed value.
+
+Four ``attribute x NoneValue`` rows on the pinned pandas tree
+(``arrays/boolean.py``, ``arrays/numeric.py``, ``indexes/accessors.py``,
+``plotting/_matplotlib/core.py``) construction_panicked with
+``owner=attribute observed=NoneValue``.
+
+These were reported as blocked on the installed-corpus locus-addressing
+question. They were not. Measured through BOTH source doors -- ``path_source``
+(absolute locus) and ``workspace_path_source`` (workspace-relative) -- the
+refusal was byte-identical: ``observed=NoneValue``, never
+``observed="absolute source locus"``. The rows never reached
+``ground_raise_effect`` at all, because ``NoneValue`` had no ``attribute`` arm.
+A plain missing floor arm, unblocked by addressing. Both doors are asserted
+below so that stays true.
+
+The arm is the established ``getattr_coordinate`` law, not a new one, and
+deliberately NOT a ground ``AttributeError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.ir import str_const
+from sugar_lift_py_tests.outcome import Complete
+
+SITE = "none-attribute-site"
+
+
+def _coordinate(outcome):
+    assert isinstance(outcome, Complete), outcome
+    assert type(outcome.value) is SymbolicValue
+    term = outcome.value.term
+    assert term.name == "py.getattr"
+    return term
+
+
+# -- positive arm ------------------------------------------------------------
+
+
+def test_none_attribute_is_the_getattr_coordinate() -> None:
+    term = _coordinate(NoneValue().attribute("foo", SITE))
+
+    assert term.args[0] == NoneValue().to_term(owner="NoneValue.attribute")
+    assert term.args[1] == str_const("foo")
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "foo",
+        # A REAL member of NoneType. Python does not raise for these, which is
+        # why the arm must not be a blanket ground AttributeError.
+        "__class__",
+        "__doc__",
+        "__bool__",
+    ),
+)
+def test_the_coordinate_makes_no_claim_that_the_attribute_exists(name) -> None:
+    """One arm for both cases.
+
+    ``None.foo`` raises and ``None.__class__`` does not. The coordinate is an
+    opaque symbol over the receiver's term and the name -- it asserts neither
+    outcome, so it is exact for both without a NoneType member table. Deciding
+    between them would mean reading a name off its spelling.
+    """
+    term = _coordinate(NoneValue().attribute(name, SITE))
+
+    assert term.args[1] == str_const(name)
+
+
+# -- the real reproducer, through BOTH source doors --------------------------
+
+
+@pytest.mark.parametrize("workspace_relative", (False, True))
+def test_the_whole_function_lifts_through_either_source_door(
+    tmp_path, workspace_relative
+) -> None:
+    """The row was reported as addressing-blocked. It is not.
+
+    The absolute-locus door is asserted alongside the workspace-relative one:
+    if this arm ever starts depending on locus addressing, the ``False`` case
+    is what says so.
+    """
+    from sugar_lift_python_source.source_oracle import (
+        path_source,
+        workspace_path_source,
+    )
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path / "none_attribute.py"
+    path.write_text("def f():\n    return None.foo\n", encoding="utf-8")
+
+    source = (
+        workspace_path_source(str(path), root=str(tmp_path))
+        if workspace_relative
+        else path_source(str(path))
+    )
+
+    fn = next(SourceFile(source).functions())
+    outcome = fn.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is UniverseValue
+
+
+# -- discriminating arm ------------------------------------------------------
+
+
+def test_the_sibling_ground_exit_is_not_stolen() -> None:
+    """``None[...]`` is still Python's exact ground ``TypeError``.
+
+    The getattr arm sits beside that exit and took nothing from it: subscript
+    is decided for every index, attribute is not decided for every name.
+    """
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    class _Fragment:
+        filename = "none_subscript.py"
+        line = 1
+        col = 0
+
+        class unit:
+            source = "def f():\n    return None[0]\n"
+
+        def __str__(self) -> str:
+            return "<none_subscript.py [0, 1)>"
+
+    outcome = NoneValue().subscript(None, _Fragment())
+
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is RaiseValue
+    assert outcome.value.exception.exception_name == "TypeError"
+
+
+def test_the_arm_invents_no_field_and_no_exit() -> None:
+    """Nothing is fabricated: not a field value, not a sentinel, not an exit."""
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    outcome = NoneValue().attribute("foo", SITE)
+
+    assert type(outcome.value) is not RaiseValue
+    assert type(outcome.value) is SymbolicValue


### PR DESCRIPTION
Retires **4 of the 6 `attribute` rows** in the #6389 tail: `arrays/boolean.py`, `arrays/numeric.py`, `indexes/accessors.py`, `plotting/_matplotlib/core.py`, all `owner=attribute observed=NoneValue`.

## These rows were not blocked. I said they were.

I reported them as blocked on the installed-corpus locus-addressing question, citing a finding that has since been retracted by its author (*"no workspace-relative lift door exists"* -- it does: `source_oracle.py:167`). Rather than restate the correction, I re-derived the rows against the real door.

**They were never addressing-blocked.** Lifted through **both** source doors:

```
None.attribute    | path_source (absolute) -> REFUSED owner=attribute observed=NoneValue
None.attribute    | workspace_path_source  -> REFUSED owner=attribute observed=NoneValue
lambda.attribute  | path_source (absolute) -> REFUSED owner=attribute observed=LambdaCallable
lambda.attribute  | workspace_path_source  -> REFUSED owner=attribute observed=LambdaCallable
dict.attribute    | path_source (absolute) -> OK  UniverseValue
dict.attribute    | workspace_path_source  -> OK  UniverseValue
```

Byte-identical through both. The locus refusal reports `observed="absolute source locus"`; these report `observed=NoneValue`. A different gap entirely -- they never reached `ground_raise_effect`, because `NoneValue` had no `attribute` arm at all.

`attribute x DictValue` is not blocked either: `{}.foo` already lifts clean through both doors.

## The arm

The established **`getattr_coordinate`** law -- the one `StringValue`, `ListValue`, `TupleValue` and the other constructed containers already stand on. Not a new law.

**Deliberately not a ground `AttributeError`.** This is the trap in this row:

| expression | Python |
|---|---|
| `None.foo` | `AttributeError` |
| `None.__class__` | `<class 'NoneType'>` |
| `None.__doc__` | `str` |
| `None.__bool__` | method |

A blanket exit would be wrong for every real member, and telling them apart would need a NoneType member table -- a name read off its spelling, which is the thing this codebase refuses. The coordinate *"is not a claim that the attribute EXISTS"* (its own docstring), so **one arm is exact for both cases** and invents neither a field nor an exit.

## Evidence

- **9 focused tests green.** Positive arm with receiver-term and name conserved; the real reproducer as a **whole-function source lift, parametrised over both source doors** so a future dependency on locus addressing shows up as the `False` case failing.
- **Discriminating arms:** all three real NoneType members yield a coordinate rather than a fabricated exit; the sibling ground exit is not stolen -- `None[...]` is still Python's exact ground `TypeError`; and nothing is fabricated (not a field, not a sentinel, not an exit).
- **Mutation:** replacing the arm with a blanket ground `AttributeError` fails **8 of 9** tests, including all three real-member arms. Reverted, verified clean after.
- **Failure-set delta: zero.** 92 passed across this file plus `test_undecided_binary_operand_law`, `test_complex_field_arithmetic_floor`, `test_sequence_membership_floor`, `test_ground_exit_workspace_locus`. Only the inherited-red `test_ground_non_string_in_string_is_type_error` fails -- and that one is an `AttributeError` crash (`ground_raise_effect` does `Path(site.filename).is_absolute()` on a prose site), not the locus law. Being fixed separately.

## Still open, not mine to close here

- **`LambdaCallable.attribute`** (1 row, `algorithms.py`) stays LOUD. A lambda is a callable, not a constructed value -- it does not denote a value, so the getattr law does not obviously extend to it. Deciding that is a separate ruling and I am not making it silently.
- **`EffectCoordinate.attribute`** (1 row, `tests/io/excel/test_openpyxl.py`) not measured.
- The installed-corpus addressing question is untouched and still real -- it will bite when a ground exit is minted on a site-packages file. It gates those rows' **installed-corpus measurement**, not their **implementation**.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return a `py.getattr` coordinate from `NoneValue.attribute` instead of a fabricated exit
> Previously, `NoneValue` had no `attribute` arm, leaving attribute access on `None` unhandled. `NoneValue.attribute(name, site)` now returns a `py.getattr` coordinate (owner `"NoneValue.attribute"`) for any attribute name, making `None.foo` stand on the standard getattr coordinate rather than raising or fabricating a `RaiseValue`. Tests in [test_none_attribute_floor.py](https://github.com/TSavo/sugar/pull/6425/files#diff-573189ac424b85834c79bf55c42b2674f368f00e599004ea780ffe35ae04e698) verify the coordinate shape, that no claim about attribute existence is made, and that lifting a function referencing `None.foo` succeeds end-to-end.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66338af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->