### PR TITLE
Designed gaps get a door in the axis: a RE-ATTRIBUTION of 12 rows, not a drain

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -623,6 +623,13 @@ def main() -> int:
     # into R_desugar and both make the run red.
     desugar_construction_panics: list[dict[str, Any]] = []
     desugar_defects: list[dict[str, Any]] = []
+    # A FOURTH, disjoint from all three and RED-NEUTRAL: a declared mechanism
+    # refusing on purpose, as its correct answer, in something that is not a
+    # SugarNotWritten. See sugar_lift_py_tests.desugar_axis._designed_gap_types
+    # for why membership is a declared TYPE and never "a ValueError from this
+    # call". Published with its MEMBERS, not a bare count: `factoringGaps = 13`
+    # as a lone scalar sent an owner hunting for a whole session.
+    desugar_designed_gaps: list[dict[str, Any]] = []
     unresolvable_dispatch: list[dict[str, Any]] = []
     files_completed = 0
     functions_total = 0
@@ -901,6 +908,7 @@ def main() -> int:
         ast_sites.update(row.get("astSites") or {})
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
         desugar_defects.extend(row.get("desugarDefects") or [])
+        desugar_designed_gaps.extend(row.get("desugarDesignedGaps") or [])
         if category == "completed":
             files_completed += 1
         elif category == "construction-panic":
@@ -1049,6 +1057,17 @@ def main() -> int:
         "R_desugar_construction_panics": len(desugar_construction_panics),
         "desugarDefects": desugar_defects,
         "R_desugar_defects": len(desugar_defects),
+        # Correct output from a named mechanism. Disjoint from desugarDefects
+        # (not a bug), from R_desugar (not a typed refusal) and from the panic
+        # collection. Never added to any of them, and never a red reason.
+        "desugarDesignedGaps": desugar_designed_gaps,
+        "R_desugar_designed_gaps": len(desugar_designed_gaps),
+        "desugarDesignedGapOwners": dict(
+            Counter(
+                str(gap.get("owner", "?"))
+                for gap in desugar_designed_gaps
+            )
+        ),
         # #6329 -- an arm reaching a dispatch target that does not exist. Its
         # own axis: never semantic R, never quietly a backend defect.
         "unresolvableDispatchTargets": unresolvable_dispatch,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -261,6 +261,44 @@ def _designed_gap_types() -> tuple[type, ...]:
     return (ExitSetFactoringGap,)
 
 
+def _is_designed_gap(exc: BaseException) -> bool:
+    """Whether THIS occurrence is correct output. Type is necessary, not sufficient.
+
+    A DECLARED TYPE ONLY SAYS WHICH MECHANISM SPOKE. It does not say that this
+    occurrence was the mechanism working. ``ExitSetFactoringGap`` has two
+    populations and its own classifier is what tells them apart:
+
+    * ``isRemainingWork: False`` — the gate doing its job. Correct output.
+    * ``isRemainingWork: True``  — ``UNSTAMPED`` and not merged: a producer that
+      owns a split and has not testified. That is CLOSABLE WORK, and it is the
+      shape #6375 actually closed at ``selectn.py:224``.
+
+    Gating on type alone would file the second kind as correct output in a
+    bucket that is never red and never summed — publishing a closable
+    producer-omission as a finished result and silencing it. That is a red
+    residual ratified as a baseline. It is the same disease this door cures,
+    pointed the other way, and it is the WORSE direction: counting correct
+    output as a defect is loud and self-correcting, counting work as correct
+    output is neither.
+
+    It is latent only because all twelve occurrences on tonight's board classify
+    ``False``. That is a fact about one measurement, not a property of the type.
+
+    NO VERDICT IS NOT A VERDICT OF "DESIGNED". ``classification()`` answers
+    ``None`` when the refusal carries no arms, and an unclassifiable occurrence
+    stays a defect and stays red rather than defaulting into the quiet bucket.
+    """
+    if type(exc) not in _designed_gap_types():
+        return False
+    classify = getattr(exc, "classification", None)
+    if not callable(classify):
+        return False
+    verdict = classify()
+    if verdict is None:
+        return False
+    return getattr(verdict, "is_remaining_work", True) is False
+
+
 class DesugarAxis:
     """Accumulates the four disjoint desugar-layer quantities for a file/run."""
 
@@ -382,10 +420,9 @@ class DesugarAxis:
             return
         if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == "defect":
             exc = outcome[1]
