### PR TITLE
Restore the undecided-binary-operand law that #6427 wrote over

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -127,6 +127,20 @@ class CallSiteValue(FloorValue):
     source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
 
+    def denotes_value(self) -> bool:
+        """A call result denotes a Python runtime value."""
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        """Undecided: no citation fixes an unexecuted call's result type.
+
+        Which ``__op__``/``__rop__`` Python would select for an operation
+        over this value is undecided too, so a binary operation with it
+        constructs a symbolic coordinate rather than standing on a ground
+        field law.
+        """
+        return False
+
     def exception_type_identity(self) -> Term | None:
         return self.exception_type_coordinate
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -98,6 +98,28 @@ BASE_CONSTRUCTION_GAP_METHOD_NAMES = tuple(
 )
 
 
+# The term coordinate each binary-operation floor constructs when the pair is
+# undecided. These are the SAME constructor names SymbolicValue already emits;
+# the map exists so one law covers all thirteen operators instead of thirteen
+# copies of it. It is keyed by floor method name -- the dispatch surface's own
+# vocabulary -- never by a lexical spelling read off a source node.
+_BINARY_OPERATOR_COORDINATE = {
+    "add": "+",
+    "subtract": "-",
+    "multiply": "*",
+    "divide": "/",
+    "floor_divide": "//",
+    "modulo": "%",
+    "power": "**",
+    "matrix_multiply": "@",
+    "bitwise_and": "&",
+    "bitwise_or": "|",
+    "bitwise_xor": "^",
+    "left_shift": "<<",
+    "right_shift": ">>",
+}
+
+
 class FloorValue:
     def _floor_gap(
         self,
@@ -823,6 +845,78 @@ class FloorValue:
             )
         )
 
+    def denotes_value(self) -> bool:
+        """Testimony: does this floor value DENOTE a Python runtime value?
+
+        The default is the honest "no". A floor value is not automatically a
+        value: ``LambdaCallable`` and ``FunctionCallable`` denote callables,
+        ``EffectCoordinate`` denotes a pending effect, exit values denote a
+        halt. Carrying a term is NOT the discriminator -- ``FunctionCallable``
+        carries one and is never an operand. Only the class itself can say,
+        and a class that has not said stays loud.
+        """
+        return False
+
+    def runtime_type_is_decided(self) -> bool:
+        """Testimony: is this value's Python runtime TYPE known at lift time?
+
+        ``StringValue`` knows it is a ``str``; ``ComprehensionValue`` knows it
+        is the sequence its own fold constructor names. ``SymbolicValue`` and
+        ``CallSiteValue`` do not know -- an unexecuted call's result type is
+        undecided, so which ``__op__``/``__rop__`` Python would select is
+        undecided too.
+
+        The default is ``True`` (decided), which keeps a class that has not
+        spoken on the LOUD side of :meth:`_undecided_binary_law`.
+        """
+        return True
+
+    def _undecided_binary_law(self, other, site, operator):
+        """The ONE law for a binary operation with an undecided operand.
+
+        Every binary-operation floor gap measured on pandas came in the same
+        shape wearing eight operator names: a left value with no arm named for
+        THIS right operand, falling through to the pair gap. Most of those
+        pairs are not eight separate arms to write. They are one law: when at
+        least one operand's runtime TYPE is undecided, Python's own operator
+        dispatch for the pair is undecided, so the exact denotation of the
+        operation is the symbolic coordinate ``operator(left, right)`` -- the
+        same coordinate ``SymbolicValue`` already constructs, hoisted off that
+        one class and onto the law it was always stating.
+
+        Two refusals are deliberate and stay loud:
+
+        * An operand that does not DENOTE a value (a callable, a class, an
+          exit) is not an operand at all. No coordinate is invented for it.
+        * Two operands of DECIDED type are a ground question -- ``list + bool``
+          is Python's ``TypeError``, not an unknown. Constructing a coordinate
+          there would launder a ground exit into a value. That pair belongs to
+          the ground field laws, and absence there is still a gap.
+
+        Returns ``None`` when the law does not apply, so the caller falls
+        through to its own pair gap.
+        """
+        if not (self.denotes_value() and other.denotes_value()):
+            return None
+        if self.runtime_type_is_decided() and other.runtime_type_is_decided():
+            return None
+
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    operator,
+                    [
+                        self.to_term(owner=str(site)),
+                        other.to_term(owner=str(site)),
+                    ],
+                )
+            )
+        )
+
     def _binary_floor_gap(self, other, site, owner, floor):
         """The ONE None arm for every binary-operation floor.
 
@@ -838,6 +932,12 @@ class FloorValue:
         The category is read from the operand's own type, which is its
         authenticated construction coordinate -- never from a lexical name.
         """
