### PR TITLE
Measure demand table identity across Python runtimes

### DIFF
--- a/bin/bpytest
+++ b/bin/bpytest
@@ -38,11 +38,12 @@ fi
 repo_root="$(cd "$repo_root" && pwd -P)"
 
 pytest_args=()
-sugarbin_args=()
+export SUGAR_BINARY_ALLOW_BUILD=0
+sugarbin_args=(--env SUGAR_BINARY_ALLOW_BUILD)
 for arg in "$@"; do
   if [[ "$arg" == "-u" ]]; then
     export PYTHONUNBUFFERED=1
-    sugarbin_args=(--env PYTHONUNBUFFERED)
+    sugarbin_args+=(--env PYTHONUNBUFFERED)
   else
     pytest_args+=("$arg")
   fi

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -7,6 +7,7 @@ exclude_args=(
   --exclude='target/' --exclude='.git/' --exclude='.jj/' --exclude='.worktrees/'
   --exclude='.claude/' --exclude='.ruff_cache/' --exclude='.venv-test-rust/'
   --exclude='.understand-anything/' --exclude='node_modules/' --exclude='bazel-bin'
+  --exclude='__pycache__/' --exclude='*.py[cod]' --exclude='.pytest_cache/'
   --exclude='bazel-out' --exclude='bazel-sugar' --exclude='bazel-testlogs'
   --exclude='sugar-warnings/' --exclude='sugar-worktrees/'
   --exclude='.sugar/runs/' --exclude='.sugar/witnesses/'
@@ -216,7 +217,13 @@ sugar_bx_build_artifacts_docker() {
     --mount "type=bind,src=$artifacts_source,dst=/out"
     --mount "type=bind,src=$cache_source,dst=/root/.cache/sugar/binaries"
     --mount "type=bind,src=$target_source,dst=/managed-target"
-    "$image" bash -lc "$build_script")
+  )
+  local name
+  for name in ${SUGAR_BX_ENV_NAMES[@]+"${SUGAR_BX_ENV_NAMES[@]}"}; do
+    [[ "$name" != SUGAR_BINARY_ALLOW_BUILD || ${!name+x} != x ]] \
+      || docker_args+=(--env "$name=${!name}")
+  done
+  docker_args+=("$image" bash -lc "$build_script")
   local arg command=""
   for arg in "${docker_args[@]}"; do command+=" $(sugar_bx_quote "$arg")"; done
   sugar_bx_ssh "exec${command}"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -26,6 +26,22 @@ class ImportIdentity:
     loaded_from: Path
 
 
+@dataclass(frozen=True)
+class InterpreterIdentity:
+    implementation: str
+    version: str
+    executable: Path
+
+
+def interpreter_identity() -> InterpreterIdentity:
+    version = sys.version_info
+    return InterpreterIdentity(
+        implementation=sys.implementation.name,
+        version=f"{version.major}.{version.minor}.{version.micro}",
+        executable=Path(sys.executable).absolute(),
+    )
+
+
 def _inside(path: Path, root: Path) -> bool:
     return path == root or root in path.parents
 
@@ -36,11 +52,13 @@ def authenticate_distribution(
     module: ModuleType,
     expected_version: str,
     metadata_version: str,
+    metadata_location: Path,
     purelib: Path,
 ) -> ImportIdentity:
     loaded_from = Path(str(getattr(module, "__file__", ""))).resolve()
     imported_version = str(getattr(module, "__version__", "<missing>"))
     purelib = purelib.resolve()