-            # A DECLARED designed gap is correct output, not an implementation
-            # defect, and gets its own counted bucket. Exact type identity
-            # against the declared set — see `_designed_gap_types`.
-            if type(exc) in _designed_gap_types():
+            # A designed gap gets its own counted bucket. TWO conditions, and
+            # the second is the load-bearing one — see `_is_designed_gap`.
+            if _is_designed_gap(exc):
                 self._designed_gap(where, exc)
                 return
             self._defect(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -22,9 +22,21 @@ them into ``R_desugar`` produces a number whose denominator is a lie:
                               named audit defects raised by the instrument
                               itself (unsupported outcome envelope, outcome
                               cycle, effect with no occurrence coordinate).
+``desugarDesignedGaps``       a DECLARED mechanism refusing on purpose, as its
+                              correct answer, in something that is not a
+                              ``SugarNotWritten``. Counted under its own owner,
+                              never red, never summed into the three above.
 
-Both new collections make the final instrument exit RED. Neither is ever added
-to ``R_desugar``.
+The first two new collections make the final instrument exit RED. None of the
+three is ever added to ``R_desugar``.
+
+WHY THE FOURTH EXISTS. ``ExitSetFactoringGap`` is a ``ValueError``, so it landed
+in ``desugarDefects`` — twelve rows of the pandas board, every one classifying
+``isRemainingWork: False``, which is ``factor_completed`` doing exactly its job.
+Counting correct output as a defect is the same disease that made ``R_desugar``
+overstate its board by 7.6x, at smaller scale. The door is by DECLARED TYPE and
+nothing else: see ``_designed_gap_types`` for why "a ValueError from this call"
+would have been a cure worse than the disease.
 
 Row identity is the *effect occurrence*, not the enclosing function line. A
 function holding three distinct stores is three rows; the same occurrence
@@ -226,6 +238,29 @@ class OutcomeWalk:
 # --------------------------------------------------------------------------
 
 
+def _designed_gap_types() -> tuple[type, ...]:
+    """THE DECLARED SET of designed gaps, by type, stated here and nowhere else.
+
+    A designed gap is a refusal a mechanism raises ON PURPOSE, as its correct
+    answer, which happens not to be a ``SugarNotWritten``. ``ExitSetFactoringGap``
+    is one: ``factor_completed`` refuses arms it cannot prove exclusive because
+    collapsing them would drop a reachable outcome, and its own module says so —
+    "the honest answer is a named gap". Twelve of the pandas board's defect rows
+    were that refusal working, every one classifying ``isRemainingWork: False``.
+
+    MEMBERSHIP IS BY DECLARED TYPE, never by "a ValueError out of this call".
+    That distinction is the whole reason this door exists rather than a wider
+    catch: ``ExitSetFactoringGap`` IS a ``ValueError``, so anything shaped like
+    "the exception class of the thing I expected" would swallow every genuine
+    ``ValueError`` bug raised anywhere under desugar — which is precisely the
+    failure this is built to prevent. Exact type identity, not ``isinstance``:
+    a subclass is a different mechanism and must earn its own line here.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+
+    return (ExitSetFactoringGap,)
+
+
 class DesugarAxis:
     """Accumulates the four disjoint desugar-layer quantities for a file/run."""
 
@@ -236,6 +271,11 @@ class DesugarAxis:
         self.by_category_owner: Counter[str] = Counter()
         self.construction_panics: list[dict[str, Any]] = []
         self.defects: list[dict[str, Any]] = []
+        # Designed gaps: correct output from a named mechanism, COUNTED in its
+        # own bucket. Never folded into defects (they are not bugs), never into
+        # R_desugar (they are not typed refusals), and never dropped — a
+        # designed refusal is reported correct output, not silence.
+        self.designed_gaps: list[dict[str, Any]] = []
         # Row identity: (owner, authenticated effect-occurrence coordinate).
         self._seen: set[tuple[str, str]] = set()
 
@@ -281,6 +321,20 @@ class DesugarAxis:
             if verdict is not None and hasattr(verdict, "row"):
                 row["classification"] = verdict.row()
         self.defects.append(row)
+
+    def _designed_gap(self, where: str, exc: BaseException) -> None:
+        """Record one designed gap: named owner, carried verdict, counted."""
+        row: dict[str, Any] = {
+            "owner": type(exc).__name__,
+            "where": where,
+            "detail": f"{type(exc).__name__}: {exc}",
+        }
+        classify = getattr(exc, "classification", None)
+        if callable(classify):
+            verdict = classify()
+            if verdict is not None and hasattr(verdict, "row"):
+                row["classification"] = verdict.row()
+        self.designed_gaps.append(row)
 
     # -- the one door -------------------------------------------------------
 
@@ -328,6 +382,12 @@ class DesugarAxis:
             return
         if isinstance(outcome, tuple) and len(outcome) == 2 and outcome[0] == "defect":
             exc = outcome[1]
+            # A DECLARED designed gap is correct output, not an implementation
+            # defect, and gets its own counted bucket. Exact type identity
+            # against the declared set — see `_designed_gap_types`.
+            if type(exc) in _designed_gap_types():
+                self._designed_gap(where, exc)
+                return
             self._defect(
                 "desugar-exception", where, f"{type(exc).__name__}: {exc}", exc=exc
             )
@@ -357,6 +417,7 @@ class DesugarAxis:
         self.by_category_owner.update(other.by_category_owner)
         self.construction_panics.extend(other.construction_panics)
         self.defects.extend(other.defects)
+        self.designed_gaps.extend(other.designed_gaps)
         self._seen |= other._seen
 
     def row(self) -> dict[str, Any]:
@@ -372,12 +433,24 @@ class DesugarAxis:
             ),
             "desugarConstructionPanics": list(self.construction_panics),
             "desugarDefects": list(self.defects),
+            # Designed gaps: correct output, counted and named, never red and
+            # never summed into any of the four quantities above.
+            "desugarDesignedGaps": list(self.designed_gaps),
+            "R_desugar_designed_gaps": len(self.designed_gaps),
+            "desugarDesignedGapOwners": dict(
+                Counter(row["owner"] for row in self.designed_gaps)
+            ),
         }
 
     @property
     def red(self) -> bool:
         """Panics and defects make the instrument exit red. R_desugar does not:
-        a typed refusal is a measured frontier row, not a broken instrument."""
+        a typed refusal is a measured frontier row, not a broken instrument.
+
+        Neither does a DESIGNED gap. It is a named mechanism answering
+        correctly, so holding the run red on it would be the 171.6x disease in
+        miniature: counting correct output as remaining work. It is counted and
+        published under its own owner instead — reported, never silent."""
         return bool(self.construction_panics or self.defects)
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_designed_gaps_reach_the_ledger.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_designed_gaps_reach_the_ledger.py
@@ -1,0 +1,148 @@
+"""A designed gap is REPORTED correct output — never silence, never a defect.
+
+`ExitSetFactoringGap` is a `ValueError`, so it landed in `desugarDefects`:
+twelve rows of the pandas board, every one classifying `isRemainingWork: False`,
+which is `factor_completed` doing exactly its job. Counting correct output as a
+defect is the same disease that made `R_desugar` overstate its board by 7.6x.
+
+The correction is a re-attribution, and it is only honest if the rows ARRIVE
+somewhere. `DesugarAxis` routing them out of `desugarDefects` while the census
+publishes no bucket for them would make twelve rows vanish from the ledger
+entirely — a free -12 on the defect axis bought by deleting the evidence, which
+is strictly worse than the miscount it replaces. These twins hold the whole
+path: the axis routes, the run's merge loop accumulates, and the result row
+publishes MEMBERS, not a bare cardinality. (`factoringGaps = 13` as a lone
+scalar once sent an owner hunting for a session with nothing to open.)
+
+The fixture is written here, not lifted from a corpus. Its shape is the one the
+real rows have: two branches assigning the SAME value merge on an equal
+destination, so the merged arm's guard carries a disjunction and no per-arm
+testimony can separate it from the third.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+# Two branches reach `["only"]` — the equal-destination merge — and a third
+# reaches a different list. The later read cannot be told apart from either.
+_MERGED_ARM_SOURCE = '''\
+def pick(mode, box):
+    if mode == "first":
+        slots = ["only"]
+    elif mode == "second":
+        slots = ["only"]
+        box = box.reindex(slots)
+    elif mode == "third":
+        slots = ["only", "extra"]
+        box = box.reindex(slots)
+    grouped = box.group(slots)
+    if mode == "first":
+        found = grouped["only"].names
+    else:
+        found = grouped.index.level("only").names
+    return found
+'''
+
+
+def _load(name: str):
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_census(tmp_path: Path, source: str) -> dict:
+    """One real census run over a one-file corpus. Subprocess, because `main`
+    owns the aggregation this is here to test — calling `_measure_file` would
+    prove the axis and skip the merge loop and the result row, which is exactly
+    where a bucket goes missing."""
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "picker.py").write_text(source, encoding="utf-8")
+    out = tmp_path / "out"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPTS / "control_effect_recensus.py"),
+            str(corpus),
+            "--corpus-root", str(corpus),
+            "--corpus-version", "0.0.0",
+            "--repo", str(_SCRIPTS.parents[3]),
+            "--out-dir", str(out),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return json.loads((out / "recensus.json").read_text(encoding="utf-8"))
+
+
+def test_a_designed_gap_reaches_the_ledger_with_its_members(tmp_path: Path) -> None:
+    result = _run_census(tmp_path, _MERGED_ARM_SOURCE)
+
+    # Counted, and reported with the rows behind the count.
+    assert result["R_desugar_designed_gaps"] == 1
+    assert result["desugarDesignedGapOwners"] == {"ExitSetFactoringGap": 1}
+    members = result["desugarDesignedGaps"]
+    assert len(members) == 1
+    assert members[0]["owner"] == "ExitSetFactoringGap"
+    assert members[0]["where"].startswith("picker.py:")
+    # The verdict rides to the ledger, so the split is readable at corpus scale
+    # without re-deriving it by parsing a repr.
+    assert members[0]["classification"]["isRemainingWork"] is False
+    assert members[0]["classification"]["mergedArm"] is True
+
+    # Disjoint: it is on NO other axis.
+    assert result["R_desugar_defects"] == 0
+    assert result["desugarDefects"] == []
+    assert result["R_desugar_construction_panics"] == 0
+
+    # Correct output does not hold the run red.
+    assert result["red"] == 0
+    assert result["redReasons"] == []
+
+
+def test_lying_a_real_defect_still_lands_on_the_defect_axis(tmp_path: Path) -> None:
+    """THE discriminator for the whole path.
+
+    A bucket that quietly absorbed neighbours would satisfy the twin above. A
+    genuine implementation defect must still be counted as one, still be listed,
+    and still make the run RED — otherwise this change bought its -12 by going
+    blind rather than by getting the category right.
+    """
+    module = _load("control_effect_recensus")
+    path = tmp_path / "boom.py"
+    # `yield from` is a typed refusal, not a defect, so it cannot be used here;
+    # the axis's own twin covers ordinary exceptions at the unit level. What
+    # this asserts is that the census still HAS a defect channel wired to red.
+    path.write_text("def a(z):\n    return z\n", encoding="utf-8")
+    row = module._measure_file(path, relative="boom.py", workspace_root=tmp_path)
+    assert row["desugarDefects"] == []
+    assert row["desugarDesignedGaps"] == []
+
+    # And the run-level predicate still names defects as a red reason.
+    census = (_SCRIPTS / "control_effect_recensus.py").read_text(encoding="utf-8")
+    assert 'red_reasons.append(f"{len(desugar_defects)} desugar defects")' in census
+    assert "desugar_designed_gaps" not in census.split("red_reasons")[-1]
+
+
+def test_a_clean_corpus_reports_an_empty_bucket_not_a_missing_key(
+    tmp_path: Path,
+) -> None:
+    """Zero must be published as zero. A key that only appears when non-empty
+    makes every clean run indistinguishable from a run of an older census that
+    never had the bucket at all."""
+    result = _run_census(tmp_path, "def a(z):\n    return z\n")
+    assert result["R_desugar_designed_gaps"] == 0
+    assert result["desugarDesignedGaps"] == []
+    assert result["desugarDesignedGapOwners"] == {}
+    assert result["red"] == 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -300,19 +300,21 @@ def _factoring_gap(*, stamped: bool):
 
 
 def test_twin_10_factoring_gap_carries_its_classification() -> None:
+    """An UNSTAMPED, unmerged pair is OWED WORK, so its row is a defect — and it
+    still carries the verdict that says so. This twin owns the READING; twin 12
+    owns the membership rule that keeps this population red."""
     axis = _axis()
     axis.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="gen.py:1:0")
     row = axis.row()
     assert row["R_desugar"] == 0
     assert row["desugarFamilies"] == {}
     assert row["desugarConstructionPanics"] == []
-    # Exactly one row, on the designed-gap axis (twin 11 owns that placement).
-    assert len(row["desugarDesignedGaps"]) == 1
-    gap = row["desugarDesignedGaps"][0]
-    assert gap["owner"] == "ExitSetFactoringGap"
-    assert gap["detail"].startswith("ExitSetFactoringGap")
-    assert gap["classification"]["kind"] == "unstamped"
-    assert gap["classification"]["isRemainingWork"] is True
+    assert len(row["desugarDefects"]) == 1
+    defect = row["desugarDefects"][0]
+    assert defect["kind"] == "desugar-exception"
+    assert defect["detail"].startswith("ExitSetFactoringGap")
+    assert defect["classification"]["kind"] == "unstamped"
+    assert defect["classification"]["isRemainingWork"] is True
 
 
 def test_twin_10_discriminator_stamped_arms_are_not_reported_as_owed_work() -> None:
@@ -328,6 +330,7 @@ def test_twin_10_discriminator_stamped_arms_are_not_reported_as_owed_work() -> N
     assert len(gaps) == 1
     assert gaps[0]["classification"]["kind"] == "stamped-not-separating"
     assert gaps[0]["classification"]["isRemainingWork"] is False
+    assert axis.red is False
 
 
 def test_twin_10_discriminator_an_exception_with_no_testimony_gets_no_key() -> None:
@@ -346,9 +349,9 @@ def test_twin_10_discriminator_an_exception_with_no_testimony_gets_no_key() -> N
 
     bare = _axis()
     bare.measure(_FakeSugar(raises=ExitSetFactoringGap("bare")), where="gen.py:2:0")
-    bare_gaps = bare.row()["desugarDesignedGaps"]
-    assert len(bare_gaps) == 1
-    assert "classification" not in bare_gaps[0]
+    bare_defects = bare.row()["desugarDefects"]
+    assert len(bare_defects) == 1
+    assert "classification" not in bare_defects[0]
 
 
 def test_twin_10_discriminator_a_merged_arm_is_not_reported_as_owed_work() -> None:
@@ -395,7 +398,10 @@ def test_twin_10_discriminator_a_merged_arm_is_not_reported_as_owed_work() -> No
 
 def test_twin_11_a_declared_designed_gap_is_counted_not_a_defect() -> None:
     axis = _axis()
-    axis.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="gen.py:1:0")
+    # `stamped=True` is the CORRECT-OUTPUT population. The other one is work and
+    # twin 12 holds it red; using it here would have made this twin assert that
+    # a closable producer-omission is a finished result.
+    axis.measure(_FakeSugar(raises=_factoring_gap(stamped=True)), where="gen.py:1:0")
     row = axis.row()
     # Off the defect axis, and NOT onto any other measured quantity.
     assert row["desugarDefects"] == []
@@ -408,7 +414,8 @@ def test_twin_11_a_declared_designed_gap_is_counted_not_a_defect() -> None:
     gap = row["desugarDesignedGaps"][0]
     assert gap["owner"] == "ExitSetFactoringGap"
     assert gap["where"] == "gen.py:1:0"
-    assert gap["classification"]["kind"] == "unstamped"
+    assert gap["classification"]["kind"] == "stamped-not-separating"
+    assert gap["classification"]["isRemainingWork"] is False
     # Correct output does not hold the instrument red.
     assert axis.red is False
 
@@ -452,7 +459,7 @@ def test_twin_11_designed_gaps_survive_merge_and_stay_disjoint() -> None:
     merge reports zero for every file but the last. Exact cardinality on both
     sides, and the four quantities stay disjoint across the merge."""
     left = _axis()
-    left.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="a.py:1:0")
+    left.measure(_FakeSugar(raises=_factoring_gap(stamped=True)), where="a.py:1:0")
     right = _axis()
     right.measure(_FakeSugar(raises=_factoring_gap(stamped=True)), where="b.py:1:0")
     right.measure(_FakeSugar(raises=KeyError("boom")), where="b.py:9:0")
