### PR TITLE
Route authenticated warnings on completed With faces

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/warning_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/warning_effect.py
@@ -15,6 +15,10 @@ class WarningEffect:
     category_name: str
     message: str | None = None
     blame: str | None = None
+    # Source-authenticated identity of the warning category.  A spelling is
+    # diagnostic only; completed-face assertion routing requires this term and
+    # refuses when the producer did not construct it.
+    category_identity: object | None = None
 
     @property
     def reason(self) -> str:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -38,6 +38,7 @@ class WithEffectBoundarySugar(Sugar):
             NoMessagePatternV1,
             RaiseEffectKindV1,
             SuppressesModeV1,
+            WarningEffectKindV1,
             project_formal_selector_v1,
         )
         from sugar_lift_py_tests.effect import ExpectationNotMetEffect
@@ -56,12 +57,14 @@ class WithEffectBoundarySugar(Sugar):
         if (
             not isinstance(semantics, EffectBoundarySemanticsV1)
             or not isinstance(semantics.mode, (ExpectsModeV1, SuppressesModeV1))
-            or not isinstance(semantics.effect_kind, RaiseEffectKindV1)
+            or not isinstance(
+                semantics.effect_kind, (RaiseEffectKindV1, WarningEffectKindV1)
+            )
         ):
             raise SugarNotWritten(
                 owner="WithEffectBoundarySugar.desugar",
                 observed="unsupported authenticated EffectBoundary mode/effect",
-                requested="EffectBoundaryV1 Expects/Raise",
+                requested="EffectBoundaryV1 Expects/Suppresses over Raise or Warning",
                 fix="keep other effect-boundary variants loud until their typed router exists",
             )
 
@@ -97,6 +100,25 @@ class WithEffectBoundarySugar(Sugar):
                     variadic_positional_actuals={},
                     variadic_keyword_actuals={},
                 )
+            if isinstance(semantics.effect_kind, WarningEffectKindV1):
+                if pattern is not None:
+                    raise SugarNotWritten(
+                        owner="WithEffectBoundarySugar.warning_observation",
+                        observed="warning boundary carries an unprojected message pattern",
+                        requested="authenticated warning message matcher",
+                        fix="keep message-bearing warning assertions loud until their matcher is constructed",
+                    )
+                routed.append(
+                    _route_completed_warning_boundary(
+                        body=tuple(self.body),
+                        ctx=ctx,
+                        manager_exit=manager_exit,
+                        expected=expected,
+                        mode=semantics.mode,
+                        site=self.site,
+                    )
+                )
+                continue
 
             body_es = promote_raise_halts(
                 reduce_block_to_exitset(self.body, ctx)
@@ -193,3 +215,117 @@ def _bind_real_actuals(signature, manager_value):
             "call actual does not fit authenticated signature"
         )
     return fixed
