### PR TITLE
No verdict is an INSTRUMENT defect, and the docstring stops claiming a type-only door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -24,7 +24,8 @@ them into ``R_desugar`` produces a number whose denominator is a lie:
                               cycle, effect with no occurrence coordinate).
 ``desugarDesignedGaps``       a DECLARED mechanism refusing on purpose, as its
                               correct answer, in something that is not a
-                              ``SugarNotWritten``. Counted under its own owner,
+                              ``SugarNotWritten`` — AND classifying as not
+                              remaining work. Counted under its own owner,
                               never red, never summed into the three above.
 
 The first two new collections make the final instrument exit RED. None of the
@@ -34,9 +35,16 @@ WHY THE FOURTH EXISTS. ``ExitSetFactoringGap`` is a ``ValueError``, so it landed
 in ``desugarDefects`` — twelve rows of the pandas board, every one classifying
 ``isRemainingWork: False``, which is ``factor_completed`` doing exactly its job.
 Counting correct output as a defect is the same disease that made ``R_desugar``
-overstate its board by 7.6x, at smaller scale. The door is by DECLARED TYPE and
-nothing else: see ``_designed_gap_types`` for why "a ValueError from this call"
-would have been a cure worse than the disease.
+overstate its board by 7.6x, at smaller scale.
+
+THE DOOR TAKES TWO CONDITIONS, and neither alone is enough. Type identity says
+which MECHANISM spoke — see ``_designed_gap_types`` for why it is an exact
+declared type and not ``isinstance``, and never "a ValueError from this call".
+The carried classification says whether THIS OCCURRENCE was that mechanism
+working — see ``_is_designed_gap``. Gating on type alone would file a producer
+that owns a split and never testified as a finished result, in a bucket that is
+never red. That is the same disease pointed the other way, and the worse
+direction: a wrong defect count is loud, a wrong designed-gap count is not.
 
 Row identity is the *effect occurrence*, not the enclosing function line. A
 function holding three distinct stores is three rows; the same occurrence
