### PR TITLE
A constructed list unpacks on the array arm, not the tuple arm

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -56,6 +56,21 @@ class ListValue(FloorValue):
             else FalseBoolLiteralSugar(site=site)
         )
 
+    def project_sequence_with(self, operation, ctx):
+        """Unpack against authenticated reduced members already in hand.
+
+        A constructed list is the same testimony an ``ArrayLiteral`` carries --
+        ``to_term`` projects both as ``array`` -- so it takes the SAME arm.
+        Routing it through ``project_tuple`` would print a tuple diagnostic for
+        an arity mismatch on a list: a correct refusal wearing the wrong name.
+        """
+        return operation.project_array(self, ctx)
+
+    @property
+    def items(self) -> tuple:
+        """Member sequence for SequenceProjectionOperation.project_array."""
+        return self.elements
+
     def length(self, site):
         # A list knows its length: the count of reduced elements.
         del site

--- a/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
@@ -36,6 +36,7 @@ import pytest
 
 from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
 from sugar_lift_py_tests.floor.array_literal import ArrayLiteral
+from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
 from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
@@ -251,17 +252,49 @@ def test_decidable_arity_mismatch_stays_loud(members, names, relation) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_unwritten_projection_floor_stays_loud(tmp_path: Path) -> None:
-    """``a, b = xs[0]`` over a list display: ``ListValue`` has no unpack port.
+def test_list_floor_projection_is_written_and_binds(tmp_path: Path) -> None:
+    """``a, b = xs[0]`` over a list display: ``ListValue`` answers now.
 
