### PR TITLE
Detect private orphan transitions

### DIFF
--- a/docs/superpowers/plans/2026-07-26-private-orphan-transition.md
+++ b/docs/superpowers/plans/2026-07-26-private-orphan-transition.md
@@ -1,0 +1,65 @@
+# Private Orphan Transition Detector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build late telemetry that reports surviving private Python definitions whose last package reference disappeared between two Git trees.
+
+**Architecture:** A focused Python audit parses package-owned source from two Git revisions, indexes private module-level definitions and syntax-authenticated references, and compares the indexes for referenced-before to zero-after transitions. A CLI renders exact definition and lost-reference locations; focused synthetic and historical twins exercise the real artifact.
+
+**Tech Stack:** Python 3 standard library (`ast`, `argparse`, `dataclasses`, `pathlib`, `subprocess`) and pytest.
+
+## Global Constraints
+
+- Base is exactly `b7feb76b8`.
+- The detector is late telemetry and must not be wired into CI.
+- No handwritten symbol whitelist and no vendor arm.
+- Count references through Python syntax, never grep/text occurrence counts.
+- Run only focused local tests; use `PYTHONUNBUFFERED=1` because `bin/bpytest` rejects `-u`.
+- Capture exit status inline, never after a pipe.
+
+---
+
+### Task 1: Transition index and comparison
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/scripts/private_orphan_transition.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py`
+
+**Interfaces:**
+- Consumes: two Git revisions or two in-memory package trees.
+- Produces: immutable definition, reference-site, and orphan-transition records plus `compare_trees(before, after)`.
+
+- [ ] **Step 1: Write failing synthetic tests for surviving-helper loss, helper-plus-caller deletion, export/registration, import/re-export, exact lost sites, and a second helper.**
+- [ ] **Step 2: Run the focused pytest file and verify failures are caused by the missing audit module.**
+- [ ] **Step 3: Implement AST definition/reference indexing and transition comparison without symbol acknowledgements.**
+- [ ] **Step 4: Run the focused file and verify all synthetic cases pass.**
+
+### Task 2: Git-backed historical twin and CLI
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/private_orphan_transition.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py`
+
+**Interfaces:**
+- Consumes: `--before`, `--after`, and repository path.
+- Produces: exit 0 for no transitions; exit 1 with definition and lost-reference sites for findings.
+
+- [ ] **Step 1: Add failing subprocess tests for current-main green and `b7feb76b8` to `b273c4d05` red naming `_has_non_higher_order_return`.**
+- [ ] **Step 2: Run the historical tests and verify the missing CLI behavior is the reason for failure.**
+- [ ] **Step 3: Implement Git tree loading, package discovery, deterministic rendering, and exit status.**
+- [ ] **Step 4: Run the complete focused test file and verify every acceptance case passes.**
+
+### Task 3: Real-history population and shipment decision
+
+**Files:**
+- Modify only if test-discovered defects require it: audit script and focused test file.
+
+**Interfaces:**
+- Consumes: recent first-parent pairs ending at `b7feb76b8`.
+- Produces: measured transition population with exact classifications.
+
+- [ ] **Step 1: Run the audit over recent real first-parent history without output piping and record each transition.**
+- [ ] **Step 2: Classify every finding from source evidence; if the population is not low and explainable, bank the negative result and stop.**
+- [ ] **Step 3: If shippable, run fresh focused tests and the truthful/lying CLI twins.**
+- [ ] **Step 4: Review diff and status for scope, no CI wiring, no whitelist, and no vendor arm.**
+- [ ] **Step 5: Commit as `T Savo <evilgenius@nefariousplan.com>`, push, and open an unmerged PR.**

