### PR TITLE
Pin the IfExp collapse: it is load-bearing, not a convenience

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1250,6 +1250,40 @@ def join_binding_state(
     when_false: BindingState,
     make_ifexp,
 ) -> BindingState:
+    """Join the two branch faces of one binding into a single state.
+
+    THE ``IfExp`` COLLAPSE BELOW IS LOAD-BEARING, NOT A CONVENIENCE. It reads
+    like an optimisation -- both sides are plain values, so express the join as
+    an if-expression instead of a guarded binding -- and it is the single thing
+    keeping the commonest conditional-binding shape in real code away from a
+    source-keyed partition.
+
+    ``GuardedBinding`` is what later mints
+    ``partition(("binding.projection", slot.slot_id))``, and ``slot_id`` is
+    keyed on ``(source_cid, span, fragment_cid)`` with NO execution component
+    (``branch_result_slot``). ``_faces_exclusive`` then proves two arms
+    exclusive from their carried faces alone and never reads their guards. So
+    two arms from DIFFERENT executions that shared one slot would be declared
+    mutually exclusive and collapsed into a single guarded value -- the second
+    execution's value re-attributed to the negation of the first's guard.
+
+    That conflation is not reachable today, and this arm is one of three
+    reasons why: a name bound in BOTH branches never becomes a
+    ``GuardedBinding`` at all, so it never mints the partition. The other two
+    are that ordinary call sites stay opaque (one callee is not reduced twice
+    into one ``ExitSet``) and that loops route through
+    ``LoopGuardedProjection`` instead.
+
+    **Making this symmetric -- returning a ``GuardedBinding`` here for
+    consistency with the arms below -- would hand a source-keyed partition to
+    the most common shape in the corpus.** Do not do it without giving the slot
+    an execution component first.
+
+    Pinned by ``tests/test_binding_partition_execution_conflation.py``
+    (``test_tripwire_a_two_branch_binding_never_mints``), which fails if this
+    arm stops collapsing, and by the tripwires beside it for the other two
+    properties.
+    """
     from sugar_source_tree.nodes import Node
 
     if when_true is when_false or when_true == when_false:
