### PR TITLE
Pin the binding partition's identity: salvage from #6403, which is dead

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py
@@ -109,9 +109,9 @@ def test_a_merge_spanning_both_outer_sides_claims_NEITHER_of_them():
 
     exits = _read(state)
     same = next(exit_ for exit_ in exits.exits if exit_.value == StringValue("same"))
-    outer_true, outer_false = _guarded_projection_faces(GuardedProjection(
-        outer, _Value("x"), _Value("y")
-    ))
+    outer_true, outer_false = _guarded_projection_faces(
+        GuardedProjection(outer, _Value("x"), _Value("y"))
+    )
 
     assert not _faces_exclusive(same.faces, frozenset({outer_true}))
     assert not _faces_exclusive(same.faces, frozenset({outer_false}))
@@ -157,3 +157,70 @@ def test_delete_stamps_the_same_authenticated_guarded_projection_faces():
         for a in left.faces
         for b in right.faces
     )
+
+
+# -- the partition's identity is the branch result, not the read site --------
+
+
+def test_the_same_slot_read_twice_mints_the_SAME_partition() -> None:
+    """Salvaged from #6403, whose mechanism landed elsewhere (#6393) while this
+    law went unpinned.
+
+    Two reads of one conditional binding are governed by the SAME branch
+    outcome, so they must mint the same partition. If the owner were the read
+    SITE, or anything allocation-based, two reads of one binding would mint
+    unrelated partitions and arms that genuinely exclude each other would look
+    merely unrelated -- `factor_completed` would then decline a split that is
+    real, silently and with every test green.
+
+    ``partition`` addresses by content, so this is reproducible rather than
+    allocation-based. Asserted across two INDEPENDENTLY constructed slot
+    objects carrying the same identity, which is what a second read is.
+    """
+    from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+        _guarded_projection_faces,
+    )
+
+    first = _guarded_projection_faces(
+        GuardedProjection(_slot("shared"), _Value("t"), _Value("f"))
+    )
+    second = _guarded_projection_faces(
+        GuardedProjection(_slot("shared"), _Value("t"), _Value("f"))
+    )
+
+    assert first == second
+
+
+def test_unrelated_conditional_bindings_do_not_share_a_partition() -> None:
+    """The discriminating face: reproducibility must not become collapse.
+
+    A single global partition would satisfy the law above and be worthless --
+    every unrelated binding would claim to exclude every other.
+    """
+    from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+        _guarded_projection_faces,
+    )
+
+    one = _guarded_projection_faces(
+        GuardedProjection(_slot("one"), _Value("t"), _Value("f"))
+    )
+    other = _guarded_projection_faces(
+        GuardedProjection(_slot("other"), _Value("t"), _Value("f"))
+    )
+
+    assert one != other
+    assert {face.partition for face in one} != {face.partition for face in other}
+
+
+def test_the_two_arms_are_opposite_sides_of_one_split() -> None:
+    """Both faces name one partition and differ only in side."""
+    from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+        _guarded_projection_faces,
+    )
+
+    true_face, false_face = _guarded_projection_faces(
+        GuardedProjection(_slot("split"), _Value("t"), _Value("f"))
+    )
+
+    assert true_face.partition == false_face.partition
+    assert true_face.side != false_face.side


### PR DESCRIPTION
**Determination: #6403 is dead and can be closed.** Both halves landed elsewhere while it sat conflicting. This lands the one law that did not travel with them.

## How I determined it -- from main, not from the PR

| half of #6403 | landed by | on main as |
|---|---|---|
| producer mint | **#6393** (`ffbec8307`) | `_guarded_projection_faces`, with `.guarded(guard, true_face)` / `.guarded(not_(guard), false_face)` |
| merge / exclusion rule | **#6420** | `_faces_exclusive` over **disjoint side sets** |

Diffing #6403's head against main confirms it: main's `exit_set.py` is the **fuller** version -- #6403 would *delete* 64 lines main has. Its three-dot diff looks substantial only because its merge-base is stale.

The two producer implementations differ solely in the owner key -- #6403 keyed on `state.slot`, main on `state.slot.slot_id`. **Main's is the tighter choice**, and it satisfies every law #6403's tests asserted. Verified directly rather than argued:

```
same slot read twice -> same partition : True
unrelated slots      -> differ         : True
two arms are opposite sides of one split: True
```

## The live remainder: one law, holding, pinned nowhere

#6403's test file never landed, and one law in it is asserted by **nothing** on main:

> two reads of one conditional binding must mint the **same** partition

It holds today. Nothing protects it. If the owner became the read *site*, or anything allocation-based, two reads of one binding would mint unrelated partitions -- and arms that genuinely exclude each other would look merely unrelated. **`factor_completed` would decline a real split, silently, with every test green.**

Three tests, added to main's own carrier file rather than resurrecting #6403's:

- **the same slot read twice mints the same partition** -- across two *independently constructed* slot objects, which is what a second read actually is
- **unrelated bindings do not share a partition** -- the discriminating face, because a single global partition would satisfy the law above and be worthless
- **the two arms are opposite sides of one split**

## Evidence

- **7 passed** in the carrier file; **58 passed** across it plus `test_exit_set_partition_testimony`, `test_partition_family_admission`, `test_floor_panic_tail_owners`.
- **Mutation:** making the owner allocation-based (`id(state)`) fails the new law **and** the existing `test_a_merge_spanning_both_outer_sides_claims_NEITHER_of_them`. Reverted, verified clean after.
- **Delta: zero.** Tests only, no mechanism change.

## Recommendation

**Close #6403.** Nothing else in it is live, and its mechanism is superseded by two better implementations.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests to pin identity semantics of `GuardedProjection` binding partitions
> Adds three new tests to [test_guarded_binding_partition_carrier.py](https://github.com/TSavo/sugar/pull/6438/files#diff-8fcafde426d9d1a215545d98b239446e4922d1347a185777f09146c6e295e5e2) to enforce partition identity rules for `GuardedProjection`:
> - Asserts that two reads of the same slot mint identical faces/partitions
> - Asserts that two reads of different slots produce distinct partitions
> - Asserts that the two faces from one `GuardedProjection` share a partition but have opposite sides
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e26c6b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->