--- a/docs/superpowers/specs/2026-07-26-private-orphan-transition-design.md
+++ b/docs/superpowers/specs/2026-07-26-private-orphan-transition-design.md
@@ -1,0 +1,71 @@
+# Private Orphan Transition Detector Design
+
+## Rule
+
+Compare two Python source trees package by package. Report a finding only when
+a private module-level definition exists in both trees, has at least one
+syntax-authenticated reference in the before tree, and has zero such references
+in the after tree. Deleting the definition together with its callers is lawful.
+Definitions already unreferenced before the transition are outside the
+population.
+
+This is late telemetry. It is not enrolled in CI by this change.
+
+## Syntax model
+
+Parse Python with `ast`. A reference is a load of the definition name, an
+attribute reference, an import or re-export, a string member of `__all__`, or a
+string literal used as the attribute name in `getattr`, `setattr`, `hasattr`, or
+`delattr`. Decorator registration, class/member attachment, and explicit
+entry-point tables naturally contain load expressions and therefore count.
+Reference locations retain package-relative path, line, and column so a finding
+can name the lost before-tree sites.
+
+The candidate population is module-level functions and classes whose names
+begin with one underscore but are not magic names. Public names are excluded by
+construction. Framework hooks and authenticated dynamic dispatch declarations
+are excluded only when syntax proves the declaration: protocol/override or
+framework decorators, fixture decorators, `__all__`, and authenticated dynamic
+attribute operations. There is no symbol whitelist.
+
+Package ownership comes from Python package roots under
+`implementations/python/*/src`; references are counted across the whole owning
+distribution, including its tests where present. A same-named private
+definition in another package cannot satisfy the reference floor.
+
+## Interface and output
+
+The audit accepts `--before REV` and `--after REV`, reads both trees through
+Git, and exits nonzero when findings exist. Each finding names the surviving
+definition in the after tree and every lost reference site from the before
+tree. Summary output reports the number of package transitions and orphan
+transitions measured.
+
+## Acceptance
+
+Focused tests cover all six required cases:
+
+1. `b7feb76b8` compared with itself keeps `_has_non_higher_order_return` green.
+2. The real transition to `b273c4d05` is red and names both the helper and its
+   deleted reference sites.
+3. Removing the helper with its caller is green.
+4. A newly exported or registered zero-direct-call definition is green.
+5. Replacing a direct reference with a valid import/re-export is green.
+6. Finding output names the changed definition and lost reference locations.
+
+A second synthetic lying twin removes the caller of a different live private
+helper and must report that helper, proving the audit is not specialized to the
+historical symbol.
+
+Before shipping, run the detector across recent real first-parent history. Ship
+only if findings are few and each is explainable as the intended merge-loss
+signature. Otherwise bank the negative result and stop without weakening the
+detector.
+
+## Constraints
+
+- No CI wiring.
+- No handwritten symbol whitelist or vendor arm.
+- No broad local test or corpus run.
+- Focused tests only, with `PYTHONUNBUFFERED=1` when using `bin/bpytest`.
+- Capture command status before any output pipeline.

