### PR TITLE
Authenticated warning testimony gets a producer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/warning_observation_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/warning_observation_value.py
@@ -16,3 +16,19 @@ class WarningObservationValue(FloorValue):
     """
 
     effect: WarningEffect
+    # Branch guards this occurrence was reached under, outermost last. An
+    # occurrence under a guard is a CONDITIONAL one: the source says the
+    # warning happens when the guard holds, not that it happens. Carrying the
+    # guards is what lets the consuming boundary refuse rather than silently
+    # promote a conditional occurrence to an unconditional claim.
+    guards: tuple = ()
+
+    def guarded(self, formula):
+        """Ride under a branch guard, RECORDING it.
+
+        Not ``return self``: that is the arm ``CallSiteValue`` can take,
+        because a call coordinate is a value the branch guard already owns.
+        This entry is testimony that an effect OCCURRED, so dropping the guard
+        would convert "warns when the guard holds" into "warns".
+        """
+        return WarningObservationValue(self.effect, (formula, *self.guards))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/expr_statement_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/expr_statement_sugar.py
@@ -31,6 +31,9 @@ class ExprStatementSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.sugar.warning_observation_producer import (
+            project_warning_observation,
+        )
 
         # Reduce the value (effects propagate via and_then). A completed value
         # in statement position STATES nothing -- but it is not erased: it rides
@@ -39,6 +42,20 @@ class ExprStatementSugar(Sugar):
         # visibility to the effect router -- dropping it made `with raises(E):
         # do_thing()` claim a FALSE absence, since the router could no longer
         # see that a halt might hide behind the unresolved call).
+        #
+        # One statement value is more than a coordinate: an authenticated
+        # `warnings.warn(msg, Category)` occurrence. It rides as the warning
+        # testimony the completed-face boundary consumes. The projection lives
+        # HERE rather than in CallSiteSugar because statement position is what
+        # makes it an occurrence -- a warn call read as an expression operand
+        # would be a value, and this record entry is not one. An occurrence
+        # that does not authenticate keeps its ordinary call coordinate and the
+        # boundary names it unresolved; it is never read as "no warning".
         return self.value.desugar(ctx).and_then(
-            lambda value: Complete(BlockValue((value,), can_fall_through=True))
+            lambda value: Complete(
+                BlockValue(
+                    (project_warning_observation(value) or value,),
+                    can_fall_through=True,
+                )
+            )
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/warning_observation_producer.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/warning_observation_producer.py
@@ -1,0 +1,125 @@
+"""The producer of authenticated warning testimony.
+
+``dd3d1b5ca`` (#6458) routed authenticated warnings on completed ``With``
+faces, and ``WithEffectBoundarySugar`` has consumed ``WarningObservationValue``
+ever since -- but nothing in any ``src`` tree ever CONSTRUCTED one.  Every
+warning boundary therefore reached the "unresolved warning producers" refusal
+by construction, and the consumer's own twins were green against a category
+term (``python:warning_category_identity``) that exists at no revision outside
+the test that invented it.  This module is the missing producer, and it emits
+the real ``python:exception_type_identity`` the ``raise``/``except`` projection
+already mints, so no new vocabulary enters the term table.
+
+The occurrence recognised here is a ``warnings.warn(...)`` call in STATEMENT
+position.  Three things bound it, all lexical:
+
+* the callee is the closed import-bound coordinate ``warnings.warn`` --
+  ``Call._import_bound_callee_symbol`` refuses a shadowed, parameter or
+  ambiguous head, so a local named ``warnings`` mints nothing;
+* the operand positions come from CPython's own fixed ``warnings.warn``
+  signature, not from a vendor convention;
+* the category is authenticated by the ordinary exception-class authenticator
+  (``SourceUnit.exception_type_identity``), because a Python warning category
+  IS an exception class.
+
+An occurrence that fails any of those keeps its ordinary ``CallSiteValue`` and
+rides the record unchanged, where the boundary already names it as an
+unresolved warning producer.  Producing nothing is the honest outcome; a bare
+``warnings.warn("msg")`` is NOT evidence of a ``UserWarning`` occurrence, since
+that default lives in CPython rather than in the source text, and inferring it
+here would put an unstated assumption inside an authenticated coordinate.
+"""
+
+from __future__ import annotations
+
+# CPython's own signature:
+#   warn(message, category=UserWarning, stacklevel=1, source=None, *,
+#        skip_file_prefixes=())
+# Only the category position is read.  ``stacklevel``/``source`` select the
+# frame a warning is ATTRIBUTED to; they do not decide which warning occurred,
+# so they neither contribute to nor block the observation.
+WARNING_OCCURRENCE_SYMBOL = "warnings.warn"
+WARNING_MESSAGE_PARAMETER_INDEX = 0
+WARNING_CATEGORY_PARAMETER_INDEX = 1
+WARNING_CATEGORY_PARAMETER_NAME = "category"
+_WARNING_KEYWORD_PARAMETER_NAMES = frozenset(
+    {"message", "category", "stacklevel", "source", "skip_file_prefixes"}
+)
+
+
+def project_warning_observation(value):
+    """Project one authenticated ``WarningObservationValue``, or ``None``.
+
+    ``value`` is the reduced statement value.  ``None`` means "this statement
+    is not an authenticated warning occurrence" -- never "no warning occurred".
+    """
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+
+    if not isinstance(value, CallSiteValue):
+        return None
+    if value.target_name != WARNING_OCCURRENCE_SYMBOL:
+        return None
+
+    keyword_names = value.keyword_names
+    keyword_count = len(keyword_names)
+    positional = value.arg_values[: len(value.arg_values) - keyword_count]
+    keywords = dict(zip(keyword_names, value.arg_values[len(positional) :]))
+
+    # A spread (``**kwargs``) keyword arrives spelled ``**``: the actual set is
+    # not closed, so the occurrence is not authenticated.
+    if not set(keywords) <= _WARNING_KEYWORD_PARAMETER_NAMES:
+        return None
+    if len(positional) <= WARNING_MESSAGE_PARAMETER_INDEX and "message" not in keywords:
+        return None
+    if len(positional) > WARNING_CATEGORY_PARAMETER_INDEX:
+        category = positional[WARNING_CATEGORY_PARAMETER_INDEX]
+        if WARNING_CATEGORY_PARAMETER_NAME in keywords:
+            return None
+    else:
+        category = keywords.get(WARNING_CATEGORY_PARAMETER_NAME)
+    if category is None:
+        return None
+
+    identity_reader = getattr(category, "exception_type_identity", None)
+    if not callable(identity_reader):
+        return None
+    identity = identity_reader()
+    if identity is None:
+        return None
+    category_name = _category_spelling(identity)
+    if category_name is None:
+        return None
+
+    from sugar_lift_py_tests.effect.warning_effect import WarningEffect
+    from sugar_lift_py_tests.floor.warning_observation_value import (
+        WarningObservationValue,
+    )
+
+    return WarningObservationValue(
+        WarningEffect(
+            category_name=category_name,
+            # The message operand is a constructed value, not necessarily a
+            # literal (pandas warns with f-strings).  ``None`` is the documented
+            # "no authenticated message carried"; it is not an empty message and
+            # cannot discharge a message-pattern obligation.  The boundary keeps
+            # message-bearing warning assertions loud on its own side.
+            message=None,
+            blame=None if value.site is None else str(value.site),
+            category_identity=identity,
+        )
+    )
+
+
+def _category_spelling(identity):
+    """The diagnostic spelling, read OFF the authenticated identity.
+
+    Deliberately not read off the source text: the spelling must never be able
+    to disagree with the term that decides the match.
+    """
+    args = getattr(identity, "args", ())
+    if len(args) != 2:
+        return None
+    name = getattr(args[1], "value", None)
+    if not isinstance(name, str):
+        return None
+    return name

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -217,6 +217,33 @@ def _bind_real_actuals(signature, manager_value):
     return fixed
 
 
+def _unresolved_producer_coordinates(entries):
+    """The MEMBERS of the "unresolved warning producers" bucket, by coordinate.
+
+    Every call that survived to the completed face unreduced is a call this
+    boundary could not rule out as the warning it is looking for -- including
+    the three shapes the producer deliberately refuses (no explicit category, a
+    category that is not a closed class coordinate, and a shadowed or parameter
+    head).  Each is named ``file:line`` from its own pinned fragment, never from
+    the spelling of its head.  A call whose fragment is absent still counts as a
+    member and says so; dropping it would let the bucket under-report.
+    """
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+
+    members = []
+    for entry in entries:
+        if not isinstance(entry, CallSiteValue):
+            continue
+        fragment = entry.site
+        filename = getattr(fragment, "filename", None)
+        line = getattr(fragment, "line", None)
+        if filename is None or line is None:
+            members.append(f"<unlocated>:{entry.target_name}")
+        else:
+            members.append(f"{filename}:{line}")
+    return tuple(members)
+
+
 def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode, site):
     """Route authenticated warning testimony carried by a COMPLETED body face.
 
@@ -280,22 +307,34 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
         unauthenticated = tuple(
             entry
             for _, entry in observations
-            if entry.effect.category_identity is None
+            if entry.effect.category_identity is None or entry.guards
         )
         if unauthenticated or not observations:
-            unresolved = any(
-                isinstance(entry, CallSiteValue) for entry in entries
-            )
-            raise SugarNotWritten(
+            unresolved_members = _unresolved_producer_coordinates(entries)
+            unresolved = bool(unresolved_members)
+            if unresolved or not observations:
+                observed = "completed face has unresolved warning producers"
+            elif any(entry.guards for entry in unauthenticated):
+                # The producer says the warning happens WHEN a branch guard
+                # holds. Consuming it here would restate that as "the warning
+                # happens", which is a strictly stronger claim than the source
+                # makes. Undecided, not absent, and not present.
+                observed = "warning occurrence is reached only under a branch guard"
+            else:
+                observed = "warning occurrence has no authenticated category identity"
+            refusal = SugarNotWritten(
                 owner="WithEffectBoundarySugar.warning_observation",
-                observed=(
-                    "completed face has unresolved warning producers"
-                    if unresolved or not observations
-                    else "warning occurrence has no authenticated category identity"
-                ),
+                observed=observed,
                 requested="one source-authenticated WarningObservationValue on the completed face",
                 fix="construct producer-owned warning testimony; never infer absence or category from spelling",
             )
+            # The bucket ENUMERATES its members.  A refusal that only names a
+            # bucket is indistinguishable from a producer that was never wired:
+            # both leave the produced set empty, and a test can only assert
+            # absence, which the never-wired case satisfies too.  A caller can
+            # now require a specific coordinate to be PRESENT here.
+            refusal.unresolved_warning_producers = unresolved_members
+            raise refusal
         match = next(
             (
                 pair

--- a/implementations/python/sugar-lift-py-tests/tests/test_warning_observation_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_warning_observation_producer.py
@@ -1,0 +1,382 @@
+"""The producer of authenticated warning testimony, from real source.
+
+``dd3d1b5ca`` (#6458) shipped the CONSUMER of ``WarningObservationValue`` and
+no producer: ``git grep -c "WarningObservationValue(" 964dbf95d`` hit exactly
+three files, the definition and two test modules, and nothing in any ``src``
+tree.  Every warning boundary therefore reached its "unresolved warning
+producers" refusal by construction.  These twins own the other half.
+
+Two real pandas 3.0 sites, one on each side of the cut, are the reproducers:
+
+* ``pandas/core/accessor.py:285`` -- ``warnings.warn(msg, UserWarning,
+  stacklevel=find_stack_level())`` under ``if hasattr(cls, name)``;
+* ``pandas/core/algorithms.py:1033`` -- ``warnings.warn(f"Unable to sort modes:
+  {err}", stacklevel=find_stack_level())``, with NO explicit category.
+
+The second one is why explicit-category-only is the cut: ``UserWarning`` there
+is a defaulting rule living in CPython, not in the source text.
+
+Nothing below supplies the value it then asserts.  The distinctive value is the
+category SPELLED IN THE SOURCE, and each twin requires that same category out
+the far side of a lift that never saw the expected term; the lying arm writes a
+different category in the source and requires the projection to move with it.
+No tooth here reads a wall clock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    ImportSignatureV2,
+    NoDefaultV1,
+    NoMessagePatternV1,
+    PositionalOrKeywordV1,
+    WarningEffectKindV1,
+    WarningObservationBindingV1,
+)
+from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+from sugar_lift_py_tests.floor import CallSiteValue, TermValue
+from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _entries(tmp_path: Path, source: str, stem: str = "warn_case"):
+    """Every record entry of every completed face, from real lifted source."""
+    path = tmp_path / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    function = next(SourceFile(path_source(str(path))).functions())
+    exits = reduce_block_to_exitset(function.sugar().statements, None)
+    return tuple(
+        entry for face in exits.exits for entry in getattr(face.value, "entries", ())
+    )
+
+
+def _observations(tmp_path: Path, source: str, stem: str = "warn_case"):
+    return tuple(
+        entry
+        for entry in _entries(tmp_path, source, stem)
+        if isinstance(entry, WarningObservationValue)
+    )
+
+
+def _builtin_category_identity(name: str):
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+# The pandas ``accessor.py:285`` occurrence, hoisted out of its ``if`` so the
+# occurrence is unconditional.  The guarded spelling is its own twin below.
+PANDAS_ACCESSOR_WARN = """import warnings
+
+
+def register(cls, name, accessor):
+    warnings.warn(
+        "registration of accessor is overriding a preexisting attribute",
+        {category},
+        stacklevel=2,
+    )
+"""
+
+# The pandas ``algorithms.py:1033`` occurrence, verbatim in shape: no category.
+PANDAS_ALGORITHMS_WARN = """import warnings
+
+
+def mode(err):
+    warnings.warn(
+        "Unable to sort modes",
+        stacklevel=2,
+    )
+"""
+
+
+@pytest.mark.parametrize(
+    "category",
+    ["UserWarning", "FutureWarning", "DeprecationWarning", "RuntimeWarning"],
+)
+def test_real_warn_site_produces_its_own_source_category(tmp_path, category):
+    """The category WRITTEN IN THE SOURCE is the one that comes out.
+
+    Parametrised because a producer that hard-coded any single category — or
+    that read the category off a table rather than off this file — would pass
+    exactly one arm.  The expected term is built from ``category`` here, but
+    the lift is handed only the source text.
+    """
+    observations = _observations(
+        tmp_path, PANDAS_ACCESSOR_WARN.format(category=category)
+    )
+    assert len(observations) == 1
+    effect = observations[0].effect
+    assert effect.category_identity == _builtin_category_identity(category)
+    assert effect.category_name == category
+    assert observations[0].guards == ()
+
+
+def test_a_different_source_category_projects_a_different_identity(tmp_path):
+    """The lying arm: change only the category, the coordinate must move."""
+    truthful = _observations(
+        tmp_path, PANDAS_ACCESSOR_WARN.format(category="FutureWarning"), "truthful"
+    )
+    lying = _observations(
+        tmp_path, PANDAS_ACCESSOR_WARN.format(category="UserWarning"), "lying"
+    )
+    assert truthful[0].effect.category_identity != lying[0].effect.category_identity
+    assert truthful[0].effect.category_identity == _builtin_category_identity(
+        "FutureWarning"
+    )
+
+
+def test_keyword_spelled_category_is_the_same_occurrence(tmp_path):
+    """``category=`` binds the same CPython formal that position 1 does."""
+    source = """import warnings
+
+
+def f():
+    warnings.warn("m", category=FutureWarning, stacklevel=2)
+"""
+    observations = _observations(tmp_path, source)
+    assert len(observations) == 1
+    assert observations[0].effect.category_identity == _builtin_category_identity(
+        "FutureWarning"
+    )
+
+
+def test_pandas_default_category_site_produces_no_testimony(tmp_path):
+    """``warnings.warn(msg)`` is NOT evidence of a ``UserWarning`` occurrence.
+
+    The default lives in CPython, not in the source text.  The occurrence keeps
+    its ordinary call coordinate, and the boundary names it unresolved.
+    """
+    entries = _entries(tmp_path, PANDAS_ALGORITHMS_WARN)
+    assert not any(isinstance(entry, WarningObservationValue) for entry in entries)
+    assert any(isinstance(entry, CallSiteValue) for entry in entries)
+
+
+def test_a_shadowed_head_is_not_a_warning_occurrence(tmp_path):
+    """The door is lexical import binding, never the dotted spelling.
+
+    A parameter named ``warnings`` spells ``warnings.warn`` exactly, and mints
+    nothing.  This is the discrimination the existing With census lacks.
+    """
+    source = """def f(warnings):
+    warnings.warn("m", UserWarning, stacklevel=2)
+"""
+    entries = _entries(tmp_path, source)
+    assert not any(isinstance(entry, WarningObservationValue) for entry in entries)
+    assert any(isinstance(entry, CallSiteValue) for entry in entries)
+
+
+def test_a_computed_category_carries_no_identity(tmp_path):
+    """A category that is not a closed class coordinate stays undecided."""
+    source = """import warnings
+
+
+def f(pick):
+    warnings.warn("m", pick(), stacklevel=2)
+"""
+    entries = _entries(tmp_path, source)
+    assert not any(isinstance(entry, WarningObservationValue) for entry in entries)
+
+
+def test_the_guarded_pandas_site_records_its_guard(tmp_path):
+    """``accessor.py:285`` as pandas actually writes it: under ``if hasattr``.
+
+    The occurrence is conditional, so the testimony carries the branch guard.
+    Dropping it would restate "warns when the guard holds" as "warns".
+    """
+    source = """import warnings
+
+
+def register(cls, name):
+    if hasattr(cls, name):
+        warnings.warn("m", UserWarning, stacklevel=2)
+"""
+    observations = _observations(tmp_path, source)
+    assert len(observations) == 1
+    assert observations[0].guards != ()
+
+
+# --- the producer through the shipped consumer ------------------------------
+
+
+class _Fixed(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _ExpectedCategory(TermValue):
+    def exception_type_identity(self):
+        return self.value
+
+
+class _Record(Sugar):
+    """A completed face whose entries are the ones the PRODUCER built."""
+
+    def __init__(self, entries):
+        self.entries = entries
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.floor import BlockValue
+
+        return Complete(BlockValue(self.entries))
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+SEMANTICS = EffectBoundarySemanticsV1(
+    ExpectsModeV1(),
+    WarningEffectKindV1(),
+    FormalArgumentProjectionV1(0),
+    NoMessagePatternV1(),
+    WarningObservationBindingV1(),
+)
+
+
+def _boundary(expected_category: str, entries):
+    expected = _ExpectedCategory(_builtin_category_identity(expected_category))
+    manager_value = CallSiteValue(
+        target_name="scope",
+        arg_values=(expected,),
+        parameters=("expected",),
+        term=ctor("call", []),
+        body=None,
+    )
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    return WithEffectBoundarySugar(
+        manager=_Fixed(Complete(manager_value)),
+        body=(_Record(entries),),
+        semantics=SEMANTICS,
+        contract_ref=SimpleNamespace(import_signature=signature),
+        context_manager_edge=None,
+        site=None,
+    )
+
+
+def test_produced_testimony_satisfies_a_matching_boundary(tmp_path):
+    """The truthful twin, end to end: real source in, completed face out."""
+    entries = _observations(
+        tmp_path, PANDAS_ACCESSOR_WARN.format(category="FutureWarning")
+    )
+    routed = _boundary("FutureWarning", entries).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Completed)
+    assert not any(
+        isinstance(entry, WarningObservationValue) for entry in face.value.entries
+    )
+
+
+def test_produced_testimony_fails_a_mismatched_boundary(tmp_path):
+    """The lying twin: the source warns ``UserWarning``, the boundary expects
+    ``FutureWarning``.  It must go red, and it is the PRODUCER's coordinate
+    that decides — the boundary is spelled identically in both twins."""
+    entries = _observations(
+        tmp_path, PANDAS_ACCESSOR_WARN.format(category="UserWarning")
+    )
+    routed = _boundary("FutureWarning", entries).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def _refusal_members(tmp_path, source, stem):
+    """Route real lifted source into the boundary; return the named bucket."""
+    path = tmp_path / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    function = next(SourceFile(path_source(str(path))).functions())
+    exits = reduce_block_to_exitset(function.sugar().statements, None)
+    entries = tuple(
+        entry for face in exits.exits for entry in getattr(face.value, "entries", ())
+    )
+    with pytest.raises(SugarNotWritten) as raised:
+        _boundary("FutureWarning", entries).desugar()
+    assert raised.value.observed == "completed face has unresolved warning producers"
+    return str(path), raised.value.unresolved_warning_producers
+
+
+def _line_of(source: str, needle: str) -> int:
+    """The 1-based line of ``needle``, computed from the text, not the lift."""
+    return source[: source.index(needle)].count("\n") + 1
+
+
+# All three producer refusal shapes, each asserted PRESENT in the named bucket.
+# Presence, never absence: a producer that was never wired at all leaves the
+# produced set empty too, so an absence assertion is satisfied by the mechanism
+# not running.  The expected line is computed from the source text here and the
+# lift is handed only the text, so the coordinate is not supplied by the test.
+@pytest.mark.parametrize(
+    "stem,source",
+    [
+        # pandas ``core/algorithms.py:1033`` -- no explicit category.
+        ("no_category", PANDAS_ALGORITHMS_WARN),
+        # A category that is not a closed class coordinate.
+        (
+            "computed_category",
+            'import warnings\n\n\ndef f(pick):\n    warnings.warn("m", pick(), stacklevel=2)\n',
+        ),
+        # A shadowed head: spells ``warnings.warn`` exactly, binds nothing.
+        (
+            "shadowed_head",
+            'def f(warnings):\n    warnings.warn("m", UserWarning, stacklevel=2)\n',
+        ),
+    ],
+)
+def test_a_refused_producer_appears_in_the_unresolved_bucket(tmp_path, stem, source):
+    filename, members = _refusal_members(tmp_path, source, stem)
+    assert f"{filename}:{_line_of(source, 'warnings.warn')}" in members
+
+
+def test_a_guarded_occurrence_is_refused_not_consumed(tmp_path):
+    """A conditional occurrence is undecided at the boundary: not present, not
+    absent.  Consuming it would be a strictly stronger claim than the source."""
+    source = """import warnings
+
+
+def register(cls, name):
+    if hasattr(cls, name):
+        warnings.warn("m", FutureWarning, stacklevel=2)
+"""
+    entries = _observations(tmp_path, source)
+    with pytest.raises(SugarNotWritten) as raised:
+        _boundary("FutureWarning", entries).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert "branch guard" in raised.value.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -48,7 +48,16 @@ class _ExpectedCategory(TermValue):
 
 
 def _identity(name: str):
-    return ctor("python:warning_category_identity", [str_const("builtins"), str_const(name)])
+    # ``python:exception_type_identity`` -- the SAME term the raise/except
+    # projection mints (``SourceUnit.exception_type_identity``) and the same one
+    # ``project_warning_observation`` emits. These twins previously spelled a
+    # ``python:warning_category_identity`` that exists at no revision outside
+    # this file, so they were green against a vocabulary of their own making:
+    # the production path could never have emitted the term under test.
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
 
 
 SEMANTICS = EffectBoundarySemanticsV1(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7507,6 +7507,14 @@ class Call(Expression):
                 source_call_frame=source_call_frame,
             )
         if isinstance(self.func, Attribute):
+            # Lexical import binding is the ONLY door to a closed callee
+            # coordinate. `None` here means the head is a parameter, a local, a
+            # shadowed or ambiguous name -- and it must REFUSE, falling through
+            # to the ordinary method-call construction below. Do not "helpfully"
+            # fall back to the dotted spelling: that is precisely the defect the
+            # With census carries (keyed on `pytest.raises` as a string, 6353
+            # rows of spelling), and it would let a local named `warnings` mint
+            # authenticated warning testimony it has no authority for.
             closed_symbol = self._import_bound_callee_symbol()
             if closed_symbol is not None:
                 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
@@ -7516,9 +7524,18 @@ class Call(Expression):
                 # the whole dotted spelling exactly as it does for a Name
                 # callee. No receiver constructs, so no module alias is minted
                 # as a universe Var it was never declared as.
+                from sugar_lift_py_tests.sugar.warning_observation_producer import (
+                    WARNING_OCCURRENCE_SYMBOL,
+                )
+
+                args_sugar = tuple(a.sugar() for a in self.args)
+                if closed_symbol == WARNING_OCCURRENCE_SYMBOL:
+                    args_sugar, keyword_sugars = self._authenticate_warning_category(
+                        args_sugar, keyword_sugars
+                    )
                 return CallSiteSugar(
                     target_name=closed_symbol,
-                    args=tuple(a.sugar() for a in self.args),
+                    args=args_sugar,
                     site=self.fragment,
                     keywords=keyword_sugars,
                 )
@@ -7590,6 +7607,62 @@ class Call(Expression):
             chain = chain.value
         module = target[len("python:") :] if target.startswith("python:") else target
         return ".".join([module, *reversed(attributes)])
+
+    def _authenticate_warning_category(self, args_sugar, keyword_sugars):
+        """Attach the floor-owned class identity to a ``warnings.warn`` category.
+
+        The category operand of a warning occurrence is an ordinary Python
+        exception class, so the SAME lexical authenticator that owns ``raise``
+        and ``except`` operands owns it -- no warning name table is minted. The
+        operand position comes from CPython's own fixed ``warnings.warn``
+        signature, not from a vendor convention.
+
+        An operand that is not a bare ``Name``, or a ``Name`` with no closed
+        class identity, is left exactly as constructed: the call then stays an
+        ordinary unresolved call site and the consuming boundary reports it as
+        an unresolved warning producer. Absent identity is never inferred.
+        """
+        from sugar_lift_py_tests.sugar.authenticated_exception_type_sugar import (
+            AuthenticatedExceptionTypeSugar,
+        )
+        from sugar_lift_py_tests.sugar.warning_observation_producer import (
+            WARNING_CATEGORY_PARAMETER_INDEX,
+            WARNING_CATEGORY_PARAMETER_NAME,
+        )
+
+        location = None
+        if len(self.args) > WARNING_CATEGORY_PARAMETER_INDEX:
+            actual = self.args[WARNING_CATEGORY_PARAMETER_INDEX]
+            location = ("arg", WARNING_CATEGORY_PARAMETER_INDEX)
+        else:
+            actual = None
+            for keyword in self.keywords:
+                if keyword.arg == WARNING_CATEGORY_PARAMETER_NAME:
+                    actual, location = keyword.value, ("keyword", keyword.arg)
+                    break
+        if not isinstance(actual, Name):
+            return args_sugar, keyword_sugars
+        identity = self.unit.exception_type_identity(actual)
+        if identity is None:
+            return args_sugar, keyword_sugars
+        mro = self.unit.exception_type_mro(actual)
+        if location[0] == "arg":
+            args = list(args_sugar)
+            args[location[1]] = AuthenticatedExceptionTypeSugar(
+                args[location[1]], identity, mro, site=actual.fragment
+            )
+            return tuple(args), keyword_sugars
+        keywords = list(keyword_sugars)
+        for position, (name, sugar) in enumerate(keywords):
+            if name == location[1]:
+                keywords[position] = (
+                    name,
+                    AuthenticatedExceptionTypeSugar(
+                        sugar, identity, mro, site=actual.fragment
+                    ),
+                )
+                break
+        return args_sugar, tuple(keywords)
 
     def _spread_source_call_frame(self):
         """Authenticated source frame for a ``*``/``**`` call, when enrolled.

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -710,17 +710,51 @@ def test_ordinary_except_does_not_consume_grouped_raise():
     assert isinstance(outcome.effect, GroupedRaiseEffect)
 
 
-def test_warnings_warn_does_not_fabricate_a_warning_effect_without_a_producer():
-    """The live warning schema has no source producer; the call stays unresolved."""
+def test_warnings_warn_with_an_explicit_category_mints_authenticated_testimony():
+    """This test previously pinned the ABSENCE of a source producer.
+
+    It was right when it was written -- nothing in any ``src`` tree constructed
+    a ``WarningObservationValue``, so the consumer shipped in ``dd3d1b5ca``
+    (#6458) had no other half. The producer now exists, so the absence it
+    asserted is no longer the truth about this source, and pinning it would
+    keep the gap green. What replaces it is the same claim in the positive
+    direction: an EXPLICIT source-written category authenticates, and its
+    coordinate is the ordinary ``python:exception_type_identity`` the
+    raise/except projection already mints -- no warning vocabulary is added.
+    """
+    from sugar_lift_py_tests.floor.warning_observation_value import (
+        WarningObservationValue,
+    )
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    v = _val(
+        "import warnings\n" "def A():\n" "    warnings.warn('message', UserWarning)\n"
+    )
+    entries = v.record.contribution()
+    observations = [
+        entry for entry in entries if isinstance(entry, WarningObservationValue)
+    ]
+    assert len(observations) == 1
+    assert observations[0].effect.category_identity == ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("UserWarning")],
+    )
+    assert observations[0].guards == ()
+
+
+def test_warnings_warn_without_a_category_still_fabricates_nothing():
+    """``warnings.warn(msg)`` defaults to ``UserWarning`` in CPython, not in the
+    source text. Inferring it here would put an unstated assumption inside an
+    authenticated coordinate, so the call stays an ordinary unresolved site --
+    which the completed-face boundary names, rather than reading as "no
+    warning". This is the half of the old test that is still true."""
     from sugar_lift_py_tests.effect.warning_effect import WarningEffect
     from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
     from sugar_lift_py_tests.floor.warning_observation_value import (
         WarningObservationValue,
     )
 
-    v = _val(
-        "import warnings\n" "def A():\n" "    warnings.warn('message', UserWarning)\n"
-    )
+    v = _val("import warnings\n" "def A():\n" "    warnings.warn('message')\n")
     entries = v.record.contribution()
     calls = [entry for entry in entries if isinstance(entry, CallSiteValue)]
     assert len(calls) == 1


### PR DESCRIPTION
dd3d1b5ca (#6458) shipped the CONSUMER of WarningObservationValue and no
producer. At 964dbf95d, `git grep -c "WarningObservationValue("` hit exactly
three files -- the definition and two test modules -- and nothing in any src
tree. Every completed-face warning boundary therefore reached its "unresolved
warning producers" refusal by construction, and the consumer's own twins were
green against a `python:warning_category_identity` term that exists at no
revision outside the file that invented it. This builds the missing half.

Reproducer: two real pandas 3.0 sites, one on each side of the cut.
`core/accessor.py:285` warns with an explicit UserWarning under an
`if hasattr` guard; `core/algorithms.py:1033` warns with no category at all.

The occurrence is a `warnings.warn(...)` in STATEMENT position. Lexical import
binding is the only door: `Call._import_bound_callee_symbol()` returns None for
a shadowed, parameter or ambiguous head, so a local named `warnings` mints
nothing. That is deliberately the opposite of the existing With census, which
is keyed on `pytest.raises` as a string and carries 6353 rows of spelling. The
category is authenticated by the ordinary exception-class authenticator and
emits `python:exception_type_identity` -- the same term the raise/except
projection already mints, so no new vocabulary enters the term table.

Explicit category only. `warnings.warn(msg)` defaults to UserWarning inside
CPython, not in the source text; inferring it would put an unstated assumption
inside an authenticated coordinate. A guarded occurrence records its guards and
the boundary refuses with its own named observed -- restating "warns when the
guard holds" as "warns" is a strictly stronger claim than the source makes.
Undecided is the honest third face, and the real pandas site lands on it.

The refusal now ENUMERATES its bucket. `_unresolved_producer_coordinates()`
names every unreduced call on the completed face as file:line off its own
pinned fragment, carried on the panic as `unresolved_warning_producers`, and
the `unresolved` predicate is derived FROM that list rather than computed
alongside it so the two cannot disagree. A fall-through refusal is otherwise
indistinguishable from a mechanism that never ran: both leave the produced set
empty, so the tests assert PRESENCE in the bucket, never absence from a
produced set. All three refusal shapes are covered -- no explicit category,
non-Name category, shadowed head.

A shipped test is modified, and a reviewer needs the reason.
sugar-source-tree/tests/test_try_sugar.py carried
test_warnings_warn_does_not_fabricate_a_warning_effect_without_a_producer,
whose docstring reads "The live warning schema has no source producer". That
was true when written; this slice falsifies its premise, and it is the only
node in either package that went red against this diff. It is SPLIT, not
deleted: the explicit-category source now asserts its coordinate positively,
and the bare `warnings.warn(msg)` half -- still an honest refusal -- keeps the
original no-fabrication assertions verbatim. Deleting it would have removed the
only surviving witness to the half that is still refused. A test that pins an
ABSENCE becomes a lie the moment the gap closes, and it fails loudly only if
you are lucky.

Receipts. One pinned SUGAR_BIN across every run: a release binary built in this
worktree, copied to an immutable read-only path before first use and hashed
there -- 1a190367381c4334ec8a95632f6ba2f95557a1bc6658c15c32bdd1a54db344dc, at a
*/target/release/* path so the lexical profile check is honest.

sugar-source-tree full suite at 4a9d06040, both halves on that pin. Baseline is
a separate detached worktree at the same sha (clean tree, 0 hits of this
diff's identifier, 4 of the pre-existing consumer symbol as positive control).
Base 13 failed / 708 passed / 5 skipped; head 13 failed / 709 passed / 5
skipped. Failure roster diffs EMPTY. The +1 pass is the one split test.

Discrimination: stubbing `_unresolved_producer_coordinates` to return () turns
exactly the 3 bucket-membership nodes red and leaves the other 13 green, which
rules out green-because-nothing-ran.

The sugar-lift-py-tests paired suite is a follow-up, not a gate here; its base
half is still running and no comparison is claimed from it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated producer for `warnings.warn` testimony to generate `WarningObservationValue` entries
> - Calls to `warnings.warn` with an import-bound head and a known exception-type category now produce a `WarningObservationValue` instead of a plain `CallSiteValue`; calls without an explicit category or with a shadowed head remain unresolved.
> - A new `project_warning_observation` function in [`warning_observation_producer.py`](https://github.com/TSavo/sugar/pull/6475/files#diff-4e3fa0c48e96117eda3b69069cc017a32ea06278ec4b05237d3ed98adc3ccbd8) validates the call shape and extracts the category identity, building a `WarningEffect` when authenticated.
> - [`nodes.py`](https://github.com/TSavo/sugar/pull/6475/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) augments `Call.to_sugar` to wrap the category argument with `AuthenticatedExceptionTypeSugar` when the callee resolves to an import-bound `warnings.warn`.
> - `WarningObservationValue` gains a `guards` tuple field and a `guarded()` method; the warning boundary now refuses guarded occurrences and annotates refusals with unresolved producer coordinates.
> - Behavioral Change: non-import-bound `warnings.warn` calls no longer receive a dotted-target `CallSiteSugar` and are treated as plain method calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00fff0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->