### PR TITLE
The raise matcher's subject is a VALUE, and its fix: line said otherwise

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -53,11 +53,36 @@ def matches_raise_effect(effect, expected) -> "MessageVerdict":
             effect.raised_value, owner=owner, role="raised exception"
         )
     if handler_term is None or raised_term is None:
+        # THIS REFUSAL IS CORRECT OUTPUT, NOT OWED WORK.
+        #
+        # The retained atom is `adt.is_python_type(raised, handler)`, and
+        # `raised` is the raised VALUE. An operand that cannot produce a value
+        # term has nothing to state that predicate over, so there is no
+        # question to retain and nothing to construct.
+        #
+        # A SOURCE COORDINATE IS NOT ADMISSIBLE AS THE SUBJECT. The effect
+        # carries an `occurrence` (`file:line:col`) and it is tempting to hand
+        # that over as the raised term, because it is authenticated and
+        # deterministic and it makes the refusal disappear. It designates WHERE
+        # THE RAISE IS WRITTEN, not WHAT WAS RAISED, so
+        # `adt.is_python_type(<coordinate>, Handler)` is a predicate about the
+        # wrong kind of thing. Emitting it would fabricate a fact about a
+        # runtime type nobody testified to -- the same shape as weakening a
+        # carried value under a guard: giving a construct a semantics it does
+        # not have. The earlier `fix:` line here read "resolve both exception
+        # operands through their lexical coordinates", which invited exactly
+        # that repair; it cost one owner three rounds and nearly landed.
         raise SugarNotWritten(
             owner="matches_raise_effect",
             observed="handler or raised exception has no term to state the test over",
-            requested="an authenticated identity or an emittable operand term",
-            fix="resolve both exception operands through their lexical coordinates",
+            requested="an authenticated exception identity or an emittable VALUE term",
+            fix=(
+                "authenticate the operand's exception identity, or give it a "
+                "value term; a source coordinate designates the raise SITE, "
+                "not the raised value, and is not admissible as the subject. "
+                "Where neither exists this refusal is correct output and the "
+                "row is accounted semantics, not owed work"
+            ),
         )
     return MatchRetained(atomic("adt.is_python_type", [raised_term, handler_term]))
 
@@ -191,6 +216,4 @@ def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
             MatchDecided(re.search(ground_pattern, ground_message) is not None)
         )
 
