### PR TITLE
Seal a multi-face loop post-state as a partition, not a binary fold

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -164,6 +164,39 @@ def _decode_binding_entry(raw: Any) -> tuple[str, dict[str, Any]]:
         )
         for field in ("guardFormulaCid", "whenTrueStateCid", "whenFalseStateCid"):
             _require_cid(state[field], field)
+    elif kind == "loopProjected":
+        # A loop post-state carried into a later statement. The faces are the
+        # loop's own completion routes -- one per kind, no else-branch -- so the
+        # wire validates the partition rather than a binary fold.
+        state = _exact(
+            state, {"kind", "targetCid", "faces"}, "loopProjected BindingStateV1"
+        )
+        _require_cid(state["targetCid"], "targetCid")
+        if not isinstance(state["faces"], list) or not state["faces"]:
+            raise LoopWireError("loopProjected BindingStateV1 requires faces")
+        kinds = []
+        for face in state["faces"]:
+            face = _exact(
+                face,
+                {"completionKind", "guardFormulaCid", "stateCid", "exitPartitionArity"},
+                "loopProjected face",
+            )
+            if face["completionKind"] not in {
+                "BodyFallthrough",
+                "BreakExit",
+                "NormalExhaustion",
+            }:
+                raise LoopWireError("unknown loop completion kind")
+            for field in ("guardFormulaCid", "stateCid"):
+                _require_cid(face[field], field)
+            arity = face["exitPartitionArity"]
+            if arity is not None and not isinstance(arity, int):
+                raise LoopWireError("exitPartitionArity must be an int or null")
+            kinds.append(face["completionKind"])
+        if len(set(kinds)) != len(kinds):
+            raise LoopWireError("loopProjected faces must be one per completion kind")
+        if kinds != sorted(kinds):
+            raise LoopWireError("loopProjected faces must be completion-kind sorted")
     else:
         raise LoopWireError("unknown BindingStateV1 variant")
     return coordinate_cid, deepcopy(raw)

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_post_state_sealing_partition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_post_state_sealing_partition.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# A NAME CARRIED ACROSS TWO LOOPS. The second loop has to seal the first loop's
+# post-state, and a loop that can `break` leaves more than one completed face.
+#
+# `live_loop_construction._seal_runtime_state` handled exactly one of those
+# faces and refused the rest:
+#
+#     BindingStateWireGap: multi-face loop projected binding sealing is
+#     unimplemented; stays loud rather than fold a multi-way completion join
+#
+# The refusal was right to exist. Folding n faces into nested
+# `GuardedBindingStateV1` means picking an order and naming one face the
+# else-branch, which asserts a fallthrough the producer never declared -- the
+# same trap the same-type partition law refuses.
+#
+# THE MECHANISM IS TO SEAL THE FACES AS A PARTITION, not to fold them. Each
+# face keeps the guard formula CID the producer minted and the arity it
+# declared, keyed by the producer OCCURRENCE (`targetCid`) that minted them --
+# two loops in one function are two occurrences and share no exclusion.
+#
+# `test_two_sequential_breaking_loops_construct` is the discrimination tooth:
+# it raises `BindingStateWireGap` with the law removed and passes with it. Every
+# other test here perturbs exactly one admission criterion and asserts refusal,
+# so the end-to-end green cannot be bought by a permissive decoder.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.loop_construction import LoopWireError, _decode_binding_entry
+from sugar_source_tree.binding_provenance import (
+    BindingProvenanceGap,
+    LoopProjectedBindingStateV1,
+    LoopProjectedFaceV1,
+    _decode_state,
+    _state_wire,
+)
+
+_CID = "blake3-512:" + "ab" * 64
+_CID2 = "blake3-512:" + "cd" * 64
+_CID3 = "blake3-512:" + "ef" * 64
+
+# The shape of `pandas/util/_exceptions.py:37` generalized: one name written by
+# a loop that can `break`, then carried past it. Two sequential loops is the
+# smallest source that forces the SECOND loop to seal the FIRST loop's
+# multi-face post-state.
+TWO_LOOPS = """\
+def two_loops(xs, ys):
+    v = 0
+    for x in xs:
+        v = v + x
+        if x.stop:
+            break
+    for y in ys:
+        v = v + y
+        if y.stop:
+            break
+    del v
+    return 1
+"""
+
+
+def _desugar_all(path: Path) -> None:
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    for function in SourceFile(path_source(str(path))).functions():
+        sugar = function.sugar()
+        if sugar is not None:
+            sugar.desugar(None)
+
+
+def _face(kind: str, *, state_cid: str = _CID2, arity: int | None = 2):
+    return LoopProjectedFaceV1(kind, _CID3, state_cid, arity)
+
+
+def _two_faces():
+    return (_face("BreakExit"), _face("NormalExhaustion", state_cid=_CID))
+
+
+# --------------------------------------------------------------------------
+# end to end: the discrimination tooth
+# --------------------------------------------------------------------------
+
+
+def test_two_sequential_breaking_loops_construct(tmp_path):
+    """POSITIVE, end to end. Raises `BindingStateWireGap` without the law.
+
+    This is the reproducer the mechanism was built from, and it is the only
+    test here that fails when the sealing arm is removed -- the rest are
+    discriminators over the wire law.
+    """
+    path = tmp_path / "fixture.py"
+    path.write_text(TWO_LOOPS)
+    _desugar_all(path)
+
+
+def test_one_face_loop_still_collapses_to_its_face(tmp_path):
+    """A loop with no `break` exits only by exhaustion: still a direct seal.
+
+    Pins that the new arm did not swallow the single-face path. A one-face
+    projection is TOTAL, so it seals as its face's own state and mints no
+    partition -- if this started producing a `loopProjected` wire, every
+    existing single-face CID would have moved.
+    """
+    path = tmp_path / "fixture.py"
+    path.write_text(
+        "def one_loop(xs, ys):\n"
+        "    v = 0\n"
+        "    for x in xs:\n"
+        "        v = v + x\n"
+        "    for y in ys:\n"
+        "        v = v + y\n"
+        "    return v\n"
+    )
+    _desugar_all(path)
+
+
+# --------------------------------------------------------------------------
+# the sealed state is a partition, and it round-trips
+# --------------------------------------------------------------------------
+
+
+def test_wire_round_trips_and_keeps_arity_and_occurrence():
+    state = LoopProjectedBindingStateV1(_CID, _two_faces())
+    wire = _state_wire(state)
+    assert wire["kind"] == "loopProjected"
+    assert wire["targetCid"] == _CID
+    assert [face["completionKind"] for face in wire["faces"]] == [
+        "BreakExit",
+        "NormalExhaustion",
+    ]
+    assert _decode_state(wire) == state
+
+
+def test_arity_none_survives_the_wire():
+    """A producer that never stated a family size is carried, not defaulted.
+
+    `None` must stay `None`: inventing an arity here would let completeness be
+    claimed downstream by a face whose producer never declared one.
+    """
+    state = LoopProjectedBindingStateV1(
+        _CID, (_face("BreakExit", arity=None), _face("NormalExhaustion", arity=None))
+    )
+    wire = _state_wire(state)
+    assert [face["exitPartitionArity"] for face in wire["faces"]] == [None, None]
+    assert _decode_state(wire) == state
+
+
+def test_two_occurrences_with_identical_faces_are_different_states():
+    """The occurrence is load-bearing, not decoration.
+
+    Two loops in one function mint two partitions that share no exclusion. If
+    `targetCid` dropped out of the identity, the second loop's post-state would
+    be indistinguishable from the first's.
+    """
+    faces = _two_faces()
+    assert LoopProjectedBindingStateV1(_CID, faces) != LoopProjectedBindingStateV1(
+        _CID2, faces
+    )
+    assert _state_wire(LoopProjectedBindingStateV1(_CID, faces)) != _state_wire(
+        LoopProjectedBindingStateV1(_CID2, faces)
+    )
+
+
+# --------------------------------------------------------------------------
+# lying twins: each perturbs exactly one admission criterion
+# --------------------------------------------------------------------------
+
+
+def test_no_faces_is_refused():
+    with pytest.raises(BindingProvenanceGap, match="requires faces"):
+        LoopProjectedBindingStateV1(_CID, ())
+
+
+def test_repeated_completion_kind_is_refused():
+    """One face per completion kind, or it is not a partition.
+
+    Two `BreakExit` faces are two values claiming the same route -- exactly the
+    same-type pair the partition law refuses to read as an exclusion.
+    """
+    with pytest.raises(BindingProvenanceGap, match="one per completion kind"):
+        LoopProjectedBindingStateV1(_CID, (_face("BreakExit"), _face("BreakExit")))
+
+
+def test_unsorted_faces_are_refused():
+    """Canonical order, or the same partition has two CIDs."""
+    with pytest.raises(BindingProvenanceGap, match="completion-kind sorted"):
+        LoopProjectedBindingStateV1(
+            _CID, (_face("NormalExhaustion"), _face("BreakExit"))
+        )
+
+
+@pytest.fixture(scope="module")
+def coordinate_wire(tmp_path_factory):
+    """One real minted coordinate, reused as the carrier for wire tests.
+
+    The coordinate is not what these tests are about -- it has to be genuine
+    only so the decoder reaches the `state` field it IS about.
+    """
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.binding_provenance import BindingCoordinateV1
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path_factory.mktemp("coord") / "fixture.py"
+    path.write_text("def f(v):\n    return v\n")
+    function = next(iter(SourceFile(path_source(str(path))).functions()))
+    return BindingCoordinateV1.mint(_CID, function.fragment, ("v",)).wire()
+
+
+def _entry(coordinate_wire, state_wire):
+    """A minimally valid entry carrying `state_wire`, for the wire decoder."""
+    return {"coordinate": coordinate_wire, "state": state_wire}
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda w: w.update(faces=[]), "requires faces"),
+        (
+            lambda w: w["faces"][0].update(completionKind="LoopExit"),
+            "unknown loop completion kind",
+        ),
+        (
+            lambda w: w["faces"][0].update(completionKind="NormalExhaustion"),
+            "one per completion kind",
+        ),
+        (lambda w: w["faces"][0].update(guardFormulaCid="nope"), "guardFormulaCid"),
+        (lambda w: w["faces"][0].update(exitPartitionArity="2"), "exitPartitionArity"),
+        (lambda w: w.update(targetCid="nope"), "targetCid"),
+    ],
+    ids=[
+        "empty-faces",
+        "unknown-completion-kind",
+        "duplicate-completion-kind",
+        "guard-cid-not-a-cid",
+        "arity-not-an-int",
+        "occurrence-not-a-cid",
+    ],
+)
+def test_the_wire_decoder_refuses_each_perturbation(coordinate_wire, mutate, match):
+    """The loop wire is a second decoder, and it must refuse the same things.
+
+    `loop_construction._decode_binding_entry` validates the sealed wire
+    independently of the dataclass. A permissive decoder here would let a
+    malformed partition through the seal even though the constructor refuses it,
+    so every criterion is asserted on both sides.
+    """
+    wire = _state_wire(LoopProjectedBindingStateV1(_CID, _two_faces()))
+    mutate(wire)
+    with pytest.raises(LoopWireError, match=match):
+        _decode_binding_entry(_entry(coordinate_wire, wire))
+
+
+def test_the_wire_decoder_accepts_the_unperturbed_partition(coordinate_wire):
+    """Positive control for the refusals above.
+
+    Every test in the block above asserts a raise. Without this one, a decoder
+    that refused EVERY `loopProjected` wire would pass all of them.
+    """
+    wire = _state_wire(LoopProjectedBindingStateV1(_CID, _two_faces()))
+    coordinate_cid, decoded = _decode_binding_entry(_entry(coordinate_wire, wire))
+    assert decoded["state"] == wire
+    assert coordinate_cid

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -206,7 +206,57 @@ class GuardedBindingStateV1:
     when_false_state_cid: str
 
 
