### PR TITLE
Instrument the law's own presence, so the next overwrite says so

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -377,3 +377,77 @@ def test_a_fold_knows_its_own_sequence_type() -> None:
     alone never makes a pair undecided -- only its operand can."""
     assert _comprehension().denotes_value() is True
     assert _comprehension().runtime_type_is_decided() is True
+
+
+# -- the law is still HERE ---------------------------------------------------
+
+
+def test_the_base_class_still_states_the_law() -> None:
+    """A merged law has no instrument saying it is still there an hour later.
+
+    #6427 wrote `floor_value.py` wholesale from a base that predated #6415 and
+    deleted this law -- the map, both testimony methods, `_undecided_binary_law`
+    and the `return` on every binary arm -- with no conflict to review, because
+    a whole-file overwrite is not a conflict. Five files lost content and 30
+    tests went red on main before anyone looked.
+
+    Those 30 caught it eventually. This one names it in a single assertion, so
+    the next overwrite reports "the law is gone" instead of thirty downstream
+    symptoms.
+    """
+    from sugar_lift_py_tests.floor.floor_value import (
+        _BINARY_OPERATOR_COORDINATE,
+        FloorValue,
+    )
+
+    for method in ("denotes_value", "runtime_type_is_decided", "_undecided_binary_law"):
+        assert method in vars(FloorValue), f"FloorValue lost {method}"
+
+    # All thirteen operators, keyed by the dispatch surface's own vocabulary.
+    assert len(_BINARY_OPERATOR_COORDINATE) == 13
+
+
+def test_no_value_class_states_testimony_the_base_class_lost() -> None:
+    """An override of a method that no longer exists is a silent no-op.
+
+    When #6427 removed the base methods, the per-class `denotes_value`
+    overrides survived on eleven value classes -- each one a dead declaration
+    that reads as intent. This fires on the orphan directly, so the state
+    cannot recur quietly on any class that has spoken or ever will.
+    """
+    import importlib
+    import inspect
+
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    testimony = ("denotes_value", "runtime_type_is_decided")
+    orphaned = []
+    for module_name in (
+        "bytes_value",
+        "call_site_value",
+        "complex_value",
+        "comprehension_value",
+        "dict_value",
+        "list_value",
+        "none_value",
+        "predicate_value",
+        "set_value",
+        "string_value",
+        "symbolic_value",
+        "term_value",
+        "tuple_value",
+    ):
+        module = importlib.import_module(f"sugar_lift_py_tests.floor.{module_name}")
+        for value in vars(module).values():
+            if not (inspect.isclass(value) and issubclass(value, FloorValue)):
+                continue
+            for method in testimony:
+                if method in vars(value) and not hasattr(FloorValue, method):
+                    orphaned.append(f"{value.__name__}.{method}")
+
+    assert orphaned == []
+
+
+def test_the_undecided_pair_still_answers_end_to_end() -> None:
+    """The one shape that proves the law is wired, not merely present."""
+    _coordinate(BytesValue(b"x").add(_symbolic(), SITE), "+")


### PR DESCRIPTION
Follow-up to #6431 (merged, law restored). **Tests only** -- no mechanism change.

## The orphaned overrides are already gone

The requested cleanup is subsumed by the restore rather than skipped: **the missing base WAS the orphaning.** With `denotes_value` and `runtime_type_is_decided` back on `FloorValue`, every per-class override is a live override again. Verified -- zero orphans across all thirteen value classes.

## What restoring does NOT fix

Nothing would report the *next* overwrite either. #6427 deleted a landed law from five files with **no conflict to review**, because a whole-file overwrite is not a conflict, and the first signal was thirty downstream failures in an unrelated test run an hour later.

Three checks, so the next one says *"the law is gone"* in one line instead of thirty symptoms:

| check | catches |
|---|---|
| the base class still states the law | both testimony methods, `_undecided_binary_law`, and all thirteen operator coordinates |
| no value class states testimony the base class lost | an override of a method that no longer exists -- a silent no-op that reads as intent; **eleven classes were in that state on main** |
| the undecided pair still answers end to end | the law being *wired*, not merely present |

## Verified against the real artifact

Not a synthetic stand-in -- I checked out `a3aa03d10`'s **exact** `floor_value.py`:

```
test_the_base_class_still_states_the_law                  FAILED
  ImportError: cannot import name '_BINARY_OPERATOR_COORDINATE'
test_no_value_class_states_testimony_the_base_class_lost  FAILED
  AssertionError: assert ['BytesValue...', ...] == []      <- names all eleven
```

Reverted, clean after.

## Evidence

**40 tests green** in `test_undecided_binary_operand_law.py`; **108 passed** across it plus `test_unpack_projection_guarded_and_callsite` (#6427's own, untouched), `test_none_attribute_floor`, `test_complex_field_arithmetic_floor`, `test_floor_panic_tail_owners`.

**Failure-set delta: zero.** The 6 remaining are inherited at pristine main; one is `test_a_partition_still_has_nowhere_to_carry_a_demand`, a real conservation hole with a fix landing next.

## Scope note

This instruments *this* law's presence. It is not the general answer to content-clobbering -- that is running the merged tree's tests, or flagging a merge that deletes lines no commit on its branch touched. This is the cheap specific guard for the law that actually got hit.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests to guard `FloorValue`'s undecided binary operand law against silent overwrites
> - Adds a test asserting `FloorValue` still defines `denotes_value`, `runtime_type_is_decided`, and `_undecided_binary_law`, and that the binary operator coordinate map has exactly 13 entries.
> - Adds a test that scans all `FloorValue` subclasses and fails if any override `denotes_value` or `runtime_type_is_decided` when the base class no longer defines that method.
> - Adds an end-to-end test that exercises the undecided pair path via `BytesValue.add(_symbolic(), SITE)` with `+` to confirm the dispatch still resolves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcbf51f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->