@@ -1257,6 +1291,9 @@ def join_binding_state(
     when_true = unwrap_binding_state(when_true)
     when_false = unwrap_binding_state(when_false)
     if isinstance(when_true, Node) and isinstance(when_false, Node):
+        # Both sides are plain values: the join is an if-expression, and NO
+        # partition is minted. See the docstring -- this is the property that
+        # keeps ordinary conditional bindings off the source-keyed partition.
         return make_ifexp(slot, when_true, when_false)
     if isinstance(when_true, UnboundBinding) and isinstance(when_false, UnboundBinding):
         return UnboundBinding(name=when_true.name, cause=when_true.cause)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1268,11 +1268,25 @@ def join_binding_state(
     execution's value re-attributed to the negation of the first's guard.
 
     That conflation is not reachable today, and this arm is one of three
-    reasons why: a name bound in BOTH branches never becomes a
-    ``GuardedBinding`` at all, so it never mints the partition. The other two
-    are that ordinary call sites stay opaque (one callee is not reduced twice
-    into one ``ExitSet``) and that loops route through
-    ``LoopGuardedProjection`` instead.
+    reasons why. The other two are that ordinary call sites stay opaque (one
+    callee is not reduced twice into one ``ExitSet``) and that loops route
+    through ``LoopGuardedProjection`` instead.
+
+    THE MINT NEEDS ALL THREE OF: a name bound in exactly ONE branch, with NO
+    PRIOR BINDING of that name, then read afterwards. Measured::
+
+        if p: x = 1 else: x = 2 ; return x   ->  no mint   (this arm)
+        x = 0 ; if p: x = 1 ; return x       ->  no mint
+        if p: x = 1 ; return x               ->  MINTS
+
+    The prior binding kills it for the same reason this arm does: ``x = 0``
+    leaves the else-face bound too, so the join has a plain Node on both sides
+    and collapses here. **Initializing the name first is the more natural way
+    to write that code**, which is why the mint is harder to reach than "bound
+    in one branch, then read" suggests -- one of twelve probed shapes reaches
+    it. Anyone checking this docstring against a shape with a prior
+    initialization will see no mint and should not conclude the docstring is
+    wrong.
 
     **Making this symmetric -- returning a ``GuardedBinding`` here for
     consistency with the arms below -- would hand a source-keyed partition to

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8195,6 +8195,12 @@ def _construct_binding_projection(state):
             _construct_binding_projection(state.when_false),
         )
     if isinstance(state, LoopProjectedBinding):
+        # A loop routes HERE, not to GuardedProjection -- which is why a loop
+        # never mints ("binding.projection", slot_id). That matters: a loop is
+        # the one shape supplying many executions over one source location by
+        # construction, and that partition's key has no execution component.
+        # See tests/test_binding_partition_execution_conflation.py
+        # (test_tripwire_c_a_loop_body_does_not_mint_this_partition).
         if any(face.guard_formula is None for face in state.completed_faces):
             raise BindingStateWireGap(
                 "loop projected binding has CID-only guards; exact guard formula "


### PR DESCRIPTION
## A load-bearing property that reads as a convenience

`join_binding_state` had **no docstring and no comment**. The arm that collapses to an if-expression when both branch faces are plain Nodes:

```python
if isinstance(when_true, Node) and isinstance(when_false, Node):
    return make_ifexp(slot, when_true, when_false)
```

reads as an optimisation — both sides are values, so express the join as an if-expression — and someone could reasonably make it **symmetric** with the `GuardedBinding` arm below it, for consistency.

**It is the single property keeping the commonest conditional-binding shape in real code away from a source-keyed partition.**

`GuardedBinding` is what later mints `partition(("binding.projection", slot_id))`. `slot_id` is keyed on `(source_cid, span, fragment_cid)` with **no execution component**, and `_faces_exclusive` proves two arms exclusive from their carried faces alone, never reading their guards. Two arms from different executions sharing one slot would therefore be declared mutually exclusive and collapsed — the second execution's value re-attributed to the negation of the first's guard.

That conflation is **not reachable today** (#6443 proves the join absent). This arm is one of three reasons why.

## What this PR is

**Comments only.** No behaviour, no CID movement, 43 insertions.

- **(a)** pinned at `join_binding_state` — the docstring states what depends on the collapse and says plainly: *making this symmetric would hand a source-keyed partition to the most common shape in the corpus.*
- **(c)** pinned at its one clean site in `_construct_binding_projection` — a loop routes to `LoopGuardedProjection` and so never mints this partition, which matters because **a loop is the one shape supplying many executions over one source location by construction.**
- **(b)** — ordinary call sites staying opaque — **has no single site to pin.** It is a property of the call path as a whole. Stated in the commit rather than forced into a location it does not belong.

## Why cause and consequence both

#6443's tripwires prove the **consequence**: they go red if the hazard becomes reachable. This pins the **cause**. Without it, a reader who tidies the asymmetry meets a failing tripwire in a different package and no explanation of why it exists.

## Known inherited

`nodes.py` fails `black --check` on **pristine main**, in a region I did not touch. Left alone rather than reformatting an 8,000-line file inside a comment-only PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document that IfExp collapse in `join_binding_state` is load-bearing, not cosmetic
> Adds explanatory comments and a docstring to clarify why two plain-value branch faces must be collapsed into an `IfExp` — skipping this step would incorrectly mint a source-keyed partition. Also adds a comment in `_construct_binding_projection` explaining why `LoopProjectedBinding` routes to `LoopGuardedProjection` instead of `GuardedProjection`, which similarly avoids minting the `("binding.projection", slot_id)` partition. No executable logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ebd972.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->