### PR TITLE
Reached opaque calls carry their obligation to the consumer site, named rather than swallowed

### DIFF
--- a/docs/superpowers/plans/2026-07-26-reachable-opaque-call-obligations.md
+++ b/docs/superpowers/plans/2026-07-26-reachable-opaque-call-obligations.md
@@ -1,0 +1,364 @@
+# Reachable Opaque-Call Obligations Implementation Plan
+
+> **For Codex:** Execute this plan inline with `superpowers:executing-plans`. Keep
+> the red/green order; do not add a vendor-name admission arm or run a census.
+
+**Goal:** Let authenticated source construction defer an unresolved named call
+to its exact source coordinate, so ordinary Sugar reachability admits the real
+`pytest.raises(...)` context-manager route while the reachable legacy callable
+route stays typed-loud.
+
+**Architecture:** `sugar-lift-python-source` discovers and parks immutable
+`OpaqueSourceCallObligationV1` rows in the lower
+`TreeConstructionContextV1`. `sugar-source-tree` consumes a row at the start of
+`Call._construct_sugar`, before spread-call selection, and returns the existing
+typed `CallSiteSugar` refusal. Ordinary Sugar construction remains the only
+reachability engine; unreachable rows remain in the context table.
+
+**Tech Stack:** Python 3, pytest, Rust/Cargo package wrapper where required,
+existing `SourceFile`/Sugar construction and manager-summary derivation.
+
+---
+
+## Task 1: Pin the Real Truthful and Lying Twins
+
+**Files:**
+
+- Modify: `implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py`
+- Reference: `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py`
+
+- [ ] **Step 1: Add a shared real-pytest source-derived setup**
+
+  Add a small test helper that writes a consumer module, constructs a
+  `TreeConstructionContextV1`, calls
+  `populate_source_derived_resource_refs`, and returns the tree and context.
+  It must use the installed authenticated `pytest` distribution path; do not
+  inject a hand-built contract table.
+
+- [ ] **Step 2: Replace the broad opaque-builtin test with the truthful twin**
+
+  Use:
+
+  ```python
+  import pytest
+
+  def use_boundary():
+      with pytest.raises(ValueError, match="boom"):
+          raise ValueError("boom")
+  ```
+
+  Assert the exact pre-patch result is
+  `ContextManagerResolutionGapV1(kind="opaque-call-target:func", ...)`.
+  Then state the post-patch assertions in the same test: the reference is
+  `SourceDerivedContextManagerRefV1`, its semantics are
+  `EffectBoundarySemanticsV1`, `with_node.sugar()` is
+  `WithEffectBoundarySugar`, and reduction completes the matching raise.
+
+- [ ] **Step 3: Add the lying legacy-callable twin**
+
+  Use a real authenticated call shaped as
+  `pytest.raises(ValueError, func)`. Assert reduction reaches a
+  `SugarNotWritten`/typed construction refusal whose observed value contains
+  exactly `opaque-call-target:func`; do not accept arbitrary exceptions.
+
+- [ ] **Step 4: Pre-resolve the test binary with builds forbidden**
+
+  Resolve the `python-lift` cap once with
+  `SUGAR_BINARY_ALLOW_BUILD=0`. If the shelf is stale, stop and repair the
+  binary explicitly instead of allowing every test to enter the 600-second
+  fixture build path.
+
+- [ ] **Step 5: Record the truthful twin red on the unpatched production tree**
+
+  With production files still byte-identical to base
+  `e0350dc43693cd86ac14017f7e72729e907d1c36`, run:
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py \
+    -k 'pytest_raises and truthful'
+  ```
+
+  Expected: FAIL because the returned resolution is the named
+  `opaque-call-target:func` gap rather than a source-derived EffectBoundary.
+  Save the exact command, base SHA, and failure line for the PR body.
+
+- [ ] **Step 6: Run the lying twin before production changes**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py \
+    -k 'pytest_raises and lying'
+  ```
+
+  Expected: PASS only if it asserts the exact typed refusal.
+
+- [ ] **Step 7: Commit the red tests**
+
+  ```bash
+  git add implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+  git commit -m "test: pin reachable opaque source call twins" \
+    --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+    --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+  ```
+
+## Task 2: Add the Typed Obligation Transport
+
+**Files:**
+
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py`
+
+- [ ] **Step 1: Write transport law tests**
+
+  Add tests that construct an immutable
+  `OpaqueSourceCallObligationV1(coordinate, target_name, resolved_object_cid)`
+  and verify:
+
+  - `TreeConstructionContextV1.opaque_source_call_obligations` starts empty;
+  - `for_source_call_construction` preserves an explicitly supplied table;
+  - a frozen obligation cannot be mutated;
+  - its coordinate and authenticated owner CID remain inspectable.
+
+- [ ] **Step 2: Run the new tests red**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py \
+    -k opaque_source_call_obligation
+  ```
+
+  Expected: FAIL because the type and table do not exist.
+
+- [ ] **Step 3: Add the minimum transport type and table**
+
+  Implement:
+
+  ```python
+  @dataclass(frozen=True)
+  class OpaqueSourceCallObligationV1:
+      coordinate: SourceFragmentCoordinateV1
+      target_name: str
+      resolved_object_cid: str
+  ```
+
+  Add `opaque_source_call_obligations: dict = field(default_factory=dict)` to
+  `TreeConstructionContextV1`, and add the optional explicit table argument to
+  `for_source_call_construction`. Do not serialize it or turn it into a call
+  resolution.
+
+- [ ] **Step 4: Run the focused transport tests green**
+
+  Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit the transport**
+
+  ```bash
+  git add \
+    implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py \
+    implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+  git commit -m "feat: carry opaque source call obligations" \
+    --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+    --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+  ```
+
+## Task 3: Park Obligations During Authenticated Frame Preparation
+
+**Files:**
+
+- Modify: `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py`
+- Modify: `implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py`
+
+- [ ] **Step 1: Add manager-construction law tests**
+
+  Add a small source fixture with one unreachable unresolved named call and
+  assert frame preparation returns a frame while the exact coordinate retains
+  one obligation. Add mutation-sensitive tests that:
+
+  - reject two different obligations at one coordinate;
+  - reject installing a source-call frame where an obligation exists;
+  - reject installing an obligation where a source-call frame exists;
+  - leave a source-resolvable external callee on the existing real-frame path.
+
+- [ ] **Step 2: Run the new parking tests red**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py \
+    -k 'opaque_call_obligation or source_resolvable_external'
+  ```
+
+  Expected: FAIL because eager `_opaque_call_targets` still aborts the whole
+  frame and no obligation table is populated.
+
+- [ ] **Step 3: Replace eager aborts with checked coordinate installs**
+
+  Change `_opaque_call_targets` to return exact `(Call, target_name)` demand
+  rows. When `_resolve_external_call_frame` returns `None`, install
+  `OpaqueSourceCallObligationV1` at `_call_coordinate(call)` instead of
+  returning `ManagerConstructionGapV1`.
+
+  Centralize checked installs:
+
+  ```python
+  def _install_opaque_call_obligation(context, call, obligation): ...
+  def _install_source_call_frame(context, call, frame): ...
+  ```
+
+  An identical duplicate obligation is idempotent. Differing testimony or a
+  frame/obligation collision raises `BackendDefect`. Preserve source-frame
+  recursion and builtin handling unchanged.
+
+- [ ] **Step 4: Run the parking laws green**
+
+  Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit frame preparation**
+
+  ```bash
+  git add \
+    implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py \
+    implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+  git commit -m "feat: park unresolved source calls by coordinate" \
+    --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+    --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+  ```
+
+## Task 4: Consume Only Reached Obligations
+
+**Files:**
+
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py`
+
+- [ ] **Step 1: Add direct `Call.sugar` reachability tests**
+
+  Construct a tree whose context has an obligation for one exact call. Assert:
+
+  - that call returns `CallSiteSugar` with
+    `contract_resolution_gap == "opaque-call-target:func"`;
+  - desugaring raises `SugarNotWritten` with that exact observed reason;
+  - an unrelated call follows the existing path;
+  - a spread call with an obligation refuses before `SpreadCallSugar` can
+    absorb it.
+
+- [ ] **Step 2: Run the source-tree tests red**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py \
+    -k opaque_call_obligation
+  ```
+
+  Expected: FAIL; current `Call._construct_sugar` selects spread construction
+  before it consults any coordinate table.
+
+- [ ] **Step 3: Move coordinate lookup to the start of `Call._construct_sugar`**
+
+  Build the exact `SourceFragmentCoordinateV1` once before `has_spread`.
+  If the context table contains an obligation, return a `CallSiteSugar` with:
+
+  ```python
+  target_name="python:unresolved-source-call"
+  contract_resolution_gap=f"opaque-call-target:{obligation.target_name}"
+  ```
+
+  Construct its argument/keyword sugars normally so reached arguments retain
+  ordinary semantics. Do not delete the obligation. Then continue through
+  spread, preconstruction resolution, source frame, and ordinary call paths
+  unchanged when no obligation exists.
+
+- [ ] **Step 4: Run the source-tree tests green**
+
+  Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit reached-coordinate consumption**
+
+  ```bash
+  git add \
+    implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py \
+    implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
+  git commit -m "feat: refuse opaque calls only when reached" \
+    --trailer "Co-authored-by: WOPR <evilgenius@nefariousplan.com>" \
+    --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
+  ```
+
+## Task 5: Close the Real Assertion-With Milestone
+
+**Files:**
+
+- Modify:
+  `implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py`
+- Verify only: all files changed in Tasks 1-4
+
+- [ ] **Step 1: Run truthful and lying twins together**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py \
+    -k pytest_raises
+  ```
+
+  Expected: truthful source-derived EffectBoundary PASS; lying twin PASS
+  because it observes exactly `opaque-call-target:func`. Inspect the context
+  table in the truthful test and confirm the unreachable obligation remains.
+
+- [ ] **Step 2: Run all three affected Python package suites**
+
+  Run each package separately and print its terminal summary:
+
+  ```bash
+  python -m pytest -q implementations/python/sugar-lift-py-tests/tests
+  python -m pytest -q implementations/python/sugar-lift-python-source/tests
+  python -m pytest -q implementations/python/sugar-source-tree/tests
+  ```
+
+  The third package is required because `Call._construct_sugar` changes there,
+  even though the initial ownership correction named only the two lift
+  packages. Record pre-existing failures separately per package.
+
+- [ ] **Step 3: Run any Cargo-backed owning-package leg without fail-fast**
+
+  Use the repository's `python-lift` task/cap and `--no-fail-fast`, preserving
+  per-target result lines. Name the known main failure
+  `sugar::term_dispatch::tests::predicate_visitor_folds_nested_deref_bitand_comparison_floor`
+  separately; do not let it hide later targets.
+
+- [ ] **Step 4: Verify focused crash and timeout axes**
+
+  Confirm every truthful/lying run completed with zero crashes and zero
+  timeouts. This is reproducer-shaped verification only; do not launch a
+  corpus sweep, scoreboard, or census.
+
+- [ ] **Step 5: Self-review**
+
+  ```bash
+  git diff e0350dc43693cd86ac14017f7e72729e907d1c36 --check
+  git diff --stat e0350dc43693cd86ac14017f7e72729e907d1c36
+  rg -n "pytest|raises" \
+    implementations/python/sugar-lift-py-tests/src \
+    implementations/python/sugar-lift-python-source/src \
+    implementations/python/sugar-source-tree/src
+  git status --short
+  ```
+
+  Inspect every new production hit: there must be no pytest/name admission
+  arm, no obligation deletion, no second evaluator, no debug code, and no
+  unrelated changes.
+
+- [ ] **Step 6: Verify trailers and exact final state**
+
+  ```bash
+  git log --format=full -5
+  git rev-parse HEAD
+  ```
+
+  Every new commit must contain identical WOPR `Co-authored-by` and
+  `Signed-off-by` trailers. Attribute all test results to the printed HEAD.
+
+- [ ] **Step 7: Publish the completion receipt**
+
+  Report the red base SHA and named failure, final commit SHA, truthful and
+  lying results, parked-obligation inspection, each package summary, known
+  pre-existing failures, and crash/timeout zeros. Mention Fizz in the completed
+  result. Do not claim a census delta.