-BindingStateV1 = BoundBindingStateV1 | UnboundBindingStateV1 | GuardedBindingStateV1
+@dataclass(frozen=True)
+class LoopProjectedFaceV1:
+    """One sealed completed face of a loop post-state."""
+
+    completion_kind: str
+    guard_formula_cid: str
+    state_cid: str
+    exit_partition_arity: int | None = None
+
+
+@dataclass(frozen=True)
+class LoopProjectedBindingStateV1:
+    """A loop post-state sealed as an n-way partition, never folded to binary.
+
+    A multi-face loop post-binding is a genuine n-way join: the faces are the
+    loop's own completion routes, and no two of them hold at once. Folding them
+    into nested ``GuardedBindingStateV1`` would require picking an order and
+    naming one face the else-branch, which asserts a fallthrough the producer
+    never declared. The faces are therefore sealed AS a partition, keyed by the
+    producer occurrence that minted them.
+
+    ``target_cid`` is that occurrence. Two loops in one function are two
+    occurrences and share no exclusion, so a downstream consumer keying on
+    anything weaker (a name, a completion kind, a value type) is the exact trap
+    the same-type partition law refuses -- the identical reason
+    ``LoopGuardedProjection`` carries the same field.
+    """
+
+    target_cid: str
+    faces: tuple[LoopProjectedFaceV1, ...]
+
+    def __post_init__(self) -> None:
+        if not self.faces:
+            raise BindingProvenanceGap("loop projected state requires faces")
+        kinds = [face.completion_kind for face in self.faces]
+        if len(set(kinds)) != len(kinds):
+            raise BindingProvenanceGap(
+                "loop projected state faces must be one per completion kind"
+            )
+        if kinds != sorted(kinds):
+            raise BindingProvenanceGap(
+                "loop projected state faces must be completion-kind sorted"
+            )
+
+
+BindingStateV1 = (
+    BoundBindingStateV1
+    | UnboundBindingStateV1
+    | GuardedBindingStateV1
+    | LoopProjectedBindingStateV1
+)
 
 
 @dataclass(frozen=True)