@@ -290,13 +298,23 @@ def _is_designed_gap(exc: BaseException) -> bool:
     """
     if type(exc) not in _designed_gap_types():
         return False
-    classify = getattr(exc, "classification", None)
-    if not callable(classify):
-        return False
-    verdict = classify()
+    verdict = _carried_verdict(exc)
     if verdict is None:
         return False
     return getattr(verdict, "is_remaining_work", True) is False
+
+
+def _carried_verdict(exc: BaseException):
+    """The verdict the exception itself carries, or ``None``. Never re-derived.
+
+    #6364 mints the classification as data ON the exception, off the arms it
+    already holds. Re-deriving it here would be a second classifier that can
+    disagree with the first, so this only READS.
+    """
+    classify = getattr(exc, "classification", None)
+    if not callable(classify):
+        return None
+    return classify()
 
 
 class DesugarAxis:
@@ -424,6 +442,21 @@ class DesugarAxis:
             # the second is the load-bearing one — see `_is_designed_gap`.
             if _is_designed_gap(exc):
                 self._designed_gap(where, exc)
+                return
+            # A DECLARED TYPE THAT CARRIES NO VERDICT IS NEITHER. The classifier
+            # is supposed to attach one, so its absence is a defect in the
+            # INSTRUMENT, not a finding about the code under measurement.
+            # Defaulting it into either bucket — quietly correct, or quietly a
+            # code defect — is the silent-lossy shape one level up from the one
+            # this door closes. It gets its own named kind and stays red.
+            if type(exc) in _designed_gap_types() and _carried_verdict(exc) is None:
+                self._defect(
+                    "instrument-gap",
+                    where,
+                    f"designed-gap-without-classification:{type(exc).__name__}: "
+                    f"{exc}",
+                    exc=exc,
+                )
                 return
             self._defect(
                 "desugar-exception", where, f"{type(exc).__name__}: {exc}", exc=exc

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -545,4 +545,12 @@ def test_twin_12_no_verdict_is_not_a_verdict_of_designed() -> None:
     row = axis.row()
     assert row["R_desugar_designed_gaps"] == 0
     assert len(row["desugarDefects"]) == 1
+    # NEITHER bucket on its merits: the classifier was supposed to attach a
+    # verdict, so its absence is a defect in the INSTRUMENT and says nothing
+    # about the code being measured. Named as such rather than filed as an
+    # ordinary desugar exception, which would blame the wrong thing.
+    assert row["desugarDefects"][0]["kind"] == "instrument-gap"
+    assert row["desugarDefects"][0]["detail"].startswith(
+        "designed-gap-without-classification:ExitSetFactoringGap"
+    )
     assert axis.red is True

--- a/implementations/python/sugar-lift-py-tests/tests/test_factoring_growth_is_linear.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factoring_growth_is_linear.py
@@ -5,9 +5,26 @@ into m ** k exit-level arms, because `sequence` appends every exit of the tail
 under every completed exit of the prefix. `factor_completed` fixed it by moving
 the partition onto the VALUE, so k steps contribute k guarded values to one arm.
 
-Any change to the exit algebra -- and in particular to what a merged arm RETAINS
-(#6336/#6420) -- can silently restore the exponential. A family that grows as
-factors are appended is `m ** k` under a new name.
+WHAT THIS GUARDS, AND WHAT IT DOES NOT. It covers `factor_completed`'s admission
+and how a factored family is built: a change there can silently restore the
+exponential, and a family that grows as factors are appended is `m ** k` under a
+new name.
+
+It does NOT cover what a merged arm RETAINS (#6336/#6420), and an earlier draft
+of this docstring claimed it did. Measured, not assumed: reverting `_merge_faces`
+to `return frozenset()` -- #6420's rule fully removed, and worse than the
+intersection that preceded it -- leaves both tests below GREEN, while
+`test_exit_set_partition_testimony.py` reds two. That surface is guarded there,
+by `test_a_disjoining_merge_keeps_every_side_either_contributor_could_be_on` and
+`test_a_merge_whose_arms_agree_KEEPS_the_face_they_share`.
+
+The reason is structural, and it is the trap below taken one turn further: the
+equal-destination merge only fires on EQUAL destinations, and the accumulation
+that makes the exponential reachable is exactly what makes every destination
+distinct. You cannot have both in one fold -- no accumulation, no exponential;
+accumulation, no merge. A retention guard therefore needs its own non-accumulating
+fold asserting on FACES RETAINED, because arm count cannot see it: with no
+accumulation the count is flat regardless of what the rule does.
 
 THE CONSTRAINT THAT MAKES THIS TEST REAL, and it is not obvious: a fold whose
 tail IGNORES the prefix value cannot blow up at all, no matter what the algebra


### PR DESCRIPTION
Follow-up to #6426 (merged as `f0e99b33b`). Two things the amended ruling asked for that the merged commit had not done.

## The docstring still asserted the rejected design

It said, in the module docstring:

> The door is by DECLARED TYPE and nothing else

That line was quoted back at me as evidence the door was type-only — and it was **fair evidence.** The routing condition had already been fixed to require the classification too, but the prose had not, so the file asserted the rejected design in the one place a reader looks first.

Prose that contradicts the code it documents is not cosmetic. It is what a reviewer trusts when deciding whether to read the routing condition at all — and in this case it cost a round trip. The module docstring now states **both** conditions and why neither alone is enough.

## A declared type carrying no verdict is neither bucket

The classifier is supposed to attach one, so its absence is a defect in the **instrument** — not a finding about the code under measurement.

It previously fell into `desugarDefects` as an ordinary `desugar-exception`. That is red, so it was never *silent* — but it **blamed the wrong party**: it read as "the measured code did something wrong" when what happened is "the classifier did not answer." It now takes the axis's existing `instrument-gap` kind with a message naming the condition, and stays red.

```
designed-gap-without-classification:ExitSetFactoringGap: ...
```

## One read of the exception's own data

`_carried_verdict` is split out so there is exactly one. #6364 mints the classification off the arms the exception already holds; a second derivation at the axis could disagree with the first, so this only reads and never re-derives.

## The ruling's named perturbation, run and reported

**Making the door type-only — literally the version originally approved — reds the lying twin:**

| mutation | twins that go red |
|---|---|
| **door type-only** | `..._a_declared_gap_that_is_REMAINING_WORK_stays_a_red_defect` **+ 3 others** |
| no-verdict filed as an ordinary defect | `..._no_verdict_is_not_a_verdict_of_designed` |
| verdict re-derived instead of read | 6 twins |

22 + 3 + 2 twins green on the rebased head. The census diff remains **additive with zero deletions**, and `gate13403` still reports `core/generic.py:13403` as correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record designed-gap exceptions without a carried verdict as instrument defects
> - Introduces a `_carried_verdict` helper in [desugar_axis.py](https://github.com/TSavo/sugar/pull/6429/files#diff-881c3a69977ae00d55b817c4db3cf34ef4f1997c99e3ea9611429dc14c1e9ecf) that safely retrieves the verdict from an exception's `classification()` method, returning `None` if absent.
> - Updates `_is_designed_gap` to delegate to `_carried_verdict` instead of inlining the callable check, and adds a docstring clarifying that declared type is necessary but not sufficient for a designed gap.
> - In `DesugarAxis.measure`, exceptions whose type matches a declared designed-gap type but carry no verdict are now recorded as `kind='instrument-gap'` with a `designed-gap-without-classification:{TypeName}` detail prefix, rather than falling through to the generic `desugar-exception` defect path.
> - Extends the test `test_twin_12_no_verdict_is_not_a_verdict_of_designed` to assert the new `instrument-gap` kind and detail prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9ed402.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of designed-gap outcomes by requiring both the declared exception type and its carried verdict to match.
  * Missing classifications are now recorded as instrumentation gaps instead of being treated as generic desugaring exceptions.
* **Tests**
  * Added coverage to verify correct defect reporting when a designed-gap outcome lacks a classification verdict.
* **Documentation**
  * Clarified guidance on designed-gap handling and classification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->