### PR TITLE
`except* (A, B)` is one handler over a union, not two handlers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -57,21 +57,42 @@ class TryStarSugar(Sugar):
             residual = original
             handler_effects = []
             completed_states = []
-            for matcher, handler_body, slot_id in self.handlers:
-                expected = matcher.desugar(ctx)
-                if not isinstance(expected, Complete):
-                    raise SugarNotWritten(
-                        owner="TryStarSugar.desugar",
-                        observed="symbolic except* type",
-                        requested="authenticated subtype partition operand",
-                        fix="keep symbolic subtype partition typed loud",
+            for matchers, handler_body, slot_id in self.handlers:
+                # One handler, one body run, however many types it lists. Each
+                # type partitions what the previous type left behind, and the
+                # matched pieces are regrouped into ONE subgroup carrying the
+                # original topology -- so `except* (A, B)` over a group holding
+                # both binds a single group of both leaves rather than entering
+                # the body twice.
+                if not isinstance(matchers, tuple):
+                    matchers = (matchers,)
+                handler_residual = residual
+                matched_parts = []
+                for matcher in matchers:
+                    expected = matcher.desugar(ctx)
+                    if not isinstance(expected, Complete):
+                        raise SugarNotWritten(
+                            owner="TryStarSugar.desugar",
+                            observed="symbolic except* type",
+                            requested="authenticated subtype partition operand",
+                            fix="keep symbolic subtype partition typed loud",
+                        )
+                    routed = route_except_star(
+                        handler_residual,
+                        expected.value,
+                        slot_id=slot_id,
+                        site=self.site,
                     )
-                routed = route_except_star(
-                    residual, expected.value, slot_id=slot_id, site=self.site
-                )
-                if routed is None or not routed.matched.children:
+                    if routed is None:
+                        continue
+                    if routed.matched.children:
+                        matched_parts.append(routed.matched)
+                    handler_residual = routed.residual
+                if not matched_parts:
                     continue
-                handler_ctx = bind_in_flight_effect(ctx, slot_id, routed.matched)
+                matched = regroup_except_star(residual, matched_parts)
+                residual = handler_residual
+                handler_ctx = bind_in_flight_effect(ctx, slot_id, matched)
                 handler_exits = promote_raise_halts(
                     reduce_block_to_exitset(handler_body, handler_ctx)
                 )
@@ -87,7 +108,6 @@ class TryStarSugar(Sugar):
                         handler_effects.append(handler_exit.effect)
                     elif isinstance(handler_exit, Completed):
                         completed_states.append(handler_exit.value)
-                residual = routed.residual
             outgoing = list(handler_effects)
             if residual.children:
                 outgoing.append(residual)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5748,30 +5748,56 @@ class TryStar(Statement):
 
         handlers = []
         for handler in self.handlers:
-            if handler.type_ is None or not isinstance(handler.type_, Name):
+            # `except* (A, B)` is ONE handler over a union of types, not two
+            # handlers. The tuple is expanded into a tuple of matchers that the
+            # router partitions with in a single pass, so the body runs once no
+            # matter how many of the listed types the group carries. Expanding
+            # it into one handler spec per type -- which is honest for ordinary
+            # `except (A, B)`, where at most one exception is in flight -- would
+            # run an except* body twice on a group holding both.
+            if handler.type_ is None:
                 raise SugarNotWritten(
                     owner="TryStar._construct_sugar",
                     observed="unsupported except* handler type",
                     requested="one authenticated exception type operand",
                     fix="keep unsupported native handler behavior loud",
                 )
-            identity = self.unit.exception_type_identity(handler.type_)
-            if identity is None:
+            type_nodes = (
+                handler.type_.elts
+                if handler.type_.kind == "Tuple"
+                else (handler.type_,)
+            )
+            if not type_nodes or any(
+                not isinstance(type_node, Name) for type_node in type_nodes
+            ):
                 raise SugarNotWritten(
                     owner="TryStar._construct_sugar",
-                    observed="except* type lacks authenticated exception identity",
-                    requested="a constructed exception-type coordinate",
-                    fix="resolve the handler type lexically or keep it loud",
+                    observed="unsupported except* handler type",
+                    requested="one authenticated exception type operand",
+                    fix="keep unsupported native handler behavior loud",
+                )
+            matchers = []
+            for type_node in type_nodes:
+                identity = self.unit.exception_type_identity(type_node)
+                if identity is None:
+                    raise SugarNotWritten(
+                        owner="TryStar._construct_sugar",
+                        observed="except* type lacks authenticated exception identity",
+                        requested="a constructed exception-type coordinate",
+                        fix="resolve the handler type lexically or keep it loud",
+                    )
+                matchers.append(
+                    AuthenticatedExceptionTypeSugar(
+                        type_node.sugar(),
+                        identity,
+                        self.unit.exception_type_mro(type_node),
+                        type_node.fragment,
+                        class_value=self.unit.exception_class_value(type_node),
+                    )
                 )
             handlers.append(
                 (
-                    AuthenticatedExceptionTypeSugar(
-                        handler.type_.sugar(),
-                        identity,
-                        self.unit.exception_type_mro(handler.type_),
-                        handler.type_.fragment,
-                        class_value=self.unit.exception_class_value(handler.type_),
-                    ),
+                    tuple(matchers),
                     tuple(stmt.sugar() for stmt in handler.body),
                     handler._effect_slot_id(),
                 )

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -967,3 +967,122 @@ if __name__ == "__main__":
     test_non_name_except_type_stays_loud()
     test_dotted_except_type_matches()
     print("ok: try sugar -- structural effect routing")
+
+
+def test_except_star_type_tuple_partitions_every_listed_type():
+    """`except* (A, B)` nets both A and B; only the unlisted leaf survives."""
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError(), KeyError()])\n"
+            "    except* (ValueError, TypeError):\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in outcome.effect.children] == ["KeyError"]
+
+
+def test_except_star_type_tuple_runs_its_body_exactly_once():
+    """The lying twin: one handler, one body run, however many types matched.
+
+    An implementation that expands `except* (A, B)` into one handler spec per
+    type -- which is honest for ordinary `except (A, B)` -- enters this body
+    twice on a group carrying both, and the raised RuntimeError appears twice.
+    Counting the leaf is what discriminates; the residual alone does not.
+    """
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* (ValueError, TypeError):\n"
+            "        raise RuntimeError()\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    names = [leaf.exception_name for leaf in outcome.effect.children]
+    assert names == ["RuntimeError"], names
+
+
+def test_except_star_type_tuple_binds_one_group_of_all_matched_leaves():
+    """A bare re-raise regroups BOTH matched leaves, in original topology."""
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError(), KeyError()])\n"
+            "    except* (ValueError, TypeError):\n"
+            "        raise\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in outcome.effect.children] == [
+        "ValueError",
+        "TypeError",
+        "KeyError",
+    ]
+
+
+def test_except_star_type_tuple_with_no_matching_leaf_stays_whole():
+    from sugar_lift_py_tests.effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    outcome = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [KeyError()])\n"
+            "    except* (ValueError, TypeError):\n"
+            "        pass\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in outcome.effect.children] == ["KeyError"]
+
+
+def test_except_star_empty_type_tuple_stays_loud():
+    """An empty tuple has no honest matcher: refuse by name, never match all."""
+    with pytest.raises(SugarNotWritten) as excinfo:
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError()])\n"
+            "    except* ():\n"
+            "        pass\n"
+        ).sugar()
+    assert "unsupported except* handler type" in str(excinfo.value)
+
+
+def test_except_star_computed_type_in_tuple_stays_loud():
+    with pytest.raises(SugarNotWritten) as excinfo:
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError()])\n"
+            "    except* (ValueError, tm.Other):\n"
+            "        pass\n"
+        ).sugar()
+    assert "unsupported except* handler type" in str(excinfo.value)


