### PR TITLE
Route assertion-With observation binding through Assign

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1589,13 +1589,16 @@ _BOUNDARY_IMPLEMENTATION = (
 )
 
 
-def _route_boundary_with_binding(tmp_path, *, body: str, as_clause: str = " as info"):
+def _route_boundary_with_binding(
+    tmp_path, *, body: str, as_clause: str = " as info", following: str = ""
+):
     distribution = _distribution(tmp_path, _BOUNDARY_IMPLEMENTATION, exported="boundary")
     consumer = (
         "import arbitrary\n"
         "def use_boundary():\n"
         f"    with arbitrary.boundary(ValueError){as_clause}:\n"
         f"        {body}\n"
+        f"    {following}\n"
     )
     path = tmp_path / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
@@ -1614,9 +1617,46 @@ def _route_boundary_with_binding(tmp_path, *, body: str, as_clause: str = " as i
     )
     from sugar_lift_py_tests.outcome import outcome_to_exitset
 
+    if following:
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        function = next(tree.functions()).sugar()
+        return reduce_block_to_exitset(function.statements)
     return outcome_to_exitset(
         next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
     )
+
+
+def test_boundary_as_binding_outlives_block_and_projects_consumed_effect(tmp_path):
+    """Concrete assertion-With: post-block `.value` reads the consumed halt."""
+    from sugar_lift_py_tests.outcome import Completed
+
+    exits = _route_boundary_with_binding(
+        tmp_path,
+        body='raise ValueError("cannot convert")',
+        following='assert "cannot convert" in str(info.value)',
+    )
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Completed)
+    assert len(_effect_binding_facts(face)) == 3
+
+
+def test_boundary_as_binding_never_reifies_a_nonmatching_halt(tmp_path):
+    """Lying twin: post-block `.value` is unreachable without testimony."""
+    from sugar_lift_py_tests.outcome import Halted
+
+    exits = _route_boundary_with_binding(
+        tmp_path,
+        body='raise TypeError("cannot convert")',
+        following='assert "cannot convert" in str(info.value)',
+    )
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Halted)
+    assert _effect_slot_facts(face) == ()
 
 
 def _effect_slot_facts(face) -> tuple:
@@ -1632,6 +1672,17 @@ def _effect_slot_facts(face) -> tuple:
     )
 
 
+def _effect_binding_facts(face) -> tuple:
+    return tuple(
+        entry
+        for entry in _effect_slot_facts(face)
+        if any(
+            name in str(entry.formula)
+            for name in ("effect_slot_kind", "effect_slot_type", "effect_slot_origin")
+        )
+    )
+
+
 def test_boundary_as_binding_authenticates_the_slot_it_consumed(tmp_path):
     """Truthful twin: the consumed halt authenticates the observation slot."""
     from sugar_lift_py_tests.outcome import Completed
@@ -1641,7 +1692,7 @@ def test_boundary_as_binding_authenticates_the_slot_it_consumed(tmp_path):
     face = exits.exits[0]
     assert isinstance(face, Completed)
     # kind, type, origin -- exactly the three rows EffectBinding.to_facts owes.
