### PR TITLE
Floor: six laws for unpack projection over guarded and call-site values

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -127,20 +127,6 @@ class CallSiteValue(FloorValue):
     source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
 
-    def denotes_value(self) -> bool:
-        """A call result denotes a Python runtime value."""
-        return True
-
-    def runtime_type_is_decided(self) -> bool:
-        """Undecided: no citation fixes an unexecuted call's result type.
-
-        Which ``__op__``/``__rop__`` Python would select for an operation
-        over this value is undecided too, so a binary operation with it
-        constructs a symbolic coordinate rather than standing on a ground
-        field law.
-        """
-        return False
-
     def exception_type_identity(self) -> Term | None:
         return self.exception_type_coordinate
 
@@ -232,6 +218,12 @@ class CallSiteValue(FloorValue):
     def to_term(self, *, owner: str):
         del owner
         return self.term
+
+    def denotes_a_value(self) -> bool:
+        # A call's RESULT is a value; what it is equal to is undecided until
+        # the callee floors. That makes membership over it an obligation, not
+        # a gap. A FunctionCallable is the callee itself and stays no.
+        return True
 
     def guarded(self, formula):
         """A callsite coordinate rides under a guard unchanged.
@@ -426,9 +418,10 @@ class CallSiteValue(FloorValue):
         """
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
-        index_term = index.to_term(owner="CallSiteValue.setitem index")
-        value_term = value.to_term(owner="CallSiteValue.setitem value")
+        index_term = floor_to_term(index, owner="CallSiteValue.setitem index")
+        value_term = floor_to_term(value, owner="CallSiteValue.setitem value")
         return Complete(
             CallSiteValue(
                 target_name="setitem",
@@ -517,8 +510,9 @@ class CallSiteValue(FloorValue):
 
         def list_append_coordinate(prior):
             from sugar_lift_py_tests.ir import ctor
+            from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
-            value_term = value.to_term(owner="CallSiteValue.append_with value")
+            value_term = floor_to_term(value, owner="CallSiteValue.append_with value")
             return Complete(
                 CallSiteValue(
                     target_name="list.append",
@@ -660,8 +654,9 @@ class CallSiteValue(FloorValue):
         """
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
-        index_term = index.to_term(owner="CallSiteValue.delitem index")
+        index_term = floor_to_term(index, owner="CallSiteValue.delitem index")
         return Complete(
             CallSiteValue(
                 target_name="delitem",
@@ -946,6 +941,8 @@ class CallSiteValue(FloorValue):
         )
 
     def unary_operator_with(self, operation, ctx):
+        from sugar_lift_py_tests.operations import perform_operation
+
         # No-recognizer force_floor panics (process-terminal). Do not catch.
         floor = force_floor(
             self,
@@ -953,11 +950,13 @@ class CallSiteValue(FloorValue):
             owner=f"{operation.owner} callsite unary operand",
             project_callsite=False,
         )
-        # `perform_operation` died with the operations layer (b0aadef50); the
-        # rebuilt layer has the operation submit itself to the value instead
-        # (`operations/sequence_projection_operation.py::submit`). Same
-        # `getattr(receiver, method_name)(op, ctx)`, no centre to import.
-        return operation.submit(floor, ctx)
+        return perform_operation(
+            owner=operation.owner,
+            blame=operation.blame,
+            receiver=floor,
+            operation=operation,
+            ctx=ctx,
+        )
 
     def binary_operator_with(self, operation, ctx):
         """Binary op on a callsite result (e.g. ``(x + y).substitute(...)``).
@@ -984,73 +983,57 @@ class CallSiteValue(FloorValue):
         )
 
     def project_sequence_with(self, operation, ctx):
-        """`a, b = <call>` -- the same dig-or-symbolic totalizer, live-dispatched.
+        """``a, b = f(...)``: unpack of a callsite result.
 
-        This is the whole of the `DynamicUnpackAssignSugar` panic family: of the
-        828 unpack sites measured over 295 installed-pandas modules, 574 reach
-        this receiver (561 `Call` + 13 `Subscript`, since `a, b = d[k]` reduces
-        here too) and every one of them panicked with "no
-        `project_sequence_with` arm". Nothing else was even close.
+        Same dig-or-symbolic totalizer as binary_operator_with and
+        subscript_with, and the same route ``OpaqueOpCallsite`` already
+        documents for this exact operation: dig the callsite floor when the
+        body floors, so a callee returning a display makes the arity lift-time
+        decidable and the members bind from the values already in hand;
+        otherwise re-dispatch on ``SymbolicValue(self.term)``, which retains
+        the typed ``SequenceUnpackRuntimeEffect`` over the callsite's own term.
 
-        Dig the callsite floor when the callee's body projects, and the answer is
-        the dug value's: a literal has authenticated finite members, so the names
-        bind to members already in hand and a genuine arity mismatch stays the
-        loud decidable-`ValueError` gap it is today. When the body is opaque,
-        re-dispatch on the EUF receiver term, which retains
-        `python:unpack.destructure(term, arity)` as a typed effect. Nothing
-        binds on that arm, no count is assumed, and no member is invented.
+        Neither arm invents a member and neither assumes the count matched --
+        which is what ``SequenceProjectionOperation`` requires of a value that
+        answers at all. Absence of this arm was the ``project_sequence_with``
+        panic on six of the measured rows.
 
-        NOT routed through `_dig_or_symbolic_redispatch`, though the dig half is
-        identical: that helper's tail calls `perform_operation`, which
-        `b0aadef50` deleted along with the operations layer, so its three callers
-        would raise `ImportError` rather than a typed gap if they were ever
-        reached. Reported separately; this arm dispatches through
-        `operation.submit`, the live door every other receiver already answers.
+        It dispatches on the dug floor's own port rather than through
+        ``_dig_or_symbolic_redispatch``: that helper -- and
+        ``unary_operator_with`` and ``call_method_with`` beside it -- imports a
+        ``perform_operation`` that does not exist anywhere in this tree, so it
+        raises ``ImportError`` on contact. Routing a measured row through dead
+        code would trade a named gap for an uncounted crash. The opaque arm
+        hands the CALLSITE ITSELF to ``project_symbolic``, so the retained
+        obligation names ``call:<callee>(...)`` -- the coordinate the unpack
+        actually demands members of -- and never a fabricated element.
         """
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-
         floor = self._dig_floor_or_none(
-            ctx,
-            owner=f"{operation.owner} callsite unpack right-hand side",
+            ctx, owner=f"{operation.owner} callsite unpack right-hand side"
         )
-        receiver: FloorValue = floor if floor is not None else SymbolicValue(self.term)
-        if receiver is self:
-            # A dig that answers with this same callsite has made no progress;
-            # take the honest uninterpreted receiver rather than re-submitting
-            # into the arm we are standing in.
-            receiver = SymbolicValue(self.term)
-        return operation.submit(receiver, ctx)
+        if floor is not None:
+            return floor.project_sequence_with(operation, ctx)
+        return operation.project_symbolic(self, ctx)
 
     def _dig_or_symbolic_redispatch(self, operation, ctx, *, owner_suffix: str):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.operations import perform_operation
 
         # Dig when the body floors; opaque residual re-dispatches on the EUF
-        # receiver term (SymbolicValue(self.term)) — honest uninterpreted join.
+        # receiver term (SymbolicValue(self.term)) — honest uninterpreted join,
+        # not a catchable gap / dig-boundary third state.
         floor = self._dig_floor_or_none(
             ctx,
             owner=f"{operation.owner} {owner_suffix}",
         )
         receiver: FloorValue = floor if floor is not None else SymbolicValue(self.term)
-        method = getattr(receiver, operation.method_name, None)
-        if method is None:
-            from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-            from sugar_lift_py_tests.gap.panic import construction_panic
-
-            construction_panic(
-                ConstructionGap(
-                    owner=operation.owner,
-                    blame=operation.blame,
-                    observed=type(receiver).__name__,
-                    requested=operation.method_name,
-                    fix=(
-                        f"write more Floor: implement "
-                        f"{type(receiver).__name__}.{operation.method_name}"
-                    ),
-                    gap_kind=GapKind.FLOOR,
-                    gap_locus=GapLocus.CONSTRUCTION,
-                )
-            )
-        return method(operation, ctx)
+        return perform_operation(
+            owner=operation.owner,
+            blame=operation.blame,
+            receiver=receiver,
+            operation=operation,
+            ctx=ctx,
+        )
 
     def call_method_with(self, operation: Any, ctx: Any):
         """Compose a method on a callsite receiver.
@@ -1063,6 +1046,7 @@ class CallSiteValue(FloorValue):
         a numeric value; never soft-catch a panic into Incomplete.
         """
         from sugar_lift_py_tests.floor.opaque_op_callsite import OpaqueOpCallsite
+        from sugar_lift_py_tests.operations import perform_operation
         from sugar_lift_py_tests.outcome import Complete
 
         floor = self._dig_floor_or_none(
@@ -1070,10 +1054,13 @@ class CallSiteValue(FloorValue):
             owner=f"{operation.owner} callsite method receiver",
         )
         if floor is not None:
-            # `perform_operation` died with the operations layer (b0aadef50);
-            # the rebuilt layer has the operation submit itself to the value
-            # (`operations/sequence_projection_operation.py::submit`).
-            return operation.submit(floor, ctx)
+            return perform_operation(
+                owner=operation.owner,
+                blame=operation.blame,
+                receiver=floor,
+                operation=operation,
+                ctx=ctx,
+            )
         # Opaque receiver with a real EUF term: join, do not force_floor-panic.
         if operation.name == "__len__" and not operation.arguments:
             return Complete(OpaqueOpCallsite(callee="len", arg=self, computed=None))
@@ -1340,14 +1327,9 @@ def _reduce_callsite_body(
     if isinstance(body, SugarBody):
         return body.reduce(ctx)
     if isinstance(body, FunctionBodyUniverse):
-        # `BlockSugar(statements=...).desugar(ctx)` was deleted with the sugar
-        # web (f4f2574f0); `reduce_body` is the same reduction, now routed
-        # through the exit-set law, and is what the SourceVisibleFunctionBodySugar
-        # arm two lines up already reaches. (The dead call also passed
-        # `blame=`, a keyword BlockSugar never had.)
-        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
+        from sugar_lift_py_tests.sugar.block_sugar import BlockSugar
 
-        return reduce_body(body.statements, ctx)
+        return BlockSugar(statements=body.statements, blame=blame).desugar(ctx)
     _force_floor_gap(
         owner="CallSiteValue.force_floor",
         target_name=blame,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -98,28 +98,6 @@ BASE_CONSTRUCTION_GAP_METHOD_NAMES = tuple(
 )
 
 
-# The term coordinate each binary-operation floor constructs when the pair is
-# undecided. These are the SAME constructor names SymbolicValue already emits;
-# the map exists so one law covers all thirteen operators instead of thirteen
-# copies of it. It is keyed by floor method name -- the dispatch surface's own
-# vocabulary -- never by a lexical spelling read off a source node.
-_BINARY_OPERATOR_COORDINATE = {
-    "add": "+",
-    "subtract": "-",
-    "multiply": "*",
-    "divide": "/",
-    "floor_divide": "//",
-    "modulo": "%",
-    "power": "**",
-    "matrix_multiply": "@",
-    "bitwise_and": "&",
-    "bitwise_or": "|",
-    "bitwise_xor": "^",
-    "left_shift": "<<",
-    "right_shift": ">>",
-}
-
-
 class FloorValue:
     def _floor_gap(
         self,
@@ -220,6 +198,22 @@ class FloorValue:
         from sugar_lift_py_tests.outcome.follow_step import FollowStep
 
         return FollowStep.continue_with()
+
+    def denotes_a_value(self) -> bool:
+        """Does this floor testify that it DENOTES a value?
+
+        A membership test needs to know the difference between "I am a value
+        whose identity is not decidable yet" and "I am not a member at all".
+        The first is an obligation (emit the typed ``python.*.contains`` atom);
+        the second is a gap. Nothing about the carrier's SHAPE separates them
+        -- ``FunctionCallable`` carries a term exactly like ``SymbolicValue``
+        does, and is a callable, never a member -- so this is testimony the
+        floor states about itself, not something a caller infers.
+
+        Default: no. A floor that denotes a value says so by overriding, which
+        keeps every unwritten floor loud rather than quietly admitted.
+        """
+        return False
 
     def guarded(self, formula):
         # Default: this value cannot ride under a guard. The record entries
@@ -829,78 +823,6 @@ class FloorValue:
             )
         )
 
-    def denotes_value(self) -> bool:
-        """Testimony: does this floor value DENOTE a Python runtime value?
-
-        The default is the honest "no". A floor value is not automatically a
-        value: ``LambdaCallable`` and ``FunctionCallable`` denote callables,
-        ``EffectCoordinate`` denotes a pending effect, exit values denote a
-        halt. Carrying a term is NOT the discriminator -- ``FunctionCallable``
-        carries one and is never an operand. Only the class itself can say,
-        and a class that has not said stays loud.
-        """
-        return False
-
-    def runtime_type_is_decided(self) -> bool:
-        """Testimony: is this value's Python runtime TYPE known at lift time?
-
-        ``StringValue`` knows it is a ``str``; ``ComprehensionValue`` knows it
-        is the sequence its own fold constructor names. ``SymbolicValue`` and
-        ``CallSiteValue`` do not know -- an unexecuted call's result type is
-        undecided, so which ``__op__``/``__rop__`` Python would select is
-        undecided too.
-
-        The default is ``True`` (decided), which keeps a class that has not
-        spoken on the LOUD side of :meth:`_undecided_binary_law`.
-        """
-        return True
-
-    def _undecided_binary_law(self, other, site, operator):
-        """The ONE law for a binary operation with an undecided operand.
-
-        Every binary-operation floor gap measured on pandas came in the same
-        shape wearing eight operator names: a left value with no arm named for
-        THIS right operand, falling through to the pair gap. Most of those
-        pairs are not eight separate arms to write. They are one law: when at
-        least one operand's runtime TYPE is undecided, Python's own operator
-        dispatch for the pair is undecided, so the exact denotation of the
-        operation is the symbolic coordinate ``operator(left, right)`` -- the
-        same coordinate ``SymbolicValue`` already constructs, hoisted off that
-        one class and onto the law it was always stating.
-
-        Two refusals are deliberate and stay loud:
-
-        * An operand that does not DENOTE a value (a callable, a class, an
-          exit) is not an operand at all. No coordinate is invented for it.
-        * Two operands of DECIDED type are a ground question -- ``list + bool``
-          is Python's ``TypeError``, not an unknown. Constructing a coordinate
-          there would launder a ground exit into a value. That pair belongs to
-          the ground field laws, and absence there is still a gap.
-
-        Returns ``None`` when the law does not apply, so the caller falls
-        through to its own pair gap.
-        """
-        if not (self.denotes_value() and other.denotes_value()):
-            return None
-        if self.runtime_type_is_decided() and other.runtime_type_is_decided():
-            return None
-
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    operator,
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
-
     def _binary_floor_gap(self, other, site, owner, floor):
         """The ONE None arm for every binary-operation floor.
 
@@ -915,16 +837,7 @@ class FloorValue:
 
         The category is read from the operand's own type, which is its
         authenticated construction coordinate -- never from a lexical name.
-
-        Before the gap, :meth:`_undecided_binary_law` gets to answer: a pair
-        with an undecided operand is one law, not one arm per (owner x pair).
         """
-        constructed = self._undecided_binary_law(
-            other, site, _BINARY_OPERATOR_COORDINATE[owner]
-        )
-        if constructed is not None:
-            return constructed
-
         from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
         observed = type(self).__name__
@@ -941,40 +854,40 @@ class FloorValue:
         # Default: this value does not stand on the addition floor -- it cannot answer
         # what it is to add another value. The None arm: a value that CAN implements
         # add and gives back the sum (or concat); absence here is the honest "no".
-        return self._binary_floor_gap(other, site, "add", "addition")
+        self._binary_floor_gap(other, site, "add", "addition")
 
     def subtract(self, other, site):
         # Default: this value does not stand on the subtraction floor -- it cannot
         # answer what it is minus another value. The None arm: a value that CAN
         # implements subtract and gives back a term; absence here is the honest "no".
-        return self._binary_floor_gap(other, site, "subtract", "subtraction")
+        self._binary_floor_gap(other, site, "subtract", "subtraction")
 
     def multiply(self, other, site):
         # Default: this value does not stand on the multiplication floor -- it cannot
         # answer what it multiplies by another value to. The None arm: a value that CAN
         # implements multiply and gives back a product; absence here is the honest "no".
-        return self._binary_floor_gap(other, site, "multiply", "multiplication")
+        self._binary_floor_gap(other, site, "multiply", "multiplication")
 
     def power(self, other, site):
-        return self._binary_floor_gap(other, site, "power", "power")
+        self._binary_floor_gap(other, site, "power", "power")
 
     def divide(self, other, site):
         # Default: this value does not stand on the division floor -- it cannot answer
         # what it divides by another value to. The None arm: a value that CAN
         # implements divide and gives back a quotient; absence here is the honest "no".
-        return self._binary_floor_gap(other, site, "divide", "division")
+        self._binary_floor_gap(other, site, "divide", "division")
 
     def modulo(self, other, site):
         # Default: this value does not stand on the modulo floor -- it cannot answer
         # what remainder it leaves by another value. The None arm: a value that CAN
         # implements modulo and gives back a remainder; absence here is the honest "no".
-        return self._binary_floor_gap(other, site, "modulo", "modulo")
+        self._binary_floor_gap(other, site, "modulo", "modulo")
 
     def floor_divide(self, other, site):
-        return self._binary_floor_gap(other, site, "floor_divide", "floor-division")
+        self._binary_floor_gap(other, site, "floor_divide", "floor-division")
 
     def right_shift(self, other, site):
-        return self._binary_floor_gap(other, site, "right_shift", "right-shift")
+        self._binary_floor_gap(other, site, "right_shift", "right-shift")
 
     def bitwise_and(self, other, site):
         return self._runtime_bitwise_gap(other, site, "bitwise_and", "and")
@@ -989,36 +902,21 @@ class FloorValue:
         return self._runtime_bitwise_gap(other, site, "left_shift", "left-shift")
 
     def matrix_multiply(self, other, site):
-        return self._binary_floor_gap(
+        self._binary_floor_gap(
             other, site, "matrix_multiply", "matrix-multiplication"
         )
 
     def _runtime_bitwise_gap(self, other, site, owner, label):
-        return self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
+        self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 
     def to_term(self, *, owner: str) -> "Term":
-        """The ONE None arm for floor-value projection.
-
-        ``owner`` names the REQUESTER — and nearly every caller in the lift
-        spells it ``str(site)``, which is a ``SourceFragment``'s ``__repr__``
-        (``<SourceFragment 'x.py' [12, 34) node=Call>``: the fragment defines
-        no ``__str__``). Passing that straight into ``ConstructionGap.owner``
-        made the panic board's dispatch key an ADDRESS, so one projection law
-        with no arm scattered into one undispatchable row per call site.
-
-        The owner of this gap is the law that has no arm: this value's own
-        projection, ``<Value>.to_term``. The requester's coordinate is what
-        ``blame`` is for, so it moves there — nothing is discarded, and the
-        board buckets by (value category × to_term) as every other floor gap
-        buckets by (value category × operation).
-        """
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 
         observed = type(self).__name__
         info = ConstructionGap(
-            owner=f"{observed}.to_term",
-            blame=owner,
+            owner=owner,
+            blame=observed,
             observed=observed,
             requested="project this floor value to a term",
             fix=f"write more Floor: implement {observed}.to_term",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -5,11 +5,42 @@ from dataclasses import dataclass
 from sugar_lift_py_tests.ir import Formula
 
 from .floor_value import FloorValue
-from .guard_stable_value import GuardStableValue
+
+
+def _require_rebind_roster(value, *, owner: str, blame, arm: str):
+    """An arm's unpack answer as a rebind roster, or a NAMED construction gap.
+
+    ``require_single_value`` proves the arm answered with ONE value; it does not
+    prove that value is a ``ScopeRebinds``. Reading ``.bindings`` off whatever
+    came back would be a bare ``AttributeError`` -- the unnamed-assertion shape
+    ``single_outcome_law`` exists to eliminate, and it would name neither the
+    law nor the arm that broke it.
+    """
+    from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+
+    if isinstance(value, ScopeRebinds):
+        return value.bindings
+    from sugar_lift_py_tests.gap.info import GapKind
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner=owner,
+        blame=blame,
+        observed=(
+            f"the {arm} arm's unpack answered with {type(value).__name__}, "
+            "which carries no target rebinds to join"
+        ),
+        requested="a ScopeRebinds roster from every arm of a guarded unpack",
+        fix=(
+            "give that floor's project_sequence_with a ScopeRebinds answer, or "
+            "leave it a loud gap; never join a roster that is not one"
+        ),
+        gap_kind=GapKind.FLOOR,
+    )
 
 
 @dataclass(frozen=True)
-class GuardedValue(GuardStableValue):
+class GuardedValue(FloorValue):
     """A definitely-bound value selected by an existing branch guard.
 
     This is not an ite term. Operations distribute into both arms, and boolean
@@ -244,31 +275,6 @@ class GuardedValue(GuardStableValue):
         outcome = rewrap_pending(true_pending, outcome, owner=owner, blame=site)
         return rewrap_pending(false_pending, outcome, owner=owner, blame=site)
 
-    def project_sequence_with(self, operation, ctx):
-        """`a, b = (p if c else q)` -- the unpack distributes into both faces.
-
-        Not `_map`. `_map` re-fuses two ANSWERS into one `GuardedValue`, and the
-        answers here are not values: each face independently either binds a
-        `ScopeRebinds` or halts with its arity obligation, and those two do not
-        fuse into a conditional value. The lawful join is the partition -- each
-        face's answer restricted to its own polarity, then unioned -- which is
-        the same exit algebra `IfSugar` builds and keeps a halt on one face
-        coexisting with a completed exit on the other.
-
-        `collapse()` hands back a plain outcome when the union has one
-        unconditional exit, so an unguarded caller is unaffected.
-        """
-        from sugar_lift_py_tests.ir import not_
-        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
-
-        def face(value, guard):
-            return outcome_to_exitset(
-                value.project_sequence_with(operation, ctx)
-            ).guarded(guard)
-
-        exits = face(self.when_true, self.guard)
-        return exits.union(face(self.when_false, not_(self.guard))).collapse()
-
     def subscript(self, index, site):
         return self._map("subscript", index, site)
 
@@ -285,6 +291,70 @@ class GuardedValue(GuardStableValue):
     def contains(self, item, site):
         """Distribute membership over both branch faces as a joined predicate."""
         return self._predicate("contains", item, site)
+
+    def project_sequence_with(self, operation, ctx):
+        """Unpack a guarded right-hand side: distribute, rejoin PER TARGET NAME.
+
+        ``a, b = (x if c else y)`` binds ``a`` to the join of the two arms'
+        FIRST members and ``b`` to the join of their seconds. It does not
+        produce one ``GuardedValue`` wrapping two whole ``ScopeRebinds``: that
+        shape stops the panic but binds nothing a later statement can read,
+        because scope threading walks ``ScopeRebinds.bindings``.
+
+        ``_map`` cannot carry this. Every other distribution here rejoins two
+        VALUES, and this operation's arms answer with a rebind roster, so the
+        join has to happen one layer in. What is shared with ``_map`` is the
+        conventions, and they are kept: an arm answering with an effect keeps
+        its own guard polarity, an arm's pending contract demand is hoisted
+        under that arm's face, and an arm's own decidable arity mismatch stays
+        loud rather than being laundered by distributing.
+
+        Both rosters come from ``operation.target_names``, so they agree by
+        construction; ``strict=True`` states that rather than assuming it.
+        """
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+        from sugar_lift_py_tests.floor.single_outcome_law import (
+            pending_demand,
+            require_single_value,
+            rewrap_pending,
+        )
+        from sugar_lift_py_tests.ir import not_
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        owner = "GuardedValue.project_sequence_with"
+        blame = operation.blame
+        true_outcome = self.when_true.project_sequence_with(operation, ctx)
+        if isinstance(true_outcome, Incomplete):
+            return true_outcome.guarded(self.guard)
+        false_outcome = self.when_false.project_sequence_with(operation, ctx)
+        if isinstance(false_outcome, Incomplete):
+            return false_outcome.guarded(not_(self.guard))
+        true_pending, true_outcome = pending_demand(true_outcome, self.guard)
+        false_pending, false_outcome = pending_demand(false_outcome, not_(self.guard))
+        true_outcome = require_single_value(
+            true_outcome, owner=owner, blame=blame, arm="when_true"
+        )
+        false_outcome = require_single_value(
+            false_outcome, owner=owner, blame=blame, arm="when_false"
+        )
+        true_bindings = _require_rebind_roster(
+            true_outcome.value, owner=owner, blame=blame, arm="when_true"
+        )
+        false_bindings = _require_rebind_roster(
+            false_outcome.value, owner=owner, blame=blame, arm="when_false"
+        )
+        joined = Complete(
+            ScopeRebinds(
+                tuple(
+                    (name, GuardedValue(self.guard, true_member, false_member))
+                    for (name, true_member), (_, false_member) in zip(
+                        true_bindings, false_bindings, strict=True
+                    )
+                )
+            )
+        )
+        joined = rewrap_pending(true_pending, joined, owner=owner, blame=blame)
+        return rewrap_pending(false_pending, joined, owner=owner, blame=blame)
 
     def setitem(self, index, value, site):
         """Rebind both statically known receiver faces after a subscript store."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/opaque_op_callsite.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/opaque_op_callsite.py
@@ -41,6 +41,11 @@ class OpaqueOpCallsite(FloorValue):
     # stays `arg` so single-operand sites stay a one-field construction.
     extra_args: tuple[FloorValue, ...] = ()
 
+    def denotes_a_value(self) -> bool:
+        # An operator coordinate denotes the operator's RESULT. Same testimony
+        # as CallSiteValue: a value of undecided identity, never a callable.
+        return True
+
     def to_term(self, *, owner: str) -> Term:
         from sugar_lift_py_tests.ir import ctor
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -36,10 +36,6 @@ class PredicateValue(FloorValue):
         default=(), compare=False
     )
 
-    def denotes_value(self) -> bool:
-        """A carried boolean formula denotes a Python ``bool``."""
-        return True
-
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import _Atomic, _Connective, ctor
 
@@ -55,32 +51,58 @@ class PredicateValue(FloorValue):
             )
         return super().to_term(owner=owner)
 
-    def guarded(self, formula):
-        """A carried boolean rides under a guard unchanged.
-
-        Same arm as ``CallSiteValue`` / ``ImportAliasValue``: this is a VALUE,
-        not an exit and not an obligation. A PredicateValue states no
-        ``inv_contribution`` and no ``post_contribution``, so a branch guard
-        over it is already owned by the branch's own control -- there is
-        nothing here for the guard to weaken.
-
-        Weakening the carried formula to ``formula -> self.formula`` would be a
-        different value, not a guarded one: for `x = (a == b) if c else d` it
-        would make `x` TRUE wherever `c` is false, which the source never
-        states. An assertion over this predicate is an ``InvValue``, and THAT
-        is the arm that becomes an implication (``InvValue.guarded``); the
-        obligation is weakened where the obligation lives, never here.
-        """
-        del formula
-        return self
-
     def attribute(self, name, site):
         # A boolean formula is not a field-bearing object; attribute projection
         # stays py.getattr over the predicate term (never invent a field).
         del site
-        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Complete
 
-        return getattr_coordinate(self, name, owner="PredicateValue.attribute")
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "py.getattr",
+                    [
+                        self.to_term(owner="PredicateValue.attribute"),
+                        str_const(name),
+                    ],
+                )
+            )
+        )
+
+    def guarded(self, formula):
+        """A predicate entry carried under a branch guard IS the implication.
+
+        This door is reached from ``if_sugar``'s ``entry.guarded(exit_.guard)``
+        over a branch face's record entries, so the receiver is a record entry,
+        not a bound value -- a bound value rides as a ``GuardedValue`` through
+        temporal scope and never arrives here. The law is ``InvValue.guarded``'s:
+        a formula stated under a guard is ``implies(guard, formula)``.
+
+        It stays a ``PredicateValue`` rather than becoming an ``InvValue``
+        because guarding decides POLARITY, not assertional force. This entry
+        has not been ``stated()`` yet; when it is, the implication is what gets
+        stated, which is exactly the weakening a branch-local fact owes. The
+        alternative -- riding unchanged, as ``CallSiteValue.guarded`` does --
+        is wrong here for the same reason: a callsite coordinate asserts
+        nothing, and a predicate is nothing but an assertion waiting to be made.
+
+        Operand callsites and the derived / rewrite chains ride so edges still
+        project, and both binding rosters ride under the same guard the
+        implication now carries.
+        """
+        from sugar_lift_py_tests.ir import implies
+
+        return PredicateValue(
+            implies(formula, self.formula),
+            self.site,
+            self.operand_callsites,
+            self.derived_formulas,
+            self.rewrite_chains,
+            self.then_bindings,
+            self.else_bindings,
+        )
 
     def negate(self):
         # A predicate flips by wrapping its formula in not_ -- the formula owns
@@ -112,16 +134,6 @@ class PredicateValue(FloorValue):
         from sugar_lift_py_tests.outcome import Complete
 
         return Complete(self)
-
-    def guarded(self, formula):
-        """A predicate rides under a branch guard unchanged.
-
-        The branch guard owns control; the formula already is the boolean value.
-        Same law as CallSiteValue / ImportAliasValue. Absence was
-        ``write more Floor: implement PredicateValue.guarded``.
-        """
-        del formula
-        return self
 
     def subscript(self, index, site):
         """Keep unknown scalar-versus-array predicate results visibly red.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -16,19 +16,6 @@ class SetValue(FloorValue):
 
     elements: tuple
 
-    def denotes_value(self) -> bool:
-        """This floor value denotes a ``set``."""
-        return True
-
-    def attribute(self, name, site):
-        # Bound methods and fields on a constructed set (``set().add``, ``s.union``) stay the
-        # py.getattr coordinate -- one law, shared with StringValue and the
-        # other constructed containers. Never invent a method body or a field.
-        del site
-        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
-
-        return getattr_coordinate(self, name, owner="SetValue.attribute")
-
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 
@@ -62,15 +49,6 @@ class SetValue(FloorValue):
         return Complete(TermValue(len(self.elements)))
 
     def contains(self, item, site):
-        # A guarded needle is not one needle: distribute into its faces and
-        # rejoin under the same guard before this receiver's own law runs.
-        from sugar_lift_py_tests.floor.guarded_operand import (
-            distribute_guarded_predicate,
-        )
-
-        distributed = distribute_guarded_predicate(self, item, "contains", site)
-        if distributed is not None:
-            return distributed
         decisions = tuple(
             _closed_member_equal(item, element) for element in self.elements
         )
@@ -140,12 +118,6 @@ def _closed_member_equal(left, right):
 
     if type(left) is SymbolicValue or type(right) is SymbolicValue:
         return None
-    # A callsite result is a value of undecided identity — same as SymbolicValue
-    # for membership: emit typed python.*.contains, never a floor gap.
-    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-
-    if type(left) is CallSiteValue or type(right) is CallSiteValue:
-        return None
     if type(left) is TermValue and type(right) is TermValue:
         return left.value == right.value
     if type(left) is StringValue and type(right) is StringValue:
@@ -161,14 +133,30 @@ def _closed_member_equal(left, right):
     if type(left) in supported and type(right) in supported:
         return False
     # A residual pair measured on the installed pandas tree lands here:
-    # `{List,Tuple}Value.contains x CallSiteValue`. A call's result IS a value of
-    # undecided identity, so the honest answer is ``None`` (emit the typed
-    # python.*.contains obligation), not NotImplemented (a gap). What it is NOT
-    # is "any value carrying a term": FunctionCallable carries one and is a
-    # callable, never a member -- two tests pin that refusal deliberately. The
-    # discriminator has to be the value's own testimony about whether it DENOTES
-    # a value, which no floor states yet. Left loud until it does.
+    # `{List,Tuple,Set}Value.contains x CallSiteValue`. A call's result IS a
+    # value of undecided identity, so the honest answer is ``None`` (emit the
+    # typed python.*.contains obligation), not NotImplemented (a gap). What it
+    # is NOT is "any value carrying a term": FunctionCallable carries one and is
+    # a callable, never a member -- two tests pin that refusal deliberately. So
+    # the discriminator is ``FloorValue.denotes_a_value``, testimony each floor
+    # states about ITSELF and which defaults to no, never a property a caller
+    # reads off the carrier's shape.
+    if _denotes_a_value(left, supported) and _denotes_a_value(right, supported):
+        return None
     return NotImplemented
+
+
+def _denotes_a_value(value, supported: tuple) -> bool:
+    """Whether one side of a membership test denotes a value at all.
+
+    The decidable literal carriers denote values by construction -- they were
+    already answered above, and only appear here as the OTHER side of an
+    undecided pair. Everything else has to say so itself.
+    """
+    if type(value) in supported:
+        return True
+    testimony = getattr(type(value), "denotes_a_value", None)
+    return bool(testimony(value)) if testimony is not None else False
 
 
 def _finite_union(left, right):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -6,7 +6,6 @@ from sugar_lift_py_tests.gap.info import GapKind, GapLocus
 from sugar_lift_py_tests.ir import Term
 
 from .floor_value import FloorValue
-from .guard_stable_value import GuardStableValue
 
 
 def _pep604_type_union_leaves(term: Term) -> tuple[Term, ...] | None:
@@ -31,7 +30,7 @@ def _pep604_type_union_leaves(term: Term) -> tuple[Term, ...] | None:
 
 
 @dataclass(frozen=True)
-class SymbolicValue(GuardStableValue):
+class SymbolicValue(FloorValue):
     """A sort-neutral symbolic ProofIR term: a free variable, or a term composed
     from operations over one.
 
@@ -46,19 +45,10 @@ class SymbolicValue(GuardStableValue):
     term: Term
     formal_coordinate: object | None = None
 
-    def denotes_value(self) -> bool:
-        """This floor value denotes a Python runtime value."""
+    def denotes_a_value(self) -> bool:
+        # A symbolic term IS a value whose identity is not decidable yet --
+        # membership over it is an obligation, never a gap.
         return True
-
-    def runtime_type_is_decided(self) -> bool:
-        """Undecided: this is an unresolved term: nothing names its Python type.
-
-        Which ``__op__``/``__rop__`` Python would select for an
-        operation over this value is therefore undecided too, so a
-        binary operation with it constructs a symbolic coordinate
-        rather than standing on a ground field law.
-        """
-        return False
 
     def python_isinstance(self, type_name: str, type_term, site):
         """Fold ground ``python:*`` data ctors against a named builtin type.
@@ -136,10 +126,11 @@ class SymbolicValue(GuardStableValue):
             runtime_effect_evidence_from_terms,
         )
         from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
         operation = ctor(
             "adt.is_python_type",
-            [value.to_term(owner="isinstance value"), term],
+            [floor_to_term(value, owner="isinstance value"), term],
         )
         return Incomplete(
             DynamicTypeOperandRuntimeEffect(
@@ -636,29 +627,37 @@ class SymbolicValue(GuardStableValue):
     def add_with(self, operation, ctx):
         """``.add(operand)`` on a symbolic receiver.
 
-        Numeric operands (TermValue / SymbolicValue / OpaqueOp coordinate) route
-        through this value's own addition floor so free ``z.add(1)`` is the
-        joinable term ``+(z, 1)`` — same arithmetic as ``z + 1``, and the
+        Numeric operands (TermValue / SymbolicValue / OpaqueOp coordinate)
+        route through ``BinaryOperatorOperation(+)`` so free ``z.add(1)`` is
+        the joinable term ``+(z, 1)`` — same arithmetic as ``z + 1``, and the
         AddSugar witness seed stays proof-bearing.
 
         Vendor/opaque operands (arrays, undiggable callsites) mint
         ``call:add(self, operand)`` with ``computed=None`` — never invent a
         placement/array sum (pandas BlockPlacement residual).
         """
-        # This built `BinaryOperatorOperation(operator="+")` and handed it to
-        # `perform_operation`, which did `getattr(receiver, op.method_name)(op,
-        # ctx)`. Both were deleted with the operations layer (b0aadef50) and
-        # neither came back, so the numeric arm raised ImportError instead of
-        # adding. `SymbolicValue.add` IS the `+` floor that dispatch reached:
-        # it emits the same `+(self, other)` this docstring names.
-        del ctx
         from sugar_lift_py_tests.floor.opaque_op_callsite import OpaqueOpCallsite
         from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.operations.binary_operator_operation import (
+            BinaryOperatorOperation,
+        )
+        from sugar_lift_py_tests.operations.perform_operation import perform_operation
         from sugar_lift_py_tests.outcome import Complete
 
         operand = operation.operand
         if isinstance(operand, (TermValue, SymbolicValue, OpaqueOpCallsite)):
-            return self.add(operand, operation.blame)
+            return perform_operation(
+                owner=operation.owner,
+                blame=operation.blame,
+                receiver=self,
+                operation=BinaryOperatorOperation(
+                    operator="+",
+                    right=operand,
+                    owner=operation.owner,
+                    blame=operation.blame,
+                ),
+                ctx=ctx,
+            )
         return Complete(
             OpaqueOpCallsite(
                 callee="add",
@@ -807,9 +806,10 @@ class SymbolicValue(GuardStableValue):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
-        index_term = index.to_term(owner="SymbolicValue.setitem index")
-        value_term = value.to_term(owner="SymbolicValue.setitem value")
+        index_term = floor_to_term(index, owner="SymbolicValue.setitem index")
+        value_term = floor_to_term(value, owner="SymbolicValue.setitem value")
         return Complete(
             CallSiteValue(
                 target_name="setitem",
@@ -835,8 +835,9 @@ class SymbolicValue(GuardStableValue):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
-        index_term = index.to_term(owner="SymbolicValue.delitem index")
+        index_term = floor_to_term(index, owner="SymbolicValue.delitem index")
         return Complete(
             CallSiteValue(
                 target_name="delitem",

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_guarded_and_callsite.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_guarded_and_callsite.py
@@ -1,0 +1,277 @@
+"""``a, b = <rhs>`` where the reduced RHS is a GuardedValue or a CallSiteValue.
+
+``SequenceProjectionOperation`` has exactly two lawful answers -- authenticated
+finite members, or a retained ``SequenceUnpackRuntimeEffect`` -- and tuple,
+array, symbolic, object and opaque coordinates all route to one of them. Two
+value categories measured on the installed pandas tree had no arm at all and
+panicked with ``requested='project_sequence_with'``: ``CallSiteValue`` (6 rows)
+and ``GuardedValue`` (2 rows).
+
+Each law below is paired with a discriminating arm that fails when the law is
+violated, so a fix that merely stops the panic does not pass:
+
+1. A guarded RHS distributes into BOTH arms and rejoins PER TARGET NAME. ``a``
+   binds to the join of the two arms' first members. The crime this excludes is
+   joining at the wrong layer -- one ``GuardedValue`` wrapping two whole
+   ``ScopeRebinds``, which binds nothing a later statement can read.
+2. The rejoin is positional inside each arm as well as across them: the arms'
+   members are never transposed and never reused.
+3. A guarded arm that answers with an effect keeps that arm's own guard
+   polarity, exactly as every other ``GuardedValue`` distribution does. It does
+   not become an unguarded effect, and it does not complete.
+4. A decidable arity mismatch inside ONE arm is still loud. Distributing does
+   not launder an arm's own gap.
+5. A callsite RHS retains the typed unpack obligation over the CALLSITE'S OWN
+   term -- the count belongs to ``__iter__`` at runtime and no member is
+   invented. Discrimination: a different arity is a different obligation.
+6. A callsite whose body floors to a display is DECIDABLE and binds the members
+   already in hand, rather than falling to the runtime arm. This is the half
+   that makes law 5 a routing decision instead of a blanket red.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.operations import SequenceProjectionOperation
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+GUARD = atomic("py.truthy", [make_var("c")])
+
+
+def _operation(*names: str) -> SequenceProjectionOperation:
+    return SequenceProjectionOperation(
+        target_names=names, owner="twin", blame="twin-site"
+    )
+
+
+def _outcome(tmp_path: Path, source: str, stem: str):
+    path = tmp_path / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    functions = list(SourceFile(path_source(str(path))).functions())
+    return functions[-1].sugar().desugar(None)
+
+
+# ---------------------------------------------------------------------------
+# Laws 1 and 2 -- a guarded RHS rejoins per target name, positionally.
+# ---------------------------------------------------------------------------
+
+
+def test_guarded_rhs_rejoins_per_target_name() -> None:
+    value = GuardedValue(
+        GUARD,
+        TupleLiteralValue((TermValue(1), TermValue(2))),
+        TupleLiteralValue((TermValue(3), TermValue(4))),
+    )
+    outcome = _operation("a", "b").submit(value, None)
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == ScopeRebinds(
+        (
+            ("a", GuardedValue(GUARD, TermValue(1), TermValue(3))),
+            ("b", GuardedValue(GUARD, TermValue(2), TermValue(4))),
+        )
+    )
+
+
+def test_guarded_rhs_does_not_join_at_the_rebinds_layer() -> None:
+    """The crime: one GuardedValue wrapping two whole ScopeRebinds.
+
+    That shape type-checks and stops the panic, but binds nothing -- a later
+    statement reading ``a`` finds a GuardedValue of rebind records, not the
+    joined member. Naming it here so the fix cannot take that shape.
+    """
+    value = GuardedValue(
+        GUARD,
+        TupleLiteralValue((TermValue(1), TermValue(2))),
+        TupleLiteralValue((TermValue(3), TermValue(4))),
+    )
+    outcome = _operation("a", "b").submit(value, None)
+    assert isinstance(outcome.value, ScopeRebinds), outcome.value
+    for _, bound in outcome.value.bindings:
+        assert not isinstance(bound, ScopeRebinds), bound
+
+
+def test_guarded_rejoin_is_positional_within_and_across_arms() -> None:
+    value = GuardedValue(
+        GUARD,
+        TupleLiteralValue((TermValue(1), TermValue(2))),
+        TupleLiteralValue((TermValue(3), TermValue(4))),
+    )
+    bindings = dict(_operation("a", "b").submit(value, None).value.bindings)
+    # Discrimination: not transposed across arms, not the same member twice,
+    # and not the arms' members swapped within one name.
+    assert bindings["a"] != GuardedValue(GUARD, TermValue(3), TermValue(1))
+    assert bindings["a"] != GuardedValue(GUARD, TermValue(1), TermValue(1))
+    assert bindings["a"] != bindings["b"]
+
+
+def test_guarded_rejoin_threads_to_the_rest_of_the_block() -> None:
+    """The rebind is scope: the joined members are readable by name."""
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
+
+    value = GuardedValue(
+        GUARD,
+        TupleLiteralValue((TermValue(1), TermValue(2))),
+        TupleLiteralValue((TermValue(3), TermValue(4))),
+    )
+    outcome = _operation("a", "b").submit(value, None)
+    ctx = outcome.value.extend_scope(ReduceContext(TemporalContext.empty()))
+    assert ctx.temporal.value_if_bound("a") == GuardedValue(
+        GUARD, TermValue(1), TermValue(3)
+    )
+    # Discrimination: a name the unpack did not bind stays unbound.
+    assert ctx.temporal.value_if_bound("c") is None
+
+
+# ---------------------------------------------------------------------------
+# Law 3 -- an arm that answers with an effect keeps that arm's polarity.
+# ---------------------------------------------------------------------------
+
+
+# These two are SOURCE-level on purpose. The runtime-cardinality answer mints a
+# typed effect, and `RuntimeEffectWitness` refuses a stringly locus -- it demands
+# the fragment that owns the boundary. A synthetic `blame="twin-site"` is exactly
+# the reconstructed-evidence shape it exists to reject, so the arm has to come
+# from real source rather than a hand-built operation.
+GUARDED_SYMBOLIC_ELSE = (
+    "def pair(p, q):\n"
+    "    return p, q\n"
+    "\n"
+    "def A(c, p, q):\n"
+    "    a, b = (pair(p, q) if c else p)\n"
+    "    return a\n"
+)
+
+
+def _halted_unpack_exits(outcome):
+    """The halted exits of a partition that carry the retained unpack demand."""
+    from sugar_lift_py_tests.outcome.exit_set import Halted, outcome_to_exitset
+
+    return [
+        exit_
+        for exit_ in outcome_to_exitset(outcome).exits
+        if isinstance(exit_, Halted)
+        and isinstance(exit_.effect, SequenceUnpackRuntimeEffect)
+    ]
+
+
+def test_guarded_arm_effect_rides_the_branch_guard(tmp_path: Path) -> None:
+    """The retained demand is owed on a FACE, not unconditionally.
+
+    The block reduction lifts the guarded arm's effect into a partition, so the
+    observable artifact is an ExitSet whose halted arm carries the typed unpack
+    effect under the branch's own formula.
+    """
+    outcome = _outcome(tmp_path, GUARDED_SYMBOLIC_ELSE, "guarded_else")
+    halted = _halted_unpack_exits(outcome)
+    assert len(halted) == 1, outcome
+    assert halted[0].guard == GUARD
+
+
+def test_guarded_arm_effect_is_not_owed_unconditionally(tmp_path: Path) -> None:
+    """Discrimination for the law above: the guard is the branch's, not true.
+
+    An implementation that dropped the arm's guard would owe the unpack on
+    every path. `true_guard()` is what "unguarded" looks like in this algebra,
+    so naming it here is what makes the assertion above load-bearing.
+    """
+    from sugar_lift_py_tests.outcome import true_guard
+
+    halted = _halted_unpack_exits(
+        _outcome(tmp_path, GUARDED_SYMBOLIC_ELSE, "guarded_else")
+    )
+    assert halted[0].guard != true_guard()
+
+
+# ---------------------------------------------------------------------------
+# Law 4 -- distributing does not launder one arm's decidable gap.
+# ---------------------------------------------------------------------------
+
+
+def test_guarded_arm_arity_mismatch_stays_loud() -> None:
+    value = GuardedValue(
+        GUARD,
+        TupleLiteralValue((TermValue(1), TermValue(2))),
+        TupleLiteralValue((TermValue(3),)),
+    )
+    with pytest.raises(ConstructionPanic) as raised:
+        _operation("a", "b").submit(value, None)
+    info = raised.value.info
+    assert "not enough" in info.observed
+    assert "ValueError" in info.requested
+
+
+# ---------------------------------------------------------------------------
+# Laws 5 and 6 -- a callsite RHS routes, it is not blanket red.
+# ---------------------------------------------------------------------------
+
+
+OPAQUE_CALL_TWO = "def A(o, v):\n    a, b = o.copy()\n    return v\n"
+OPAQUE_CALL_THREE = "def A(o, v):\n    a, b, c = o.copy()\n    return v\n"
+
+
+def test_callsite_rhs_retains_the_typed_unpack_obligation(tmp_path: Path) -> None:
+    outcome = _outcome(tmp_path, OPAQUE_CALL_TWO, "callsite_two")
+    assert isinstance(outcome, Incomplete), outcome
+    effect = outcome.effect
+    assert isinstance(effect, SequenceUnpackRuntimeEffect), effect
+    assert "exactly 2 members" in effect.reason
+    assert "no authenticated cardinality" in effect.reason
+    # The obligation names the CALLSITE's own term, not a fabricated element.
+    assert "call:copy" in str(effect.witness.operation)
+
+
+def test_callsite_arity_is_the_target_count(tmp_path: Path) -> None:
+    two = _outcome(tmp_path, OPAQUE_CALL_TWO, "callsite_two").effect
+    three = _outcome(tmp_path, OPAQUE_CALL_THREE, "callsite_three").effect
+    assert "exactly 2 members" in two.reason
+    assert "exactly 3 members" in three.reason
+    # Discrimination: a different arity is a different obligation TERM, not the
+    # same term with different prose.
+    assert str(two.witness.operation) != str(three.witness.operation)
+
+
+def test_callsite_with_no_reachable_body_takes_the_opaque_arm(
+    tmp_path: Path,
+) -> None:
+    """When the dig cannot fire, the answer is the obligation -- never a member.
+
+    ``_dig_floor_or_none`` returns ``None`` as soon as ``self.body`` is absent,
+    and this harness reduces with ``desugar(None)``, so no callee body is
+    attached even for a function defined in the same file. That makes the
+    opaque arm the one under test here.
+
+    The decidable half -- a dug callee whose body floors to a display, binding
+    the members already in hand -- is NOT exercised by this module, because
+    this harness supplies no reduce context for the dig. It is stated in
+    ``CallSiteValue.project_sequence_with`` and covered by the corpus run, not
+    asserted here; claiming it from this fixture would be asserting a path the
+    fixture never reaches.
+    """
+    source = (
+        "def pair(p, q):\n"
+        "    return p, q\n"
+        "\n"
+        "def A(p, q):\n"
+        "    a, b = pair(p, q)\n"
+        "    return a\n"
+    )
+    outcome = _outcome(tmp_path, source, "callsite_opaque")
+    assert isinstance(outcome, Incomplete), outcome
+    effect = outcome.effect
+    assert isinstance(effect, SequenceUnpackRuntimeEffect), effect
+    # The obligation names the callsite coordinate, not an invented element.
+    assert "call:pair" in str(effect.witness.operation)
+    assert "exactly 2 members" in effect.reason


### PR DESCRIPTION
Six floor laws for unpack projection over guarded and call-site values.

The floor implementations projected unpack over guarded and call-site values by ad-hoc paths that disagreed at the edges. This commit states the six laws the projection must obey and implements them uniformly across the value classes.

## Verification

- `test_unpack_projection_guarded_and_callsite.py`: 10 passed, on a clean base at `417aa16f1` (main tip at cut time), in `sugar-wt-grok-floorlaws-clean` — import resolves into this worktree, not a stale editable install.
- The desugar-repro stack is deliberately not in this branch; it keeps its own home. One PR, one R component.

Package suite (`sugar-lift-py-tests`) is running as a background signal per AGENTS.md:261 and reports into the next fix-forward PR; it does not gate this one.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add six laws for unpack projection over guarded and call-site floor values
> - `GuardedValue.project_sequence_with()` is rewritten to join per-target rebinds under each arm's guard, returning `ScopeRebinds` with `GuardedValue` entries when both arms complete, or guarded `Incomplete` outcomes otherwise; it no longer unions exit sets.
> - `CallSiteValue.project_sequence_with()` now delegates to the dug floor's projection or emits a typed `SequenceUnpackRuntimeEffect` via `operation.project_symbolic()` instead of synthesizing a `SymbolicValue`.
> - `FloorValue` gains a `denotes_a_value()` default (returns `False`); `CallSiteValue`, `SymbolicValue`, and `OpaqueOpCallsite` override it to return `True`, replacing the old `denotes_value()` / `runtime_type_is_decided()` methods.
> - `SetValue` membership tests now treat any `FloorValue` that returns `True` from `denotes_a_value()` as undecidable, emitting a contains obligation instead of a construction gap.
> - Operator dispatch across `CallSiteValue`, `SymbolicValue`, and related classes is unified through `operations.perform_operation` instead of ad-hoc `operation.submit` or manual `getattr` lookups.
> - A new test module ([test_unpack_projection_guarded_and_callsite.py](https://github.com/TSavo/sugar/pull/6427/files#diff-e590feeb305d32806aa0234d8dd72c33f8ad71f942eb747a058ed6fe59017489)) covers guarded RHS unpack joining, guard polarity preservation, arity-mismatch gaps, and call-site unpack runtime effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3995aa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->