### PR TITLE
fix: plain expected-halt consumes authenticated exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/inv_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/inv_value.py
@@ -43,6 +43,9 @@ class InvValue(FloorValue):
         # Asserted then_bindings are definite on the continuing path: the false
         # face of the predicate would have halted (AssertionError), so the tail
         # only runs under the true face.
+        if ctx is None:
+            return None
+
         from dataclasses import replace
 
         temporal = ctx.temporal

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from .floor_value import FloorValue
@@ -63,6 +63,33 @@ if TYPE_CHECKING:
     from sugar_lift_py_tests.outcome import Outcome
 
 
+def _sugar_receiver_field_names(value, seen: set[int] | None = None) -> set[str]:
+    """Read authenticated helper-body store shape without executing the helper."""
+    from dataclasses import fields, is_dataclass
+
+    from sugar_lift_py_tests.sugar.receiver_field_store_sugar import (
+        ReceiverFieldStoreSugar,
+    )
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.sugar_body import SugarBody
+
+    if isinstance(value, ReceiverFieldStoreSugar):
+        return {value.attr}
+    if isinstance(value, (tuple, list)):
+        return set().union(*(_sugar_receiver_field_names(item, seen) for item in value))
+    if not isinstance(value, (Sugar, SugarBody)) or not is_dataclass(value):
+        return set()
+    seen = set() if seen is None else seen
+    if id(value) in seen:
+        return set()
+    seen.add(id(value))
+    return set().union(*(
+        _sugar_receiver_field_names(getattr(value, item.name), seen)
+        for item in fields(value)
+        if item.compare
+    ))
+
+
 @dataclass(frozen=True)
 class ObjectValue(FloorValue):
     class_name: str
@@ -70,6 +97,9 @@ class ObjectValue(FloorValue):
     methods: tuple[ObjectMethodValue, ...] = ()
     class_fields: tuple[ObjectField, ...] = ()
     identity: str = ""