-    assert len(_effect_slot_facts(face)) == 3
+    assert len(_effect_binding_facts(face)) == 3
 
 
 def test_boundary_as_binding_is_absent_when_the_halt_was_restored(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5173,13 +5173,17 @@ class With(Statement):
     def _effect_boundary_observation_slot(self, item, resolved_ref):
         return self._effect_boundary_binding(item, resolved_ref)[0]
 
+    def _with_assignment_binding(self, item, value, scope):
+        """Delegate a with-as binding to Python's ordinary Assign seam."""
+        assignment = self._make_assign(item.optional_vars, value)
+        return assignment.substitution_binding(scope)
+
     def substitution_binding(self, scope):
-        """Export ObservationRef for resolved resource enter-result as-names."""
+        """Export a contract projection through ordinary Assign binding."""
         from sugar_lift_py_tests.context_manager_contract import (
             ENTER_RESULT,
         )
 
-        del scope
         if self.unit.construction_context is not None:
             if len(self.items) != 1:
                 return self._nest_items().substitution_binding(None)
@@ -5207,15 +5211,17 @@ class With(Statement):
                 # an enter result. Exporting enter-result here would have made
                 # the body read a projection the contract never declared.
                 slot, projection = self._effect_boundary_binding(item, resolved_ref)
-                return {
-                    item.optional_vars.id: item._make_observation_ref(slot, projection)
-                }
-            enter_slot = f"{item._manager_slot_id()}#enter_result"
-            return {
-                item.optional_vars.id: item._make_observation_ref(
-                    enter_slot, ENTER_RESULT
+                return self._with_assignment_binding(
+                    item,
+                    item._make_observation_ref(slot, projection),
+                    scope,
                 )
-            }
+            enter_slot = f"{item._manager_slot_id()}#enter_result"
+            return self._with_assignment_binding(
+                item,
+                item._make_observation_ref(enter_slot, ENTER_RESULT),
+                scope,
+            )
         return None
 
 

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -192,6 +192,32 @@ def test_effect_boundary_projects_real_call_actuals_and_routes_exitset(
         assert isinstance(face.effect, effect_type)
 
 
+def test_effect_boundary_as_name_exports_through_assign(tmp_path, monkeypatch):
+    """The post-With binding uses Assign's one lexical binding algebra."""
+    path = tmp_path / "observed.py"
+    path.write_text(
+        "from pytest import raises\n"
+        "def f():\n"
+        "    with raises(ValueError) as info:\n"
+        "        raise ValueError('cannot convert')\n"
+        "    return info.value\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.nodes import Assign
+
+    seen = []
+    original = Assign.substitution_binding
+
+    def observe(self, scope):
+        if self.value.kind == "ObservationRef":
+            seen.append((self.targets[0].kind, self.value.projection))
+        return original(self, scope)
+
+    monkeypatch.setattr(Assign, "substitution_binding", observe)
+    _function_sugar(path_source(str(path)), _effect_resolved)
+    assert seen == [("Name", "exception_info")]
+
+
 def _effect_boundary_face(tmp_path, source):
     path = tmp_path / "identity_boundary.py"
     path.write_text(source)


### PR DESCRIPTION
## What changed

- delegate authenticated `with ... as name` observation export to the ordinary `Assign.substitution_binding` algebra
- drive a real source-derived assertion-With through a post-block `info.value` projection
- add a lying twin proving a nonmatching halt remains halted and carries no observation testimony

No vendor/name arm, compatibility path, placeholder value, census, or pin-only gate is added.

## Classification

The authenticated source-derived reproducer already constructed and desugared on main. This change closes the binding ownership gap: the post-With name now routes through Assign rather than a private binding map.

## Validation

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py` — 69 passed
- mutation transaction: changed exception-info projection to enter-result; Assign law and truthful `.value` twin failed; reverted; focused twins passed

Heavy/full suites intentionally not run.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `With` assertion-as bindings through `Assign.substitution_binding`
> - `With.substitution_binding` in [nodes.py](https://github.com/TSavo/sugar/pull/6457/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) no longer returns a direct name→`ObservationRef` mapping; it now delegates to a new `_with_assignment_binding` helper that routes through `Assign.substitution_binding`, honoring its lexical scoping behavior.
> - A new test in [test_with_authenticated_contract_ref.py](https://github.com/TSavo/sugar/pull/6457/files#diff-24ed90dba7c15724cef255c1d44a25011bfd98f07aba873f4fa4de7241417552) verifies that `Assign.substitution_binding` is called with the correct `ObservationRef` (projection `exception_info`) and a `Name` target.
> - Tests in [test_sole_path_manager_construction.py](https://github.com/TSavo/sugar/pull/6457/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) cover post-with-block assertion analysis for both matching and non-matching boundary halts.
> - Behavioral Change: `With`-as bindings now go through `Assign`'s binding path rather than directly producing a substitution dict, which may affect scope resolution for complex cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 045b116.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->