### PR TITLE
Authenticate managed Python corpus execution

### DIFF
--- a/bin/bpytest
+++ b/bin/bpytest
@@ -37,4 +37,16 @@ if [[ -z "$repo_root" ]]; then
 fi
 repo_root="$(cd "$repo_root" && pwd -P)"
 
-exec "$sugarbin" run --host bx --task python-unit -- "$@"
+pytest_args=()
+sugarbin_args=()
+for arg in "$@"; do
+  if [[ "$arg" == "-u" ]]; then
+    export PYTHONUNBUFFERED=1
+    sugarbin_args=(--env PYTHONUNBUFFERED)
+  else
+    pytest_args+=("$arg")
+  fi
+done
+
+exec "$sugarbin" run --host bx "${sugarbin_args[@]}" \
+  --task authenticated-python-lift -- "${pytest_args[@]}"

--- a/implementations/python/sugar-lift-py-tests/pyproject.toml
+++ b/implementations/python/sugar-lift-py-tests/pyproject.toml
@@ -47,6 +47,12 @@ test = [
     "pandas==3.0.3",
 ]
 
+[tool.sugar.measured-corpus]
+# SourceTree(pandas_root).paths(), sorted and JSON-canonicalized before sha256.
+# This is the 1,421-file pandas 3.0.3 denominator in the immutable managed
+# closure. Older 1,415-file receipts have a different CID and cannot mix.
+pandas-manifest-cid = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+
 [project.scripts]
 sugar-lift-python = "sugar_lift_py_tests.lift_rpc:main"
 sugar-python-factory-floor-idd = "sugar_lift_py_tests.idd.cli:main"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -1,0 +1,203 @@
