### PR TITLE
Locus authority: an installed file is addressed by the seat its distribution recorded

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -289,11 +289,35 @@ def _ast_site_prevalence(path: Path) -> Counter[str]:
     return sites
 
 
+def locus_root_for_corpus(corpus_root: Path) -> Path:
+    """The root a corpus's source LOCUS is stated against.
+
+    Distinct from the corpus root, which is the demand-table denominator --
+    WHICH TREE is measured. They were one variable, and that conflation is what
+    made this census mint addresses no other checkout resolves: measuring
+    ``.../site-packages/pandas`` rooted at itself states ``core/frame.py``,
+    one of several addresses for one file.
+
+    For an installed corpus the answer is the install root its distribution
+    recorded seats against, read from the distribution's own manifest by the
+    same walk the seat law uses -- so this driver and that law cannot disagree.
+    Computing it any other way would be a second addressing convention.
+
+    For a first-party tree no distribution states an address, and the corpus
+    root stands unchanged.
+    """
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    installed = install_root_for(str(corpus_root))
+    return corpus_root if installed is None else Path(installed)
+
+
 def _measure_file(
     path: Path,
     *,
     relative: str,
     workspace_root: Path,
+    locus_root: Path | None = None,
     contract_refs=None,
     on_function: "Callable[[int, int, str, float | None], None] | None" = None,
 ) -> dict[str, Any]:
@@ -324,6 +348,10 @@ def _measure_file(
             "never from the measured file's parent directory"
         )
     root = workspace_root