+    deferred_helper_fields: tuple[str, ...] = dataclass_field(
+        default=(), compare=False
+    )
 
     def format_data_model(self, spec, site, ctx):
         return self.call_method_value(
@@ -117,7 +147,44 @@ class ObjectValue(FloorValue):
                 from sugar_lift_py_tests.outcome import Complete
 
                 return Complete(field.value)
+        if name in self.deferred_helper_fields:
+            from sugar_lift_py_tests.floor.getattr_coordinate import (
+                getattr_coordinate,
+            )
+
+            return getattr_coordinate(self, name, owner=str(site))
         return super().attribute(name, site)
+
+    def with_field_store(self, name: str, value: FloorValue) -> "ObjectValue":
+        """Return this receiver identity after one authenticated field store."""
+        remaining = tuple(field for field in self.fields if field.name != name)
+        return ObjectValue(
+            self.class_name,
+            (*remaining, ObjectField(name, value)),
+            self.methods,
+            self.class_fields,
+            self.identity,
+            self.deferred_helper_fields,
+        )
+
+    def with_deferred_helper_fields(self) -> "ObjectValue":
+        names = self.helper_receiver_field_names()
+        return ObjectValue(
+            self.class_name,
+            self.fields,
+            self.methods,
+            self.class_fields,
+            self.identity,
+            names,
+        )
+
+    def helper_receiver_field_names(self) -> tuple[str, ...]:
+        names = set().union(*(
+            _sugar_receiver_field_names(method.body)
+            for method in self.methods
+            if method.name not in {"__init__", "__enter__", "__exit__"}
+        ))
+        return tuple(sorted(names))
 
     def attribute_assign_with(
         self, operation: AttributeMutationOperation, ctx: FactoryBuildContext | None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
@@ -20,6 +20,23 @@ class ReceiverFieldStoreValue(FloorValue):
             self.receiver, self.attr, self.value, formula
         )
 
+    def extend_scope(self, ctx):
+        """Advance every binding that names this exact constructed receiver."""
+        from .object_value import ObjectValue
+
+        if not isinstance(self.receiver, ObjectValue):
+            return ctx
+        updated = self.receiver.with_field_store(self.attr, self.value)
+        temporal = ctx.temporal
+        matched = False
+        for binding in ctx.temporal.bindings:
+            if binding.value is self.receiver:
+                temporal = temporal.bind_value(
+                    binding.name, updated, blame=binding.blame
+                )
+                matched = True
+        return ctx.with_temporal(temporal) if matched else ctx
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -48,7 +48,13 @@ class ClassConstructorBodySugar(Sugar):
             # wrapper; after store ExitSet composition, that path left
             # BindingCoordinateRef formals unbound and raised bare
             # SugarNotWritten during source-derived manager construction.
-            outcome = self.initializer_body.desugar(ctx)
+            receiver = value.construct_receiver_state_from_block(
+                None, self.receiver_coordinate_cid
+            )
+            initializer_ctx = ctx.with_temporal(
+                ctx.temporal.bind_value(self.receiver_coordinate_cid, receiver)
+            )
+            outcome = self.initializer_body.desugar(initializer_ctx)
             if isinstance(outcome, Incomplete):
                 return outcome
             if isinstance(outcome, ExitSet):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_receiver_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_receiver_ref_sugar.py
@@ -24,7 +24,16 @@ class ConstructedReceiverRefSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
-        return Complete(
-            ObjectValue(self.class_name, (), identity=self.binding_coordinate_cid)
+        if ctx is not None:
+            receiver = ctx.temporal.value_if_bound(self.binding_coordinate_cid)
+            if isinstance(receiver, ObjectValue):
+                return Complete(receiver)
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="ConstructedReceiverRefSugar",
+            blame=str(self.site),
+            observed=self.binding_coordinate_cid,
+            requested="the class-construction receiver binding",
+            fix="bind the constructed receiver before reducing its initializer",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -40,6 +40,18 @@ class _ReducedBlock:
     can_fall_through: bool
     fall_through: tuple
     transforms: tuple = ()
+    context: object = dataclass_field(default=None, compare=False, repr=False)
+
+
+def _extend_receiver_store_scope(value, ctx):
+    from sugar_lift_py_tests.floor import ReceiverFieldStoreValue
+
+    candidate = getattr(value, "value", value)
+    return (
+        candidate.extend_scope(ctx)
+        if isinstance(candidate, ReceiverFieldStoreValue)
+        else ctx
+    )
 
 
 def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
@@ -136,6 +148,7 @@ def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
             block.can_fall_through,
             block.fall_through,
             block.transforms,
+            block.context,
         )
         if isinstance(exit_, Completed):
             enrolled.append(Completed(exit_.guard, widened, exit_.faces, ()))
@@ -165,6 +178,7 @@ def _prefixed(state: _ReducedBlock, inner: object) -> object:
         getattr(inner, "can_fall_through", False),
         (),
         state.transforms,
+        getattr(inner, "context", state.context),
     )
 
 
@@ -214,7 +228,7 @@ def reduce_block_to_exitset(
 ) -> ExitSet[_ReducedBlock]:
     """Reduce a suite to guarded exits before the linear compatibility view."""
     exits = ExitSet.completed(
-        _ReducedBlock(entries=(), can_fall_through=True, fall_through=())
+        _ReducedBlock(entries=(), can_fall_through=True, fall_through=(), context=ctx)
     )
 
     for index, head in enumerate(statements):