--- a/docs/superpowers/plans/2026-07-26-reachable-opaque-call-obligations.md
+++ b/docs/superpowers/plans/2026-07-26-reachable-opaque-call-obligations.md
@@ -283,13 +283,74 @@ existing `SourceFile`/Sugar construction and manager-summary derivation.
     --trailer "Signed-off-by: WOPR <evilgenius@nefariousplan.com>"
   ```
 
-## Task 5: Close the Real Assertion-With Milestone
+## Task 5: Defer Discarded With Validation to Construction
+
+**Files:**
+
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py`
+- Verify:
+  `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py`
+
+- [ ] **Step 1: Add a selected-With deferral/refusal tooth**
+
+  Build a function containing `with manager() as entered:` under an enrolled
+  but empty context-manager resolution table. Assert that
+  `with_node.substitute({})` succeeds and exports the enter-result observation,
+  then assert that `with_node.sugar()` raises `BackendDefect` with owner
+  `With._construct_sugar` and observed text
+  `BackendDefect: enrolled context-manager demand missing from resolution table`.
+
+- [ ] **Step 2: Run the tooth red**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py \
+    -k selected_with_defers_resolution_validation_until_construction
+  ```
+
+  Expected: FAIL during `substitute({})`, proving the discarded-return demand
+  still adjudicates reachability before construction.
+
+- [ ] **Step 3: Remove only the two discarded-return demands**
+
+  Delete the `_require_narrow_cm_ref(item)` call in `With.substitute` and the
+  matching call in `With.substitution_binding`. Keep the call in
+  `With._construct_sugar` byte-for-byte: it is the producer consumed by
+  `WithResourceSugar` / `ContextManagerEdgeDtoV1`.
+
+- [ ] **Step 4: Run the tooth green**
+
+  Run the Step 2 command. Expected: PASS, with substitution completing and
+  construction preserving the exact typed refusal.
+
+- [ ] **Step 5: Verify the existing authority law**
+
+  ```bash
+  python -m pytest -q \
+    implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py \
+    -k with_only_admits_never_suppresses_via_authenticated_disposition_type
+  ```
+
+  Expected: PASS. Its `_require_narrow_cm_ref` spelling assertion witnesses the
+  surviving construction demand, not either discarded substitution call.
+
+- [ ] **Step 6: Commit the deferral**
+
+  ```bash
+  git add \
+    implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py \
+    implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+  git commit -m "fix: defer With resolution validation to construction"
+  ```
+
+## Task 6: Close the Real Assertion-With Milestone
 
 **Files:**
 
 - Modify:
   `implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py`
-- Verify only: all files changed in Tasks 1-4
+- Verify only: all files changed in Tasks 1-5
 
 - [ ] **Step 1: Run truthful and lying twins together**
 

--- a/docs/superpowers/specs/2026-07-26-reachable-opaque-call-obligations-design.md
+++ b/docs/superpowers/specs/2026-07-26-reachable-opaque-call-obligations-design.md
@@ -1,0 +1,196 @@
+# Reachable Opaque-Call Obligations for Assertion-With
+
+## Objective
+
+Construct a source-authenticated `pytest.raises(...)` context manager without
+adding a pytest name arm or a second evaluator.
+
+The concrete defect is in source-call frame preparation. The authenticated
+`pytest.raises` function has a context-manager route when variadic positional
+`args` is empty and a legacy callable route containing `func(*args[1:],
+**kwargs)`. Current frame preparation scans the entire function before binding
+actuals and aborts at the unresolved free call target `func`, even though the
+empty-`args` context-manager route returns before that call can execute.
+
+The missing general law is:
+
+> An unresolved source call is a typed obligation at its exact source
+> coordinate. It refuses construction if and only if ordinary Sugar reduction
+> reaches that coordinate. Unreachable obligations are deferred, never erased
+> or discharged.
+
+## Scope
+
+This cut changes source-visible call construction only.
+
+In scope:
+
+- carry unresolved-call obligations by exact call coordinate;
+- let ordinary source reduction decide reachability after authenticated actual
+  binding;
+- raise the existing typed `opaque-call-target:<name>` refusal when a deferred
+  coordinate is reached;
+- construct the existing `EffectBoundarySemanticsV1` through the current
+  manager protocol and summary derivation once the reachable manager route
+  succeeds.
+
+Out of scope:
+
+- pytest, pandas, or vendor-name dispatch;
+- a contract admitted from callable spelling or signature shape;
+- pre-pruning the AST with a second evaluator;
+- changes to `ExitSet`, partition testimony, or resource-With semantics;
+- census, scoreboard, baseline, or pin work.
+
+## Architecture
+
+### 1. Typed obligation
+
+Add an immutable `OpaqueSourceCallObligationV1` beside
+`TreeConstructionContextV1` in
+`sugar_lift_py_tests.context_manager_resolution`. The lower package owns the
+transport type so `sugar-source-tree` never imports the higher
+`sugar-lift-python-source` package. The source-construction package only mints
+the obligation. It records:
+
+- the exact `SourceFragmentCoordinateV1` of the unresolved `Call`;
+- the unresolved target name, such as `func`;
+- the authenticated resolved-object CID whose source frame contains the call.
+
+The obligation is testimony about a missing callee frame. It is not a
+resolution, a placeholder return value, or evidence that the call is safe.
+
+### 2. Construction-context transport
+
+Extend `TreeConstructionContextV1` with an initially empty coordinate-keyed
+table of opaque-call obligations. The table follows the same source-call
+construction lifetime as `source_call_frames`.
+
+During `resolve_source_visible_frame`:
+
+- source-resolvable external callees continue to populate
+  `source_call_frames`;
+- unresolved callees no longer abort the containing function;
+- each unresolved call coordinate receives one obligation;
+- duplicate writes must agree exactly, otherwise construction raises a backend
+  defect rather than selecting one.
+
+The eager scan still discovers and records obligations, but it no longer
+decides whether they are reachable.
+
+### 3. Reachability door
+
+At `Call.sugar`, before ordinary call construction:
+
+- look up the call coordinate in the construction context;
+- if an opaque-call obligation exists, raise the existing source-construction
+  gap with kind `opaque-call-target` and detail equal to the recorded target;
+- otherwise follow the existing source-frame or ordinary call path unchanged.
+
+This makes ordinary Sugar control flow the only reachability engine. A branch
+not reduced never asks its nested call for Sugar and therefore never consumes
+or deletes its parked obligation.
+
+### 4. Manager construction result
+
+For `pytest.raises(ValueError)`:
+
+1. authenticated dependency resolution selects the real exported function;
+2. frame preparation parks the legacy `func(...)` obligation;
+3. authenticated empty variadic actuals select the context-manager return
+   route;
+4. the parked coordinate is never reached;
+5. the returned manager protocol constructs;
+6. existing `derive_manager_summary` produces
+   `EffectBoundarySemanticsV1`;
+7. existing `WithEffectBoundarySugar` routes the matching raise over the
+   factored `ExitSet`.
+
+No special case in these steps knows the names `pytest` or `raises`.
+
+## Error Semantics
+
+- Reaching a parked call must raise a typed gap whose externally visible kind
+  is exactly `opaque-call-target:func` for the lying twin.
+- An unreachable obligation remains in the construction context after the
+  truthful route completes. Tests must inspect the table so a patch that drops
+  obligations cannot pass.
+- A coordinate collision with conflicting target or owner testimony is a
+  backend defect.
+- A resolvable external frame and an opaque obligation may not coexist at the
+  same coordinate.
+- Existing later-stage `force-floor`, `non-manager-result`,
+  `protocol-construction`, and `summary-derivation` gaps remain unchanged.
+
+## Tests
+
+### Real reproducer
+
+Use a reduced pandas-style assertion boundary:
+
+```python
+import pytest
+
+def f():
+    with pytest.raises(ValueError, match="boom"):
+        raise ValueError("boom")
+```
+
+It must pass through authenticated dependency resolution and source-derived
+manager construction, not a hand-built contract-ref table.
+
+### Truthful twin
+
+The context-manager form above supplies no legacy callable arguments.
+
+Before production changes, the test must fail on base
+`e0350dc43693cd86ac14017f7e72729e907d1c36` with
+`opaque-call-target:func`. After the change it must construct
+`WithEffectBoundarySugar`, derive `EffectBoundarySemanticsV1`, and complete the
+matching raise. The parked `func` obligation must still be present in the
+construction context.
+
+### Lying twin
+
+Use the legacy callable route:
+
+```python
+pytest.raises(ValueError, func)
+```
+
+Binding actuals makes `func(*args[1:], **kwargs)` reachable. The test must
+assert the exact typed refusal `opaque-call-target:func`; any-red is
+insufficient.
+
+### Additional law tests
+
+- a source-resolvable external callee still installs and uses its real frame;
+- conflicting obligations at one coordinate refuse loudly;
+- a coordinate cannot hold both a frame and an opaque obligation;
+- an unrelated ordinary call without an obligation follows the existing path.
+
+### Verification
+
+Run:
+
+- the new focused truthful and lying twins;
+- all tests in the owning `sugar-lift-python-source` package, printing
+  per-target results and using `--no-fail-fast` for any Cargo leg;
+- existing source-tree authenticated EffectBoundary tests affected by the
+  construction-context schema.
+
+The focused outcomes must retain zero crash and timeout rows. No corpus sweep
+is part of this cut.
+
+## Acceptance
+
+The cut is complete when:
+
+1. the truthful twin is recorded red at base `e0350dc43` for
+   `opaque-call-target:func`;
+2. it becomes green through source-derived EffectBoundary construction;
+3. the lying twin remains red for exactly `opaque-call-target:func`;
+4. the obligation is demonstrably parked rather than erased;
+5. focused owning-package tests pass, with any pre-existing failures named
+   separately;
+6. no focused crash or timeout axis increases.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -66,6 +66,7 @@ class OpaqueSourceCallObligationV1:
     coordinate: SourceFragmentCoordinateV1
     target_name: str
     resolved_object_cid: str
+    resolution_kind: str = "opaque-call-target"
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -60,6 +60,15 @@ class SourceFragmentCoordinateV1:
 
 
 @dataclass(frozen=True)
+class OpaqueSourceCallObligationV1:
+    """Authenticated unresolved callee testimony parked at one source call."""
+
+    coordinate: SourceFragmentCoordinateV1
+    target_name: str
+    resolved_object_cid: str
+
+
+@dataclass(frozen=True)
 class ContextManagerContractRefV1:
     resolution_cid: str
     demand_cid: str
@@ -175,6 +184,9 @@ class TreeConstructionContextV1:
     # installed only beside a successful authenticated row; every other row is
     # a typed loud classification consumed by census/linking.
     source_call_resolutions: dict = field(default_factory=dict)
+    # Unresolved named calls parked at exact source coordinates. Ordinary Sugar
+    # construction consumes the testimony only when execution reaches the call.
+    opaque_source_call_obligations: dict = field(default_factory=dict)
     source_derived_contract_refs: dict = field(default_factory=dict)
     # Runtime-only, prebound class-base Sugar children keyed by the exact
     # subclass definition coordinate.  These are never serialized; the class
@@ -192,6 +204,7 @@ class TreeConstructionContextV1:
         cls,
         *,
         source_call_frames: dict | None = None,
+        opaque_source_call_obligations: dict | None = None,
         call_contract_refs: object | None = None,
         workspace_root: str | None = None,
         frame_projection: bool = False,
@@ -203,6 +216,11 @@ class TreeConstructionContextV1:
             workspace_root=workspace_root,
             source_call_frames={} if source_call_frames is None else source_call_frames,
             frame_projection=frame_projection,
+            opaque_source_call_obligations=(
+                {}
+                if opaque_source_call_obligations is None
+                else opaque_source_call_obligations
+            ),
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -53,9 +53,9 @@ class CallSiteSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         if self.contract_resolution_gap is not None:
-            from sugar_source_tree.panic import SugarNotWritten
+            from sugar_source_tree.panic import OpaqueSourceCallResolutionGap
 
-            raise SugarNotWritten(
+            raise OpaqueSourceCallResolutionGap(
                 owner="CallSiteSugar.desugar",
                 observed=self.contract_resolution_gap,
                 requested="authenticated resolved-call contract reference",

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -1,3 +1,4 @@
+from dataclasses import FrozenInstanceError
 from types import MappingProxyType
 
 import pytest
@@ -5,11 +6,40 @@ import pytest
 from sugar_lift_py_tests import lift_rpc
 from sugar_lift_py_tests.context_manager_resolution import (
     ContractRefProtocolError,
+    OpaqueSourceCallObligationV1,
     ResolvedContractRefsV1,
     SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
     _hash_json,
     decode_resolved_contract_refs,
 )
+
+
+def test_opaque_source_call_obligation_transport_is_frozen_and_inspectable():
+    coordinate = SourceFragmentCoordinateV1(
+        "blake3-512:" + "a" * 128,
+        7,
+        8,
+        7,
+        19,
+    )
+    owner_cid = "blake3-512:" + "b" * 128
+    obligation = OpaqueSourceCallObligationV1(coordinate, "func", owner_cid)
+    table = {coordinate: obligation}
+    context = TreeConstructionContextV1.for_source_call_construction(
+        opaque_source_call_obligations=table
+    )
+
+    assert context.opaque_source_call_obligations is table
+    assert context.opaque_source_call_obligations[coordinate] == obligation
+    assert obligation.coordinate == coordinate
+    assert obligation.target_name == "func"
+    assert obligation.resolved_object_cid == owner_cid
+    with pytest.raises(FrozenInstanceError):
+        obligation.target_name = "other"
+
+    empty = TreeConstructionContextV1.for_source_call_construction()
+    assert empty.opaque_source_call_obligations == {}
 
 
 def unresolved_table():

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
-from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    OpaqueSourceCallObligationV1,
+    TreeConstructionContextV1,
+)
 from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
@@ -778,26 +781,18 @@ def _resolve_source_visible_frame_uncached(
     external_frames: dict[str, object] = {}
     external_opaque: dict[str, str] = {}
 
-    def _blocking_call_targets(
+    def _parked_call_targets(
         function: FunctionDef,
-    ) -> tuple[str, tuple[str, ...]] | None:
-        """The structural condition blocking this definition's named callees.
+    ) -> tuple[tuple[Call, str, str], ...]:
+        """Return exact unresolved callees with their landed typed kind.
 
-        Returns ``(kind, names)`` where ``names`` is the WHOLE blocking set for
-        that kind, sorted -- never a first-hit projection.  The old
-        ``opaque[0]`` made the reported symbol depend on statement order, so a
-        definition blocked on several callees named one arbitrarily and
-        discarded the rest.
-
-        When a definition is blocked by more than one condition it is genuinely
-        blocked by all of them, and the row carries one kind, so the reported
-        kind follows the fixed precedence in ``_CALL_TARGET_GAP_PRECEDENCE``:
-        the capability gap that no coverage change can close, then the door
-        defect, then coverage.  The order is a property of this module, not of
-        the corpus.
+        Frame preparation classifies every named call through main's closed
+        call-target vocabulary, but it does not decide reachability.  Each
+        unresolved call is parked at its own coordinate; ordinary Sugar
+        control flow selects which obligation, if any, becomes a refusal.
         """
         binders = _frame_bound_names(function)
-        blocked: dict[str, set[str]] = {}
+        blocked: list[tuple[Call, str, str]] = []
         for call in _local_named_calls(function):
             name = call.func.id
             if name in external_frames:
@@ -810,7 +805,7 @@ def _resolve_source_visible_frame_uncached(
             if classification == "frame-bound-value":
                 # Bound HERE: a value, not a symbol.  The export door is never
                 # asked, because there is nothing for it to look up.
-                blocked.setdefault("value-call-target", set()).add(name)
+                blocked.append((call, name, "value-call-target"))
                 continue
             declined = external_opaque.get(name)
             if declined is None:
@@ -826,7 +821,7 @@ def _resolve_source_visible_frame_uncached(
                     # callee; memoizing it against the name would serve a
                     # traversal verdict to an unrelated one.
                     external_opaque[name] = declined
-            blocked.setdefault(declined, set()).add(name)
+            blocked.append((call, name, declined))
         # Dual-mode EffectBoundary factories return a concrete manager
         # (``return RaisesExc(...)``) without requiring every frame-bound
         # callee on the function-form branch (``func = args[0]; func(...)``).
@@ -834,11 +829,12 @@ def _resolve_source_visible_frame_uncached(
         # ``return helper()`` — pure higher-order sole returns and methods
         # with no return (``self.x = helper()``) still block (see twins).
         if _has_non_higher_order_return(function, binders):
-            blocked.pop("value-call-target", None)
-        for kind in _CALL_TARGET_GAP_PRECEDENCE:
-            if kind in blocked:
-                return kind, tuple(sorted(blocked[kind]))
-        return None
+            blocked = [
+                obligation
+                for obligation in blocked
+                if obligation[2] != "value-call-target"
+            ]
+        return tuple(blocked)
 
     # Every reachable definition is scanned, whether it is written as a
     # module-level function or as a method of a reachable class.
@@ -856,10 +852,18 @@ def _resolve_source_visible_frame_uncached(
     # loudly, so the two faces disagreed and the silent one was wrong.
     for definition in (target,) + tuple(definitions):
         for scanned in _scanned_definitions(definition):
-            blocking = _blocking_call_targets(scanned)
-            if blocking is not None:
-                kind, names = blocking
-                return ManagerConstructionGapV1(kind, resolved.cid, ",".join(names))
+            for call, name, kind in _parked_call_targets(scanned):
+                coordinate = _call_coordinate(call)
+                _install_opaque_call_obligation(
+                    context,
+                    call,
+                    OpaqueSourceCallObligationV1(
+                        coordinate,
+                        name,
+                        resolved.cid,
+                        resolution_kind=kind,
+                    ),
+                )
 
     frames: dict[str, object] = {}
     reaching_classes: dict[str, ClassDef] = {}
@@ -884,10 +888,18 @@ def _resolve_source_visible_frame_uncached(
         progressed = False
         for function in tuple(pending):
             local_calls = tuple(_local_named_calls(function))
-            blocking = _blocking_call_targets(function)
-            if blocking is not None:
-                kind, names = blocking
-                return ManagerConstructionGapV1(kind, resolved.cid, ",".join(names))
+            for call, name, kind in _parked_call_targets(function):
+                coordinate = _call_coordinate(call)
+                _install_opaque_call_obligation(
+                    context,
+                    call,
+                    OpaqueSourceCallObligationV1(
+                        coordinate,
+                        name,
+                        resolved.cid,
+                        resolution_kind=kind,
+                    ),
+                )
             unresolved = tuple(
                 call.func.id
                 for call in local_calls
@@ -900,7 +912,7 @@ def _resolve_source_visible_frame_uncached(
                 if nested is None:
                     nested = external_frames.get(call.func.id)
                 if nested is not None:
-                    context.source_call_frames[_call_coordinate(call)] = nested
+                    _install_source_call_frame(context, call, nested)
             frames[function.name] = function.source_visible_call_frame()
             pending.remove(function)
             progressed = True
@@ -1175,3 +1187,62 @@ def _call_coordinate(call: Call):
         span.end_line,
         span.end_col,
     )
+
+
+def _install_opaque_call_obligation(
+    context: TreeConstructionContextV1,
+    call: Call,
+    obligation: OpaqueSourceCallObligationV1,
+) -> None:
+    from sugar_source_tree.panic import BackendDefect
+
+    coordinate = _call_coordinate(call)
+    if obligation.coordinate != coordinate:
+        raise BackendDefect(
+            owner="manager_construction._install_opaque_call_obligation",
+            observed="obligation/call coordinate mismatch",
+            requested="exact source-call coordinate testimony",
+            fix="mint the obligation from the call being installed",
+        )
+    if coordinate in context.source_call_frames:
+        raise BackendDefect(
+            owner="manager_construction._install_opaque_call_obligation",
+            observed="frame/obligation collision",
+            requested="one source-call classification at the exact coordinate",
+            fix="keep authenticated frames and opaque obligations disjoint",
+        )
+    existing = context.opaque_source_call_obligations.get(coordinate)
+    if existing is not None and existing != obligation:
+        raise BackendDefect(
+            owner="manager_construction._install_opaque_call_obligation",
+            observed="conflicting opaque-call obligation",
+            requested="byte-identical duplicate testimony",
+            fix="resolve the conflicting target or authenticated owner",
+        )
+    context.opaque_source_call_obligations[coordinate] = obligation
+
+
+def _install_source_call_frame(
+    context: TreeConstructionContextV1,
+    call: Call,
+    frame: object,
+) -> None:
+    from sugar_source_tree.panic import BackendDefect
+
+    coordinate = _call_coordinate(call)
+    if coordinate in context.opaque_source_call_obligations:
+        raise BackendDefect(
+            owner="manager_construction._install_source_call_frame",
+            observed="frame/obligation collision",
+            requested="one source-call classification at the exact coordinate",
+            fix="keep authenticated frames and opaque obligations disjoint",
+        )
+    existing = context.source_call_frames.get(coordinate)
+    if existing is not None and existing != frame:
+        raise BackendDefect(
+            owner="manager_construction._install_source_call_frame",
+            observed="conflicting source-call frame",
+            requested="byte-identical duplicate frame testimony",
+            fix="resolve the conflicting authenticated source frame",
+        )
+    context.source_call_frames[coordinate] = frame

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -589,8 +589,13 @@ def construct_manager_behavior(
     except Exception as exc:
         # BindingCoordinateRefSugar and other SugarNotWritten arms are Exception,
         # not ConstructionPanic — still stage-keyed residuals for derivation.
-        from sugar_source_tree.panic import SugarNotWritten
+        from sugar_source_tree.panic import (
+            OpaqueSourceCallResolutionGap,
+            SugarNotWritten,
+        )
 
+        if isinstance(exc, OpaqueSourceCallResolutionGap):
+            raise
         if isinstance(exc, SugarNotWritten):
             owner = getattr(exc, "owner", None) or type(exc).__name__
             observed = getattr(exc, "observed", None) or str(exc)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -893,6 +893,7 @@ def _resolve_source_visible_frame_uncached(
         progressed = False
         for function in tuple(pending):
             local_calls = tuple(_local_named_calls(function))
+            frame_binders = _frame_bound_names(function)
             for call, name, kind in _parked_call_targets(function):
                 coordinate = _call_coordinate(call)
                 _install_opaque_call_obligation(
@@ -913,6 +914,11 @@ def _resolve_source_visible_frame_uncached(
             if unresolved:
                 continue
             for call in local_calls:
+                if call.func.id in frame_binders:
+                    # A parameter/local shadows any module-level definition
+                    # with the same spelling.  Its parked value-call-target
+                    # obligation is the sole classification at this site.
+                    continue
                 nested = frames.get(call.func.id)
                 if nested is None:
                     nested = external_frames.get(call.func.id)

--- a/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
@@ -54,12 +54,12 @@ from sugar_lift_python_source.manager_construction import (
     CALL_TARGET_GAP_KINDS,
     ConstructedCallActualV1,
     ConstructedManagerBehaviorV1,
-    ManagerConstructionGapV1,
     _frame_bound_names,
     construct_manager_behavior,
 )
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.nodes import Call, Constant, FunctionDef
+from sugar_source_tree.panic import OpaqueSourceCallResolutionGap
 from sugar_source_tree.tree import SourceFile
 
 
@@ -119,6 +119,12 @@ def _construct(root: Path, manager_source: str, **extra_modules: str):
     )
 
 
+def _opaque_gap(root: Path, manager_source: str, **extra_modules: str):
+    with pytest.raises(OpaqueSourceCallResolutionGap) as raised:
+        _construct(root, manager_source, **extra_modules)
+    return raised.value
+
+
 # --------------------------------------------------------------------------
 # value-call-target -- the callee is a VALUE bound by the enclosing definition
 # --------------------------------------------------------------------------
@@ -132,14 +138,12 @@ def test_called_parameter_is_a_value_call_target_not_a_missing_import(tmp_path):
     because there is nothing to look up.  Reporting this as an unresolvable
     external symbol claims a coverage problem that does not exist.
     """
-    result = _construct(
+    gap = _opaque_gap(
         tmp_path,
         "def make_guard(helper):\n    return helper()\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "value-call-target"
-    assert result.detail == "helper"
+    assert gap.observed == "value-call-target:helper"
 
 
 def test_called_local_binding_is_a_value_call_target(tmp_path):
@@ -149,7 +153,7 @@ def test_called_local_binding_is_a_value_call_target(tmp_path):
     this frame.  Parameter and local must not split into two kinds, because the
     missing capability is one capability.
     """
-    result = _construct(
+    gap = _opaque_gap(
         tmp_path,
         "def picked(value):\n"
         "    return value\n"
@@ -159,9 +163,7 @@ def test_called_local_binding_is_a_value_call_target(tmp_path):
         "    return helper(expected)\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "value-call-target"
-    assert result.detail == "helper"
+    assert gap.observed == "value-call-target:helper"
 
 
 def test_module_level_definition_of_the_same_spelling_constructs(tmp_path):
@@ -195,7 +197,7 @@ def test_parameter_shadowing_a_module_definition_is_still_a_value(tmp_path):
     would resolve a frame the call never reaches, which is a soundness bug and
     not only a reporting one.
     """
-    result = _construct(
+    gap = _opaque_gap(
         tmp_path,
         "class Slot:\n"
         "    def __init__(self, label):\n"
@@ -208,20 +210,17 @@ def test_parameter_shadowing_a_module_definition_is_still_a_value(tmp_path):
         "    return helper()\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "value-call-target"
+    assert gap.observed == "value-call-target:helper"
 
 
 def test_parameter_shadowing_a_builtin_is_still_a_value(tmp_path):
     """A parameter shadows the builtin temporal too, for the same reason."""
-    result = _construct(
+    gap = _opaque_gap(
         tmp_path,
         "def make_guard(len):\n    return len(7)\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "value-call-target"
-    assert result.detail == "len"
+    assert gap.observed == "value-call-target:len"
 
 
 # --------------------------------------------------------------------------
@@ -231,27 +230,23 @@ def test_parameter_shadowing_a_builtin_is_still_a_value(tmp_path):
 
 def test_callee_outside_the_artifact_is_coverage_not_a_defect(tmp_path):
     """POSITIVE: the export door declines -- no defining source in the artifact."""
-    result = _construct(
+    gap = _opaque_gap(
         tmp_path,
         "def make_guard(expected):\n    return unbound_helper(expected)\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    assert result.detail == "unbound_helper"
+    assert gap.observed == "call-target-source-absent:unbound_helper"
 
 
-def test_in_artifact_callee_whose_frame_fails_is_a_door_defect(tmp_path):
-    """POSITIVE: the callee IS authenticated here, and its frame still failed.
+def test_in_artifact_callee_carries_nested_refusal_to_nested_consumer(tmp_path):
+    """The callee resolves; its reached opaque child names its own consumer.
 
     ``support.build_slot`` is a real definition inside this artifact's own file
-    manifest, statically exported and reached through the same door.  Its own
-    body is what refuses.  Under the fused key this was indistinguishable from
-    a stdlib symbol the artifact does not contain -- a real defect hidden inside
-    a much larger coverage bucket, and therefore never worked.  Tracked at
-    #6410; this test only makes it nameable.
+    manifest, statically exported and reached through the same door.  Therefore
+    the outer ``build_slot`` call is not the refusal: ordinary control flow
+    reaches ``absent_from_artifact`` inside its authenticated body.
     """
-    result = _construct(
+    gap = _opaque_gap(
         tmp_path,
         "from arbitrary.support import build_slot\n"
         "\n"
@@ -260,22 +255,21 @@ def test_in_artifact_callee_whose_frame_fails_is_a_door_defect(tmp_path):
         support="def build_slot(label):\n    return absent_from_artifact(label)\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-export-unresolved"
-    assert result.detail == "build_slot"
+    assert gap.observed == "call-target-source-absent:absent_from_artifact"
 
 
-def test_coverage_and_defect_do_not_share_a_kind(tmp_path):
-    """DISCRIMINATION: run both arms and require the kinds to DIFFER.
+def test_resolved_outer_callee_does_not_relabel_the_nested_gap(tmp_path):
+    """DISCRIMINATION: direct and nested routes identify the same consumer.
 
-    Asserting each arm separately would still pass if both collapsed onto the
-    same kind tomorrow.  This is the assertion that cannot.
+    The nested route adds an authenticated ``build_slot`` frame.  If eager frame
+    preparation still adjudicated the route, it would relabel the refusal at
+    that outer call rather than carrying the reached inner obligation.
     """
-    absent = _construct(
+    absent = _opaque_gap(
         tmp_path / "absent",
         "def make_guard(expected):\n    return unbound_helper(expected)\n",
     )
-    defect = _construct(
+    defect = _opaque_gap(
         tmp_path / "defect",
         "from arbitrary.support import build_slot\n"
         "\n"
@@ -284,9 +278,8 @@ def test_coverage_and_defect_do_not_share_a_kind(tmp_path):
         support="def build_slot(label):\n    return absent_from_artifact(label)\n",
     )
 
-    assert isinstance(absent, ManagerConstructionGapV1), absent
-    assert isinstance(defect, ManagerConstructionGapV1), defect
-    assert absent.kind != defect.kind
+    assert absent.observed == "call-target-source-absent:unbound_helper"
+    assert defect.observed == "call-target-source-absent:absent_from_artifact"
 
 
 # --------------------------------------------------------------------------
@@ -311,24 +304,18 @@ def test_the_kind_is_a_structural_key_and_never_carries_a_spelling(
     chars.  A key that can be truncated is not an identity, and a key whose
     cardinality is the cardinality of callee spellings is a name table.
     """
-    result = _construct(tmp_path, manager_source)
+    gap = _opaque_gap(tmp_path, manager_source)
+    kind, spelling = gap.observed.split(":", 1)
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind in CALL_TARGET_GAP_KINDS, result.kind
-    assert ":" not in result.kind
+    assert kind in CALL_TARGET_GAP_KINDS, kind
+    assert ":" not in kind
     # The spelling exists -- it just is not the key.
-    assert result.detail and ":" not in result.detail
+    assert spelling and ":" not in spelling
 
 
-def test_the_whole_blocking_set_rides_the_row_not_the_first_hit(tmp_path):
-    """``detail`` is the SORTED blocking set, not whichever callee sorted first.
-
-    ``opaque[0]`` made the reported symbol depend on statement order, so a term
-    reading ``N sites blocked on <callee>`` actually meant ``N sites whose
-    blocking set happened to put <callee> first``.  Order-dependent, and lossy
-    about every other blocker.
-    """
-    result = _construct(
+def test_ordinary_control_flow_selects_the_first_reached_blocker(tmp_path):
+    """Every blocker is parked; statement order decides which one is reached."""
+    gap = _opaque_gap(
         tmp_path,
         "def make_guard(expected):\n"
         "    zulu(expected)\n"
@@ -336,9 +323,7 @@ def test_the_whole_blocking_set_rides_the_row_not_the_first_hit(tmp_path):
         "    return mike(expected)\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    assert result.detail == "alpha,mike,zulu"
+    assert gap.observed == "call-target-source-absent:zulu"
 
 
 # --------------------------------------------------------------------------
@@ -473,20 +458,16 @@ def test_method_calling_an_absent_symbol_refuses_instead_of_fabricating(tmp_path
     fabricated contract, which ``_resolve_external_call_frame`` explicitly
     promises never to yield.
     """
-    result = _construct(tmp_path, _ABSENT_FROM_ARTIFACT_METHOD)
+    gap = _opaque_gap(tmp_path, _ABSENT_FROM_ARTIFACT_METHOD)
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    assert result.detail == "absent_from_artifact"
+    assert gap.observed == "call-target-source-absent:absent_from_artifact"
 
 
 def test_method_calling_a_parameter_is_a_value_call_target(tmp_path):
     """A called parameter is higher-order dispatch inside a method too."""
-    result = _construct(tmp_path, _CALLED_PARAMETER_METHOD)
+    gap = _opaque_gap(tmp_path, _CALLED_PARAMETER_METHOD)
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "value-call-target"
-    assert result.detail == "helper"
+    assert gap.observed == "value-call-target:helper"
 
 
 def test_method_calling_a_module_definition_still_constructs(tmp_path):
@@ -531,10 +512,9 @@ def test_both_spellings_of_the_same_opacity_reach_the_same_kind(
     the assertion that cannot: same condition, same kind, whichever syntax
     carries it.
     """
-    result = _construct(tmp_path, source)
+    gap = _opaque_gap(tmp_path, source)
 
-    assert isinstance(result, ManagerConstructionGapV1), (spelling, result)
-    assert result.kind == "call-target-source-absent", spelling
+    assert gap.observed == "call-target-source-absent:absent_from_artifact", spelling
 
 
 def test_scanned_definitions_reaches_methods_and_nothing_else(tmp_path):

--- a/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
@@ -63,7 +63,9 @@ from sugar_source_tree.panic import OpaqueSourceCallResolutionGap
 from sugar_source_tree.tree import SourceFile
 
 
-def _distribution(root: Path, modules: dict[str, str]) -> importlib.metadata.Distribution:
+def _distribution(
+    root: Path, modules: dict[str, str]
+) -> importlib.metadata.Distribution:
     """One authenticated distribution whose file manifest is exactly ``modules``."""
     package = root / "arbitrary"
     package.mkdir(parents=True)

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -47,6 +47,7 @@ from sugar_lift_python_source.manager_construction import (
 from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.nodes import Call, Constant
+from sugar_source_tree.panic import OpaqueSourceCallResolutionGap
 from sugar_source_tree.tree import SourceFile
 
 # No hermetic-frames fixture: there is no process state left to clear.  Every
@@ -113,6 +114,14 @@ def _construct(root: Path, *, factory_source: str, support_source: str):
         ),
         value,
     )
+
+
+def _opaque_gap(root: Path, *, factory_source: str, support_source: str):
+    with pytest.raises(OpaqueSourceCallResolutionGap) as raised:
+        _construct(
+            root, factory_source=factory_source, support_source=support_source
+        )
+    return raised.value
 
 
 _CROSS_MODULE_CLASS_FACTORY = (
@@ -216,7 +225,7 @@ def test_cross_module_function_hop_then_class_reduces(tmp_path):
 
 def test_reexport_chain_call_target_reduces(tmp_path):
     """POSITIVE: the callee name is reached through a re-export hop, not a definition."""
-    result, value = _construct(
+    gap = _opaque_gap(
         tmp_path,
         factory_source=(
             "from arbitrary import ScopedSlot\n"
@@ -229,11 +238,7 @@ def test_reexport_chain_call_target_reduces(tmp_path):
     # ``arbitrary/__init__.py`` written by the fixture only re-exports
     # make_guard, so ``arbitrary.ScopedSlot`` is NOT statically exported.
     # This is the honest negative face of the re-export door.
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    # The KEY names the condition and carries no spelling.
-    assert ":" not in result.kind
-    assert result.detail == "ScopedSlot"
+    assert gap.observed == "call-target-source-absent:ScopedSlot"
 
 
 def test_unavailable_callee_stays_typed_loud(tmp_path):
@@ -242,7 +247,7 @@ def test_unavailable_callee_stays_typed_loud(tmp_path):
     ``pathlib`` is not part of this distribution's authenticated file
     manifest.  No source, no contract -- and specifically no fabricated one.
     """
-    result, _ = _construct(
+    gap = _opaque_gap(
         tmp_path,
         factory_source=(
             "from pathlib import Path\n"
@@ -253,16 +258,12 @@ def test_unavailable_callee_stays_typed_loud(tmp_path):
         support_source="MARKER = 1\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    # The KEY names the condition and carries no spelling.
-    assert ":" not in result.kind
-    assert result.detail == "Path"
+    assert gap.observed == "call-target-source-absent:Path"
 
 
 def test_absent_module_callee_stays_typed_loud(tmp_path):
     """REQUIRED LOUD TWIN: import of a module absent from the artifact."""
-    result, _ = _construct(
+    gap = _opaque_gap(
         tmp_path,
         factory_source=(
             "from arbitrary.missing import ScopedSlot\n"
@@ -273,16 +274,12 @@ def test_absent_module_callee_stays_typed_loud(tmp_path):
         support_source="MARKER = 1\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    # The KEY names the condition and carries no spelling.
-    assert ":" not in result.kind
-    assert result.detail == "ScopedSlot"
+    assert gap.observed == "call-target-source-absent:ScopedSlot"
 
 
 def test_undefined_free_name_call_stays_typed_loud(tmp_path):
     """REQUIRED LOUD TWIN: no import, no definition -- nothing to authenticate."""
-    result, _ = _construct(
+    gap = _opaque_gap(
         tmp_path,
         factory_source=(
             "def make_guard(expected):\n    return unbound_helper(expected)\n"
@@ -290,11 +287,7 @@ def test_undefined_free_name_call_stays_typed_loud(tmp_path):
         support_source="MARKER = 1\n",
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    assert result.kind == "call-target-source-absent"
-    # The KEY names the condition and carries no spelling.
-    assert ":" not in result.kind
-    assert result.detail == "unbound_helper"
+    assert gap.observed == "call-target-source-absent:unbound_helper"
 
 
 def _resolved_pair(root: Path, *, factory_source: str, support_source: str):
@@ -381,7 +374,7 @@ def test_external_call_frame_is_the_callee_defining_source_not_the_caller(tmp_pa
 
 def test_mutually_recursive_cross_module_call_stays_typed_loud(tmp_path):
     """REQUIRED LOUD TWIN: a cross-module cycle must not loop or fabricate."""
-    result, _ = _construct(
+    gap = _opaque_gap(
         tmp_path,
         factory_source=(
             "from arbitrary.support import build_slot\n"
@@ -397,11 +390,4 @@ def test_mutually_recursive_cross_module_call_stays_typed_loud(tmp_path):
         ),
     )
 
-    assert isinstance(result, ManagerConstructionGapV1), result
-    # Recursion is a different condition from an unresolvable callee: the
-    # cycle is reported as itself even though it is reached through the
-    # export door, and it carries NO symbol.
-    assert result.kind == "call-graph-cycle"
-    assert ":" not in result.kind
-    # detail is DATA: which callee's projection cycled.  It is never the key.
-    assert result.detail == "build_slot"
+    assert gap.observed == "call-graph-cycle:make_guard"

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -118,9 +118,7 @@ def _construct(root: Path, *, factory_source: str, support_source: str):
 
 def _opaque_gap(root: Path, *, factory_source: str, support_source: str):
     with pytest.raises(OpaqueSourceCallResolutionGap) as raised:
-        _construct(
-            root, factory_source=factory_source, support_source=support_source
-        )
+        _construct(root, factory_source=factory_source, support_source=support_source)
     return raised.value
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -349,8 +349,8 @@ def test_memo_disablement_changes_performance_only(tmp_path: Path) -> None:
 # --------------------------------------------------- gaps are memoized too
 
 
-def test_disablement_preserves_gap_verdicts(tmp_path: Path) -> None:
-    """A gap answers identically warm, cold, and with the memo switched off."""
+def test_disablement_preserves_parked_obligation_verdicts(tmp_path: Path) -> None:
+    """A parked gap answers identically warm, cold, and with the memo off."""
     root = tmp_path / "gap"
     _install(root, implementation_source="def build(value):\n    return other(value)\n")
     distribution = importlib.metadata.Distribution.at(
@@ -362,7 +362,18 @@ def test_disablement_preserves_gap_verdicts(tmp_path: Path) -> None:
     def answer(session):
         resolved = resolve_import_binding(receipt, graph=graph, session=session)
         assert isinstance(resolved, ResolvedPythonObjectV1)
-        return resolve_source_visible_frame(resolved, graph=graph, session=session)
+        projected = resolve_source_visible_frame(
+            resolved, graph=graph, session=session
+        )
+        assert isinstance(projected, tuple), projected
+        frame, target = projected
+        obligations = tuple(
+            sorted(
+                target.unit.construction_context.opaque_source_call_obligations.values(),
+                key=lambda obligation: repr(obligation.coordinate),
+            )
+        )
+        return frame.frame_cid, target.name, obligations
 
     warm_session = SourceResolutionSession()
     first_warm = answer(warm_session)
@@ -370,8 +381,10 @@ def test_disablement_preserves_gap_verdicts(tmp_path: Path) -> None:
     cold = answer(SourceResolutionSession())
     off = answer(SourceResolutionSession(enabled=False))
 
-    assert isinstance(first_warm, mc.ManagerConstructionGapV1), first_warm
     assert first_warm == second_warm == cold == off
+    assert len(first_warm[2]) == 1
+    assert first_warm[2][0].resolution_kind == "call-target-source-absent"
+    assert first_warm[2][0].target_name == "other"
 
 
 # ------------------------------------------------- both sides of the door

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -362,9 +362,7 @@ def test_disablement_preserves_parked_obligation_verdicts(tmp_path: Path) -> Non
     def answer(session):
         resolved = resolve_import_binding(receipt, graph=graph, session=session)
         assert isinstance(resolved, ResolvedPythonObjectV1)
-        projected = resolve_source_visible_frame(
-            resolved, graph=graph, session=session
-        )
+        projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
         assert isinstance(projected, tuple), projected
         frame, target = projected
         obligations = tuple(

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1081,19 +1081,16 @@ def test_call_result_attribute_keeps_the_exact_constructed_call_coordinate():
     assert projected.value.term.args[1].value == "__name__"
 
 
-def test_installed_source_boundary_with_opaque_builtin_verdict_stays_loud(tmp_path):
+def _installed_pytest_boundary(tmp_path, manager_call: str, body: str):
     consumer = (
         "import pytest\n"
         "def use_boundary():\n"
-        "    with pytest.raises(ValueError):\n"
-        "        raise ValueError('boom')\n"
+        f"    with {manager_call}:\n"
+        f"        {body}\n"
     )
     path = tmp_path / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
-    from sugar_lift_py_tests.context_manager_resolution import (
-        ContextManagerResolutionGapV1,
-        TreeConstructionContextV1,
-    )
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
@@ -1101,31 +1098,42 @@ def test_installed_source_boundary_with_opaque_builtin_verdict_stays_loud(tmp_pa
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    return tree, context
 
-    resolution = next(iter(context.source_derived_contract_refs.values()))
-    assert isinstance(resolution, ContextManagerResolutionGapV1)
-    # Stage-keyed residual — not a silent generic no-derived-contract, and not
-    # a resource-membrane admission. pytest.raises stays typed-loud until its
-    # free-name / force-floor chain constructs without vendor arms.
-    assert resolution.kind != "derived-contract"
-    assert resolution.target_symbol and "raises" in resolution.target_symbol
-    # EXACT membership, not `startswith`: the kind is now the whole key, so a
-    # prefix match would pass on a fused `kind:symbol` string too -- which is
-    # precisely the shape this control has to refuse.
-    assert resolution.kind in (
-        _CALL_TARGET_GAP_KINDS
-        | {
-            "force-floor",
-            "non-manager-result",
-            "no-derived-contract",
-            "enter-missing",
-            "exit-missing",
-            "method-construction",
-            "enter-may-halt",
-            "exit-may-halt",
-            "opaque-exit-truthiness",
-        }
-    ), resolution.kind
+
+def test_installed_pytest_raises_truthful_route_keeps_missing_derivation_typed(
+    tmp_path,
+):
+    from sugar_source_tree.panic import (
+        WithConstructionGap,
+        WithConstructionGapKind,
+    )
+
+    with pytest.raises(WithConstructionGap) as caught:
+        _installed_pytest_boundary(
+            tmp_path,
+            'pytest.raises(ValueError, match="boom")',
+            'raise ValueError("boom")',
+        )
+
+    assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+
+def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
+    tmp_path,
+):
+    from sugar_source_tree.panic import (
+        WithConstructionGap,
+        WithConstructionGapKind,
+    )
+
+    with pytest.raises(WithConstructionGap) as caught:
+        _installed_pytest_boundary(
+            tmp_path,
+            'pytest.raises(ValueError, int, "bad")',
+            "pass",
+        )
+
+    assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
 
 
 def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1487,8 +1487,9 @@ def _guarded_literal_boundary(tmp_path, *, exit_body: str):
         "        self.expected = expected\n"
         "    def __enter__(self):\n"
         "        return self\n"
-        "    def __exit__(self, effect_type, effect, traceback):\n" + exit_body +
-        "def make_guard(expected):\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        + exit_body
+        + "def make_guard(expected):\n"
         "    return ArbitraryBoundary(expected)\n",
     )
     behavior = construct_manager_behavior(
@@ -1701,7 +1702,9 @@ _BOUNDARY_IMPLEMENTATION = (
 def _route_boundary_with_binding(
     tmp_path, *, body: str, as_clause: str = " as info", following: str = ""
 ):
-    distribution = _distribution(tmp_path, _BOUNDARY_IMPLEMENTATION, exported="boundary")
+    distribution = _distribution(
+        tmp_path, _BOUNDARY_IMPLEMENTATION, exported="boundary"
+    )
     consumer = (
         "import arbitrary\n"
         "def use_boundary():\n"

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1197,6 +1197,7 @@ def test_installed_pytest_raises_truthful_route_keeps_missing_derivation_typed(
 
     assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
 
+
 def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
     tmp_path,
 ):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1181,7 +1181,7 @@ def _installed_pytest_boundary(tmp_path, manager_call: str, body: str):
     return tree, context
 
 
-def test_installed_pytest_raises_truthful_route_keeps_missing_derivation_typed(
+def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
     tmp_path,
 ):
     from sugar_source_tree.panic import (
@@ -1189,20 +1189,24 @@ def test_installed_pytest_raises_truthful_route_keeps_missing_derivation_typed(
         WithConstructionGapKind,
     )
 
-    with pytest.raises(WithConstructionGap) as caught:
-        _installed_pytest_boundary(
-            tmp_path,
-            'pytest.raises(ValueError, match="boom")',
-            'raise ValueError("boom")',
-        )
+    tree, context = _installed_pytest_boundary(
+        tmp_path,
+        'pytest.raises(ValueError, match="boom")',
+        'raise ValueError("boom")',
+    )
 
-    assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+    assert len(context.source_derived_contract_refs) == 1
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    with pytest.raises(WithConstructionGap) as caught:
+        with_node.sugar()
+
+    assert caught.value.gap_kind is WithConstructionGapKind.ENTER_MAY_HALT
     assert (
         caught.value.coordinate.start_line,
         caught.value.coordinate.start_col,
         caught.value.coordinate.end_line,
         caught.value.coordinate.end_col,
-    ) == (295, 9, 295, 38)
+    ) == (3, 9, 3, 48)
 
 
 def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
@@ -1213,20 +1217,24 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
         WithConstructionGapKind,
     )
 
-    with pytest.raises(WithConstructionGap) as caught:
-        _installed_pytest_boundary(
-            tmp_path,
-            'pytest.raises(ValueError, int, "bad")',
-            "pass",
-        )
+    tree, context = _installed_pytest_boundary(
+        tmp_path,
+        'pytest.raises(ValueError, int, "bad")',
+        "pass",
+    )
 
-    assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+    assert len(context.source_derived_contract_refs) == 1
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    with pytest.raises(WithConstructionGap) as caught:
+        with_node.sugar()
+
+    assert caught.value.gap_kind is WithConstructionGapKind.ENTER_MAY_HALT
     assert (
         caught.value.coordinate.start_line,
         caught.value.coordinate.start_col,
         caught.value.coordinate.end_line,
         caught.value.coordinate.end_col,
-    ) == (295, 9, 295, 38)
+    ) == (3, 9, 3, 46)
 
 
 def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -166,14 +166,14 @@ def test_free_name_call_stays_typed_loud(tmp_path):
         tmp_path, "def make_guard(expected):\n    return missing_helper(expected)\n"
     )
 
-    result = construct_manager_behavior(
-        resolved, graph=graph, actuals=(actual,), call_site=call_site
-    )
+    from sugar_source_tree.panic import SugarNotWritten
 
-    assert isinstance(result, ManagerConstructionGapV1)
-    assert result.kind == "call-target-source-absent"
-    assert ":" not in result.kind
-    assert result.detail == "missing_helper"
+    with pytest.raises(
+        SugarNotWritten, match="call-target-source-absent:missing_helper"
+    ):
+        construct_manager_behavior(
+            resolved, graph=graph, actuals=(actual,), call_site=call_site
+        )
 
 
 def test_unresolved_source_call_is_parked_at_its_exact_coordinate(tmp_path):
@@ -202,6 +202,7 @@ def test_unresolved_source_call_is_parked_at_its_exact_coordinate(tmp_path):
     assert obligation.coordinate == coordinate
     assert obligation.target_name == "missing_helper"
     assert obligation.resolved_object_cid == resolved.cid
+    assert obligation.resolution_kind == "call-target-source-absent"
 
 
 def test_source_call_coordinate_rejects_conflicting_testimony():
@@ -1196,6 +1197,12 @@ def test_installed_pytest_raises_truthful_route_keeps_missing_derivation_typed(
         )
 
     assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+    assert (
+        caught.value.coordinate.start_line,
+        caught.value.coordinate.start_col,
+        caught.value.coordinate.end_line,
+        caught.value.coordinate.end_col,
+    ) == (295, 9, 295, 38)
 
 
 def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
@@ -1214,6 +1221,12 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
         )
 
     assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+    assert (
+        caught.value.coordinate.start_line,
+        caught.value.coordinate.start_col,
+        caught.value.coordinate.end_line,
+        caught.value.coordinate.end_col,
+    ) == (295, 9, 295, 38)
 
 
 def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -19,7 +19,11 @@ from sugar_lift_python_source.manager_construction import (
     ConstructedCallActualV1,
     ConstructedManagerBehaviorV1,
     ManagerConstructionGapV1,
+    _call_coordinate,
+    _install_opaque_call_obligation,
+    _install_source_call_frame,
     construct_manager_behavior,
+    resolve_source_visible_frame,
 )
 from sugar_lift_python_source.manager_protocol_construction import (
     ConstructedManagerProtocolV1,
@@ -34,7 +38,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
 )
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.binding_state import BindingEntryV1
-from sugar_source_tree.nodes import Call, ClassDef, Constant
+from sugar_source_tree.nodes import Call, ClassDef, Constant, Name
 from sugar_source_tree.tree import SourceFile
 
 
@@ -170,6 +174,81 @@ def test_free_name_call_stays_typed_loud(tmp_path):
     assert result.kind == "call-target-source-absent"
     assert ":" not in result.kind
     assert result.detail == "missing_helper"
+
+
+def test_unresolved_source_call_is_parked_at_its_exact_coordinate(tmp_path):
+    graph, resolved, _, _ = _resolved(
+        tmp_path,
+        "def make_guard(expected):\n"
+        "    if expected:\n"
+        "        return expected\n"
+        "    return missing_helper(expected)\n",
+    )
+
+    projected = resolve_source_visible_frame(resolved, graph=graph)
+
+    assert isinstance(projected, tuple), projected
+    _, target = projected
+    context = target.unit.construction_context
+    missing_call = next(
+        node
+        for node in target.walk()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "missing_helper"
+    )
+    coordinate = _call_coordinate(missing_call)
+    obligation = context.opaque_source_call_obligations[coordinate]
+    assert obligation.coordinate == coordinate
+    assert obligation.target_name == "missing_helper"
+    assert obligation.resolved_object_cid == resolved.cid
+
+
+def test_source_call_coordinate_rejects_conflicting_testimony():
+    source = "missing_helper(1)\n"
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+        TreeConstructionContextV1,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, "conflict.py", blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    coordinate = _call_coordinate(call)
+    from sugar_source_tree.panic import BackendDefect
+
+    obligation = OpaqueSourceCallObligationV1(
+        coordinate,
+        "missing_helper",
+        "blake3-512:" + "1" * 128,
+    )
+    _install_opaque_call_obligation(context, call, obligation)
+    _install_opaque_call_obligation(context, call, obligation)
+
+    with pytest.raises(BackendDefect, match="conflicting opaque-call obligation"):
+        _install_opaque_call_obligation(
+            context,
+            call,
+            OpaqueSourceCallObligationV1(
+                coordinate,
+                "other_helper",
+                "blake3-512:" + "2" * 128,
+            ),
+        )
+    with pytest.raises(BackendDefect, match="frame/obligation collision"):
+        _install_source_call_frame(context, call, object())
+
+    context.opaque_source_call_obligations.clear()
+    frame = object()
+    _install_source_call_frame(context, call, frame)
+    _install_source_call_frame(context, call, frame)
+    with pytest.raises(BackendDefect, match="frame/obligation collision"):
+        _install_opaque_call_obligation(context, call, obligation)
+    with pytest.raises(BackendDefect, match="conflicting source-call frame"):
+        _install_source_call_frame(context, call, object())
 
 
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4601,6 +4601,7 @@ class With(Statement):
 
             panic = WithConstructionGap(
                 gap_kind=WithConstructionGapKind.NO_DERIVED_CONTRACT,
+                coordinate=coordinate,
                 owner="With._construct_sugar",
                 observed=(
                     "no context-manager derivation for source coordinate "

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4624,6 +4624,7 @@ class With(Statement):
             kind=resolution.kind,
             demand_cid=resolution.demand_cid,
             candidate_member_cids=resolution.candidate_member_cids,
+            coordinate=resolution.use_site,
             owner="With._construct_sugar",
             observed=(
                 f"authenticated preconstruction resolution gap: {resolution.kind}"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4596,13 +4596,21 @@ class With(Statement):
             return derived
         try:
             return context.contract_refs.require(coordinate)
-        except ContractRefProtocolError as exc:
-            backend_defect(
+        except ContractRefProtocolError:
+            from .panic import WithConstructionGap, WithConstructionGapKind
+
+            panic = WithConstructionGap(
+                gap_kind=WithConstructionGapKind.NO_DERIVED_CONTRACT,
                 owner="With._construct_sugar",
-                observed=str(exc),
-                requested="one contract-resolution row for every enrolled With demand",
-                fix="repair prereq-2 demand/table generation; never search at construction",
+                observed=(
+                    "no context-manager derivation for source coordinate "
+                    f"{coordinate}"
+                ),
+                requested="one resolved authenticated ContextManagerContractRefV1",
+                fix="publish or derive the exact typed CM contract before construction",
             )
+            self.reporter.report_gap(self, panic)
+            raise panic
 
     def _raise_resolution_gap(self, resolution) -> None:
         from .panic import ContextManagerResolutionConstructionGap

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5107,19 +5107,6 @@ class With(Statement):
                 if bound is not current:
                     return bound.substitute(scope)
             if item.optional_vars is not None and item.optional_vars.kind == "Name":
-                if self._generator_manager_frame(item) is None:
-                    context = self.unit.construction_context
-                    if getattr(context, "frame_projection", False):
-                        # Authenticated dual-mode factories may nest With only
-                        # on the non-CM branch. Soft projection skips closed-row
-                        # enrollment for those sites so the CM return path can
-                        # still project a call frame.
-                        try:
-                            self._require_narrow_cm_ref(item)
-                        except Exception:  # noqa: BLE001 — soft projection only
-                            pass
-                    else:
-                        self._require_narrow_cm_ref(item)
                 enter_slot = f"{item._manager_slot_id()}#enter_result"
                 body_scope[item.optional_vars.id] = item._make_observation_ref(
                     enter_slot, ENTER_RESULT
@@ -7195,6 +7182,42 @@ class Call(Expression):
         built, so a callee with no sugar (a Lambda called inline) still stays
         loud through the ordinary recursion. Named keywords and ``**`` spreads
         ride explicitly on every coordinate; none is dropped or interpreted."""
+        context = self.unit.construction_context
+        coordinate = None
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+
+        if isinstance(context, TreeConstructionContextV1):
+            span = self.line_col_span()
+            coordinate = SourceFragmentCoordinateV1(
+                self.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            obligation = context.opaque_source_call_obligations.get(coordinate)
+            if obligation is not None:
+                from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+                return CallSiteSugar(
+                    target_name="python:unresolved-source-call",
+                    args=tuple(a.sugar() for a in self.args),
+                    site=self.fragment,
+                    keywords=tuple(
+                        (
+                            kw.arg if kw.arg is not None else "**",
+                            kw.value.sugar(),
+                        )
+                        for kw in self.keywords
+                    ),
+                    contract_resolution_gap=(
+                        f"{obligation.resolution_kind}:{obligation.target_name}"
+                    ),
+                )
+
         # Either spread form selects the reference call coordinate. In
         # particular, a lone ``**d`` must not fall through to the legacy
         # keyword bridge as ``py.kwarg("**", d)``.
@@ -7242,37 +7265,18 @@ class Call(Expression):
             (kw.arg if kw.arg is not None else "**", kw.value.sugar())
             for kw in self.keywords
         )
-        context = self.unit.construction_context
         source_call_frame = None
         source_call_resolution = None
-        from sugar_lift_py_tests.context_manager_resolution import (
-            SourceFragmentCoordinateV1,
-            TreeConstructionContextV1,
-        )
 
         if (
             isinstance(context, TreeConstructionContextV1)
             and context.source_call_frames
         ):
-            span = self.line_col_span()
-            coordinate = SourceFragmentCoordinateV1(
-                self.unit.source_cid,
-                span.start_line,
-                span.start_col,
-                span.end_line,
-                span.end_col,
-            )
+            assert coordinate is not None
             source_call_frame = context.source_call_frames.get(coordinate)
             source_call_resolution = context.source_call_resolutions.get(coordinate)
         elif isinstance(context, TreeConstructionContextV1):
-            span = self.line_col_span()
-            coordinate = SourceFragmentCoordinateV1(
-                self.unit.source_cid,
-                span.start_line,
-                span.start_col,
-                span.end_line,
-                span.end_col,
-            )
+            assert coordinate is not None
             source_call_resolution = context.source_call_resolutions.get(coordinate)
         if source_call_resolution is not None:
             from sugar_lift_py_tests.source_call_resolution import (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -199,6 +199,7 @@ class WithConstructionGap(SugarNotWritten):
         demand_cid: str | None = None,
         candidate_member_cids: tuple[str, ...] = (),
         member_cid: str | None = None,
+        coordinate: object | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -207,6 +208,7 @@ class WithConstructionGap(SugarNotWritten):
         self.demand_cid = demand_cid
         self.candidate_member_cids = candidate_member_cids
         self.member_cid = member_cid
+        self.coordinate = coordinate
 
 
 class ContextManagerResolutionConstructionGap(WithConstructionGap):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -88,6 +88,12 @@ class SugarNotWritten(SourceTreePanic):
     _LABEL = "SUGAR NOT WRITTEN"
 
 
+class OpaqueSourceCallResolutionGap(SugarNotWritten):
+    """A reached source-call obligation whose target stayed unresolved."""
+
+    _LABEL = "OPAQUE SOURCE CALL RESOLUTION GAP"
+
+
 class RuntimeSelectedContextManager(SugarNotWritten):
     """A `with` whose manager has no authenticated exit-suppression contract.
 

--- a/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import (
+    OpaqueSourceCallObligationV1,
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
@@ -34,6 +35,7 @@ from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
     BindingCoordinateRefSugar,
 )
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.panic import SugarNotWritten
@@ -106,6 +108,36 @@ class _ReduceCtx:
 
     def __init__(self, temporal: TemporalContext) -> None:
         self.temporal = temporal
+
+
+# ---------------------------------------------------------------------------
+# 0. Opaque source calls refuse only at their reached coordinate.
+# ---------------------------------------------------------------------------
+
+
+def test_opaque_source_call_obligation_precedes_spread_selection() -> None:
+    context, _, calls = _tree("func(*[1], **{})\nordinary(2)\n")
+    opaque_call, ordinary_call = calls
+    coordinate = _coordinate(opaque_call)
+    obligation = OpaqueSourceCallObligationV1(
+        coordinate,
+        "func",
+        "blake3-512:" + "c" * 128,
+    )
+    context.opaque_source_call_obligations[coordinate] = obligation
+
+    opaque = opaque_call.sugar()
+
+    assert isinstance(opaque, CallSiteSugar)
+    assert opaque.contract_resolution_gap == "opaque-call-target:func"
+    with pytest.raises(SugarNotWritten) as raised:
+        opaque.desugar()
+    assert raised.value.observed == "opaque-call-target:func"
+    assert context.opaque_source_call_obligations[coordinate] is obligation
+
+    ordinary = ordinary_call.sugar()
+    assert isinstance(ordinary, CallSiteSugar)
+    assert ordinary.contract_resolution_gap is None
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -440,7 +440,7 @@ def test_async_with_stays_typed_loud_even_with_sync_ref(tmp_path):
     assert type(caught.value).__name__ == "AsyncContextManagerUnsupported"
 
 
-def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
+def test_missing_manager_derivation_is_typed_construction_gap(tmp_path):
     path = tmp_path / "missing_row.py"
     path.write_text(
         "from dependency import manager\n"
@@ -449,7 +449,10 @@ def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
         "        pass\n"
     )
     from sugar_lift_python_source.source_oracle import path_source
-    from sugar_source_tree.panic import BackendDefect
+    from sugar_source_tree.panic import (
+        WithConstructionGap,
+        WithConstructionGapKind,
+    )
 
     identity = path_source(str(path))
     table = ResolvedContractRefsV1(
@@ -458,8 +461,9 @@ def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
         by_use_site=MappingProxyType({}),
     )
     source = SourceFile(identity, construction_context=TreeConstructionContextV1(table))
-    with pytest.raises(BackendDefect):
+    with pytest.raises(WithConstructionGap) as caught:
         next(source.functions()).sugar()
+    assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
 
 
 def test_selected_with_defers_resolution_validation_until_construction(tmp_path):
@@ -472,7 +476,10 @@ def test_selected_with_defers_resolution_validation_until_construction(tmp_path)
         "        return entered\n"
     )
     from sugar_lift_python_source.source_oracle import path_source
-    from sugar_source_tree.panic import BackendDefect
+    from sugar_source_tree.panic import (
+        WithConstructionGap,
+        WithConstructionGapKind,
+    )
 
     table = ResolvedContractRefsV1(
         catalog_cid=_cid("c"),
@@ -488,13 +495,10 @@ def test_selected_with_defers_resolution_validation_until_construction(tmp_path)
     substituted = with_node.substitute({})
     assert substituted.body[0].value.projection == "enter-result"
 
-    with pytest.raises(BackendDefect) as caught:
+    with pytest.raises(WithConstructionGap) as caught:
         substituted.sugar()
     assert caught.value.owner == "With._construct_sugar"
-    assert (
-        caught.value.observed
-        == "BackendDefect: enrolled context-manager demand missing from resolution table"
-    )
+    assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
 
 
 def test_multiple_items_nest_and_store_binding_target_constructs(tmp_path):

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -462,6 +462,41 @@ def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
         next(source.functions()).sugar()
 
 
+def test_selected_with_defers_resolution_validation_until_construction(tmp_path):
+    """As-name substitution does not adjudicate whether this With is reached."""
+    path = tmp_path / "selected_missing_row.py"
+    path.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager() as entered:\n"
+        "        return entered\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import BackendDefect
+
+    table = ResolvedContractRefsV1(
+        catalog_cid=_cid("c"),
+        table_cid=_cid("t"),
+        by_use_site=MappingProxyType({}),
+    )
+    source = SourceFile(
+        path_source(str(path)),
+        construction_context=TreeConstructionContextV1(table),
+    )
+    with_node = next(node for node in source.nodes() if node.kind == "With")
+
+    substituted = with_node.substitute({})
+    assert substituted.body[0].value.projection == "enter-result"
+
+    with pytest.raises(BackendDefect) as caught:
+        substituted.sugar()
+    assert caught.value.owner == "With._construct_sugar"
+    assert (
+        caught.value.observed
+        == "BackendDefect: enrolled context-manager demand missing from resolution table"
+    )
+
+
 def test_multiple_items_nest_and_store_binding_target_constructs(tmp_path):
     """Multi-item With is no longer a gap: it nests into single-item Withs.
 


### PR DESCRIPTION
> **Body rewritten 2026-07-27 04:0xZ to match what ships.** The original text described a three-file `NO_DERIVED_CONTRACT` change; two rebases and the `#6452` integration moved the semantics, and a stale body on a merged commit is its own defect. Superseded text is at the bottom.

