### PR TITLE
fix: generator never-yield enter is an ExitSet raise, not a refusal

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
@@ -58,10 +58,17 @@ class GeneratorWithSugar(Sugar):
                 )
             entered = machine.resume()
             if isinstance(entered, GeneratorTerminationV1):
-                self._loud(
-                    "generator terminated before first yield",
-                    "terminated before first yield",
+                # Never-yield / premature-return at enter: Python's manager
+                # protocol raises. Type and message come from the observed
+                # vendor conversion (generator_entry_refusal), not a transcribed
+                # string and not a SugarNotWritten refusal of a real outcome.
+                routed.append(
+                    self._entry_refusal_exit(
+                        manager_exit,
+                        entered,
+                    )
                 )
+                continue
             if isinstance(entered, GeneratorTransitionGapV1):
                 self._loud(entered.observed, "opaque generator transition")
             if not isinstance(entered, YieldEffect):
@@ -103,6 +110,37 @@ class GeneratorWithSugar(Sugar):
         for part in routed[1:]:
             result = result.union(part)
         return exitset_to_outcome(result)
+
+    @staticmethod
+    def _entry_refusal_exit(manager_exit, termination: GeneratorTerminationV1):
+        """Turn first-resume termination into the authenticated raise ExitSet arm.
+
+        Observation lives in ``generator_entry_refusal`` (vendor conversion).
+        This consumer only asks for it — no vendor module name here
+        (``generator_construction_law``).
+        """
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal
+        from sugar_lift_py_tests.outcome.exit_set import Halted
+
+        refusal = observed_entry_refusal()
+        blame = str(manager_exit.value.instance_coordinate)
+        effect = RaiseEffect(
+            exception_name=refusal.exception_name,
+            blame=blame,
+            occurrence=f"generator-entry-refusal:{blame}",
+            raised_value=refusal.message,
+        )
+        return ExitSet(
+            (
+                Halted(
+                    manager_exit.guard,
+                    effect,
+                    termination,
+                    manager_exit.faces,
+                ),
+            )
+        )
 
     @staticmethod
     def _loud(observed: str, label: str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_entry_refusal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_entry_refusal.py
@@ -19,10 +19,9 @@ hand would be a second copy of a spec that already exists and executes; the
 vendor is the spec, so a runtime change must move the lift rather than silently
 diverge from it.
 
-THIS LANDS THE OBSERVATION ONLY. The consumer that will ask it -- the
-`with` entry path that today refuses this outcome -- is not wired here.
-The vendor spelling lives in this module and not in that consumer, which
-`generator_construction_law` independently enforces.
+Observation lives here; ``GeneratorWithSugar`` asks it on enter-time
+termination and projects the raise into the block ExitSet. Vendor spelling
+stays out of the consumer (``generator_construction_law``).
 """
 
 from __future__ import annotations
@@ -93,3 +92,18 @@ def test_a_different_exception_spelling_would_flip_the_twin() -> None:
 
     for wrong in ("StopAsyncIteration", "ValueError", "generator did not yield"):
         assert wrong not in source or wrong == "StopIteration"
+
+
+# -- consumer arm: observation reaches the final ExitSet / block -----------
+
+
+def test_lying_consumer_would_still_refuse_rather_than_emit_the_raise() -> None:
+    """Discrimination: if GeneratorWithSugar still loud-refused termination at
+    enter, the With would panic instead of presenting Incomplete(RaiseEffect).
+
+    The productive twin lives in sugar-source-tree construction tests; this
+    pins the observation contract the consumer must use (same type, same text).
+    """
+    refusal = observed_entry_refusal()
+    assert refusal.exception_name == "RuntimeError"
+    assert "didn't yield" in refusal.message

--- a/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
@@ -73,11 +73,50 @@ def test_second_yield_stays_typed_loud_on_normal_exit():
         sugar.desugar()
 
 
-def test_premature_return_stays_typed_loud_on_enter():
-    sugar = _with_sugar("    return 7\n    yield 8")
+def test_premature_return_on_enter_is_the_observed_manager_raise():
+    """Return-before-yield at enter is RuntimeError("generator didn't yield").
 
-    with pytest.raises(SugarNotWritten, match="terminated before first yield"):
-        sugar.desugar()
+    Not a SugarNotWritten refusal of a real Python outcome: the consumer
+    routes GeneratorTerminationV1 through the observed entry refusal into
+    a Halted RaiseEffect arm that exitset_to_outcome projects as Incomplete
+    inside the block.
+    """
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    sugar = _with_sugar("    return 7\n    yield 8", bind_entered=False)
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+    raises = [
+        entry
+        for entry in outcome.value.statements
+        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect)
+    ]
+    assert len(raises) == 1, outcome.value.statements
+    refusal = observed_entry_refusal()
+    assert raises[0].effect.exception_name == refusal.exception_name
+    assert raises[0].effect.raised_value == refusal.message
+
+
+def test_never_yield_on_enter_is_the_observed_manager_raise():
+    """``if False: yield`` never suspends — same enter raise as premature return."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    sugar = _with_sugar("    if False:\n        yield 1", bind_entered=False)
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+    raises = [
+        entry
+        for entry in outcome.value.statements
+        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect)
+    ]
+    assert len(raises) == 1
+    refusal = observed_entry_refusal()
+    assert raises[0].effect.exception_name == refusal.exception_name
+    assert raises[0].effect.raised_value == refusal.message
 
 
 def test_opaque_transition_stays_typed_loud():


### PR DESCRIPTION
## Summary

Finish the #6447 consumer arm: when a managed generator terminates before the first yield, `GeneratorWithSugar` now emits the **observed** manager-protocol raise as a `Halted(RaiseEffect)` ExitSet arm (projected as `Incomplete` in the block), instead of `SugarNotWritten` ("terminated before first yield").

Observation remains sole-sourced in `generator_entry_refusal.observed_entry_refusal()` — no vendor module name in the consumer (`generator_construction_law` stays R=0).

## Gate

- Real reproducers: `return` before yield; `if False: yield`
- Truthful: exception name + message match observed vendor conversion
- Lying: wrong spellings still fail observation twins; opaque branch still loud
- Focused: 28 tests green; R_generator_construction = 0

## Not

- No census / scoreboard / pin-only
- Does not invent a second raise spelling

Follow-on to #6447 observation-only land.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix generator never-yield enter to return an ExitSet raise instead of a refusal
> - When a generator manager terminates at first resume (never-yield/premature return), `GeneratorWithSugar.desugar()` previously raised `SugarNotWritten`; it now returns a `Complete` outcome containing an `Incomplete` arm with a `RaiseEffect` (RuntimeError).
> - A new static helper `_entry_refusal_exit()` converts enter-time `GeneratorTerminationV1` into an `ExitSet` with a single `Halted` arm, using `observed_entry_refusal()` to retrieve the vendor-observed exception name and message.
> - Tests in [`test_generator_context_manager_construction.py`](https://github.com/TSavo/sugar/pull/6449/files#diff-94e55387dc77922abd716e297c564377f0ce63e91fa8966cbf7a8c9c13e83402) and [`test_generator_entry_refusal.py`](https://github.com/TSavo/sugar/pull/6449/files#diff-5ead9f42f001b8e0b7ce1d44ac5e2e155509d87311db3ffec69c272774d28346) are updated to assert the new `RaiseEffect` outcome rather than expecting a panic.
> - Behavioral Change: callers that previously caught `SugarNotWritten` on never-yield generators will no longer see that exception; they will instead receive a structured `Halted` outcome carrying a RuntimeError raise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aacbf5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generator-based context managers that return or never yield now complete desugaring while surfacing the observed runtime refusal as a raised effect.
  * Replaced the previous diagnostic failure with consistent handling of generator-entry refusals.

* **Tests**
  * Added coverage for immediate returns, unreachable yields, and consumer behavior when generators fail to yield.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->