### PR TITLE
An opaque generator step says whether it holds a suspension

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -22,7 +22,37 @@ class ReturnStepV1:
 
 @dataclass(frozen=True)
 class OpaqueStepV1:
+    """A body statement the step vocabulary cannot yet name.
+
+    ``carries_suspension`` is the discrimination that makes this row
+    dispatchable. Without it, ``x = 1`` and ``x = yield 1`` are the SAME row --
+    ``OpaqueStepV1("Assign")`` -- and they are not the same obligation:
+
+    * an opaque statement that owns NO suspension owes ordinary statement
+      execution inside a generator frame;
+    * an opaque statement that OWNS one owes a generator-protocol law (the
+      resumed value's binding, a branched suspension's partition).
+
+    Bucketing them together is why the two suspension owners read as one
+    undifferentiated mass. The flag is read from ``_owns_yield``, the same
+    authenticated predicate the step builder already uses to decide whether a
+    body is a generator at all -- never from the statement's spelling.
+    """
+
     observed: str
+    carries_suspension: bool = False
+
+    def gap_observed(self) -> str:
+        """What the transition gap should NAME as unconsumed.
+
+        The statement kind alone (``Assign``, ``If``, ``Expr``) names the
+        shape of the container, not the thing that could not be consumed, so a
+        board keyed on it cannot tell generator-protocol work from ordinary
+        unsupported statements.
+        """
+        if not self.carries_suspension:
+            return self.observed
+        return f"{self.observed} carrying a suspension"
 
 
 @dataclass(frozen=True)
@@ -141,7 +171,7 @@ class GeneratorConstructionV1:
             return GeneratorTerminationV1(None, self.binding_state)
         step = self.steps[self.cursor]
         if isinstance(step, OpaqueStepV1):
