### PR TITLE
Follow returned assertion manager imports

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -346,12 +346,17 @@ def _suite_binds_export(statements, name: str) -> bool:
 
 
 def _statement_contains_module_init_raise(statement: ast.AST) -> bool:
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        # The definition statement executes decorators/bases, not its body.
+        # A Raise nested in that deferred body is not a module-init edge and
+        # cannot make a later module binding control-dependent.
+        return False
     stack: list[ast.AST] = [statement]
     while stack:
         node = stack.pop()
         if isinstance(node, ast.Raise):
             return True
-        if node is not statement and isinstance(
+        if isinstance(
             node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
         ):
             continue

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -26,6 +26,7 @@ from sugar_source_tree.binding_state import BindingEntryV1
 from sugar_source_tree.nodes import (
     AnnAssign,
     Assign,
+    Attribute,
     AugAssign,
     Call,
     ClassDef,
@@ -46,7 +47,11 @@ from sugar_source_tree.tree import SourceFile
 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
 from .canonical import cid_of_json
-from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
+from .dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
 from .resolution_session import SourceResolutionSession, session_or_new
 
 
@@ -802,6 +807,114 @@ def _resolve_source_visible_frame_uncached(
                 pending_names.append(name)
     definitions = tuple(item for item in definitions if item.name in reachable_names)
 
+    # Imported calls inside the authenticated factory body are ordinary source
+    # calls too.  In particular, a function-local ``import package`` followed
+    # by ``return package.factory(...)`` is invisible to a module-import-only
+    # scan and cannot be recovered from the outer With-head spelling.  Reuse
+    # the lexical import testimony at the exact inner call coordinate, then
+    # project the imported callable through the same artifact/frame doors.
+    from pathlib import Path
+
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    reachable_calls = {
+        (
+            call.line_col_span().start_line,
+            call.line_col_span().start_col,
+            call.line_col_span().end_line,
+            call.line_col_span().end_col,
+        ): call
+        for definition in definitions
+        for function in _scanned_definitions(definition)
+        for call in _local_imported_attribute_calls(function)
+    }
+    if reachable_calls:
+        module_path = Path(module.source_seat)
+        import_receipts, _ = authenticated_import_use_receipts(
+            Path("."),
+            module_path,
+            module.source,
+            module.source_cid,
+            module_identities={},
+        )
+    else:
+        import_receipts = ()
+    dependency_graphs: dict[str, DependencyArtifactGraph] = {
+        resolved.module_name.split(".", 1)[0]: graph
+    }
+    for receipt in import_receipts:
+        raw_site = receipt.use["useSite"]
+        call = reachable_calls.get(
+            (
+                raw_site["startLine"],
+                raw_site["startCol"],
+                raw_site["endLine"],
+                raw_site["endCol"],
+            )
+        )
+        if call is None:
+            continue
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        dependency_graph = dependency_graphs.get(top_level)
+        if dependency_graph is None:
+            from .dependency_artifact import (
+                DependencyArtifactAuthenticationError,
+                authenticate_dependency_top_level,
+            )
+
+            try:
+                dependency_graph = authenticate_dependency_top_level(top_level)
+            except DependencyArtifactAuthenticationError:
+                _install_opaque_call_obligation(
+                    context,
+                    call,
+                    OpaqueSourceCallObligationV1(
+                        _call_coordinate(call),
+                        receipt.target_symbol,
+                        resolved.cid,
+                        resolution_kind="call-target-source-absent",
+                    ),
+                )
+                continue
+            dependency_graphs[top_level] = dependency_graph
+        imported = resolve_import_binding(
+            receipt, graph=dependency_graph, session=session
+        )
+        if not isinstance(imported, ResolvedPythonObjectV1):
+            _install_opaque_call_obligation(
+                context,
+                call,
+                OpaqueSourceCallObligationV1(
+                    _call_coordinate(call),
+                    receipt.target_symbol,
+                    resolved.cid,
+                    resolution_kind="call-target-source-absent",
+                ),
+            )
+            continue
+        projected = resolve_source_visible_frame(
+            imported, graph=dependency_graph, session=session
+        )
+        if isinstance(projected, ManagerConstructionGapV1):
+            kind = (
+                "call-graph-cycle"
+                if projected.kind == "call-graph-cycle"
+                else "call-target-export-unresolved"
+            )
+            _install_opaque_call_obligation(
+                context,
+                call,
+                OpaqueSourceCallObligationV1(
+                    _call_coordinate(call),
+                    receipt.target_symbol,
+                    resolved.cid,
+                    resolution_kind=kind,
+                ),
+            )
+            continue
+        imported_frame, _ = projected
+        _install_source_call_frame(context, call, imported_frame)
+
     definition_names = {item.name for item in definitions}
     from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
 
@@ -1176,6 +1289,41 @@ def _local_named_calls(function: FunctionDef):
             yield node
         children = [child for _, _, child in node.children()]
         stack.extend(reversed(children))
+
+
+def _local_imported_attribute_calls(function: FunctionDef):
+    """Direct attribute calls rooted in an import bound by this function.
+
+    The lexical receipt remains the authority at each use coordinate.  This
+    syntax walk only bounds the expensive receipt pass to the missing native
+    shape; it does not decide what module or callable the spelling denotes.
+    """
+    imported_slots: set[str] = set()
+    stack = list(reversed(function.body))
+    calls: list[Call] = []
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (FunctionDef, ClassDef)):
+            continue
+        if isinstance(node, (Import, ImportFrom)):
+            imported_slots.update(
+                alias.asname or alias.name.split(".", 1)[0] for alias in node.names
+            )
+        elif (
+            isinstance(node, Call)
+            and isinstance(node.func, Attribute)
+            and isinstance(node.func.value, Name)
+        ):
+            calls.append(node)
+        children = [child for _, _, child in node.children()]
+        stack.extend(reversed(children))
+    return tuple(
+        call
+        for call in calls
+        if isinstance(call.func, Attribute)
+        and isinstance(call.func.value, Name)
+        and call.func.value.id in imported_slots
+    )
 
 
 def _has_non_higher_order_return(

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -506,6 +506,34 @@ def test_with_suppressible_exceptional_prefix_does_not_authenticate_unreachable_
     assert result.kind == "dynamic-export"
 
 
+def test_raise_inside_earlier_function_does_not_make_later_export_dynamic(
+    tmp_path: Path,
+) -> None:
+    """A deferred raise is not a module-initialization edge.
+
+    pandas._testing defines helpers containing ``raise`` before defining
+    ``external_error_raised``. Walking into those earlier function bodies made
+    the later, unconditional helper definition look dynamically reachable.
+    """
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source=(
+                "def earlier():\n"
+                "    raise RuntimeError()\n\n"
+                "def build(value):\n"
+                "    return value\n"
+            ),
+        )
+    )
+
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.start_line == 4
+
+
 def test_export_transfer_exhaustively_classifies_running_ast_statement_grammar() -> (
     None
 ):

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.metadata
+from functools import cache
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+)
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_python_source.canonical import blake3_512_of
+
+
+_TABLE_CID = "blake3-512:" + "t" * 128
+_CATALOG_CID = "blake3-512:" + "c" * 128
+_DEMAND_CID = (
+    "blake3-512:6e13b2f2c9e67794d662ff357cf8c0ddc2a1509902c0130bfe1ee63377695a113"
+    "b6111d3e44accbd277c993149c8d9f7cabd5f63fc0f3707fc8a49a967abf523"
+)
+_OPAQUE_DEMAND_CID = (
+    "blake3-512:f299951a254712ea1fb53f4f9611aa80c9fe2dd92814cc28b4300540cbc5214d"
+    "7cf4b7d11832f7ba113be17d73b79a34d0fb7c4ddc1705ea1bfa272ecfa58c65"
+)
+_SOURCE_CID = (
+    "blake3-512:3a71aa9c523d26a6a541cb6fdc124d37c364245b959d41873619701b421fbe370"
+    "7b50d44f9d87083a783b17ec779000a4480863c8dc8435761e6f17238dd3ee0"
+)
+
+
+def _install_root() -> Path:
+    distribution = importlib.metadata.distribution("pandas")
+    package = Path(distribution.locate_file("pandas")).resolve()
+    assert package.is_dir()
+    return package.parent
+
+
+@cache
+def _feather_tree():
+    """The pandas helper is a named construction refusal, not an assertion.
+
+    The coordinate and CIDs are the exact row consumed from the authenticated
+    demand table at content key ``e225...3499``.  The local import and returned
+    ``pytest.raises(..., match=None)`` are behind a dynamic export: construction
+    may name that missing preimage, but must not invent it from the With head.
+    """
+    root = _install_root()
+    path = root / "pandas/tests/io/test_feather.py"
+    source_cid = blake3_512_of(path.read_bytes())
+    assert source_cid == _SOURCE_CID
+    external_site = SourceFragmentCoordinateV1(source_cid, 40, 13, 40, 48)
+    opaque_site = SourceFragmentCoordinateV1(source_cid, 33, 13, 33, 46)
+    external_gap = ContextManagerResolutionGapV1(
+        _DEMAND_CID,
+        external_site,
+        "pandas._testing.external_error_raised",
+        "runtime-selected",
+        (),
+    )
+    opaque_gap = ContextManagerResolutionGapV1(
+        _OPAQUE_DEMAND_CID,
+        opaque_site,
+        "pytest.raises",
+        "runtime-selected",
+        (),
+    )
+    refs = ResolvedContractRefsV1(
+        _CATALOG_CID,
+        _TABLE_CID,
+        MappingProxyType({external_site: external_gap, opaque_site: opaque_gap}),
+    )
+
+    return open_source_file_for_construction(
+        path, root=root, contract_refs=refs, populate_derived=True
+    )
+
+
+def test_external_error_raised_follows_return_to_named_formal_refusal() -> None:
+    """The pandas helper is followed without inventing an assertion boundary.
+
+    The coordinate and CIDs are the exact row consumed from the authenticated
+    demand table at content key ``e225...3499``.  The local import and returned
+    ``pytest.raises(..., match=None)`` is followed from source.  Its returned
+    manager currently stops at an unspecialized formal, before semantics exist;
+    neither the With-head spelling nor the helper name may bridge that refusal.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+    )
+    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
+
+    tree = _feather_tree()
+    with_node = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 40
+    )
+    reference = tree.unit.construction_context.source_derived_contract_refs[
+        SourceFragmentCoordinateV1(_SOURCE_CID, 40, 13, 40, 48)
+    ]
+    assert isinstance(reference, ContextManagerResolutionGapV1)
+    assert reference.kind == "force-floor"
+    assert reference.detail == (
+        "BindingCoordinateRefSugar.desugar:unspecialized source-call formal"
+    )
+    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
+        with_node.sugar()
+    assert caught.value.kind == "force-floor"
+    assert "unspecialized source-call formal" in caught.value.observed
+
+
+def test_adjacent_computed_class_raises_stays_typed_opaque() -> None:
+    """The adjacent direct raises call differs only by its computed operands."""
+    from sugar_source_tree.panic import WithConstructionGap, WithConstructionGapKind
+
+    tree = _feather_tree()
+    with_node = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 33
+    )
+
+    with pytest.raises(WithConstructionGap) as caught:
+        with_node.sugar()
+
+    assert caught.value.coordinate.start_line == 33
+    assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
+    assert "ExitSet with 4 arms" in caught.value.observed

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1120,6 +1120,75 @@ def test_renamed_source_visible_exit_derives_expects_raise_boundary(tmp_path):
     assert summary.semantics.expected_type_operand == FormalArgumentProjectionV1(0)
 
 
+def test_external_error_raised_spelling_cannot_replace_native_return_shape(tmp_path):
+    """The tempting pandas helper spelling has no assertion authority.
+
+    This is the lying twin for the returned-manager reproducer.  It uses the
+    exact helper name but returns an ordinary resource manager; native protocol
+    testimony must keep it out of the EffectBoundary arm.
+    """
+    graph, resolved, actual, call_site = _resolved_type_actual(
+        tmp_path,
+        "class OrdinaryResource:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "def external_error_raised(expected):\n"
+        "    return OrdinaryResource(expected)\n",
+        exported="external_error_raised",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="lying-name-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol, behavior=behavior)
+
+    from sugar_lift_py_tests.context_manager_contract import EffectBoundarySemanticsV1
+
+    assert not (
+        isinstance(summary, DerivedManagerSummaryV1)
+        and isinstance(summary.semantics, EffectBoundarySemanticsV1)
+    ), summary
+
+
+def test_renamed_returned_assertion_manager_is_derived_from_protocol(tmp_path):
+    """A source-authenticated returned manager is the truthful native twin."""
+    graph, resolved, actual, call_site = _resolved_type_actual(
+        tmp_path,
+        "class RenamedBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n"
+        "def returned_boundary(expected):\n"
+        "    return RenamedBoundary(expected)\n",
+        exported="returned_boundary",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="truthful-return-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    summary = derive_manager_summary(protocol, behavior=behavior)
+
+    from sugar_lift_py_tests.context_manager_contract import EffectBoundarySemanticsV1
+
+    assert isinstance(summary, DerivedManagerSummaryV1)
+    assert isinstance(summary.semantics, EffectBoundarySemanticsV1)
+
+
 def test_renamed_source_visible_exit_derives_suppresses_mode(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,


### PR DESCRIPTION
## Boundary

The corrected pandas 3.0.3 reproducer **refuses during construction** after following the helper return into authenticated `pytest.raises`: `force-floor: BindingCoordinateRefSugar.desugar:unspecialized source-call formal`. Desugar is never entered and no assertion semantics are invented.

The adjacent `pytest.raises(exc, match=err_msg)` control independently refuses at construction as `force-floor: ExitSet with 4 arms`.

## What changed

- Rebase onto requested main `675c5de7b`.
- Fix the generic export walk so a `raise` inside an earlier function body is not mistaken for a module-initialization edge controlling later exports.
- Follow function-local imported attribute calls through their exact lexical import receipts and authenticated dependency source frames.
- Preserve typed opaque obligations when cross-artifact authentication or frame projection declines.
- Pin the exact pandas 3.0.3 feather source CID and both shared-demand-table coordinates.
- Retain vendor-neutral truthful and same-spelling lying twins.

No pandas/pytest name arm, helper-name table, exit-set change, outcome change, generator change, placeholder, or detector weakening is included.

## Validation

- Focused corrected-corpus gate: 6 passed, 66 deselected.
- Mutation transaction: disabling imported-attribute following made the real reproducer fail before the named formal refusal; source restored; focused gate reran green.
- Shared table consumed at content key `blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d896cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499`.
- Authenticated launcher attempted the focused gate and refused before collection because the branch source-stamp binary cell is absent; build fallback is disabled.
- Full `test_dependency_artifact_graph.py`: 25 passed, 1 unrelated corrected-corpus failure (`pandas._testing.ensure_clean` is absent under 3.0.3). That existing live-corpus detector was not weakened or deleted.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Follow returned assertion manager imports to resolve source-visible call frames
> - Extends `_resolve_source_visible_frame_uncached` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6477/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to resolve imported attribute calls inside authenticated factory bodies, installing frames or opaque obligations with specific resolution kinds (`call-target-source-absent`, `call-graph-cycle`, `call-target-export-unresolved`).
> - Adds `_local_imported_attribute_calls` helper to scan function bodies for `Call` nodes whose callee is an `Attribute` with a locally imported base, skipping nested function/class bodies.
> - Fixes `_statement_contains_module_init_raise` in [dependency_export_adapter.py](https://github.com/TSavo/sugar/pull/6477/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) to skip `FunctionDef`, `AsyncFunctionDef`, `ClassDef`, and `Lambda` bodies unconditionally, so raises inside nested scopes no longer mark later module bindings as control-dependent-on-raise.
> - Adds tests covering: returned assertion manager protocol derivation, external-error-raised spelling guard, `force-floor` gap kinds, and the raise-in-earlier-function export regression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8511a7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->