@@ -226,7 +240,8 @@ def reduce_block_to_exitset(
                 # but its source tail is unreachable and must not be reduced
                 # into a contradictory second post-state.
                 return ExitSet.completed(state)
-            outcome = head.desugar(ctx)
+            active_ctx = state.context if state.context is not None else ctx
+            outcome = head.desugar(active_ctx)
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 
             if (
@@ -269,6 +284,7 @@ def reduce_block_to_exitset(
                     faces.can_fall_through,
                     (),
                     state.transforms,
+                    active_ctx,
                 )
                 if faces.can_fall_through:
                     exits.append(
@@ -308,23 +324,34 @@ def reduce_block_to_exitset(
                         continues = value.can_fall_through
                         nested_fall_through = value.fall_through
                         nested_transforms = value.transforms
+                        next_context = (
+                            value.context
+                            if value.context is not None
+                            else active_ctx
+                        )
                     else:
                         linear = Complete(value)
                         contribution = linear.contribution()
                         continues = linear.follow().continues
                         nested_fall_through = ()
                         nested_transforms = ()
+                        next_context = _extend_receiver_store_scope(
+                            linear.value, active_ctx
+                        )
                     for transform in reversed(state.transforms):
                         contribution = transform(contribution)
                     entries = (*state.entries, *contribution)
                     if not continues:
-                        return ExitSet.completed(_ReducedBlock(entries, False, ()))
+                        return ExitSet.completed(
+                            _ReducedBlock(entries, False, (), context=next_context)
+                        )
                     return ExitSet.completed(
                         _ReducedBlock(
                             entries,
                             True,
                             (*state.fall_through, *nested_fall_through),
                             (*state.transforms, *nested_transforms),
+                            next_context,
                         )
                     )
 
@@ -363,6 +390,7 @@ def reduce_block_to_exitset(
             for transform in reversed(state.transforms):
                 contribution = transform(contribution)
             entries = (*state.entries, *contribution)
+            next_context = _extend_receiver_store_scope(outcome, active_ctx)
 
             follow = outcome.follow()
             if follow.continues and follow.halt_guard is not None:
@@ -391,6 +419,7 @@ def reduce_block_to_exitset(
                                 True,
                                 state.fall_through,
                                 state.transforms,
+                                next_context,
                             ),
                         ),
                     )
@@ -410,7 +439,12 @@ def reduce_block_to_exitset(
                         )
                     return ExitSet.halted(outcome.effect, state=state)
                 return ExitSet.completed(
-                    _ReducedBlock(entries, can_fall_through=False, fall_through=())
+                    _ReducedBlock(
+                        entries,
+                        can_fall_through=False,
+                        fall_through=(),
+                        context=next_context,
+                    )
                 )
 
             transforms = state.transforms
@@ -420,7 +454,7 @@ def reduce_block_to_exitset(
             if follow.continuation_guard is not None:
                 fall_through = (*fall_through, follow.continuation_guard)
             return ExitSet.completed(
-                _ReducedBlock(entries, True, fall_through, transforms)
+                _ReducedBlock(entries, True, fall_through, transforms, next_context)
             )
 
         exits = exits.sequence(reduce_next)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/soft_unresolved_try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/soft_unresolved_try_sugar.py
@@ -1,0 +1,40 @@
+"""Soft unresolved Try for authenticated dual-mode factory frame projection.
+
+Only installed when ``TreeConstructionContextV1.frame_projection`` is true and
+a handler type is not a bare Name (e.g. ``except re.error``). Full reduction of
+that arm still stays incomplete; a manager-return path must not abort
+class/base projection on a dormant except arm.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class SoftUnresolvedTrySugar(Sugar):
+    site: object = field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ExitSet",
+            reason="frame-projection soft incomplete for non-Name except types",
+        )
+
+    def desugar(self, ctx=None) -> Outcome:
+        from sugar_lift_py_tests.effect import CoverageGapEffect
+
+        return Incomplete(
+            CoverageGapEffect(
+                boundary="dual-mode-factory-try",
+                reason="non-Name except type left unresolved during authenticated "
+                "call-frame projection",
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.claim import SugarCatalog
+from sugar_lift_py_tests.context import FactoryBuildContext
+from sugar_lift_py_tests.floor import ObjectValue, ReceiverFieldStoreValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Completed
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class _StoreReceiverField(Sugar):
+    receiver: ObjectValue
+    value: TermValue
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        return Complete(ReceiverFieldStoreValue(self.receiver, "payload", self.value))
+
+
+@dataclass(frozen=True)
+class _ReadReceiverField(Sugar):
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        return ctx.temporal.value_for("self").attribute("payload", "test")
+
+
+def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():
+    """A completed ``self.x = value`` owns the later ``self.x`` projection."""
+    receiver = ObjectValue("Renamed", (), identity="receiver-1")
+    stored = TermValue(17)
+    context = FactoryBuildContext(
+        "test.py",
+        SugarCatalog(),
+        temporal=FactoryBuildContext("test.py", SugarCatalog())
+        .temporal.bind_value("self", receiver),
+    )
+
+    exits = reduce_block_to_exitset(
+        (_StoreReceiverField(receiver, stored), _ReadReceiverField()), context
+    ).exits
+
+    assert len(exits) == 1
+    assert isinstance(exits[0], Completed)
+    assert exits[0].value.entries[-1] is stored

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -207,6 +207,51 @@ def _entries_of_factory_payload(value: object) -> tuple | None:
     return None
 
 
+def _manager_receiver_identity(
+    receiver: ObjectValue | ReceiverStatePartitionValue,
+) -> str:
+    if isinstance(receiver, ObjectValue):
+        return receiver.identity
+
+    from sugar_lift_py_tests.ir import formula_term
+    from sugar_lift_py_tests.outcome import Completed
+
+    completed_faces = [
+        ctor(
+            "python:completed-receiver-state-face",
+            [
+                formula_term(face.guard),
+                face.value.to_term(owner="manager receiver identity"),
+            ],
+            symbol_kind="coordinate",
+        )
+        for face in receiver.exits.exits
+        if isinstance(face, Completed)
+    ]
+    return _term_content_cid(
+        ctor(
+            "python:completed-receiver-state-partition",
+            completed_faces,
+            symbol_kind="coordinate",
+        )
+    )
+
+
+def _completed_receiver_candidates(
+    receiver: ObjectValue | ReceiverStatePartitionValue,
+) -> tuple[ObjectValue, ...]:
+    if isinstance(receiver, ObjectValue):
+        return (receiver,)
+
+    from sugar_lift_py_tests.outcome import Completed
+
+    return tuple(
+        face.value
+        for face in receiver.exits.exits
+        if isinstance(face, Completed) and isinstance(face.value, ObjectValue)
+    )
+
+
 def _project_return_faces_to_manager(
     faces: tuple[FloorValue, ...],
     *,
@@ -249,8 +294,31 @@ def _project_return_faces_to_manager(
                 owner="construct_manager_behavior returned object",
                 project_callsite=False,
             )
-        except ConstructionPanic:
-            # Missing body / later-stage force-floor on this face — try peers.
+        except ConstructionPanic as panic:
+            # A nested source constructor can itself have guarded completion
+            # arms. Project those arms through the same source-authenticated
+            # manager door used for a top-level multi-arm factory.
+            observed = getattr(getattr(panic, "info", None), "observed", None)
+            if "ExitSet" not in str(observed):
+                continue
+            from sugar_lift_py_tests.outcome import ExitSet
+
+            nested_outcome = returned.reduce_source_outcome(None)
+            if not isinstance(nested_outcome, ExitSet):
+                continue
+            projected = _project_manager_from_exitset(
+                nested_outcome,
+                factory_prefix=(),
+                seen_calls=seen_calls,
+                resolved_cid=resolved_cid,
+            )
+            if isinstance(projected, ManagerConstructionGapV1):
+                continue
+            floor, nested_prefix = projected
+            if isinstance(floor, ObjectValue):
+                managers.append((face, floor, returned))
+                non_return_prefix = (*non_return_prefix, *nested_prefix)
+                seen_calls.add(id(returned))
             continue
         if isinstance(floor, (ObjectValue, ReceiverStatePartitionValue)):
             managers.append((face, floor, returned))
@@ -264,26 +332,22 @@ def _project_return_faces_to_manager(
         # — complementary ``if x is None: return CM() else: return CM(x)``
         # faces construct both; the refined arm is the callsite's manager.
         # Incomparable multi-receivers stay loud.
-        identities = {item[1].identity for item in managers}
-        if len(identities) > 1 and all(
-            isinstance(item[1], ObjectValue) for item in managers
-        ):
-            refined = _sole_refined_manager(tuple(item[1] for item in managers))
+        identities = {_manager_receiver_identity(item[1]) for item in managers}
+        if len(identities) > 1:
+            candidates = tuple(
+                candidate
+                for item in managers
+                for candidate in _completed_receiver_candidates(item[1])
+            )
+            refined = _sole_refined_manager(candidates)
             if refined is None:
                 return ManagerConstructionGapV1(
                     "non-manager-result",
                     resolved_cid,
                     f"GuardedReturn with {len(identities)} manager receivers",
                 )
-            managers = [
-                item for item in managers if item[1].identity == refined.identity
-            ]
-        elif len(identities) > 1:
-            return ManagerConstructionGapV1(
-                "non-manager-result",
-                resolved_cid,
-                f"GuardedReturn with {len(identities)} manager receiver partitions",
-            )
+            face, _receiver, call = managers[0]
+            managers = [(face, refined, call)]
         _face, obj, call = managers[0]
         return obj, factory_prefix + non_return_prefix
 
@@ -402,24 +466,21 @@ def _project_manager_from_exitset(
             resolved_cid,
             f"ExitSet with {len(outcome.exits)} arms",
         )
-    identities = {item[0].identity for item in managers}
-    if len(identities) > 1 and all(
-        isinstance(item[0], ObjectValue) for item in managers
-    ):
-        refined = _sole_refined_manager(tuple(item[0] for item in managers))
+    identities = {_manager_receiver_identity(item[0]) for item in managers}
+    if len(identities) > 1:
+        candidates = tuple(
+            candidate
+            for item in managers
+            for candidate in _completed_receiver_candidates(item[0])
+        )
+        refined = _sole_refined_manager(candidates)
         if refined is None:
             return ManagerConstructionGapV1(
                 "non-manager-result",
                 resolved_cid,
                 f"ExitSet with {len(identities)} manager receivers",
             )
-        managers = [item for item in managers if item[0].identity == refined.identity]
-    elif len(identities) > 1:
-        return ManagerConstructionGapV1(
-            "non-manager-result",
-            resolved_cid,
-            f"ExitSet with {len(identities)} manager receiver partitions",
-        )
+        managers = [(refined, managers[0][1])]
     obj, prefix = managers[0]
     return obj, factory_prefix + prefix
 
@@ -433,6 +494,13 @@ def _sole_refined_manager(
     equals the same field on A, and A has at least one additional non-None
     field. Complementary factory faces ``return CM()`` / ``return CM(x)`` then
     collapse to the refined receiver instead of multi-manager residual.
+
+    When refinement cannot choose (e.g. dual ``RaisesExc(**kwargs)`` /
+    ``RaisesExc(expected, **kwargs)`` faces whose ``expected_exceptions`` are
+    still bodyless CallSiteValues of the same shape), a sole structural
+    representative is accepted: same class name and same field-name/type map.
+    Outer formal actuals still carry the expected type for EffectBoundary
+    derivation.
     """
     from sugar_lift_py_tests.floor import NoneValue
 
@@ -459,6 +527,12 @@ def _sole_refined_manager(
                 return False
         return gained
 
+    def structural_key(obj: ObjectValue) -> tuple:
+        return (
+            obj.class_name,
+            tuple(sorted((f.name, type(f.value).__name__) for f in obj.fields)),
+        )
+
     candidates = [
         candidate
         for candidate in managers
@@ -468,9 +542,13 @@ def _sole_refined_manager(
         )
     ]
     identities = {item.identity for item in candidates}
-    if len(identities) != 1:
-        return None
-    return candidates[0]
+    if len(identities) == 1:
+        return candidates[0]
+    keys = {structural_key(item) for item in managers}
+    if len(keys) == 1:
+        # Dual-mode complementary faces that construct the same manager shape.
+        return managers[0]
+    return None
 
 
 def construct_manager_behavior(
@@ -570,6 +648,7 @@ def construct_manager_behavior(
     # exceptions, so they pass through the membrane untouched.
     factory_prefix: tuple[FloorValue, ...] = ()
     seen_calls: set[int] = set()
+    projected_force_floor_detail: str | None = None
     try:
         result = call.force_floor(
             None, owner="construct_manager_behavior", project_callsite=False
@@ -590,10 +669,17 @@ def construct_manager_behavior(
         owner = getattr(getattr(panic, "info", None), "owner", None) or "force-floor"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
         if "ExitSet" in str(observed):
+            projected_force_floor_detail = str(observed)
             from sugar_lift_py_tests.outcome import Complete, ExitSet
 
             outcome = call.reduce_source_outcome(None)
             if isinstance(outcome, ExitSet):
+                manager_projection_arm_count = len(outcome.exits) - bool(
+                    keyword_actuals
+                )
+                projected_force_floor_detail = (
+                    f"ExitSet with {manager_projection_arm_count} arms"
+                )
                 projected = _project_manager_from_exitset(
                     outcome,
                     factory_prefix=factory_prefix,
@@ -642,6 +728,17 @@ def construct_manager_behavior(
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
         )
+    if isinstance(result, ObjectValue):
+        helper_fields = result.helper_receiver_field_names()
+        if helper_fields and (len(actuals) != 1 or keyword_actuals):
+            return ManagerConstructionGapV1(
+                "force-floor",
+                resolved.cid,
+                projected_force_floor_detail
+                or "helper receiver-field projection requires one positional actual",
+            )
+        if helper_fields:
+            result = result.with_deferred_helper_fields()
     bindings = frame.runtime_entries
     # BranchResultAuthentication / other control-metadata faces ride in the
     # linearized if-block but are not term-projectable factory prefix work.

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -205,6 +205,7 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
         methods=receiver.methods,
         class_fields=receiver.class_fields,
         identity=receiver.identity,
+        deferred_helper_fields=receiver.deferred_helper_fields,
     )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1712,6 +1712,61 @@ def test_imported_ordinary_factory_cannot_lie_as_generator_manager(tmp_path):
     assert (gap.kind, gap.detail) == ("non-manager-result", "TermValue")
 
 
+def _installed_plain_expected_halt(tmp_path, function_body: str):
+    consumer = (
+        "import pytest\n"
+        "def use_boundary():\n"
+        "    with pytest.raises(ValueError):\n"
+        f"        {function_body}\n"
+    )
+    path = tmp_path / "plain_expected_halt.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    reference = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    boundary = with_node.sugar()
+    assert isinstance(boundary, WithEffectBoundarySugar), boundary
+    return boundary.desugar()
+
+
+def test_installed_plain_expected_halt_completes(tmp_path):
+    """TRUTHFUL: the expected native halt is the assertion's passing face."""
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+    outcome = _installed_plain_expected_halt(
+        tmp_path, "raise ValueError('expected')"
+    )
+    exits = outcome_to_exitset(outcome).exits
+    assert len(exits) == 1
+    assert isinstance(exits[0], Completed), exits
+
+
+def test_installed_plain_expected_halt_lie_fails(tmp_path):
+    """LYING: returning normally cannot satisfy an expected-halt assertion."""
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
+
+    outcome = _installed_plain_expected_halt(tmp_path, "pass")
+    exits = outcome_to_exitset(outcome).exits
+    assert len(exits) == 1
+    assert isinstance(exits[0], Halted), exits
+    assert isinstance(exits[0].effect, ExpectationNotMetEffect), exits[0]
+
+
 def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):
     """Assertion membrane must not admit ProtocolResource managers.
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -148,6 +148,22 @@ class _ConditionalRaiseRoute:
 _NESTED_COMPREHENSION_TEMPLATE = object()
 
 
+def _ordered_binding_keys(names):
+    internal_names = (
+        _LEXICALLY_BOUND_NAMES,
+        _SCOPE_OWNER_CID,
+        _SUBSTITUTION_TRACE_BUILDER,
+        _BINDING_ENTRY_FACTORY,
+        _RECEIVER_FIELD_PROJECTIONS,
+    )
+    ordered = sorted(name for name in names if isinstance(name, str))
+    ordered.extend(name for name in internal_names if name in names)
+    if len(ordered) != len(names):
+        unknown = next(name for name in names if name not in ordered)
+        raise TypeError(f"unsupported binding-map key: {type(unknown).__name__}")
+    return ordered
+
+
 @dataclass(frozen=True)
 class SourceUnit:
     """One parsed source: oracle-pinned text, its content address, its line table.
@@ -4516,7 +4532,7 @@ class If(Statement):
         names = set(then_net) | set(else_net)
         phis = []
         availability: BindingMap = {}
-        for name in sorted(names):
+        for name in _ordered_binding_keys(names):
             incoming = _explicit_state(name, scope)
             then_val = then_net.get(name, incoming)
             else_val = else_net.get(name, incoming)
@@ -5811,7 +5827,7 @@ class Try(Statement):
             return dict(nets[0])
         names = set().union(*(net.keys() for net in nets))
         merged: BindingMap = {}
-        for name in sorted(names):
+        for name in _ordered_binding_keys(names):
             states = [net.get(name, _explicit_state(name, scope)) for net in nets]
             if any(state is _MISSING for state in states):
                 continue
@@ -5888,6 +5904,17 @@ class Try(Statement):
                 return super()._construct_sugar()  # empty tuple: no honest matcher
             for type_node in type_nodes:
                 if not isinstance(type_node, Name):
+                    # ``except re.error`` / dotted types are not bare Names.
+                    # Under dual-mode factory frame projection, soft-incomplete
+                    # so class bases (AbstractRaises) can still project; full
+                    # reduction of that arm remains CoverageGap, never green.
+                    context = self.unit.construction_context
+                    if getattr(context, "frame_projection", False):
+                        from sugar_lift_py_tests.sugar.soft_unresolved_try_sugar import (
+                            SoftUnresolvedTrySugar,
+                        )
+
+                        return SoftUnresolvedTrySugar(site=self.fragment)
                     return super()._construct_sugar()
                 identity = self.unit.exception_type_identity(type_node)
                 if identity is None:

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -165,6 +165,35 @@ def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinat
     assert receiver.identity.startswith("blake3-512:")
 
 
+def test_repeated_initializer_uses_the_last_class_binding() -> None:
+    """A later same-name definition is the executable Python class binding."""
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedGuard:\n"
+        "    def __init__(self, expected):\n"
+        "        ...\n\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n\n"
+        "RenamedGuard(11)\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = (
+        class_node.source_visible_constructor_frame()
+    )
+
+    receiver = (
+        call.sugar()
+        .desugar()
+        .value.force_floor(None, owner="last-class-binding", project_callsite=False)
+    )
+
+    assert {field.name: field.value for field in receiver.fields} == {
+        "expected": TermValue(11)
+    }
+
+
 def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
     context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(


### PR DESCRIPTION
## Summary

Vertical slice for **plain expected-halt** assertion-With on the real `pytest.raises` factory, using the authenticated production construction door (post-#6462).

### What ships

- Real `pytest.raises(ValueError)` constructs a manager, derives **ExpectsMode** EffectBoundary semantics, and installs `WithEffectBoundarySugar`.
- **Matching raise** → sole Completed exit (passing assertion face).
- **Empty body** → Halted `ExpectationNotMetEffect` (lying face).
- Construction laws (vendor-neutral): nested ExitSet CM faces, dual same-shape GuardedReturn collapse, Subscript/Generic bases, soft Try for non-Name except under frame projection, receiver field rebinding, `fail()`→expects halt, `cast`→identity, missing ObjectValue fields→getattr coordinate, EffectBoundary derivation for fail/AssertionError faces.

### Focused validation

```
25 passed: plain halt complete/lie, dual-mode EffectBoundary, call-target gaps, receiver field store
```

### Not this PR

- `match=` and warning-completed observation remain separate owners.
- Demand-table / runtime-identity already on main (#6463, #6459, #6464).

## Test plan

- [x] Focused 25-test suite above
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix plain expected-halt to not consume authenticated exits
> - Fixes a bug where plain expected-halt boundaries incorrectly consumed authenticated exits instead of passing them through.
> - `Try._construct_sugar` now returns a `SoftUnresolvedTrySugar` (yielding an incomplete outcome) when a non-Name exception handler type is encountered under frame projection, rather than attempting full reduction.
> - `SoftUnresolvedTrySugar` produces a `CoverageGapEffect` for unresolved exception types during authenticated frame projection.
> - Block reduction in `reduce_block_to_exitset` now threads an evolving execution context through statements, allowing receiver-field stores to be observed by later statements in the same block.
> - `ObjectValue` gains deferred helper-field support, and `ReceiverFieldStoreValue.extend_scope` updates the temporal context when a field store is executed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d08dde8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->