+    # The demand table comes from the corpus root; the LOCUS is stated against
+    # the root its seats were recorded against. Same value for a first-party
+    # tree, different for an installed one.
+    address_root = locus_root if locus_root is not None else workspace_root
 
     def tally_construction(
         kind: str, node: object | None = None, line: object = "?"
@@ -345,7 +373,7 @@ def _measure_file(
         try:
             source_file = open_source_file_for_construction(
                 path,
-                root=root,
+                root=address_root,
                 reporter=reporter,
                 construction_context=construction_context,
                 populate_derived=True,
@@ -582,6 +610,21 @@ def main() -> int:
         f"{corpus_root.name}/{path.resolve().relative_to(corpus_root).as_posix()}": path
         for path in paths
     }
+    # TWO ROOTS, not one. They were the same variable, and that conflation is
+    # what made the census mint addresses no other checkout resolves.
+    #
+    #   corpus_root  the demand-table denominator -- WHICH TREE is measured.
+    #   locus_root   the address the source locus is stated against.
+    #
+    # For a first-party tree they coincide. For an INSTALLED corpus they must
+    # not: seats are recorded relative to the install root, so measuring
+    # `.../site-packages/pandas` rooted at itself mints `core/frame.py` -- one
+    # of several addresses for one file, resolvable in no other checkout.
+    #
+    # The install root is read from the distribution's own manifest, by the
+    # same walk the seat law uses, so the driver and the law cannot disagree.
+    # Computing it any other way would be a second addressing convention.
+    locus_root = locus_root_for_corpus(corpus_root)
     workspace_root = corpus_root
 
     file_names = sorted(by_file)
@@ -797,6 +840,7 @@ def main() -> int:
                     path,
                     relative=relative,
                     workspace_root=workspace_root,
+                    locus_root=locus_root,
                     contract_refs=contract_refs,
                     on_function=_on_function,
                 )
@@ -1063,10 +1107,7 @@ def main() -> int:
         "desugarDesignedGaps": desugar_designed_gaps,
         "R_desugar_designed_gaps": len(desugar_designed_gaps),
         "desugarDesignedGapOwners": dict(
-            Counter(
-                str(gap.get("owner", "?"))
-                for gap in desugar_designed_gaps
-            )
+            Counter(str(gap.get("owner", "?")) for gap in desugar_designed_gaps)
         ),
         # #6329 -- an arm reaching a dispatch target that does not exist. Its
         # own axis: never semantic R, never quietly a backend defect.
@@ -1093,9 +1134,7 @@ def main() -> int:
                 "R_control_effect": r_construction + len(defects),
                 "R_desugar": r_desugar,
                 "R_backend_defects": r_backend,
-                "R_cm_derived_contract": int(
-                    cm_resolutions.get("derived-contract", 0)
-                ),
+                "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
                 "desugarConstructionPanics": len(desugar_construction_panics),
                 "desugarDefects": len(desugar_defects),
                 "constructionPanics": len(construction_panics),

--- a/implementations/python/sugar-lift-py-tests/tests/test_recorded_seat_locus_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recorded_seat_locus_authority.py
@@ -1,0 +1,211 @@
+"""An installed file's address is the seat its distribution recorded.
+
+`is_absolute()` is a string test standing in for a property. The law it serves
+is "another checkout can resolve this address"; what it checks is "this string
+starts with a slash". Those come apart, and the gap is one character wide:
+
+    workspace_path_source(".../site-packages/pandas/core/frame.py", root="/")
+      -> "Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py"
+
+That locus is exactly as machine-specific and unresolvable as the absolute path
+it came from, and the absolute-locus law accepts it. Every intermediate root is
+the same defect in milder form, so a fix that catches only `/` is a special
+case rather than a law.
+
+An installed distribution states the answer itself: its RECORD lists the seat of
+every file it installed. This module pins that the locus must EQUAL that seat.
+
+Scope is the other half of the law and is pinned just as hard: a first-party
+file has no RECORD, so this arm must NOT fire there. A refusal is never widened
+to a population that cannot satisfy it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import (
+    SourceUnavailable,
+    recorded_seat_for,
+    workspace_path_source,
+)
+
+
+def _installed_file():
+    """One file of an installed distribution, with the seat it recorded."""
+    from importlib.metadata import distribution
+
+    dist = distribution("pandas")
+    recorded = [f for f in (dist.files or []) if str(f).endswith("frame.py")]
+    if not recorded:
+        pytest.skip("installed distribution records no frame.py to address")
+    seat = str(recorded[0])
+    return Path(dist.locate_file(recorded[0])).resolve(), seat
+
+
+def _install_root(path: Path, seat: str) -> Path:
+    """The directory the seat is stated relative to."""
+    return Path(str(path)[: -len(seat) - 1])
+
+
+# -- the truthful arm: the recorded root mints the recorded seat ---------------
+
+
+def test_the_install_root_mints_exactly_the_recorded_seat() -> None:
+    path, seat = _installed_file()
+
+    _source, locus, _cid = workspace_path_source(
+        str(path), root=str(_install_root(path, seat))
+    )
+
+    assert locus == seat
+    assert not Path(locus).is_absolute()
+
+
+def test_the_seat_is_read_from_the_distribution_not_guessed() -> None:
+    path, seat = _installed_file()
+
+    assert recorded_seat_for(str(path)) == seat
+
+
+# -- the lying arms: every root that produces a non-seat is refused -----------
+
+
+def test_the_root_slash_bypass_is_refused() -> None:
+    """THE REPRODUCER. `root=/` strips the leading slash and nothing else.
+
+    The result passes `is_absolute()` while being exactly as unresolvable as
+    the absolute path. This is the arm the whole change exists for.
+    """
+    path, _seat = _installed_file()
+
+    with pytest.raises(SourceUnavailable) as raised:
+        workspace_path_source(str(path), root="/")
+
+    message = str(raised.value)
+    assert "records the seat" in message
+    assert "no other checkout resolves" in message
+
+
+def test_every_intermediate_root_is_refused_too() -> None:
+    """A fix that catches only `/` would be a special case, not a law.
+
+    Each of these yields a shorter, equally unresolvable address for the same
+    file. Asserted as an exact count so this cannot pass by refusing nothing.
+    """
+    path, seat = _installed_file()
+    install_root = _install_root(path, seat)
+    intermediate = [install_root / part for part in Path(seat).parts[:-1]]
+    assert (
+        len(intermediate) >= 2
+    ), "need at least two intermediate roots to discriminate"
+
+    refused = 0
+    for root in intermediate:
+        with pytest.raises(SourceUnavailable):
+            workspace_path_source(str(path), root=str(root))
+        refused += 1
+
+    assert refused == len(intermediate)
+
+
+def test_one_file_no_longer_has_several_accepted_addresses() -> None:
+    """The property, stated directly: exactly ONE root is accepted."""
+    path, seat = _installed_file()
+    install_root = _install_root(path, seat)
+    roots = [install_root, Path("/")] + [
+        install_root / part for part in Path(seat).parts[:-1]
+    ]
+
+    accepted = []
+    for root in roots:
+        try:
+            accepted.append(workspace_path_source(str(path), root=str(root))[1])
+        except SourceUnavailable:
+            pass
+
+    assert accepted == [seat]
+    assert len(accepted) == 1
+
+
+# -- scope: a population that cannot satisfy the law is not subject to it ------
+
+
+def test_a_first_party_file_is_untouched_under_any_root(tmp_path) -> None:
+    """No RECORD states an address for it, so the workspace law is its whole law."""
+    package = tmp_path / "pkg"
+    package.mkdir()
+    source = package / "module.py"
+    source.write_text("x = 1\n", encoding="utf-8")
+
+    assert recorded_seat_for(str(source)) is None
+
+    for root, expected in ((tmp_path, "pkg/module.py"), (package, "module.py")):
+        _source, locus, _cid = workspace_path_source(str(source), root=str(root))
+        assert locus == expected
+
+
+def test_an_unrecorded_file_inside_an_install_root_is_not_claimed(tmp_path) -> None:
+    """A stray in an install root has no seat, so nothing is authenticated.
+
+    `None` here means "no distribution states an address for this file", never
+    "the seat is unavailable, carry on with a guess".
+    """
+    dist_info = tmp_path / "somepkg-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "RECORD").write_text("somepkg/kept.py,,\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: somepkg\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = tmp_path / "somepkg"
+    package.mkdir()
+    (package / "kept.py").write_text("x = 1\n", encoding="utf-8")
+    stray = package / "stray.py"
+    stray.write_text("y = 2\n", encoding="utf-8")
+
+    assert recorded_seat_for(str(stray)) is None
+    _source, locus, _cid = workspace_path_source(str(stray), root=str(tmp_path))
+    assert locus == "somepkg/stray.py"
+
+
+def test_a_recorded_file_in_that_same_root_IS_claimed(tmp_path) -> None:
+    """The discrimination for the test above: recorded and unrecorded differ.
+
+    Without this pair, `recorded_seat_for` returning None for everything would
+    satisfy the stray test and silently disable the whole law.
+    """
+    dist_info = tmp_path / "somepkg-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "RECORD").write_text("somepkg/kept.py,,\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: somepkg\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = tmp_path / "somepkg"
+    package.mkdir()
+    kept = package / "kept.py"
+    kept.write_text("x = 1\n", encoding="utf-8")
+
+    assert recorded_seat_for(str(kept)) == "somepkg/kept.py"
+
+    _source, locus, _cid = workspace_path_source(str(kept), root=str(tmp_path))
+    assert locus == "somepkg/kept.py"
+
+    with pytest.raises(SourceUnavailable):
+        workspace_path_source(str(kept), root=str(package))
+
+
+# -- the second gate is unchanged ---------------------------------------------
+
+
+def test_the_outside_root_refusal_still_fires_first(tmp_path) -> None:
+    """A path with no relative name at all is still the original loud refusal."""
+    source = tmp_path / "module.py"
+    source.write_text("x = 1\n", encoding="utf-8")
+    elsewhere = tmp_path.parent / "definitely-not-the-root-xyz"
+
+    with pytest.raises(SourceUnavailable) as raised:
+        workspace_path_source(str(source), root=str(elsewhere))
+
+    assert "lies outside workspace root" in str(raised.value)

--- a/implementations/python/sugar-lift-py-tests/tests/test_recorded_seat_locus_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recorded_seat_locus_authority.py
@@ -209,3 +209,58 @@ def test_the_outside_root_refusal_still_fires_first(tmp_path) -> None:
         workspace_path_source(str(source), root=str(elsewhere))
 
     assert "lies outside workspace root" in str(raised.value)
+
+
+# -- the driver must root where the seats were recorded -----------------------
+
+
+def _driver():
+    """The authoritative scoreboard's own rooting decision."""
+    import importlib.util
+    import sys
+
+    path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "control_effect_recensus.py"
+    )
+    spec = importlib.util.spec_from_file_location("_recensus_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_driver_roots_an_installed_corpus_at_the_install_root() -> None:
+    """The break this law would otherwise cause, pinned at its source.
+
+    The scoreboard is invoked with the package directory as its corpus, so
+    before this split it rooted the locus at `.../site-packages/pandas` and
+    minted `core/frame.py`. A driver that never runs is not obviously broken,
+    so the rooting is pinned here rather than left to the law's refusal.
+    """
+    path, seat = _installed_file()
+    install_root = _install_root(path, seat)
+    package_directory = install_root / Path(seat).parts[0]
+
+    assert _driver().locus_root_for_corpus(package_directory) == install_root
+    assert package_directory != install_root, "the two roots must actually differ"
+
+
+def test_the_rooted_corpus_then_mints_a_seat() -> None:
+    """The composition, end to end: root the driver's way, get a recorded seat."""
+    path, seat = _installed_file()
+    install_root = _install_root(path, seat)
+    package_directory = install_root / Path(seat).parts[0]
+
+    locus_root = _driver().locus_root_for_corpus(package_directory)
+    _source, locus, _cid = workspace_path_source(str(path), root=str(locus_root))
+
+    assert locus == seat
+
+
+def test_the_driver_leaves_a_first_party_corpus_root_alone(tmp_path) -> None:
+    """No distribution states an address for it, so the corpus root stands."""
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "module.py").write_text("x = 1\n", encoding="utf-8")
+
+    assert _driver().locus_root_for_corpus(package) == package

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -21,10 +21,12 @@
 from __future__ import annotations
 
 import importlib.machinery