A construction-time demand whose coordinate was absent from both resolution stores was reported as `BackendDefect` — us announcing we broke our own invariant. This lands the honest typed refusal, and then carries the obligation to the consumer site where `#6452`'s frame projection puts it.

## What ships

- **A named gap instead of a generic one.** `OpaqueSourceCallResolutionGap(SugarNotWritten)` (`sugar_source_tree/panic.py`) replaces one bare `SugarNotWritten` raise in `call_site_sugar.py`. `#6452`'s generic `SugarNotWritten` membrane was swallowing reached parked-call refusals into `force-floor`; only this named subclass escapes it, and every other arm keeps main's stage-keyed conversion. `#6452` is otherwise untouched.
- **The obligation reaches the consumer.** With `#6452`'s global frame projection in place, the real pytest twins no longer stop at an internal `NO_DERIVED_CONTRACT` at `_pytest/raises.py:295`; they reach a consumer-site `ENTER_MAY_HALT` obligation. The twins assert the exact kind **and** the consumer coordinates `(3,9,3,48)` / `(3,9,3,46)` — coordinate, not just label, so a future upstream population failure names the site instead of nodding at the kind.
- **Authenticated coordinates.** `resolution.use_site` is carried into `ContextManagerResolutionConstructionGap.coordinate`.
- **`With.substitute`** keeps the approved removal of the discarded-return resolution demand; construction-time validation remains.

