### PR TITLE
Restore the suspension flag the #6439/#6445 merge silently dropped

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_step_names_its_suspension.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_step_names_its_suspension.py
@@ -54,7 +54,7 @@ def _first_opaque(steps):
         # Same statement kind, opposite obligations.
         ("def g():\n    x = yield 1\n    return x\n", "Assign", True),
         ("def g():\n    x = 1\n    yield 2\n", "Assign", False),
-        ("def g(c):\n    if c:\n        yield 1\n", "If", True),
+        ("def g(c):\n    if c:\n        x = yield 1\n", "If", True),
         ("def g(c):\n    if c:\n        pass\n    yield 2\n", "If", False),
         # Every bare `yield from` -- where the delegation debt actually lives.
         ("def g(xs):\n    yield from xs\n", "Expr", True),
@@ -73,7 +73,7 @@ def test_an_opaque_step_states_whether_it_holds_a_suspension(
     ("source", "observed"),
     (
         ("def g():\n    x = yield 1\n    return x\n", "Assign carrying a suspension"),
-        ("def g(c):\n    if c:\n        yield 1\n", "If carrying a suspension"),
+        ("def g(c):\n    if c:\n        x = yield 1\n", "If carrying a suspension"),
         ("def g(xs):\n    yield from xs\n", "Expr carrying a suspension"),
     ),
 )
@@ -124,7 +124,7 @@ def test_an_opaque_step_without_a_suspension_is_named_unchanged(tmp_path) -> Non
     "source",
     (
         "def g():\n    x = yield 1\n    return x\n",
-        "def g(c):\n    if c:\n        yield 1\n",
+        "def g(c):\n    if c:\n        x = yield 1\n",
         "def g(xs):\n    yield from xs\n",
     ),
 )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2099,7 +2099,20 @@ class FunctionDef(Statement):
                 then_body = branch_steps(statement.body)
                 else_body = branch_steps(statement.orelse)
                 if then_body is None or else_body is None:
-                    steps.append(OpaqueStepV1(statement.kind))
+                    # A branch holds a step the vocabulary cannot name, so the
+                    # whole `If` stays opaque -- but it is still an `If` that
+                    # may CARRY a suspension, and that is the discrimination
+                    # #6439 landed. Dropping the flag here would report
+                    # `if c: x = yield 1` as a plain `If`, which is the exact
+                    # row-merge #6439 exists to prevent. #6439 and #6445 were
+                    # each green and merged with NO textual conflict; this
+                    # line is what the clean merge silently lost.
+                    steps.append(
+                        OpaqueStepV1(
+                            statement.kind,
+                            carries_suspension=self._owns_yield((statement,)),
+                        )
+                    )
                 else:
                     steps.append(
                         IfStepV1(


### PR DESCRIPTION
**#6439 and #6445 merged with no textual conflict, both green independently, and the merged tree was wrong.** Main was red on arrival.

## The dropped flag

#6445's `If` arm falls back to an opaque step when a branch holds something the vocabulary cannot name. That fallback was written before #6439 landed:

```python
if then_body is None or else_body is None:
    steps.append(OpaqueStepV1(statement.kind))     # no carries_suspension
```

It fires exactly on `if c: x = yield 1` — an `If` that **genuinely carries a suspension and genuinely cannot be named**. That is the precise row #6439's discrimination exists to separate from an ordinary `If`. Git merged both hunks and lost the flag on one.

## Three superseded assertions

`if c: yield 1` was opaque when #6439 pinned it. #6445 makes it an `IfStepV1`, **correctly** — so three parametrized cases were asserting a shape that no longer exists, and they were failing on main independent of the producer fix.

Re-pointed at `if c: x = yield 1`, which **keeps the discrimination they were written to make** and is still opaque for the reason #6445 bounds it out: `Assign` remains blocked on `ResumeBindingV1.resume_value` being read by nothing.

No detector weakened, no test deleted or skipped. The cases now assert the same property about a shape that still has it.

## Measured

```
mutation: drop the flag  -> 2 fail
revert                   -> 14 pass
three merged test files  -> 35 passed
```

Both directions run: the three failures reproduce on clean main **with and without** the producer fix, which is how the superseded assertions were distinguished from anything this change caused.

## The general finding

**A clean auto-merge between two PRs touching one dispatch block is not evidence the semantics survived.** Both sides were green, nothing conflicted, and the result silently undid a landed discrimination.

Adopted as a gate: **a PR states its join-check at the merged tree against every other open PR touching adjacent code.** Verifying against `main` alone is one layer short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `carries_suspension` flag on opaque If steps in `FunctionDef.source_visible_call_frame`
> - The `carries_suspension` flag was silently dropped from opaque `If` steps during a prior merge (#6439/#6445), causing them to always report no suspension even when the `If` owns a yield.
> - [nodes.py](https://github.com/TSavo/sugar/pull/6448/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now passes `carries_suspension=self._owns_yield((statement,))` when appending an `OpaqueStepV1` for an `If` whose branches could not be fully analyzed.
> - Tests in [test_generator_step_names_its_suspension.py](https://github.com/TSavo/sugar/pull/6448/files#diff-83abc5c6b6e84c0f937f95c95e7e5b3adf1adb805ec3f2558265f4b708ab6429) are updated to use `x = yield 1` (assigned yield) instead of bare `yield 1` in the affected parametrized cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85ec723.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->