### PR TITLE
Law: construction never enters through the bare door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
@@ -221,8 +221,14 @@ def main() -> int:
                     syntax[_syntax_coordinate(node, lines)] = _shape(node)
 
             def construct_file():
+                from sugar_lift_py_tests.lift_rpc import (
+                    open_source_file_for_construction,
+                )
+
                 reporter = CollectingReporter()
-                source_file = SourceFile.from_path(str(path), reporter=reporter)
+                source_file = open_source_file_for_construction(
+                    path, root=args.corpus, reporter=reporter
+                )
                 for function in source_file.functions():
                     try:
                         function.sugar()

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_context_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_context_door_law.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""R_bare_construction_door — construction never enters through the bare door.
+
+``SourceFile.from_path`` builds a tree with **no construction context**. That is
+a legitimate door: a demand-table scan, a roll-call discharge, a parse-only
+corpus emit all use it correctly, because none of them construct sugar.
+
+Constructing through it is a different act, and it does not fail — it LIES.
+Without a context every ``with`` paints ``RuntimeSelectedContextManager``
+regardless of resolvability, so the tree answers every question with a plausible
+wrong number instead of a refusal.
+
+That door has manufactured a false frontier three times:
+
+1. The old census used it and reported ``With 4125 assertion / 811 resource``
+   sites. Measured through the production door, whole-corpus construction R is
+   **4**. Two owners worked against the phantom for hours.
+2. A scoreboard repair found ``census.py`` still on it -- and the backend-defect
+   tooth written to catch that was itself patching ``SourceFile.from_path``, a
+   door that code path no longer called, so the tooth would have gone green
+   measuring nothing.
+3. ``panic_probe.py`` (this instrument's own author, tonight) reported eleven
+   residual floor pairs. Five were artifacts of the door: three ``ground_*``
+   rows it manufactured outright, and two ``attribute`` rows wrongly declared
+   blocked behind them.
+
+Three phantoms, one door, and the defence was a comment reading
+``# Production door: never a bare SourceFile.from_path``. Prose is the bottom
+rung of the enforcement ladder. This is the next rung up.
+
+**THE LAW.** Within one scope, obtaining a ``SourceFile`` from the bare door and
+then driving ``.sugar()`` is an offender. Both halves are required:
+
+* ``SourceFile.from_path`` alone is fine -- that is the door working.
+* ``.sugar()`` alone is fine -- the file came from somewhere else.
+* Together in one scope, construction is being driven over a tree that has no
+  context to construct against.
+
+Scope granularity is the FUNCTION, never the module. A module-level rule reads
+one layer too shallow and produces a false population: ``lift_rpc`` calls the
+bare door in a demand scan and in a roll-call discharge, and calls ``.sugar()``
+in unrelated functions elsewhere. Those are correct uses, and a law that named
+them would be allowlisted within a week -- which is how a law dies.
+
+The replacement is ``open_source_file_for_construction(path, root=...)``, which
+threads the construction context and the locus root together.
+
+No baseline, no threshold, no allowlist. Exit 1 while R > 0.
+
+    python scripts/construction_context_door_law.py [ROOT ...]
+    python scripts/construction_context_door_law.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+BARE_DOOR = "from_path"
+BARE_DOOR_OWNER = "SourceFile"
+CONSTRUCTION_DRIVER = "sugar"
+
+
+@dataclass(frozen=True)
+class Offender:
+    path: str
+    scope: str
+    door_lines: tuple[int, ...]
+    construction_lines: tuple[int, ...]
+
+    def to_json(self) -> dict:
+        return {
+            "path": self.path,
+            "scope": self.scope,
+            "doorLines": list(self.door_lines),
+            "constructionLines": list(self.construction_lines),
+            "law": "construction never enters through the bare door",
+            "fix": (
+                "open_source_file_for_construction(path, root=<corpus root>) --"
+                " it threads the construction context and the locus root"
+            ),
+        }
+
+
+def _own_statements(scope: ast.AST) -> Iterable[ast.AST]:
+    """Nodes belonging to this scope, excluding nested function bodies.
+
+    A nested function is its own scope and is judged separately, so an outer
+    function is never blamed for what an inner one does (or credited with it).
+    """
+    nested: set[int] = set()
+    for node in ast.walk(scope):
+        if node is scope:
+            continue
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            nested.update(id(inner) for inner in ast.walk(node))
+    for node in ast.walk(scope):
+        if node is not scope and id(node) not in nested:
+            yield node
+
+
+def offenders_in_source(text: str, *, path: str) -> list[Offender]:
+    """Every scope that reaches the bare door and then constructs."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        # A file this instrument cannot parse is not silently clean. The caller
+        # reports it as its own row; it is never counted as R=0.
+        raise
+    found: list[Offender] = []
+    scopes: list[ast.AST] = [tree]
+    scopes.extend(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    for scope in scopes:
+        door: list[int] = []
+        construction: list[int] = []
+        for node in _own_statements(scope):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            attribute = node.func
+            if (
+                attribute.attr == BARE_DOOR
+                and isinstance(attribute.value, ast.Name)
+                and attribute.value.id == BARE_DOOR_OWNER
+            ):
+                door.append(node.lineno)
+            elif attribute.attr == CONSTRUCTION_DRIVER:
+                construction.append(node.lineno)
+        if door and construction:
+            found.append(
+                Offender(
+                    path=path,
+                    scope=getattr(scope, "name", "<module>"),
+                    door_lines=tuple(sorted(door)),
+                    construction_lines=tuple(sorted(construction)),
+                )
+            )
+    return found
+
+
+def scan_roots(roots: Iterable[Path]) -> tuple[list[Offender], list[dict]]:
+    offenders: list[Offender] = []
+    unreadable: list[dict] = []
+    for root in roots:
+        for path in sorted(root.rglob("*.py")):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as error:
+                unreadable.append({"path": str(path), "reason": str(error)})
+                continue
+            try:
+                offenders.extend(offenders_in_source(text, path=str(path)))
+            except SyntaxError as error:
+                unreadable.append({"path": str(path), "reason": f"syntax: {error}"})
+    return offenders, unreadable
+
+
+# ---------------------------------------------------------------------------
+# self-test: the law proved on the incident it exists to prevent
+# ---------------------------------------------------------------------------
+
+HISTORICAL_PROBE = """
+def main() -> int:
+    path = Path(sys.argv[1])
+    root = Path(sys.argv[2])
+    from sugar_lift_py_tests.desugar_axis import DesugarAxis
+    from sugar_source_tree.tree import SourceFile
+    rel = str(path.relative_to(root))
+    desugar = DesugarAxis()
+    reporter = CollectingReporter()
+    sf = SourceFile.from_path(str(path), reporter=reporter)
+    for fn in sf.functions():
+        try:
+            sugar = fn.sugar()
+        except SugarNotWritten:
+            sugar = None
+        if sugar is not None:
+            desugar.measure(sugar, where=rel)
+    return 0
+"""
+
+PRODUCTION_DOOR = """
+def main() -> int:
+    sf = open_source_file_for_construction(path, root=root, reporter=reporter)
+    for fn in sf.functions():
+        fn.sugar()
+    return 0
+"""
+
+DEMAND_SCAN_ONLY = """
+def demand_rows(root):
+    for path in SourceTree(root).paths():
+        source_file = SourceFile.from_path(path)
+        for node in source_file.nodes():
+            rows.append(node)
+    return rows
+"""
+
+CONSTRUCTION_ONLY = """
+def measure(source_file):
+    for fn in source_file.functions():
+        fn.sugar()
+"""
+
+NESTED_SCOPES = """
+def outer(path):
+    source_file = SourceFile.from_path(path)
+    def inner(other):
+        other.sugar()
+    return source_file, inner
+"""
+
+
+def self_test() -> int:
+    """Prove the law fires on the real incident and stays quiet on correct use."""
+    failures: list[str] = []
+
+    def expect(label: str, source: str, *, offends: bool) -> None:
+        found = offenders_in_source(source, path=f"<{label}>")
+        if bool(found) is not offends:
+            failures.append(
+                f"{label}: expected {'an offender' if offends else 'clean'}, "
+                f"got {[o.scope for o in found]}"
+            )
+
+    # THE incident. Not a synthetic stand-in: this is the shape of the probe
+    # that produced five withdrawn residual pairs.
+    expect("historical panic_probe", HISTORICAL_PROBE, offends=True)
+    expect("production door", PRODUCTION_DOOR, offends=False)
+    expect("demand scan, no construction", DEMAND_SCAN_ONLY, offends=False)
+    expect("construction, no bare door", CONSTRUCTION_ONLY, offends=False)
+    # The outer scope opens the door; only the INNER scope constructs. Blaming
+    # the outer one would be the module-level granularity error in miniature.
+    expect("nested scopes", NESTED_SCOPES, offends=False)
+
+    for line in failures:
+        print(f"SELF-TEST FAIL {line}")
+    print(f"self-test: {'FAIL' if failures else 'PASS'} ({len(failures)} failures)")
+    return 1 if failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("roots", nargs="*", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    roots = args.roots or [Path(__file__).resolve().parents[3]]
+    offenders, unreadable = scan_roots(roots)
+    report = {
+        "law": "R_bare_construction_door",
+        "R": len(offenders),
+        "offenders": [offender.to_json() for offender in offenders],
+        "unreadable": unreadable,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"R_bare_construction_door = {len(offenders)}")
+        for offender in offenders:
+            print(
+                f"  {offender.path}:{offender.door_lines[0]} "
+                f"{offender.scope}() constructs at {offender.construction_lines}"
+            )
+        for row in unreadable:
+            print(f"  UNREADABLE {row['path']}: {row['reason']}")
+    return 1 if offenders or unreadable else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_raise_from_direct_gaps.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_raise_from_direct_gaps.py
@@ -81,9 +81,15 @@ def measure(root: Path) -> dict[str, object]:
             continue
 
         selected_files += 1
+        from sugar_lift_py_tests.lift_rpc import (
+            open_source_file_for_construction,
+        )
+
         reporter = CollectingReporter()
         try:
-            source_file = SourceFile.from_path(str(path), reporter=reporter)
+            source_file = open_source_file_for_construction(
+                path, root=root, reporter=reporter
+            )
             # This instrument owns Raise classification, so construct every
             # Raise directly. An unwritten enclosing function must not hide a
             # cause descendant, and an unrelated sibling gap must not label

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -191,7 +191,7 @@ def fact_of(node) -> Optional[Any]:
 # trivially and no gap is counted twice across a function/module split.
 
 
-def audit_file_gaps(full_path: Path):
+def audit_file_gaps(full_path: Path, *, root: Path):
     """The file's frontier: ONE construction per top-level statement; the
     reporter witnesses every gap underneath it as it is built.
 
@@ -211,8 +211,13 @@ def audit_file_gaps(full_path: Path):
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
 
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
     reporter = CollectingReporter()
-    sf = SourceFile.from_path(str(full_path), reporter=reporter)
+    # Construction needs its context: the bare door builds a tree with none,
+    # and a context-less tree paints every With RuntimeSelectedContextManager
+    # regardless of resolvability. See scripts/construction_context_door_law.py.
+    sf = open_source_file_for_construction(full_path, root=root, reporter=reporter)
     for stmt in sf.root.body:
         try:
             stmt.sugar()
@@ -405,6 +410,16 @@ def source_audit_from_roll_call(full_path: Path, file_rel: str) -> dict:
     }
 
 
