### PR TITLE
fix: dual-mode EffectBoundary factory construction through GuardedReturn

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -180,6 +180,12 @@ class TreeConstructionContextV1:
     # subclass definition coordinate.  These are never serialized; the class
     # definition projects their sealed CIDs into its own preimage.
     source_class_bases: dict = field(default_factory=dict)
+    # When projecting an authenticated definition into a call frame, dual-mode
+    # factory bodies may contain With sites only on non-manager return paths
+    # (e.g. pytest.raises function form). Soft projection does not require
+    # those nested Withs to already carry a closed CM row — the CM form's
+    # return path is what construct_manager_behavior force_floors.
+    frame_projection: bool = False
 
     @classmethod
     def for_source_call_construction(
@@ -188,6 +194,7 @@ class TreeConstructionContextV1:
         source_call_frames: dict | None = None,
         call_contract_refs: object | None = None,
         workspace_root: str | None = None,
+        frame_projection: bool = False,
     ) -> "TreeConstructionContextV1":
         """Construction context for sole-path source-call frames without CM enrollment."""
         return cls(
@@ -195,6 +202,7 @@ class TreeConstructionContextV1:
             call_contract_refs=call_contract_refs,
             workspace_root=workspace_root,
             source_call_frames={} if source_call_frames is None else source_call_frames,
+            frame_projection=frame_projection,
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -27,6 +27,17 @@ class ClassValue(FloorValue):
 
         return ctor("python:type", [str_const(self.name)])
 
+    def truth(self, site):
+        # Python type objects are always truthy. Dual-mode EffectBoundary
+        # factories gate validation with ``if not expected_exception:``; the
+        # class actual must stand as a condition without force-floor:truth:ClassValue.
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(TrueBoolLiteralSugar(site=site))
+
     def test_python_type(self, value, site):
         return value.python_isinstance(self.name, self.to_term(owner=self.name), site)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
@@ -29,6 +29,16 @@ class RaiseValue(FloorValue):
 
         return FollowStep.halt(keeps_rest=False)
 
+    def truth(self, site):
+        # A raise is not a Python boolean. Expression evaluation already halted
+        # with the exceptional exit; demanding truthiness of the raise terminal
+        # is a force-floor stage bug (owner=truth, observed=RaiseValue). Re-emit
+        # the effect so `if <expr-that-raises>:` propagates rather than panics.
+        del site
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        return Incomplete(self.effect)
+
     def guarded(self, formula):
         from sugar_lift_py_tests.floor.guarded_raise import GuardedRaise
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -48,12 +48,39 @@ class SourceVisibleCallFrameV1:
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
 
     def bind_actuals(self, positional: tuple, keywords: tuple, ctx=None) -> tuple:
+        """Bind positional/keyword FloorValues onto this frame's formals.
+
+        ``keywords`` is ``(name, value)`` pairs in source order. A name of
+        ``None`` or ``\"**\"`` is a typed ``**`` expansion: when the value is a
+        constructed ``DictValue`` with string keys, its entries join the
+        named-keyword map (Python's call-time ``**mapping`` projection). Other
+        expansion shapes stay a ``SourceCallBindingGap`` so the call remains
+        loud rather than inventing keys.
+        """
         from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
 
         remaining = list(positional)
-        named = dict(keywords)
-        if len(named) != len(keywords):
-            raise SourceCallBindingGap("duplicate keyword actual")
+        named: dict = {}
+        for key, value in keywords:
+            if key is None or key == "**":
+                if type(value) is not DictValue:
+                    raise SourceCallBindingGap(
+                        "spread keyword requires typed DictValue projection"
+                    )
+                for entry_key, entry_value in value.entries:
+                    if type(entry_key) is not StringValue:
+                        raise SourceCallBindingGap(
+                            "non-string keyword expansion key"
+                        )
+                    if entry_key.value in named:
+                        raise SourceCallBindingGap(
+                            "duplicate keyword actual from expansion"
+                        )
+                    named[entry_key.value] = entry_value
+                continue
+            if key in named:
+                raise SourceCallBindingGap("duplicate keyword actual")
+            named[key] = value
         bound = []
         for index, (name, kind, default) in enumerate(
             zip(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -116,14 +116,26 @@ class IfSugar(Sugar):
         cond = self.test.desugar(ctx)
         if not isinstance(cond, Complete):
             return cond
+        # Condition expression itself raised: the if never selects a branch.
+        # Do not demand truth of RaiseValue (that was force-floor:truth:RaiseValue).
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        if isinstance(cond.value, RaiseValue):
+            return Incomplete(cond.value.effect)
         observed_formula = predicate_formula(cond.value, self.site)
         formula = branch_result_guard(self.branch_slot, self.site)
         authentication = BranchResultAuthentication(
             self.branch_slot, observed_formula, self.site
         )
 
-        then_exits = reduce_block_to_exitset(self.then_body)
-        else_exits = reduce_block_to_exitset(self.else_body)
+        # Carry the call-frame temporal into each branch. Formals are
+        # BindingCoordinateRefSugar keyed by coordinate cid; without ctx the
+        # branch suite cannot resolve authenticated actuals and panics as
+        # unspecialized source-call formal (dual-mode EffectBoundary factories
+        # nest further ifs that read those formals).
+        then_exits = reduce_block_to_exitset(self.then_body, ctx)
+        else_exits = reduce_block_to_exitset(self.else_body, ctx)
 
         # If is union in the exit algebra: each branch is restricted to its
         # polarity, then the partitions normalize together. In particular, a

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/soft_unresolved_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/soft_unresolved_with_sugar.py
@@ -1,0 +1,41 @@
+"""Soft unresolved With for authenticated dual-mode factory frame projection.
+
+Only installed when ``TreeConstructionContextV1.frame_projection`` is true.
+The CM return path of factories like ``pytest.raises`` never desugars this
+arm; the function-form branch may contain nested Withs that lack a closed
+contract row during frame projection. Soft incompletes keep that branch from
+aborting the factory's source-visible call frame.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class SoftUnresolvedWithSugar(Sugar):
+    site: object = field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ExitSet",
+            reason="frame-projection soft incomplete for dual-mode factory branches",
+        )
+
+    def desugar(self, ctx=None) -> Outcome:
+        from sugar_lift_py_tests.effect import CoverageGapEffect
+
+        return Incomplete(
+            CoverageGapEffect(
+                boundary="dual-mode-factory-with",
+                reason="dual-mode factory function-form With left unresolved "
+                "during authenticated call-frame projection",
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -201,12 +201,19 @@ class SpreadDictSugar(Sugar):
 
 @dataclass(frozen=True)
 class SpreadCallSugar(Sugar):
-    """A call containing ``*``/``**``, using the reference call vocabulary."""
+    """A call containing ``*``/``**``, using the reference call vocabulary.
+
+    When an authenticated source-visible callee frame is enrolled (class
+    constructor / function body), typed ``**`` expansions project through that
+    frame so the CallSiteValue carries the factory-built body. Opaque spreads
+    without a frame keep the reference bodyless coordinate.
+    """
 
     callee_name: str | None
     callee: Sugar | None
     arguments: tuple  # (role, optional-name, sugar), source order
     site: object = dataclass_field(compare=False)
+    source_call_frame: object | None = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -225,14 +232,14 @@ class SpreadCallSugar(Sugar):
                 sugars,
                 ctx,
                 (),
-                lambda values: self._finish(callee_value, values),
+                lambda values: self._finish(callee_value, values, ctx),
             )
 
         if self.callee is None:
             return after_callee(None)
         return self.callee.desugar(ctx).and_then(after_callee)
 
-    def _finish(self, callee_value, values) -> Outcome:
+    def _finish(self, callee_value, values, ctx=None) -> Outcome:
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
 
@@ -253,6 +260,11 @@ class SpreadCallSugar(Sugar):
                 term = ctor("python:kwarg", [str_const(name), term])
             arg_terms.append(term)
         term = ctor("python:call", [callee_term, *arg_terms])
+
+        framed = self._body_bearing_callsite(values, term, ctx)
+        if framed is not None:
+            return Complete(framed)
+
         return Complete(
             CallSiteValue(
                 target_name=self.callee_name or "python:call",
@@ -262,4 +274,54 @@ class SpreadCallSugar(Sugar):
                 body=None,
                 site=self.site,
             )
+        )
+
+    def _body_bearing_callsite(self, values, term, ctx) -> object | None:
+        """Project ``*``/``**`` actuals onto an enrolled source frame when lawful.
+
+        Star operands stay bodyless (no typed vararg projection here). A
+        double-star must be a constructed DictValue so bind_actuals can merge
+        keys onto formals — the same law FunctionCallable uses for ``**``.
+        """
+        frame = self.source_call_frame
+        if frame is None:
+            return None
+        if any(role == "star" for role, _, _ in self.arguments):
+            return None
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.source_call_frame import (
+            SourceCallBindingGap,
+            SourceVisibleCallFrameV1,
+        )
+
+        if not isinstance(frame, SourceVisibleCallFrameV1):
+            return None
+        positional: list = []
+        keywords: list = []
+        for (role, name, _), value in zip(self.arguments, values):
+            if role == "positional":
+                positional.append(value)
+            elif role == "keyword":
+                keywords.append((name, value))
+            elif role == "double-star":
+                keywords.append(("**", value))
+            else:
+                return None
+        try:
+            bound = frame.bind_actuals(tuple(positional), tuple(keywords), ctx)
+        except SourceCallBindingGap:
+            return None
+        source_body = frame.body
+        owner = getattr(frame, "owner", None)
+        if owner is not None and hasattr(owner, "source_visible_constructor_frame"):
+            source_body = owner.source_visible_constructor_frame().body
+        return CallSiteValue(
+            target_name=self.callee_name or "python:call",
+            arg_values=bound,
+            parameters=frame.parameters,
+            term=term,
+            body=source_body,
+            site=self.site,
+            source_call_frame_cid=frame.frame_cid,
+            formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
         )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -10,6 +10,7 @@ from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
     FloorValue,
+    GuardedReturn,
     ObjectValue,
     ReturnValue,
 )
@@ -174,6 +175,266 @@ class ManagerConstructionGapV1:
     detail: str
 
 
+def _factory_return_faces_from_entries(
+    entries: tuple,
+) -> tuple[FloorValue, ...]:
+    """ReturnValue / GuardedReturn faces in a statement or reduced-entry sequence."""
+    return tuple(
+        item for item in entries if isinstance(item, (ReturnValue, GuardedReturn))
+    )
+
+
+def _entries_of_factory_payload(value: object) -> tuple | None:
+    """Statement/entry sequence carried by a factory force_floor payload."""
+    if isinstance(value, BlockValue):
+        return value.statements
+    entries = getattr(value, "entries", None)
+    if isinstance(entries, tuple):
+        return entries
+    statements = getattr(value, "statements", None)
+    if isinstance(statements, tuple):
+        return statements
+    return None
+
+
+def _project_return_faces_to_manager(
+    faces: tuple[FloorValue, ...],
+    *,
+    non_return_prefix: tuple[FloorValue, ...],
+    factory_prefix: tuple[FloorValue, ...],
+    seen_calls: set[int],
+    resolved_cid: str,
+) -> tuple[FloorValue, tuple[FloorValue, ...]] | ManagerConstructionGapV1 | None:
+    """Project ReturnValue/GuardedReturn faces to a sole manager ObjectValue.
+
+    Returns None when no face force_floors to ObjectValue yet (caller may try
+    nested hops). Returns a gap when multi-manager identities refuse.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    managers: list[tuple[FloorValue, ObjectValue, CallSiteValue | None]] = []
+    nested: list[tuple[FloorValue, FloorValue, CallSiteValue | None]] = []
+    for face in faces:
+        returned = face.value
+        if isinstance(returned, ObjectValue):
+            managers.append((face, returned, None))
+            continue
+        if not isinstance(returned, CallSiteValue):
+            continue
+        if id(returned) in seen_calls:
+            # Same CallSiteValue often appears on several ExitSet arms after
+            # GuardedFaces sequencing (Halted validation arms carry the CM
+            # GuardedReturn in prefix state). Already projected — skip, do not
+            # invent a call-graph-cycle residual for a peer harvest.
+            continue
+        try:
+            floor = returned.force_floor(
+                None,
+                owner="construct_manager_behavior returned object",
+            )
+        except ConstructionPanic:
+            # Missing body / later-stage force-floor on this face — try peers.
+            continue
+        if isinstance(floor, ObjectValue):
+            managers.append((face, floor, returned))
+            seen_calls.add(id(returned))
+        else:
+            nested.append((face, floor, returned))
+
+    if managers:
+        # Sole manager identity wins. Multiple distinct receivers: prefer a
+        # field-wise refinement (more bound fields, equal where both bound)
+        # — complementary ``if x is None: return CM() else: return CM(x)``
+        # faces construct both; the refined arm is the callsite's manager.
+        # Incomparable multi-receivers stay loud.
+        identities = {item[1].identity for item in managers}
+        if len(identities) > 1:
+            refined = _sole_refined_manager(tuple(item[1] for item in managers))
+            if refined is None:
+                return ManagerConstructionGapV1(
+                    "non-manager-result",
+                    resolved_cid,
+                    f"GuardedReturn with {len(identities)} manager receivers",
+                )
+            managers = [
+                item for item in managers if item[1].identity == refined.identity
+            ]
+        _face, obj, call = managers[0]
+        return obj, factory_prefix + non_return_prefix
+
+    if len(nested) == 1:
+        _face, floor, call = nested[0]
+        if call is not None:
+            seen_calls.add(id(call))
+        # Nested hop: recurse via _project_factory_manager on the floor.
+        return _project_factory_manager(
+            floor,
+            factory_prefix=factory_prefix + non_return_prefix,
+            seen_calls=seen_calls,
+            resolved_cid=resolved_cid,
+        )
+
+    if len(faces) == 1:
+        return faces[0].value, factory_prefix + non_return_prefix
+
+    return None
+
+
+def _project_factory_manager(
+    result: FloorValue,
+    *,
+    factory_prefix: tuple[FloorValue, ...],
+    seen_calls: set[int],
+    resolved_cid: str,
+) -> tuple[FloorValue, tuple[FloorValue, ...]] | ManagerConstructionGapV1:
+    """Unwrap factory block returns (bare or guarded) to a manager ObjectValue.
+
+    ``if not args: return CM(...)`` yields GuardedReturn, not ReturnValue.  A
+    factory body may also carry several guarded return faces; project every
+    face that force_floors to ObjectValue and keep a sole manager receiver.
+    """
+    while True:
+        entries = _entries_of_factory_payload(result)
+        if entries is None:
+            break
+        faces = _factory_return_faces_from_entries(entries)
+        if not faces:
+            break
+        non_return_prefix = tuple(
+            item
+            for item in entries
+            if not isinstance(item, (ReturnValue, GuardedReturn))
+        )
+        projected = _project_return_faces_to_manager(
+            faces,
+            non_return_prefix=non_return_prefix,
+            factory_prefix=factory_prefix,
+            seen_calls=seen_calls,
+            resolved_cid=resolved_cid,
+        )
+        if projected is None:
+            break
+        return projected
+
+    return result, factory_prefix
+
+
+def _project_manager_from_exitset(
+    outcome,
+    *,
+    factory_prefix: tuple[FloorValue, ...],
+    seen_calls: set[int],
+    resolved_cid: str,
+) -> tuple[FloorValue, tuple[FloorValue, ...]] | ManagerConstructionGapV1:
+    """Project a multi-arm factory ExitSet to its manager return face.
+
+    Dual-mode factories keep validation raises and CM returns as sibling faces.
+    After GuardedFaces sequencing, the CM ``GuardedReturn`` often rides in the
+    *prefix state* of a Halted raise arm rather than on a Completed arm alone.
+    Harvest ReturnValue/GuardedReturn from every arm's payload and state;
+    validation Halted effects without a manager return do not block the CM face.
+    """
+    from sugar_lift_py_tests.outcome import Completed, Halted
+
+    managers: list[tuple[ObjectValue, tuple[FloorValue, ...]]] = []
+
+    def _collect_from_payload(payload) -> ManagerConstructionGapV1 | None:
+        projected = _project_factory_manager(
+            payload,
+            factory_prefix=(),
+            seen_calls=seen_calls,
+            resolved_cid=resolved_cid,
+        )
+        if isinstance(projected, ManagerConstructionGapV1):
+            return projected
+        mgr, prefix = projected
+        if isinstance(mgr, ObjectValue):
+            managers.append((mgr, prefix))
+        return None
+
+    for exit_ in outcome.exits:
+        if isinstance(exit_, Completed):
+            gap = _collect_from_payload(exit_.value)
+            if gap is not None:
+                return gap
+            continue
+        if isinstance(exit_, Halted) and exit_.state is not None:
+            # GuardedReturn on the CM face is often only preserved here after
+            # IfSugar flattens multi-exit then-bodies into GuardedFaces and the
+            # fall-through polarity continues into later raise validation.
+            gap = _collect_from_payload(exit_.state)
+            if gap is not None:
+                return gap
+
+    if not managers:
+        return ManagerConstructionGapV1(
+            "force-floor",
+            resolved_cid,
+            f"ExitSet with {len(outcome.exits)} arms",
+        )
+    identities = {item[0].identity for item in managers}
+    if len(identities) > 1:
+        refined = _sole_refined_manager(tuple(item[0] for item in managers))
+        if refined is None:
+            return ManagerConstructionGapV1(
+                "non-manager-result",
+                resolved_cid,
+                f"ExitSet with {len(identities)} manager receivers",
+            )
+        managers = [item for item in managers if item[0].identity == refined.identity]
+    obj, prefix = managers[0]
+    return obj, factory_prefix + prefix
+
+
+def _sole_refined_manager(
+    managers: tuple[ObjectValue, ...],
+) -> ObjectValue | None:
+    """Return the unique manager that field-wise refines every peer, else None.
+
+    Manager A refines B when they share field names, every non-None field of B
+    equals the same field on A, and A has at least one additional non-None
+    field. Complementary factory faces ``return CM()`` / ``return CM(x)`` then
+    collapse to the refined receiver instead of multi-manager residual.
+    """
+    from sugar_lift_py_tests.floor import NoneValue
+
+    def fields_of(obj: ObjectValue) -> dict[str, FloorValue]:
+        return {field.name: field.value for field in obj.fields}
+
+    def is_none(value: FloorValue) -> bool:
+        return isinstance(value, NoneValue)
+
+    def refines(a: ObjectValue, b: ObjectValue) -> bool:
+        if a.identity == b.identity:
+            return False
+        fa, fb = fields_of(a), fields_of(b)
+        if set(fa) != set(fb):
+            return False
+        gained = False
+        for name, vb in fb.items():
+            va = fa[name]
+            if is_none(vb):
+                if not is_none(va):
+                    gained = True
+                continue
+            if is_none(va) or va != vb:
+                return False
+        return gained
+
+    candidates = [
+        candidate
+        for candidate in managers
+        if all(
+            candidate.identity == peer.identity or refines(candidate, peer)
+            for peer in managers
+        )
+    ]
+    identities = {item.identity for item in candidates}
+    if len(identities) != 1:
+        return None
+    return candidates[0]
+
+
 def construct_manager_behavior(
     resolved: ResolvedPythonObjectV1,
     *,
@@ -254,6 +515,14 @@ def construct_manager_behavior(
     # refused its own cycles at resolution; a repeated call identity is still
     # reported as a typed gap rather than looped on.
     #
+    # raises-style factories gate the CM on `if not args: return CM(...)`.
+    # That return is a GuardedReturn under the branch polarity, not a bare
+    # ReturnValue.  Multi-arm ExitSet factories (if/raise faces) similarly
+    # carry manager returns on Completed arms while Halted RaiseValue arms
+    # are non-manager exits.  Both shapes must project the ObjectValue return
+    # face — never demand truth of a raise terminal and never stall as
+    # non-manager-result:BlockValue solely because the return was guarded.
+    #
     # Every force_floor in the chain -- the factory call and each unwrapped hop
     # -- projects under ONE typed membrane: a ConstructionPanic raised by the
     # floor is the force-floor STAGE refusing, and becomes the stage-keyed
@@ -267,41 +536,83 @@ def construct_manager_behavior(
         result = call.force_floor(
             None, owner="construct_manager_behavior", project_callsite=False
         )
-        while (
-            isinstance(result, BlockValue)
-            and result.statements
-            and isinstance(result.statements[-1], ReturnValue)
-        ):
-            factory_prefix = factory_prefix + result.statements[:-1]
-            returned = result.statements[-1].value
-            if not isinstance(returned, CallSiteValue):
-                result = returned
-                break
-            if id(returned) in seen_calls:
-                return ManagerConstructionGapV1(
-                    "call-graph-cycle", resolved.cid, "recursive source call graph"
-                )
-            seen_calls.add(id(returned))
-            result = returned.force_floor(
-                None, owner="construct_manager_behavior returned object"
-            )
+        projected = _project_factory_manager(
+            result,
+            factory_prefix=factory_prefix,
+            seen_calls=seen_calls,
+            resolved_cid=resolved.cid,
+        )
+        if isinstance(projected, ManagerConstructionGapV1):
+            return projected
+        result, factory_prefix = projected
     except ConstructionPanic as panic:
         # Typed floor projection failure — not a bare crash, not soft silence.
-        # Surface as a construction gap so derivation can install a stage-keyed
-        # residual (opaque-call vs force-floor) for assertion-membrane census.
+        # Multi-arm ExitSet is still a factory with Completed return arms: dig
+        # the source outcome and project manager returns from those arms.
         owner = getattr(getattr(panic, "info", None), "owner", None) or "force-floor"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
-        return ManagerConstructionGapV1(
-            "force-floor", resolved.cid, f"{owner}:{observed}"
-        )
+        if "ExitSet" in str(observed):
+            from sugar_lift_py_tests.outcome import Complete, ExitSet
+
+            outcome = call.reduce_source_outcome(None)
+            if isinstance(outcome, ExitSet):
+                projected = _project_manager_from_exitset(
+                    outcome,
+                    factory_prefix=factory_prefix,
+                    seen_calls=seen_calls,
+                    resolved_cid=resolved.cid,
+                )
+                if isinstance(projected, ManagerConstructionGapV1):
+                    return projected
+                result, factory_prefix = projected
+            elif isinstance(outcome, Complete):
+                projected = _project_factory_manager(
+                    outcome.value,
+                    factory_prefix=factory_prefix,
+                    seen_calls=seen_calls,
+                    resolved_cid=resolved.cid,
+                )
+                if isinstance(projected, ManagerConstructionGapV1):
+                    return projected
+                result, factory_prefix = projected
+            else:
+                return ManagerConstructionGapV1(
+                    "force-floor", resolved.cid, f"{owner}:{observed}"
+                )
+        else:
+            return ManagerConstructionGapV1(
+                "force-floor", resolved.cid, f"{owner}:{observed}"
+            )
+    except Exception as exc:
+        # BindingCoordinateRefSugar and other SugarNotWritten arms are Exception,
+        # not ConstructionPanic — still stage-keyed residuals for derivation.
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if isinstance(exc, SugarNotWritten):
+            owner = getattr(exc, "owner", None) or type(exc).__name__
+            observed = getattr(exc, "observed", None) or str(exc)
+            return ManagerConstructionGapV1(
+                "force-floor", resolved.cid, f"{owner}:{observed}"
+            )
+        raise
     if not isinstance(result, ObjectValue):
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
         )
     bindings = frame.runtime_entries
-    prefix_cids = tuple(
-        _term_content_cid(item.to_term(owner=resolved.cid)) for item in factory_prefix
-    )
+    # BranchResultAuthentication / other control-metadata faces ride in the
+    # linearized if-block but are not term-projectable factory prefix work.
+    # Keep only prefix entries that mint a content CID; never panic the door.
+    prefix_cids_list: list[str] = []
+    kept_prefix: list[FloorValue] = []
+    for item in factory_prefix:
+        try:
+            prefix_cids_list.append(_term_content_cid(item.to_term(owner=resolved.cid)))
+            kept_prefix.append(item)
+        except ConstructionPanic:
+            continue
+    factory_prefix = tuple(kept_prefix)
+    prefix_cids = tuple(prefix_cids_list)
     preimage = {
         "kind": "constructed-manager-behavior",
         "schemaVersion": "1",
@@ -406,7 +717,11 @@ def _resolve_source_visible_frame_uncached(
     module,
     session: SourceResolutionSession,
 ) -> tuple[object, Node, object] | ManagerConstructionGapV1:
-    context = TreeConstructionContextV1.for_source_call_construction()
+    # frame_projection: dual-mode factories may nest With only on non-CM
+    # branches; soft-require those so call-frame projection can complete.
+    context = TreeConstructionContextV1.for_source_call_construction(
+        frame_projection=True
+    )
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
         construction_context=context,
@@ -512,6 +827,14 @@ def _resolve_source_visible_frame_uncached(
                     # traversal verdict to an unrelated one.
                     external_opaque[name] = declined
             blocked.setdefault(declined, set()).add(name)
+        # Dual-mode EffectBoundary factories return a concrete manager
+        # (``return RaisesExc(...)``) without requiring every frame-bound
+        # callee on the function-form branch (``func = args[0]; func(...)``).
+        # Only drop value-call-target when some return is NOT higher-order
+        # ``return helper()`` — pure higher-order sole returns and methods
+        # with no return (``self.x = helper()``) still block (see twins).
+        if _has_non_higher_order_return(function, binders):
+            blocked.pop("value-call-target", None)
         for kind in _CALL_TARGET_GAP_PRECEDENCE:
             if kind in blocked:
                 return kind, tuple(sorted(blocked[kind]))
@@ -801,6 +1124,42 @@ def _local_named_calls(function: FunctionDef):
             yield node
         children = [child for _, _, child in node.children()]
         stack.extend(reversed(children))
+
+
+def _has_non_higher_order_return(
+    function: FunctionDef, binders: frozenset[str]
+) -> bool:
+    """True when some ``return`` is not ``return <frame-bound-name>(...)``.
+
+    Dual-mode EffectBoundary factories return a free/local constructor on the
+    CM path (``return RaisesExc(...)``) while the function-form branch may call
+    a formal. Pure higher-order (``return helper()`` only) and methods with no
+    return statement keep value-call-target blocked.
+    """
+    from sugar_source_tree.nodes import Return
+
+    returns: list = []
+    stack = list(reversed(function.body))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (FunctionDef, ClassDef)):
+            continue
+        if isinstance(node, Return):
+            returns.append(node)
+            continue
+        children = [child for _, _, child in node.children()]
+        stack.extend(reversed(children))
+    if not returns:
+        return False
+    for ret in returns:
+        value = ret.value
+        if not (
+            isinstance(value, Call)
+            and isinstance(value.func, Name)
+            and value.func.id in binders
+        ):
+            return True
+    return False
 
 
 def _call_coordinate(call: Call):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -90,12 +90,32 @@ def derive_manager_summary(
     and every exit face completes with exact Python ``False`` or ``None``.
     Symbolic truthiness remains loud; it is never interpreted by target name.
     """
-    enter = outcome_to_exitset(protocol.enter_outcome())
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    try:
+        enter = outcome_to_exitset(protocol.enter_outcome())
+    except ConstructionPanic as panic:
+        owner = getattr(getattr(panic, "info", None), "owner", None) or "enter"
+        observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
+        return DerivedManagerSummaryGapV1(
+            "enter-may-halt",
+            protocol.protocol_construction_cid,
+            f"{owner}:{observed}",
+        )
     if not enter.exits or any(not isinstance(face, Completed) for face in enter.exits):
         return DerivedManagerSummaryGapV1(
             "enter-may-halt", protocol.protocol_construction_cid, "__enter__ ExitSet"
         )
-    exit_ = outcome_to_exitset(protocol.exit_outcome())
+    try:
+        exit_ = outcome_to_exitset(protocol.exit_outcome())
+    except ConstructionPanic as panic:
+        owner = getattr(getattr(panic, "info", None), "owner", None) or "exit"
+        observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
+        return DerivedManagerSummaryGapV1(
+            "exit-may-halt",
+            protocol.protocol_construction_cid,
+            f"{owner}:{observed}",
+        )
     boundary = (
         _derive_effect_boundary(exit_, protocol, behavior)
         if behavior is not None

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -192,6 +192,155 @@ def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):
     assert result.kind in {"non-manager-result", "force-floor"}, result
 
 
+def test_raises_style_if_not_args_factory_projects_guarded_return(tmp_path):
+    """Dual-mode EffectBoundary factory: ``if not args: return CM(x)`` constructs.
+
+    Residual without GuardedReturn unwrap was non-manager-result:BlockValue or
+    force-floor:truth:RaiseValue / unspecialized formal. Vendor-neutral shape —
+    no pytest/pandas name branch.
+    """
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return effect_type is self.expected_exception\n\n"
+        "def raises(expected_exception=None, *args):\n"
+        "    if not args:\n"
+        "        return RaisesExc(expected_exception)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert "BindingCoordinateRefSugar" not in detail, result
+    assert "unspecialized source-call formal" not in detail, result
+    assert "truth:RaiseValue" not in detail, result
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "non-manager-result"
+        and result.detail == "BlockValue"
+    ), result
+    assert isinstance(result, ConstructedManagerBehaviorV1), (
+        f"expected ConstructedManagerBehaviorV1, got {type(result).__name__}"
+        f" kind={getattr(result, 'kind', None)} detail={detail!r}"
+    )
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected_exception"] is actual.value
+
+
+def test_raises_style_kwargs_return_attaches_constructor_body(tmp_path):
+    """General ``return CM(x, **kwargs)`` is not bodyless CallSiteValue."""
+    implementation = (
+        "class RaisesExc:\n"
+        "    def __init__(self, expected_exception=None, match=None, check=None):\n"
+        "        self.expected_exception = expected_exception\n"
+        "        self.match = match\n"
+        "        self.check = check\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def raises(expected_exception=None, *args, **kwargs):\n"
+        "    if not args:\n"
+        "        return RaisesExc(expected_exception, **kwargs)\n"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, implementation, exported="raises"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    detail = getattr(result, "detail", None) or ""
+    assert not (
+        isinstance(result, ManagerConstructionGapV1)
+        and result.kind == "non-manager-result"
+        and result.detail == "CallSiteValue"
+    ), result
+    assert "missing callsite body" not in detail, result
+    assert isinstance(result, ConstructedManagerBehaviorV1), (
+        f"expected ConstructedManagerBehaviorV1, got {type(result).__name__}"
+        f" kind={getattr(result, 'kind', None)} detail={detail!r}"
+    )
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected_exception"] is actual.value
+
+
+def test_dual_mode_effect_boundary_installs_with_effect_boundary_sugar(tmp_path):
+    """Vendor-neutral dual-mode factory populates EffectBoundary With sugar."""
+    implementation = (
+        "class RenamedBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n\n"
+        "def make_boundary(expected, *args):\n"
+        "    if not args:\n"
+        "        return RenamedBoundary(expected)\n"
+    )
+    distribution = _distribution(tmp_path, implementation, exported="make_boundary")
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        "    with arbitrary.make_boundary(ValueError):\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExpectsModeV1,
+    )
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    reference = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(reference.semantics.mode, ExpectsModeV1)
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    boundary = with_node.sugar()
+    assert isinstance(boundary, WithEffectBoundarySugar)
+    # Empty body when expects-raise: red ExpectationNotMet (normal completion
+    # while an effect was required). Matching raise is a separate shape.
+    exits = outcome_to_exitset(boundary.desugar()).exits
+    assert len(exits) == 1
+    assert isinstance(exits[0], Halted)
+    assert isinstance(exits[0].effect, ExpectationNotMetEffect)
+
+
 def test_renamed_manager_protocol_retains_ordinary_method_call_frames(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,
@@ -560,7 +709,6 @@ def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
         "def make_guard(expected):\n"
         "    return OpaqueBoundary(expected)\n",
     )
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
     behavior = construct_manager_behavior(
         resolved, graph=graph, actuals=(actual,), call_site=call_site
@@ -569,8 +717,15 @@ def test_opaque_suppression_predicate_stays_summary_gap(tmp_path):
     protocol = construct_manager_protocol(behavior, exit_face_id="boundary-face")
     assert isinstance(protocol, ConstructedManagerProtocolV1)
 
-    with pytest.raises(ConstructionPanic, match="Python type operand"):
-        derive_manager_summary(protocol)
+    # TermValue expected is not a typed class operand: summary stays a typed gap
+    # (force-floor membrane), never a bare ConstructionPanic or green resource.
+    summary = derive_manager_summary(protocol)
+    assert isinstance(summary, DerivedManagerSummaryGapV1)
+    assert summary.kind in {
+        "exit-may-halt",
+        "opaque-exit-truthiness",
+        "enter-may-halt",
+    }, summary
 
 
 def test_renamed_issubclass_boundary_derives_through_authenticated_floor(tmp_path):
@@ -1107,7 +1262,10 @@ def test_installed_stdlib_suppress_reaches_grouped_unpack_after_graph_authentica
     )
     path = tmp_path / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
-    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        TreeConstructionContextV1,
+    )
 
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
@@ -1115,16 +1273,25 @@ def test_installed_stdlib_suppress_reaches_grouped_unpack_after_graph_authentica
         construction_context=context,
     )
     graphs = {}
-    from sugar_source_tree.panic import SugarNotWritten
-
-    with pytest.raises(SugarNotWritten, match="DynamicUnpackAssignSugar"):
-        populate_source_derived_resource_refs(
-            tree, root=tmp_path, path=path, artifact_graph_cache=graphs
-        )
+    # Graph authentication of stdlib contextlib succeeds. Later-stage residual
+    # (exit method ExitSet / unpack) stays a typed gap — not a bare SugarNotWritten.
+    populate_source_derived_resource_refs(
+        tree, root=tmp_path, path=path, artifact_graph_cache=graphs
+    )
 
     graph = graphs["contextlib"]
     assert graph.artifact_kind == "stdlib"
     assert "contextlib" in graph.modules
+    resolution = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(resolution, ContextManagerResolutionGapV1)
+    assert resolution.kind in {
+        "exit-may-halt",
+        "enter-may-halt",
+        "force-floor",
+        "non-manager-result",
+        "method-construction",
+        "opaque-exit-truthiness",
+    }, resolution.kind
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4854,7 +4854,21 @@ class With(Statement):
                 site=self.fragment,
             )
 
-        resolved_ref = self._require_narrow_cm_ref(item)
+        context = self.unit.construction_context
+        if getattr(context, "frame_projection", False):
+            try:
+                resolved_ref = self._require_narrow_cm_ref(item)
+            except Exception:  # noqa: BLE001 — soft dual-mode factory projection
+                # Nested With only on the function-form branch of dual-mode
+                # EffectBoundary factories (pytest.raises). Leave a soft
+                # incomplete so the CM return path can still project a frame.
+                from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import (
+                    SoftUnresolvedWithSugar,
+                )
+
+                return SoftUnresolvedWithSugar(site=self.fragment)
+        else:
+            resolved_ref = self._require_narrow_cm_ref(item)
         if resolved_ref is not None:
             from sugar_lift_py_tests.context_manager_contract import (
                 EffectBoundarySemanticsV1,
@@ -5088,7 +5102,18 @@ class With(Statement):
                     return bound.substitute(scope)
             if item.optional_vars is not None and item.optional_vars.kind == "Name":
                 if self._generator_manager_frame(item) is None:
-                    self._require_narrow_cm_ref(item)
+                    context = self.unit.construction_context
+                    if getattr(context, "frame_projection", False):
+                        # Authenticated dual-mode factories may nest With only
+                        # on the non-CM branch. Soft projection skips closed-row
+                        # enrollment for those sites so the CM return path can
+                        # still project a call frame.
+                        try:
+                            self._require_narrow_cm_ref(item)
+                        except Exception:  # noqa: BLE001 — soft projection only
+                            pass
+                    else:
+                        self._require_narrow_cm_ref(item)
                 enter_slot = f"{item._manager_slot_id()}#enter_result"
                 body_scope[item.optional_vars.id] = item._make_observation_ref(
                     enter_slot, ENTER_RESULT
@@ -5163,7 +5188,14 @@ class With(Statement):
                 return None
             resolved_ref = None
             if self._generator_manager_frame(item) is None:
-                resolved_ref = self._require_narrow_cm_ref(item)
+                context = self.unit.construction_context
+                if getattr(context, "frame_projection", False):
+                    try:
+                        resolved_ref = self._require_narrow_cm_ref(item)
+                    except Exception:  # noqa: BLE001 — soft dual-mode projection
+                        resolved_ref = None
+                else:
+                    resolved_ref = self._require_narrow_cm_ref(item)
             from sugar_lift_py_tests.context_manager_contract import (
                 EffectBoundarySemanticsV1,
             )
@@ -7180,11 +7212,18 @@ class Call(Expression):
                 # call-site branch below.
                 self.func.discharge_by_substitution()
             callee_name = self._spread_callee_name(self.func)
+            # Enroll an authenticated source-visible frame when the call is a
+            # local constructor/function use-site. Typed ``**`` actuals then
+            # project onto formals at desugar (SpreadCallSugar) so the manager
+            # factory return `CM(x, **kwargs)` carries a body — the law that
+            # bare CallSiteSugar already obeys for non-spread calls.
+            source_call_frame = self._spread_source_call_frame()
             return SpreadCallSugar(
                 callee_name=callee_name,
                 callee=(None if isinstance(self.func, Name) else self.func.sugar()),
                 arguments=arguments,
                 site=self.fragment,
+                source_call_frame=source_call_frame,
             )
 
         keyword_sugars = tuple(
@@ -7481,6 +7520,62 @@ class Call(Expression):
             chain = chain.value
         module = target[len("python:") :] if target.startswith("python:") else target
         return ".".join([module, *reversed(attributes)])
+
+    def _spread_source_call_frame(self):
+        """Authenticated source frame for a ``*``/``**`` call, when enrolled.
+
+        Looks up the same ``source_call_frames`` table the non-spread Call path
+        uses, then binds non-spread positionals and named keywords onto the
+        frame. Double-star keywords are *not* node-bound here — their FloorValue
+        is projected at desugar via ``bind_actuals`` once the mapping is a
+        constructed DictValue. Star operands leave the frame unbound so
+        SpreadCallSugar stays bodyless (no typed vararg projection yet).
+        """
+        if any(isinstance(arg, Starred) for arg in self.args):
+            return None
+        context = self.unit.construction_context
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+        from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+        source_call_frame = None
+        if (
+            isinstance(context, TreeConstructionContextV1)
+            and context.source_call_frames
+        ):
+            span = self.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                self.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            source_call_frame = context.source_call_frames.get(coordinate)
+        if source_call_frame is None and isinstance(self.func, Name):
+            definition = self.unit.source_allocation_definition_for_call(self)
+            if (
+                definition is not None
+                and self.unit.source_class_has_authenticated_default_attribute_behavior(
+                    definition
+                )
+            ):
+                source_call_frame = definition.source_visible_constructor_frame()
+        if source_call_frame is None:
+            return None
+        try:
+            return source_call_frame.bind_node_actuals(
+                tuple(arg for arg in self.args if not isinstance(arg, Starred)),
+                tuple(
+                    (keyword.arg, keyword.value)
+                    for keyword in self.keywords
+                    if keyword.arg is not None
+                ),
+            )
+        except SourceCallBindingGap:
+            return None
 
     @staticmethod
     def _spread_callee_name(callee: Expression) -> Optional[str]:

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -236,7 +236,14 @@ def test_effect_boundary_does_not_match_distinct_same_spelling_type(tmp_path):
     assert isinstance(face.effect, RaiseEffect)
 
 
-def test_effect_boundary_without_exception_identity_stays_loud(tmp_path):
+def test_effect_boundary_with_formal_expected_type_stays_symbolic(tmp_path):
+    """A formal expected type is not a ground identity — keep both faces.
+
+    ``with raises(expected):`` when ``expected`` is a parameter cannot collapse
+    to a single authenticated exception-type identity. Desugar must stay a
+    multi-arm ExitSet under the symbolic type predicate, never invent a green
+    sole face and never panic as missing identity sugar.
+    """
     path = tmp_path / "unknown_identity.py"
     path.write_text(
         "from pytest import raises\n"
@@ -245,6 +252,7 @@ def test_effect_boundary_without_exception_identity_stays_loud(tmp_path):
         "        raise ValueError('boom')\n"
     )
     from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
 
     sugar = _function_sugar(path_source(str(path)), _effect_resolved)
     boundary = next(
@@ -252,8 +260,11 @@ def test_effect_boundary_without_exception_identity_stays_loud(tmp_path):
         for statement in sugar.statements
         if isinstance(statement, WithEffectBoundarySugar)
     )
-    with pytest.raises(SugarNotWritten, match="authenticated exception-type identity"):
-        boundary.desugar()
+    outcome = boundary.desugar()
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) >= 2
+    assert any(isinstance(exit_, Completed) for exit_ in outcome.exits)
+    assert any(isinstance(exit_, Halted) for exit_ in outcome.exits)
 
 
 def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(


### PR DESCRIPTION
## Summary

Closes the general EffectBoundary-With construction path for dual-mode manager factories (the shape of `pytest.raises`: `if not args: return CM(...)` plus function-form branch).

Diagnosed from the production `construct_manager_behavior` / `populate_source_derived_resource_refs` door used by scoreboard and `sugar lift --report` — not a probe-specific constructor.

### Law (vendor-neutral)

- **IfSugar** carries call-frame temporal into branch suites (formals as `BindingCoordinateRefSugar` resolve).
- Dual-mode factories with a non-higher-order return drop only `value-call-target` on the function-form formal call; coverage gaps stay blocking.
- Frame projection soft-requires nested With only on non-CM branches (`SoftUnresolvedWithSugar`).
- Factory unwrap projects **GuardedReturn** and multi-arm **ExitSet** CM faces (including GuardedReturn trapped in Halted-arm state after GuardedFaces sequencing).
- **`return CM(x, **kwargs)`** enrolls constructor body via SpreadCallSugar + DictValue `**` bind.
- **ClassValue.truth** / **RaiseValue.truth** so `if not expected` / raise-as-condition never force-floor as truth residual.
- Summary derivation membranes ConstructionPanic into typed enter/exit gaps.

### Twins

- `if not args: return CM(x)` → `ConstructedManagerBehaviorV1`
- `return CM(x, **kwargs)` → constructor body attached
- Dual-mode factory preconstruction installs `WithEffectBoundarySugar` + ExpectsMode red on empty body
- Existing higher-order / coverage gap twins remain red where required
- No pytest/pandas/manager-name branches in the construction consumer

### Residual

Real `pytest.raises` / `RaisesExc` still residual at exit-method floor (complex inheritance) as typed `exit-may-halt` after manager construct — not silent, not vendor arm. Renamed dual-mode factories install EffectBoundary-With fully.

## Test plan

- [x] `pytest tests/test_sole_path_manager_construction.py tests/test_call_target_gap_mechanisms.py` (72 passed)
- [x] dual-mode / kwargs / EffectBoundary install twins green
- [ ] CI full suite

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dual-mode EffectBoundary factory construction through GuardedReturn
> - Adds projection utilities (`_project_factory_manager`, `_project_return_faces_to_manager`, `_project_manager_from_exitset`) in [manager_construction.py](https://github.com/TSavo/sugar/pull/6452/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) so that factories with guarded or nested returns and `ExitSet` outcomes can produce `ConstructedManagerBehaviorV1` instead of gaps or panics.
> - Introduces `SoftUnresolvedWithSugar` so that unresolved `With` sites on non-manager branches during authenticated call-frame projection (when `frame_projection=True`) become soft incompletes rather than hard failures.
> - Extends `SpreadCallSugar` and `SourceVisibleCallFrameV1.bind_actuals` to support `**kwargs` spread calls, enabling body-bearing `CallSiteValue` construction when an authenticated source frame is available.
> - Adds `truth()` to `ClassValue` and `RaiseValue` so truthiness evaluation no longer panics; `IfSugar` now propagates raises in conditions without selecting a branch.
> - Wraps `derive_manager_summary` enter/exit evaluation in a `ConstructionPanic` catch that surfaces a `DerivedManagerSummaryGapV1` instead of raising.
> - Risk: `construct_manager_behavior` now filters factory prefix entries to only those that can mint content CIDs, which changes what is included in the behavior preimage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8965a87.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved context-manager analysis for factories that can either return normally or raise.
  * Added support for projecting typed keyword expansions through authenticated call frames.
  * Context-manager and spread-call handling now preserve more source-level information when available.

* **Bug Fixes**
  * Boolean conditions involving raising expressions now correctly propagate the exception.
  * Type objects consistently evaluate as true.
  * Duplicate and invalid expanded keyword arguments are now detected more reliably.
  * Construction-time failures produce clearer manager summary gaps instead of unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->