+    metadata_location = metadata_location.resolve()
     if imported_version != expected_version:
         raise ExecutionEnvironmentMismatch(
             f"{name} corpus mismatch: imported {imported_version} from "
@@ -50,6 +68,11 @@ def authenticate_distribution(
         raise ExecutionEnvironmentMismatch(
             f"{name} loaded from {loaded_from}, outside this interpreter's own "
             f"site-packages {purelib}; refusing a leaking environment"
+        )
+    if not _inside(metadata_location, purelib):
+        raise ExecutionEnvironmentMismatch(
+            f"{name} dist-info loaded from {metadata_location}, outside this "
+            f"interpreter's own site-packages {purelib}; refusing foreign metadata"
         )
     if metadata_version != imported_version:
         raise ExecutionEnvironmentMismatch(
@@ -140,18 +163,22 @@ def authenticate_environment() -> (
     pandas = import_module("pandas")
     numpy = import_module("numpy")
     lift = import_module("sugar_lift_py_tests")
+    pandas_distribution = metadata.distribution("pandas")
+    numpy_distribution = metadata.distribution("numpy")
     pandas_identity = authenticate_distribution(
         name="pandas",
         module=pandas,
         expected_version=pins["pandas"],
-        metadata_version=metadata.version("pandas"),
+        metadata_version=pandas_distribution.version,
+        metadata_location=Path(pandas_distribution.locate_file("")),
         purelib=purelib,
     )
     numpy_identity = authenticate_distribution(
         name="numpy",
         module=numpy,
         expected_version=pins["numpy"],
-        metadata_version=metadata.version("numpy"),
+        metadata_version=numpy_distribution.version,
+        metadata_location=Path(numpy_distribution.locate_file("")),
         purelib=purelib,
     )
     lift_identity = authenticate_lift(lift, repo_root)
@@ -186,8 +213,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 78
 
+    interpreter = interpreter_identity()
     print(
         "authenticated execution environment: "
+        f"python={interpreter.implementation}-{interpreter.version} "
+        f"pythonExecutable={interpreter.executable} "
         f"corpusManifestCid={manifest_cid} "
         f"pandas={pandas_identity.version} pandasPath={pandas_identity.loaded_from} "
         f"numpy={numpy_identity.version} numpyPath={numpy_identity.loaded_from} "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -24,7 +24,7 @@ per-checkout cache wearing a CID. That is the discriminating face, and it is
 the one that proves the key was taken over the preimage rather than the
 location.
 
-RUNTIME IS IN THE KEY, AND THE FIRST ANSWER WAS WRONG.
+RUNTIME IS REPORTED, BUT A MEASURED TWIN REMOVED IT FROM THE CONTENT KEY.
 
 An earlier version of this module excluded runtime identity, on two
 independently-traced verdicts that demand production never CALLS anything
@@ -42,16 +42,19 @@ tree, says so:
 per interpreter for that reason, and it names 3.12 and 3.14 -- which is the
 offload host versus the workstations exactly.
 
-So runtime joins the content key until a measurement says it may leave. The
+So runtime joined the content key until a measurement said it could leave. The
 two failures are not symmetric: a key that is too SPECIFIC costs a rebuild per
 interpreter and announces itself as a cache miss; a key that is too LOOSE
 silently shares a table built under a different parser behind a valid-looking
-CID, and announces nothing. Loudly-lossy over silently-wrong.
+CID, and announces nothing. Loudly-lossy over silently-wrong was the correct
+default while the comparison was absent.
 
-RELAXING IS A MEASUREMENT, NOT AN ARGUMENT. Build the table for one corpus on
-3.12 and on 3.14 and compare. If the CIDs match, runtime may leave the key
-WITH a test pinning that they match. If they differ, the key is already right
-and that comparison is its twin. Until one of those exists, it stays.
+MEASURED RELAXATION. The authenticated producer was run on the same small
+corpus and the same pinned pandas manifest under Battleaxe CPython 3.12.13 and
+workstation CPython 3.14.4. Both produced three demand rows with output CID
+``blake3-512:171cb05a5903a2d929596d9ea33b35432c4f5721f37c5553d2b012063495ee183b0e0281f23f3dbf9ceeadc4d1fb107163e78bfe4d570d457b4a0ae2867fe7fb``.
+The acceptance test pins that output. Runtime therefore stays in the receipt
+and cell-path testimony, but no longer enters the content preimage.
 """
 
 from __future__ import annotations
@@ -102,7 +105,6 @@ class DemandTableIdentityV1:
             "corpusManifestCid": self.corpus_manifest_cid,
             "producerSourceCid": self.producer_source_cid,
             "resolutionConfigCid": self.resolution_config_cid,
-            "parserIdentity": self.parser_identity,
             "fileCount": self.file_count,
         }
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -232,38 +232,26 @@ def test_the_named_exception_is_not_a_producer() -> None:
         )
 
 
-# -- the correction: runtime IS in the key, until measured otherwise ----------
+# -- measured relaxation: runtime is testimony, not content identity ----------
 
 
-def test_the_parser_identity_is_in_the_preimage(tmp_path) -> None:
-    """THE correction.
-
-    An earlier version excluded runtime on two independently-traced verdicts
-    that production never CALLS anything observing the interpreter. Both were
-    correct and both answered the wrong question: production's OUTPUT can
-    differ across interpreters with no such call, because the parse itself is
-    version-dependent. `CPythonAstBackend.fingerprint` documents it and names
-    3.12 versus 3.14 -- the offload host versus the workstations.
-    """
+def test_the_parser_identity_is_reported_but_not_in_the_preimage(tmp_path) -> None:
+    """The measured 3.12/3.14 twin earned runtime's removal from content."""
     import sys
 
     identity = _identity(_corpus(tmp_path / "corpus", _FILES))
 
-    assert identity.preimage()["parserIdentity"] == (
+    assert identity.parser_identity == (
         f"{sys.implementation.name}-{sys.version_info.major}."
         f"{sys.version_info.minor}"
     )
+    assert "parserIdentity" not in identity.preimage()
 
 
-def test_a_different_parser_identity_changes_the_key(tmp_path) -> None:
-    """The tooth. Two interpreters must not share one key while it is unproven
-    that they produce the same table.
-
-    Asymmetric on purpose: a too-specific key costs a rebuild and announces
-    itself as a miss; a too-loose key silently shares a table built under a
-    different parser behind a valid-looking CID. Loudly-lossy over
-    silently-wrong.
-    """
+def test_a_different_parser_identity_preserves_the_measured_content_key(
+    tmp_path,
+) -> None:
+    """3.12 and 3.14 share only after the real output twin proved equality."""
     import sugar_lift_py_tests.demand_table_identity as module
 
     root = _corpus(tmp_path / "corpus", _FILES)
@@ -276,23 +264,18 @@ def test_a_different_parser_identity_changes_the_key(tmp_path) -> None:
     finally:
         module.parser_identity = original
 
-    assert elsewhere != here
+    assert elsewhere == here
 
 
-def test_the_relaxing_condition_is_a_measurement_not_an_argument() -> None:
-    """Records what would let runtime leave the key, so the next reader does
-    not remove it on the strength of the two traces that were already wrong.
-
-    The gate is: build the table for one corpus on 3.12 and on 3.14 and
-    compare CIDs. Matching CIDs plus a test pinning the match is the only
-    thing that earns the removal.
-    """
+def test_the_runtime_relaxation_is_bound_to_the_measured_twin() -> None:
+    """Runtime left only after two authenticated producers matched exactly."""
     from sugar_lift_py_tests import demand_table_identity as module
 
     doc = " ".join((module.__doc__ or "").split())
 
-    assert "RELAXING IS A MEASUREMENT, NOT AN ARGUMENT" in doc
+    assert "MEASURED RELAXATION" in doc
     assert "3.12" in doc and "3.14" in doc
+    assert "171cb05a5903" in doc
 
 
 def test_the_reason_the_first_answer_was_wrong_is_recorded() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
@@ -1,0 +1,78 @@
+"""Measured 3.12/3.14 demand-table output twin on one small corpus."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from sugar_lift_py_tests.authenticated_pytest import (
+    authenticate_environment,
+    interpreter_identity,
+)
+from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_source_tree.cpython_adapter import CPythonAstBackend
+
+_SOURCE = """\
+from contextlib import nullcontext
+
+def render(value, width):
+    with nullcontext(f"value={value:{width}}") as rendered:
+        return rendered
+"""
+
+# Independently produced under authenticated CPython 3.12.13 on Battleaxe and
+# CPython 3.14.4 on the workstation. Both runs named the same pandas manifest
+# CID and produced this exact three-row table CID.
+MEASURED_312_314_OUTPUT_CID = (
+    "blake3-512:171cb05a5903a2d929596d9ea33b35432c4f5721f37c5553d2b012063495ee18"
+    "3b0e0281f23f3dbf9ceeadc4d1fb107163e78bfe4d570d457b4a0ae2867fe7fb"
+)
+MEASURED_PARSER_AST_CIDS = {
+    "cpython-ast-cpython-3.12": (
+        "blake3-512:9981672e8b2c342a55f1c6f9e063bb4df7ae79b705aebf5c8c13c351d0574cf"
+        "bf632e8cfab087382857bdf2582e73e92e02e2d0ba9dc4ba0fd0ab68e64f66910"
+    ),
+    "cpython-ast-cpython-3.14": (
+        "blake3-512:3bb9334b3359eeb822259f977144f1d05bc5ed5854efa92fd2cb28372a94c3d7"
+        "f1ff3b249358ac7dfd87af98c013c114ab01060515b71c110d2d34514088ff96"
+    ),
+}
+
+
+def test_demand_table_output_interpreter_twin(tmp_path: Path) -> None:
+    """Produce, content-address, and report the real table after corpus auth."""
+    pandas, numpy, lift, manifest_cid = authenticate_environment()
+    corpus = tmp_path / "small-demand-table-corpus"
+    package = corpus / "sample"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "format_context.py").write_text(_SOURCE, encoding="utf-8")
+
+    rows = _preconstruction_demand_rows(corpus)
+    assert rows, "the acceptance corpus produced no demand-table rows"
+    output_cid = cid_of_json(
+        {"kind": "python-preconstruction-demand-table", "rows": rows}
+    )
+    assert output_cid == MEASURED_312_314_OUTPUT_CID
+    interpreter = interpreter_identity()
+    parser_ast_cid = blake3_512_of(
+        ast.dump(ast.parse(_SOURCE), include_attributes=False).encode("utf-8")
+    )
+    parser_identity = CPythonAstBackend().fingerprint()
+    assert parser_ast_cid == MEASURED_PARSER_AST_CIDS[parser_identity]
+    receipt = {
+        "schema": "demand-table-interpreter-twin/v1",
+        "python": f"{interpreter.implementation}-{interpreter.version}",
+        "pythonExecutable": str(interpreter.executable),
+        "parserIdentity": parser_identity,
+        "parserAstCid": parser_ast_cid,
+        "corpusManifestCid": manifest_cid,
+        "pandas": pandas.version,
+        "numpy": numpy.version,
+        "liftPath": str(lift.loaded_from),
+        "demandTableOutputCid": output_cid,
+        "rows": len(rows),
+    }
+    print("DEMAND_TABLE_INTERPRETER_TWIN " + json.dumps(receipt, sort_keys=True))

--- a/tests/bpytest_authenticated_wrapper.sh
+++ b/tests/bpytest_authenticated_wrapper.sh
@@ -13,12 +13,14 @@ cat >"$fixture/bin/sugarbin" <<'SH'
 #!/usr/bin/env bash
 printf '%s\0' "$@" >"$SUGARBIN_WRAPPER_LOG"
 printf '%s' "${PYTHONUNBUFFERED:-}" >"$SUGARBIN_WRAPPER_ENV_LOG"
+printf '%s' "${SUGAR_BINARY_ALLOW_BUILD:-}" >"$SUGARBIN_WRAPPER_BUILD_POLICY_LOG"
 exit "${SUGARBIN_WRAPPER_STATUS:-0}"
 SH
 chmod +x "$fixture/bin/sugarbin"
 
 export SUGARBIN_WRAPPER_LOG="$tmp/args.log"
 export SUGARBIN_WRAPPER_ENV_LOG="$tmp/env.log"
+export SUGARBIN_WRAPPER_BUILD_POLICY_LOG="$tmp/build-policy.log"
 
 assert_args() {
   python3 - "$SUGARBIN_WRAPPER_LOG" "$@" <<'PY'
@@ -35,14 +37,16 @@ PY
 }
 
 status=0
-(cd "$fixture" && SUGARBIN_WRAPPER_STATUS=37 bin/bpytest -q tests/unit) || status=$?
+(cd "$fixture" && SUGAR_BINARY_ALLOW_BUILD=1 SUGARBIN_WRAPPER_STATUS=37 bin/bpytest -q tests/unit) || status=$?
 [[ "$status" -eq 37 ]] || { echo "bpytest returned $status, expected 37" >&2; exit 1; }
-assert_args run --host bx --task authenticated-python-lift -- -q tests/unit
+[[ "$(cat "$SUGARBIN_WRAPPER_BUILD_POLICY_LOG")" == 0 ]] || { echo "bpytest did not refuse binary builds" >&2; exit 1; }
+assert_args run --host bx --env SUGAR_BINARY_ALLOW_BUILD --task authenticated-python-lift -- -q tests/unit
 
 status=0
 (cd "$fixture" && SUGARBIN_WRAPPER_STATUS=41 bin/bpytest -u -q tests/unit) || status=$?
 [[ "$status" -eq 41 ]] || { echo "bpytest -u returned $status, expected 41" >&2; exit 1; }
 [[ "$(cat "$SUGARBIN_WRAPPER_ENV_LOG")" == 1 ]] || { echo "bpytest -u did not set PYTHONUNBUFFERED=1" >&2; exit 1; }
-assert_args run --host bx --env PYTHONUNBUFFERED --task authenticated-python-lift -- -q tests/unit
+[[ "$(cat "$SUGARBIN_WRAPPER_BUILD_POLICY_LOG")" == 0 ]] || { echo "bpytest -u did not refuse binary builds" >&2; exit 1; }
+assert_args run --host bx --env SUGAR_BINARY_ALLOW_BUILD --env PYTHONUNBUFFERED --task authenticated-python-lift -- -q tests/unit
 
 echo "PASS: authenticated bpytest wrapper"

--- a/tests/sugarbin_bx_exec.sh
+++ b/tests/sugarbin_bx_exec.sh
@@ -49,6 +49,9 @@ status=0
 BX_FAKE_REMOTE_STATUS=41 run_bx -- "$repo_root/tools/check.sh" "two words" >/dev/null || status=$?
 [[ "$status" -eq 41 ]] || fail "remote exit status was $status, want 41"
 [[ "$(grep -c -- '-azR --delete' "$rsync_log")" -eq 1 ]] || fail "workspace must use exactly one rsync"
+grep -Fq -- '--exclude=__pycache__/' "$rsync_log" || fail "workspace sync admitted interpreter-specific __pycache__ output"
+grep -Fq -- '--exclude=*.py[cod]' "$rsync_log" || fail "workspace sync admitted compiled Python bytecode"
+grep -Fq -- '--exclude=.pytest_cache/' "$rsync_log" || fail "workspace sync admitted local pytest cache output"
 inner="$(grep -F 'exec ' "$ssh_log" || true)"
 [[ "$inner" == *"/sugar/implementations/rust"* ]] || fail "repo-relative cwd not preserved: $inner"
 [[ "$inner" == *"/sugar/tools/check.sh"* ]] || fail "repo path not translated: $inner"

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -100,6 +100,11 @@ if grep -F 'bin/sugarbin --platform' "$tmp/ssh.log" | grep -Fvq "'docker' 'run'"
 fi
 [[ "$line" == *"'$python_test_ref'"* ]] || fail "python-unit did not select managed test closure"
 [[ "$line" == *"'python' '-m' 'pytest' '-q'"* ]] || fail "python-unit command did not always execute"
+
+: >"$tmp/docker.log"
+SUGAR_BINARY_ALLOW_BUILD=0 run run --host bx --env SUGAR_BINARY_ALLOW_BUILD --task python-unit -- -q >/dev/null
+build_line="$(head -1 "$tmp/docker.log")"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_ALLOW_BUILD=0'"* ]] || fail "managed artifact resolver did not inherit fail-fast binary policy: $build_line"
 : >"$tmp/docker.log"
 solver_ref="$(python3 "$repo/tools/sugar-build/contract.py" resolve-environment docker:solver-z3 | python3 -c 'import json,sys; print(json.load(sys.stdin)["image"])')"
 [[ "$solver_ref" == *@sha256:* && "$solver_ref" != "$core_ref" ]] || fail "solver closure did not select its own fixture image"

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 import subprocess
+import sys
 from types import ModuleType
 
 import pytest
@@ -13,6 +14,7 @@ from sugar_lift_py_tests.authenticated_pytest import (
     authenticate_distribution,
     authenticate_lift,
     corpus_manifest_cid,
+    interpreter_identity,
     main,
 )
 
@@ -34,6 +36,7 @@ def test_truthful_distribution_inside_own_site_packages_is_accepted(tmp_path) ->
         module=module,
         expected_version="3.0.3",
         metadata_version="3.0.3",
+        metadata_location=purelib,
         purelib=purelib,
     )
 
@@ -51,6 +54,7 @@ def test_lying_233_distribution_is_refused_loudly(tmp_path) -> None:
             module=module,
             expected_version="3.0.3",
             metadata_version="2.3.3",
+            metadata_location=purelib,
             purelib=purelib,
         )
 
@@ -69,6 +73,7 @@ def test_leaking_distribution_outside_own_site_packages_is_refused(tmp_path) -> 
             module=module,
             expected_version="3.0.3",
             metadata_version="3.0.3",
+            metadata_location=foreign,
             purelib=purelib,
         )
 
@@ -83,6 +88,26 @@ def test_dist_info_disagreement_is_refused(tmp_path) -> None:
             module=module,
             expected_version="3.0.3",
             metadata_version="3.0.5",
+            metadata_location=purelib,
+            purelib=purelib,
+        )
+
+
+def test_same_version_foreign_dist_info_is_refused(tmp_path) -> None:
+    purelib = tmp_path / "managed/lib/python3.12/site-packages"
+    foreign = tmp_path / "ambient/lib/python3.12/site-packages"
+    module = fake_module("pandas", "3.0.3", purelib / "pandas/__init__.py")
+
+    with pytest.raises(
+        ExecutionEnvironmentMismatch,
+        match="dist-info loaded from.*outside this interpreter's own site-packages",
+    ):
+        authenticate_distribution(
+            name="pandas",
+            module=module,
+            expected_version="3.0.3",
+            metadata_version="3.0.3",
+            metadata_location=foreign,
             purelib=purelib,
         )
 
@@ -111,6 +136,16 @@ def test_manifest_cid_is_order_independent_and_path_bound() -> None:
         "sha256:194cbd45be1fdf143d4ed8dca52fb946dc88b5a15198dbef26426ef514503ca6"
     )
     assert corpus_manifest_cid(["pandas/a.py"]) != corpus_manifest_cid(["pandas/b.py"])
+
+
+def test_selected_interpreter_identity_is_named() -> None:
+    identity = interpreter_identity()
+
+    assert identity.implementation == sys.implementation.name
+    assert identity.version == (
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
+    assert identity.executable == Path(sys.executable).absolute()
 
 
 def test_checkout_import_roots_come_from_the_managed_closure_declaration(


### PR DESCRIPTION
## Headline

Authenticated CPython 3.12.13 and CPython 3.14.4 produced the same real three-row demand-table output CID:

`blake3-512:171cb05a5903a2d929596d9ea33b35432c4f5721f37c5553d2b012063495ee183b0e0281f23f3dbf9ceeadc4d1fb107163e78bfe4d570d457b4a0ae2867fe7fb`

The fixture exercises the documented parser difference: its raw AST CIDs differ and are pinned for both runtimes. Therefore runtime remains named in receipts and cell-path testimony but is removed from the demand-table content-key preimage.

## What changed

- report the selected interpreter implementation, full version, and executable in authenticated launcher receipts
- bind pandas/numpy dist-info location to the selected interpreter's own site-packages, including a same-version foreign-metadata lying twin
- add an authenticated real-producer 3.12/3.14 demand-table acceptance twin
- pin the distinct parser AST CIDs and identical demand-table output CID
- remove parser identity from only the demand-table content-key preimage after that measurement

## Focused validation

- post-rebase focused suite: 61 passed
- wrapper contract: passed, including `bpytest -u` translation
- workstation truthful twin: CPython 3.14.4, pandas 3.0.3, numpy 2.5.1, manifest `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`, exit 0
- Battleaxe truthful twin: CPython 3.12.13, same corpus manifest and output CID, exit 0
- Battleaxe lying twin: ambient pandas 2.3.3 from `/home/tsavo/.local/...` refused before pytest, exit 78
- Black check, Bash syntax, and `git diff --check`: passed
- independent scope/authentication re-review: clean

PR #6462, containing the launcher foundation, was merged externally while this scope addition was being completed. This PR is rebased onto that merged state and is intentionally left open and draft.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Measure demand table identity across Python runtimes by removing parser identity from content preimage
> - Removes `parserIdentity` from `DemandTableIdentityV1.preimage()` after a measured twin between CPython 3.12.13 and 3.14.4 confirmed identical demand-table CIDs; runtime remains in receipt/testimony only.
> - Adds `interpreter_identity()` in [authenticated_pytest.py](https://github.com/TSavo/sugar/pull/6463/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120) to capture Python implementation, version, and executable path.
> - Extends `authenticate_distribution` with a `metadata_location` parameter that rejects distributions whose dist-info directory falls outside the interpreter's own site-packages.
> - Adds a new integration test in [test_demand_table_interpreter_twin.py](https://github.com/TSavo/sugar/pull/6463/files#diff-e38143f960e267cf09b853231140fa148d68d00865bdf9e770f2084dda863469) that asserts the demand-table CID matches a fixed CPython 3.12/3.14 twin CID.
> - Behavioral Change: content keys for demand tables no longer vary by parser identity; existing keys computed with `parserIdentity` in the preimage will differ from keys computed after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35f89d8. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->