+def _root_of(full_path: Path, file_rel: str) -> Path:
+    """The root ``file_rel`` is stated against -- the locus's own denominator."""
+    resolved = Path(full_path).resolve()
+    relative = Path(file_rel)
+    root = resolved
+    for _ in relative.parts:
+        root = root.parent
+    return root
+
+
 def frontier_leaf_rpc(full_path: Path, file_rel: str) -> dict:
     """The recovered-construction audit leaf for one file, tree-walked.
 
@@ -421,7 +436,9 @@ def frontier_leaf_rpc(full_path: Path, file_rel: str) -> dict:
         RecoveredConstructionPanicDto,
     )
 
-    sf, gaps = audit_file_gaps(full_path)
+    # The workspace root is what `file_rel` is stated against, by definition.
+    root = _root_of(full_path, file_rel)
+    sf, gaps = audit_file_gaps(full_path, root=root)
     demanded_source = f"module:{sf.unit.source_cid}"
     panics = []
     for node, panic in gaps:

--- a/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
@@ -258,8 +258,14 @@ def test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer():
         return out
 
     BS._constructed_preimage = watched
+    from pathlib import Path
+
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
     try:
-        sf = SourceFile.from_path(path, reporter=CollectingReporter())
+        sf = open_source_file_for_construction(
+            Path(path), root=Path(path).parent, reporter=CollectingReporter()
+        )
         fn = [f for f in sf.functions() if getattr(f, "name", None) == "f"][0]
         fn.sugar()
     finally:

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_context_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_context_door_law.py
@@ -1,0 +1,145 @@
+"""Permanent floor: construction never enters through the bare door.
+
+``SourceFile.from_path`` builds a tree with no construction context. That is a
+legitimate door -- demand scans, roll-call discharge and parse-only corpus emit
+all use it correctly. Constructing through it does not fail; it LIES, because a
+context-less tree paints every ``with`` ``RuntimeSelectedContextManager``
+regardless of resolvability.
+
+The law is proved on the incident it exists to prevent, not on a synthetic
+stand-in: ``test_the_historical_probe_is_caught`` feeds the scanner the actual
+shape of ``panic_probe.py``, the probe that reported eleven residual floor pairs
+of which five were artifacts of this door.
+
+Zero is MEASURED here, never inferred from a missing run -- the live scan runs
+against the real packages, and a planted offender must still trip the same
+scanner.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_KIT = Path(__file__).resolve().parents[1]
+_SCANNER_PATH = _KIT / "scripts" / "construction_context_door_law.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "construction_context_door_law", _SCANNER_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+# Registered before execution: the scanner declares a frozen dataclass, and
+# dataclasses resolve field types through sys.modules[cls.__module__].
+sys.modules[_SPEC.name] = _SCANNER
+_SPEC.loader.exec_module(_SCANNER)
+
+
+def _offenders(source: str):
+    return _SCANNER.offenders_in_source(source, path="<twin>")
+
+
+# -- the law proved on the incident, not a synthetic --------------------------
+
+
+def test_the_historical_probe_is_caught() -> None:
+    """The guard proven on the artifact it exists to prevent.
+
+    This is the shape of panic_probe.py as it was actually written and run:
+    a bare door, then `.sugar()` over every function, then a DesugarAxis
+    measurement. It produced five residual pairs that had to be withdrawn.
+    """
+    found = _offenders(_SCANNER.HISTORICAL_PROBE)
+
+    assert len(found) == 1
+    assert found[0].scope == "main"
+    assert found[0].door_lines and found[0].construction_lines
+
+
+def test_the_production_door_is_not_caught() -> None:
+    """The replacement must be clean, or the law has no achievable green."""
+    assert _offenders(_SCANNER.PRODUCTION_DOOR) == []
+
+
+# -- both halves are required -------------------------------------------------
+
+
+def test_the_bare_door_alone_is_clean() -> None:
+    """A demand scan opens the door and never constructs. That is correct use."""
+    assert _offenders(_SCANNER.DEMAND_SCAN_ONLY) == []
+
+
+def test_construction_alone_is_clean() -> None:
+    """Constructing over a file that came from elsewhere is not this law's business."""
+    assert _offenders(_SCANNER.CONSTRUCTION_ONLY) == []
+
+
+def test_the_two_halves_together_are_the_offence() -> None:
+    """The discrimination: neither half alone, both together."""
+    door = _offenders(_SCANNER.DEMAND_SCAN_ONLY)
+    construction = _offenders(_SCANNER.CONSTRUCTION_ONLY)
+    both = _offenders(_SCANNER.HISTORICAL_PROBE)
+
+    assert door == [] and construction == []
+    assert len(both) == 1
+
+
+# -- granularity: the function, never the module ------------------------------
+
+
+def test_a_nested_scope_does_not_blame_its_parent() -> None:
+    """Module-level granularity would produce a false population.
+
+    `lift_rpc` opens the bare door in a demand scan and in a roll-call
+    discharge, and constructs in unrelated functions elsewhere. A law that
+    named it would be allowlisted within a week, which is how a law dies.
+    """
+    assert _offenders(_SCANNER.NESTED_SCOPES) == []
+
+
+def test_the_real_demand_scan_and_roll_call_stay_clean() -> None:
+    """Pinned on the live module, not a paraphrase of it."""
+    lift_rpc = (_KIT / "src" / "sugar_lift_py_tests" / "lift_rpc.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "SourceFile.from_path" in lift_rpc, "fixture stale: the door moved"
+    assert _SCANNER.offenders_in_source(lift_rpc, path="lift_rpc.py") == []
+
+
+# -- zero is measured, and a planted offender still trips it ------------------
+
+
+def test_live_packages_hold_at_zero() -> None:
+    offenders, unreadable = _SCANNER.scan_roots([_KIT.parent])
+
+    assert offenders == [], [o.to_json() for o in offenders]
+    assert unreadable == []
+
+
+def test_a_planted_offender_trips_the_live_scan(tmp_path: Path) -> None:
+    """Zero measured over a tree that cannot fail proves nothing."""
+    planted = tmp_path / "probe.py"
+    planted.write_text(_SCANNER.HISTORICAL_PROBE, encoding="utf-8")
+
+    offenders, unreadable = _SCANNER.scan_roots([tmp_path])
+
+    assert len(offenders) == 1
+    assert offenders[0].scope == "main"
+    assert unreadable == []
+
+
+def test_an_unparseable_file_is_reported_not_skipped(tmp_path: Path) -> None:
+    """A file the scanner cannot read is never counted as clean."""
+    (tmp_path / "broken.py").write_text("def (\n", encoding="utf-8")
+
+    offenders, unreadable = _SCANNER.scan_roots([tmp_path])
+
+    assert offenders == []
+    assert len(unreadable) == 1
+    assert "syntax" in unreadable[0]["reason"]
+
+
+def test_the_scanner_self_test_and_cli_agree() -> None:
+    assert _SCANNER.self_test() == 0
+    assert _SCANNER.main(["--self-test"]) == 0

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -97,6 +97,19 @@ axis "R_construction_side_doors discrimination" \
   python -m pytest --noconftest "$TESTS/tests/test_construction_side_door_law.py" -q
 axis "R_construction_side_doors = 0" python "$SCRIPTS/construction_side_door_law.py"
 
+# The bare construction door. SourceFile.from_path builds a tree with no
+# construction context; constructing through it does not fail, it LIES --
+# every With paints RuntimeSelectedContextManager regardless of resolvability.
+# Three false frontiers came out of that door and the defence was a comment.
+# The discrimination arm feeds the scanner the actual shape of the probe that
+# produced five withdrawn residual pairs -- proved on the incident, not a
+# synthetic stand-in.
+axis "R_bare_construction_door discrimination" \
+  python -m pytest --noconftest \
+  "$TESTS/tests/test_construction_context_door_law.py" -q
+axis "R_bare_construction_door = 0" \
+  python "$SCRIPTS/construction_context_door_law.py"
+
 echo
 echo "sole-construction floors: ${#green_axes[@]} green, ${#red_axes[@]} red"
 if [ ${#red_axes[@]} -gt 0 ]; then


### PR DESCRIPTION
## Three phantoms, one door, and the defence was a comment

`SourceFile.from_path` builds a tree with **no construction context**. That is a legitimate door — demand scans, roll-call discharge and parse-only corpus emit all use it correctly, because none of them construct sugar.

Constructing through it does not fail. **It lies.** Without a context every `with` paints `RuntimeSelectedContextManager` regardless of resolvability, so the tree answers every question with a plausible wrong number instead of a refusal.

1. The old census used it and reported `With 4125 assertion / 811 resource` sites. Measured through the production door, whole-corpus construction R is **4**. Two owners worked against the phantom for hours.
2. A scoreboard repair found `census.py` still on it — and the backend-defect tooth written to catch that was itself patching `SourceFile.from_path`, a door that code path no longer called, so **the tooth would have gone green measuring nothing**.
3. `panic_probe.py` — mine, tonight. Eleven residual floor pairs, five of them artifacts of this door.

The defence was `# Production door: never a bare SourceFile.from_path`. Prose is the bottom rung of the enforcement ladder.

## The law

Within one scope, opening the bare door **and** driving `.sugar()` is an offender. Both halves are required:

- the door alone is fine — that is the door working
- `.sugar()` alone is fine — the file came from somewhere else
- together, construction is being driven over a tree with no context to construct against

**Granularity is the function, never the module.** A module rule reads one layer too shallow and produces a false population: `lift_rpc` opens the bare door in a demand scan *and* in a roll-call discharge, and constructs in unrelated functions elsewhere. Both uses are correct. A law that named them would be allowlisted within a week — which is how a law dies. A twin pins the **live `lift_rpc.py`** clean, not a paraphrase of it.

No baseline, no threshold, no allowlist. Exit 1 while R > 0.

## Proved on the incident, not a synthetic

`test_the_historical_probe_is_caught` feeds the scanner **the actual shape of `panic_probe.py`** — the probe whose residual pairs had to be withdrawn. The same string is the scanner's own `--self-test` fixture, so the CLI and the suite agree on the artifact.

## Landing at R=0 required fixing what it named

The scan named four scopes, all genuine:

| scope | fix |
|---|---|
| `tree_enumerate.audit_file_gaps` (production) | root threaded from the `file_rel` the locus is stated against |
| `comprehension_iteration_recensus.construct_file` | `args.corpus` |
| `measure_raise_from_direct_gaps.measure` | its own `root` parameter |
| `test_canonicalization_value_memo` | the tmp file's directory |

Baselined against pristine `main`: those three construction test modules were **24 passed / 0 failed before and after**.

## Enforcement rung, and why I stopped there

**An auditor in the sole-construction floor set** (`run_sole_construction_floors.sh`), with a discrimination arm and a live R=0 arm, matching the house pattern for `construction_side_door_law` and its siblings.

The higher rung is real and is **not** this PR: *a `SourceFile` with no construction context should refuse to construct at all.* That is the true structural fix — it makes the defect impossible rather than detectable. It is not here because many legitimate callers build context-free trees today, so it needs its own migration rather than being smuggled in behind a scanner. Stating it rather than silently skipping it.

## Evidence

**Focused:** 11 passed / 0 failed on the law suite; live scan `R_bare_construction_door = 0`, exit 0.

**Perturbations**, each applied to a copy and **run from the perturbed tree**:

| perturbation | result |
|---|---|
| law never fires | **4 fail** |
| module granularity instead of function | **7 fail** — including the live `lift_rpc` pin |
| the door alone is an offence | **6 fail** |
| unparseable file silently skipped | **1 fail** |

Running from the perturbed tree is not incidental. Twice in the previous PR I produced a green perturbation result that meant nothing — once because the mutation changed no observed behaviour, once because the test file loaded its subject from the *unperturbed* tree. **A perturbation that fails to perturb is indistinguishable from a law that holds**, and this is a check whose entire value is that it fires.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce bare construction door law by routing all SourceFile construction through context-aware opener
> - Introduces [construction_context_door_law.py](https://github.com/TSavo/sugar/pull/6437/files#diff-587d0969bd50334a0da9ed05f011a90b1bc7761c42bb178f567b7367fe9f4357), a scanner that detects scopes calling both `SourceFile.from_path` and `sugar()` directly, reporting violators as JSON or text with non-zero exit status.
> - Replaces direct `SourceFile.from_path(...)` calls with `open_source_file_for_construction(path, root=..., reporter=...)` in scripts and library code so construction is always context-aware.
> - Adds tests and a self-test harness for the scanner, and wires both into [run_sole_construction_floors.sh](https://github.com/TSavo/sugar/pull/6437/files#diff-2425932b3b3850c1dce0e1350ce9dadb9c8d59942a7fb072ba19c29e2f913421).
> - Behavioral Change: gap detection, construction panics, and `CollectingReporter` output in `audit_file_gaps`, `measure_raise_from_direct_gaps`, and `comprehension_iteration_recensus` may differ from before because sugar() now receives corpus root context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83ed688.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->