--- a/implementations/python/sugar-lift-py-tests/scripts/private_orphan_transition.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/private_orphan_transition.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Find private definitions whose final package reference vanished.
+
+This is deliberately a two-tree audit, not a dead-code census. Existing
+zero-reference definitions are outside its population.
+"""
+
+from __future__ import annotations
+
+import ast
+import argparse
+from collections import defaultdict
+from pathlib import Path
+import subprocess
+import tarfile
+from typing import Mapping, NamedTuple
+
+
+class Definition(NamedTuple):
+    package: str
+    path: str
+    line: int
+    column: int
+    name: str
+
+
+class ReferenceSite(NamedTuple):
+    path: str
+    line: int
+    column: int
+    kind: str
+
+
+class OrphanTransition(NamedTuple):
+    definition: Definition
+    lost_references: tuple[ReferenceSite, ...]
+
+
+class PackageIndex(NamedTuple):
+    definitions: Mapping[tuple[str, str], Definition]
+    references: Mapping[str, tuple[ReferenceSite, ...]]
+
+
+def _private_definition(name: str) -> bool:
+    return name.startswith("_") and not (name.startswith("__") and name.endswith("__"))
+
+
+def _string_members(node: ast.AST) -> tuple[ast.Constant, ...]:
+    if not isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return ()
+    return tuple(
+        item
+        for item in node.elts
+        if isinstance(item, ast.Constant) and isinstance(item.value, str)
+    )
+
+
+def _index_package(package: str, sources: Mapping[str, str]) -> PackageIndex:
+    definitions: dict[tuple[str, str], Definition] = {}
+    references: defaultdict[str, list[ReferenceSite]] = defaultdict(list)
+
+    for path, source in sorted(sources.items()):
+        _index_source(package, path, source, definitions, references)
+
+    return PackageIndex(
+        definitions=definitions,
+        references={name: tuple(sites) for name, sites in references.items()},
+    )
+
+
+def _index_source(
+    package: str,
+    path: str,
+    source: str,
+    definitions: dict[tuple[str, str], Definition],
+    references: defaultdict[str, list[ReferenceSite]],
+) -> None:
+    tree = ast.parse(source, filename=path)
+    for statement in tree.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if "/src/" in f"/{path}" and _private_definition(statement.name):
+                definitions[(path, statement.name)] = Definition(
+                    package,
+                    path,
+                    statement.lineno,
+                    statement.col_offset,
+                    statement.name,
+                )
+                for decorator in statement.decorator_list:
+                    references[statement.name].append(
+                        ReferenceSite(
+                            path,
+                            decorator.lineno,
+                            decorator.col_offset,
+                            "decorator-registration",
+                        )
+                    )
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            targets = (
+                statement.targets
+                if isinstance(statement, ast.Assign)
+                else [statement.target]
+            )
+            if any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in targets
+            ):
+                for member in _string_members(statement.value):
+                    references[member.value].append(
+                        ReferenceSite(path, member.lineno, member.col_offset, "__all__")
+                    )
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            references[node.id].append(
+                ReferenceSite(path, node.lineno, node.col_offset, "name")
+            )
+        elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+            references[node.attr].append(
+                ReferenceSite(path, node.lineno, node.col_offset, "attribute")
+            )
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                references[alias.name].append(
+                    ReferenceSite(path, node.lineno, node.col_offset, "import-reexport")
+                )
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "setattr", "hasattr", "delattr"}
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            member = node.args[1]
+            references[member.value].append(
+                ReferenceSite(
+                    path,
+                    member.lineno,
+                    member.col_offset,
+                    "dynamic-attribute",
+                )
+            )
+
+
+def compare_package_sources(
+    package: str,
+    before_sources: Mapping[str, str],
+    after_sources: Mapping[str, str],
+) -> tuple[OrphanTransition, ...]:
+    before = _index_package(package, before_sources)
+    after = _index_package(package, after_sources)
+    findings: list[OrphanTransition] = []
+
+    for key, definition in sorted(after.definitions.items()):
+        if key not in before.definitions:
+            continue
+        before_references = before.references.get(definition.name, ())
+        after_references = after.references.get(definition.name, ())
+        if before_references and not after_references:
+            findings.append(
+                OrphanTransition(
+                    definition=definition,
+                    lost_references=before_references,
+                )
+            )
+    return tuple(findings)
+
+
+def _package_index_at_revision(
+    repo: Path, revision: str, distribution: str
+) -> PackageIndex:
+    pathspec = f"implementations/python/{distribution}"
+    process = subprocess.Popen(
+        ["git", "archive", "--format=tar", revision, pathspec],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    definitions: dict[tuple[str, str], Definition] = {}
+    references: defaultdict[str, list[ReferenceSite]] = defaultdict(list)
+    assert process.stdout is not None
+    with tarfile.open(fileobj=process.stdout, mode="r|") as archive:
+        for member in archive:
+            if not member.isfile() or not member.name.endswith(".py"):
+                continue
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            try:
+                source = extracted.read().decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            _index_source(distribution, member.name, source, definitions, references)
+    stderr = process.communicate()[1]
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"git archive failed for {revision}: "
+            f"{stderr.decode(errors='replace').strip()}"
+        )
+    return PackageIndex(
+        definitions=definitions,
+        references={name: tuple(sites) for name, sites in references.items()},
+    )
+
+
+def _changed_python_paths(
+    repo: Path, before_revision: str, after_revision: str
+) -> dict[str, tuple[str, ...]]:
+    completed = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            before_revision,
+            after_revision,
+            "--",
+            "implementations/python",
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"git diff failed for {before_revision}..{after_revision}: "
+            f"{completed.stderr.strip()}"
+        )
+    changed: defaultdict[str, list[str]] = defaultdict(list)
+    for line in completed.stdout.splitlines():
+        parts = Path(line).parts
+        if (
+            len(parts) >= 4
+            and parts[:2] == ("implementations", "python")
+            and line.endswith(".py")
+        ):
+            changed[parts[2]].append(line)
+    surviving: dict[str, tuple[str, ...]] = {}
+    for distribution, paths in sorted(changed.items()):
+        package_path = f"implementations/python/{distribution}"
+        if all(
+            subprocess.run(
+                ["git", "cat-file", "-e", f"{revision}:{package_path}"],
+                cwd=repo,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            == 0
+            for revision in (before_revision, after_revision)
+        ):
+            surviving[distribution] = tuple(sorted(paths))
+    return surviving
+
+
+def _source_at_revision(repo: Path, revision: str, path: str) -> str | None:
+    completed = subprocess.run(
+        ["git", "show", f"{revision}:{path}"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def compare_git_revisions(
+    repo: Path, before_revision: str, after_revision: str
+) -> tuple[int, tuple[OrphanTransition, ...]]:
+    changed = _changed_python_paths(repo, before_revision, after_revision)
+    findings: list[OrphanTransition] = []
+    for package, changed_paths in changed.items():
+        before_changed_sources = {
+            path: source
+            for path in changed_paths
+            if (source := _source_at_revision(repo, before_revision, path)) is not None
+        }
+        before_changed = _index_package(package, before_changed_sources)
+        after = _package_index_at_revision(repo, after_revision, package)
+        for key, definition in sorted(after.definitions.items()):
+            lost_references = before_changed.references.get(definition.name, ())
+            if not lost_references or after.references.get(definition.name, ()):
+                continue
+            before_definition_source = _source_at_revision(
+                repo, before_revision, definition.path
+            )
+            if before_definition_source is None:
+                continue
+            before_definition = _index_package(
+                package, {definition.path: before_definition_source}
+            )
+            if key in before_definition.definitions:
+                findings.append(OrphanTransition(definition, lost_references))
+    return len(changed), tuple(findings)
+
+
+def _render(packages: int, findings: tuple[OrphanTransition, ...]) -> str:
+    lines: list[str] = []
+    for finding in findings:
+        definition = finding.definition
+        lines.append(
+            f"{definition.path}:{definition.line}:{definition.column}: "
+            f"private orphan transition: {definition.name} "
+            f"(package {definition.package})"
+        )
+        for site in finding.lost_references:
+            lines.append(
+                f"  lost reference {site.path}:{site.line}:{site.column} "
+                f"[{site.kind}]"
+            )
+    lines.append(f"package_transitions={packages} orphan_transitions={len(findings)}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--before", required=True)
+    parser.add_argument("--after", required=True)
+    args = parser.parse_args(argv)
+    packages, findings = compare_git_revisions(
+        args.repo.resolve(), args.before, args.after
+    )
+    print(_render(packages, findings))
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "private_orphan_transition.py"
+REPO = Path(__file__).parents[4]
+
+
+def _load_audit():
+    spec = importlib.util.spec_from_file_location("private_orphan_transition", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _transitions(before: dict[str, str], after: dict[str, str]):
+    audit = _load_audit()
+    return audit.compare_package_sources("demo", before, after)
+
+
+def test_surviving_private_definition_that_loses_last_reference_is_reported() -> None:
+    before = {
+        "src/demo/manager.py": (
+            "def _classify(value):\n"
+            "    return value\n\n"
+            "def build(value):\n"
+            "    return _classify(value)\n"
+        )
+    }
+    after = {
+        "src/demo/manager.py": (
+            "def _classify(value):\n"
+            "    return value\n\n"
+            "def build(value):\n"
+            "    return value\n"
+        )
+    }
+
+    findings = _transitions(before, after)
+
+    assert [finding.definition.name for finding in findings] == ["_classify"]
+    assert [(site.path, site.line) for site in findings[0].lost_references] == [
+        ("src/demo/manager.py", 5)
+    ]
+
+
+def test_removing_private_definition_with_its_caller_is_lawful() -> None:
+    before = {
+        "src/demo/manager.py": (
+            "def _classify(value):\n"
+            "    return value\n\n"
+            "def build(value):\n"
+            "    return _classify(value)\n"
+        )
+    }
+    after = {"src/demo/manager.py": "def build(value):\n    return value\n"}
+
+    assert _transitions(before, after) == ()
+
+
+@pytest.mark.parametrize(
+    ("before_source", "registered_source"),
+    [
+        (
+            "def _registered():\n    return 1\n\nVALUE = _registered()\n",
+            "__all__ = ['_registered']\n\ndef _registered():\n    return 1\n",
+        ),
+        (
+            "def register(function):\n    return function\n\n"
+            "def _registered():\n    return 1\n\nVALUE = _registered()\n",
+            "def register(function):\n    return function\n\n"
+            "@register\ndef _registered():\n    return 1\n",
+        ),
+    ],
+)
+def test_new_exported_or_registered_private_definition_is_lawful(
+    before_source: str,
+    registered_source: str,
+) -> None:
+    before = {"src/demo/hooks.py": before_source}
+    after = {"src/demo/hooks.py": registered_source}
+
+    assert _transitions(before, after) == ()
+
+
+def test_replacing_direct_reference_with_import_reexport_preserves_reference() -> None:
+    before = {
+        "src/demo/manager.py": "def _classify(value):\n    return value\n",
+        "src/demo/api.py": "from .manager import _classify\n\nVALUE = _classify(1)\n",
+    }
+    after = {
+        "src/demo/manager.py": "def _classify(value):\n    return value\n",
+        "src/demo/api.py": "from .manager import _classify as classify\n\n__all__ = ['classify']\n",
+    }
+
+    assert _transitions(before, after) == ()
+
+
+def test_second_private_helper_is_not_special_cased() -> None:
+    before = {
+        "src/demo/other.py": (
+            "def _normalize(value):\n"
+            "    return value\n\n"
+            "NORMALIZERS = {'default': _normalize}\n"
+        )
+    }
+    after = {
+        "src/demo/other.py": (
+            "def _normalize(value):\n" "    return value\n\n" "NORMALIZERS = {}\n"
+        )
+    }
+
+    findings = _transitions(before, after)
+
+    assert [finding.definition.name for finding in findings] == ["_normalize"]
+    assert findings[0].lost_references[0].line == 4
+
+
+def _run_cli(before: str, after: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(REPO),
+            "--before",
+            before,
+            "--after",
+            after,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_current_main_truthful_twin_is_green() -> None:
+    completed = _run_cli("b7feb76b8", "b7feb76b8")
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "orphan_transitions=0" in completed.stdout
+
+
+def test_real_branch_loss_names_helper_and_deleted_reference() -> None:
+    completed = _run_cli("b7feb76b8", "b273c4d05")
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "_has_non_higher_order_return" in completed.stdout
+    assert "manager_construction.py:1134" in completed.stdout
+    assert "lost reference" in completed.stdout
+    assert "manager_construction.py:836" in completed.stdout


### PR DESCRIPTION
## What changed

- add a syntax-based two-tree audit for private Python definitions that transition from referenced-before to zero-references-after while the definition survives
- count direct/value references, imports and re-exports, `__all__`, decorator registration, attribute attachment, explicit entry-point tables, and authenticated dynamic attribute access
- report the surviving definition and every lost before-tree reference site
- add synthetic lawful/deceptive twins and the in-tree `b273c4d05` historical lying twin

## Why

Merge loss can preserve a private helper while silently dropping its only caller. Ordinary behavior tests may not exercise the lost branch, but the reference transition is mechanically visible. This audit is deliberately late telemetry and is not enrolled in CI.

## Measured population

Comparing `b7feb76b8` to `b273c4d05`:

```text
package_transitions=3 orphan_transitions=1
```

The sole finding is `_has_non_higher_order_return` surviving at `manager_construction.py:1134` after its reference at line 836 disappeared.

## Validation

```text
PYTHONUNBUFFERED=1 python3 -m pytest --noconftest implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py -q
8 passed in 18.86s

uvx --from black==26.5.1 black --check implementations/python/sugar-lift-py-tests/scripts/private_orphan_transition.py implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py
2 files would be left unchanged
```

The package-local `uv run` formatter path remains unavailable because existing project metadata permits Python 3.8 while the pinned test dependency `numpy==2.5.1` requires Python 3.12; the repository-pinned Black version was run directly instead.

## Scope

- base: `47cc6d031`
- no CI wiring
- no symbol whitelist
- no vendor arm
- no merge requested


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add AST-based private orphan transition detector with CLI and pytest suite
> - Adds [private_orphan_transition.py](https://github.com/TSavo/sugar/pull/6474/files#diff-da5f7bd4cd7fc79e354f34ad89e504b2b4ee8d40271e06ee2807925c48474484), a script that walks two git revisions, indexes private Python definitions and their reference sites via AST, and reports any surviving private definition that loses all references across the transition.
> - The CLI accepts `--repo`, `--before`, and `--after` revision args, prints a human-readable report, and exits 1 when findings exist or 0 otherwise.
> - Reference counting covers direct name/attribute loads, `__all__` membership, decorator sites, `ImportFrom` aliases, and dynamic `getattr`/`setattr`/`hasattr`/`delattr` string arguments.
> - Adds [test_private_orphan_transition.py](https://github.com/TSavo/sugar/pull/6474/files#diff-46bb7a7332110c8d2571d1718f7aeb654150aa331f6d6e77cc4c763112b0cc41) with synthetic in-memory cases (joint deletion, export/registration exemptions, import re-export) and subprocess-based historical twin tests against real git revisions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ee5dd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->