### PR TITLE
A branch inside a generator body is a two-face partition the producer owns

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -30,7 +30,32 @@ class FinallyStepV1:
     statements: tuple[object, ...]
 
 
-GeneratorStepV1 = YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | FinallyStepV1
+@dataclass(frozen=True)
+class IfStepV1:
+    """A branch inside a generator body, with each side's own step sequence.
+
+    Carries SOURCE data only -- the guard's sugar, both branches' steps, and the
+    `If` statement's own fragment CID. It deliberately does NOT carry a
+    partition: the composite key needs the machine's `instance_coordinate`, and
+    `allocate` mints that AFTER the producer has built the steps. Minting at
+    TRANSITION time instead keeps the step tuple instance-agnostic, so one
+    generator's steps can be shared by every instance over it while each mints
+    its own partition. That is the property the key exists for.
+
+    Admitted by the producer only when EVERY step in both branches is one the
+    vocabulary can already execute. A branch holding a shape we cannot resume --
+    `x = yield v`, whose resumed value reaches no name -- keeps the whole `If`
+    an `OpaqueStepV1` and loud. Naming a step we cannot resume is worse than an
+    honest opaque one.
+    """
+
+    guard: object
+    then_steps: tuple
+    else_steps: tuple
+    fragment_cid: str
+
+
+GeneratorStepV1 = YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | FinallyStepV1 | IfStepV1
 
 
 @dataclass(frozen=True)
@@ -150,6 +175,8 @@ class GeneratorConstructionV1:
                 return cleanup
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
+        if isinstance(step, IfStepV1):
+            return self._transition_branch(step, requested)
         if isinstance(step, ReturnStepV1):
             value = self._reduce_value(step.value, requested)
             if isinstance(value, GeneratorTransitionGapV1):
@@ -165,6 +192,140 @@ class GeneratorConstructionV1:
             suspended_resume_coordinate=resume_coordinate,
         )
         return YieldEffect(value, resume_coordinate, machine)
+
+    def _transition_branch(self, step: "IfStepV1", requested: str):
+        """A branch is a two-face partition, or a splice when the guard decides.
+
+        A DECIDED guard is not a partition: exactly one side runs, so its steps
+        are spliced into this machine's sequence and nothing is minted. Minting
+        a family over a route the producer does not actually decide would assert
+        an exhaustiveness that is not true.
+
+        An UNDECIDED guard is a genuine two-face split. Each face is a distinct
+        successor machine with its own cursor -- the partition lives in the
+        `ExitSet`, never in the machine, which is why no `faces` field is needed
+        here. `factor_completed` then moves the partition from the exit level
+        (where `sequence` multiplies it, m ** k over k steps) to the value level
+        (one arm carrying a `GuardedValue` chain, which composes).
+
+        THE KEY IS COMPOSITE. `("generator.branch", instance_coordinate,
+        fragment_cid)`: the fragment gives reproducibility -- two reads of one
+        instance's branch mint the same partition -- and the instance
+        coordinate keeps two live generators over one source branch from
+        looking like two sides of ONE split. `_faces_exclusive` never reads the
+        arms' guards, so a source-only key would let the algebra declare two
+        unrelated executions exclusive and re-attribute one's value to the
+        negation of the other's guard. Same shape as the loop carrier's
+        `targetCid` occurrence (see
+        `test_two_occurrences_with_identical_faces_are_different_states`).
+        """
+        from dataclasses import replace as _replace
+
+        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, partition
+
+        decided = self._decide_guard(step.guard)
+        if decided is True:
+            return self._spliced(step.then_steps)._transition(requested)
+        if decided is False:
+            return self._spliced(step.else_steps)._transition(requested)
+
+        guard_formula = self._guard_formula(step.guard)
+        if guard_formula is None:
+            return self._gap(requested, "If carrying a suspension")
+
+        then_face, else_face = partition(
+            ("generator.branch", self.instance_coordinate, step.fragment_cid)
+        )
+        from sugar_lift_py_tests.ir import not_
+
+        return ExitSet(
+            (
+                Completed(
+                    guard_formula,
+                    self._spliced(step.then_steps),
+                    frozenset({then_face}),
+                    (),
+                ),
+                Completed(
+                    not_(guard_formula),
+                    self._spliced(step.else_steps),
+                    frozenset({else_face}),
+                    (),
+                ),
+            )
+        ).factor_completed()
+
+    def _spliced(self, branch_steps: tuple) -> "GeneratorConstructionV1":
+        """This machine with the branch's steps in place of the `If`."""
+        from dataclasses import replace as _replace
+
+        steps = (
+            *self.steps[: self.cursor],
+            *branch_steps,
+            *self.steps[self.cursor + 1 :],
+        )
+        return _replace(self, steps=steps)
+
+    def _guard_truth(self, guard: object):
+        """The guard's TRUTH as a floor value, or None if it cannot stand.
+
+        A branch guard is not the operand -- it is the operand's truth, which
+        is exactly what `FloorValue.truth` already states for every value that
+        can answer it. Reading the operand's type directly would be a second,
+        weaker copy of that law: `NoneValue.truth` is False, a container's is
+        its non-emptiness, and a symbolic value's is a predicate. Routing
+        through `truth` keeps one owner for the question.
+        """
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+        value = guard
+        if isinstance(guard, Sugar):
+            outcome = guard.desugar()
+            if not isinstance(outcome, Complete):
+                return None
+            value = outcome.value
+        truth = getattr(value, "truth", None)
+        if truth is None:
+            return None
+        try:
+            outcome = truth(self.instance_coordinate)
+        except BaseException:
+            return None
+        if not isinstance(outcome, Complete):
+            return None
+        return outcome.value
+
+    def _decide_guard(self, guard: object):
+        """True/False when the guard's truth is ground, None when it is not."""
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        truth = self._guard_truth(guard)
+        if isinstance(truth, TrueBoolLiteralSugar):
+            return True
+        if isinstance(truth, FalseBoolLiteralSugar):
+            return False
+        return None
+
+    def _guard_formula(self, guard: object):
+        """The guard's truth as a Formula, or None when it cannot stand."""
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+        truth = self._guard_truth(guard)
+        if isinstance(truth, PredicateValue):
+            return truth.formula
+        to_formula = getattr(truth, "to_formula", None)
+        if to_formula is not None:
+            try:
+                return to_formula()
+            except BaseException:
+                return None
+        return None
 
     def _reduce_value(self, value: object, requested: str):
         if value is None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -1,0 +1,257 @@