@@ -371,6 +421,20 @@ def _state_wire(state: BindingStateV1) -> dict[str, Any]:
             "whenTrueStateCid": _cid(state.when_true_state_cid, "whenTrueStateCid"),
             "whenFalseStateCid": _cid(state.when_false_state_cid, "whenFalseStateCid"),
         }
+    if isinstance(state, LoopProjectedBindingStateV1):
+        return {
+            "kind": "loopProjected",
+            "targetCid": _cid(state.target_cid, "targetCid"),
+            "faces": [
+                {
+                    "completionKind": face.completion_kind,
+                    "guardFormulaCid": _cid(face.guard_formula_cid, "guardFormulaCid"),
+                    "stateCid": _cid(face.state_cid, "stateCid"),
+                    "exitPartitionArity": face.exit_partition_arity,
+                }
+                for face in state.faces
+            ],
+        }
     raise BindingProvenanceGap(f"unknown binding state {type(state).__name__}")
 
 
@@ -395,6 +459,33 @@ def _decode_state(raw: object) -> BindingStateV1:
             _cid(raw["whenTrueStateCid"], "whenTrueStateCid"),
             _cid(raw["whenFalseStateCid"], "whenFalseStateCid"),
         )
+    if kind == "loopProjected":
+        raw = _exact(
+            raw, {"kind", "targetCid", "faces"}, "loopProjected BindingStateV1"
+        )
+        if not isinstance(raw["faces"], list):
+            raise BindingProvenanceGap("loop projected faces must be an array")
+        faces = []
+        for item in raw["faces"]:
+            item = _exact(
+                item,
+                {"completionKind", "guardFormulaCid", "stateCid", "exitPartitionArity"},
+                "loopProjected face",
+            )
+            arity = item["exitPartitionArity"]
+            if arity is not None and not isinstance(arity, int):
+                raise BindingProvenanceGap("exitPartitionArity must be an int or null")
+            faces.append(
+                LoopProjectedFaceV1(
+                    item["completionKind"],
+                    _cid(item["guardFormulaCid"], "guardFormulaCid"),
+                    _cid(item["stateCid"], "stateCid"),
+                    arity,
+                )
+            )
+        return LoopProjectedBindingStateV1(
+            _cid(raw["targetCid"], "targetCid"), tuple(faces)
+        )
     raise BindingProvenanceGap("unknown BindingStateV1 variant")
 
 
