### PR TITLE
Carry authenticated receiver state across manager methods

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -63,6 +63,8 @@ from .object_field import ObjectField
 from .object_method_value import ObjectMethodValue
 from .object_value import ObjectValue
 from .receiver_field_store_value import ReceiverFieldStoreValue
+from .guarded_receiver_field_store_value import GuardedReceiverFieldStoreValue
+from .receiver_state_partition_value import ReceiverStatePartitionValue
 from .opaque_op_callsite import OpaqueOpCallsite
 from .predicate_value import PredicateValue
 from .raise_value import RaiseValue
@@ -131,6 +133,8 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     RaiseValue,
     RaisesWithValue,
     ReceiverFieldStoreValue,
+    GuardedReceiverFieldStoreValue,
+    ReceiverStatePartitionValue,
     ReturnValue,
     ScopeRebind,
     SequenceConstructor,
@@ -205,6 +209,8 @@ __all__ = [
     "ObjectMethodValue",
     "ObjectValue",
     "ReceiverFieldStoreValue",
+    "GuardedReceiverFieldStoreValue",
+    "ReceiverStatePartitionValue",
     "OpaqueOpCallsite",
     "PredicateValue",
     "RaiseValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -46,12 +46,22 @@ class ClassDefinitionValue(GuardStableValue):
 
     def construct_receiver_state_from_block(self, block, receiver_coordinate_cid):
         from sugar_lift_py_tests.floor import (
+            GuardedReceiverFieldStoreValue,
             ObjectField,
             ObjectMethodValue,
             ObjectValue,
             ReceiverFieldStoreValue,
+            ReceiverStatePartitionValue,
         )
-        from sugar_lift_py_tests.ir import _term_content_cid, ctor, str_const
+        from sugar_lift_py_tests.ir import (
+            _term_content_cid,
+            and_,
+            ctor,
+            not_,
+            str_const,
+        )
+        from sugar_lift_py_tests.outcome import Completed, ExitSet
+        from sugar_lift_py_tests.outcome.exit_set import partition, true_guard
 
         receiver = ObjectValue(
             self.class_name,
@@ -62,6 +72,64 @@ class ClassDefinitionValue(GuardStableValue):
         )
         if block is None:
             return receiver
+        guarded_stores = tuple(
+            statement
+            for statement in block.statements
+            if isinstance(statement, GuardedReceiverFieldStoreValue)
+        )
+        if guarded_stores:
+            states = [(true_guard(), (), frozenset())]
+            for statement in block.statements:
+                if isinstance(statement, ReceiverFieldStoreValue) and not isinstance(
+                    statement, GuardedReceiverFieldStoreValue
+                ):
+                    states = [
+                        (guard, (*stores, statement), faces)
+                        for guard, stores, faces in states
+                    ]
+                    continue
+                if not isinstance(statement, GuardedReceiverFieldStoreValue):
+                    continue
+                store = statement
+                then_face, else_face = partition(
+                    (
+                        "receiver-field-store",
+                        store.to_term(owner=self.class_definition_cid),
+                    )
+                )
+                next_states = []
+                for guard, stores, faces in states:
+                    next_states.append(
+                        (
+                            and_([guard, store.guard]),
+                            (
+                                *stores,
+                                ReceiverFieldStoreValue(
+                                    store.receiver, store.attr, store.value
+                                ),
+                            ),
+                            faces | {then_face},
+                        )
+                    )
+                    next_states.append(
+                        (
+                            and_([guard, not_(store.guard)]),
+                            stores,
+                            faces | {else_face},
+                        )
+                    )
+                states = next_states
+            exits = tuple(
+                Completed(
+                    guard,
+                    self.construct_receiver_state_from_block(
+                        type(block)(stores), receiver_coordinate_cid
+                    ),
+                    faces,
+                )
+                for guard, stores, faces in states
+            )
+            return ReceiverStatePartitionValue(ExitSet(exits).normalize())
         fields: dict[str, object] = {}
         for statement in block.statements:
             if not isinstance(statement, ReceiverFieldStoreValue):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_receiver_field_store_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_receiver_field_store_value.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.ir import Formula
+
+from .receiver_field_store_value import ReceiverFieldStoreValue
+
+
+@dataclass(frozen=True)
+class GuardedReceiverFieldStoreValue(ReceiverFieldStoreValue):
+    guard: Formula
+
+    def guarded(self, formula):
+        from sugar_lift_py_tests.ir import and_
+
+        return GuardedReceiverFieldStoreValue(
+            self.receiver,
+            self.attr,
+            self.value,
+            and_([formula, self.guard]),
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, formula_term
+
+        return ctor(
+            "python:guarded-receiver-field-store",
+            [formula_term(self.guard), super().to_term(owner=owner)],
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
@@ -11,6 +11,15 @@ class ReceiverFieldStoreValue(FloorValue):
     attr: str
     value: FloorValue
 
+    def guarded(self, formula):
+        from .guarded_receiver_field_store_value import (
+            GuardedReceiverFieldStoreValue,
+        )
+
+        return GuardedReceiverFieldStoreValue(
+            self.receiver, self.attr, self.value, formula
+        )
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_state_partition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_state_partition_value.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ReceiverStatePartitionValue(FloorValue):
+    """Constructor exits before one unconditional receiver state exists."""
+
+    exits: object
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, formula_term, str_const
+        from sugar_lift_py_tests.outcome import Completed, Halted
+
+        faces = []
+        for face in self.exits.exits:
+            if isinstance(face, Completed):
+                payload = face.value.to_term(owner=owner)
+                kind = "completed"
+            elif isinstance(face, Halted):
+                payload = face.effect.to_term(owner=owner)
+                kind = "halted"
+            else:  # pragma: no cover - ExitSet is closed over these two faces.
+                raise TypeError(type(face).__name__)
+            faces.append(
+                ctor(
+                    "python:receiver-state-face",
+                    [str_const(kind), formula_term(face.guard), payload],
+                    symbol_kind="coordinate",
+                )
+            )
+        return ctor(
+            "python:receiver-state-partition",
+            faces,
+            symbol_kind="coordinate",
+        )
+
+    @property
+    def identity(self) -> str:
+        from sugar_lift_py_tests.ir import _term_content_cid
+
+        return _term_content_cid(
+            self.to_term(owner="ReceiverStatePartitionValue.identity")
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -32,8 +32,14 @@ class ClassConstructorBodySugar(Sugar):
                     )
                 )
             from sugar_lift_py_tests.floor import BlockValue
+            from sugar_lift_py_tests.floor import (
+                EllipsisValue,
+                ReceiverStatePartitionValue,
+            )
             from sugar_lift_py_tests.outcome import Incomplete
+            from sugar_lift_py_tests.outcome import Completed, Halted
             from sugar_lift_py_tests.outcome.exit_set import ExitSet
+            from sugar_source_tree.panic import SugarNotWritten
 
             # The outer CallSiteValue.force_floor already curried constructor
             # formals into ``ctx`` (formal_coordinate_cids → actuals). Reduce the
@@ -46,10 +52,28 @@ class ClassConstructorBodySugar(Sugar):
             if isinstance(outcome, Incomplete):
                 return outcome
             if isinstance(outcome, ExitSet):
-                collapsed = outcome.collapse()
-                if not isinstance(collapsed, Complete):
-                    return outcome
-                outcome = collapsed
+                projected = []
+                for face in outcome.exits:
+                    if isinstance(face, Halted):
+                        projected.append(face)
+                        continue
+                    assert isinstance(face, Completed)
+                    block = face.value
+                    if not isinstance(block, BlockValue):
+                        block = BlockValue((block,), can_fall_through=True)
+                    projected.append(
+                        Completed(
+                            face.guard,
+                            value.construct_receiver_state_from_block(
+                                block, self.receiver_coordinate_cid
+                            ),
+                            face.faces,
+                            face.pending_contracts,
+                        )
+                    )
+                return Complete(
+                    ReceiverStatePartitionValue(ExitSet(tuple(projected)).normalize())
+                )
             if not isinstance(outcome, Complete):
                 return outcome
             block = outcome.value
@@ -58,6 +82,15 @@ class ClassConstructorBodySugar(Sugar):
                 block = BlockValue(
                     (block,),
                     can_fall_through=True,
+                )
+            if block.statements and all(
+                isinstance(statement, EllipsisValue) for statement in block.statements
+            ):
+                raise SugarNotWritten(
+                    owner="ClassConstructorBodySugar.desugar",
+                    observed="initializer body is EllipsisValue only",
+                    requested="one source-visible runtime initializer implementation",
+                    fix="keep overload-only or stub-only constructors typed loud",
                 )
             return Complete(
                 value.construct_receiver_state_from_block(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -15,6 +15,7 @@ from sugar_lift_py_tests.floor import (
     FloorValue,
     GuardedReturn,
     ObjectValue,
+    ReceiverStatePartitionValue,
     ReturnValue,
 )
 from sugar_lift_py_tests.ir import _term_content_cid, ctor
@@ -67,7 +68,7 @@ class ConstructedCallActualV1:
 class ConstructedManagerBehaviorV1:
     resolved_object_cid: str
     manager_construction_cid: str
-    receiver_state: ObjectValue = field(compare=False)
+    receiver_state: ObjectValue | ReceiverStatePartitionValue = field(compare=False)
     receiver_state_cid: str
     formal_actual_bindings: tuple[BindingEntryV1, ...]
     source_call_frame_cid: str
@@ -215,7 +216,13 @@ def _project_return_faces_to_manager(
     """
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
-    managers: list[tuple[FloorValue, ObjectValue, CallSiteValue | None]] = []
+    managers: list[
+        tuple[
+            FloorValue,
+            ObjectValue | ReceiverStatePartitionValue,
+            CallSiteValue | None,
+        ]
+    ] = []
     nested: list[tuple[FloorValue, FloorValue, CallSiteValue | None]] = []
     for face in faces:
         returned = face.value
@@ -234,11 +241,12 @@ def _project_return_faces_to_manager(
             floor = returned.force_floor(
                 None,
                 owner="construct_manager_behavior returned object",
+                project_callsite=False,
             )
         except ConstructionPanic:
             # Missing body / later-stage force-floor on this face — try peers.
             continue
-        if isinstance(floor, ObjectValue):
+        if isinstance(floor, (ObjectValue, ReceiverStatePartitionValue)):
             managers.append((face, floor, returned))
             seen_calls.add(id(returned))
         else:
@@ -251,7 +259,9 @@ def _project_return_faces_to_manager(
         # faces construct both; the refined arm is the callsite's manager.
         # Incomparable multi-receivers stay loud.
         identities = {item[1].identity for item in managers}
-        if len(identities) > 1:
+        if len(identities) > 1 and all(
+            isinstance(item[1], ObjectValue) for item in managers
+        ):
             refined = _sole_refined_manager(tuple(item[1] for item in managers))
             if refined is None:
                 return ManagerConstructionGapV1(
@@ -262,6 +272,12 @@ def _project_return_faces_to_manager(
             managers = [
                 item for item in managers if item[1].identity == refined.identity
             ]
+        elif len(identities) > 1:
+            return ManagerConstructionGapV1(
+                "non-manager-result",
+                resolved_cid,
+                f"GuardedReturn with {len(identities)} manager receiver partitions",
+            )
         _face, obj, call = managers[0]
         return obj, factory_prefix + non_return_prefix
 
@@ -339,7 +355,12 @@ def _project_manager_from_exitset(
     """
     from sugar_lift_py_tests.outcome import Completed, Halted
 
-    managers: list[tuple[ObjectValue, tuple[FloorValue, ...]]] = []
+    managers: list[
+        tuple[
+            ObjectValue | ReceiverStatePartitionValue,
+            tuple[FloorValue, ...],
+        ]
+    ] = []
 
     def _collect_from_payload(payload) -> ManagerConstructionGapV1 | None:
         projected = _project_factory_manager(
@@ -351,7 +372,7 @@ def _project_manager_from_exitset(
         if isinstance(projected, ManagerConstructionGapV1):
             return projected
         mgr, prefix = projected
-        if isinstance(mgr, ObjectValue):
+        if isinstance(mgr, (ObjectValue, ReceiverStatePartitionValue)):
             managers.append((mgr, prefix))
         return None
 
@@ -376,7 +397,9 @@ def _project_manager_from_exitset(
             f"ExitSet with {len(outcome.exits)} arms",
         )
     identities = {item[0].identity for item in managers}
-    if len(identities) > 1:
+    if len(identities) > 1 and all(
+        isinstance(item[0], ObjectValue) for item in managers
+    ):
         refined = _sole_refined_manager(tuple(item[0] for item in managers))
         if refined is None:
             return ManagerConstructionGapV1(
@@ -385,6 +408,12 @@ def _project_manager_from_exitset(
                 f"ExitSet with {len(identities)} manager receivers",
             )
         managers = [item for item in managers if item[0].identity == refined.identity]
+    elif len(identities) > 1:
+        return ManagerConstructionGapV1(
+            "non-manager-result",
+            resolved_cid,
+            f"ExitSet with {len(identities)} manager receiver partitions",
+        )
     obj, prefix = managers[0]
     return obj, factory_prefix + prefix
 
@@ -603,7 +632,7 @@ def construct_manager_behavior(
                 "force-floor", resolved.cid, f"{owner}:{observed}"
             )
         raise
-    if not isinstance(result, ObjectValue):
+    if not isinstance(result, (ObjectValue, ReceiverStatePartitionValue)):
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
         )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    CallSiteValue,
+    ObjectField,
+    ObjectValue,
+    ReceiverFieldStoreValue,
+    ReceiverStatePartitionValue,
+)
 from sugar_lift_py_tests.floor.manager_coordinate import (
     ExitTracebackCoordinate,
     ExitTypeCoordinate,
     ExitValueCoordinate,
 )
-from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome import Complete, Completed
 
 from .canonical import cid_of_json
 from .manager_construction import ConstructedManagerBehaviorV1
@@ -26,6 +33,7 @@ class ConstructedManagerProtocolV1:
     enter_frame_cid: str
     exit_frame_cid: str
     exit_face_id: str
+    receiver_state: ObjectValue | ReceiverStatePartitionValue = field(compare=False)
 
     @property
     def preimage(self):
@@ -43,10 +51,131 @@ class ConstructedManagerProtocolV1:
             raise ValueError("manager protocol CID does not match its preimage")
 
     def enter_outcome(self, ctx: object = None):
-        return self.enter_call.reduce_source_outcome(ctx)
+        if isinstance(self.receiver_state, ObjectValue):
+            return self.enter_call.reduce_source_outcome(ctx)
+        from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+        return self.receiver_state.exits.sequence(
+            lambda receiver: outcome_to_exitset(
+                _call_protocol_method(
+                    receiver,
+                    "__enter__",
+                    (),
+                    self.exit_face_id,
+                    ctx,
+                ).reduce_source_outcome(ctx)
+            )
+        )
 
     def exit_outcome(self, ctx: object = None):
-        return self.exit_call.reduce_source_outcome(ctx)
+        def run_exit(receiver):
+            enter = _call_protocol_method(
+                receiver, "__enter__", (), self.exit_face_id, ctx
+            ).reduce_source_outcome(ctx)
+            entered = _receiver_state_after_enter(receiver, enter)
+            return _call_protocol_method(
+                entered,
+                "__exit__",
+                (
+                    ExitTypeCoordinate(self.exit_face_id, None),
+                    ExitValueCoordinate(self.exit_face_id, None),
+                    ExitTracebackCoordinate(self.exit_face_id, None),
+                ),
+                self.exit_face_id,
+                ctx,
+            ).reduce_source_outcome(ctx)
+
+        if isinstance(self.receiver_state, ObjectValue):
+            return run_exit(self.receiver_state)
+        from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+        return self.receiver_state.exits.sequence(
+            lambda receiver: outcome_to_exitset(run_exit(receiver))
+        )
+
+
+def _call_protocol_method(receiver, name, arguments, exit_face_id, ctx):
+    from sugar_source_tree.panic import SugarNotWritten
+
+    call = receiver.call_method_value(
+        name,
+        arguments,
+        owner="ConstructedManagerProtocolV1.protocol_method",
+        blame=exit_face_id,
+        ctx=ctx,
+    )
+    if not isinstance(call, Complete) or not isinstance(call.value, CallSiteValue):
+        raise SugarNotWritten(
+            owner="ConstructedManagerProtocolV1.protocol_method",
+            observed=type(call).__name__,
+            requested=f"authenticated {name} call over projected receiver state",
+            fix="preserve the exact receiver method frame or keep protocol loud",
+        )
+    return call.value
+
+
+def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectValue:
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+    from sugar_source_tree.panic import SugarNotWritten
+
+    exits = outcome_to_exitset(enter_outcome).exits
+    completed = tuple(face for face in exits if isinstance(face, Completed))
+    observed_stores = tuple(
+        statement
+        for face in completed
+        if isinstance(face.value, BlockValue)
+        for statement in face.value.statements
+        if isinstance(statement, ReceiverFieldStoreValue)
+    )
+    if not observed_stores:
+        return receiver
+    if not exits or len(completed) != len(exits):
+        raise SugarNotWritten(
+            owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
+            observed="non-completed __enter__ face",
+            requested="total completed enter testimony before __exit__",
+            fix="derive exit state only after every authenticated enter face completes",
+        )
+    projected_faces = []
+    for face in completed:
+        block = face.value
+        if not isinstance(block, BlockValue):
+            raise SugarNotWritten(
+                owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
+                observed=type(block).__name__,
+                requested="completed enter block carrying exact receiver stores",
+                fix="preserve the ordinary enter block or keep receiver state loud",
+            )
+        fields = {field.name: field.value for field in receiver.fields}
+        for statement in block.statements:
+            if not isinstance(statement, ReceiverFieldStoreValue):
+                continue
+            if statement.receiver.identity != receiver.identity:
+                raise SugarNotWritten(
+                    owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
+                    observed="receiver coordinate mismatch",
+                    requested="stores from the exact authenticated manager receiver",
+                    fix="preserve ObjectValue.identity across protocol method binding",
+                )
+            fields[statement.attr] = statement.value
+        projected_faces.append(
+            tuple(ObjectField(name, fields[name]) for name in sorted(fields))
+        )
+    first = projected_faces[0]
+    if any(fields != first for fields in projected_faces[1:]):
+        raise SugarNotWritten(
+            owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
+            observed="guarded enter faces disagree on receiver fields",
+            requested="one exact post-enter ObjectValue.fields projection",
+            fix="carry guarded object-state testimony before reducing __exit__",
+        )
+    return ObjectValue(
+        receiver.class_name,
+        first,
+        methods=receiver.methods,
+        class_fields=receiver.class_fields,
+        identity=receiver.identity,
+    )
 
 
 @dataclass(frozen=True)
@@ -68,18 +197,34 @@ def construct_manager_protocol(
     and the typed exit-face operands to those bodies.
     """
     receiver = behavior.receiver_state
-    if not receiver.has_method("__enter__"):
+    receivers = (
+        (receiver,)
+        if isinstance(receiver, ObjectValue)
+        else tuple(
+            face.value
+            for face in receiver.exits.exits
+            if isinstance(face, Completed) and isinstance(face.value, ObjectValue)
+        )
+    )
+    if not receivers:
+        return ManagerProtocolConstructionGapV1(
+            "method-construction",
+            behavior.manager_construction_cid,
+            "constructor partition has no completed receiver face",
+        )
+    if any(not item.has_method("__enter__") for item in receivers):
         return ManagerProtocolConstructionGapV1(
             "enter-missing", behavior.manager_construction_cid, "source-visible method"
         )
-    if not receiver.has_method("__exit__"):
+    if any(not item.has_method("__exit__") for item in receivers):
         return ManagerProtocolConstructionGapV1(
             "exit-missing", behavior.manager_construction_cid, "source-visible method"
         )
-    enter = receiver.call_method_value(
+    representative = receivers[0]
+    enter = representative.call_method_value(
         "__enter__", (), owner="construct_manager_protocol", blame=exit_face_id
     )
-    exit_ = receiver.call_method_value(
+    exit_ = representative.call_method_value(
         "__exit__",
         (
             ExitTypeCoordinate(exit_face_id, None),
@@ -97,8 +242,18 @@ def construct_manager_protocol(
         return ManagerProtocolConstructionGapV1(
             "method-construction", behavior.manager_construction_cid, "__exit__"
         )
-    enter_frame_cid = _method_frame_cid(receiver, "__enter__")
-    exit_frame_cid = _method_frame_cid(receiver, "__exit__")
+    enter_frame_cid = _method_frame_cid(representative, "__enter__")
+    exit_frame_cid = _method_frame_cid(representative, "__exit__")
+    if any(
+        _method_frame_cid(item, "__enter__") != enter_frame_cid
+        or _method_frame_cid(item, "__exit__") != exit_frame_cid
+        for item in receivers[1:]
+    ):
+        return ManagerProtocolConstructionGapV1(
+            "method-construction",
+            behavior.manager_construction_cid,
+            "constructor faces disagree on protocol method frames",
+        )
     preimage = {
         "kind": "constructed-manager-protocol",
         "schemaVersion": "1",
@@ -115,6 +270,7 @@ def construct_manager_protocol(
         enter_frame_cid,
         exit_frame_cid,
         exit_face_id,
+        receiver,
     )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_real_pandas_plain_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_real_pandas_plain_halt.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 
-def test_real_pandas_plain_halt_advances_to_typed_exit_gap():
+def test_real_pandas_plain_halt_names_constructor_partition_floor():
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
@@ -33,7 +33,7 @@ def test_real_pandas_plain_halt_advances_to_typed_exit_gap():
         function.sugar().desugar()
 
     gap = raised.value
-    assert gap.kind == "exit-may-halt"
+    assert gap.kind == "force-floor"
     assert gap.coordinate.start_line == 84
     assert gap.coordinate.start_col == 9
-    assert "attribute:ObjectValue" in gap.observed
+    assert "ExitSet with 3 arms" in gap.observed

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -460,6 +460,147 @@ def test_renamed_manager_protocol_retains_ordinary_method_call_frames(tmp_path):
     assert exit_block.statements == (ReturnValue(actual.value),)
 
 
+def test_enter_receiver_store_populates_same_identity_for_exit_read(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        ...\n\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        self.after_enter = self.marker\n"
+        "        return self.after_enter\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return self.after_enter\n\n"
+        "def make_guard(marker):\n"
+        "    return RenamedGuard(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="renamed-state-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+    exit_ = outcome_to_exitset(protocol.exit_outcome())
+
+    assert len(exit_.exits) == 1
+    assert isinstance(exit_.exits[0], Completed)
+    block = exit_.exits[0].value
+    assert isinstance(block, BlockValue)
+    assert block.statements[-1] == ReturnValue(actual.value)
+
+
+def test_unwritten_receiver_field_stays_typed_loud_across_method_lifetimes(
+    tmp_path,
+):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self.marker\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return self.never_written\n\n"
+        "def make_guard(marker):\n"
+        "    return RenamedGuard(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="missing-state-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic) as raised:
+        protocol.exit_outcome()
+
+    assert raised.value.info.owner == "attribute"
+    assert raised.value.info.observed == "ObjectValue"
+
+
+def test_constructor_partition_does_not_inherit_store_across_guarded_faces(
+    tmp_path,
+):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        if marker:\n"
+        "            self.maybe_written = marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return self.maybe_written\n\n"
+        "def make_guard(marker):\n"
+        "    return RenamedGuard(marker)\n",
+    )
+    from sugar_lift_py_tests.floor import (
+        ReceiverStatePartitionValue,
+        SymbolicValue,
+    )
+    from sugar_lift_py_tests.ir import _term_content_cid, make_var
+
+    symbolic = SymbolicValue(make_var("constructor-guard"))
+    actual = ConstructedCallActualV1(
+        actual.node,
+        symbolic,
+        ConstructedValueTestimonyV1.mint(
+            actual.node.fragment,
+            _term_content_cid(symbolic.to_term(owner="partition-lying-twin")),
+        ),
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    assert isinstance(behavior.receiver_state, ReceiverStatePartitionValue)
+    from sugar_lift_py_tests.outcome import Completed
+
+    field_sets = {
+        tuple(field.name for field in face.value.fields)
+        for face in behavior.receiver_state.exits.exits
+        if isinstance(face, Completed)
+    }
+    assert field_sets == {(), ("maybe_written",)}
+
+    protocol = construct_manager_protocol(behavior, exit_face_id="partition-lying-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic):
+        protocol.exit_outcome()
+
+
+def test_ellipsis_only_initializer_stays_typed_loud(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        ...\n\n"
+        "    def __enter__(self):\n"
+        "        return self\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_guard(marker):\n"
+        "    return RenamedGuard(marker)\n",
+    )
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ManagerConstructionGapV1)
+    assert behavior.kind == "force-floor"
+    assert "EllipsisValue only" in behavior.detail
+
+
 def test_manager_missing_source_protocol_method_stays_typed_loud(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,
@@ -1200,7 +1341,8 @@ def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
     with pytest.raises(WithConstructionGap) as caught:
         with_node.sugar()
 
-    assert caught.value.gap_kind is WithConstructionGapKind.ENTER_MAY_HALT
+    assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
+    assert "ExitSet with 3 arms" in caught.value.observed
     assert (
         caught.value.coordinate.start_line,
         caught.value.coordinate.start_col,
@@ -1228,7 +1370,8 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
     with pytest.raises(WithConstructionGap) as caught:
         with_node.sugar()
 
-    assert caught.value.gap_kind is WithConstructionGapKind.ENTER_MAY_HALT
+    assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
+    assert "ExitSet with 4 arms" in caught.value.observed
     assert (
         caught.value.coordinate.start_line,
         caught.value.coordinate.start_col,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2736,7 +2736,7 @@ class ClassDef(Statement):
         initializer = next(
             (
                 item
-                for item in self.body
+                for item in reversed(self.body)
                 if isinstance(item, FunctionDef) and item.name == "__init__"
             ),
             None,
@@ -2810,7 +2810,7 @@ class ClassDef(Statement):
         initializer = next(
             (
                 item
-                for item in self.body
+                for item in reversed(self.body)
                 if isinstance(item, FunctionDef) and item.name == "__init__"
             ),
             None,


### PR DESCRIPTION
## Summary

- carry authenticated constructor receiver fields into `ObjectValue.fields`
  across `__enter__` and `__exit__` method lifetimes, keyed by the existing
  receiver identity
- preserve conditional constructor states as an authenticated partition so an
  unwritten face remains undecided instead of borrowing another face's field
- select Python's last source-visible `__init__`; overload/stub definitions no
  longer hide the runtime implementation, while an Ellipsis-only initializer
  stays typed-loud

Closes #6468.

The real pandas receipt at `pandas/tests/test_errors.py:84:9` is intentionally
not claimed as constructed:

- before #6469: `enter-may-halt`
- after #6469: `exit-may-halt`
- after selecting the runtime `__init__`: `force-floor [ExitSet with 3 arms]`
- after this partition slice: `force-floor [ExitSet with 3 arms]`

The enter edge remains drained. The constructor partition exposes work that the
first-definition selector skipped, and the three-arm floor remains named and
typed rather than being collapsed or suppressed.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | +0 | the real pandas site remains at the named constructor floor |
| `mandatory_panics` | +0 | no panic is converted to construction |
| `suppressed_descendants` | +0 | no descendant suppression was added |
| `typed_effects` | +0 | the same site moves only within typed construction gaps |
| `silent` | 0 | symbolic and unwritten receiver faces remain explicitly loud |

## Validation

- `62 passed`:
  `test_sole_path_manager_construction.py` plus
  `test_real_pandas_plain_halt.py`
- conditional-state tooth proves completed constructor faces have exactly
  `{(), ("maybe_written",)}` and the unwritten face raises at the `__exit__`
  consumer
- renamed structural receiver twin passes without `excinfo` spelling authority
- Ellipsis-only initializer remains `force-floor` with explicit
  `EllipsisValue only` testimony
- pandas native axis:
  `discovered=1 completed=1 timeouts=0 non_native_red=0 R_native_crashes=0`
- broad owning-package run was interrupted and is not green:
  `496 passed`, one environment-sensitive live pandas
  `static-export-absent` failure, then `KeyboardInterrupt`

## Floors preserved

- no second heap or manager-only state overlay
- no completed constructor arm is selected as authoritative
- no missing field defaults to absent and no guarded face inherits a sibling's
  store
- no pytest, pandas, vendor, manager-name, or field-name dispatch
- `data_loss=0`; no tests deleted; `silent=0`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry authenticated receiver state across manager protocol methods for partitioned constructors
> - Introduces `ReceiverStatePartitionValue` and `GuardedReceiverFieldStoreValue` to represent receiver state split across guarded constructor outcomes (e.g. conditional branches in `__init__`).
> - `ClassDefinitionValue.construct_receiver_state_from_block` now returns a `ReceiverStatePartitionValue` when guarded field stores are present, instead of collapsing into a single `ObjectValue`.
> - `ConstructedManagerProtocolV1` sequences `__enter__`/`__exit__` over each receiver face of a partitioned receiver, propagating field stores from `__enter__` into the receiver state used by `__exit__`.
> - `construct_manager_behavior` and related helpers in [manager_construction.py](https://github.com/TSavo/sugar/pull/6470/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) accept `ReceiverStatePartitionValue` alongside `ObjectValue` and return a typed gap when multiple distinct partition identities are found.
> - Fixes last-defined `__init__` selection in `ClassDef.sugar` by iterating `reversed(self.body)` when multiple `__init__` methods exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9146cc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for guarded receiver-field updates and partitioned receiver states.
  * Manager construction and protocol handling now support conditional receiver states.
  * Constructor processing preserves distinct outcomes across guarded execution paths.
  * The latest `__init__` definition is selected when classes contain multiple initializers.

* **Bug Fixes**
  * Improved handling of unwritten receiver fields and ellipsis-only initializers.
  * Preserved receiver state consistently between enter and exit operations.

* **Tests**
  * Added coverage for guarded partitions, receiver identity, typed construction gaps, and initializer validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->