### PR TITLE
Restore three more laws #6427 removed: a guard does not weaken a carried value

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -76,37 +76,23 @@ class PredicateValue(FloorValue):
         )
 
     def guarded(self, formula):
-        """A predicate entry carried under a branch guard IS the implication.
+        """A carried boolean rides under a guard unchanged.
 
-        This door is reached from ``if_sugar``'s ``entry.guarded(exit_.guard)``
-        over a branch face's record entries, so the receiver is a record entry,
-        not a bound value -- a bound value rides as a ``GuardedValue`` through
-        temporal scope and never arrives here. The law is ``InvValue.guarded``'s:
-        a formula stated under a guard is ``implies(guard, formula)``.
+        Same arm as ``CallSiteValue`` / ``ImportAliasValue``: this is a VALUE,
+        not an exit and not an obligation. A PredicateValue states no
+        ``inv_contribution`` and no ``post_contribution``, so a branch guard
+        over it is already owned by the branch's own control -- there is
+        nothing here for the guard to weaken.
 
-        It stays a ``PredicateValue`` rather than becoming an ``InvValue``
-        because guarding decides POLARITY, not assertional force. This entry
-        has not been ``stated()`` yet; when it is, the implication is what gets
-        stated, which is exactly the weakening a branch-local fact owes. The
-        alternative -- riding unchanged, as ``CallSiteValue.guarded`` does --
-        is wrong here for the same reason: a callsite coordinate asserts
-        nothing, and a predicate is nothing but an assertion waiting to be made.
-
-        Operand callsites and the derived / rewrite chains ride so edges still
-        project, and both binding rosters ride under the same guard the
-        implication now carries.
+        Weakening the carried formula to ``formula -> self.formula`` would be a
+        different value, not a guarded one: for `x = (a == b) if c else d` it
+        would make `x` TRUE wherever `c` is false, which the source never
+        states. An assertion over this predicate is an ``InvValue``, and THAT
+        is the arm that becomes an implication (``InvValue.guarded``); the
+        obligation is weakened where the obligation lives, never here.
         """
-        from sugar_lift_py_tests.ir import implies
-
-        return PredicateValue(
-            implies(formula, self.formula),
-            self.site,
-            self.operand_callsites,
-            self.derived_formulas,
-            self.rewrite_chains,
-            self.then_bindings,
-            self.else_bindings,
-        )
+        del formula
+        return self
 
     def negate(self):
         # A predicate flips by wrapping its formula in not_ -- the formula owns

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -16,6 +16,15 @@ class SetValue(FloorValue):
 
     elements: tuple
 
+    def attribute(self, name, site):
+        # Bound methods and fields on a constructed set (``set().add``, ``s.union``) stay the
+        # py.getattr coordinate -- one law, shared with StringValue and the
+        # other constructed containers. Never invent a method body or a field.
+        del site
+        from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
+
+        return getattr_coordinate(self, name, owner="SetValue.attribute")
+
     def denotes_value(self) -> bool:
         """This floor value denotes a ``set``."""
         return True
@@ -53,6 +62,15 @@ class SetValue(FloorValue):
         return Complete(TermValue(len(self.elements)))
 
     def contains(self, item, site):
+        # A guarded needle is not one needle: distribute into its faces and
+        # rejoin under the same guard before this receiver's own law runs.
+        from sugar_lift_py_tests.floor.guarded_operand import (
+            distribute_guarded_predicate,
+        )
+
+        distributed = distribute_guarded_predicate(self, item, "contains", site)
+        if distributed is not None:
+            return distributed
         decisions = tuple(
             _closed_member_equal(item, element) for element in self.elements
         )


### PR DESCRIPTION
**The last five unowned reds on main were all one PR.** `a3aa03d10` (#6427) removed three more things besides the undecided-binary law that #6431 put back:

| removed | effect |
|---|---|
| `PredicateValue.guarded` ride-unchanged, replaced by `implies(guard, formula)` | 2 reds |
| `SetValue.attribute`, deleted outright | 2 reds |
| `SetValue.contains` guarded-needle distribution block, deleted | 1 red |

`test_floor_panic_tail_owners.py` is now **fully green: 23 passed, 0 failed.**

## The ruling: the pins are right, the wrap is wrong

I was asked to establish which side was correct before touching either, and **not** to assume the newer code wins. Unlike the law deletion, this change arrived **with an argument** -- a new docstring asserting that a carried predicate IS the implication. Three things refute it.

**1. It is unsound, and the pin already said how.** For `x = (a == b) if c else d` the wrap makes `x` **true wherever `c` is false**, which the source never states. A carried boolean is a VALUE; weakening belongs where the obligation lives.

**2. It collapses a distinction the suite deliberately protects.** Measured on main before the fix:

```
PredicateValue(carried).guarded(g)  ->  implies(g, carried)
InvValue(carried).guarded(g)        ->  implies(g, carried)     IDENTICAL
```

`test_an_obligation_does_weaken_under_the_same_guard` is titled *"the discriminating face"* -- and it only discriminates while the other arm does **not** weaken. So it **kept passing while the property it exists to guard was gone.** After this PR the value rides unchanged and the obligation weakens: both arms of the discriminator run again.

**3. Its own central claim is false.** The docstring justifies the wrap by saying the receiver is always a record entry, because *"a bound value ... never arrives here."* But `caller_parameter_contract.py:285` calls `self.value.guarded(formula)` on the carried **value** -- and that function's own docstring enumerates the cases as *"ReturnValue -> GuardedReturn, **InvValue -> implication**"*, naming implication as the **obligation** case specifically.

## Evidence

- **94 passed, 0 failed** across `test_floor_panic_tail_owners`, `test_unpack_projection_guarded_and_callsite` (#6427's own), `test_undecided_binary_operand_law`, `test_partition_demand_conservation`, `test_caller_parameter_contract`, `test_sequence_membership_floor`.
- **Both arms of the discriminator run**, verified directly: value rides unchanged, obligation weakens to `implies`.
- **Mutation:** re-applying #6427's exact wrap fails both pins. Reverted, verified clean after.
- **Delta: −5 failures, zero new.**

## Not a judgement on #6427's own work

Its six unpack-projection laws are **untouched**, and `test_unpack_projection_guarded_and_callsite.py` passes alongside -- same as with #6431. This is a judgement on three deletions that rode along with it, not on the work the PR was for.

Between #6431 and this PR, **that one merge accounted for 35 failing tests**: 30 from the deleted law, 5 from these three. Worth noting for whatever review rule comes out of it -- the diffstat said `28 insertions, 130 deletions` on a file the PR had no reason to shrink.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore law that a guard does not weaken a carried value in `PredicateValue.guarded`
> - `PredicateValue.guarded` now returns `self` unchanged instead of wrapping the formula in an implication (`implies(guard, self.formula)`), restoring the law that a carried boolean value rides under a guard unchanged.
> - `SetValue.contains` now distributes a guarded predicate item across membership evaluation before applying existing True/False/unknown logic.
> - `SetValue.attribute` is added, returning a `py.getattr` coordinate for the receiver and attribute name instead of falling through to a panic.
> - Behavioral Change: `guarded()` on a `PredicateValue` no longer produces a new instance with an implication formula; callers that relied on that wrapping will see different results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6dc838a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->