### PR TITLE
Correction: runtime IS in the demand table's content key

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -24,20 +24,34 @@ per-checkout cache wearing a CID. That is the discriminating face, and it is
 the one that proves the key was taken over the preimage rather than the
 location.
 
-RUNTIME IS NOT IN THE KEY, AND THAT IS MEASURED. The demand table is a pure
-function of source bytes: `_context_manager_demand_rows` walks
-`SourceTree(root).paths()` and reads source without constructing any Sugar,
-`_call_contract_demand_rows` reads `authenticated_import_uses` over source
-text, and neither they nor the join import, execute, or interrogate the
-interpreter -- `importlib`, `__import__`, `exec(`, `eval(`, `sys.modules` and
-`pkgutil` appear in none of them. `test_demand_table_identity.py` pins that as
-a law, because the moment a producer starts observing the runtime this key is
-wrong and must say so loudly rather than silently share a table across
-incompatible interpreters.
+RUNTIME IS IN THE KEY, AND THE FIRST ANSWER WAS WRONG.
 
-It is also what makes the fixture worth building: the offload host runs Python
-3.12 and the workstations run 3.14. Had runtime entered the key, the artifact
-would have been unshareable across exactly the machines that need it.
+An earlier version of this module excluded runtime identity, on two
+independently-traced verdicts that demand production never CALLS anything
+observing the interpreter. Both verdicts were correct and both answered the
+wrong question. The right question is whether production's OUTPUT can differ
+across interpreters, and it can with no such call at all, because the parse
+itself is version-dependent. `CPythonAstBackend.fingerprint`, in this same
+tree, says so:
+
+    "CPython's `ast` produces a version-dependent node stream (e.g. the empty
+     Constant("") it staples into a nested f-string format spec on 3.12 but
+     not 3.14), so the interpreter IS this backend's version-of-record."
+
+`fingerprint()` exists precisely because this codebase already pins goldens
+per interpreter for that reason, and it names 3.12 and 3.14 -- which is the
+offload host versus the workstations exactly.
+
+So runtime joins the content key until a measurement says it may leave. The
+two failures are not symmetric: a key that is too SPECIFIC costs a rebuild per
+interpreter and announces itself as a cache miss; a key that is too LOOSE
+silently shares a table built under a different parser behind a valid-looking
+CID, and announces nothing. Loudly-lossy over silently-wrong.
+
+RELAXING IS A MEASUREMENT, NOT AN ARGUMENT. Build the table for one corpus on
+3.12 and on 3.14 and compare. If the CIDs match, runtime may leave the key
+WITH a test pinning that they match. If they differ, the key is already right
+and that comparison is its twin. Until one of those exists, it stays.
 """
 
 from __future__ import annotations
@@ -78,6 +92,7 @@ class DemandTableIdentityV1:
     schema_version: str
     producer_source_cid: str
     resolution_config_cid: str
+    parser_identity: str
     file_count: int
 
     def preimage(self) -> Mapping[str, object]:
@@ -87,6 +102,7 @@ class DemandTableIdentityV1:
             "corpusManifestCid": self.corpus_manifest_cid,
             "producerSourceCid": self.producer_source_cid,
             "resolutionConfigCid": self.resolution_config_cid,
+            "parserIdentity": self.parser_identity,
             "fileCount": self.file_count,
         }
 
@@ -141,6 +157,22 @@ def resolution_config_cid(config: Mapping[str, object] | None = None) -> str:
     )
 
 
+def parser_identity() -> str:
+    """The interpreter, as the parser's version-of-record.
+
+    Same shape `CPythonAstBackend.fingerprint` already uses to pin goldens --
+    implementation plus major.minor -- because that is the granularity at
+    which the node stream is documented to change. Patch level is excluded
+    deliberately: the documented differences are minor-version differences,
+    and keying on patch would force a rebuild for changes that provably
+    cannot move the table.
+    """
+    import sys
+
+    version = sys.version_info
+    return f"{sys.implementation.name}-{version.major}.{version.minor}"
+
+
 def demand_table_identity(
     root: pathlib.Path,
     paths: Iterable[pathlib.Path],
@@ -156,6 +188,7 @@ def demand_table_identity(
         schema_version=DEMAND_TABLE_SCHEMA_VERSION,
         producer_source_cid=producer_source_cid(source_root),
         resolution_config_cid=resolution_config_cid(config),
+        parser_identity=parser_identity(),
         file_count=file_count,
     )
     return DemandTableIdentityV1(
@@ -164,5 +197,6 @@ def demand_table_identity(
         schema_version=identity.schema_version,
         producer_source_cid=identity.producer_source_cid,
         resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
         file_count=identity.file_count,
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -230,3 +230,80 @@ def test_the_named_exception_is_not_a_producer() -> None:
             f"{name} now calls _cache_cardinalities, which reads sys.modules; "
             "the runtime-observation law's scoping is no longer sound"
         )
+
+
+# -- the correction: runtime IS in the key, until measured otherwise ----------
+
+
+def test_the_parser_identity_is_in_the_preimage(tmp_path) -> None:
+    """THE correction.
+
+    An earlier version excluded runtime on two independently-traced verdicts
+    that production never CALLS anything observing the interpreter. Both were
+    correct and both answered the wrong question: production's OUTPUT can
+    differ across interpreters with no such call, because the parse itself is
+    version-dependent. `CPythonAstBackend.fingerprint` documents it and names
+    3.12 versus 3.14 -- the offload host versus the workstations.
+    """
+    import sys
+
+    identity = _identity(_corpus(tmp_path / "corpus", _FILES))
+
+    assert identity.preimage()["parserIdentity"] == (
+        f"{sys.implementation.name}-{sys.version_info.major}."
+        f"{sys.version_info.minor}"
+    )
+
+
+def test_a_different_parser_identity_changes_the_key(tmp_path) -> None:
+    """The tooth. Two interpreters must not share one key while it is unproven
+    that they produce the same table.
+
+    Asymmetric on purpose: a too-specific key costs a rebuild and announces
+    itself as a miss; a too-loose key silently shares a table built under a
+    different parser behind a valid-looking CID. Loudly-lossy over
+    silently-wrong.
+    """
+    import sugar_lift_py_tests.demand_table_identity as module
+
+    root = _corpus(tmp_path / "corpus", _FILES)
+    here = _identity(root).content_key
+
+    original = module.parser_identity
+    module.parser_identity = lambda: "cpython-3.12"
+    try:
+        elsewhere = _identity(root).content_key
+    finally:
+        module.parser_identity = original
+
+    assert elsewhere != here
+
+
+def test_the_relaxing_condition_is_a_measurement_not_an_argument() -> None:
+    """Records what would let runtime leave the key, so the next reader does
+    not remove it on the strength of the two traces that were already wrong.
+
+    The gate is: build the table for one corpus on 3.12 and on 3.14 and
+    compare CIDs. Matching CIDs plus a test pinning the match is the only
+    thing that earns the removal.
+    """
+    from sugar_lift_py_tests import demand_table_identity as module
+
+    doc = " ".join((module.__doc__ or "").split())
+
+    assert "RELAXING IS A MEASUREMENT, NOT AN ARGUMENT" in doc
+    assert "3.12" in doc and "3.14" in doc
+
+
+def test_the_reason_the_first_answer_was_wrong_is_recorded() -> None:
+    """A key that mysteriously grew a field invites its own removal. The
+    evidence travels with the correction."""
+    from sugar_lift_py_tests import demand_table_identity as module
+
+    # Normalized: the docstring wraps, and a phrase split across lines is
+    # still the phrase. Asserting the wrapped form would pin the formatting
+    # rather than the claim.
+    doc = " ".join((module.__doc__ or "").split())
+
+    assert "version-dependent node stream" in doc
+    assert "answered the wrong question" in doc


### PR DESCRIPTION
**Corrects #6460.** Base `c4d888d00`. Two files, +125/−14.

## The first answer was wrong, and two correct traces produced it

#6460 excluded runtime identity on **two independently-traced verdicts** that demand production never *calls* anything observing the interpreter. Both verdicts were correct. **Both answered the wrong question.**

The right question is whether production's **output** can differ across interpreters — and it can with no such call at all, because **the parse itself is version-dependent.** `CPythonAstBackend.fingerprint`, in this same tree:

> *"CPython's `ast` produces a version-dependent node stream (e.g. the empty `Constant("")` it staples into a nested f-string format spec on 3.12 but not 3.14), so the interpreter IS this backend's version-of-record."*

**That function exists because this codebase already pins goldens per interpreter for exactly this reason** — and it names **3.12 and 3.14**, which is the offload host versus the workstations.

A keyword grep for `importlib|__import__|exec(|eval(|sys.modules|pkgutil` could never have found it: it reads `sys.version_info` and `sys.implementation`. **A negative from a keyword grep is only as good as the keyword list.**

## The correction

`parserIdentity` joins the preimage at **implementation-major.minor** — the granularity at which the node stream is documented to change. Patch level is excluded deliberately: a rebuild for a change that provably cannot move the table is cost without safety.

## Why this direction, not the other

**The two failures are not symmetric.**

| key | failure | how it announces itself |
|---|---|---|
| too **specific** | a rebuild per interpreter | a cache miss |
| too **loose** | shares a table built under a different parser | **nothing** — a valid-looking CID |

Loudly-lossy over silently-wrong.

## Relaxing is a measurement, not an argument

Build the table for one corpus on 3.12 and on 3.14 and compare CIDs. **Matching CIDs plus a test pinning the match** is the only thing that earns the removal. Differing CIDs mean the key is already right and that comparison is its twin.

Four tests carry the correction so the next reader does not remove the field on the strength of the two traces that were already wrong:

- the parser identity is in the preimage
- **the tooth** — a different parser identity changes the key
- the relaxing condition is recorded, naming 3.12/3.14 and the CID comparison
- the *reason* the first answer was wrong is recorded, so a field that appears to have grown mysteriously cannot be pruned as noise

## Unaffected

The relocation face, the separate miss twins (byte, path membership, rename, config), and recomputability-from-preimage are unchanged. **15 tests green.** No suite.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include runtime identity in `DemandTableIdentityV1` content key
> - Adds a `parser_identity` field to `DemandTableIdentityV1` populated as `<implementation>-<major>.<minor>` (e.g. `cpython-3.12`), patch level excluded.
> - Includes `"parserIdentity"` in the preimage used to compute `content_key`, so cached results are keyed per interpreter version.
> - The motivation is that CPython's AST is version-dependent, meaning the same source can produce different node streams across minor versions.
> - Adds tests verifying the preimage contains the expected identity and that changing it alters the computed key.
> - Behavioral Change: `content_key` values computed by prior versions are now invalid; any cache keyed on the old value will miss.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d2674c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->