## Scope

```
1065 insertions, 117 deletions, 11 files
  621  docs (plan + design)
  269  production: nodes.py +92, manager_construction.py +146, context_manager_resolution.py +19,
                   panic.py +8, call_site_sugar.py 4
  175  tests
```

Three packages: `sugar-source-tree`, `sugar-lift-py-tests`, `sugar-lift-python-source`.

## Receipts at final head `ad1f4ddd9` on main `649fd4977`

- source-tree reachability / selected-With teeth: `3 passed, 24 deselected`
- source-manager exact call + real pytest twins: `5 passed, 52 deselected`
- opaque-obligation transport + `#6452` dual-mode construction: `2 passed`

Rebase conflict handling preserved landed behaviour: `TreeConstructionContextV1` retains main's `frame_projection` alongside the branch's obligation table; manager construction retains main's dual-mode `value-call-target` exemption while parking every other unresolved call at its exact coordinate.

**Broad package suites have not been rerun since the final rebase.** The pre-rebase paired `sugar-lift-py-tests` row (base `285159cc0` 1842/1685/143/5/9 vs head 1843/1685/144/5/9) is superseded and is not claimed for this head. Its `+1` was `test_supervised_timeout_restarts_and_continues`, an order-dependent `ModuleNotFoundError: _enum_floor_runtime` that fails identically on both halves on rerun — not a regression from this branch.

