### PR TITLE
Drain the authenticated receiver-field enter edge

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_real_pandas_plain_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_real_pandas_plain_halt.py
@@ -1,0 +1,39 @@
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+
+
+def test_real_pandas_plain_halt_advances_to_typed_exit_gap():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
+
+    pandas_distribution = metadata.distribution("pandas")
+    install_root = Path(pandas_distribution.locate_file("")).resolve()
+    pandas_root = install_root / "pandas"
+    path = pandas_root / "tests/test_errors.py"
+    assert path.is_file()
+
+    source_file = open_source_file_for_construction(
+        path,
+        root=install_root,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=True,
+    )
+    function = next(
+        function
+        for function in source_file.functions()
+        if function.name == "test_catch_undefined_variable_error"
+    )
+
+    with pytest.raises(ContextManagerResolutionConstructionGap) as raised:
+        function.sugar().desugar()
+
+    gap = raised.value
+    assert gap.kind == "exit-may-halt"
+    assert gap.coordinate.start_line == 84
+    assert gap.coordinate.start_col == 9
+    assert "attribute:ObjectValue" in gap.observed

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -78,7 +78,24 @@ _LEXICALLY_BOUND_NAMES = object()
 _SCOPE_OWNER_CID = object()
 _SUBSTITUTION_TRACE_BUILDER = object()
 _BINDING_ENTRY_FACTORY = object()
+_RECEIVER_FIELD_PROJECTIONS = object()
 _MISSING = object()
+
+
+@dataclass(frozen=True)
+class _ReceiverFieldProjection:
+    receiver_coordinate_cid: str
+    selector: str
+    store_occurrence: object
+    value: "Node"
+
+
+def _receiver_coordinate_cid(receiver) -> str | None:
+    if isinstance(receiver, BindingCoordinateRef):
+        return receiver.coordinate.cid
+    if isinstance(receiver, ConstructedReceiverRef):
+        return receiver.binding_coordinate_cid
+    return None
 
 
 @dataclass(frozen=True)
@@ -1211,6 +1228,9 @@ class Node(Typed):
             return binding
         wrapped: BindingMap = {}
         for local_index, (name, state) in enumerate(binding.items()):
+            if not isinstance(name, str):
+                wrapped[name] = state
+                continue
             if isinstance(state, BindingEntryV1):
                 wrapped[name] = state
                 continue
@@ -3053,6 +3073,24 @@ def _store_target_binding(statement, target, scope):
     }
 
 
+def _receiver_field_projection_binding(statement, target, scope):
+    if not isinstance(target, Attribute):
+        return None
+    receiver_coordinate_cid = _receiver_coordinate_cid(target.value)
+    if receiver_coordinate_cid is None:
+        return None
+    prior = scope.get(_RECEIVER_FIELD_PROJECTIONS)
+    projections = dict(prior) if isinstance(prior, dict) else {}
+    key = (receiver_coordinate_cid, target.attr)
+    projections[key] = _ReceiverFieldProjection(
+        receiver_coordinate_cid=receiver_coordinate_cid,
+        selector=target.attr,
+        store_occurrence=statement.fragment,
+        value=statement.value,
+    )
+    return {_RECEIVER_FIELD_PROJECTIONS: projections}
+
+
 class Assign(Statement):
     targets: Tuple[Expression, ...]
     value: Expression
@@ -3254,6 +3292,9 @@ class Assign(Statement):
                     return threaded
                 if isinstance(target.value, ObjectPlaceStateV1):
                     return None
+                projected = _receiver_field_projection_binding(self, target, scope)
+                if projected is not None:
+                    return projected
             # Name-only nested/flat display unpack.
             name_only = self._destructured_binding()
             if name_only is not None:
@@ -3762,7 +3803,10 @@ class AnnAssign(Statement):
         if isinstance(self.target, Name):
             return {self.target.id: self.value}
         if isinstance(self.target, (Attribute, Subscript)):
-            return _store_target_binding(self, self.target, scope)
+            threaded = _store_target_binding(self, self.target, scope)
+            if threaded is not None:
+                return threaded
+            return _receiver_field_projection_binding(self, self.target, scope)
         return None
 
     def _construct_sugar(self):
@@ -8153,6 +8197,12 @@ class Attribute(Expression):
         from .shadow import rewrite
 
         receiver, changed = self._substitute_field(self.value, scope)
