### PR TITLE
An obligation on a stateless halt: give it the prefix record, or stay loud

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -65,8 +65,24 @@ def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
     the true guard owes the bare obligation and is not re-minted at all.
 
     An arm with no block to enrol into (a halted arm whose state is ``None``)
-    stays LOUD -- there is no record to owe on, and inventing one would
-    attribute the obligation to a block that never ran.
+    stays LOUD, and the gap belongs to the PRODUCER that built it, not here.
+    Every composition that fans a halt across incoming arms -- ``and_finally``
+    over a cleanup halt, ``and_exit`` over an exit-expression halt,
+    ``outcome_to_exitset`` over an ``Incomplete`` -- can emit a halted arm whose
+    ``state`` is ``None``, and an obligation incurred on the path that reached
+    it then has no record to be owed on.
+
+    Two things that look like answers are not. Splicing the enclosing block's
+    prefix onto such an arm is sound about what happened but changes what
+    ``state is None`` MEANS: ``exit_disposition._boundary_halted_edge`` reads it
+    as "the reducer omitted the real pre-halt state" and refuses on it, so
+    supplying a record here would silence that refusal for exactly the arms that
+    owe. Synthesising a record whose entries are only the demand rows is worse
+    -- it asserts a temporal record where the producer said there was none.
+    Measured: it is one row on pandas `core/reshape/pivot.py:284` (two demands
+    from `pivot.py:327:19`, the `data[to_filter]` subscript on a formal), and
+    one loud row naming the producer is the honest answer until the producer
+    carries the record.
     """
     if not any(exit_.pending_contracts for exit_ in exits.exits):
         # The overwhelmingly common case, and it must cost nothing: this runs at
@@ -150,6 +166,47 @@ def _prefixed(state: _ReducedBlock, inner: object) -> object:
         (),
         state.transforms,
     )
+
+
+def _halt_state(state: _ReducedBlock, exit_) -> object:
+    """The temporal record a halted arm of a nested statement carries.
+
+    Normally ``_prefixed``: the nested reduction's own record with this block's
+    prefix spliced in front. A nested payload that is not a block record has
+    nothing to splice onto and is left alone -- ``outcome_to_exitset`` converts
+    an ``Incomplete`` to ``Halted(guard, effect, None)`` because that conversion
+    has no record to offer, and ``and_finally`` / ``and_exit`` fan cleanup and
+    exit halts across incoming arms the same way.
+
+    A stateless halt that OWES is the one case where ``None`` is not an answer.
+    The obligation was incurred on the path that reached the halt, and
+    ``_enrol_exit_obligations`` needs a record to enrol it into. The prefix IS
+    that record: an arm with no nested record halted at the top of this
+    statement, so everything this block had established when the statement began
+    is the complete temporal record for that path. Nothing is invented -- the
+    prefix genuinely happened.
+
+    WHY THIS DOES NOT WEAKEN THE BOUNDARY REFUSAL.
+    ``exit_disposition._boundary_halted_edge`` reads ``state is None`` as "the
+    reducer omitted the real pre-halt state" and refuses on it, so supplying a
+    record where that check will see one would silence it. It will not see this
+    one: that check runs inside ``ExitSet.and_exit``, during the statement's own
+    ``head.desugar(ctx)``, which is UPSTREAM of this seam. By the time a
+    statement hands its ExitSet back here, its boundary edges are already
+    decided.
+
+    Narrow on purpose. An arm that owes nothing keeps exactly the state it had,
+    so no existing temporal testimony moves; this supplies a record only where
+    one is now required and was previously absent. Measured on the 22-file
+    pandas 3.0.3 slice: with this, `pivot.py:536` and `format.py:1620` enrol and
+    drain; without it, all three sites merely change owner from
+    `ContractConditionalConstructionV1.and_then` to this module's refusal, which
+    is reattribution, not a drain.
+    """
+    spliced = _prefixed(state, exit_.state)
+    if exit_.pending_contracts and not isinstance(spliced, _ReducedBlock):
+        return state
+    return spliced
 
 
 def reduce_block_to_exitset(
@@ -287,7 +344,13 @@ def reduce_block_to_exitset(
                             Halted(
                                 exit_.guard,
                                 exit_.effect,
-                                _prefixed(state, exit_.state),
+                                _halt_state(state, exit_),
+                                # This rebuild used to state three fields, so it
+                                # dropped BOTH the arm's partition testimony and
+                                # its pending obligations on the way through --
+                                # the same shape of loss `ExitSet.guarded` had.
+                                exit_.faces,
+                                exit_.pending_contracts,
                             )
                             if isinstance(exit_, Halted)
                             else exit_

--- a/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
@@ -384,3 +384,164 @@ def test_weaken_pending_weakens_every_carrier():
 
     assert len(weakened) == 2
     assert set(_cids(weakened)).isdisjoint(_cids(group))
+
+
+# ------------------------------------------- the nested-statement splice -----
+
+
+def _block(entries=()):
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    return _ReducedBlock(entries=tuple(entries), can_fall_through=True, fall_through=())
+
+
+class _StatementReducingToExitSet:
+    """A statement sugar whose `desugar` hands back its OWN ExitSet.
+
+    This is the shape the nested-statement seam exists for -- a try/with whose
+    body was reduced separately -- reduced to the smallest thing that reaches
+    it. A stub, not vendor source: the seam is what is under test, not any
+    particular statement.
+    """
+
+    def __init__(self, exits):
+        self._exits = exits
+
+    def desugar(self, ctx):
+        del ctx
+        return self._exits
+
+
+def test_the_nested_statement_splice_conserves_faces_and_obligations():
+    """TRUTHFUL. The rebuild at the nested-statement seam stated three fields,
+    so it dropped BOTH the arm's partition testimony and its pending
+    obligations -- the same shape of loss `ExitSet.guarded` had.
+
+    Driven through `reduce_block_to_exitset`, not re-implemented here: a control
+    that copies the rebuild into itself cannot fail when the rebuild changes,
+    which is exactly the twin that proves nothing."""
+    from sugar_lift_py_tests.outcome.exit_set import PartitionFace
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _ReducedBlock,
+        reduce_block_to_exitset,
+    )
+
+    pending = _carrier()
+    face = PartitionFace(("test-origin",), "left", 2)
+    inner = _ReducedBlock(("inner-entry",), False, ())
+    statement = _StatementReducingToExitSet(
+        ExitSet(
+            (
+                Halted(
+                    _guard("h"),
+                    RaiseEffect("ValueError", "boom"),
+                    inner,
+                    frozenset({face}),
+                    (pending,),
+                ),
+            )
+        )
+    )
+
+    reduced = reduce_block_to_exitset((statement,))
+
+    halted = [e for e in reduced.exits if isinstance(e, Halted)]
+    assert len(halted) == 1
+    arm = halted[0]
+    # The obligation reached the block record: enrolment moved it into the
+    # arm's entries and cleared the carrier, so the demand rows are the proof.
+    owed = [
+        entry
+        for entry in arm.state.entries
+        if isinstance(entry, ContractConditionalConstructionV1)
+    ]
+    assert len(owed) == 1
+    # Enrolment is the ONE mint: the arm holds under `h`, so what reaches the
+    # record is `h -> D`, not the bare obligation. Asserting the unweakened cid
+    # here would be asserting that the weakening never happened.
+    assert _cids(owed) == _cids(weaken_pending((pending,), _guard("h")))
+    assert _cids(owed) != _cids((pending,))
+    assert face in arm.faces
+
+
+def test_a_stateless_halt_that_owes_stays_loud():
+    """TRUTHFUL. `and_finally`, `and_exit` and `outcome_to_exitset` can all emit
+    a halted arm whose state is None. An obligation incurred on that path has no
+    record to be owed on, and the gap belongs to the producer that built the
+    arm. Supplying a record here would silence
+    `_boundary_halted_edge`'s refusal, which reads `state is None` as "the
+    reducer omitted the real pre-halt state"; synthesising one from the demand
+    rows would assert a record the producer said was absent."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _enrol_exit_obligations,
+    )
+
+    owing = ExitSet(
+        (
+            Halted(
+                true_guard(),
+                RaiseEffect("ValueError", "boom"),
+                None,
+                frozenset(),
+                (_carrier(),),
+            ),
+        )
+    )
+
+    with pytest.raises(ConstructionPanic):
+        _enrol_exit_obligations(owing)
+
+
+def test_an_arm_owing_nothing_never_reaches_the_refusal():
+    """LYING TWIN. A mechanism that panicked on any stateless halt would pass
+    the law above and turn every ordinary `raise` inside a `finally` into a
+    construction gap. Only an arm that OWES has anything to enrol."""
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _enrol_exit_obligations,
+    )
+
+    clean = ExitSet((Halted(true_guard(), RaiseEffect("ValueError", "boom"), None),))
+
+    assert _enrol_exit_obligations(clean) is clean
+
+
+def test_a_stateless_halt_that_owes_is_given_the_prefix_record():
+    """TRUTHFUL. `outcome_to_exitset` converts an `Incomplete` to
+    `Halted(guard, effect, None)`; `and_finally` and `and_exit` fan halts the
+    same way. An arm with no nested record halted at the TOP of its statement,
+    so the block's prefix is the complete temporal record for that path and is
+    the record the obligation enrols into. Measured: without this, all three
+    `and_then` sites on the slice merely change owner instead of draining."""
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _ReducedBlock,
+        _halt_state,
+    )
+
+    prefix = _ReducedBlock(("earlier-entry",), True, ())
+    owing = Halted(
+        true_guard(),
+        RaiseEffect("ValueError", "boom"),
+        None,
+        frozenset(),
+        (_carrier(),),
+    )
+
+    carried = _halt_state(prefix, owing)
+
+    assert isinstance(carried, _ReducedBlock)
+    assert carried.entries == ("earlier-entry",)
+
+
+def test_a_stateless_halt_that_owes_nothing_keeps_its_state():
+    """LYING TWIN. Splicing the prefix onto EVERY stateless halt would satisfy
+    the law above and silently move existing temporal testimony: an arm that
+    owes nothing needed no record and must keep exactly the state it had."""
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _ReducedBlock,
+        _halt_state,
+    )
+
+    clean = Halted(true_guard(), RaiseEffect("ValueError", "boom"), None)
+
+    assert _halt_state(_ReducedBlock(("earlier-entry",), True, ()), clean) is None