-            return self._gap(requested, step.observed)
+            return self._gap(requested, step.gap_observed())
         if isinstance(step, FinallyStepV1):
             cleanup = self._reduce_finally(step)
             from sugar_lift_py_tests.outcome import Completed, Halted

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_step_names_its_suspension.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_step_names_its_suspension.py
@@ -1,0 +1,164 @@
+"""An opaque generator step says whether it holds a suspension.
+
+``OpaqueStepV1(statement.kind)`` gave ``x = 1`` and ``x = yield 1`` the SAME
+row -- ``Assign`` -- and they are not the same obligation:
+
+* an opaque statement owning NO suspension owes ordinary statement execution
+  inside a generator frame;
+* one that OWNS a suspension owes a generator-protocol law -- the resumed
+  value's binding for an assignment, a partition for a branch.
+
+That is the misnamed-bucket shape twice over. ``add x TermValue`` said "a
+number does not stand on the addition floor" for 34 rows that were all complex
+literals, and the binary-operation gaps said nothing about their right operand
+until the pair became the dispatch unit. A gap that cannot name what it could
+not consume cannot be dispatched, and this one names the CONTAINER's kind
+rather than the construct inside it.
+
+WHAT THIS IS NOT. It does not name a single new step. Nothing here executes a
+suspension that did not execute before, and every previously-opaque shape is
+still opaque and still refuses by name. The vocabulary is unchanged; only its
+testimony about itself is sharper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    GeneratorTransitionGapV1,
+    OpaqueStepV1,
+)
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(tmp_path, source: str):
+    path = tmp_path / "m.py"
+    path.write_text(source, encoding="utf-8")
+    functions = list(SourceFile(path_source(str(path))).functions())
+    return functions[0]._source_visible_generator_steps({})
+
+
+def _first_opaque(steps):
+    return next(step for step in steps if isinstance(step, OpaqueStepV1))
+
+
+# -- the discrimination ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("source", "kind", "carries"),
+    (
+        # Same statement kind, opposite obligations.
+        ("def g():\n    x = yield 1\n    return x\n", "Assign", True),
+        ("def g():\n    x = 1\n    yield 2\n", "Assign", False),
+        ("def g(c):\n    if c:\n        yield 1\n", "If", True),
+        ("def g(c):\n    if c:\n        pass\n    yield 2\n", "If", False),
+        # Every bare `yield from` -- where the delegation debt actually lives.
+        ("def g(xs):\n    yield from xs\n", "Expr", True),
+    ),
+)
+def test_an_opaque_step_states_whether_it_holds_a_suspension(
+    tmp_path, source, kind, carries
+) -> None:
+    step = _first_opaque(_steps(tmp_path, source))
+
+    assert step.observed == kind
+    assert step.carries_suspension is carries
+
+
+@pytest.mark.parametrize(
+    ("source", "observed"),
+    (
+        ("def g():\n    x = yield 1\n    return x\n", "Assign carrying a suspension"),
+        ("def g(c):\n    if c:\n        yield 1\n", "If carrying a suspension"),
+        ("def g(xs):\n    yield from xs\n", "Expr carrying a suspension"),
+    ),
+)
+def test_the_transition_gap_names_the_construct_it_could_not_consume(
+    tmp_path, source, observed
+) -> None:
+    """The row has to be dispatchable. `Assign` names the container; a board
+    keyed on it cannot tell generator-protocol work from an ordinary
+    unsupported statement."""
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="probe",
+        frame_coordinate="frame",
+        binding_state=(),
+        steps=_steps(tmp_path, source),
+    )
+
+    gap = machine.resume()
+
+    assert isinstance(gap, GeneratorTransitionGapV1)
+    assert gap.observed == observed
+    assert gap.owner == "GeneratorConstructionV1.transition"
+
+
+def test_an_opaque_step_without_a_suspension_is_named_unchanged(tmp_path) -> None:
+    """The discriminating face: the flag must not decorate every opaque row.
+
+    If it did, the distinction would be worthless -- every statement would
+    claim to hold a suspension and the board would be exactly as
+    undifferentiated as before, one word longer.
+    """
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="probe",
+        frame_coordinate="frame",
+        binding_state=(),
+        steps=_steps(tmp_path, "def g():\n    x = 1\n    yield 2\n"),
+    )
+
+    gap = machine.resume()
+
+    assert isinstance(gap, GeneratorTransitionGapV1)
+    assert gap.observed == "Assign"
+
+
+# -- nothing was named, nothing was drained ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "def g():\n    x = yield 1\n    return x\n",
+        "def g(c):\n    if c:\n        yield 1\n",
+        "def g(xs):\n    yield from xs\n",
+    ),
+)
+def test_every_previously_opaque_shape_is_still_opaque(tmp_path, source) -> None:
+    """`panic = gap`. Sharper testimony must not become a drain: these still
+    refuse, and nothing constructs a suspension the vocabulary cannot execute.
+    """
+    from sugar_lift_py_tests.generator_construction import YieldStepV1
+
+    steps = _steps(tmp_path, source)
+
+    assert any(isinstance(step, OpaqueStepV1) for step in steps)
+    assert not any(isinstance(step, YieldStepV1) for step in steps)
+
+
+def test_a_named_step_is_untouched_and_still_suspends(tmp_path) -> None:
+    """The shapes the vocabulary DOES name keep working, unchanged."""
+    from sugar_lift_py_tests.generator_construction import YieldEffect, YieldStepV1
+
+    steps = _steps(tmp_path, "def g():\n    yield 1\n")
+
+    assert isinstance(steps[0], YieldStepV1)
+
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="probe",
+        frame_coordinate="frame",
+        binding_state=(),
+        steps=steps,
+    )
+
+    assert isinstance(machine.resume(), YieldEffect)
+
+
+def test_the_flag_defaults_to_the_honest_no() -> None:
+    """A step constructed without the testimony claims nothing."""
+    assert OpaqueStepV1("Whatever").carries_suspension is False
+    assert OpaqueStepV1("Whatever").gap_observed() == "Whatever"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2059,7 +2059,20 @@ class FunctionDef(Statement):
                     FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
                 )
             else:
-                steps.append(OpaqueStepV1(statement.kind))
+                # The step vocabulary cannot name this shape. Say WHETHER it
+                # holds a suspension, because the two obligations differ:
+                # `x = 1` owes ordinary statement execution, `x = yield 1`
+                # owes the resumed value's binding. Bucketing them as one
+                # `Assign` row is why the suspension owners read as an
+                # undifferentiated mass. Read from `_owns_yield`, the same
+                # authenticated predicate that decided this body is a
+                # generator -- never from the statement's spelling.
+                steps.append(
+                    OpaqueStepV1(
+                        statement.kind,
+                        carries_suspension=self._owns_yield((statement,)),
+                    )
+                )
 
         for statement in body:
             append_statement(statement)


### PR DESCRIPTION
Follow-up to the killed universe-routing attempt. **This names no new step and drains nothing** -- deliberately. Three of the four unnamed kinds cannot be named yet, and this reports the prerequisites instead of papering them.

## The bucket was misnamed

`OpaqueStepV1(statement.kind)` gave `x = 1` and `x = yield 1` the **same row**:

| statement | row today | actual obligation |
|---|---|---|
| `x = 1` | `Assign` | ordinary statement execution in a generator frame |
| `x = yield 1` | `Assign` | a generator-protocol law: the resumed value's binding |

Same for `If`. And every bare `yield from` is an `Expr`. All four kinds bucket by the **container**, not by the construct that could not be consumed -- which is why the two suspension owners read as one undifferentiated mass.

This is the `add x TermValue` shape: 34 rows saying *"a number does not stand on the addition floor"*, every one a complex literal. **A gap that cannot name what it could not consume cannot be dispatched.**

```
x = yield 1     ->  "Assign carrying a suspension"
x = 1           ->  "Assign"
if c: yield 1   ->  "If carrying a suspension"
if c: pass      ->  "If"
yield from xs   ->  "Expr carrying a suspension"
```

Read from `_owns_yield` -- the same authenticated predicate that already decided the body is a generator -- never from a spelling. Defaults to the honest "no".

## What the vocabulary still owes, and why none of it is named here

Constraint accepted: *do not widen the vocabulary past what you can prove resumes correctly; naming a step you cannot execute is worse than an honest `OpaqueStepV1`.* Measured, each kind is blocked on a prerequisite that does not exist yet:

| kind | blocked on |
|---|---|
| `Assign` (`x = yield v`) | **`ResumeBindingV1.resume_value` is written by `send()` and read by nothing** -- `grep` across both packages finds one write and one *test assertion*. The resumed value reaches no name, so the binding cannot be proven. |
| `If` | the machine is a flat `steps` tuple with an integer `cursor`; it has **no face or partition representation at all**. A branched suspension needs `factor_completed` *and* a machine shape that can carry faces -- not a new step kind. |
| `Expr` (`yield from`) | delegation over an **opaque** iterable must stay a gap by `panic = gap`. Only a ground finite sequence is decidable, which is a narrow slice of the real rows. |
| `LoopRecurrenceStatement` | blocked by ruling, pending the measured arm histogram. |

## Evidence

- **25 passed** across this file plus `test_generator_construction_v1`, `test_generator_construction_law`; **117 passed** across the wider focused set.
- **Mutation:** claiming a suspension on every opaque row fails the three discriminating arms. Reverted, verified clean.
- **`panic = gap` preserved:** every previously-opaque shape is still opaque, still refuses by name, and no `YieldStepV1` is constructed where one did not exist.

### Failure-set delta, per package, at the merged tree

```
sugar-source-tree     base 14 failed   head 14 failed   ZERO new
sugar-lift-py-tests   base  2 failed   head  2 failed   ZERO new
```

`sugar-lift-py-tests`: both are `test_call_contract_resolution`, inherited and verified at base.

**The census-door pin is GREEN** -- `test_source_visible_constructor_door.py::test_census_door_refuses_both_yield_constructors_with_no_call_site` passes. That pin is what killed the previous attempt; this change does not touch the refusal.

### Typed-refusal axis

**Unmoved, as required.** The two suspension owners still refuse identically at the census door -- they are accounted semantics, correct output, and nothing here drains them. Only the *constructed-effect* side gains testimony.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `carries_suspension` flag to `OpaqueStepV1` to identify suspension-bearing opaque steps
> - Adds a `carries_suspension: bool` field (default `False`) to `OpaqueStepV1` in [generator_construction.py](https://github.com/TSavo/sugar/pull/6439/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072), along with a `gap_observed()` method that returns a labelled string when the flag is set.
> - `FunctionDef._source_visible_generator_steps` in [nodes.py](https://github.com/TSavo/sugar/pull/6439/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now sets `carries_suspension=self._owns_yield((statement,))` when constructing opaque steps, so downstream consumers know whether a statement owns a suspension.
> - `GeneratorConstructionV1._transition` passes `step.gap_observed()` instead of `step.observed` so transition gap labels reflect the suspension state.
> - New parametrized tests in [test_generator_step_names_its_suspension.py](https://github.com/TSavo/sugar/pull/6439/files#diff-83abc5c6b6e84c0f937f95c95e7e5b3adf1adb805ec3f2558265f4b708ab6429) cover Assign/If/Expr cases and verify default behaviour is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e1fdda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generator transition reporting for opaque statements that contain suspension points.
  * Transition gaps now identify the specific construct that could not consume the suspension.
  * Preserved existing behavior for statements without suspension points and for recognized yield steps.

* **Tests**
  * Added coverage for suspension ownership, opaque-step behavior, transition gap labels, and existing yield-step semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->