### PR TITLE
A test may not patch process-global os.name

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py
@@ -53,13 +53,25 @@ def sugarbin_route(*, os_name: str, hostname: str) -> str:
     return "posix-broker"
 
 
+def current_os_name() -> str:
+    """The platform family this process is running as.
+
+    Exists so a test can substitute the routing input WITHOUT patching
+    ``os.name`` itself. ``os.name`` is process-global and ``pathlib.Path.__new__``
+    dispatches on it, so patching it makes every ``Path`` in the interpreter --
+    including pytest's own reporter -- a ``WindowsPath``, which aborts the
+    session. Patch this function instead.
+    """
+    return os.name
+
+
 def resolve_sugar_binary(
     *,
     env: Mapping[str, str] | None = None,
     profile: str = "release",
 ) -> Path:
     child_env = dict(os.environ if env is None else env)
-    route = sugarbin_route(os_name=os.name, hostname=platform.node())
+    route = sugarbin_route(os_name=current_os_name(), hostname=platform.node())
     if route == "battleaxe-native":
         command = [
             "powershell.exe",

--- a/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
@@ -607,7 +607,7 @@ def test_python_wrapper_uses_native_windows_sugarbin(monkeypatch) -> None:
         calls.append((command, kwargs))
         return subprocess.CompletedProcess(command, 0, f"{resolved}\n", "")
 
-    monkeypatch.setattr(sugar_binary.os, "name", "nt")
+    monkeypatch.setattr(sugar_binary, "current_os_name", lambda: "nt")
     monkeypatch.setattr(sugar_binary.platform, "node", lambda: "Battleaxe")
     monkeypatch.setattr(sugar_binary, "subprocess_run", fake_run)
 
@@ -632,7 +632,7 @@ def test_python_wrapper_keeps_non_battleaxe_windows_on_broker(monkeypatch) -> No
         calls.append((command, kwargs))
         return subprocess.CompletedProcess(command, 0, f"{resolved}\n", "")
 
-    monkeypatch.setattr(sugar_binary.os, "name", "nt")
+    monkeypatch.setattr(sugar_binary, "current_os_name", lambda: "nt")
     monkeypatch.setattr(sugar_binary.platform, "node", lambda: "MapLaptop")
     monkeypatch.setattr(sugar_binary, "subprocess_run", fake_run)
 


### PR DESCRIPTION
## The defect

`tests/test_binary_handoff_policy.py:610` and `:635` did:

```python
monkeypatch.setattr(sugar_binary.os, "name", "nt")
```

`sugar_binary.os` is not a module-local alias — **it is the `os` module**. `pathlib.Path.__new__` dispatches on `os.name`, so for the duration of those two tests **every `Path(...)` constructed anywhere in the process becomes a `WindowsPath`**, which cannot be instantiated on this system.

Verified on a quiet interpreter, no suite, no load:

```
before: PosixPath | during: WindowsPath | after: PosixPath
```

## Why it mattered beyond two tests

Under `-v`, pytest's reporter formats a location line while the patch is live, builds a `Path`, and the **session aborts**:

```
INTERNALERROR> _pytest/terminal.py:1048 _locationline
INTERNALERROR> _pytest/config/__init__.py:1279 cwd_relative_nodeid
INTERNALERROR> pathlib/__init__.py:490 relative_to
pathlib.UnsupportedOperation: cannot instantiate 'WindowsPath' on your system
```

Under `-q` the session survives — but any `Path` created in that window is still a `WindowsPath`. **So an unknown share of downstream failures were consequences of the leak rather than independent defects**, and no full-suite count taken while it was present is a denominator.

This is why two independent captures of main disagreed: `-v` died at ~2%, `-q` ran to 52%. That is **reporter verbosity, not machine load** — the difference was initially misattributed to contention.

## The fix

`resolve_sugar_binary` already read `os.name` exactly once and passed it as a parameter:

```python
route = sugarbin_route(os_name=os.name, hostname=platform.node())
```

The seam existed; the tests reached past it into the shared module. `current_os_name()` makes it patchable without a process-global mutation.

**Both tests keep their assertions. The Windows routing stays covered.** Nothing deleted, nothing skipped, no detector weakened.

## Measured

```
module before:  8 failed, 15 passed
module after:   6 failed, 17 passed
-v INTERNALERROR:  present -> gone (0 lines)
Path during patch: WindowsPath -> PosixPath
```

The two repaired tests are exactly the two that patched `os.name`.

**The remaining six failures are pre-existing and unrelated** — `sugarbin` rung exhaustion and source-stamp rows — and are deliberately not touched here. They are the real red on main and belong to a separate diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `current_os_name()` helper in `sugar_binary` to allow safe test patching
> Patching `os.name` directly in tests mutates a process-global value, which can affect other tests. This PR adds a `sugar_binary.current_os_name()` wrapper that returns `os.name`, and updates `resolve_sugar_binary` to call it. Tests now monkeypatch `sugar_binary.current_os_name` instead of `sugar_binary.os.name`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8245d41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->