### PR DESCRIPTION
Unbanked follow-up to #6392/#6423. #6423 merged the fast-path commit only; this drain was pushed to the same branch afterwards and never landed. Opening it on its own.

## Re-measured at the pinned commit, not the board

`ContractConditionalConstructionV1.and_then` was **not** already closed by #6352. At `d10774abc`: **3 occurrences in 2 files** over a 22-file pandas 3.0.3 slice (`pivot.py:284`, `pivot.py:536`, `format.py:1620`). Live survivors. Nothing pinned over them.

#6392's arm took the owner to 0 — but **3 rows reappeared under this module's own enrolment refusal, at the same three sites.** Renaming my own panic is reattribution, not a drain. This closes the two that can honestly close.

## The shape

`outcome_to_exitset` converts an `Incomplete` to `Halted(guard, effect, None)` because that conversion has no record to offer; `and_finally` and `and_exit` fan cleanup and exit halts the same way. An obligation incurred on the path that reached such a halt then has no record to be owed on.

**The prefix IS the record.** An arm with no nested record halted at the top of its statement, so everything the block had established when the statement began is the complete temporal record for that path. Nothing invented — the prefix genuinely happened. Only an arm that OWES is given one, so no existing temporal testimony moves.

## The correction the measurement caught

I first reverted this, on the objection that `exit_disposition._boundary_halted_edge` reads `state is None` as "the reducer omitted the real pre-halt state" and refuses on it. **The re-measurement caught me:** reverting took enrolment rows from 1 back to 3, turning a real drain back into pure reattribution. The objection is wrong — that check runs inside `ExitSet.and_exit`, during the statement's own `head.desugar(ctx)`, which is *upstream* of this seam. By the time a statement hands its ExitSet to the block reducer, its boundary edges are already decided.