+        receiver_coordinate_cid = _receiver_coordinate_cid(receiver)
+        projections = scope.get(_RECEIVER_FIELD_PROJECTIONS, {})
+        if receiver_coordinate_cid is not None and isinstance(projections, dict):
+            projection = projections.get((receiver_coordinate_cid, self.attr))
+            if isinstance(projection, _ReceiverFieldProjection):
+                return projection.value
         if (
             isinstance(receiver, IfExp)
             and isinstance(receiver.body, ObjectPlaceStateV1)

--- a/implementations/python/sugar-source-tree/tests/test_receiver_field_projection.py
+++ b/implementations/python/sugar-source-tree/tests/test_receiver_field_projection.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor import ObjectValue, ReturnValue, TermValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.temporal import TemporalContext
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _frame(source: str):
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    tree = SourceFile(
+        (source, "renamed_fixture.py", blake3_512_of(source.encode("utf-8")))
+    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function.source_visible_call_frame()
+
+
+class _ReduceCtx:
+    def __init__(self, temporal: TemporalContext) -> None:
+        self.temporal = temporal
+
+
+@pytest.mark.parametrize(
+    ("selector", "annotation"),
+    [("renamed_field", ""), ("another_name", ": object")],
+)
+def test_authenticated_receiver_store_projects_exact_rhs_to_later_read(
+    selector: str,
+    annotation: str,
+) -> None:
+    """Removing Assign's projection or matching a fixed spelling breaks this."""
+    frame = _frame(
+        "def enter(receiver):\n"
+        f"    receiver.{selector}{annotation} = 7\n"
+        f"    return receiver.{selector}\n"
+    )
+    coordinate = frame.formal_coordinates[0]
+    temporal = TemporalContext.empty().bind_value(
+        coordinate.cid,
+        ObjectValue("RenamedManager", (), identity=coordinate.cid),
+    )
+
+    block = frame.body.desugar(_ReduceCtx(temporal)).value
+
+    assert isinstance(block.statements[-1], ReturnValue)
+    assert block.statements[-1].value == TermValue(7)
+
+
+def test_different_authenticated_receiver_does_not_consume_projection() -> None:
+    """Dropping receiver-coordinate discrimination makes this lying twin green."""
+    frame = _frame(
+        "def enter(receiver, other):\n"
+        "    receiver.renamed_field = 7\n"
+        "    return other.renamed_field\n"
+    )
+    first, second = frame.formal_coordinates
+    temporal = (
+        TemporalContext.empty()
+        .bind_value(first.cid, ObjectValue("Manager", (), identity=first.cid))
+        .bind_value(second.cid, ObjectValue("Manager", (), identity=second.cid))
+    )
+
+    with pytest.raises(ConstructionPanic):
+        frame.body.desugar(_ReduceCtx(temporal))


### PR DESCRIPTION
## Summary

Carry exact straight-line receiver-field stores through the existing source-tree substitution temporal. `Assign` and `AnnAssign` publish private testimony keyed by authenticated receiver-coordinate CID plus selector; `Attribute.substitute` consumes only an exact matching coordinate and selector.

This has no pytest, vendor, context-manager, or `excinfo` spelling arm. A different authenticated receiver remains typed-loud.

The real pandas site does **not** construct yet. At `pandas/tests/test_errors.py:84:4`, the exact before/after receipt is:

```text
before: enter-may-halt [attribute:ObjectValue]
after:  exit-may-halt [attribute:ObjectValue]
```

The enter edge is drained. The site now refuses at the named `exit-may-halt` gap. Cross-method receiver state for `RaisesExc.__exit__` is tracked separately in #6468; this PR does not widen into that boundary.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | the real site advances but remains a typed gap |
| `mandatory_panics` | -1 enter edge, +1 named exit edge at same site | boundary advances without claiming site completion |
| `suppressed_descendants` | 0 | no suppression or fallback path added |
| `typed_effects` | 0 | no effect classification changes |
| `silent` | 0 | symbolic and unmatched receivers remain explicitly loud |

## Validation

- Focused gate: `4 passed` — plain and annotated renamed truthful stores, different-coordinate lying twin, and real pandas `exit-may-halt` presence at manager coordinate `(84,9)`.
- Exact `sugar-source-tree` base/head pair at `964dbf95d`:
  - base: `705 passed, 13 failed, 5 skipped`
  - head: `708 passed, 13 failed, 5 skipped`
  - delta: `+3 passed, +0 failed, +0 skipped`
- Native process floor over the real pandas file: `discovered=1 completed=1 timeouts=0 non_native_red=0`, `R_native_crashes=0`.
- Black `26.5.1`: three touched Python files unchanged.
- `git diff --check`: clean.
- Broader `sugar-lift-python-source` telemetry was interrupted after `496 passed / 1 unrelated pandas static-export failure` at 7m38s; it is not reported green.

## Floors preserved

- `silent=0`: the real unresolved site asserts the presence of `ContextManagerResolutionConstructionGap(kind="exit-may-halt")`.
- No test deleted for green; no secret or reconstructed authority added.
- Cross-method object state remains loud and filed as #6468.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drain the authenticated receiver-field enter edge by substituting projected attribute values in scope
> - When a receiver attribute is assigned (`receiver.attr = expr` or `receiver.attr: T = expr`), a `_ReceiverFieldProjection` is recorded in scope keyed by the receiver's coordinate id and attribute name.
> - On a subsequent read of `receiver.attr` within the same substitution context, `Attribute.substitute` checks for a matching projection and returns the RHS directly, bypassing object place state resolution.
> - Non-string binding keys (used by the new projection sentinel `_RECEIVER_FIELD_PROJECTIONS`) are passed through unchanged in `Node._binding_entries` instead of being wrapped with substitution trace entries.
> - Projections are scoped to a specific receiver coordinate, so they do not bleed across different authenticated receivers.
> - Tests in [test_receiver_field_projection.py](https://github.com/TSavo/sugar/pull/6469/files#diff-05448d83f33c6912ffc0379661c6453ac07401fc73bfbb06bcc40238b64c6c13) and [test_real_pandas_plain_halt.py](https://github.com/TSavo/sugar/pull/6469/files#diff-6cdd73374da044e3c77e80653fa36830bb2588d48802794fa80e892b381f5d97) cover both the new happy path and the pandas regression case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6afc41c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->