-    return _conjoin(
-        MatchRetained(atomic("py.re_search", [pattern_term, message_term]))
-    )
+    return _conjoin(MatchRetained(atomic("py.re_search", [pattern_term, message_term])))

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -1,0 +1,170 @@
+"""The raise matcher's subject is a VALUE, and a coordinate is not one.
+
+`matches_raise_effect` retains `adt.is_python_type(raised, handler)` when the
+question is real but undecidable. `raised` is the raised VALUE. When an operand
+cannot produce a value term there is no question to retain, and the refusal is
+correct output -- accounted semantics, not owed work.
+
+WHY THIS FILE EXISTS. The refusal's own `fix:` line used to read
+
+    "resolve both exception operands through their lexical coordinates"
+
+and a `RaiseEffect` does carry an `occurrence` (`file:line:col`) that is
+authenticated, deterministic, and content-addressable. Handing it over as the
+raised term makes the refusal disappear and every count move. It is also wrong:
+the coordinate designates WHERE THE RAISE IS WRITTEN, not WHAT WAS RAISED, so
+the emitted atom would be a predicate about the wrong kind of thing --
+fabricating a fact about a runtime type nobody testified to.
+
+That guidance cost three rounds of probing and nearly landed. The `fix:` text
+is corrected; this file makes the ruling a law rather than a comment, because
+the next person to meet this refusal will feel the same pull.
+
+The measured shape that produced it, for the record: `pandas/core/apply.py`
+`wrap_results_list_like`, whose incoming effect carries
+`exception_name='NameError'`, `raised_value=None`,
+`exception_type_coordinate=None`, and `occurrence='pandas/core/apply.py:402:19'`.
+Reproduces on two independently installed pandas versions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_exception_matching import (
+    MatchRetained,
+    matches_raise_effect,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_source_tree.panic import SugarNotWritten
+
+OCCURRENCE = "renamed_module.py:402:19"
+
+
+class _AuthenticatedHandler:
+    """A handler whose exception identity IS authenticated."""
+
+    def __init__(self, identity):
+        self._identity = identity
+
+    def exception_type_identity(self):
+        return self._identity
+
+
+class _TermBearingHandler:
+    """A handler with no authenticated identity but a projectable value term."""
+
+    def exception_type_identity(self):
+        return None
+
+    def to_term(self, *, owner: str):
+        del owner
+        return TermValue(99).to_term(owner="handler value")
+
+
+def _valueless_effect() -> RaiseEffect:
+    """The measured shape: a raise with no value and no authenticated type."""
+    return RaiseEffect(
+        exception_name="NameError",
+        blame=OCCURRENCE,
+        occurrence=OCCURRENCE,
+    )
+
+
+# -- the refusal is correct output -------------------------------------------
+
+
+def test_an_effect_with_no_raised_value_refuses() -> None:
+    handler = _AuthenticatedHandler(TermValue(1).to_term(owner="handler"))
+
+    with pytest.raises(SugarNotWritten) as raised:
+        matches_raise_effect(_valueless_effect(), handler)
+
+    assert raised.value.owner == "matches_raise_effect"
+
+
+def test_the_refusal_says_the_row_is_accounted_semantics() -> None:
+    """`panic = gap`. The next reader must learn this is correct output, not a
+    row to drain -- that reading is what sent one owner at an unsound repair."""
+    handler = _AuthenticatedHandler(TermValue(1).to_term(owner="handler"))
+
+    with pytest.raises(SugarNotWritten) as raised:
+        matches_raise_effect(_valueless_effect(), handler)
+
+    fix = raised.value.fix
+    assert "accounted semantics" in fix
+    assert "not owed work" in fix
+
+
+def test_the_refusal_names_the_coordinate_as_inadmissible() -> None:
+    """THE guidance defect, pinned.
+
+    The old `fix:` invited using the lexical coordinate as the operand term.
+    The corrected one must say the opposite, and say WHY, or the next reader
+    re-derives the wrong repair from the effect's own fields.
+    """
+    handler = _AuthenticatedHandler(TermValue(1).to_term(owner="handler"))
+
+    with pytest.raises(SugarNotWritten) as raised:
+        matches_raise_effect(_valueless_effect(), handler)
+
+    fix = raised.value.fix
+    assert "not admissible" in fix
+    assert "raise SITE" in fix or "raise site" in fix.lower()
+    assert "value term" in fix
+    # And the requested field must ask for a VALUE, not "an operand term".
+    assert "VALUE term" in raised.value.requested
+
+
+# -- lying twin: a coordinate must never become the subject ------------------
+
+
+def test_a_coordinate_as_the_raised_term_is_the_repair_this_forbids() -> None:
+    """THE lying twin.
+
+    This is the repair the old `fix:` line invited, written out. Passing the
+    occurrence as the raised operand makes the refusal vanish and produces an
+    atom -- and the atom's subject is a source coordinate, which is precisely
+    the fabrication. If a future change makes the FIRST assertion here fail,
+    someone has taken that repair and the second assertion says what is wrong
+    with it.
+    """
+    from sugar_lift_py_tests.ir import str_const
+
+    handler = _AuthenticatedHandler(TermValue(1).to_term(owner="handler"))
+
+    # The real call refuses, because the effect has no value term.
+    with pytest.raises(SugarNotWritten):
+        matches_raise_effect(_valueless_effect(), handler)
+
+    # Had the coordinate been admitted, this is the atom it would have built.
+    would_have_been = str_const(OCCURRENCE)
+    assert would_have_been != TermValue(1).to_term(owner="handler")
+    # It designates a source location, not a raised object -- so an
+    # `adt.is_python_type` over it asserts a runtime type of a *coordinate*.
+    assert OCCURRENCE.count(":") == 2
+
+
+def test_a_real_value_term_still_retains_the_question() -> None:
+    """The discriminating face: the refusal must not swallow the live case.
+
+    When the raised operand CAN produce a value term, the question is real and
+    undecidable and must leave as `MatchRetained` over the tester atom -- not
+    as a refusal. A guard that refused everything would pass every test above
+    and destroy the mechanism.
+    """
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        blame=OCCURRENCE,
+        occurrence=OCCURRENCE,
+        raised_value=TermValue(7),
+    )
+    # A handler with NO authenticated identity but WITH a value term: the
+    # question is then real and undecidable rather than unstatable.
+    handler = _TermBearingHandler()
+
+    verdict = matches_raise_effect(effect, handler)
+
+    assert isinstance(verdict, MatchRetained)
+    assert verdict.obligation.name == "adt.is_python_type"


### PR DESCRIPTION
**No mechanism change.** The refusal behaves exactly as before. What changes is the guidance it hands the next person, which was pointing at an unsound repair.

## The refusal is correct output

`matches_raise_effect` retains `adt.is_python_type(raised, handler)` when the question is real but undecidable. **`raised` is the raised VALUE.** An operand that cannot produce a value term has nothing to state the predicate over, so there is no question to retain. The function's own docstring already says it:

> *"Loud only where there is no question to retain: an operand that cannot even produce a term has nothing to state the predicate over."*

## Its `fix:` line said the opposite

```python
fix="resolve both exception operands through their lexical coordinates"
```

A `RaiseEffect` carries an `occurrence` (`file:line:col`) that is authenticated, deterministic and content-addressable — so that sentence reads as *"hand the coordinate over as the operand term."* Doing so makes the refusal disappear and every count move.

**It is unsound.** The coordinate designates **where the raise is written**, not **what was raised**, so the emitted atom would assert a runtime type of a source location — fabricating a fact about a runtime type nobody testified to. Same shape as weakening a carried value under a guard: giving a construct a semantics it does not have.

## What it cost

Three rounds of probing against a real site before the contradiction surfaced:

```
pandas/core/apply.py :: wrap_results_list_like
  exception_name             'NameError'
  raised_value               None
  exception_type_coordinate  None
  occurrence                 'pandas/core/apply.py:402:19'
```

Reproduces on two independently installed pandas versions. **The repair was nearly built.** The deciding evidence was in the same file, two paragraphs above the line that misdirected it.

## The correction

- `requested` now asks for an authenticated exception identity or an emittable **VALUE** term.
- `fix` states that **a source coordinate is not admissible as the subject**, gives the reason, and says that where neither exists **the refusal is correct output and the row is accounted semantics, not owed work.**

## Five tests make it a law rather than a comment

- the refusal fires on the measured shape
- it names the row as **accounted semantics** — the reading that stops someone counting it as drainable
- it names the coordinate as **inadmissible**, with the reason
- **lying twin:** the forbidden repair written out, so a future change that admits a coordinate has to come here and say so
- **discriminating face:** a real value term still retains the question — a guard that refused everything would pass every other test and destroy the mechanism

## Evidence

**24 passed** across this file plus `test_builtin_exception_ancestry`, `test_retained_exception_identity`, `test_grouped_raise_effect`. Two files, +198/−5. No suite run — pushed for CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `matches_raise_effect` refusal message to clarify the subject is a VALUE, not a coordinate
> - Updates the `SugarNotWritten` error in [`authenticated_exception_matching.py`](https://github.com/TSavo/sugar/pull/6453/files#diff-b708c62aea2f4d18c3905c4cf348081f6c83d00d7864779eedc94b32ad948d03) to correctly state that the subject must be a VALUE term, explicitly disallowing source coordinates as admissible subjects.
> - Adds a new test module [`test_raise_matcher_subject_is_a_value.py`](https://github.com/TSavo/sugar/pull/6453/files#diff-d0b0486bafe728847517ec06ae7e3695c27270c46f67be09c55fe95651401480) with five tests covering refusal semantics, error message content, coordinate inadmissibility, and the positive case where a real value term produces `MatchRetained`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 778399f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->