### PR TITLE
Route imported generator managers through native frames

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -652,6 +652,26 @@ def populate_source_derived_resource_refs(
             kind = getattr(resolved, "kind", None) or "no-derived-contract"
             _install_derivation_gap(context, coordinate, receipt, str(kind))
             continue
+        # A source-owned suspension is already the native manager testimony
+        # consumed by With._generator_manager_frame.  Install that exact frame
+        # before attempting object-protocol derivation: forcing a generator
+        # function's intentionally empty ordinary body only manufactures the
+        # misleading residual ``non-manager-result:BlockValue``.  The generator
+        # transition remains independently loud when its steps are opaque.
+        from .manager_construction import (
+            ManagerConstructionGapV1,
+            _install_source_call_frame,
+            resolve_source_visible_frame,
+        )
+
+        frame_result = resolve_source_visible_frame(
+            resolved, graph=graph, session=session
+        )
+        if not isinstance(frame_result, ManagerConstructionGapV1):
+            frame, _ = frame_result
+            if frame.generator_steps is not None:
+                _install_source_call_frame(context, call, frame)
+                continue
         actuals = []
         for node in call.args:
             outcome = node.sugar().desugar()

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1479,6 +1479,107 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
     ) == (3, 9, 3, 46)
 
 
+def test_installed_pandas_warning_manager_names_opaque_generator_transition(tmp_path):
+    """Real producer advances to its first still-opaque native transition.
+
+    The imported generator frame comes only from authenticated pandas source.
+    Its outer warning-capture ``With`` is not in the generator-step vocabulary,
+    so construction names that transition instead of inventing warning
+    testimony or collapsing the site to ``non-manager-result:BlockValue``.
+    """
+    consumer = (
+        "import pandas._testing as tm\n"
+        "def use_boundary(f):\n"
+        "    with tm.assert_produces_warning(FutureWarning):\n"
+        "        f()\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.generator_with_sugar import (
+        GeneratorWithSugar,
+    )
+    from sugar_source_tree.panic import SugarNotWritten
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    assert isinstance(boundary, GeneratorWithSugar)
+    with pytest.raises(SugarNotWritten) as caught:
+        boundary.desugar()
+    assert caught.value.owner == "GeneratorWithSugar.desugar"
+    assert caught.value.observed == "opaque generator transition: With"
+
+
+def test_imported_renamed_generator_manager_installs_native_frame(tmp_path):
+    """Truthful twin: suspension testimony, not a manager-name table, opens it."""
+    distribution = _distribution(
+        tmp_path,
+        "def make_guard(expected):\n    yield expected\n",
+    )
+    consumer = "import arbitrary\nwith arbitrary.make_guard(23):\n    pass\n"
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    assert isinstance(
+        next(node for node in tree.nodes() if node.kind == "With").sugar(),
+        GeneratorWithSugar,
+    )
+
+
+def test_imported_ordinary_factory_cannot_lie_as_generator_manager(tmp_path):
+    """Lying twin: same import/call shape without a suspension gets no frame."""
+    distribution = _distribution(
+        tmp_path,
+        "def make_guard(expected):\n    return expected\n",
+    )
+    consumer = "import arbitrary\nwith arbitrary.make_guard(23):\n    pass\n"
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        TreeConstructionContextV1,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    assert context.source_call_frames == {}
+    gap = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(gap, ContextManagerResolutionGapV1)
+    assert (gap.kind, gap.detail) == ("non-manager-result", "TermValue")
+
+
 def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):
     """Assertion membrane must not admit ProtocolResource managers.
 


### PR DESCRIPTION
## What changed

- installs an authenticated imported function frame at a `with` use site when that frame owns native generator suspension testimony
- routes that site through the existing name-independent `GeneratorWithSugar` door before object-protocol derivation can collapse the generator's empty ordinary body to `non-manager-result: BlockValue`
- adds a concrete pandas 3.0.3 `tm.assert_produces_warning(FutureWarning)` reproducer
- adds a renamed truthful generator twin and an ordinary-function lying twin

## Why

Imported generator managers already carry the same source-owned `generator_steps` testimony consumed for local generator managers. Population attempted object-manager derivation first, forced the deliberately empty ordinary generator body, and reported `BlockValue`. This change preserves the native testimony and lets the existing generator transition machine own the next decision.

For the real pandas warning manager, the next honest result is still loud: its outer warning-capture `With` is an opaque generator transition. This PR does not invent a warning observation, treat missing observation as false, add a pandas/name arm, or claim the completed-warning path is closed.

## Validation

- `git diff --check 47cc6d031..HEAD` — exit 0
- Python compile check for both touched files — exit 0 before rebase; the rebase was conflict-free
- authenticated focused command attempted after rebase:
  `bin/bpytest -u implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py -k 'installed_pandas_warning_manager or imported_renamed_generator_manager or imported_ordinary_factory_cannot_lie'`
  — refused before pytest collection with `artifact identity mismatch: sourceStamp`; no matching `sugar-linux-x86_64-release` binary for source stamp `blake3-512_0d86c18ac3f8593f55fc55986ff959b39d4fdada70a87b518d628a81a8c06bda30a524b429d2024d85979f8247a15515332c445bed6e71fdda652867c202b8c7`, and build fallback was correctly disabled. Exit 1.

## Incomplete gate / named blocker

The focused green receipt and mutation transaction are not complete. The authenticated launcher refuses before collection because the exact source-stamped binary is absent. A matching build must be made available to the launcher off the shared Mac, then the focused truthful/lying/real-site tests and clean/present/bites/reverted/clean mutation transaction must run. No corpus census or demand-table build was run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route imported generator-based context managers through native source frames in `populate_source_derived_resource_refs`
> - When a `With` call resolves to a generator-based context manager with an available native frame, `populate_source_derived_resource_refs` now installs that frame via `_install_source_call_frame` and skips further contract derivation for that call.
> - Previously, these calls fell through to object-protocol derivation, which forced execution through the generator's empty ordinary body and could emit a misleading `non-manager-result:BlockValue` gap.
> - Three new tests cover: pandas `assert_produces_warning` (opaque generator transition), imported/renamed generator managers installing a native frame, and ordinary (non-generator) factories correctly recording a `ContextManagerResolutionGapV1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8253404.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->