### PR TITLE
Format nodes.py so main passes black --check

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4880,9 +4880,7 @@ class With(Statement):
                 )
 
             manager_slot = item._manager_slot_id()
-            enter_slot = (
-                f"{manager_slot}#enter_result" if binds_enter_result else None
-            )
+            enter_slot = f"{manager_slot}#enter_result" if binds_enter_result else None
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,


### PR DESCRIPTION
`nodes.py` fails `black --check` on **pristine main**, in a region no open PR touches. Every contributor's format check inherits a red that is not theirs, and any PR touching that file gets blamed for it.

```
$ black --check sugar-source-tree/src/sugar_source_tree/nodes.py
Oh no! 1 file would be reformatted.
```

The whole change:

```diff
-            enter_slot = (
-                f"{manager_slot}#enter_result" if binds_enter_result else None
-            )
+            enter_slot = f"{manager_slot}#enter_result" if binds_enter_result else None
```

**1 insertion, 3 deletions. Whitespace only — no behaviour, no CID movement.**

Formatted with **black 26.5.1**, the version pinned exactly in the `[test]` extra, so this is the formatter the repo declares rather than whichever one happens to be installed locally.

Reported by the owner of #6444, who deliberately left it alone rather than reformatting an 8,000-line file inside a comment-only PR — that was the right call, and it belongs on its own instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format `nodes.py` to pass `black --check`
> Reformats a conditional assignment in `With._prebound_manager_resolution` in [nodes.py](https://github.com/TSavo/sugar/pull/6446/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) from a multi-line parenthesized expression to a single-line ternary. Logic and behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f88959.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->