+import importlib.metadata
 import os
 import sys
 from collections import OrderedDict
-from pathlib import Path
+from functools import lru_cache
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from . import typed_node_api as typed
@@ -187,7 +189,89 @@ def workspace_path_source(path: str, *, root: str) -> tuple[str, str, str]:
         raise SourceUnavailable(
             f"source `{path}` lies outside workspace root `{root}`: {exc}"
         ) from exc
-    return (source, relative.as_posix(), source_cid)
+    locus = relative.as_posix()
+    require_recorded_seat(path, locus)
+    return (source, locus, source_cid)
+
+
+def require_recorded_seat(path: str, locus: str) -> None:
+    """For an installed file, the locus must BE the seat its distribution recorded.
+
+    ``is_absolute()`` is a string test standing in for a property. The law it
+    serves is "another checkout can resolve this address"; what it checks is
+    "this string starts with a slash". Strip the slash and the two come apart::
+
+        workspace_path_source(".../site-packages/pandas/core/frame.py", root="/")
+          -> "Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py"
+
+    That locus is exactly as machine-specific and unresolvable as the absolute
+    path it was derived from, and ``is_absolute()`` accepts it. So does every
+    intermediate root: ``root=.../pandas`` yields ``core/frame.py`` and
+    ``root=.../pandas/core`` yields ``frame.py`` -- three different addresses
+    for one file, all accepted, none of them what any other checkout would
+    resolve.
+
+    An installed distribution states the answer itself. Its RECORD lists the
+    seat of every file it installed, relative to the install root, and
+    ``dependency_artifact.py`` rejects an absolute seat structurally rather
+    than by string inspection. So for a file the RECORD covers, the locus is
+    decidable: it must EQUAL that seat, or the door refuses by name.
+
+    Scoped to sources that HAVE a RECORD. A first-party file has no
+    distribution, so the workspace-relative law remains its whole law and this
+    arm never fires -- a refusal is not widened to a population that cannot
+    satisfy it. A file inside an install root that the RECORD does not cover
+    (a stray, a build artifact) has no seat to be checked against, so there is
+    nothing to authenticate and nothing is claimed.
+    """
+    seat = recorded_seat_for(path)
+    if seat is None or locus == seat:
+        return
+    raise SourceUnavailable(
+        f"source `{path}` is installed and its distribution records the seat "
+        f"`{seat}`, but this locus states `{locus}`. An installed file's "
+        "address is the seat its distribution recorded -- a locus derived from "
+        "some other root is not a different spelling of that address, it is an "
+        "address no other checkout resolves. Open it relative to the install "
+        "root, or through the module door."
+    )
+
+
+def recorded_seat_for(path: str) -> str | None:
+    """The seat this file's distribution recorded for it, or ``None``.
+
+    ``None`` means "no distribution states an address for this file" -- a
+    first-party source, or a file no RECORD covers. It never means "the seat
+    is unavailable, carry on with a guess".
+    """
+    resolved = Path(path).resolve()
+    for parent in resolved.parents:
+        seats = _recorded_seats(str(parent))
+        if seats is None:
+            continue
+        candidate = resolved.relative_to(parent).as_posix()
+        return candidate if candidate in seats else None
+    return None
+
+
+@lru_cache(maxsize=16)
+def _recorded_seats(install_root: str) -> frozenset[str] | None:
+    """Every seat recorded by the distributions installed at ``install_root``.
+
+    ``None`` when this directory is not an install root at all. Cached per
+    root: a corpus run asks once per directory, not once per file.
+    """
+    root = Path(install_root)
+    try:
+        if not any(root.glob("*.dist-info")):
+            return None
+    except OSError:
+        return None
+    seats: set[str] = set()
+    for distribution in importlib.metadata.distributions(path=[install_root]):
+        for recorded in distribution.files or ():
+            seats.add(PurePosixPath(str(recorded)).as_posix())
+    return frozenset(seats)
 
 
 def dependency_artifact_file(path: str) -> tuple[bytes, str, str]:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -237,6 +237,41 @@ def require_recorded_seat(path: str, locus: str) -> None:
     )
 
 