+"""A branch inside a generator body is a two-face partition the producer owns.
+
+`if c: yield 1` landed on `OpaqueStepV1("If")` -- the step vocabulary kept the
+container's kind and threw away the guard and both branches, so the machine had
+nothing to transition with.
+
+THE THREE ARMS. A DECIDED guard is not a partition: exactly one side runs, so
+its steps splice into the sequence and nothing is minted -- minting a family
+over a route the producer does not decide would assert an exhaustiveness that
+is not true. An UNDECIDED guard is a genuine two-face split, and each face is a
+distinct successor machine with its own cursor.
+
+WHY THERE IS NO `faces` FIELD ON THE MACHINE. The partition lives in the
+`ExitSet`; the machine that partitions does not advance, it is replaced by two
+successors. That is the shape the machine already used -- `YieldEffect` carries
+a successor machine, `ExitSet.halted(effect, state=self)` carries state.
+
+THE KEY IS COMPOSITE, and this is the load-bearing part. A source-only key
+makes two live generators over one source branch look like two sides of ONE
+split, because `_faces_exclusive` never reads the arms' guards. Measured on the
+algebra directly in `test_partition_key_execution_discriminator.py`: two
+executions collapse into one arm and the second's value is re-attributed to the
+negation of the first's guard. The instance coordinate discriminates them; the
+fragment keeps two reads of ONE instance reproducible.
+
+That shape is not novel -- the loop carrier already keys on the producer
+OCCURRENCE (`targetCid`), pinned by
+`test_two_occurrences_with_identical_faces_are_different_states`. This is the
+same law at a second producer.
+
+THE BOUND. Only when EVERY step in both branches is one the vocabulary can
+already execute. `x = yield v` resumes to a value that reaches no name --
+`ResumeBindingV1.resume_value` is written by `send()` and read by nothing -- so
+a branch holding one keeps the whole `If` opaque and loud. Naming a step we
+cannot resume is worse than an honest `OpaqueStepV1`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    GeneratorTerminationV1,
+    IfStepV1,
+    OpaqueStepV1,
+    ReturnStepV1,
+    YieldEffect,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    directory = pathlib.Path(tempfile.mkdtemp())
+    path = directory / "m.py"
+    path.write_text(source, encoding="utf-8")
+    function = next(iter(SourceFile(path_source(str(path))).functions()))
+    return function._source_visible_generator_steps({})
+
+
+def _machine(steps, allocation: str = "call-site"):
+    return GeneratorConstructionV1.allocate(
+        allocation_coordinate=allocation,
+        frame_coordinate="frame",
+        binding_state=(),
+        steps=steps,
+    )
+
+
+def _completed(exits) -> list:
+    return [e for e in exits.exits if isinstance(e, Completed)]
+
+
+# -- the producer names the branch, and refuses what it cannot resume --------
+
+
+@pytest.mark.parametrize(
+    ("source", "first_step"),
+    (
+        # THE reproducer.
+        ("def g(c):\n    if c:\n        yield 1\n", IfStepV1),
+        (
+            "def g(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n",
+            IfStepV1,
+        ),
+        # THE BOUND: a branch holding a shape we cannot resume stays opaque.
+        ("def g(c):\n    if c:\n        x = yield 1\n", OpaqueStepV1),
+    ),
+)
+def test_the_producer_admits_only_a_wholly_nameable_branch(source, first_step) -> None:
+    assert isinstance(_steps(source)[0], first_step)
+
+
+def test_a_branch_step_carries_both_sides_and_its_own_fragment(tmp_path) -> None:
+    step = _steps(
+        "def g(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n"
+    )[0]
+
+    assert isinstance(step.then_steps[0], YieldStepV1)
+    assert isinstance(step.else_steps[0], YieldStepV1)
+    assert step.fragment_cid
+    # The step is instance-agnostic: no partition is minted at producer time,
+    # because the key needs an instance_coordinate that does not exist yet.
+    assert not hasattr(step, "partition")
+
+
+def test_an_if_without_a_suspension_is_untouched() -> None:
+    """The discriminating face: this arm must not claim every branch."""
+    steps = _steps("def g(c):\n    if c:\n        pass\n    yield 2\n")
+
+    assert isinstance(steps[0], OpaqueStepV1)
+    assert isinstance(steps[1], YieldStepV1)
+
+
+# -- the three transition arms -----------------------------------------------
+
+
+def test_a_ground_true_guard_splices_the_then_branch() -> None:
+    step = IfStepV1(
+        TrueBoolLiteralSugar(site="s"), (YieldStepV1(TermValue(1)),), (), "frag"
+    )
+
+    assert isinstance(_machine((step, ReturnStepV1())).resume(), YieldEffect)
+
+
+def test_a_ground_false_guard_splices_the_else_branch() -> None:
+    step = IfStepV1(
+        FalseBoolLiteralSugar(site="s"), (YieldStepV1(TermValue(1)),), (), "frag"
+    )
+
+    assert isinstance(_machine((step, ReturnStepV1())).resume(), GeneratorTerminationV1)
+
+
+def test_an_undecided_guard_partitions_into_two_faces() -> None:
+    outcome = _machine(_steps("def g(c):\n    if c:\n        yield 1\n")).resume()
+
+    assert isinstance(outcome, ExitSet)
+
+
+# -- the arm count: factoring holds, so sequencing does not multiply ---------
+
+
+@pytest.mark.parametrize("branch_suspensions", (1, 2, 3))
+def test_a_branch_with_k_suspensions_stays_one_arm(branch_suspensions) -> None:
+    """THE m ** k gate.
+
+    `factor_completed` moves the partition from the exit level -- where
+    `sequence` multiplies it -- to the value level, where it composes. If this
+    ever reports the branch count instead of 1, sequencing has gone exponential
+    and the defect surfaces as a corpus timeout days later, never in a twin.
+    """
+    branch = tuple(YieldStepV1(TermValue(n)) for n in range(branch_suspensions))
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    from sugar_lift_py_tests.ir import atomic
+
+    step = IfStepV1(PredicateValue(atomic("c", ()), "s"), branch, (), "frag")
+    outcome = _machine((step, ReturnStepV1())).resume()
+
+    assert len(_completed(outcome)) == 1
+
+
+def test_sequential_branches_stay_one_arm() -> None:
+    """k branches in sequence would be 2 ** k unfactored."""
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    from sugar_lift_py_tests.ir import atomic
+
+    steps = tuple(
+        IfStepV1(
+            PredicateValue(atomic(f"c{n}", ()), "s"),
+            (YieldStepV1(TermValue(n)),),
+            (),
+            f"frag{n}",
+        )
+        for n in range(3)
+    ) + (ReturnStepV1(),)
+
+    assert len(_completed(_machine(steps).resume())) == 1
+
+
+def test_the_factored_arm_carries_the_partition_as_a_value() -> None:
+    """Where the partition went: a GuardedValue chain, not two exit arms."""
+    outcome = _machine(_steps("def g(c):\n    if c:\n        yield 1\n")).resume()
+
+    assert type(_completed(outcome)[0].value).__name__ == "GuardedValue"
+
+
+# -- the two-live-instances twin: REQUIRED, and it caught a real defect ------
+
+
+def test_two_live_instances_mint_different_partitions() -> None:
+    """THE twin the composite key exists for.
+
+    Two generators over ONE source branch are two executions. With a
+    source-only key their arms carry the same origin on opposite sides, and
+    `_faces_exclusive` -- which never reads guards -- declares them exclusive.
+    Measured: they collapse and one execution's value is re-attributed to the
+    negation of the other's guard.
+
+    If this ever fails, the key has regressed to source-alone.
+    """
+    from sugar_lift_py_tests.outcome import exit_set as exit_set_module
+
+    minted = []
+    original = exit_set_module.partition
+
+    def _record(owner):
+        minted.append(owner)
+        return original(owner)
+
+    steps = _steps("def g(c):\n    if c:\n        yield 1\n")
+    exit_set_module.partition = _record
+    try:
+        _machine(steps, allocation="call-site-1").resume()
+        _machine(steps, allocation="call-site-2").resume()
+    finally:
+        exit_set_module.partition = original
+
+    assert len(minted) == 2
+    # Same source fragment, different instance coordinate, different partition.
+    assert minted[0][2] == minted[1][2]
+    assert minted[0][1] != minted[1][1]
+    assert minted[0] != minted[1]
+
+
+def test_the_key_carries_the_instance_and_the_fragment() -> None:
+    """Both halves are required and neither alone is sound: the fragment gives
+    reproducibility across reads of one instance, the instance coordinate keeps
+    two executions apart."""
+    from sugar_lift_py_tests.outcome import exit_set as exit_set_module
+
+    minted = []
+    original = exit_set_module.partition
+
+    def _record(owner):
+        minted.append(owner)
+        return original(owner)
+
+    exit_set_module.partition = _record
+    try:
+        machine = _machine(_steps("def g(c):\n    if c:\n        yield 1\n"))
+        machine.resume()
+    finally:
+        exit_set_module.partition = original
+
+    owner = minted[0]
+    assert owner[0] == "generator.branch"
+    assert owner[1] == machine.instance_coordinate
+    assert owner[2]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2029,12 +2029,38 @@ class FunctionDef(Statement):
             return None
         from sugar_lift_py_tests.generator_construction import (
             FinallyStepV1,
+            IfStepV1,
             OpaqueStepV1,
             ReturnStepV1,
             YieldStepV1,
         )
 
         steps = []
+
+        def branch_steps(body):
+            """Steps for one branch, or None if any shape is unnameable.
+
+            None keeps the whole `If` opaque. A partially-nameable branch is
+            not provable: `x = yield v` resumes to a value that reaches no
+            name, so naming the branch holding it would claim an execution we
+            cannot perform. An honest `OpaqueStepV1` is the better answer.
+            """
+            collected = []
+            for nested in body:
+                if isinstance(nested, Expr) and isinstance(nested.value, Yield):
+                    value = nested.value.value
+                    collected.append(
+                        YieldStepV1(None if value is None else value.sugar())
+                    )
+                elif isinstance(nested, Return):
+                    collected.append(
+                        ReturnStepV1(
+                            None if nested.value is None else nested.value.sugar()
+                        )
+                    )
+                else:
+                    return None
+            return tuple(collected)
 
         def append_statement(statement):
             if isinstance(statement, Expr) and isinstance(statement.value, Yield):
@@ -2058,6 +2084,31 @@ class FunctionDef(Statement):
                 steps.append(
                     FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
                 )
+            elif isinstance(statement, If) and self._owns_yield((statement,)):
+                # A BRANCH IS A TWO-FACE PARTITION and this producer owns it.
+                # Admitted only when BOTH branches are wholly nameable: a
+                # branch holding a shape the machine cannot resume keeps the
+                # whole `If` opaque and loud rather than half-named.
+                #
+                # The partition is NOT minted here. Its key needs the machine's
+                # `instance_coordinate`, which `allocate` mints AFTER these
+                # steps exist, so the mint happens at transition time and this
+                # step stays instance-agnostic -- which is what lets one
+                # generator's steps be shared by every instance over it while
+                # each mints its own partition.
+                then_body = branch_steps(statement.body)
+                else_body = branch_steps(statement.orelse)
+                if then_body is None or else_body is None:
+                    steps.append(OpaqueStepV1(statement.kind))
+                else:
+                    steps.append(
+                        IfStepV1(
+                            statement.test.sugar(),
+                            then_body,
+                            else_body,
+                            statement.fragment.seal().cid,
+                        )
+                    )
             else:
                 steps.append(OpaqueStepV1(statement.kind))
 


### PR DESCRIPTION
`if c: yield 1` landed on `OpaqueStepV1("If")` — the step kept the **container's** kind and threw away the guard and both branches, so the machine had nothing to transition with.

## The three arms

- **decided guard** — not a partition. Exactly one side runs, so its steps splice into the sequence and **nothing is minted**. Minting a family over a route the producer does not decide would assert an exhaustiveness that is not true.
- **undecided guard** — a genuine two-face split, each face a distinct successor machine with its own cursor.

**No `faces` field was added to the machine.** The partition lives in the `ExitSet`; the machine that partitions does not advance, it is *replaced* by two successors — the shape already used by `YieldEffect`'s successor machine and `ExitSet.halted(state=self)`.

## The key is composite, and this is the load-bearing part

```
("generator.branch", instance_coordinate, fragment_cid)
```

A **source-only** key makes two live generators over one source branch look like two sides of ONE split, because `_faces_exclusive` never reads the arms' guards. Measured directly on the algebra: two executions collapse into one arm and the second's value is **re-attributed to the negation of the first's guard**.

The instance coordinate discriminates executions; the fragment keeps two reads of one instance reproducible. **Neither half alone is sound.**

**This shape is already law elsewhere.** The loop carrier keys on the producer OCCURRENCE (`targetCid`), pinned by `test_two_occurrences_with_identical_faces_are_different_states` — *"If `targetCid` dropped out of the identity, the second loop's post-state would be indistinguishable from the first's."* This is the same law at a second producer, not an invention.

**Minted at transition time, not by the producer.** The key needs `instance_coordinate`, which `allocate` mints *after* the steps exist. Minting later avoids the circularity **and** keeps the step tuple instance-agnostic — one generator's steps are shared by every instance while each mints its own partition.

The guard's truth routes through `FloorValue.truth`, the established owner of that question, rather than a second copy reading operand types.

## The bound holds

Admitted only when **every** step in both branches is one the vocabulary can execute:

```
if c: yield 1                     -> IfStepV1
if c: yield 1 else: yield 2       -> IfStepV1
if c: x = yield 1                 -> OpaqueStepV1   (bound)
if c: pass  (no suspension)       -> OpaqueStepV1   (untouched)
```

`x = yield v` resumes to a value that reaches no name — `ResumeBindingV1.resume_value` is written by `send()` and read by nothing — so a branch holding one keeps the whole `If` opaque and loud.

## Arm count — the `m ** k` gate

| shape | arms |
|---|---|
| branch with 1 suspension | **1** |
| branch with 2 suspensions | **1** |
| branch with 3 suspensions | **1** |
| three sequential branches (unfactored: 2³ = 8) | **1** |

`factor_completed` is holding: the partition sits at the value level as a `GuardedValue` chain, where it composes, not at the exit level where `sequence` multiplies it.

## Evidence

- **15 tests green**, including the required two-live-instances twin; **73 passed** across the generator, partition-growth, floor-tail and loop-carrier files.
- **Mutation:** regressing the key to source-only fails the two-instance twin *and* the key-composition test. Reverted, verified clean.
- `sugar-source-tree`: **14 failed / 694 passed**, identical to base. **Zero new.**

## Not included

The entry `ExitSet` arm in `generator_with_sugar`. A `with`-managed generator whose first step is a branch still refuses — **loud before this change and loud after**, so no regression and no drain on that path. That arm carries the ruled `RuntimeError("generator didn't yield")` lift and is the natural next piece.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `IfStepV1` branch step to generator bodies as a two-faced partition owned by the producer
> - Introduces `IfStepV1`, a new generator step type representing an `if`/`else` branch where both arms contain only yields or returns.
> - `FunctionDef._source_visible_generator_steps_from` in [nodes.py](https://github.com/TSavo/sugar/pull/6445/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) emits `IfStepV1` instead of `OpaqueStepV1` when both branches are fully nameable.
> - `GeneratorConstructionV1._transition_branch` in [generator_construction.py](https://github.com/TSavo/sugar/pull/6445/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072) handles transition: splices the chosen arm's steps when the guard is ground-true/false, or constructs a two-armed `Completed` partition (keyed by `'generator.branch'`, instance coordinate, and fragment CID) for undecided guards.
> - New test module [test_generator_if_step.py](https://github.com/TSavo/sugar/pull/6445/files#diff-e7f04300f9176598150536fbc96220011539afaa5aba465eb73ff6de7842d65f) covers guard splicing, partition structure, arm factoring, and partition key uniqueness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5cebc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->