## Error-semantics caveat

The consumer can observe only "coordinate absent from both resolution stores"; it cannot independently prove whether that absence is genuine missing source-local derivation or an upstream population failure. No second signal was invented to paper over the gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of unresolved named calls by preserving precise coordinates and producing more specific typed diagnostics.
  * Enhanced `pytest.raises` context-manager behavior to distinguish reachable paths from legacy callable execution.
* **Bug Fixes**
  * Prevented unreachable unresolved calls from incorrectly blocking valid context-manager construction.
  * Added safeguards to detect and refuse conflicting call-resolution information.
* **Documentation**
  * Added detailed implementation plan and design specification for reachable opaque-call obligations.
* **Tests**
  * Expanded and updated coverage for parked obligations, immutability, and deferred validation, with stronger typed-gap assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate opaque source-call obligations to consumer sites as named gaps rather than swallowing them
> - Introduces `OpaqueSourceCallObligationV1`, a typed record parked at a call coordinate in `TreeConstructionContextV1` when an external callee cannot be resolved during frame construction.
> - `Call._construct_sugar` now checks for a parked obligation at its coordinate and returns a `CallSiteSugar` with `contract_resolution_gap` set to `opaque-call-target:<name>`, surfacing the gap at the call site instead of aborting frame resolution.
> - `OpaqueSourceCallResolutionGap` is a new `SugarNotWritten` subclass raised by `CallSiteSugar.desugar` and `construct_manager_behavior` when a reached opaque obligation is encountered, replacing the previous `force-floor` `ManagerConstructionGapV1` wrapping.
> - `_install_opaque_call_obligation` and `_install_source_call_frame` helpers enforce mutual exclusivity per coordinate, raising `BackendDefect` on conflicting duplicates.
> - `WithConstructionGap` gains a `coordinate` attribute for use-site reporting; missing enrolled manager derivation now raises a typed `NO_DERIVED_CONTRACT` gap instead of a backend defect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15cbbea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->