+
+
+def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode, site):
+    """Route authenticated warning testimony carried by a COMPLETED body face.
+
+    Warnings never become halted exits.  Their producer contributes a
+    ``WarningObservationValue`` to the completed block record.  The manager
+    consumes a matching observation; an authenticated mismatch fails an
+    Expects boundary; and missing identity/occurrence testimony stays a named
+    refusal.  In particular, an empty record is not evidence that no warning
+    occurred.
+    """
+    from sugar_lift_py_tests.context_manager_contract import ExpectsModeV1
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.floor import CallSiteValue
+    from sugar_lift_py_tests.floor.warning_observation_value import (
+        WarningObservationValue,
+    )
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.exit_set_routing import (
+        promote_raise_halts,
+    )
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+    from sugar_source_tree.panic import SugarNotWritten
+
+    # Python warning categories are exception classes.  The ordinary lexical
+    # class authenticator therefore owns their identity too; no warning/vendor
+    # name table is needed.
+    identity_projection = getattr(expected, "exception_type_identity", None)
+    if not callable(identity_projection):
+        raise SugarNotWritten(
+            owner="WithEffectBoundarySugar.warning_observation",
+            observed="expected warning operand has no authenticated category identity",
+            requested="source-authenticated warning category operand",
+            fix="keep the completed observation undecided; never match category spelling",
+        )
+    expected_identity = identity_projection()
+    body_es = promote_raise_halts(reduce_block_to_exitset(body, ctx)).guarded(
+        manager_exit.guard
+    )
+    exits = []
+    for face in body_es.exits:
+        if isinstance(face, Halted):
+            exits.append(face)
+            continue
+        entries = getattr(face.value, "entries", None)
+        if not isinstance(entries, tuple):
+            raise SugarNotWritten(
+                owner="WithEffectBoundarySugar.warning_observation",
+                observed=f"completed face carries {type(face.value).__name__}, not a reduced block record",
+                requested="completed reduced block carrying authenticated warning observations",
+                fix="preserve the completed face until its record is constructed",
+            )
+        observations = tuple(
+            (index, entry)
+            for index, entry in enumerate(entries)
+            if isinstance(entry, WarningObservationValue)
+        )
+        unauthenticated = tuple(
+            entry
+            for _, entry in observations
+            if entry.effect.category_identity is None
+        )
+        if unauthenticated or not observations:
+            unresolved = any(
+                isinstance(entry, CallSiteValue) for entry in entries
+            )
+            raise SugarNotWritten(
+                owner="WithEffectBoundarySugar.warning_observation",
+                observed=(
+                    "completed face has unresolved warning producers"
+                    if unresolved or not observations
+                    else "warning occurrence has no authenticated category identity"
+                ),
+                requested="one source-authenticated WarningObservationValue on the completed face",
+                fix="construct producer-owned warning testimony; never infer absence or category from spelling",
+            )
+        match = next(
+            (
+                pair
+                for pair in observations
+                if pair[1].effect.category_identity == expected_identity
+            ),
+            None,
+        )
+        if match is not None and len(observations) == 1:
+            index, _ = match
+            remaining = entries[:index] + entries[index + 1 :]
+            exits.append(
+                Completed(
+                    face.guard,
+                    replace(face.value, entries=remaining),
+                    face.faces,
+                    face.pending_contracts,
+                )
+            )
+            continue
+        if isinstance(mode, ExpectsModeV1):
+            exits.append(
+                Halted(
+                    face.guard,
+                    ExpectationNotMetEffect("warning", site),
+                    face.value,
+                    face.faces,
+                    face.pending_contracts,
+                )
+            )
+        else:
+            exits.append(face)
+    return ExitSet(tuple(exits)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -1,0 +1,139 @@
+"""Completed-face warning observation twins for ``WithEffectBoundarySugar``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    ImportSignatureV2,
+    NoDefaultV1,
+    NoMessagePatternV1,
+    PositionalOrKeywordV1,
+    WarningEffectKindV1,
+    WarningObservationBindingV1,
+)
+from sugar_lift_py_tests.effect import ExpectationNotMetEffect, WarningEffect
+from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, TermValue
+from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_source_tree.panic import SugarNotWritten
+
+
+class _Fixed(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _ExpectedCategory(TermValue):
+    def exception_type_identity(self):
+        return self.value
+
+
+def _identity(name: str):
+    return ctor("python:warning_category_identity", [str_const("builtins"), str_const(name)])
+
+
+SEMANTICS = EffectBoundarySemanticsV1(
+    ExpectsModeV1(),
+    WarningEffectKindV1(),
+    FormalArgumentProjectionV1(0),
+    NoMessagePatternV1(),
+    WarningObservationBindingV1(),
+)
+
+
+def _boundary(*entries):
+    expected = _ExpectedCategory(_identity("FutureWarning"))
+    manager_value = CallSiteValue(
+        target_name="scope",
+        arg_values=(expected,),
+        parameters=("expected",),
+        term=ctor("call", []),
+        body=None,
+    )
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    return WithEffectBoundarySugar(
+        manager=_Fixed(Complete(manager_value)),
+        body=(_Fixed(Complete(BlockValue(tuple(entries)))),),
+        semantics=SEMANTICS,
+        contract_ref=SimpleNamespace(import_signature=signature),
+        context_manager_edge=None,
+        site=None,
+    )
+
+
+def _warning(name: str):
+    return WarningObservationValue(
+        WarningEffect(name, category_identity=_identity(name))
+    )
+
+
+def test_truthful_warning_observation_completes_and_is_consumed():
+    routed = _boundary(_warning("FutureWarning")).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Completed)
+    assert not any(
+        isinstance(entry, WarningObservationValue)
+        for entry in face.value.entries
+    )
+
+
+def test_lying_warning_observation_fails_the_assertion():
+    routed = _boundary(_warning("DeprecationWarning")).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_matching_warning_plus_extra_warning_fails_the_assertion():
+    routed = _boundary(
+        _warning("FutureWarning"), _warning("DeprecationWarning")
+    ).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_unresolved_completed_face_is_undecided_not_false():
+    unresolved = CallSiteValue(
+        target_name="f",
+        arg_values=(),
+        parameters=(),
+        term=ctor("call", []),
+        body=None,
+    )
+    with pytest.raises(SugarNotWritten) as raised:
+        _boundary(unresolved).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert "unresolved" in raised.value.observed

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4664,6 +4664,7 @@ class With(Statement):
             ExpectsModeV1,
             SuppressesModeV1,
             RaiseEffectKindV1,
+            WarningEffectKindV1,
             NeverSuppressesDispositionV1,
             ProtocolResourceSemanticsV1,
             TotalCompletionV1,
@@ -4702,7 +4703,9 @@ class With(Statement):
             isinstance(semantics, EffectBoundarySemanticsV1)
             and semantics.schema_version == "1"
             and isinstance(semantics.mode, (ExpectsModeV1, SuppressesModeV1))
-            and isinstance(semantics.effect_kind, RaiseEffectKindV1)
+            and isinstance(
+                semantics.effect_kind, (RaiseEffectKindV1, WarningEffectKindV1)
+            )
         )
         if not (admitted_resource or admitted_boundary):
             panic = UnsupportedContextManagerSemantics(
@@ -4713,7 +4716,10 @@ class With(Statement):
                     "authenticated CM member carries unsupported enter/exit semantics "
                     f"at {resolution.contract_cid}"
                 ),
-                requested="total Value/NeverSuppresses resource or typed Expects/Raise boundary",
+                requested=(
+                    "total Value/NeverSuppresses resource or typed "
+                    "Expects/Suppresses Raise/Warning boundary"
+                ),
                 fix="leave unsupported authenticated semantics loud; never upgrade testimony",
             )
             self.reporter.report_gap(self, panic)

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -1013,19 +1013,21 @@ def test_expected_observation_with_no_constructed_occurrence_stays_loud(tmp_path
     ``ExpectationNotMet`` halt, which would assert the opposite. Both are facts
     about an observation nobody constructed. The site stays loud instead.
 
-    The refusal lands one rung earlier than a desugar gap: the contract never
-    installs a boundary sugar at all, so there is no object that could later be
-    routed into a completion by a hopeful arm.
+    The typed warning boundary now constructs, but routing still refuses: this
+    body has no authenticated warning occurrence on its completed face.  That
+    is the useful distinction from an unsupported-manager refusal -- the
+    manager contract is understood, while the observation remains undecided.
     """
-    from sugar_source_tree.panic import UnsupportedContextManagerSemantics
+    from sugar_source_tree.panic import SugarNotWritten
 
-    with pytest.raises(UnsupportedContextManagerSemantics) as raised:
-        _with_statement(
-            tmp_path, MATCHING_BODY, OBSERVATION_SEMANTICS, stem="observation"
-        )
-    assert raised.value.owner == "With._construct_sugar"
-    # The refusal names the observation as the missing thing, not the manager.
-    assert "semantics" in raised.value.observed
+    boundary = _with_statement(
+        tmp_path, MATCHING_BODY, OBSERVATION_SEMANTICS, stem="observation"
+    )
+    assert isinstance(boundary, WithEffectBoundarySugar)
+    with pytest.raises(SugarNotWritten) as raised:
+        boundary.desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert raised.value.observed == "warning boundary carries an unprojected message pattern"
 
 
 def test_discrimination_the_same_site_routes_under_a_constructed_effect_kind(tmp_path):


### PR DESCRIPTION
## What changed

- admit typed Warning EffectBoundary contracts without manager/vendor spelling dispatch
- route producer-authenticated WarningObservationValue testimony on completed body faces
- consume the truthful occurrence, fail authenticated wrong/extra-warning twins, and keep missing or unresolved observations as a named refusal
- require category identity from the ordinary authenticated exception-class coordinate; category spelling is diagnostic only

## Concrete classification

The installed pandas 3.0.3 `with tm.assert_produces_warning(FutureWarning): f()` source constructs its SourceFile and distribution resolution, then currently stops during context-manager construction at `ContextManagerResolutionConstructionGap(kind=call-target-source-absent, detail=cast)`; desugar is not reached. This PR wires the general completed-face mechanism behind an authenticated Warning contract and deliberately does not invent a pandas/vendor arm or fabricate a warning producer. A body whose warning producer remains unresolved refuses as `WithEffectBoundarySugar.warning_observation`, never as False.

## Validation

- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py implementations/python/sugar-lift-py-tests/tests/test_effect_router.py` — 18 passed
- `bin/bpytest implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py -k "expected_observation or discrimination_the_same_site_routes"` — 2 passed, 33 deselected
- mutation transaction: clean baseline; invert authenticated category identity comparison; truthful and lying twins both fail in opposite directions; revert; clean; restored focused module 4 passed

No full suite or census was run.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route authenticated warning observations on completed `With` effect boundary faces
> - Extends `WithEffectBoundarySugar.desugar` to handle `WarningEffectKindV1` boundaries in addition to raise boundaries, routing them through a new `_route_completed_warning_boundary` helper.
> - The helper matches a single authenticated warning observation against the expected category identity on the completed face, consumes it if matched, or halts with `ExpectationNotMetEffect` under `ExpectsModeV1` on mismatch or extra observations.
> - `With._require_narrow_cm_ref` in [nodes.py](https://github.com/TSavo/sugar/pull/6458/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now accepts `WarningEffectKindV1` semantics at construction time.
> - `WarningEffect` gains a `category_identity` field to carry the source-authenticated warning category used for downstream matching.
> - Behavioral Change: warning boundaries with a message pattern are rejected with `SugarNotWritten`; unauthenticated categories and unresolved bodies also raise `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d70124e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->