-    The members ARE authenticated here, so this is not an undecidable shape --
-    it is an unwritten floor, and it says so. Next owner: the floor value's
-    ``project_sequence_with``.
+    This row previously asserted the panic and named the next owner as
+    ``ListValue.project_sequence_with``. That owner has been written, so it
+    asserts the discharge instead of the gap. It is kept rather than deleted
+    because it is the only reachable-from-source witness that a constructed
+    list reaches the projection port at all -- the members ARE authenticated
+    here, so this was never an undecidable shape.
     """
-    source = "def A(p, q, r, s):\n    xs = [[p, q], [r, s]]\n    a, b = xs[0]\n    return a\n"
+    list_src = "def A(p, q, r, s):\n    xs = [[p, q], [r, s]]\n    a, b = xs[0]\n    return a\n"
+    outcome = _outcome(tmp_path, list_src, "list_floor")
+
+    # The discharge: no ConstructionPanic. What remains is a typed effect, not
+    # a silent success -- the subscript read is still unresolved downstream.
+    assert isinstance(outcome, Incomplete), outcome
+    assert type(outcome.effect).__name__ == "NameErrorEffect"
+
+    # The control, and the whole point of the arm: the TUPLE twin -- which has
+    # had its port all along -- answers identically. The list is now at parity
+    # with its sibling rather than panicking where the sibling does not, and
+    # the residual NameError is a property of `xs[0]`, not of the list.
+    tuple_src = "def A(p, q, r, s):\n    xs = [(p, q), (r, s)]\n    a, b = xs[0]\n    return a\n"
+    twin = _outcome(tmp_path, tuple_src, "tuple_floor")
+    assert isinstance(twin, Incomplete), twin
+    assert type(twin.effect).__name__ == type(outcome.effect).__name__
+
+
+def test_unwritten_projection_floor_stays_loud() -> None:
+    """The law outlives its old reproducer: no arm means a loud gap.
+
+    With ``ListValue`` written, no floor value in the tree still lacks
+    ``project_sequence_with``, so the law can no longer be shown from source.
+    A bare ``FloorValue`` subclass carries it instead: the default arm must
+    still name the frontier rather than silently succeeding, which is what
+    stops the next unwritten value from binding invented members.
+    """
+
+    class UnwrittenFloorValue(FloorValue):
+        pass
+
     with pytest.raises(ConstructionPanic) as raised:
-        _outcome(tmp_path, source, "list_floor")
+        _operation("a", "b").submit(UnwrittenFloorValue(), None)
     info = raised.value.info
     assert info.requested == "project_sequence_with"
-    assert info.observed == "ListValue"
-    assert info.owner == "DynamicUnpackAssignSugar"
+    assert info.observed == "UnwrittenFloorValue"

--- a/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
@@ -298,3 +298,15 @@ def test_unwritten_projection_floor_stays_loud() -> None:
     info = raised.value.info
     assert info.requested == "project_sequence_with"
     assert info.observed == "UnwrittenFloorValue"
+    # The third axis the old row carried: a frontier named without an owner is
+    # half a diagnostic. The synthetic form cannot make the old claim -- there is
+    # no sugar in this row, so `owner` is whatever the submitting operation was
+    # built with, and asserting the module helper's own string back would be an
+    # echo, not a test. It asserts the weaker thing it actually shows: the gap
+    # PROPAGATES the submitter's owner rather than losing it or inventing one.
+    probe = SequenceProjectionOperation(
+        target_names=("a", "b"), owner="unwritten-floor-probe", blame="probe-site"
+    )
+    with pytest.raises(ConstructionPanic) as probed:
+        probe.submit(UnwrittenFloorValue(), None)
+    assert probed.value.info.owner == "unwritten-floor-probe"

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_list_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_list_value.py
@@ -2,12 +2,16 @@
 
 ``ListValue`` had no ``project_sequence_with`` arm, so it fell to the
 ``FloorValue`` default and panicked with ``requested='project_sequence_with'``.
-The reachable path is narrow and worth naming exactly, because the obvious
-statement of the gap is wrong: a bare ``a, b = [1, 2]`` submits NO projection
+The reachable set is worth naming exactly, because the obvious statement of the
+gap is wrong in BOTH directions. A bare ``a, b = [1, 2]`` submits NO projection
 demand -- the unpack sugar reads the display's members directly and the port is
-never entered -- so constructed lists are not broadly broken. The one path that
-reaches the port is a list UNDER A GUARD, where ``GuardedValue`` distributes the
-operation into each face and the list face is asked the question directly.
+never entered -- so constructed lists are not broadly broken. But the gap is
+also not guard-only, which is what an earlier draft of this file claimed: two
+paths reach the port. A list UNDER A GUARD, where ``GuardedValue`` distributes
+the operation into each face and the list face is asked directly; and a list
+reached through a SUBSCRIPT, ``a, b = xs[0]`` over a list of lists, which is
+the row asserted in ``test_dynamic_unpack_projection.py`` and is where this gap
+was first written down as an unwritten floor.
 
 The guarded-TUPLE twin below is the control: same shape, same distribution, one
 face-type answered and its twin panicked. That asymmetry is the finding.
@@ -82,13 +86,13 @@ def test_guarded_tuple_twin_answers_identically() -> None:
     assert from_list.value == from_tuple.value
 
 
-def test_unguarded_list_rhs_never_reaches_the_port() -> None:
-    """Scoping the finding: this is why the gap is guard-only.
+def test_direct_submit_binds_from_the_value_s_own_members() -> None:
+    """The unguarded submit, asserted at the port rather than from source.
 
-    ``ListValue`` answers the port now, so the bug is not observable here --
-    but the reason a bare ``a, b = [1, 2]`` was never broken is that the sugar
-    reads the display directly. Asserting the direct submit still keeps this
-    row honest about which member testimony is used.
+    A bare ``a, b = [1, 2]`` never reaches the port -- the sugar reads the
+    display directly -- so this row does not claim a source-level path. It
+    asserts the narrower thing it actually shows: submitted directly, the list
+    answers from the members it holds and does not consult anything else.
     """
     outcome = _operation("a", "b").submit(
         ListValue((TermValue(7), TermValue(8))), None

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_list_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_list_value.py
@@ -1,0 +1,124 @@
+"""``a, b = <rhs>`` where the reduced RHS is a constructed ``ListValue``.
+
+``ListValue`` had no ``project_sequence_with`` arm, so it fell to the
+``FloorValue`` default and panicked with ``requested='project_sequence_with'``.
+The reachable path is narrow and worth naming exactly, because the obvious
+statement of the gap is wrong: a bare ``a, b = [1, 2]`` submits NO projection
+demand -- the unpack sugar reads the display's members directly and the port is
+never entered -- so constructed lists are not broadly broken. The one path that
+reaches the port is a list UNDER A GUARD, where ``GuardedValue`` distributes the
+operation into each face and the list face is asked the question directly.
+
+The guarded-TUPLE twin below is the control: same shape, same distribution, one
+face-type answered and its twin panicked. That asymmetry is the finding.
+
+Law: a constructed list answers from its own authenticated members, on the
+``project_array`` arm -- the same arm ``ArrayLiteral`` takes. Both project to
+``ctor("array", ...)`` in ``to_term``, and the arm choice is observable: it is
+what names the value in a decidable arity-mismatch diagnostic. Delegating to
+``project_tuple`` would stop the panic while printing a tuple diagnostic for a
+list, which is a correct refusal wearing the wrong name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+from sugar_lift_py_tests.floor.list_value import ListValue
+from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.operations import SequenceProjectionOperation
+from sugar_lift_py_tests.outcome import Complete
+
+GUARD = atomic("py.truthy", [make_var("c")])
+
+
+def _operation(*names: str) -> SequenceProjectionOperation:
+    return SequenceProjectionOperation(
+        target_names=names, owner="list-unpack", blame="list-unpack-site"
+    )
+
+
+def _guarded(true_face):
+    """``true_face`` under the guard, against a fixed authenticated tuple."""
+    return GuardedValue(
+        GUARD, true_face, TupleLiteralValue((TermValue(3), TermValue(4)))
+    )
+
+
+# ---------------------------------------------------------------------------
+# The reachable path: a list face under a guard, and its tuple twin.
+# ---------------------------------------------------------------------------
+
+
+def test_guarded_list_face_binds_its_authenticated_members() -> None:
+    outcome = _operation("a", "b").submit(
+        _guarded(ListValue((TermValue(1), TermValue(2)))), None
+    )
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == ScopeRebinds(
+        (
+            ("a", GuardedValue(GUARD, TermValue(1), TermValue(3))),
+            ("b", GuardedValue(GUARD, TermValue(2), TermValue(4))),
+        )
+    )
+
+
+def test_guarded_tuple_twin_answers_identically() -> None:
+    """The control: the same shape with a tuple face, which already worked.
+
+    Both rows must produce the SAME rebinds. If they ever diverge, the list arm
+    is doing something other than what its sibling does.
+    """
+    names = _operation("a", "b")
+    from_list = names.submit(_guarded(ListValue((TermValue(1), TermValue(2)))), None)
+    from_tuple = names.submit(
+        _guarded(TupleLiteralValue((TermValue(1), TermValue(2)))), None
+    )
+    assert from_list.value == from_tuple.value
+
+
+def test_unguarded_list_rhs_never_reaches_the_port() -> None:
+    """Scoping the finding: this is why the gap is guard-only.
+
+    ``ListValue`` answers the port now, so the bug is not observable here --
+    but the reason a bare ``a, b = [1, 2]`` was never broken is that the sugar
+    reads the display directly. Asserting the direct submit still keeps this
+    row honest about which member testimony is used.
+    """
+    outcome = _operation("a", "b").submit(
+        ListValue((TermValue(7), TermValue(8))), None
+    )
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == ScopeRebinds((("a", TermValue(7)), ("b", TermValue(8))))
+
+
+# ---------------------------------------------------------------------------
+# The arm is observable: a decidable mismatch names the list, not a tuple.
+# ---------------------------------------------------------------------------
+
+
+def test_list_arity_mismatch_is_loud_and_names_the_array_arm() -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        _operation("a", "b").submit(_guarded(ListValue((TermValue(1),))), None)
+    info = raised.value.info
+    assert "not enough" in info.observed
+    assert "ListValue of 1 members" in info.observed
+    assert "ValueError" in info.requested
+    # Discrimination: the fix is `project_array`, not `project_tuple`. A tuple
+    # diagnostic for a list mismatch is the wrong-name refusal this excludes.
+    assert "array unpack arity mismatch" in info.requested
+    assert "tuple" not in info.requested
+
+
+def test_list_members_are_never_fabricated_or_padded() -> None:
+    """Too many members is equally loud -- no truncation to fit the targets."""
+    with pytest.raises(ConstructionPanic) as raised:
+        _operation("a", "b").submit(
+            _guarded(ListValue((TermValue(1), TermValue(2), TermValue(3)))), None
+        )
+    assert "too many" in raised.value.info.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_list_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_projection_list_value.py
@@ -94,9 +94,7 @@ def test_direct_submit_binds_from_the_value_s_own_members() -> None:
     asserts the narrower thing it actually shows: submitted directly, the list
     answers from the members it holds and does not consult anything else.
     """
-    outcome = _operation("a", "b").submit(
-        ListValue((TermValue(7), TermValue(8))), None
-    )
+    outcome = _operation("a", "b").submit(ListValue((TermValue(7), TermValue(8))), None)
     assert isinstance(outcome, Complete), outcome
     assert outcome.value == ScopeRebinds((("a", TermValue(7)), ("b", TermValue(8))))
 


### PR DESCRIPTION
`ListValue` had no `project_sequence_with`, so a list that reaches
`SequenceProjectionOperation` fell to the `FloorValue` default and panicked with
`observed=ListValue requested=project_sequence_with`. This writes the arm and
discharges the marker row that pinned the gap as unwritten.

## The gap is narrower than it looks

A bare `a, b = [1, 2]` submits **no** projection demand at all — the unpack sugar
reads the display's members directly — so constructed lists were not broadly
broken. The path that reaches the port is a list **under a guard**, where
`GuardedValue` distributes the operation into each face and the list face is
asked directly. The guarded-tuple twin is the control: same shape, same
distribution, one face answered and its twin panicked.

Correction to my own first statement of this: I asserted the negative over "the
one path that reaches the port" before I had searched the space. `a, b = xs[0]`
had no guard in it at all and reaches the port too. The scoped claim is: *of the
shapes exercised by these rows*, the guarded face and the subscript read are the
two that reach it.

## Why `project_array`, not `project_tuple`

Term identity. `list_value.py` and `array_literal.py` both project to
`ctor("array", ...)` in `to_term`. The choice is observable, because
`_arity_mismatch_gap` interpolates `display` verbatim into `requested` —
delegating to `project_tuple` would stop the panic while printing a *tuple*
diagnostic for a list, a correct refusal wearing the wrong name. The mismatch row
asserts `"array unpack arity mismatch"` is present and `"tuple"` is absent.

## The control changed the assertion

`test_list_floor_projection_is_written_and_binds` was going to assert `Complete`.
Running the tuple sibling first showed `Incomplete(NameErrorEffect)` on **both** —
the residual belongs to the subscript shape, not to the list. So the row asserts
parity-with-the-twin, which is what the arm actually earns. Asserting the outcome
I expected rather than the one I measured would have been a lying twin I authored
myself, and it would have passed.

## Law 7 on a synthetic carrier

With `ListValue` written, **no floor value in the tree still lacks
`project_sequence_with`**, so `test_unwritten_projection_floor_stays_loud` can no
longer be demonstrated from production source. Deleting it loses the law the next
time someone adds a floor value; so it now hangs off a bare `FloorValue` subclass
declared in the test. A reader who finds a test pointing at a class with no
production callers should read it as the law's carrier, not as dead code.

## Receipts

Base `d31ce3595` (current `origin/main`), tip `6e7efdde4`. The differential is
**two separate worktrees**, not an in-place `git checkout` A/B — base detached at
`d31ce3595` in its own tree, with the reproducer file copied in at digest
`4203d4c8…`, byte-identical to the tip copy. Both arms share one prebuilt
`sugar` binary (`b65b88d0…`), so the only difference between them is one file:

| file | base | tip |
|---|---|---|
| `floor/list_value.py` | `0ae34951…` | `1b541364…` |

**Reproducer red→green** — `test_unpack_projection_list_value.py`, 5 rows:
`5 failed` at base (all five trace to the same
`ConstructionPanic: observed=ListValue requested=project_sequence_with`; the
tuple-twin row fails only because it submits the list face first), all green at tip.

**Marker green→red** — the pre-change `test_unwritten_projection_floor_stays_loud`
passes at base and fails against the tip src with `DID NOT RAISE ConstructionPanic`.
The marker stops testifying at the exact line the fix lands, rather than continuing
to pass after the gap it pinned is gone.

**Owning-package rows at the tip:** `18 passed in 203.89s`
(`test_dynamic_unpack_projection.py` + `test_unpack_projection_list_value.py`) at
`6e7efdde4`. No new crash or timeout axis. The full `sugar-lift-py-tests` surface
is **not** quoted here: its baseline is red for reasons that predate this branch,
and an unpaired number would not be a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `ListValue` sequence projection through the array arm instead of panicking
> - Adds `project_sequence_with` to `ListValue` in [list_value.py](https://github.com/TSavo/sugar/pull/6465/files#diff-eeacaa87aa5806ebb12e29086e825199b416c15725bb8735d0c4c86c747515bf) so it calls `operation.project_array` rather than hitting the unimplemented default path.
> - Adds an `items` property on `ListValue` returning `self.elements`, satisfying the interface expected by `SequenceProjectionOperation.project_array`.
> - Updates tests so list unpack no longer expects a `ConstructionPanic` but instead expects the same `Incomplete`/`NameErrorEffect` outcome as tuple unpack.
> - Adds a new test module covering `ListValue` array projection, including arity mismatch diagnostics and parity with the tuple arm.
> - Behavioral Change: unpacking a constructed list now succeeds (or raises a typed arity error) instead of raising an unimplemented panic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e01d30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->