@@ -468,3 +475,74 @@ def test_twin_11_designed_gaps_survive_merge_and_stay_disjoint() -> None:
     # The real defect is untouched by any of it, and still red.
     assert len(row["desugarDefects"]) == 1
     assert left.red is True
+
+
+# -- 12. TYPE IS NECESSARY, NOT SUFFICIENT ----------------------------------
+#
+# A declared type says which MECHANISM spoke, never that this occurrence was the
+# mechanism working. `ExitSetFactoringGap` has two populations and its own
+# classifier separates them: `isRemainingWork: False` is the gate doing its job,
+# `isRemainingWork: True` is UNSTAMPED-and-not-merged — a producer that owns a
+# split and has not testified, which is closable work and exactly what #6375
+# closed at `selectn.py:224`.
+#
+# Gating on type alone files the second kind into a bucket that is never red and
+# never summed: a closable producer-omission published as a finished result and
+# silenced. That is the worse direction — counting correct output as a defect is
+# loud and self-correcting; counting work as correct output is neither. It is
+# latent only because every occurrence on today's board classifies `False`,
+# which is a fact about one measurement and not a property of the type.
+
+
+def test_twin_12_a_declared_gap_that_is_REMAINING_WORK_stays_a_red_defect() -> None:
+    """The arm that cannot be bought back later."""
+    gap = _factoring_gap(stamped=False)
+    # Precondition asserted, not assumed: if the classifier ever stops calling
+    # this shape owed work, this test must fail loudly rather than pass because
+    # its fixture drifted into the other population.
+    assert gap.classification().is_remaining_work is True
+
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=gap), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar_designed_gaps"] == 0
+    assert row["desugarDesignedGaps"] == []
+    assert len(row["desugarDefects"]) == 1
+    assert row["desugarDefects"][0]["classification"]["isRemainingWork"] is True
+    assert axis.red is True
+
+
+def test_twin_12_the_mirror_correct_output_still_reaches_the_quiet_bucket() -> None:
+    """The other face. A gate that refused everything would satisfy the twin
+    above; correct output must still be re-attributed and must not hold the
+    run red."""
+    gap = _factoring_gap(stamped=True)
+    assert gap.classification().is_remaining_work is False
+
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=gap), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar_designed_gaps"] == 1
+    assert row["desugarDefects"] == []
+    assert axis.red is False
+
+
+def test_twin_12_no_verdict_is_not_a_verdict_of_designed() -> None:
+    """An unclassifiable occurrence must not DEFAULT into the quiet bucket.
+
+    `classification()` answers `None` when the refusal carries no arms. Silence
+    from the classifier is not a finding of correct output, so the row stays a
+    defect and stays red — the same rule as the absent-key discipline in twin 10,
+    applied to membership instead of to reporting.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+
+    bare = ExitSetFactoringGap("carries no arms")
+    assert bare.classification() is None
+
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=bare), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar_designed_gaps"] == 0
+    assert len(row["desugarDefects"]) == 1
+    assert axis.red is True

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -267,13 +267,13 @@ def test_effect_without_occurrence_is_an_instrument_gap_not_a_fabricated_key() -
     assert axis.red is True
 
 
-# -- 10. a defect row carries the classification its exception already holds --
+# -- 10. a row carries the classification its exception already holds --------
 #
 # The pandas board reported thirteen `ExitSetFactoringGap` occurrences as
-# undifferentiated `desugar-exception` rows, while the exception itself carried
-# the two refusing arms and a classifier that splits them into closable work and
-# correct output. Both twins below assert EXACT cardinality and that the row
-# stays on the defect axis: reading testimony must not move a row anywhere.
+# undifferentiated rows, while the exception itself carried the two refusing
+# arms and a classifier that splits them into closable work and correct output.
+# These twins own the READING of that testimony and assert EXACT cardinality;
+# twin 11 owns which axis the row lands on.
 
 
 def _factoring_gap(*, stamped: bool):
@@ -299,21 +299,20 @@ def _factoring_gap(*, stamped: bool):
     return ExitSetFactoringGap("arms are not provably exclusive", left, right)
 
 
-def test_twin_10_factoring_gap_defect_carries_its_classification() -> None:
+def test_twin_10_factoring_gap_carries_its_classification() -> None:
     axis = _axis()
     axis.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="gen.py:1:0")
     row = axis.row()
-    # Still exactly one DEFECT: reading testimony moves nothing off this axis.
     assert row["R_desugar"] == 0
     assert row["desugarFamilies"] == {}
     assert row["desugarConstructionPanics"] == []
-    assert len(row["desugarDefects"]) == 1
-    defect = row["desugarDefects"][0]
-    assert defect["kind"] == "desugar-exception"
-    assert defect["detail"].startswith("ExitSetFactoringGap")
-    assert defect["classification"]["kind"] == "unstamped"
-    assert defect["classification"]["isRemainingWork"] is True
-    assert axis.red is True
+    # Exactly one row, on the designed-gap axis (twin 11 owns that placement).
+    assert len(row["desugarDesignedGaps"]) == 1
+    gap = row["desugarDesignedGaps"][0]
+    assert gap["owner"] == "ExitSetFactoringGap"
+    assert gap["detail"].startswith("ExitSetFactoringGap")
+    assert gap["classification"]["kind"] == "unstamped"
+    assert gap["classification"]["isRemainingWork"] is True
 
 
 def test_twin_10_discriminator_stamped_arms_are_not_reported_as_owed_work() -> None:
@@ -325,10 +324,10 @@ def test_twin_10_discriminator_stamped_arms_are_not_reported_as_owed_work() -> N
     """
     axis = _axis()
     axis.measure(_FakeSugar(raises=_factoring_gap(stamped=True)), where="gen.py:1:0")
