### PR TITLE
Pin the measured corpus: numpy and pandas ARE the denominator

### DIFF
--- a/implementations/python/sugar-lift-py-tests/pyproject.toml
+++ b/implementations/python/sugar-lift-py-tests/pyproject.toml
@@ -34,8 +34,17 @@ test = [
     "black==26.5.1",
     "pyright==1.1.411",
     "itsdangerous==2.2.0",
-    "numpy",
-    "pandas",
+    # The measured corpus is PINNED. numpy and pandas are not ordinary test
+    # dependencies -- they ARE the corpus every board, ledger, and residual
+    # count ranges over, so an unpinned spec makes the denominator drift
+    # silently. Three versions were in play on one box before this pin: the
+    # ledgers key to 3.0.3, one venv carried 2.2.3, and a fresh
+    # `pip install -e '.[test]'` on 2026-07-27 resolved 3.0.5 -- installing the
+    # repo exactly as specified got you a different corpus than everyone else
+    # was measuring. The three tools beside them were already pinned exactly;
+    # the two that constitute the measurement were the two that could move.
+    "numpy==2.5.1",
+    "pandas==3.0.3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Closes the unpinned-corpus gap (#6428), with a demonstration stronger than the original report.

## The defect, demonstrated

`[test]` pinned `black`, `pyright` and `itsdangerous` **exactly** — and left `numpy` and `pandas` unconstrained. Those two are not test dependencies; **they are the corpus** every board, ledger and residual count ranges over.

Three versions were live on one box at the same time:

| source | pandas |
|---|---|
| ledgers / published boards | **3.0.3** |
| one working venv | **2.2.3** |
| fresh `pip install -e '.[test]'`, 2026-07-27 | **3.0.5** |

**Installing the repo exactly as specified got you a different corpus than everyone else was measuring.** No count from any of the three was comparable to any other, and nothing announced it.

## The pin

```toml
"numpy==2.5.1",
"pandas==3.0.3",
```

`pandas==3.0.3` matches the published boards. **`numpy==2.5.1` was resolved, not chosen** — a `pip install --dry-run` of `pandas==3.0.3` reports numpy already satisfied at 2.5.1, so that is the version the pinned corpus actually resolves against. (An earlier draft of this PR guessed `2.2.6`; it had no basis and was replaced by the resolution result.)

## Known, and deliberately NOT fixed here

**Pinning the spec does not by itself make the measured corpus authentic.**

On this box `sugar-lift-py-tests/.venv` carries its own `pandas-2.2.3.dist-info` **and still imports pandas from a different venv's site-packages**. So "which pandas ranged over this measurement" is not answerable from the interpreter you invoked.

The pin fixes what a fresh install resolves. **The cross-environment leak is a separate defect and needs its own repair before any count is authenticated.** Stating it rather than letting the pin read as closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `numpy` and `pandas` versions in test dependencies to prevent measurement drift
> Pins `numpy==2.5.1` and `pandas==3.0.3` in [pyproject.toml](https://github.com/TSavo/sugar/pull/6451/files#diff-261ec8796a9b416fbd4a4be1c4d29020ef3e684186d192280285d81a390a3a94) to lock the measured corpus at known versions. An explanatory comment is added clarifying that these libraries are the denominator for measurements and must not drift with upstream releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92de81a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->