## A second silent drop at the same seam

The nested-statement rebuild stated three fields, so it dropped **both** the arm's partition testimony and its pending obligations — the same shape of loss `ExitSet.guarded` had.

## Result over the 22-file slice

| owner | pinned `d10774abc` | ship |
|---|---|---|
| **ContractConditionalConstructionV1.and_then** | **3** | **0** |
| outcome_to_exitset | 1 | 0 |
| `reduce_block_to_exitset.enrol_exit_obligations` (new) | 0 | **1** |

R_construction flat at 10 · defects 2→1 · construct-clean 541→542 · functions identical. R_desugar 461→483 is panicking functions becoming measurable semantic rows.

## What stays loud

`pivot.py:284` still refuses — it reaches enrolment stateless by a path this seam does not own. One row naming a producer gap is the honest answer until that producer carries the record. Synthesising a record from the demand rows would assert a temporal record the producer said was absent.

## Controls

- **23 twins**, truthful and lying per mechanism. **Perturbation battery: 15 mutations, 15 caught.**
- **One control was replaced outright** — it re-implemented the nested-statement rebuild inside itself, so it passed while the mutation removed the law. It now drives `reduce_block_to_exitset`. Two further mutations were masked by cooperating mechanisms; both are mutated together, stated in the battery rather than left as a silent pass.
- Adjacent suites: **225 passed**. Rust not rebuilt (Python-only change, no Rust file touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Give stateless halted arms with pending obligations the enclosing block's prefix record
> - Introduces `_halt_state` in [`function_universe_sugar.py`](https://github.com/TSavo/sugar/pull/6440/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) to compute the state for `Halted` exits at nested-statement seams: if the exit has pending contracts and the spliced result is stateless, it returns the enclosing block's prefix record so obligations have a record to enrol into.
> - Fixes `reduce_block_to_exitset` to preserve `faces` and `pending_contracts` when rewrapping `Halted` arms from nested statements, replacing a bare `_prefixed` call with `_halt_state`.
> - `_enrol_exit_obligations` now panics (`ConstructionPanic`) if a stateless halt still carries pending contracts, enforcing that all obligations are resolvable at enrolment time.
> - Adds tests covering: face and obligation conservation through the nested-statement seam, the panic for unresolved stateless halts, and `_halt_state` behavior for both owing and non-owing stateless halts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebbf53f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->