### PR DESCRIPTION
`TryStar._construct_sugar` refused any handler type that was not a bare `Name`, so every `except* (ValueError, TypeError)` in the corpus died at construction with `unsupported except* handler type` — a live `SugarNotWritten` reproducible in three lines, not a designed gap. Ordinary `Try` already expands a tuple handler; `except*` did not.

## The obvious port of Try's expansion is wrong, and that is the whole mechanism

`Try` emits one handler spec per listed type because at most one exception is in flight, so first-match ordering makes the expansion equivalent. **A group breaks exactly that premise**: it carries many leaves at once, so one spec per type enters the *same* body once per type that matched.

The lying twin holds a group of `ValueError` and `TypeError` under `except* (ValueError, TypeError): raise RuntimeError()`:

- the per-type expansion answers `['RuntimeError', 'RuntimeError']`
- this implementation answers `['RuntimeError']`

The three residual-shaped tests stay green under **both**. That is why the count is the discriminating assertion and the residual is not.

So the handler spec now carries a tuple of matchers. Each type partitions what the previous type left behind; the matched pieces are regrouped through the existing `regroup_except_star`, which restores the original topology restricted to the union of matched leaves. The body runs once against that one subgroup.

Empty tuples and non-`Name` elements stay loud by name, unchanged. Single-name `except*` is the one-element case of the same path — the desugar side still accepts a bare matcher, so no other producer of `TryStarSugar` is silently broken.