+        constructed = self._undecided_binary_law(
+            other, site, _BINARY_OPERATOR_COORDINATE[owner]
+        )
+        if constructed is not None:
+            return constructed
+
         from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
         observed = type(self).__name__
@@ -854,40 +954,40 @@ class FloorValue:
         # Default: this value does not stand on the addition floor -- it cannot answer
         # what it is to add another value. The None arm: a value that CAN implements
         # add and gives back the sum (or concat); absence here is the honest "no".
-        self._binary_floor_gap(other, site, "add", "addition")
+        return self._binary_floor_gap(other, site, "add", "addition")
 
     def subtract(self, other, site):
         # Default: this value does not stand on the subtraction floor -- it cannot
         # answer what it is minus another value. The None arm: a value that CAN
         # implements subtract and gives back a term; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "subtract", "subtraction")
+        return self._binary_floor_gap(other, site, "subtract", "subtraction")
 
     def multiply(self, other, site):
         # Default: this value does not stand on the multiplication floor -- it cannot
         # answer what it multiplies by another value to. The None arm: a value that CAN
         # implements multiply and gives back a product; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "multiply", "multiplication")
+        return self._binary_floor_gap(other, site, "multiply", "multiplication")
 
     def power(self, other, site):
-        self._binary_floor_gap(other, site, "power", "power")
+        return self._binary_floor_gap(other, site, "power", "power")
 
     def divide(self, other, site):
         # Default: this value does not stand on the division floor -- it cannot answer
         # what it divides by another value to. The None arm: a value that CAN
         # implements divide and gives back a quotient; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "divide", "division")
+        return self._binary_floor_gap(other, site, "divide", "division")
 
     def modulo(self, other, site):
         # Default: this value does not stand on the modulo floor -- it cannot answer
         # what remainder it leaves by another value. The None arm: a value that CAN
         # implements modulo and gives back a remainder; absence here is the honest "no".
-        self._binary_floor_gap(other, site, "modulo", "modulo")
+        return self._binary_floor_gap(other, site, "modulo", "modulo")
 
     def floor_divide(self, other, site):
-        self._binary_floor_gap(other, site, "floor_divide", "floor-division")
+        return self._binary_floor_gap(other, site, "floor_divide", "floor-division")
 
     def right_shift(self, other, site):
-        self._binary_floor_gap(other, site, "right_shift", "right-shift")
+        return self._binary_floor_gap(other, site, "right_shift", "right-shift")
 
     def bitwise_and(self, other, site):
         return self._runtime_bitwise_gap(other, site, "bitwise_and", "and")
@@ -902,12 +1002,12 @@ class FloorValue:
         return self._runtime_bitwise_gap(other, site, "left_shift", "left-shift")
 
     def matrix_multiply(self, other, site):
-        self._binary_floor_gap(
+        return self._binary_floor_gap(
             other, site, "matrix_multiply", "matrix-multiplication"
         )
 
     def _runtime_bitwise_gap(self, other, site, owner, label):
-        self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
+        return self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 
     def to_term(self, *, owner: str) -> "Term":
         from sugar_lift_py_tests.gap.panic import construction_panic

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -36,6 +36,10 @@ class PredicateValue(FloorValue):
         default=(), compare=False
     )
 
