### PR TITLE
Authenticate assertion managers and retain message obligations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -140,29 +140,36 @@ def _ground_string(term):
 
 
 def _message_term(effect, *, owner):
-    """The term of the raised call's message operand, or the ground empty message.
+    """The testified message operand, or rendered-message projection of a value.
 
     ``raise E()`` constructs no argument, and the message of such a value is
-    exactly ``""`` -- a ground fact, not an absence. Anything that is not a
-    constructed call has no authenticated message operand at all and is loud.
+    exactly ``""`` -- a ground fact, not an absence. A non-call raised value
+    can still testify to the value being rendered; its message stays open as
+    ``py.exception_message(value)``. Only a valueless effect is loud, because
+    there is then no admissible subject for the projection.
     """
     from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-    from sugar_lift_py_tests.ir import str_const
+    from sugar_lift_py_tests.ir import ctor, str_const
     from sugar_source_tree.panic import SugarNotWritten
 
     raised = effect.raised_value
-    if not isinstance(raised, CallSiteValue):
+    if isinstance(raised, CallSiteValue):
+        args = raised.arg_values
+        return args[0].to_term(owner=owner) if args else str_const("")
+
+    raised_term = _operand_term(raised, owner=owner, role="raised exception")
+    if raised_term is None:
         raise SugarNotWritten(
             owner="authenticated_exception_matching._message_term",
-            observed="raised value is not a constructed call occurrence",
-            requested="a CallSiteValue whose first actual is the message operand",
+            observed="raised exception has no value term to render as a message",
+            requested="a message operand or an emittable raised VALUE term",
             fix=(
-                "construct the raised exception through its call site; never "
-                "read a message off an unconstructed value"
+                "authenticate the raised value or its message operand; a source "
+                "coordinate designates the raise SITE, not the raised value, "
+                "and is not admissible as the rendered-message subject"
             ),
         )
-    args = raised.arg_values
-    return args[0].to_term(owner=owner) if args else str_const("")
+    return ctor("py.exception_message", [raised_term])
 
 
 def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -34,8 +34,10 @@ import pytest
 from sugar_lift_py_tests.authenticated_exception_matching import (
     MatchRetained,
     matches_raise_effect,
+    raise_effect_message_verdict,
 )
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_source_tree.panic import SugarNotWritten
 
@@ -168,3 +170,45 @@ def test_a_real_value_term_still_retains_the_question() -> None:
 
     assert isinstance(verdict, MatchRetained)
     assert verdict.obligation.name == "adt.is_python_type"
+
+
+def test_matching_halt_without_message_operand_retains_message_obligation() -> None:
+    """Truthful twin: the raised VALUE exists, but its rendered message is open."""
+    identity = TermValue(1).to_term(owner="exception identity")
+    raised_value = TermValue(7)
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        exception_type_coordinate=identity,
+        occurrence=OCCURRENCE,
+        raised_value=raised_value,
+    )
+    expected = _AuthenticatedHandler(identity)
+
+    verdict = raise_effect_message_verdict(
+        effect, expected, StringValue("boom")
+    )
+
+    assert isinstance(verdict, MatchRetained)
+    assert verdict.obligation.name == "py.re_search"
+    assert verdict.obligation.args[0].value == "boom"
+    message = verdict.obligation.args[1]
+    assert message.name == "py.exception_message"
+    assert message.args == (raised_value.to_term(owner="raised value"),)
+
+
+def test_valueless_halt_cannot_use_occurrence_as_message_evidence() -> None:
+    """Lying twin: a source coordinate is not a rendered-message operand."""
+    identity = TermValue(1).to_term(owner="exception identity")
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        exception_type_coordinate=identity,
+        occurrence=OCCURRENCE,
+        raised_value=None,
+    )
+    expected = _AuthenticatedHandler(identity)
+
+    with pytest.raises(SugarNotWritten) as raised:
+        raise_effect_message_verdict(effect, expected, StringValue("boom"))
+
+    assert raised.value.owner == "authenticated_exception_matching._message_term"
+    assert OCCURRENCE not in str(raised.value)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -39,6 +39,7 @@ from sugar_source_tree.nodes import (
     NamedExpr,
     Node,
     Starred,
+    Subscript,
     Tuple_,
     With,
 )
@@ -777,6 +778,20 @@ def _resolve_source_visible_frame_uncached(
         )
 
     definitions_by_name = {item.name: item for item in definitions}
+
+    def _local_class_base_name(base: Node) -> str | None:
+        """The local class named by ``Base`` or the native generic ``Base[T]``.
+
+        Subscription supplies type arguments; it does not change which class
+        owns inherited runtime methods. Computed and attributed bases remain
+        loud because neither shape authenticates a local class coordinate.
+        """
+        if isinstance(base, Name):
+            return base.id
+        if isinstance(base, Subscript) and isinstance(base.value, Name):
+            return base.value.id
+        return None
+
     reachable_names = {target.name}
     pending_names = [target.name]
     while pending_names:
@@ -784,7 +799,9 @@ def _resolve_source_visible_frame_uncached(
         dependencies = []
         if isinstance(current, ClassDef):
             dependencies.extend(
-                base.id for base in current.bases if isinstance(base, Name)
+                name
+                for base in current.bases
+                if (name := _local_class_base_name(base)) is not None
             )
             functions = tuple(
                 item for item in current.body if isinstance(item, FunctionDef)
@@ -901,15 +918,25 @@ def _resolve_source_visible_frame_uncached(
 
     frames: dict[str, object] = {}
     reaching_classes: dict[str, ClassDef] = {}
+    from sugar_source_tree.panic import SugarNotWritten
+
     for item in definitions:
         if not isinstance(item, ClassDef):
             continue
         local_bases = []
         for base in item.bases:
-            if not isinstance(base, Name) or base.id not in reaching_classes:
+            base_name = _local_class_base_name(base)
+            if base_name is None or base_name not in reaching_classes:
                 local_bases = []
                 break
-            local_bases.append(reaching_classes[base.id].sugar())
+            try:
+                local_bases.append(reaching_classes[base_name].sugar())
+            except SugarNotWritten as exc:
+                owner = getattr(exc, "owner", None) or type(exc).__name__
+                observed = getattr(exc, "observed", None) or str(exc)
+                return ManagerConstructionGapV1(
+                    "force-floor", resolved.cid, f"{owner}:{observed}"
+                )
         if local_bases and len(local_bases) == len(item.bases):
             context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
         reaching_classes[item.name] = item

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -556,3 +556,45 @@ def test_construction_names_value_call_target_at_the_opaque_coordinate() -> None
         "to an export door that cannot resolve it"
     )
     assert _CALL_TARGET_GAP_PRECEDENCE.index("value-call-target") == 1
+
+
+def test_name_pattern_reaches_authenticated_base_try_gap() -> None:
+    """The line-16 manager now reaches its generic base, then stays loud.
+
+    ``RaisesExc(AbstractRaises[T])`` inherits its initializer from a local,
+    source-authenticated generic base.  Construction must cross that edge and
+    name the first unsupported statement in the inherited body.  It must not
+    keep reporting the earlier synthetic ``ExitSet with 3 arms`` manager-face
+    gap, and it must not assume the regex-compilation ``try`` succeeds.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.manager_summary_derivation import (
+        populate_source_derived_resource_refs,
+    )
+
+    site = next(site for site in ENROLLED_SITES if site.shape == "name-ref")
+    path = _corpus_root() / site.relative_path
+    source = path.read_text(encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (source, str(path), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+
+    populate_source_derived_resource_refs(
+        source_file, root=_corpus_root().parent, path=path
+    )
+
+    row = next(
+        result
+        for coordinate, result in context.source_derived_contract_refs.items()
+        if coordinate.start_line == site.line
+    )
+    assert isinstance(row, ContextManagerResolutionGapV1)
+    assert row.kind == "force-floor"
+    assert row.detail.startswith("Try.sugar:")
+    assert "has no sugar written" in row.detail
+    assert "ExitSet with 3 arms" not in row.detail

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -598,3 +598,56 @@ def test_name_pattern_reaches_authenticated_base_try_gap() -> None:
     assert row.detail.startswith("Try.sugar:")
     assert "has no sugar written" in row.detail
     assert "ExitSet with 3 arms" not in row.detail
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "line", "expression"),
+    [
+        ("tests/indexing/test_indexing.py", 111, "msg"),
+        ("tests/io/json/test_normalize.py", 175, '"^$"'),
+        ("tests/indexes/multi/test_analytics.py", 247, "msg"),
+    ],
+)
+def test_computed_class_patterns_cross_the_authenticated_generic_base(
+    relative_path: str, line: int, expression: str
+) -> None:
+    """Four-arm constructors cross ``AbstractRaises[T]`` and stop at Try.
+
+    These real sites cover an accumulated alternation plus tuple exception
+    classes, a parametrized exception class plus the corpus's written ``^$``
+    predicate, and a source-bound constant exception class.  Their argument
+    values differ; their provider inherits through the same authenticated
+    generic base.  None may regress to the synthetic four-arm floor.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.manager_summary_derivation import (
+        populate_source_derived_resource_refs,
+    )
+
+    path = _corpus_root() / relative_path
+    source = path.read_text(encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (source, str(path), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    call = _raises_call_on_line(source_file, line)
+    argument = _match_argument(call)
+    assert argument.segment().strip() == expression
+
+    populate_source_derived_resource_refs(
+        source_file, root=_corpus_root().parent, path=path
+    )
+
+    row = next(
+        result
+        for coordinate, result in context.source_derived_contract_refs.items()
+        if coordinate.start_line == line
+    )
+    assert isinstance(row, ContextManagerResolutionGapV1)
+    assert row.kind == "force-floor"
+    assert row.detail.startswith("Try.sugar:")
+    assert "ExitSet with 4 arms" not in row.detail

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -855,6 +855,67 @@ def test_local_inherited_manager_methods_follow_authenticated_mro(tmp_path):
     assert protocol.exit_outcome() is not None
 
 
+def test_subscripted_local_base_supplies_inherited_constructor_method(tmp_path):
+    """Truthful twin: ``Base[T]`` names Base; its method body is testimony."""
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class Ancestor:\n"
+        "    def project(self, value):\n"
+        "        return value\n\n"
+        "class Descendant(Ancestor[Marker]):\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self.marker\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_guard(marker):\n"
+        "    return Descendant(marker)\n",
+    )
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    assert behavior.receiver_state.has_method("project")
+    fields = {field.name: field.value for field in behavior.receiver_state.fields}
+    assert fields["marker"] is actual.value
+
+
+def test_computed_base_does_not_supply_inherited_constructor_method(tmp_path):
+    """Lying twin: ``base_factory()[T]`` states no source class coordinate."""
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class Ancestor:\n"
+        "    def project(self, value):\n"
+        "        return value\n\n"
+        "class Descendant(base_factory()[Marker]):\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self.marker\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_guard(marker):\n"
+        "    return Descendant(marker)\n",
+    )
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    assert not behavior.receiver_state.has_method("project")
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic) as caught:
+        behavior.receiver_state.call_method_value(
+            "project", (actual.value,), owner="computed-base liar", blame=call_site
+        )
+    assert "Descendant.project" in str(caught.value)
+
+
 def test_opaque_base_never_fabricates_inherited_manager_methods(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,
@@ -1441,7 +1502,8 @@ def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
         with_node.sugar()
 
     assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert "ExitSet with 3 arms" in caught.value.observed
+    assert "Try.sugar:Try at _pytest/raises.py:" in caught.value.observed
+    assert "ExitSet with 3 arms" not in caught.value.observed
     assert (
         caught.value.coordinate.start_line,
         caught.value.coordinate.start_col,
@@ -1470,7 +1532,8 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
         with_node.sugar()
 
     assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert "ExitSet with 4 arms" in caught.value.observed
+    assert "Try.sugar:Try at _pytest/raises.py:" in caught.value.observed
+    assert "ExitSet with 4 arms" not in caught.value.observed
     assert (
         caught.value.coordinate.start_line,
         caught.value.coordinate.start_col,


### PR DESCRIPTION
## What changed

- authenticate a local generic base written as `Base[T]` as the same runtime class coordinate as `Base`
- carry its source-constructed methods into the descendant receiver through the existing C3 path
- keep computed and attributed bases unadmitted
- membrane an unsupported authenticated base body back into the typed manager `force-floor` gap

## Frontier advanced

The real `pandas/tests/test_optional_dependency.py:16` route no longer stops at the synthetic `ExitSet with 3 arms` manager-face gap. It reaches the source-authenticated `AbstractRaises[...]` base and stops at the first genuinely unsupported statement in that inherited initializer:

`force-floor / Try.sugar / _pytest/raises.py`

The variable pattern, `as exc_info`, and message matcher remain downstream of that honest gap. This PR does not claim they execute, and it does not assume regex compilation succeeds.

## Twins and mutation

- truthful: `Descendant(Ancestor[Marker])` inherits the authenticated `project` method
- lying: `Descendant(base_factory()[Marker])` does not acquire `project`, and calling it raises `ConstructionPanic`
- mutation transaction: clean -> implementation present/passes -> generic-base projection removed/fails on missing `project` -> restored/passes -> clean

## Focused validation

- authenticated pinned launcher: 5 passed, 2 inherited deprecation warnings, pandas 3.0.3 / numpy 2.5.1 / authenticated corpus manifest
- local focused mirror: 5 passed
- Black 26.5.1: 3 files unchanged
- `git diff --check`: clean

No full suite was run. No `exit_set.py`, `outcome/`, generator construction, matcher, census, scoreboard, or private demand-table code changed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate assertion managers and retain message obligations for raised exceptions
> - `_message_term` in [authenticated_exception_matching.py](https://github.com/TSavo/sugar/pull/6478/files#diff-b708c62aea2f4d18c3905c4cf348081f6c83d00d7864779eedc94b32ad948d03) now returns a `ctor("py.exception_message", [raised_term])` projection when a raised value has a term, and raises `SugarNotWritten` (instead of silently returning an empty string) when no value term exists.
> - `_resolve_source_visible_frame_uncached` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6478/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now recognizes subscripted bases like `Base[T]` as local dependencies and catches `SugarNotWritten` from base `.sugar()` calls, returning a `ManagerConstructionGapV1` with kind `force-floor` instead of propagating the error.
> - Tests added to confirm that a raised value without a message operand retains a `py.re_search` obligation over `py.exception_message(raised_value)`, and that name-patterns through authenticated generic bases surface a `force-floor` Try.sugar gap.
> - Behavioral Change: `_message_term` no longer returns an empty string for valueless effects; callers that previously relied on silent fallback will now receive a `SugarNotWritten` exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68a55c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->