+"""Authenticate the managed pandas corpus before pytest can collect work."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+import sysconfig
+import tomllib
+from dataclasses import dataclass
+from importlib import import_module, metadata
+from pathlib import Path
+from types import ModuleType
+from typing import Sequence
+
+
+class ExecutionEnvironmentMismatch(RuntimeError):
+    """The interpreter cannot truthfully name the corpus it would measure."""
+
+
+@dataclass(frozen=True)
+class ImportIdentity:
+    name: str
+    version: str
+    loaded_from: Path
+
+
+def _inside(path: Path, root: Path) -> bool:
+    return path == root or root in path.parents
+
+
+def authenticate_distribution(
+    *,
+    name: str,
+    module: ModuleType,
+    expected_version: str,
+    metadata_version: str,
+    purelib: Path,
+) -> ImportIdentity:
+    loaded_from = Path(str(getattr(module, "__file__", ""))).resolve()
+    imported_version = str(getattr(module, "__version__", "<missing>"))
+    purelib = purelib.resolve()
+    if imported_version != expected_version:
+        raise ExecutionEnvironmentMismatch(
+            f"{name} corpus mismatch: imported {imported_version} from "
+            f"{loaded_from}; required exact {expected_version}"
+        )
+    if not _inside(loaded_from, purelib):
+        raise ExecutionEnvironmentMismatch(
+            f"{name} loaded from {loaded_from}, outside this interpreter's own "
+            f"site-packages {purelib}; refusing a leaking environment"
+        )
+    if metadata_version != imported_version:
+        raise ExecutionEnvironmentMismatch(
+            f"{name} dist-info records {metadata_version}, but imported module "
+            f"reports {imported_version} from {loaded_from}"
+        )
+    return ImportIdentity(name, imported_version, loaded_from)
+
+
+def authenticate_lift(module: ModuleType, repo_root: Path) -> ImportIdentity:
+    expected_root = (
+        repo_root / "implementations/python/sugar-lift-py-tests/src"
+    ).resolve()
+    loaded_from = Path(str(getattr(module, "__file__", ""))).resolve()
+    if not _inside(loaded_from, expected_root):
+        raise ExecutionEnvironmentMismatch(
+            f"lift import escaped the synced checkout: loaded "
+            f"sugar_lift_py_tests from {loaded_from}; required {expected_root}"
+        )
+    return ImportIdentity("sugar_lift_py_tests", "checkout-source", loaded_from)
+
+
+def corpus_manifest_cid(files: Sequence[str]) -> str:
+    ordered = sorted(str(path) for path in files)
+    if not ordered:
+        raise ExecutionEnvironmentMismatch("pandas corpus manifest is empty")
+    if len(set(ordered)) != len(ordered):
+        raise ExecutionEnvironmentMismatch("pandas corpus manifest contains duplicates")
+    preimage = json.dumps(ordered, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(preimage.encode("utf-8")).hexdigest()
+
+
+def activate_checkout_import_roots(repo_root: Path, search_path: list[str]) -> None:
+    """Activate exactly the mounted roots declared by the managed closure."""
+    dockerfile = repo_root / "tools/sugar-build/Dockerfile"
+    matches = re.findall(
+        r"^ENV PYTHONPATH=(.*)$",
+        dockerfile.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if len(matches) != 1:
+        raise ExecutionEnvironmentMismatch(
+            f"expected one managed PYTHONPATH declaration in {dockerfile}, found {len(matches)}"
+        )
+    prefix = "/workspace/sugar/"
+    roots: list[str] = []
+    for entry in matches[0].split(":"):
+        if not entry.startswith(prefix):
+            raise ExecutionEnvironmentMismatch(
+                f"managed PYTHONPATH entry escaped the synced checkout: {entry}"
+            )
+        root = (repo_root / entry[len(prefix) :]).resolve()
+        if not root.is_dir():
+            raise ExecutionEnvironmentMismatch(
+                f"managed PYTHONPATH entry does not exist in the synced checkout: {root}"
+            )
+        roots.append(str(root))
+    search_path[0:0] = roots
+
+
+def _declared_corpus(package_root: Path) -> tuple[dict[str, str], str]:
+    pyproject = package_root / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    requirements = data["project"]["optional-dependencies"]["test"]
+    pins: dict[str, str] = {}
+    for requirement in requirements:
+        for name in ("numpy", "pandas"):
+            prefix = f"{name}=="
+            if requirement.startswith(prefix):
+                pins[name] = requirement[len(prefix) :]
+    if set(pins) != {"numpy", "pandas"}:
+        raise ExecutionEnvironmentMismatch(
+            f"measured corpus pins are incomplete in {pyproject}: {pins}"
+        )
+    expected_cid = data["tool"]["sugar"]["measured-corpus"]["pandas-manifest-cid"]
+    return pins, str(expected_cid)
+
+
+def authenticate_environment() -> (
+    tuple[ImportIdentity, ImportIdentity, ImportIdentity, str]
+):
+    package_root = Path(__file__).resolve().parents[2]
+    repo_root = Path(__file__).resolve().parents[5]
+    activate_checkout_import_roots(repo_root, sys.path)
+    pins, expected_cid = _declared_corpus(package_root)
+    purelib = Path(sysconfig.get_paths()["purelib"])
+
+    pandas = import_module("pandas")
+    numpy = import_module("numpy")
+    lift = import_module("sugar_lift_py_tests")
+    pandas_identity = authenticate_distribution(
+        name="pandas",
+        module=pandas,
+        expected_version=pins["pandas"],
+        metadata_version=metadata.version("pandas"),
+        purelib=purelib,
+    )
+    numpy_identity = authenticate_distribution(
+        name="numpy",
+        module=numpy,
+        expected_version=pins["numpy"],
+        metadata_version=metadata.version("numpy"),
+        purelib=purelib,
+    )
+    lift_identity = authenticate_lift(lift, repo_root)
+
+    from sugar_source_tree.tree import SourceTree
+
+    pandas_root = pandas_identity.loaded_from.parent
+    files = [
+        path.resolve().relative_to(pandas_root).as_posix()
+        for path in SourceTree(pandas_root).paths()
+    ]
+    observed_cid = corpus_manifest_cid(files)
+    if observed_cid != expected_cid:
+        raise ExecutionEnvironmentMismatch(
+            "pandas corpus manifest CID mismatch: "
+            f"observed {observed_cid} over {len(files)} files; "
+            f"required {expected_cid}"
+        )
+    return pandas_identity, numpy_identity, lift_identity, observed_cid
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        pandas_identity, numpy_identity, lift_identity, manifest_cid = (
+            authenticate_environment()
+        )
+    except Exception as error:
+        print(
+            "BATTLEAXE EXECUTION ENVIRONMENT REFUSED: " + str(error),
+            file=sys.stderr,
+            flush=True,
+        )
+        return 78
+
+    print(
+        "authenticated execution environment: "
+        f"corpusManifestCid={manifest_cid} "
+        f"pandas={pandas_identity.version} pandasPath={pandas_identity.loaded_from} "
+        f"numpy={numpy_identity.version} numpyPath={numpy_identity.loaded_from} "
+        f"liftPath={lift_identity.loaded_from}",
+        flush=True,
+    )
+    import pytest
+
+    return int(pytest.main(list(argv) if argv is not None else sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -76,6 +76,12 @@ binaries = ["sugar"]
 command = ["python", "-m", "pytest"]
 network = "none"
 
+[tasks.authenticated-python-lift]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-m", "sugar_lift_py_tests.authenticated_pytest"]
+network = "none"
+
 [tasks.datetime-claim-twins]
 capabilities = ["python-test", "solver-z3"]
 binaries = ["sugar"]

--- a/tests/bpytest_authenticated_wrapper.sh
+++ b/tests/bpytest_authenticated_wrapper.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:?usage: bpytest_authenticated_wrapper.sh REPO_ROOT}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fixture="$tmp/repo"
+mkdir -p "$fixture/bin"
+cp "$repo_root/bin/bpytest" "$fixture/bin/"
+git -C "$fixture" init -q
+
+cat >"$fixture/bin/sugarbin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\0' "$@" >"$SUGARBIN_WRAPPER_LOG"
+printf '%s' "${PYTHONUNBUFFERED:-}" >"$SUGARBIN_WRAPPER_ENV_LOG"
+exit "${SUGARBIN_WRAPPER_STATUS:-0}"
+SH
+chmod +x "$fixture/bin/sugarbin"
+
+export SUGARBIN_WRAPPER_LOG="$tmp/args.log"
+export SUGARBIN_WRAPPER_ENV_LOG="$tmp/env.log"
+
+assert_args() {
+  python3 - "$SUGARBIN_WRAPPER_LOG" "$@" <<'PY'
+import sys
+from pathlib import Path
+
+actual = Path(sys.argv[1]).read_bytes().split(b"\0")
+if actual[-1:] == [b""]:
+    actual.pop()
+expected = [arg.encode() for arg in sys.argv[2:]]
+if actual != expected:
+    raise SystemExit(f"argument mismatch:\nactual={actual!r}\nexpected={expected!r}")
+PY
+}
+
+status=0
+(cd "$fixture" && SUGARBIN_WRAPPER_STATUS=37 bin/bpytest -q tests/unit) || status=$?
+[[ "$status" -eq 37 ]] || { echo "bpytest returned $status, expected 37" >&2; exit 1; }
+assert_args run --host bx --task authenticated-python-lift -- -q tests/unit
+
+status=0
+(cd "$fixture" && SUGARBIN_WRAPPER_STATUS=41 bin/bpytest -u -q tests/unit) || status=$?
+[[ "$status" -eq 41 ]] || { echo "bpytest -u returned $status, expected 41" >&2; exit 1; }
+[[ "$(cat "$SUGARBIN_WRAPPER_ENV_LOG")" == 1 ]] || { echo "bpytest -u did not set PYTHONUNBUFFERED=1" >&2; exit 1; }
+assert_args run --host bx --env PYTHONUNBUFFERED --task authenticated-python-lift -- -q tests/unit
+
+echo "PASS: authenticated bpytest wrapper"

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+import subprocess
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import (
+    ExecutionEnvironmentMismatch,
+    activate_checkout_import_roots,
+    authenticate_distribution,
+    authenticate_lift,
+    corpus_manifest_cid,
+    main,
+)
+
+
+def fake_module(name: str, version: str, path: Path) -> ModuleType:
+    module = ModuleType(name)
+    module.__version__ = version
+    module.__file__ = str(path)
+    module.__spec__ = ModuleSpec(name, loader=None, origin=str(path))
+    return module
+
+
+def test_truthful_distribution_inside_own_site_packages_is_accepted(tmp_path) -> None:
+    purelib = tmp_path / "venv/lib/python3.12/site-packages"
+    module = fake_module("pandas", "3.0.3", purelib / "pandas/__init__.py")
+
+    identity = authenticate_distribution(
+        name="pandas",
+        module=module,
+        expected_version="3.0.3",
+        metadata_version="3.0.3",
+        purelib=purelib,
+    )
+
+    assert identity.version == "3.0.3"
+    assert identity.loaded_from == (purelib / "pandas/__init__.py").resolve()
+
+
+def test_lying_233_distribution_is_refused_loudly(tmp_path) -> None:
+    purelib = tmp_path / "venv/lib/python3.12/site-packages"
+    module = fake_module("pandas", "2.3.3", purelib / "pandas/__init__.py")
+
+    with pytest.raises(ExecutionEnvironmentMismatch, match=r"pandas.*2\.3\.3.*3\.0\.3"):
+        authenticate_distribution(
+            name="pandas",
+            module=module,
+            expected_version="3.0.3",
+            metadata_version="2.3.3",
+            purelib=purelib,
+        )
+
+
+def test_leaking_distribution_outside_own_site_packages_is_refused(tmp_path) -> None:
+    purelib = tmp_path / "managed/lib/python3.12/site-packages"
+    foreign = tmp_path / "ambient/lib/python3.12/site-packages"
+    module = fake_module("pandas", "3.0.3", foreign / "pandas/__init__.py")
+
+    with pytest.raises(
+        ExecutionEnvironmentMismatch,
+        match="outside this interpreter's own site-packages",
+    ):
+        authenticate_distribution(
+            name="pandas",
+            module=module,
+            expected_version="3.0.3",
+            metadata_version="3.0.3",
+            purelib=purelib,
+        )
+
+
+def test_dist_info_disagreement_is_refused(tmp_path) -> None:
+    purelib = tmp_path / "venv/lib/python3.12/site-packages"
+    module = fake_module("pandas", "3.0.3", purelib / "pandas/__init__.py")
+
+    with pytest.raises(ExecutionEnvironmentMismatch, match="dist-info records 3.0.5"):
+        authenticate_distribution(
+            name="pandas",
+            module=module,
+            expected_version="3.0.3",
+            metadata_version="3.0.5",
+            purelib=purelib,
+        )
+
+
+def test_lift_must_resolve_from_the_synced_checkout(tmp_path) -> None:
+    repo = tmp_path / "sugar"
+    expected = repo / "implementations/python/sugar-lift-py-tests/src"
+    truthful = fake_module(
+        "sugar_lift_py_tests", "0.1.0", expected / "sugar_lift_py_tests/__init__.py"
+    )
+    foreign = fake_module(
+        "sugar_lift_py_tests",
+        "0.1.0",
+        tmp_path / "ambient/site-packages/sugar_lift_py_tests/__init__.py",
+    )
+
+    assert authenticate_lift(truthful, repo).loaded_from.is_relative_to(expected)
+    with pytest.raises(
+        ExecutionEnvironmentMismatch, match="lift import escaped the synced checkout"
+    ):
+        authenticate_lift(foreign, repo)
+
+
+def test_manifest_cid_is_order_independent_and_path_bound() -> None:
+    assert corpus_manifest_cid(["pandas/b.py", "pandas/a.py"]) == (
+        "sha256:194cbd45be1fdf143d4ed8dca52fb946dc88b5a15198dbef26426ef514503ca6"
+    )
+    assert corpus_manifest_cid(["pandas/a.py"]) != corpus_manifest_cid(["pandas/b.py"])
+
+
+def test_checkout_import_roots_come_from_the_managed_closure_declaration(
+    tmp_path,
+) -> None:
+    repo = tmp_path / "sugar"
+    declared = repo / "implementations/python/sugar-source-tree/src"
+    declared.mkdir(parents=True)
+    dockerfile = repo / "tools/sugar-build/Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text(
+        "ENV PYTHONPATH=/workspace/sugar/implementations/python/sugar-source-tree/src\n",
+        encoding="utf-8",
+    )
+    path = ["ambient"]
+
+    activate_checkout_import_roots(repo, path)
+
+    assert path == [str(declared.resolve()), "ambient"]
+
+
+def test_launcher_refuses_before_pytest_on_environment_mismatch(
+    monkeypatch, capsys
+) -> None:
+    import sugar_lift_py_tests.authenticated_pytest as launcher
+
+    def refuse():
+        raise ExecutionEnvironmentMismatch(
+            "pandas corpus mismatch: imported 2.3.3; required exact 3.0.3"
+        )
+
+    invoked = False
+
+    def forbidden_pytest_main(args):
+        nonlocal invoked
+        invoked = True
+        return 0
+
+    monkeypatch.setattr(launcher, "authenticate_environment", refuse)
+    monkeypatch.setattr(pytest, "main", forbidden_pytest_main)
+
+    assert main(["-q"]) == 78
+    assert invoked is False
+    stderr = capsys.readouterr().err
+    assert "BATTLEAXE EXECUTION ENVIRONMENT REFUSED" in stderr
+    assert "imported 2.3.3; required exact 3.0.3" in stderr
+
+
+def test_bpytest_wrapper_contract_is_collected_by_pytest() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    completed = subprocess.run(
+        ["bash", str(repo / "tests/bpytest_authenticated_wrapper.sh"), str(repo)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "PASS: authenticated bpytest wrapper" in completed.stdout

--- a/tests/test_sugar_build_contract.py
+++ b/tests/test_sugar_build_contract.py
@@ -60,6 +60,7 @@ def test_declared_tool_versions_have_exact_syntax_and_capability_mapping(tmp_pat
 
 @pytest.mark.parametrize(("name", "capabilities", "digest", "binaries", "command", "network"), [
     ("python-unit", ["core", "python-test"], "12ca8a6768630ae70afb37d63a48b5035da365c4c2fe4cd99117ae4327932674", ["sugar"], ["python", "-m", "pytest"], "none"),
+    ("authenticated-python-lift", ["core", "python-scientific", "python-test", "solver-z3"], "f96731de7b4eb9a5660a6f8a14fc37f23ead4a0a9221667e9073ee0853070db3", ["sugar"], ["python", "-m", "sugar_lift_py_tests.authenticated_pytest"], "none"),
     ("python-lift", ["core", "python-scientific", "python-test", "solver-z3"], "f96731de7b4eb9a5660a6f8a14fc37f23ead4a0a9221667e9073ee0853070db3", ["sugar"], ["python", "-m", "pytest"], "none"),
     ("rust-unit", ["core", "solver-z3"], "ea84add5822935318b6be07dba38980b81d947b077b077ca7e6f70febdf2d497", [], ["cargo", "test", "--manifest-path", "implementations/rust/Cargo.toml"], "required"),
     ("examples-gate", ["core", "java", "node", "python-scientific", "python-test", "solver-coq", "solver-z3", "vampire"], "f3474a1e1badba67f3daaf5c589f2844da28a7be6beda929ca5f7f2e5d95785e", ["sugar", "sugar-ir-smt-lib"], ["make", "examples-gate"], "required"),
@@ -101,9 +102,9 @@ def test_python_unit_has_a_distinct_published_test_runtime():
     assert environment["image"] == "ghcr.io/tsavo/sugar-env@sha256:12ca8a6768630ae70afb37d63a48b5035da365c4c2fe4cd99117ae4327932674"
 
 
-def test_bpytest_selects_published_python_unit_task():
+def test_bpytest_selects_authenticated_python_lift_task():
     wrapper = (ROOT / "bin/bpytest").read_text()
-    assert 'exec "$sugarbin" run --host bx --task python-unit -- "$@"' in wrapper
+    assert "authenticated-python-lift" in wrapper
 
 
 def test_pyright_private_node_is_not_the_node_capability():


### PR DESCRIPTION
## What changed

- route bin/bpytest through the immutable scientific Python closure instead of the pytest-only closure
- authenticate pandas and numpy versions, own-site-packages load paths, dist-info agreement, the synced lift import, and the declared pandas manifest CID before pytest collection
- refuse mismatched or leaking environments with a named non-zero exit
- translate bpytest -u into forwarded PYTHONUNBUFFERED=1 rather than passing an invalid pytest flag

## Root cause

The wrapper selected python-unit, whose managed closure did not contain the scientific corpus. Ambient Battleaxe therefore exposed /usr/bin/python3, user-site pandas 2.3.3, and no importable lift. No launcher gate prevented those bytes from becoming measurement input.

## Focused validation

- 44 focused Python tests passed
- authenticated bpytest wrapper contract passed, including -u forwarding
- Battleaxe truthful twin: pandas 3.0.3, numpy 2.5.1, manifest CID sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0, lift from synced checkout, 9 tests passed, exit 0
- Battleaxe lying twin: ambient pandas 2.3.3 from /home/tsavo/.local refused before pytest, exit 78
- Black check, bash syntax check, and git diff --check passed

## Measurement accounting

R_wrong_managed_corpus: 1 -> 0
R_ambient_fallback_acceptance: 1 -> 0
R_bpytest_u_rejection: 1 -> 0

No existing environments were normalized or cleaned. This PR is intentionally unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate managed Python corpus execution before running pytest
> - Adds `authenticated_pytest.py`, an authentication layer that validates pandas/numpy versions, file corpus CID, and import paths against declared managed closure pins before running pytest; exits with code 78 on mismatch.
> - Adds a new `authenticated-python-lift` task in `sugar-build.toml` that runs `python -m sugar_lift_py_tests.authenticated_pytest` with `python-scientific` and `solver-z3` capabilities and no network access.
> - Updates `bin/bpytest` to invoke `authenticated-python-lift` instead of `python-unit`, and to convert the `-u` flag into `PYTHONUNBUFFERED=1` + `--env PYTHONUNBUFFERED` rather than passing it to pytest.
> - Records the expected 1,421-file pandas 3.0.3 corpus manifest CID in `pyproject.toml` under `[tool.sugar.measured-corpus]`.
> - Behavioral Change: `bpytest` now routes through environment authentication on every run; any mismatch in package versions or file corpus aborts the test run before pytest is invoked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 824e5cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->