### PR TITLE
Pin python-demand-table shelf identity and publication teeth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -23,10 +23,7 @@ import shutil
 
 import pytest
 
-from sugar_lift_py_tests.demand_table_identity import (
-    DEMAND_TABLE_SCHEMA_VERSION,
-    demand_table_identity,
-)
+from sugar_lift_py_tests.demand_table_identity import demand_table_identity
 
 _SOURCE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src"
 
@@ -74,11 +71,16 @@ _FILES = {
 }
 
 
-def _identity(root: pathlib.Path, **kwargs):
+def _identity(
+    root: pathlib.Path,
+    *,
+    source_root: pathlib.Path = _SOURCE_ROOT,
+    **kwargs,
+):
     return demand_table_identity(
         root,
         sorted(root.rglob("*.py")),
-        source_root=_SOURCE_ROOT,
+        source_root=source_root,
         **kwargs,
     )
 
@@ -151,18 +153,32 @@ def test_a_changed_resolution_config_changes_the_key(tmp_path) -> None:
     assert _identity(root).content_key != _identity(root, config={"k": "v"}).content_key
 
 
-def test_the_schema_version_is_in_the_preimage(tmp_path) -> None:
+def test_a_changed_schema_version_changes_the_key(tmp_path, monkeypatch) -> None:
     """A consumer holding an older-schema artifact must MISS, not decode it."""
+    import sugar_lift_py_tests.demand_table_identity as module
+
     root = _corpus(tmp_path / "corpus", _FILES)
+    before = _identity(root).content_key
 
-    assert _identity(root).preimage()["schemaVersion"] == DEMAND_TABLE_SCHEMA_VERSION
+    monkeypatch.setattr(module, "DEMAND_TABLE_SCHEMA_VERSION", "python-demand-table/v2")
+
+    assert _identity(root).content_key != before
 
 
-def test_the_producer_source_is_in_the_preimage(tmp_path) -> None:
+def test_a_changed_producer_source_changes_the_key(tmp_path) -> None:
     """A change to the code that builds the table changes the table."""
     root = _corpus(tmp_path / "corpus", _FILES)
+    producer = tmp_path / "producer"
+    shutil.copytree(_SOURCE_ROOT, producer)
+    before = _identity(root, source_root=producer).content_key
 
-    assert _identity(root).preimage()["producerSourceCid"]
+    lift_rpc = producer / "sugar_lift_py_tests" / "lift_rpc.py"
+    lift_rpc.write_text(
+        lift_rpc.read_text(encoding="utf-8") + "\n# producer source mutation\n",
+        encoding="utf-8",
+    )
+
+    assert _identity(root, source_root=producer).content_key != before
 
 
 # -- the key is reproducible from its preimage alone --------------------------

--- a/tests/sugarbin_artifact_manifest.sh
+++ b/tests/sugarbin_artifact_manifest.sh
@@ -198,3 +198,7 @@ grep -Fq 'sugar-ir-smt-lib' "$tmp/ssh.log"
 ! grep -Eq 'target/(release|debug)/sugar.*:' "$tmp/rsync.log"
 
 echo 'PASS: sugarbin per-executable artifact manifests'
+
+# The new kind must be admitted by the existing artifact protocol, not by a
+# package-named cache or a second publication path.
+"$repo/tests/sugarbin_python_demand_table_fixture.sh" "$repo"