Not registered with #6433's presence instrument: that instrument is specific to `floor_value.py`'s undecided-binary-operand law, not a general register. Said rather than skipped.

## Receipts

Base `0f40c8a251b53d8773cc9afa58715473be670140`, head `81e827091f1fb78c2871413aa355d0330941ad2c`, both trees clean, file digests pinned identical before and after every run.

**`sugar-source-tree`**

| half | result |
|---|---|
| head | 700 passed, 5 skipped, 14 failed |
| base `0f40c8a25` | 694 passed, 5 skipped, 14 failed |

The 14 are the same 14 by name. Delta is **+6, all mine**.

**`sugar-lift-py-tests`** — full package suite, not a scoped run, each half against an explicitly named binary stamp built *before* the run so the fixture's 600s budget never did the building:

| half | stamp | result |
|---|---|---|
| head | `blake3-512_d69b96a1…e293a` | `145 failed, 1626 passed, 9 skipped, 5 errors in 1987.66s`, rc=1 |
| base | `blake3-512_fc1e8629…c6544` | `145 failed, 1623 passed, 9 skipped, 5 errors in 2153.67s`, rc=1 |

`comm` over the sorted FAILED/ERROR name sets — 152 lines each side — is **empty in both directions**. Not the same count: the same names. Delta is zero.

The +3 passes are **not** from this PR. `pytest --collect-only` diffs 1785 head vs 1782 base, and the three extra are `test_guarded_binding_partition_carrier.py::{test_the_same_slot_read_twice_mints_the_SAME_partition, test_the_two_arms_are_opposite_sides_of_one_split, test_unrelated_conditional_bindings_do_not_share_a_partition}` — those are #6438, which sits at `head~1`. So this row brackets a two-commit delta, not one. Named because it is true, not because it changes the verdict.

## Unrelated pre-existing breakage found while measuring

`tests/test_try_sat_unsat.py` sends JSON-RPC `method: "lift"`. `lift_rpc.py:56` defines `ENUMERATE_RPC_METHOD = "sugar.enumerate"`, and the dispatcher's `else` branch (`lift_rpc.py:2612`) answers `-32601 method 'lift' not found`. The test file was last touched at `1b162924d` (#6165), so those tests have been red on main since the rename and are not testifying about try/except at all. Red on both halves here; **not** addressed by this PR, filed as an observation.

Base is behind current `origin/main` (`285159cc0` and four others landed during the 37m48s baseline build). The measurements above hold at `0f40c8a25`, which is where they were taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `except* (A, B)` to act as one handler over a union, not two separate handlers
> - Updates `TryStar._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6450/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to produce a tuple of authenticated type matchers for `except* (A, B, ...)` instead of a single matcher; empty or non-`Name` types raise `SugarNotWritten` loudly.
> - Updates `TryStarSugar.desugar` in [try_star_sugar.py](https://github.com/TSavo/sugar/pull/6450/files#diff-99f26fcb4995527f2b79466b9e0376e13c152b9d06b39e9e4c6eec4ba4fc8f0e) to iterate over all matchers in a single handler pass, collecting matched subgroups across all listed types, regrouping them into one `ExceptionGroup`, and running the handler body exactly once.
> - Adds six tests covering: multi-type partitioning, single body execution, regrouped leaf binding, no-match passthrough, and rejection of empty or computed tuple types.
> - Behavioral Change: previously, `except* (A, B)` would route only one type per handler; now all listed types are matched in a single pass and the body runs once with all matched leaves combined.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81e8270.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->