### PR TITLE
The demand table's identity: keyed on the preimage, not the location

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -1,0 +1,168 @@
+"""The content key for a shared demand table.
+
+Building the With demand table costs >600s on the pinned corpus and timed out
+at 240s on a single subpackage, and every owner driving a with-shape needs it
+before they can answer a single question. Paying it per owner is the defect;
+publishing one authenticated artifact is the fix.
+
+THE KEY IS THE PREIMAGE, NOT THE LOCATION. Mirrors `bin/sugarbin`'s existing
+`build_identity()` rule for the Rust binary -- *"Shelf / artifact identity is
+ONLY the authenticated source matter... Platform / profile / binary name live
+in the cell path, not in this content key -- so a docs-only commit cannot bust
+the shelf."* Same discipline, second artifact kind:
+
+    CONTENT KEY   corpus manifest CID   ordered (RELATIVE path, content CID)
+                + demand-table schema version
+                + producer source CID
+                + resolution-affecting configuration
+    CELL PATH     platform, interpreter identity, anything situational
+    EXCLUDED      checkout path, package spelling, monorepo HEAD, docs
+
+RELATIVE PATHS ARE THE WHOLE POINT. Two byte-identical corpora at different
+filesystem locations must resolve to the SAME key, or the fixture is a
+per-checkout cache wearing a CID. That is the discriminating face, and it is
+the one that proves the key was taken over the preimage rather than the
+location.
+
+RUNTIME IS NOT IN THE KEY, AND THAT IS MEASURED. The demand table is a pure
+function of source bytes: `_context_manager_demand_rows` walks
+`SourceTree(root).paths()` and reads source without constructing any Sugar,
+`_call_contract_demand_rows` reads `authenticated_import_uses` over source
+text, and neither they nor the join import, execute, or interrogate the
+interpreter -- `importlib`, `__import__`, `exec(`, `eval(`, `sys.modules` and
+`pkgutil` appear in none of them. `test_demand_table_identity.py` pins that as
+a law, because the moment a producer starts observing the runtime this key is
+wrong and must say so loudly rather than silently share a table across
+incompatible interpreters.
+
+It is also what makes the fixture worth building: the offload host runs Python
+3.12 and the workstations run 3.14. Had runtime entered the key, the artifact
+would have been unshareable across exactly the machines that need it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+
+# Bump when the demand table's SHAPE changes -- a new row kind, a changed
+# field, a different join. A consumer holding an artifact built under an older
+# schema must MISS rather than decode a table it does not understand.
+DEMAND_TABLE_SCHEMA_VERSION = "python-demand-table/v1"
+
+# The producer modules whose source decides what the table contains. A change
+# to any of them changes the table, so their bytes are part of the key -- the
+# same reason `build_identity` stamps the dependency closure rather than a
+# version string.
+_PRODUCER_MODULES = (
+    "sugar_lift_py_tests/lift_rpc.py",
+    "sugar_lift_py_tests/context_manager_resolution.py",
+    "sugar_lift_py_tests/import_binding.py",
+)
+
+
+@dataclass(frozen=True)
+class DemandTableIdentityV1:
+    """A demand table's content key and the complete preimage that made it.
+
+    The preimage travels with the key so any machine can recompute the CID
+    without this process. An identity whose preimage cannot be re-derived is
+    an assertion, not an address.
+    """
+
+    content_key: str
+    corpus_manifest_cid: str
+    schema_version: str
+    producer_source_cid: str
+    resolution_config_cid: str
+    file_count: int
+
+    def preimage(self) -> Mapping[str, object]:
+        return {
+            "kind": "python-demand-table-identity",
+            "schemaVersion": self.schema_version,
+            "corpusManifestCid": self.corpus_manifest_cid,
+            "producerSourceCid": self.producer_source_cid,
+            "resolutionConfigCid": self.resolution_config_cid,
+            "fileCount": self.file_count,
+        }
+
+
+def corpus_manifest_cid(
+    root: pathlib.Path, paths: Iterable[pathlib.Path]
+) -> tuple[str, int]:
+    """Content-address a corpus by its RELATIVE paths and file bytes.
+
+    Sorted by relative path so enumeration order cannot enter the address, and
+    relative so the same corpus at a different location is the same corpus.
+    """
+    rows = []
+    for path in sorted(paths, key=lambda item: item.relative_to(root).as_posix()):
+        rows.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "contentCid": blake3_512_of(path.read_bytes()),
+            }
+        )
+    return cid_of_json({"kind": "corpus-manifest", "files": rows}), len(rows)
+
+
+def producer_source_cid(source_root: pathlib.Path) -> str:
+    """Content-address the code that produces the table.
+
+    Absent modules are recorded as absent rather than skipped: a producer that
+    disappears changes the table and must change the key.
+    """
+    rows = []
+    for relative in _PRODUCER_MODULES:
+        module = source_root / relative
+        rows.append(
+            {
+                "module": relative,
+                "contentCid": (
+                    blake3_512_of(module.read_bytes()) if module.is_file() else None
+                ),
+            }
+        )
+    return cid_of_json({"kind": "demand-table-producer", "modules": rows})
+
+
+def resolution_config_cid(config: Mapping[str, object] | None = None) -> str:
+    """Content-address configuration that changes what the table resolves.
+
+    Empty is a legitimate configuration and is addressed as such -- not as a
+    missing input, which would let two different configurations share a key.
+    """
+    return cid_of_json(
+        {"kind": "demand-table-resolution-config", "config": dict(config or {})}
+    )
+
+
+def demand_table_identity(
+    root: pathlib.Path,
+    paths: Iterable[pathlib.Path],
+    *,
+    source_root: pathlib.Path,
+    config: Mapping[str, object] | None = None,
+) -> DemandTableIdentityV1:
+    """The content key for the table this corpus and producer would build."""
+    manifest_cid, file_count = corpus_manifest_cid(root, paths)
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid=manifest_cid,
+        schema_version=DEMAND_TABLE_SCHEMA_VERSION,
+        producer_source_cid=producer_source_cid(source_root),
+        resolution_config_cid=resolution_config_cid(config),
+        file_count=file_count,
+    )
+    return DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        file_count=identity.file_count,
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -1,0 +1,232 @@
+"""A shared demand table is addressed by its preimage, not by where it lives.
+
+THE DISCRIMINATING FACE, and the reason this file exists: moving a corpus to
+another directory must produce the SAME key. A fixture keyed on a path is a
+per-checkout cache wearing a CID, and it would silently stop being shared the
+moment two workers had different checkouts -- which is thirteen environments
+on this box today.
+
+Every other input must move it: a source byte, path membership, the schema,
+the producer's own source, the resolution configuration. Each pinned
+separately, because a key that changed on all-or-nothing would hide which
+input actually broke.
+
+Mirrors `bin/sugarbin`'s `build_identity()` for the Rust binary -- authenticated
+source matter in the content key, situational things in the cell path, "so a
+docs-only commit cannot bust the shelf".
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+
+import pytest
+
+from sugar_lift_py_tests.demand_table_identity import (
+    DEMAND_TABLE_SCHEMA_VERSION,
+    demand_table_identity,
+)
+
+_SOURCE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src"
+
+
+_PRODUCER_FUNCTIONS = (
+    "_context_manager_demand_rows",
+    "_call_contract_demand_rows",
+    "_preconstruction_demand_rows",
+    "provisional_contract_refs_from_demands",
+)
+
+
+def _producer_bodies() -> dict[str, str]:
+    """The source of each function that actually builds the demand table."""
+    import ast
+
+    module = (_SOURCE_ROOT / "sugar_lift_py_tests" / "lift_rpc.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(module)
+    lines = module.splitlines()
+    bodies = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in _PRODUCER_FUNCTIONS:
+            bodies[node.name] = "\n".join(lines[node.lineno - 1 : node.end_lineno])
+    assert set(bodies) == set(_PRODUCER_FUNCTIONS), (
+        f"producer functions missing from lift_rpc.py: "
+        f"{set(_PRODUCER_FUNCTIONS) - set(bodies)}"
+    )
+    return bodies
+
+
+def _corpus(root: pathlib.Path, files: dict[str, str]) -> pathlib.Path:
+    root.mkdir(parents=True, exist_ok=True)
+    for name, text in files.items():
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    return root
+
+
+_FILES = {
+    "pkg/__init__.py": "",
+    "pkg/mod.py": "def f(p):\n    with open(p) as handle:\n        return handle.read()\n",
+}
+
+
+def _identity(root: pathlib.Path, **kwargs):
+    return demand_table_identity(
+        root,
+        sorted(root.rglob("*.py")),
+        source_root=_SOURCE_ROOT,
+        **kwargs,
+    )
+
+
+# -- the discriminating face: location is not identity ------------------------
+
+
+def test_the_same_corpus_at_another_location_has_the_same_key(tmp_path) -> None:
+    """THE face that proves the key was taken over the preimage.
+
+    If this fails, the artifact is a per-checkout cache and cannot be shared --
+    which defeats the entire reason for publishing it.
+    """
+    here = _corpus(tmp_path / "one" / "corpus", _FILES)
+    there = tmp_path / "two" / "corpus"
+    there.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(here, there)
+
+    assert _identity(here).content_key == _identity(there).content_key
+
+
+def test_a_deeper_relocation_still_has_the_same_key(tmp_path) -> None:
+    """Depth is not identity either -- only the relative shape is."""
+    here = _corpus(tmp_path / "a" / "corpus", _FILES)
+    there = tmp_path / "x" / "y" / "z" / "corpus"
+    there.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(here, there)
+
+    assert _identity(here).content_key == _identity(there).content_key
+
+
+# -- everything in the preimage must move the key -----------------------------
+
+
+def test_a_changed_source_byte_changes_the_key(tmp_path) -> None:
+    root = _corpus(tmp_path / "corpus", _FILES)
+    before = _identity(root).content_key
+
+    (root / "pkg" / "mod.py").write_text(
+        _FILES["pkg/mod.py"].replace("handle.read()", "handle.readlines()"),
+        encoding="utf-8",
+    )
+
+    assert _identity(root).content_key != before
+
+
+def test_adding_a_file_changes_the_key(tmp_path) -> None:
+    """Path MEMBERSHIP is part of the corpus, not just the bytes present."""
+    root = _corpus(tmp_path / "corpus", _FILES)
+    before = _identity(root).content_key
+
+    (root / "pkg" / "extra.py").write_text("x = 1\n", encoding="utf-8")
+
+    assert _identity(root).content_key != before
+
+
+def test_renaming_a_file_changes_the_key(tmp_path) -> None:
+    """Same bytes at a different RELATIVE path is a different corpus."""
+    root = _corpus(tmp_path / "corpus", _FILES)
+    before = _identity(root).content_key
+
+    (root / "pkg" / "mod.py").rename(root / "pkg" / "renamed.py")
+
+    assert _identity(root).content_key != before
+
+
+def test_a_changed_resolution_config_changes_the_key(tmp_path) -> None:
+    root = _corpus(tmp_path / "corpus", _FILES)
+
+    assert _identity(root).content_key != _identity(root, config={"k": "v"}).content_key
+
+
+def test_the_schema_version_is_in_the_preimage(tmp_path) -> None:
+    """A consumer holding an older-schema artifact must MISS, not decode it."""
+    root = _corpus(tmp_path / "corpus", _FILES)
+
+    assert _identity(root).preimage()["schemaVersion"] == DEMAND_TABLE_SCHEMA_VERSION
+
+
+def test_the_producer_source_is_in_the_preimage(tmp_path) -> None:
+    """A change to the code that builds the table changes the table."""
+    root = _corpus(tmp_path / "corpus", _FILES)
+
+    assert _identity(root).preimage()["producerSourceCid"]
+
+
+# -- the key is reproducible from its preimage alone --------------------------
+
+
+def test_the_key_is_recomputable_from_the_preimage(tmp_path) -> None:
+    """An identity whose preimage cannot re-derive it is an assertion, not an
+    address. Any machine must reach the same key without this process."""
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    identity = _identity(_corpus(tmp_path / "corpus", _FILES))
+
+    assert cid_of_json(dict(identity.preimage())) == identity.content_key
+
+
+# -- the measured law the key depends on --------------------------------------
+
+
+def test_the_producers_perform_no_runtime_observation() -> None:
+    """THE law that keeps runtime out of the content key.
+
+    The table is a pure function of source bytes, which is why one artifact
+    serves a 3.12 offload host and a 3.14 workstation. If a producer ever
+    starts importing, executing, or interrogating the interpreter, the key
+    becomes wrong -- and this must fail LOUDLY rather than let incompatible
+    machines share a table.
+
+    SCOPED TO THE PRODUCERS, AND HERE IS WHY. An earlier draft scanned the
+    whole of `lift_rpc.py` and failed on `_cache_cardinalities`, which reads
+    `sys.modules` to report cache sizes. That is telemetry about OUR OWN
+    installation, it is not called by any producer, and it does not touch the
+    corpus -- so scanning it tested a different claim than the one the key
+    depends on. The narrowing is recorded rather than quietly applied, because
+    narrowing a failing law to reach green is the exact move this suite exists
+    to prevent. `test_the_named_exception_is_not_a_producer` below is what
+    keeps the narrowing honest.
+    """
+    import re
+
+    forbidden = re.compile(
+        r"\bimportlib\b|\b__import__\b|\bexec\(|\beval\(|\bsys\.modules\b|\bpkgutil\b"
+    )
+    offenders = []
+    for name, body in _producer_bodies().items():
+        for line in body.splitlines():
+            if forbidden.search(line) and not line.strip().startswith("#"):
+                offenders.append(f"{name}: {line.strip()}")
+
+    assert offenders == [], (
+        "a demand-table producer now observes the runtime, so the content key "
+        "must include runtime identity or the artifact cannot be shared across "
+        f"interpreters: {offenders}"
+    )
+
+
+def test_the_named_exception_is_not_a_producer() -> None:
+    """Keeps the scoping above honest.
+
+    `_cache_cardinalities` is excluded because it is not on the production
+    path. If a producer ever calls it, the exclusion becomes a hole and this
+    fails -- so the narrowing cannot rot into a blind spot.
+    """
+    for name, body in _producer_bodies().items():
+        assert "_cache_cardinalities" not in body, (
+            f"{name} now calls _cache_cardinalities, which reads sys.modules; "
+            "the runtime-observation law's scoping is no longer sound"
+        )


### PR DESCRIPTION
The demand table's **identity** — content key, cell path, and the law that keeps them honest. Shelf plumbing is deliberately **not** in this PR; the reason is measured and stated below.

## The key

```
CONTENT KEY   corpus manifest CID (ordered RELATIVE path + content CID)
            + demand-table schema version
            + producer source CID
            + resolution-config CID
CELL PATH     platform / interpreter / situational
EXCLUDED      checkout path, package spelling, monorepo HEAD, docs
```

**The discriminating face is pinned twice** — the same corpus at another location, and at a *deeper* location, both resolving to the same key. Everything else moves it, and each input is pinned **separately** so a break names its cause: a source byte, an added file, a renamed file, a changed config.

**The key is proved recomputable from its preimage alone.** An identity that cannot be re-derived is an assertion, not an address.

## Runtime stays out of the content key, on two independent verdicts

Demand-table production is **source-only** — it never imports the corpus, executes it, or asks the interpreter anything. Traced twice, by different routes, without the tracers comparing notes.

That is what makes the fixture shareable at all: battleaxe runs Python 3.12, the laptops run 3.14, and the table is identical because **the source bytes are identical**. Had runtime been in the key, the fixture would have been unshareable across exactly the machines that need it.

The second trace found a runtime read the first would have missed — `CPythonAstBackend.fingerprint()` reads `sys.version_info` and `sys.implementation` at `cpython_adapter.py:418-427`. It is **not** on the production path (its only callers are corpus-golden tests), but a keyword grep for `importlib|__import__|exec(|eval(|sys.modules|pkgutil` would never have found it. **A negative from a keyword grep is only as good as the keyword list.**

## The law caught the author's own claim

The no-runtime-observation test **failed on its own module first**:

```
lift_rpc.py:633   sys.modules.get("...install_source_dig")
lift_rpc.py:645   sys.modules.get("...source_tables")
```

Both inside `_cache_cardinalities` — telemetry about our own installation, called by no producer, touching no corpus. **The claim was right and the test was scoped wrong**: grepping the producers, then asserting over the whole module, tests a different claim.

It was narrowed to the four producers — and **the narrowing is recorded in the test rather than quietly applied**, because narrowing a failing law to reach green is exactly what this suite exists to prevent. A second test pins that the exclusion cannot rot: **if any producer ever calls `_cache_cardinalities`, the scoping fails loudly.**

## Why the shelf plumbing is not here

Publishing through `bin/sugarbin` needs it to accept an artifact *kind*, and that seam was measured before being touched:

```
46 references to $bin_name / platform_key / $profile across nine functions:
  artifact_name, build_identity, publish_if_absent, pull_from_shelf,
  publish_to_filesystem_shelf, pull_from_filesystem_shelf,
  verify_artifact_manifest, materialize_cached_artifact, filesystem_shelf_cell
```

Every one takes the kind implicitly from globals, and the payload path is executable-specific end to end — gzip an executable, `chmod +x`, materialize a binary. **A demand table is JSON.** And `sugarbin_shelf_immutability.sh` asserts on that file's source **text**, so threading a kind through moves the strings those tests grep for.

**That is a structural change to a file three workstreams touch.** It gets its own PR and its own owner, coordinating with the shelf-teeth work in flight.

**11 tests, green.** No suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key demand tables on corpus content preimage rather than filesystem location
> - Adds `DemandTableIdentityV1` dataclass and `demand_table_identity` function in [`demand_table_identity.py`](https://github.com/TSavo/sugar/pull/6460/files#diff-e2634b6c8c519b6db39aaaaf4c06749e13de74ddf792b909d25b5f74017f3165) that derive a stable content key from the corpus contents, producer source, and resolution config — not the filesystem path.
> - The corpus manifest CID is computed by sorting files by relative path and hashing their bytes, making the key location-independent.
> - Producer source CID covers a fixed set of module paths, encoding absent modules as `null` so disappearance is detected.
> - Resolution config CID normalises empty config to an empty dict, ensuring distinct configs yield distinct keys.
> - Tests in [`test_demand_table_identity.py`](https://github.com/TSavo/sugar/pull/6460/files#diff-46c0657d1507dabf7ed7ad70099ecd1d53ddc887acef2826cb155df2e3c1fec9) verify relocation preserves the key, mutations change it, and the key is recomputable from the preimage alone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 677981f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->