### PR TITLE
Carry resource acquisition state into exit

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -58,6 +58,7 @@ from .inv_value import InvValue
 from .bytes_value import BytesValue
 from .complex_value import ComplexValue
 from .ellipsis_value import EllipsisValue
+from .entered_manager_state_value import EnteredManagerStateValue
 from .none_value import NoneValue
 from .object_field import ObjectField
 from .object_method_value import ObjectMethodValue
@@ -108,6 +109,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     ExceptionCauseValue,
     ExceptionalExitValue,
     ExceptionValue,
+    EnteredManagerStateValue,
     ExceptionClassValue,
     LocalExceptionClassValue,
     FunctionCallable,
@@ -204,6 +206,7 @@ __all__ = [
     "BytesValue",
     "ComplexValue",
     "EllipsisValue",
+    "EnteredManagerStateValue",
     "NoneValue",
     "ObjectField",
     "ObjectMethodValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/entered_manager_state_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/entered_manager_state_value.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+from .object_value import ObjectValue
+
+
+@dataclass(frozen=True)
+class EnteredManagerStateValue(FloorValue):
+    """One completed ``__enter__`` face and its exact receiver state."""
+
+    enter_value: FloorValue
+    receiver_state: ObjectValue
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:entered-manager-state",
+            (
+                self.enter_value.to_term(owner=owner),
+                self.receiver_state.to_term(owner=owner),
+            ),
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -24,6 +24,7 @@ class WithSourceResourceSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.outcome import outcome_to_exitset
         from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
         from sugar_lift_py_tests.outcome.resource_bindings import (
             EnterResultBinding,
@@ -48,13 +49,14 @@ class WithSourceResourceSugar(Sugar):
             manager_facts = ManagerBinding(
                 self.manager_slot_id, manager_face.value
             ).to_facts(site=self.site)
-            enter_es = sugar_outcome_to_exitset(self.protocol.enter_outcome(ctx))
+            enter_es = outcome_to_exitset(self.protocol.enter_resource_outcome(ctx))
             for enter_face in enter_es.exits:
                 guard = _and(manager_face.guard, enter_face.guard)
                 if isinstance(enter_face, Halted):
                     parts.append(ExitSet((Halted(guard, enter_face.effect),)))
                     continue
-                enter_value = _returned_value(enter_face.value)
+                entered = enter_face.value
+                enter_value = _returned_value(entered.enter_value)
                 enter_facts = ()
                 if self.enter_slot_id is not None and enter_value is not None:
                     enter_facts = EnterResultBinding(
@@ -63,7 +65,9 @@ class WithSourceResourceSugar(Sugar):
                 body_es = promote_raise_halts(
                     reduce_block_to_exitset(self.body)
                 ).guarded(guard)
-                exit_es = sugar_outcome_to_exitset(self.protocol.exit_outcome(ctx))
+                exit_es = outcome_to_exitset(
+                    self.protocol.exit_outcome_for(entered, ctx)
+                )
                 for body_face in body_es.exits:
                     face_facts = ExitFaceBinding.from_body_exit(
                         self.exit_face_id, body_face

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -26,12 +26,19 @@ class _FixedSugar(Sugar):
 
 
 class _CompletedProtocol:
-    def enter_outcome(self, ctx=None):
-        del ctx
-        return Complete(TermValue(2))
+    def __init__(self):
+        self.enter_calls = 0
+        self.exit_calls = 0
 
-    def exit_outcome(self, ctx=None):
+    def enter_resource_outcome(self, ctx=None):
         del ctx
+        self.enter_calls += 1
+        return Complete(SimpleNamespace(enter_value=TermValue(2)))
+
+    def exit_outcome_for(self, entered, ctx=None):
+        assert entered.enter_value == TermValue(2)
+        del ctx
+        self.exit_calls += 1
         return Complete(BlockValue((), can_fall_through=True))
 
 
@@ -40,9 +47,10 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
     summary = SimpleNamespace(
         semantics=SimpleNamespace(exit=SimpleNamespace(disposition=disposition))
     )
+    protocol = _CompletedProtocol()
     sugar = WithSourceResourceSugar(
         manager=_FixedSugar(Complete(TermValue(1))),
-        protocol=_CompletedProtocol(),
+        protocol=protocol,
         summary=summary,
         body=(
             _FixedSugar(
@@ -67,3 +75,5 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
         and getattr(face.effect, "exception_name", None) == "ValueError"
         for face in exits
     )
+    assert protocol.enter_calls == 1
+    assert protocol.exit_calls == 1

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -8,6 +8,8 @@ from typing import Literal
 from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
+    EnteredManagerStateValue,
+    GuardedReceiverFieldStoreValue,
     ObjectField,
     ObjectValue,
     ReceiverFieldStoreValue,
@@ -93,6 +95,34 @@ class ConstructedManagerProtocolV1:
             lambda receiver: outcome_to_exitset(run_exit(receiver))
         )
 
+    def enter_resource_outcome(self, ctx: object = None):
+        """Run enter once and carry each face's exact receiver into resource exit."""
+
+        def run_enter(receiver):
+            enter = _call_protocol_method(
+                receiver, "__enter__", (), self.exit_face_id, ctx
+            ).reduce_source_outcome(ctx)
+            return _resource_enter_transitions(receiver, enter)
+
+        if isinstance(self.receiver_state, ObjectValue):
+            return run_enter(self.receiver_state)
+        return self.receiver_state.exits.sequence(run_enter)
+
+    def exit_outcome_for(self, entered: EnteredManagerStateValue, ctx: object = None):
+        if not isinstance(entered, EnteredManagerStateValue):
+            raise TypeError(type(entered).__name__)
+        return _call_protocol_method(
+            entered.receiver_state,
+            "__exit__",
+            (
+                ExitTypeCoordinate(self.exit_face_id, None),
+                ExitValueCoordinate(self.exit_face_id, None),
+                ExitTracebackCoordinate(self.exit_face_id, None),
+            ),
+            self.exit_face_id,
+            ctx,
+        ).reduce_source_outcome(ctx)
+
 
 def _call_protocol_method(receiver, name, arguments, exit_face_id, ctx):
     from sugar_source_tree.panic import SugarNotWritten
@@ -172,6 +202,92 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
     return ObjectValue(
         receiver.class_name,
         first,
+        methods=receiver.methods,
+        class_fields=receiver.class_fields,
+        identity=receiver.identity,
+    )
+
+
+def _resource_enter_transitions(receiver: ObjectValue, enter_outcome):
+    from sugar_lift_py_tests.ir import and_, not_
+    from sugar_lift_py_tests.outcome import (
+        Completed,
+        ExitSet,
+        Halted,
+        outcome_to_exitset,
+    )
+    from sugar_lift_py_tests.outcome.exit_set import partition
+    from sugar_source_tree.panic import SugarNotWritten
+
+    projected = []
+    for face in outcome_to_exitset(enter_outcome).exits:
+        if isinstance(face, Halted):
+            projected.append(face)
+            continue
+        if not isinstance(face.value, BlockValue):
+            raise SugarNotWritten(
+                owner="ConstructedManagerProtocolV1.enter_resource_outcome",
+                observed=type(face.value).__name__,
+                requested="completed enter block carrying exact acquisition stores",
+                fix="preserve the ordinary enter block or keep resource state loud",
+            )
+        states = [(face.guard, receiver, face.faces)]
+        for statement in face.value.statements:
+            if isinstance(statement, GuardedReceiverFieldStoreValue):
+                then_face, else_face = partition(
+                    ("resource-enter-store", statement.to_term(owner=receiver.identity))
+                )
+                next_states = []
+                for guard, state, faces in states:
+                    next_states.append(
+                        (
+                            and_([guard, statement.guard]),
+                            _apply_receiver_store(state, statement),
+                            faces | {then_face},
+                        )
+                    )
+                    next_states.append(
+                        (
+                            and_([guard, not_(statement.guard)]),
+                            state,
+                            faces | {else_face},
+                        )
+                    )
+                states = next_states
+            elif isinstance(statement, ReceiverFieldStoreValue):
+                states = [
+                    (guard, _apply_receiver_store(state, statement), faces)
+                    for guard, state, faces in states
+                ]
+        projected.extend(
+            Completed(
+                guard,
+                EnteredManagerStateValue(face.value, state),
+                faces,
+                face.pending_contracts,
+            )
+            for guard, state, faces in states
+        )
+    return ExitSet(tuple(projected)).normalize()
+
+
+def _apply_receiver_store(
+    receiver: ObjectValue, statement: ReceiverFieldStoreValue
+) -> ObjectValue:
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if statement.receiver.identity != receiver.identity:
+        raise SugarNotWritten(
+            owner="ConstructedManagerProtocolV1.enter_resource_outcome",
+            observed="receiver coordinate mismatch",
+            requested="acquisition store from the exact authenticated receiver",
+            fix="preserve ObjectValue.identity across the enter transition",
+        )
+    fields = {field.name: field.value for field in receiver.fields}
+    fields[statement.attr] = statement.value
+    return ObjectValue(
+        receiver.class_name,
+        tuple(ObjectField(name, fields[name]) for name in sorted(fields)),
         methods=receiver.methods,
         class_fields=receiver.class_fields,
         identity=receiver.identity,

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -578,6 +578,105 @@ def test_constructor_partition_does_not_inherit_store_across_guarded_faces(
         protocol.exit_outcome()
 
 
+def test_resource_enter_partition_does_not_inherit_unacquired_state(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedResource:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        if self.marker:\n"
+        "            self.acquired = self.marker\n"
+        "        return self\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return self.acquired\n\n"
+        "def make_resource(marker):\n"
+        "    return RenamedResource(marker)\n",
+        exported="make_resource",
+    )
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.ir import _term_content_cid, make_var
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+    symbolic = SymbolicValue(make_var("resource-acquisition-guard"))
+    actual = ConstructedCallActualV1(
+        actual.node,
+        symbolic,
+        ConstructedValueTestimonyV1.mint(
+            actual.node.fragment,
+            _term_content_cid(symbolic.to_term(owner="resource-lying-twin")),
+        ),
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="resource-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    transitions = outcome_to_exitset(protocol.enter_resource_outcome())
+    completed = tuple(face for face in transitions.exits if isinstance(face, Completed))
+    assert {
+        tuple(field.name for field in face.value.receiver_state.fields)
+        for face in completed
+    } == {("marker",), ("acquired", "marker")}
+
+    written = next(
+        face.value
+        for face in completed
+        if any(field.name == "acquired" for field in face.value.receiver_state.fields)
+    )
+    unwritten = next(
+        face.value
+        for face in completed
+        if all(field.name != "acquired" for field in face.value.receiver_state.fields)
+    )
+    assert protocol.exit_outcome_for(written) is not None
+
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic) as raised:
+        protocol.exit_outcome_for(unwritten)
+    assert raised.value.info.owner == "attribute"
+    assert raised.value.info.observed == "ObjectValue"
+
+
+def test_resource_enter_state_reaches_exit_without_second_enter(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedResource:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        self.acquired = self.marker\n"
+        "        return self.acquired\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return self.acquired\n\n"
+        "def make_resource(marker):\n"
+        "    return RenamedResource(marker)\n",
+        exported="make_resource",
+    )
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="resource-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    transitions = outcome_to_exitset(protocol.enter_resource_outcome())
+    assert len(transitions.exits) == 1
+    transition = transitions.exits[0]
+    assert isinstance(transition, Completed)
+    assert transition.value.enter_value.statements[-1] == ReturnValue(actual.value)
+
+    exit_ = outcome_to_exitset(protocol.exit_outcome_for(transition.value))
+    assert len(exit_.exits) == 1
+    assert isinstance(exit_.exits[0], Completed)
+    assert exit_.exits[0].value.statements[-1] == ReturnValue(actual.value)
+
+
 def test_ellipsis_only_initializer_stays_typed_loud(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,


### PR DESCRIPTION
## Summary

- run a source-derived resource manager's `__enter__` exactly once and carry
  each completed acquisition face with its exact authenticated receiver state
- route every body exit through `__exit__` using that carried state instead of
  invoking `__enter__` a second time
- preserve guarded acquisition partitions so an unacquired face remains
  undecided and typed-loud rather than inheriting a sibling face's resource

This is the resource-With slice directly following #6468/#6470 over the same
factored `ExitSet` algebra. It does not revisit or claim construction at the
pandas `(84,9)` `force-floor [ExitSet with 3 arms]` boundary.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | +0 | no corpus-wide resource census is claimed in this slice |
| `mandatory_panics` | +0 | unacquired and unobserved state remain typed-loud |
| `suppressed_descendants` | +0 | no suppression or fallback path was added |
| `typed_effects` | +0 | body and exit effects still route through `ExitSet.and_exit` |
| `silent` | 0 | every acquisition face is carried or refuses explicitly |

## Validation

- tested commit: `f09171ce6cf3b134673362a8100fb4ae34911ce7`
- focused owning tests: `65 passed`
- truthful source manager: `__enter__` writes an arbitrary renamed acquisition
  field, returns its real value, and `__exit__` reads the same carried value
- lying partition: exact receiver-field faces are
  `{("marker",), ("acquired", "marker")}`; the unacquired face raises the typed
  `attribute:ObjectValue` gap at the exit consumer
- resource routing unit asserts `enter_calls == 1` and `exit_calls == 1`
- pandas native axis:
  `discovered=1 completed=1 timeouts=0 non_native_red=0 R_native_crashes=0`

## Floors preserved

- no second heap or resource-specific temporal store
- no completed acquisition face selected as authoritative
- no default-to-absent and no inheritance from a sibling acquisition face
- no resource, field, package, class, or vendor spelling dispatch
- manager/enter evaluation remains once; exit fans over body faces through the
  existing `ExitSet` disposition algebra
- `data_loss=0`; no tests deleted; `silent=0`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry resource acquisition state from `__enter__` into `__exit__` processing
> - Introduces `EnteredManagerStateValue` to pair the `__enter__` return value with the exact post-enter receiver state, so exit can operate on the captured state rather than recomputing it.
> - Adds `enter_resource_outcome` and `exit_outcome_for` to `ConstructedManagerProtocolV1`, replacing the previous `enter_outcome`/`exit_outcome` pair.
> - `_resource_enter_transitions` reflects receiver field stores (including guarded stores via `GuardedReceiverFieldStoreValue`) into the carried receiver state, producing partitioned exit-set branches per guard outcome.
> - Updates `WithSourceResourceSugar.desugar` to use the new protocol methods, threading the `EnteredManagerStateValue` from enter through to exit.
> - Behavioral Change: exit outcomes are now computed against the receiver state observed after enter; previously exit used a separately reconstructed receiver state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f09171c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->