@@ -415,6 +506,8 @@ __all__ = [
     "BoundBindingStateV1",
     "ConstructedValueTestimonyV1",
     "GuardedBindingStateV1",
+    "LoopProjectedBindingStateV1",
+    "LoopProjectedFaceV1",
     "SubstitutionTraceRecordV1",
     "SubstitutionTraceV1",
     "UnboundBindingStateV1",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -13,7 +13,11 @@ from sugar_lift_py_tests.loop_construction import (
     seal_loop_record,
 )
 
-from .binding_provenance import _state_wire
+from .binding_provenance import (
+    LoopProjectedBindingStateV1,
+    LoopProjectedFaceV1,
+    _state_wire,
+)
 from .binding_state import (
     BindingEntryV1,
     BindingMap,
@@ -90,14 +94,29 @@ def _seal_runtime_state(state):
         # NormalExhaustion, so that face's LoopBindingRef IS the unconditional
         # post-value (the ref itself carries the completion identity). Seal it
         # directly. A multi-face projection (a loop that can break) is a genuine
-        # multi-way join whose binary-guarded folding is not yet built -- it
-        # stays LOUD rather than guess a fallthrough and bind the wrong value.
+        # multi-way join. It is sealed AS a partition over the loop's own
+        # completion routes rather than folded into nested binary guards: a
+        # fold has to pick an order and name one face the else-branch, which
+        # asserts a fallthrough the producer never declared. Each face keeps
+        # the guard formula CID the producer minted and the arity it declared,
+        # so completeness travels instead of being reconstructed downstream.
         if len(state.completed_faces) == 1:
             return _seal_runtime_state(state.completed_faces[0].state)
-        raise BindingStateWireGap(
-            "multi-face loop projected binding sealing is unimplemented; "
-            "stays loud rather than fold a multi-way completion join"
+        faces = tuple(
+            sorted(
+                (
+                    LoopProjectedFaceV1(
+                        face.completion_kind,
+                        face.guard_formula_cid,
+                        cid_of_json(_state_wire(_seal_runtime_state(face.state))),
+                        face.exit_partition_arity,
+                    )
+                    for face in state.completed_faces
+                ),
+                key=lambda face: face.completion_kind,
+            )
         )
+        return LoopProjectedBindingStateV1(state.target_cid, faces)
     raise BindingStateWireGap(
         f"live loop state has no authenticated sealed projection: "
         f"{type(state).__name__}"


### PR DESCRIPTION
Seal a multi-face loop post-state as a partition, not a binary fold

A name written by a loop that can `break` and then carried into a later
loop leaves a `LoopProjectedBinding` with more than one completed face.
`_seal_runtime_state` sealed exactly one of them and refused the rest:

  BindingStateWireGap: multi-face loop projected binding sealing is
  unimplemented; stays loud rather than fold a multi-way completion join

The refusal was right to exist. Folding n faces into nested
`GuardedBindingStateV1` requires picking an order and naming one face the
else-branch, which asserts a fallthrough the producer never declared --
the same trap the same-type partition law refuses.

THE MECHANISM SEALS THE FACES AS A PARTITION. `LoopProjectedBindingStateV1`
carries one face per completion kind, each keeping the guard formula CID
the producer minted and the arity it declared, keyed by the producer
OCCURRENCE. Two loops in one function are two occurrences and share no
exclusion, which is why `targetCid` is part of the identity -- the same
reason `LoopGuardedProjection` already carries it. `None` arity stays
`None`; completeness is never invented for a producer that declared no
family size.

The wire law is enforced on BOTH decoders. `loop_construction` validates
the sealed wire independently of the dataclass, and the reproducer -- not
inspection -- is what found it: the first fix moved the failure from
`BindingStateWireGap` to `LoopWireError: unknown BindingStateV1 variant`.
A permissive second decoder would have admitted a malformed partition the
constructor refuses.

The single-face path is untouched. A loop with no `break` exits only by
`NormalExhaustion`, so that face is TOTAL and still seals directly; had
it started minting partitions, every existing single-face CID would have
moved.

REPRODUCER, and it is the discrimination tooth:

  def two_loops(xs, ys):
      v = 0
      for x in xs:
          v = v + x
          if x.stop:
              break
      for y in ys:
          v = v + y
          if y.stop:
              break
      del v
      return 1

Replacing the sealing arm with a raise fails exactly one node -- the
end-to-end one -- and leaves the other fourteen green: 1 failed, 14
passed. The twin is not ceremony.

GATE, own-baseline, both halves in separate detached worktrees at
e0350dc43, one pinned SUGAR_BIN sha256 5a04851c933a5fae..., mechanism
count asserted per half (head 2, base 0) before and after each run:

  head  1575 collected  132 failed  1429 passed  9 skipped  5 errors
  base  1560 collected  132 failed  1414 passed  9 skipped  5 errors

  failing node sets: 137 vs 137, IDENTICAL both directions
  passed delta:      +15, exactly this commit's new tests
  crash/timeout:     10 vs 10, unchanged
                     (grep -cE "Terminated|DEADLINE|TimeoutExpired|FileTimeout")

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal multi-face loop post-state as a `LoopProjectedBindingStateV1` partition instead of raising an error
> - Adds `LoopProjectedFaceV1` and `LoopProjectedBindingStateV1` dataclasses to [binding_provenance.py](https://github.com/TSavo/sugar/pull/6430/files#diff-31a51c7781695c73ae1a14807ce7047e4b99d195b5d82fed68253687a818e78a), representing a loop post-state sealed as a partition over completion routes (e.g. `BodyFallthrough`, `BreakExit`, `NormalExhaustion`).
> - Updates `_seal_runtime_state` in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6430/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) to build a `LoopProjectedBindingStateV1` for multi-face projections rather than raising `BindingStateWireGap`; single-face projections still collapse as before.
> - Extends wire encoding (`_state_wire`) and decoding (`_decode_state`) to handle the new `loopProjected` kind, including per-face validation of CIDs, arity, uniqueness, and sort order.
> - Adds corresponding decoder support in [loop_construction.py](https://github.com/TSavo/sugar/pull/6430/files#diff-82ae08e844ec0a3ad333125f7e4a0609af140be5e2413837fe63ad5a63de3bbc) and a comprehensive test suite in [test_loop_post_state_sealing_partition.py](https://github.com/TSavo/sugar/pull/6430/files#diff-4f4d10084dffdc3852748ac578c4a7f0f58a2454299e6c5da553e013762c01d4) covering round-trip encoding, construction errors, and wire decoding errors.
> - Behavioral Change: multi-face `LoopProjectedBinding` now produces a `loopProjected` wire state instead of raising an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a96a3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->