+    def denotes_value(self) -> bool:
+        """A carried boolean formula denotes a Python ``bool``."""
+        return True
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import _Atomic, _Connective, ctor
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -16,6 +16,10 @@ class SetValue(FloorValue):
 
     elements: tuple
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a ``set``."""
+        return True
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -45,6 +45,20 @@ class SymbolicValue(FloorValue):
     term: Term
     formal_coordinate: object | None = None
 
+    def denotes_value(self) -> bool:
+        """This floor value denotes a Python runtime value."""
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        """Undecided: this is an unresolved term: nothing names its Python type.
+
+        Which ``__op__``/``__rop__`` Python would select for an
+        operation over this value is therefore undecided too, so a
+        binary operation with it constructs a symbolic coordinate
+        rather than standing on a ground field law.
+        """
+        return False
+
     def denotes_a_value(self) -> bool:
         # A symbolic term IS a value whose identity is not decidable yet --
         # membership over it is an obligation, never a gap.


### PR DESCRIPTION
**Main is red right now.** #6415 landed the undecided-binary-operand law; **#6427 removed it, without a conflict, and nothing objected.**

On pristine `origin/main`, no edits:

```
grep -c "denotes_value|runtime_type_is_decided|_undecided_binary_law"  floor/floor_value.py  ->  0
pytest tests/test_undecided_binary_operand_law.py                      ->  30 failed, 7 passed
```

## Five files lost content, all to `a3aa03d10`

| file | lost |
|---|---|
| `floor/floor_value.py` | the operator map, both testimony methods, `_undecided_binary_law`, the gap hook, and the `return` on all ten binary arms |
| `floor/symbolic_value.py` | `denotes_value` + `runtime_type_is_decided` |
| `floor/call_site_value.py` | `denotes_value` + `runtime_type_is_decided` |
| `floor/set_value.py` | `denotes_value` |
| `floor/predicate_value.py` | `denotes_value` |

Every binop pair the law retired was panicking again on main.

## This is not the stale-base merge it looks like

`git merge-base --is-ancestor 14fef8fcd a3aa03d10^` confirms **#6415 IS in #6427's base.** #6427's own commit message names the real cause:

> Run on the clean main base (**417aa16f1**, no desugar-repro stack)

`417aa16f1` **predates** `14fef8fcd`. The work was *developed* against a main without the law and then *written over* a main that had it. A whole-file overwrite, so git recorded 130 deletions on `floor_value.py` and produced no conflict to review.

## Restored as a pure addition, not a revert

#6427's six unpack-projection laws are good work and are **untouched** here -- `tests/test_unpack_projection_guarded_and_callsite.py` passes alongside. The diff against main is `+146 / -10`, and the 10 are the `return` statements being restored to the binary arms.

## Evidence

```
                                            base (f0e99b33b)    head
test_undecided_binary_operand_law.py        30 failed           0 failed  (37 pass)
test_unpack_projection_guarded_and_callsite  pass                pass
test_none_attribute_floor.py                 pass                pass
test_complex_field_arithmetic_floor.py       pass                pass
test_floor_panic_tail_owners.py              6 failed            6 failed  (inherited)
                                            ------------        ----------
                                            37 failed / 74      6 failed / 105
```

**Delta: −31 failures, zero new.** The remaining 6 are inherited at pristine main and untouched by this branch; one of them (`test_a_partition_still_has_nowhere_to_carry_a_demand`) is a real conservation hole I have a separate fix for and will land next.

## The fifth drop today, and a different shape

Four earlier drops were **squashes taking a snapshot one commit early** -- a *handoff* failure, which pinning the merged branch SHA catches.

**This one had the right SHA and stale file CONTENT.** Pinning the SHA would not have caught it. What catches this shape is running the *merged tree's* tests, or flagging a merge that deletes lines no commit on the branch ever touched. Worth treating as its own instrument.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore the undecided-binary-operand law for `FloorValue` binary operations
> - Restores a law (overwritten in #6427) that handles binary operations where both operands denote runtime values but at least one operand's runtime type is undecided.
> - `FloorValue._binary_floor_gap` now attempts `_undecided_binary_law` first, returning `Complete(SymbolicValue(...))` for undecided-type operand pairs instead of always raising a construction panic.
> - Adds `denotes_value()` and `runtime_type_is_decided()` methods to `CallSiteValue`, `PredicateValue`, `SetValue`, and `SymbolicValue` so the undecided-binary-operand check works correctly.
> - Fixes several binary operation methods (`add`, `subtract`, `multiply`, etc.) that were not returning the result of `_binary_floor_gap`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d95646.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->