--- a/tests/sugarbin_python_demand_table_fixture.sh
+++ b/tests/sugarbin_python_demand_table_fixture.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:?usage: sugarbin_python_demand_table_fixture.sh REPO_ROOT}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/corpus/pkg" "$tmp/seed-shelf" "$tmp/partial-shelf" "$tmp/race-shelf"
+printf 'alpha = 1\n' >"$tmp/corpus/pkg/a.py"
+printf 'beta = 2\n' >"$tmp/corpus/pkg/b.py"
+printf '{"rows":["publisher-a"]}\n' >"$tmp/table-a.json"
+printf '{"rows":["publisher-b"]}\n' >"$tmp/table-b.json"
+
+python_path="$repo/implementations/python/sugar-lift-py-tests/src:$repo/implementations/python/sugar-lift-python-source/src:$repo/implementations/python/sugar-source-tree/src"
+content_key="$(PYTHONPATH="$python_path" python3 - "$repo" "$tmp/corpus" <<'PY'
+import pathlib
+import sys
+
+from sugar_lift_py_tests.demand_table_identity import demand_table_identity
+
+repo = pathlib.Path(sys.argv[1])
+corpus = pathlib.Path(sys.argv[2])
+identity = demand_table_identity(
+    corpus,
+    sorted(corpus.rglob("*.py")),
+    source_root=repo / "implementations/python/sugar-lift-py-tests/src",
+)
+print(identity.content_key)
+PY
+)"
+
+publish() {
+  local shelf="$1" input="$2"
+  "$repo/bin/sugarbin" artifact publish \
+    --kind python-demand-table \
+    --content-key "$content_key" \
+    --input "$input" \
+    --runtime python-test-runtime \
+    --platform test-platform \
+    --profile test-profile \
+    --shelf-root "$shelf"
+}
+
+pull() {
+  local shelf="$1" output="$2"
+  "$repo/bin/sugarbin" artifact pull \
+    --kind python-demand-table \
+    --content-key "$content_key" \
+    --output "$output" \
+    --runtime python-test-runtime \
+    --platform test-platform \
+    --profile test-profile \
+    --shelf-root "$shelf"
+}
+
+# Obtain a real completed cell through the production publisher, then remove
+# its compressed payload in a separate shelf. Pull must refuse that incomplete
+# cell without materializing a placeholder into the destination.
+publish "$tmp/seed-shelf" "$tmp/table-a.json"
+cp -R "$tmp/seed-shelf/." "$tmp/partial-shelf/"
+payload_count="$(find "$tmp/partial-shelf" -type f -name '*.gz' | wc -l | tr -d ' ')"
+[[ "$payload_count" == 1 ]] || {
+  echo "python-demand-table publication exposed $payload_count compressed payloads; expected one existing-shelf artifact cell" >&2
+  exit 1
+}
+find "$tmp/partial-shelf" -type f -name '*.gz' -delete
+set +e
+pull "$tmp/partial-shelf" "$tmp/partial-pull.json" 2>"$tmp/partial.err"
+partial_status=$?
+set -e
+[[ "$partial_status" != 0 ]] || { echo 'python-demand-table consumed a partially published shelf cell' >&2; exit 1; }
+[[ ! -e "$tmp/partial-pull.json" ]] || { echo 'python-demand-table materialized bytes from an incomplete shelf cell' >&2; exit 1; }
+
+# Two producers may race on one immutable content cell. Exactly one complete
+# artifact may win; the consumer must observe all bytes from A or all from B.
+set +e
+publish "$tmp/race-shelf" "$tmp/table-a.json" >"$tmp/publish-a.out" 2>"$tmp/publish-a.err" &
+publisher_a=$!
+publish "$tmp/race-shelf" "$tmp/table-b.json" >"$tmp/publish-b.out" 2>"$tmp/publish-b.err" &
+publisher_b=$!
+wait "$publisher_a"; status_a=$?
+wait "$publisher_b"; status_b=$?
+set -e
+[[ "$status_a" == 0 && "$status_b" == 0 ]] || {
+  echo "python-demand-table racing publishers failed: publisher-a=$status_a publisher-b=$status_b" >&2
+  exit 1
+}
+pull "$tmp/race-shelf" "$tmp/race-pull.json"
+if cmp -s "$tmp/race-pull.json" "$tmp/table-a.json"; then
+  winner=a
+elif cmp -s "$tmp/race-pull.json" "$tmp/table-b.json"; then
+  winner=b
+else
+  echo 'python-demand-table consumer observed a torn artifact from racing publishers' >&2
+  exit 1
+fi
+
+echo "PASS: python-demand-table rejects incomplete publication and consumes coherent racing winner $winner"

--- a/tests/sugarbin_shelf_immutability.sh
+++ b/tests/sugarbin_shelf_immutability.sh
@@ -42,3 +42,8 @@ if grep -Eq 'pull_from_shelf|publish_if_absent' <<<"$main_body"; then
 fi
 
 echo 'PASS: sugarbin shelf assets are immutable and race-idempotent'
+
+# Exercise the python-demand-table artifact through the shelf boundary. Static
+# inspection cannot prove that a partial cell is refused or that concurrent
+# publication never exposes a mixture of two producers' bytes.
+"$repo/tests/sugarbin_python_demand_table_fixture.sh" "$repo"


### PR DESCRIPTION
## Summary

- assert `python-demand-table` content identity directly through the merged Python-owned `demand_table_identity` module
- pin relocation hits and independent misses for corpus bytes, relative path membership, producer source, schema version, resolution config, and `parserIdentity`
- pass only the Python-computed `--content-key` and artifact path into the shared `sugarbin artifact` publish/pull route
- prove incomplete shelf cells are never materialized and concurrent publishers yield one coherent artifact

Tests only. This PR does not edit `bin/sugarbin`, the Python identity module, or the Python publication path. It does not add a parallel cache.

## Ruled contract

Python computes the key and payload. `bin/sugarbin` receives `--content-key` and a file path; it does not receive corpus/schema/producer/config inputs and does not derive identity. Platform, profile, and runtime remain cell-path inputs.

## Focused validation

- `PYTHONPATH=<three Python src roots> PYTHONUNBUFFERED=1 python3 -m pytest --noconftest implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py -q` — PASS, 15 passed in 3.31s
- `bash -n tests/sugarbin_python_demand_table_fixture.sh tests/sugarbin_shelf_immutability.sh tests/sugarbin_artifact_manifest.sh` — PASS
- `git diff --check` — PASS
- `PYTHONUNBUFFERED=1 tests/sugarbin_python_demand_table_fixture.sh "$PWD"` — expected RED, exit 2: `sugarbin: unknown argument: artifact`
- `bash tests/sugarbin_shelf_immutability.sh "$PWD"` — existing immutability detector PASS, then expected RED at the absent artifact route

## Shot accounting

Current identity R is zero for all seven named axes. Publication R remains two: incomplete-cell refusal and racing-publisher coherence cannot execute until the peer-owned keyed artifact route lands. Floors preserved: no skipped/deleted tests, no package-name dispatch, no CLI identity derivation, no fabricated artifact, no partial publication accepted.