-    defects = axis.row()["desugarDefects"]
-    assert len(defects) == 1
-    assert defects[0]["classification"]["kind"] == "stamped-not-separating"
-    assert defects[0]["classification"]["isRemainingWork"] is False
+    gaps = axis.row()["desugarDesignedGaps"]
+    assert len(gaps) == 1
+    assert gaps[0]["classification"]["kind"] == "stamped-not-separating"
+    assert gaps[0]["classification"]["isRemainingWork"] is False
 
 
 def test_twin_10_discriminator_an_exception_with_no_testimony_gets_no_key() -> None:
@@ -341,14 +340,15 @@ def test_twin_10_discriminator_an_exception_with_no_testimony_gets_no_key() -> N
     assert len(defects) == 1
     assert "classification" not in defects[0]
 
-    # ...and neither does a factoring gap that carries no arms at all.
+    # ...and neither does a factoring gap that carries no arms at all, on its
+    # own axis. An absent verdict is an ABSENT KEY, never an "unknown".
     from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
 
     bare = _axis()
     bare.measure(_FakeSugar(raises=ExitSetFactoringGap("bare")), where="gen.py:2:0")
-    bare_defects = bare.row()["desugarDefects"]
-    assert len(bare_defects) == 1
-    assert "classification" not in bare_defects[0]
+    bare_gaps = bare.row()["desugarDesignedGaps"]
+    assert len(bare_gaps) == 1
+    assert "classification" not in bare_gaps[0]
 
 
 def test_twin_10_discriminator_a_merged_arm_is_not_reported_as_owed_work() -> None:
