### PR TITLE
A demand joined onto a partition must land on a face, or be LOUD

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -143,7 +143,50 @@ def rewrap_pending(pending, outcome, *, owner, blame):
                         exit_.guard, exit_.effect, exit_.state, exit_.faces, owed
                     )
                 )
-        return ExitSet(tuple(exits)).normalize()
+        joined = ExitSet(tuple(exits)).normalize()
+
+        # "On EVERY face" carries the obligation only while there IS a face.
+        # Over ZERO faces the same loop puts it nowhere, and the caller would
+        # discharge nothing while looking resolved -- the exact silent drop
+        # this whole module exists to make loud.
+        #
+        # Two ways to arrive with nothing left to carry, and this states the
+        # property rather than either symptom: an ExitSet that was already
+        # empty, and one whose faces `normalize` dropped as provably false.
+        # Checked AFTER normalize so it is the surviving faces that answer.
+        carried = {
+            demand.demand_cid
+            for exit_ in joined.exits
+            for contract in exit_.pending_contracts
+            for demand in contract.demands
+        }
+        dropped = tuple(
+            demand.demand_cid
+            for demand in pending.demands
+            if demand.demand_cid not in carried
+        )
+        if not dropped:
+            return joined
+
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap as _gap
+
+        _gap(
+            owner=owner,
+            blame=blame,
+            observed=(
+                "pending parameter contract demands ("
+                + ", ".join(dropped)
+                + ") joined onto a partition with no surviving face to carry "
+                "them, so the obligation cannot share one carried value"
+            ),
+            requested="one joined outcome that can carry every pending demand",
+            fix=(
+                "a partition with no face owes the demand nowhere: give the "
+                "obligation a face to be owed on, or refuse the join at the "
+                "construction that emptied it -- never let it resolve carrying "
+                "nothing"
+            ),
+        )
 
     # ANYTHING ELSE stays LOUD: an outcome kind this law has never seen has no
     # arm here by construction, and inventing one would be a guess about where

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
@@ -1,0 +1,195 @@
+"""A demand joined onto a partition must land on a face, or be LOUD.
+
+``rewrap_pending`` gained an arm for a pending obligation meeting a partition:
+the demand is owed on EVERY face, because every face is downstream of the
+construction that incurred it. That arm is right, and it carries the obligation
+only while there IS a face.
+
+Over a partition with **zero** faces the same loop puts it **nowhere**. The
+obligation vanishes, the join returns a clean ``ExitSet``, and the caller
+discharges nothing while looking resolved -- the exact silent drop this module
+exists to make loud, and the same conservation hole ``outcome_to_exitset`` had
+at the effect->halted boundary.
+
+``test_a_partition_still_has_nowhere_to_carry_a_demand`` had been red on main
+for the whole window. It is not a superseded panic: its name states the surviving
+law exactly. A partition with no face still has nowhere to carry a demand.
+
+The guard is a CONSERVATION POST-CONDITION, not an emptiness check, and it runs
+AFTER ``normalize()``. Two different ways to arrive with nothing left to carry --
+an ExitSet that was already empty, and one whose faces ``normalize`` dropped as
+provably false -- are one property: every demand must be found on some surviving
+face.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.single_outcome_law import rewrap_pending
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+
+OWNER = "renamed_join"
+BLAME = "renamed_module.py:1:0"
+
+
+@dataclass(frozen=True)
+class _Demand:
+    demand_cid: str
+
+    def demanded_under(self, guard):
+        del guard
+        return self
+
+
+def _pending(cid: str, value):
+    return ContractConditionalConstructionV1(
+        source_node=BLAME,
+        candidate=ctor("renamed_candidate", []),
+        candidate_cid=f"blake3-512:{cid}",
+        demands=(_Demand(f"blake3-512:{cid}"),),
+        value=value,
+    )
+
+
+def _carried(result) -> set[str]:
+    return {
+        demand.demand_cid
+        for exit_ in getattr(result, "exits", ())
+        for contract in exit_.pending_contracts
+        for demand in contract.demands
+    }
+
+
+# -- positive arm: a face exists, so the demand is owed on it ----------------
+
+
+def test_every_face_of_a_partition_carries_the_demand() -> None:
+    """The arm that already worked, pinned so the guard cannot swallow it."""
+    partition = ExitSet(
+        (
+            Completed(ctor("g_true", []), TermValue(7), (), ()),
+            Halted(
+                ctor("g_false", []),
+                RaiseEffect(exception_name="ValueError", blame=BLAME),
+                None,
+                (),
+                (),
+            ),
+        )
+    )
+
+    result = rewrap_pending(
+        _pending("aaaa", TermValue(1)), partition, owner=OWNER, blame=BLAME
+    )
+
+    assert _carried(result) == {"blake3-512:aaaa"}
+    # Owed on EVERY face -- owing it on one only would drop it on the others.
+    for exit_ in result.exits:
+        assert any(
+            demand.demand_cid == "blake3-512:aaaa"
+            for contract in exit_.pending_contracts
+            for demand in contract.demands
+        )
+
+
+def test_a_single_face_partition_still_carries() -> None:
+    partition = ExitSet((Completed(ctor("g", []), TermValue(7), (), ()),))
+
+    result = rewrap_pending(
+        _pending("bbbb", TermValue(1)), partition, owner=OWNER, blame=BLAME
+    )
+
+    assert _carried(result) == {"blake3-512:bbbb"}
+
+
+# -- the hole: nowhere to carry ---------------------------------------------
+
+
+def test_an_empty_partition_has_nowhere_to_carry_and_stays_loud() -> None:
+    """The measured drop. Before the guard this returned a clean ExitSet with
+    the obligation nowhere -- a caller could discharge nothing and still look
+    resolved."""
+    with pytest.raises(ConstructionPanic) as raised:
+        rewrap_pending(
+            _pending("aaaa", TermValue(1)),
+            ExitSet(()),
+            owner=OWNER,
+            blame=BLAME,
+        )
+
+    observed = raised.value.info.observed
+    assert "no surviving face to carry" in observed
+    # The gap names the obligation that would have been dropped.
+    assert "blake3-512:aaaa" in observed
+
+
+def test_the_gap_names_every_demand_that_would_have_been_dropped() -> None:
+    pending = ContractConditionalConstructionV1(
+        source_node=BLAME,
+        candidate=ctor("renamed_candidate", []),
+        candidate_cid="blake3-512:aaaa",
+        demands=(_Demand("blake3-512:aaaa"), _Demand("blake3-512:bbbb")),
+        value=TermValue(1),
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        rewrap_pending(pending, ExitSet(()), owner=OWNER, blame=BLAME)
+
+    observed = raised.value.info.observed
+    assert "blake3-512:aaaa" in observed
+    assert "blake3-512:bbbb" in observed
+
+
+def test_the_guard_is_a_conservation_check_not_an_emptiness_check() -> None:
+    """Checked AFTER ``normalize()``, so a partition whose faces normalize
+    drops as provably false is caught by the same property -- not by a second
+    special case for a second symptom.
+    """
+    false_faced = ExitSet((Completed(ctor("python:false", []), TermValue(7), (), ()),))
+
+    # If normalize keeps the face, the demand rides it and this is not the
+    # scenario; if normalize drops it, conservation must fire. Either is
+    # correct -- what is NOT correct is a clean result carrying nothing.
+    try:
+        result = rewrap_pending(
+            _pending("cccc", TermValue(1)), false_faced, owner=OWNER, blame=BLAME
+        )
+    except ConstructionPanic as panic:
+        assert "no surviving face to carry" in panic.info.observed
+    else:
+        assert _carried(result) == {"blake3-512:cccc"}
+
+
+# -- discriminating arm: the other three arms are untouched ------------------
+
+
+def test_a_value_still_takes_the_obligation_back() -> None:
+    from sugar_lift_py_tests.outcome import Complete
+
+    result = rewrap_pending(
+        _pending("aaaa", TermValue(1)),
+        Complete(TermValue(9)),
+        owner=OWNER,
+        blame=BLAME,
+    )
+
+    assert isinstance(result, ContractConditionalConstructionV1)
+    assert result.value == TermValue(9)
+    assert {demand.demand_cid for demand in result.demands} == {"blake3-512:aaaa"}
+
+
+def test_no_pending_demand_passes_the_partition_through_untouched() -> None:
+    """The guard must not fire where there was never an obligation."""
+    partition = ExitSet(())
+
+    assert rewrap_pending(None, partition, owner=OWNER, blame=BLAME) is partition


### PR DESCRIPTION
Closes the assigned red: `test_a_partition_still_has_nowhere_to_carry_a_demand`, failing on pristine main for the whole window.

## It is not a superseded panic. It is a real conservation hole.

`rewrap_pending`'s partition arm puts a pending obligation on **every face** -- correct, and it carries the obligation only while there **is** a face. Measured both ways:

```
EMPTY      ExitSet(())  ->  ExitSet, 0 exits, demand  *** NOWHERE — DROPPED ***
POPULATED  one face     ->  ExitSet, 1 exit,  demand  ['blake3-512:bbbb']
```

**"On every face" over zero faces puts it nowhere.** The join returns a clean `ExitSet`, the obligation is gone, and the caller discharges nothing while looking resolved -- the silent drop this module exists to make loud, and the same conservation hole `outcome_to_exitset` had at the effect->halted boundary.

The test's name states the surviving law exactly: **a partition with no face still has nowhere to carry a demand.**

## The assertion is not weakened

The guard is a **conservation post-condition**, not an emptiness check: after building and `normalize()`, every demand must be found on some surviving face, else LOUD with the dropped `demand_cid`s named.

**Checked AFTER `normalize()` on purpose.** Two different ways to arrive with nothing left to carry --

- an `ExitSet` that was already empty
- one whose faces `normalize` dropped as provably false

-- become **one property** instead of two special cases chasing two symptoms.

## Evidence

**7 focused tests**, both arms:

- **positive** -- a two-face partition (`Completed` + `Halted`) carries the demand on *every* face; a single-face partition still carries
- **the hole** -- an empty partition stays loud, and the gap names *every* demand that would have been dropped
- **the post-condition is not an emptiness check** -- an all-false-faced partition either keeps its face and carries, or fires conservation; what is refused is a clean result carrying nothing
- **discriminating** -- the other three arms are untouched: a value still takes the obligation back, and `pending is None` still passes the partition through unchanged

**Mutation:** removing the post-condition fails both new loud arms **and** the original `test_a_partition_still_has_nowhere_to_carry_a_demand`. Reverted, verified clean after.

## Failure-set delta

```
                                   base            head
test_a_partition_still_has_...     FAILED          PASSES
test_partition_demand_conservation  (new)          7 pass
test_floor_panic_tail_owners       6 failed        5 failed
test_caller_parameter_contract     pass            pass
test_undecided_binary_operand_law  pass            pass
```

**−1 failure, zero new.** The remaining 5 are inherited at pristine main and untouched here -- `SetValue.attribute` (2), the carried-predicate guard pair (2), and the guarded `SetValue` needle. They are a separate shape and not mine; flagging them as still unowned.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise a construction panic when a demand joined onto a partition is dropped by `rewrap_pending`
> - When pending demands are joined onto a partition, `rewrap_pending` in [single_outcome_law.py](https://github.com/TSavo/sugar/pull/6435/files#diff-83138b0992d2a78091fde1db7a22872748a9537647d3184f281c55ddda192acb) now checks that every pending demand is carried on at least one surviving face after `normalize()`.
> - If any demands are absent from all surviving faces (e.g. the partition is empty or all faces were removed), a construction panic is raised naming the dropped demand identifiers.
> - Six tests in [test_partition_demand_conservation.py](https://github.com/TSavo/sugar/pull/6435/files#diff-6d43801a5eef2fa4918821f88be8977155c3a25fd72a4ee3b59f45674870855d) cover the happy path, single-face, empty-partition, post-normalize, value-arm, and no-pending-demand cases.
> - Behavioral Change: previously, joining demands onto a zero-face or fully-normalized-away partition would silently return a clean `ExitSet`; it now raises `ConstructionPanic`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d3de36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->