### PR TITLE
The loop outward-face family is already retired, and its twin is ceremony

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
+++ b/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
@@ -511,3 +511,22 @@ def test_loop_outward_face_with_a_plain_return_stays_one_completed_face() -> Non
         if isinstance(row, ReturnValue) or isinstance(getattr(row, "value", None), ReturnValue)
     ]
     assert len(returns) >= 1
+
+
+def test_loop_outward_face_returning_a_parameter_contract_lifts() -> None:
+    """POSITIVE, and the only shape in this family that DISCRIMINATES.
+
+    The two twins above were measured against the law itself: with the general
+    arm in `loop_recurrence_sugar` replaced by the raise it retired, BOTH still
+    pass. `d.setdefault(k, v)` never reaches that arm, so the partition twin
+    cannot fail when the law is removed -- it is the ceremony shape the ruling
+    names, and this test is the refutation rather than a third no-op.
+
+    `return p[0]` DOES reach it: the face owes a caller-parameter contract, so
+    it reduces to neither one return value nor one effect, which is exactly the
+    residue `BindingStateWireGap: loop outward face did not construct return or
+    raise testimony` was refusing to state. Removing the arm fails this node and
+    only this node.
+    """
+    out = _out("def f(xs, p):\n for x in xs:\n  if x:\n   return p[0]\n return 0\n")
+    assert _statements(out)


### PR DESCRIPTION
The loop outward-face family is already retired, and its twin is ceremony

DeltaR=0 at current baseline; historical 2 already retired by #6322.

`BindingStateWireGap: loop outward face did not construct return or raise
testimony` raises at no revision under `implementations/python` at
e8fa3c148 -- introduced by eb565f809 (#6187), removed by 0c64014d1
(#6322). Five shapes that reach the outward-face path desugar clean at
the tip: a return whose expression partitions, a guarded return, a return
owing a caller-parameter contract, a raising face, and the `while`
variant of the first. This is NOT a drain and is not counted as a cut.

What is worth shipping is the twin, because the two that exist do not
discriminate. Measured against the law itself -- the general arm in
`loop_recurrence_sugar` replaced by the raise it retired:

  test_loop_outward_face_returning_a_partition_lifts        PASSES
  test_loop_outward_face_with_a_plain_return_stays_...      PASSES
  (run against the shipped file, not a paraphrase: 2 passed)

`d.setdefault(k, v)` never reaches the arm, so the positive twin cannot
fail when the law is removed. That is the ceremony shape the ruling
names, and the refutation is this commit rather than a third no-op.

`return p[0]` DOES reach it: the face owes a caller-parameter contract,
so it reduces to neither one return value nor one effect -- exactly the
residue the raise was refusing to state.

  with the law      3 passed
  law removed       1 failed, 2 passed   <- the failure is this new node

The two shipped twins are left alone. Removing a teammate's test is not
this commit's call; naming what it does not gate is.

Owning package, `sugar-source-tree`, full suite, same worktree, one
pinned SUGAR_BIN sha256 5a04851c933a5fae...:

  head  13 failed  695 passed  5 skipped
  base  13 failed  694 passed  5 skipped   (this test stashed out)

  failing node sets: 13 vs 13, IDENTICAL both directions
  passed delta:      +1, exactly this test
  crash/timeout:     0 vs 0
                     grep -cE "Terminated|DEADLINE|TimeoutExpired|FileTimeout"
                     positive control, same form: grep -cE "FAILED|passed" -> 14

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test for loop outward-face returning a parameter contract in desugar twin family
> Adds `test_loop_outward_face_returning_a_parameter_contract_lifts` to [test_desugar_defect_family_twins.py](https://github.com/TSavo/sugar/pull/6434/files#diff-cd024db81bb220534c47790ad3814c4dabdf7fc6e43b3e22d9c2d8e0597de824). The test constructs a function snippet with a loop containing a conditional early return of a caller-provided parameter element, passes it through `_out`, and asserts that `_statements(out)` is truthy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 809f75a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->