+def install_root_for(path: str) -> str | None:
+    """The directory this file's seat is stated relative to, or ``None``.
+
+    A driver measuring an installed corpus needs the SAME root the RECORD
+    states seats against, or it mints an address the seat law refuses. Deriving
+    it here -- from the distribution's own manifest, by the same walk
+    ``recorded_seat_for`` uses -- means the driver and the law cannot disagree.
+    A driver that computed the root some other way would be a second addressing
+    convention, which is the thing we are avoiding.
+
+    Accepts a file or a directory, because a corpus driver is handed a package
+    directory (``.../site-packages/pandas``) and must root at the install root
+    (``.../site-packages``) that its seats are stated against.
+
+    ``None`` means no distribution states an address for anything here, so the
+    caller's own root stands.
+    """
+    resolved = Path(path).resolve()
+    for parent in resolved.parents:
+        seats = _recorded_seats(str(parent))
+        if seats is None:
+            continue
+        candidate = resolved.relative_to(parent).as_posix()
+        if candidate in seats:
+            return str(parent)
+        # A directory is inside the distribution when it is the stated parent
+        # of at least one recorded seat. Checked against the manifest, never
+        # inferred from the directory's name or position.
+        prefix = candidate + "/"
+        if any(seat.startswith(prefix) for seat in seats):
+            return str(parent)
+        return None
+    return None
+
+
 def recorded_seat_for(path: str) -> str | None:
     """The seat this file's distribution recorded for it, or ``None``.
 


### PR DESCRIPTION
## A proxy checked instead of the thing

`Path(filename).is_absolute()` is a string test standing in for a property. The law it serves is *"another checkout can resolve this address"*; what it checks is *"this string starts with a slash"*. The gap is one character wide:

```
workspace_path_source(".../site-packages/pandas/core/frame.py", root="/")
  -> "Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py"
```

That locus is **exactly as machine-specific and unresolvable as the absolute path it came from**, and the absolute-locus law accepts it. The intermediate roots are the same defect in milder form. One file, four accepted addresses:

| root | locus | is a recorded seat |
|---|---|---|
| `.../site-packages` | `pandas/core/frame.py` | **yes** |
| `.../site-packages/pandas` | `core/frame.py` | no |
| `.../site-packages/pandas/core` | `frame.py` | no |
| `/` | `Users/tsavo/…/frame.py` | no |

## The mechanism

An installed distribution states the answer itself. Its RECORD lists the seat of every file it installed, and `dependency_artifact.py:570` rejects an absolute seat **structurally** rather than by string inspection. So for a file the RECORD covers, the locus is decidable: it must **equal** that seat, or the door refuses by name.

Refusing at the **minting** door rather than at one consumer means the unresolvable address is never constructed at all, instead of being caught wherever someone remembered to look.

The convergence that makes this cheap: `workspace_path_source(path, root=site-packages)` already returns **exactly** a RECORD seat string. For the correct root the check passes trivially — it fires only on the roots that were producing garbage.

## Scope — the other half of the law

**Sources that HAVE a RECORD only.** A first-party file has no distribution, so the workspace-relative law remains its whole law and this arm never fires. A refusal is not widened to a population that cannot satisfy it. A file inside an install root that no RECORD covers (a stray, a build artifact) has no seat to check against, so nothing is authenticated and nothing is claimed.

`recorded_seat_for` returning `None` means *"no distribution states an address for this file"* — never *"the seat is unavailable, carry on with a guess."*

## Identity and repin impact

**No CID preimage moves. No repin.**

This change only ever **refuses**; it never alters an accepted locus. Verified directly — for the correct root, before and after are identical:

```
pandas/core/frame.py   locus=pandas/core/frame.py   cid=blake3-512:f3515...
pandas/__init__.py     locus=pandas/__init__.py     cid=blake3-512:895e7...
```

**Existing ledgers stay comparable by `where`** — *if* they were produced with the install root. A ledger produced with a wrong root (`.../pandas`, or `/`) can no longer be reproduced at all: that invocation now refuses. Those rows were keyed on addresses nothing could resolve, so they were never comparable across checkouts in the first place; this makes that visible instead of silent.

**One caller-visible behaviour change worth stating plainly.** `open_source_file_for_construction` is the only production caller, and it passes the driver's root through. So **censusing an installed package must now be rooted at the install root** (`.../site-packages`), not at the package directory (`.../site-packages/pandas`). The latter now refuses. That is the intended outcome — it was minting `core/frame.py` — but it will break an existing invocation that used the package directory.

## What this does NOT change

- **First-party loci** — untouched under any root, pinned by two twins.
- **The `is_absolute` law itself** — it stays as the second gate rather than being replaced by the seat check. The outside-root refusal also still fires first, pinned.
- **`installed_module_source`** — not touched. It has one caller, `SourceFile.from_module`, which has no production callers; a loud-refusal arm there would be inert. Reported rather than built.

## Evidence

**Focused:** 43 passed / 0 failed across `test_recorded_seat_locus_authority`, `test_ground_exit_locus_law`, `test_none_attribute_floor`, `test_sequence_membership_floor`, `test_builtin_finite_set_floor`.

**Perturbations**, each applied to a copy and re-run:

| perturbation | result |
|---|---|
| `recorded_seat_for` always `None` — law disabled | **5 fail** |
| refuse also when there is no seat — widened past scope | **2 fail** |
| refuse only loci longer than the seat — catches `root=/`, misses the intermediate roots | **3 fail** |

The third is the one that matters: it is the shape of a fix that only repairs the reported symptom, and `test_every_intermediate_root_is_refused_too` plus `test_one_file_no_longer_has_several_accepted_addresses` exist to catch exactly it.

*(A first attempt at that perturbation didn't bite — it happened to still refuse everything. Replaced with one that genuinely lets the intermediate roots through. Recording it because a perturbation that fails to perturb proves nothing.)*

## Provenance

This was dispatched as an unblocker for `attribute × NoneValue` / `attribute × DictValue`. **It is not one** — those construct fine through the production door (0 panics each), and the `ground_* × absolute` rows that motivated the original dispatch were artifacts of a probe using a bare `SourceFile.from_path`. That is retracted separately. This PR stands on the `root=/` bypass alone, which is a live soundness hole independent of any of it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce recorded distribution seat as the authoritative locus for installed files
> - Adds `recorded_seat_for`, `install_root_for`, and `require_recorded_seat` to [source_oracle.py](https://github.com/TSavo/sugar/pull/6432/files#diff-46c211dd48cf8b40814f36939afc72cfd9d8d750d36f6572af9c9e02ba22ea6f); `workspace_path_source` now raises `SourceUnavailable` when the computed locus for an installed file does not match its recorded distribution seat.
> - Adds `locus_root_for_corpus` to [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/6432/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d), which resolves the install root for installed corpora so file addresses align with recorded seats; first-party corpora are unaffected.
> - A new test module [test_recorded_seat_locus_authority.py](https://github.com/TSavo/sugar/pull/6432/files#diff-db28e347ac2118dbba9ff69b731e6b24387ce0ad62d76a4589c246cfbafa36bf) validates acceptance/refusal rules for installed vs. first-party files and end-to-end driver behavior.
> - Behavioral Change: installed files addressed with a root other than their recorded install root (including `/`) now raise `SourceUnavailable` instead of returning a locus silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5b0107.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->