### PR TITLE
Route no-warning assertions on completed faces

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -259,6 +259,7 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
     from dataclasses import replace
 
     from sugar_lift_py_tests.floor import CallSiteValue
+    from sugar_lift_py_tests.floor.none_value import NoneValue
     from sugar_lift_py_tests.floor.warning_observation_value import (
         WarningObservationValue,
     )
@@ -270,6 +271,17 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
         reduce_block_to_exitset,
     )
     from sugar_source_tree.panic import SugarNotWritten
+
+    # Exact ``None`` is the manager's inverted contract: no warning may arrive.
+    # NoneValue is the literal's floor type, not a placeholder warning class.
+    if isinstance(expected, NoneValue):
+        return _route_completed_no_warning_boundary(
+            body=body,
+            ctx=ctx,
+            manager_exit=manager_exit,
+            mode=mode,
+            site=site,
+        )
 
     # Python warning categories are exception classes.  The ordinary lexical
     # class authenticator therefore owns their identity too; no warning/vendor
@@ -367,4 +379,68 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
             )
         else:
             exits.append(face)
+    return ExitSet(tuple(exits)).normalize()
+
+
+def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
+    """Accept a completed face only when warning absence is decidable."""
+    from sugar_lift_py_tests.context_manager_contract import ExpectsModeV1
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.floor import CallSiteValue
+    from sugar_lift_py_tests.floor.warning_observation_value import (
+        WarningObservationValue,
+    )
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+    from sugar_lift_py_tests.sugar.exit_set_routing import promote_raise_halts
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+    from sugar_source_tree.panic import SugarNotWritten
+
+    body_es = promote_raise_halts(reduce_block_to_exitset(body, ctx)).guarded(
+        manager_exit.guard
+    )
+    exits = []
+    for face in body_es.exits:
+        if isinstance(face, Halted):
+            exits.append(face)
+            continue
+        entries = getattr(face.value, "entries", None)
+        if not isinstance(entries, tuple):
+            raise SugarNotWritten(
+                owner="WithEffectBoundarySugar.warning_observation",
+                observed=(
+                    f"completed face carries {type(face.value).__name__}, "
+                    "not a reduced block record"
+                ),
+                requested=(
+                    "completed reduced block carrying authenticated warning observations"
+                ),
+                fix="preserve the completed face until its record is constructed",
+            )
+        if any(isinstance(entry, WarningObservationValue) for entry in entries):
+            if isinstance(mode, ExpectsModeV1):
+                exits.append(
+                    Halted(
+                        face.guard,
+                        ExpectationNotMetEffect("warning", site),
+                        face.value,
+                        face.faces,
+                        face.pending_contracts,
+                    )
+                )
+            else:
+                exits.append(face)
+            continue
+        if any(isinstance(entry, CallSiteValue) for entry in entries):
+            raise SugarNotWritten(
+                owner="WithEffectBoundarySugar.warning_observation",
+                observed="completed face has unresolved warning producers",
+                requested="authenticated absence of warning observations",
+                fix=(
+                    "construct every producer on the completed face; never infer "
+                    "absence from an empty observation set"
+                ),
+            )
+        exits.append(face)
     return ExitSet(tuple(exits)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -19,7 +19,7 @@ from sugar_lift_py_tests.context_manager_contract import (
     WarningObservationBindingV1,
 )
 from sugar_lift_py_tests.effect import ExpectationNotMetEffect, WarningEffect
-from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, TermValue
+from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, NoneValue, TermValue
 from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
 from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
 from sugar_lift_py_tests.outcome import Complete
@@ -69,8 +69,9 @@ SEMANTICS = EffectBoundarySemanticsV1(
 )
 
 
-def _boundary(*entries):
-    expected = _ExpectedCategory(_identity("FutureWarning"))
+def _boundary(*entries, expected=None):
+    if expected is None:
+        expected = _ExpectedCategory(_identity("FutureWarning"))
     manager_value = CallSiteValue(
         target_name="scope",
         arg_values=(expected,),
@@ -146,3 +147,42 @@ def test_unresolved_completed_face_is_undecided_not_false():
         _boundary(unresolved).desugar()
     assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
     assert "unresolved" in raised.value.observed
+
+
+def test_truthful_no_warning_contract_completes_over_multi_statement_body():
+    routed = _boundary(TermValue(1), TermValue(2), expected=NoneValue()).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Completed)
+    assert face.value.entries == (TermValue(1), TermValue(2))
+
+
+def test_warning_arriving_at_no_warning_contract_fails_assertion():
+    routed = _boundary(_warning("FutureWarning"), expected=NoneValue()).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_no_warning_contract_with_unresolved_producer_is_undecided():
+    unresolved = CallSiteValue(
+        target_name="f",
+        arg_values=(),
+        parameters=(),
+        term=ctor("call", []),
+        body=None,
+    )
+    with pytest.raises(SugarNotWritten) as raised:
+        _boundary(unresolved, expected=NoneValue()).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert raised.value.observed == "completed face has unresolved warning producers"
+
+
+def test_two_no_warning_boundaries_do_not_share_observations():
+    first = _boundary(TermValue("first"), expected=NoneValue()).desugar()
+    second = _boundary(_warning("FutureWarning"), expected=NoneValue()).desugar()
+
+    assert isinstance(first.exits[0], Completed)
+    assert isinstance(second.exits[0], Halted)
+    assert isinstance(second.exits[0].effect, ExpectationNotMetEffect)

--- a/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
@@ -1,0 +1,102 @@
+"""Pinned real-site testimony for the inverted completed-warning boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_source_tree.nodes import Call, Constant, With
+from sugar_source_tree.tree import SourceFile
+
+
+DEMAND_TABLE_CONTENT_KEY = (
+    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
+    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+)
+FILE_SHA256 = "ef0819d48825f4614ec088f25b4d342a8808a12b1c5d45cff3281b481ec13252"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _corpus_file() -> Path:
+    import pandas
+
+    return Path(pandas.__file__).resolve().parent / "tests/series/test_constructors.py"
+
+
+def _demand_rows(source_cid: str) -> tuple[dict, ...]:
+    with tempfile.TemporaryDirectory() as scratch:
+        output = Path(scratch) / "demand-table.json"
+        completed = subprocess.run(
+            [
+                str(_repo_root() / "bin/sugarbin"),
+                "artifact",
+                "pull",
+                "--kind",
+                "python-demand-table",
+                "--content-key",
+                DEMAND_TABLE_CONTENT_KEY,
+                "--output",
+                str(output),
+                "--runtime",
+                "cpython-3.14.4",
+            ],
+            cwd=_repo_root(),
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0 and output.is_file(), completed.stderr
+        payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["contentKey"] == DEMAND_TABLE_CONTENT_KEY
+    return tuple(
+        row
+        for row in payload["rows"]
+        if (row.get("useSite") or {}).get("sourceCid") == source_cid
+    )
+
+
+def test_real_pandas_back_to_back_none_warning_managers_are_distinct_native_sites():
+    path = _corpus_file()
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode("utf-8")).hexdigest() == FILE_SHA256
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=context,
+    )
+
+    sites = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, With)
+        and node.line_col_span().start_line in {1290, 1296}
+    )
+    assert len(sites) == 2
+    assert tuple(len(site.body) for site in sites) == (2, 1)
+    for site in sites:
+        manager = site.items[0].context_expr
+        assert isinstance(manager, Call)
+        assert len(manager.args) == 1
+        assert isinstance(manager.args[0], Constant)
+        assert manager.args[0].value is None
+
+    rows = _demand_rows(source_cid)
+    manager_rows = tuple(
+        row
+        for row in rows
+        if (row.get("useSite") or {}).get("startLine") in {1290, 1296}
+        and row.get("expectedKind") == "context-manager-contract"
+    )
+    assert tuple(
+        (row["useSite"]["startLine"], row["useSite"]["startCol"])
+        for row in manager_rows
+    ) == ((1290, 13), (1296, 13))
+    assert all(row.get("gapKind") is None for row in manager_rows)


### PR DESCRIPTION
## What changed

- interprets the real `NoneValue` warning operand as an inverted completed-face contract: no warning may arrive
- preserves completed multi-statement bodies when warning absence is decidable
- fails the assertion when any authenticated warning observation arrives
- keeps an empty observation set undecided when the completed face still contains an unresolved call producer
- pins the two back-to-back real pandas 3.0.3 sites in `tests/series/test_constructors.py` against the shared authenticated demand table

## Why

`assert_produces_warning(None)` does not name an empty warning class. Its literal `None` inverts the warning boundary: ordinary completion is expected, while an observed warning is the assertion failure. Treating `None` as a category placeholder would silently turn a real absence contract into a false value.

The implementation discriminates only the native `NoneValue` floor type. It contains no pandas, `tm`, or manager-name recognition.

## Evidence

- shared demand-table pull: content key `blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d896cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499`, filesystem shelf hit, exit 0
- focused worktree-import diagnostic: truthful multi-statement twin, warning-arrival lying twin, unresolved third-value twin, adjacent-manager isolation twin, and real pandas/table reproducer; 5/5 passed, exit 0
- mutation transaction: clean hash `47c2456b...`; mutation hash `7a4b4e76...`; truthful twin bit with exit 1 at the named `warning_observation` refusal; restored hash exactly `47c2456b...`; restored 5/5 diagnostic passed, exit 0
- compile check for all three touched files: exit 0
- `git diff --check 47cc6d031..HEAD`: exit 0
- production vendor-spelling search: no matches

## Official focused-test blocker

The required authenticated command was run:

`bin/bpytest -u implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py`

It refused before pytest collection with `artifact identity mismatch: sourceStamp`: no matching Linux release binary exists for exact stamp `blake3-512_546ddebcb29e32cebc7bc09cbd90c7c4ca5392df680879a1665e3fa3c2ff86a1cf63127e734ab84ba706a316cc4ee44531f109066fefda52cae76f584ed485a7`, and build fallback was correctly disabled. Exit 1. This draft does not represent that refusal as a focused green receipt.

No census or demand-table build was run. No changes touch `exit_set.py`, `outcome/`, or generator construction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route no-warning assertions on completed faces in effect boundary sugar
> - Adds `_route_completed_no_warning_boundary` to handle the inverted 'no warning' contract: halts with `ExpectationNotMetEffect` when a warning is observed, raises `SugarNotWritten` when producers are unresolved, and completes normally otherwise.
> - Updates `_route_completed_warning_boundary` to detect a `NoneValue` expected operand and delegate to the new function instead of applying category identity logic.
> - Adds four new tests covering: successful completion with no warnings, failure on warning arrival, undecided state with unresolved producers, and non-sharing of observations across back-to-back no-warning boundaries.
> - Adds an integration test in `test_warning_none_argument_shape.py` that parses a real pandas source file and verifies two `with`-statement managers each receive a single `None` argument and map to distinct native sites in the demand table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 510669d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->