@@ -373,8 +373,98 @@ def test_twin_10_discriminator_a_merged_arm_is_not_reported_as_owed_work() -> No
     )
     axis = _axis()
     axis.measure(_FakeSugar(raises=gap), where="gen.py:1:0")
-    defects = axis.row()["desugarDefects"]
-    assert len(defects) == 1
-    assert defects[0]["classification"]["kind"] == "unstamped"
-    assert defects[0]["classification"]["mergedArm"] is True
-    assert defects[0]["classification"]["isRemainingWork"] is False
+    gaps = axis.row()["desugarDesignedGaps"]
+    assert len(gaps) == 1
+    assert gaps[0]["classification"]["kind"] == "unstamped"
+    assert gaps[0]["classification"]["mergedArm"] is True
+    assert gaps[0]["classification"]["isRemainingWork"] is False
+
+
+# -- 11. a DECLARED designed gap is correct output, counted in its own bucket --
+#
+# `ExitSetFactoringGap` is a `ValueError`, so it landed in `desugarDefects` —
+# twelve rows of the pandas board, every one classifying `isRemainingWork:
+# False`, which is `factor_completed` doing exactly its job. Counting correct
+# output as a defect is the 7.6x disease at smaller scale.
+#
+# The door is BY DECLARED TYPE. The lying face below is the one that matters:
+# an undeclared `ValueError` must still be a defect, because a door shaped like
+# "a ValueError out of this call" would swallow every genuine `ValueError` bug
+# under desugar — a cure worse than the disease.
+
+
+def test_twin_11_a_declared_designed_gap_is_counted_not_a_defect() -> None:
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="gen.py:1:0")
+    row = axis.row()
+    # Off the defect axis, and NOT onto any other measured quantity.
+    assert row["desugarDefects"] == []
+    assert row["R_desugar"] == 0
+    assert row["desugarConstructionPanics"] == []
+    # Counted, named, and carrying the verdict it already held.
+    assert row["R_desugar_designed_gaps"] == 1
+    assert row["desugarDesignedGapOwners"] == {"ExitSetFactoringGap": 1}
+    assert len(row["desugarDesignedGaps"]) == 1
+    gap = row["desugarDesignedGaps"][0]
+    assert gap["owner"] == "ExitSetFactoringGap"
+    assert gap["where"] == "gen.py:1:0"
+    assert gap["classification"]["kind"] == "unstamped"
+    # Correct output does not hold the instrument red.
+    assert axis.red is False
+
+
+def test_twin_11_lying_an_undeclared_ValueError_is_still_a_defect() -> None:
+    """THE discriminator. `ExitSetFactoringGap` IS a `ValueError`, so a door
+    keyed on the exception's base class — or on "whatever came out of this
+    call" — would silently absorb every genuine `ValueError` bug raised under
+    desugar. Membership is the declared type and nothing else."""
+    axis = _axis()
+    axis.measure(_FakeSugar(raises=ValueError("a real bug")), where="gen.py:1:0")
+    row = axis.row()
+    assert row["R_desugar_designed_gaps"] == 0
+    assert row["desugarDesignedGaps"] == []
+    assert len(row["desugarDefects"]) == 1
+    assert row["desugarDefects"][0]["detail"].startswith("ValueError")
+    assert axis.red is True
+
+
+def test_twin_11_lying_a_subclass_is_a_different_mechanism() -> None:
+    """Exact type identity, not `isinstance`. A subclass of a declared gap is a
+    mechanism nobody declared; admitting it would let a new refusal join the
+    correct-output bucket without anyone deciding that it should."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSetFactoringGap
+
+    class UndeclaredSubclassGap(ExitSetFactoringGap):
+        pass
+
+    axis = _axis()
+    axis.measure(
+        _FakeSugar(raises=UndeclaredSubclassGap("not declared")), where="gen.py:1:0"
+    )
+    row = axis.row()
+    assert row["R_desugar_designed_gaps"] == 0
+    assert len(row["desugarDefects"]) == 1
+    assert axis.red is True
+
+
+def test_twin_11_designed_gaps_survive_merge_and_stay_disjoint() -> None:
+    """Per-file axes are merged into the run's row; a bucket that does not
+    merge reports zero for every file but the last. Exact cardinality on both
+    sides, and the four quantities stay disjoint across the merge."""
+    left = _axis()
+    left.measure(_FakeSugar(raises=_factoring_gap(stamped=False)), where="a.py:1:0")
+    right = _axis()
+    right.measure(_FakeSugar(raises=_factoring_gap(stamped=True)), where="b.py:1:0")
+    right.measure(_FakeSugar(raises=KeyError("boom")), where="b.py:9:0")
+
+    left.merge(right)
+    row = left.row()
+    assert row["R_desugar_designed_gaps"] == 2
+    assert row["desugarDesignedGapOwners"] == {"ExitSetFactoringGap": 2}
+    assert [gap["where"] for gap in row["desugarDesignedGaps"]] == [
+        "a.py:1:0",
+        "b.py:1:0",
+    ]
+    # The real defect is untouched by any of it, and still red.
+    assert len(row["desugarDefects"]) == 1
+    assert left.red is True

--- a/implementations/python/sugar-lift-py-tests/tests/test_factoring_growth_is_linear.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factoring_growth_is_linear.py
@@ -1,0 +1,69 @@
+"""`factor_completed` keeps sequenced growth LINEAR — and the check can fail.
+
+#6333's defect was `m ** k`: k sequenced steps of m completed arms distributing
+into m ** k exit-level arms, because `sequence` appends every exit of the tail
+under every completed exit of the prefix. `factor_completed` fixed it by moving
+the partition onto the VALUE, so k steps contribute k guarded values to one arm.
+
+Any change to the exit algebra -- and in particular to what a merged arm RETAINS
+(#6336/#6420) -- can silently restore the exponential. A family that grows as
+factors are appended is `m ** k` under a new name.
+
+THE CONSTRAINT THAT MAKES THIS TEST REAL, and it is not obvious: a fold whose
+tail IGNORES the prefix value cannot blow up at all, no matter what the algebra
+does. Every path reaches the same destination, the equal-destination merge
+collapses them, and the arm count sits flat at m forever. Written that way this
+test is green by construction and proves nothing about factoring. It was
+measured: the same fold reads a flat 2 at every k without accumulation, and
+2/4/16/256/4096 with it. The tail here therefore accumulates onto the prefix
+value, so distinct paths reach distinct destinations and the exponential is
+actually reachable -- which is what gives the assertion below its teeth.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.ir import atomic, make_var, not_
+from sugar_lift_py_tests.outcome import true_guard
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, partition
+
+_KS = (1, 2, 4, 8, 12)
+
+
+def _arms_after_k_steps(k: int, *, factor: bool) -> int:
+    """k sequenced two-way partitions, each factored before the next or not."""
+    exits = ExitSet((Completed(true_guard(), "seed"),))
+    for step in range(k):
+        left_face, right_face = partition(f"producer-{step}")
+        guard = atomic(f"g{step}", [make_var("state")])
+
+        def build(value, guard=guard, lf=left_face, rf=right_face, step=step):
+            # ACCUMULATES onto the prefix value -- see the module docstring.
+            return ExitSet(
+                (
+                    Completed(guard, (value, f"a{step}"), frozenset({lf})),
+                    Completed(not_(guard), (value, f"b{step}"), frozenset({rf})),
+                )
+            )
+
+        exits = exits.sequence(build)
+        if factor:
+            exits = exits.factor_completed()
+    return len(exits.exits)
+
+
+def test_appended_factors_do_not_grow_the_arm_count() -> None:
+    """STRICT, not a loose bound. When every step is an admitted partition the
+    arm count must not grow with k AT ALL: the partition lives on the value."""
+    counts = {k: _arms_after_k_steps(k, factor=True) for k in _KS}
+    assert len(set(counts.values())) == 1, counts
+
+
+def test_lying_the_same_fold_without_factoring_really_does_blow_up() -> None:
+    """The discriminator. Without this arm the twin above is a control that
+    cannot fail, and a control that cannot fail is worse than no control: it
+    reports a law is held by a mechanism that may no longer be running."""
+    counts = {k: _arms_after_k_steps(k, factor=False) for k in _KS}
+    assert counts[1] == 2
+    # Exactly 2 ** k -- #6333's exponential, reachable and measured.
+    assert all(counts[k] == 2**k for k in _KS), counts
+    assert counts[12] == 4096


### PR DESCRIPTION
## Read this line first

**The defect axis falls by 12 because the rows were miscategorized, not because anything was fixed.** Nothing is closed here. No mechanism changes behaviour. This is a re-attribution *between* axes, and it must read that way on the board.

## The row

`ExitSetFactoringGap` is a `ValueError`, so it landed in `desugarDefects` — twelve rows of the pandas board, **every one classifying `isRemainingWork: False`**, which is `factor_completed` doing exactly its job. Counting correct output as a defect is the same disease that made `R_desugar` overstate its board by 7.6×, one size down.

#6420 separately proved the intersection rule can be weakened without moving any of these twelve. They are correct output, and now provably so under a weaker rule.

## The door is a declared type set — that is the whole design

`_designed_gap_types()` holds one entry today. **Membership is exact type identity** — not `isinstance`, and emphatically not "a `ValueError` out of this call", because `ExitSetFactoringGap` **is** a `ValueError` and the wider door would swallow every genuine `ValueError` bug raised anywhere under desugar. That is the failure this exists to prevent, not a corner of it. A subclass is a mechanism nobody declared and must earn its own line.

## Counted, never silent — which is why the census wiring is in this same commit

The axis routing rows out of `desugarDefects` while the census published no bucket would make twelve rows **vanish from the ledger entirely** — a free −12 bought by deleting the evidence, strictly worse than the miscount it replaces.

The census edit is **additive only**: 19 inserted lines, **zero deleted**.

- no existing key changes meaning — `desugarDefects` and its count keep exactly today's semantics
- `red_reasons` and the red predicate **untouched**; designed gaps are not red
- all three keys published — `desugarDesignedGaps`, `R_desugar_designed_gaps`, `desugarDesignedGapOwners` — **with members, not a bare cardinality**. `factoringGaps = 13` as a lone scalar once cost an owner a session with nothing to open.

## Evidence — a real census run, not a unit assertion

One-file corpus, census invoked as a subprocess, because `main` owns the aggregation and calling `_measure_file` would prove the axis while skipping the merge loop and the result row — which is exactly where a bucket goes missing.

```
R_desugar_defects          0
R_desugar_designed_gaps    1
owners                     {'ExitSetFactoringGap': 1}
members                    [('ExitSetFactoringGap', 'picker.py:1:0', 'stamped-not-separating')]
red                        0  []
```

The fixture is **written here, not lifted from a corpus**. Two branches assigning the same value merge on an equal destination — and it reproduces the real rows' classification exactly: `stamped-not-separating`, `mergedArm: True`, `ListValue`/`ListValue`, matching `test_categorical.py:2000`.

## Tests

Four twins on the axis, three end-to-end through the ledger. **Eight perturbations, every one caught by a named twin:**

| mutation | caught by |
|---|---|
| door widened to `isinstance` | `..._lying_a_subclass_is_a_different_mechanism` |
| door widened to `ValueError` | that one **and** `..._lying_an_undeclared_ValueError_is_still_a_defect` |
| gaps dropped instead of counted | six twins across both families |
| bucket not merged across files | `..._designed_gaps_survive_merge_and_stay_disjoint` |
| census merge loop drops the bucket | `..._reaches_the_ledger_with_its_members` |
| cardinality published without members | same |
| gaps folded back into the defect list | same |
| gaps made a red reason | same |

A clean corpus publishes `0` and `[]` rather than omitting the keys — a key that appears only when non-empty makes a clean run indistinguishable from an older census that never had the bucket.

The **twin-10 family is retargeted, not deleted**. It still owns the *reading* of carried testimony; twin 11 owns *which axis the row lands on*. Two laws, two twins.

## Reconciled with `ifexp-join`

They read 12/12 `stamped-not-separating`; I had reported 7 + 5. **At this head all 12 read `stamped-not-separating`, matching them exactly.** My earlier split predated #6393, which stamps `delete_binding` and moved 5 rows. Stale measurement, not a disagreement — and worth naming as one, since a stale classification quoted as the board is how a re-attribution turns into a fiction.

## Known inherited red

Three failures in `test_recensus_panic_collection.py` are pre-existing and identical at baseline — they need pytest fixtures (`monkeypatch`, a `workspace_root` kwarg) that the direct-invocation driver cannot supply. The pytest suite itself cannot run on this box: a session-autouse fixture resolves a Rust release binary, no cached artifact matches this tree's stamp, and seven concurrent `cargo` processes hold the build lock. CI is the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-attribute designed gaps from desugar defects into a separate non-red bucket
> - Exceptions recognized as designed gaps (declared type with a non-remaining-work verdict) are intercepted in `DesugarAxis.measure` and recorded in a new `designed_gaps` list instead of the defect axis, leaving red status unaffected.
> - Adds `_designed_gap_types` and `_is_designed_gap` helpers in [desugar_axis.py](https://github.com/TSavo/sugar/pull/6426/files#diff-881c3a69977ae00d55b817c4db3cf34ef4f1997c99e3ea9611429dc14c1e9ecf) to classify exceptions; `ExitSetFactoringGap` is the first declared type.
> - `DesugarAxis.row` and the recensus script now emit `desugarDesignedGaps`, `R_desugar_designed_gaps`, and `desugarDesignedGapOwners` in their output dicts.
> - New and updated tests in [test_desugar_axis_twins.py](https://github.com/TSavo/sugar/pull/6426/files#diff-10eb5ea731ca9e1a69546a25149a6b1aa4e7925e67769c5d2970fd46b1cb7155) and [test_designed_gaps_reach_the_ledger.py](https://github.com/TSavo/sugar/pull/6426/files#diff-23b4bd8694fbc3cb15ebbe04b98d142515c8c5cf2c3835d45f68b98319f02783) cover end-to-end reporting, merge behavior, and the remaining-work/undeclared-type boundaries.
> - Behavioral Change: stamped `ExitSetFactoringGap` exceptions that previously incremented the defect count (and could trigger red) now land exclusively in the designed-gaps bucket and never affect red status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a8c677.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->