### PR TITLE
Compose nested assertion manager boundaries

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -217,3 +217,52 @@ def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
         )
 
     return _conjoin(MatchRetained(atomic("py.re_search", [pattern_term, message_term])))
+
+
+def warning_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
+    """Match one constructed warning observation without spelling authority.
+
+    Warning categories use the same source-authenticated class coordinates as
+    exception handlers.  A message pattern is the vendor's ``re.search`` over
+    the projected call operand and the producer-carried warning message.  Two
+    ground strings decide it; otherwise the predicate is retained.  A warning
+    without a constructed category identity or message has no predicate
+    preimage and remains loud rather than becoming a false observation.
+    """
+    import re
+
+    from sugar_lift_py_tests.ir import atomic, str_const
+    from sugar_source_tree.panic import SugarNotWritten
+
+    identity_projection = getattr(expected, "exception_type_identity", None)
+    expected_identity = (
+        identity_projection() if callable(identity_projection) else None
+    )
+    observed_identity = getattr(effect, "category_identity", None)
+    if expected_identity is None or observed_identity is None:
+        raise SugarNotWritten(
+            owner="warning_effect_message_verdict",
+            observed="warning category operand or occurrence has no authenticated identity",
+            requested="two source-authenticated warning category coordinates",
+            fix="construct category identity at the producer; never match warning spelling",
+        )
+    if expected_identity != observed_identity:
+        return MatchDecided(False)
+    if pattern is None:
+        return MatchDecided(True)
+
+    owner = "authenticated_exception_matching.warning_effect_message_verdict"
+    pattern_term = pattern.to_term(owner=owner)
+    message = getattr(effect, "message", None)
+    if not isinstance(message, str):
+        raise SugarNotWritten(
+            owner="warning_effect_message_verdict",
+            observed="warning occurrence has no constructed message",
+            requested="producer-carried warning message for the authenticated occurrence",
+            fix="construct the emitted warning message; never treat absence as an empty string",
+        )
+    message_term = str_const(message)
+    ground_pattern = _ground_string(pattern_term)
+    if ground_pattern is not None:
+        return MatchDecided(re.search(ground_pattern, message) is not None)
+    return MatchRetained(atomic("py.re_search", [pattern_term, message_term]))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -101,19 +101,13 @@ class WithEffectBoundarySugar(Sugar):
                     variadic_keyword_actuals={},
                 )
             if isinstance(semantics.effect_kind, WarningEffectKindV1):
-                if pattern is not None:
-                    raise SugarNotWritten(
-                        owner="WithEffectBoundarySugar.warning_observation",
-                        observed="warning boundary carries an unprojected message pattern",
-                        requested="authenticated warning message matcher",
-                        fix="keep message-bearing warning assertions loud until their matcher is constructed",
-                    )
                 routed.append(
-                    _route_completed_warning_boundary(
+                    _route_warning_boundary(
                         body=tuple(self.body),
                         ctx=ctx,
                         manager_exit=manager_exit,
                         expected=expected,
+                        pattern=pattern,
                         mode=semantics.mode,
                         site=self.site,
                     )
@@ -244,15 +238,15 @@ def _unresolved_producer_coordinates(entries):
     return tuple(members)
 
 
-def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode, site):
-    """Route authenticated warning testimony carried by a COMPLETED body face.
+def _route_warning_boundary(
+    *, body, ctx, manager_exit, expected, pattern, mode, site
+):
+    """Route warning testimony on every face while preserving body control.
 
-    Warnings never become halted exits.  Their producer contributes a
-    ``WarningObservationValue`` to the completed block record.  The manager
-    consumes a matching observation; an authenticated mismatch fails an
-    Expects boundary; and missing identity/occurrence testimony stays a named
-    refusal.  In particular, an empty record is not evidence that no warning
-    occurred.
+    A warning observation can precede a later halt, so consuming the warning
+    must preserve that halt for an enclosing boundary.  Message predicates
+    keep their three-valued result: ground matches decide, symbolic matches
+    partition, and missing producer testimony remains a named refusal.
     """
     from sugar_lift_py_tests.context_manager_contract import ExpectsModeV1
     from sugar_lift_py_tests.effect import ExpectationNotMetEffect
@@ -263,7 +257,19 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
     from sugar_lift_py_tests.floor.warning_observation_value import (
         WarningObservationValue,
     )
-    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.authenticated_exception_matching import (
+        MatchDecided,
+        MatchRetained,
+        warning_effect_message_verdict,
+    )
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome.exit_set import (
+        Completed,
+        ExitSet,
+        Halted,
+        complement_guard,
+        partition,
+    )
     from sugar_lift_py_tests.sugar.exit_set_routing import (
         promote_raise_halts,
     )
@@ -283,33 +289,19 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
             site=site,
         )
 
-    # Python warning categories are exception classes.  The ordinary lexical
-    # class authenticator therefore owns their identity too; no warning/vendor
-    # name table is needed.
-    identity_projection = getattr(expected, "exception_type_identity", None)
-    if not callable(identity_projection):
-        raise SugarNotWritten(
-            owner="WithEffectBoundarySugar.warning_observation",
-            observed="expected warning operand has no authenticated category identity",
-            requested="source-authenticated warning category operand",
-            fix="keep the completed observation undecided; never match category spelling",
-        )
-    expected_identity = identity_projection()
     body_es = promote_raise_halts(reduce_block_to_exitset(body, ctx)).guarded(
         manager_exit.guard
     )
     exits = []
     for face in body_es.exits:
-        if isinstance(face, Halted):
-            exits.append(face)
-            continue
-        entries = getattr(face.value, "entries", None)
+        record = face.value if isinstance(face, Completed) else face.state
+        entries = getattr(record, "entries", None)
         if not isinstance(entries, tuple):
             raise SugarNotWritten(
                 owner="WithEffectBoundarySugar.warning_observation",
-                observed=f"completed face carries {type(face.value).__name__}, not a reduced block record",
-                requested="completed reduced block carrying authenticated warning observations",
-                fix="preserve the completed face until its record is constructed",
+                observed=f"body face carries {type(record).__name__}, not a reduced block record",
+                requested="reduced block carrying authenticated warning observations",
+                fix="preserve the body face until its temporal record is constructed",
             )
         observations = tuple(
             (index, entry)
@@ -347,38 +339,65 @@ def _route_completed_warning_boundary(*, body, ctx, manager_exit, expected, mode
             # now require a specific coordinate to be PRESENT here.
             refusal.unresolved_warning_producers = unresolved_members
             raise refusal
-        match = next(
-            (
-                pair
-                for pair in observations
-                if pair[1].effect.category_identity == expected_identity
-            ),
-            None,
-        )
-        if match is not None and len(observations) == 1:
-            index, _ = match
+        if len(observations) != 1:
+            verdict = MatchDecided(False)
+            index = None
+        else:
+            index, observation = observations[0]
+            verdict = warning_effect_message_verdict(
+                observation.effect, expected, pattern
+            )
+
+        def successful(guard, faces):
+            assert index is not None
             remaining = entries[:index] + entries[index + 1 :]
-            exits.append(
-                Completed(
-                    face.guard,
-                    replace(face.value, entries=remaining),
-                    face.faces,
+            carried = replace(record, entries=remaining)
+            if isinstance(face, Completed):
+                return Completed(guard, carried, faces, face.pending_contracts)
+            return Halted(
+                guard,
+                face.effect,
+                carried,
+                faces,
+                face.pending_contracts,
+            )
+
+        def failed(guard, faces):
+            if isinstance(mode, ExpectsModeV1):
+                return Halted(
+                    guard,
+                    ExpectationNotMetEffect("warning", site),
+                    record,
+                    faces,
                     face.pending_contracts,
+                )
+            return replace(face, guard=guard, faces=faces)
+
+        if isinstance(verdict, MatchDecided):
+            exits.append(
+                successful(face.guard, face.faces)
+                if verdict.value
+                else failed(face.guard, face.faces)
+            )
+            continue
+        if isinstance(verdict, MatchRetained):
+            held, rejected = partition(
+                ("warning-boundary-message", verdict.obligation, face.guard)
+            )
+            exits.extend(
+                (
+                    successful(
+                        and_([face.guard, verdict.obligation]),
+                        face.faces | {held},
+                    ),
+                    failed(
+                        and_([face.guard, complement_guard(verdict.obligation)]),
+                        face.faces | {rejected},
+                    ),
                 )
             )
             continue
-        if isinstance(mode, ExpectsModeV1):
-            exits.append(
-                Halted(
-                    face.guard,
-                    ExpectationNotMetEffect("warning", site),
-                    face.value,
-                    face.faces,
-                    face.pending_contracts,
-                )
-            )
-        else:
-            exits.append(face)
+        raise TypeError(f"unknown warning message verdict {type(verdict).__name__}")
     return ExitSet(tuple(exits)).normalize()
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -14,16 +14,25 @@ from sugar_lift_py_tests.context_manager_contract import (
     ImportSignatureV2,
     NoDefaultV1,
     NoMessagePatternV1,
+    OptionalFormalArgumentProjectionV1,
     PositionalOrKeywordV1,
+    RaiseEffectKindV1,
     WarningEffectKindV1,
     WarningObservationBindingV1,
 )
-from sugar_lift_py_tests.effect import ExpectationNotMetEffect, WarningEffect
-from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, NoneValue, TermValue
+from sugar_lift_py_tests.effect import ExpectationNotMetEffect, RaiseEffect, WarningEffect
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    CallSiteValue,
+    NoneValue,
+    StringValue,
+    TermValue,
+)
 from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
-from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
 from sugar_lift_py_tests.outcome import Complete
-from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted, true_guard
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
 from sugar_source_tree.panic import SugarNotWritten
@@ -45,6 +54,12 @@ class _Fixed(Sugar):
 class _ExpectedCategory(TermValue):
     def exception_type_identity(self):
         return self.value
+
+
+class _SymbolicPattern(StringValue):
+    def to_term(self, *, owner):
+        del owner
+        return make_var("warning_pattern")
 
 
 def _identity(name: str):
@@ -186,3 +201,148 @@ def test_two_no_warning_boundaries_do_not_share_observations():
     assert isinstance(first.exits[0], Completed)
     assert isinstance(second.exits[0], Halted)
     assert isinstance(second.exits[0].effect, ExpectationNotMetEffect)
+
+
+WARNING_WITH_PATTERN = EffectBoundarySemanticsV1(
+    ExpectsModeV1(),
+    WarningEffectKindV1(),
+    FormalArgumentProjectionV1(0),
+    OptionalFormalArgumentProjectionV1(1),
+    WarningObservationBindingV1(),
+)
+
+RAISE_WITH_PATTERN = EffectBoundarySemanticsV1(
+    ExpectsModeV1(),
+    RaiseEffectKindV1(),
+    FormalArgumentProjectionV1(0),
+    OptionalFormalArgumentProjectionV1(1),
+    WarningObservationBindingV1(),
+)
+
+
+def _pattern_boundary(*, semantics, expected, pattern, body):
+    manager_value = CallSiteValue(
+        target_name="renamed_boundary",
+        arg_values=(expected, pattern),
+        parameters=("expected", "match"),
+        term=ctor("call", []),
+        body=None,
+        keyword_names=("match",),
+    )
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "match",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    return WithEffectBoundarySugar(
+        manager=_Fixed(Complete(manager_value)),
+        body=body,
+        semantics=semantics,
+        contract_ref=SimpleNamespace(import_signature=signature),
+        context_manager_edge=None,
+        site="renamed.py:4:4",
+    )
+
+
+def _raise_after_warning(*, warning_message="deprecated operand"):
+    type_identity = _identity("TypeError")
+    raised_value = CallSiteValue(
+        target_name="renamed_error",
+        arg_values=(StringValue("unsupported operand type for &:"),),
+        parameters=("message",),
+        term=ctor("call", []),
+        body=None,
+    )
+    state = _ReducedBlock(
+        entries=(
+            WarningObservationValue(
+                WarningEffect(
+                    "FutureWarning",
+                    message=warning_message,
+                    category_identity=_identity("FutureWarning"),
+                )
+            ),
+        ),
+        can_fall_through=False,
+        fall_through=(),
+    )
+    return ExitSet(
+        (
+            Halted(
+                true_guard(),
+                RaiseEffect(
+                    exception_name="TypeError",
+                    exception_type_coordinate=type_identity,
+                    occurrence="renamed.py:6:8",
+                    raised_value=raised_value,
+                ),
+                state,
+            ),
+        )
+    )
+
+
+def _nested_assertion_boundaries(
+    *, warning_pattern="deprecated", raise_pattern="unsupported operand type"
+):
+    inner = _pattern_boundary(
+        semantics=WARNING_WITH_PATTERN,
+        expected=_ExpectedCategory(_identity("FutureWarning")),
+        pattern=StringValue(warning_pattern),
+        body=(_Fixed(_raise_after_warning()),),
+    )
+    outer = _pattern_boundary(
+        semantics=RAISE_WITH_PATTERN,
+        expected=_ExpectedCategory(_identity("TypeError")),
+        pattern=StringValue(raise_pattern),
+        body=(inner,),
+    )
+    return inner, outer
+
+
+def test_nested_warning_completion_reaches_outer_raise_boundary():
+    """Truthful: the inner completed assertion exposes the original body halt."""
+    _inner, outer = _nested_assertion_boundaries()
+    routed = outer.desugar()
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Completed)
+
+
+def test_nested_warning_lie_bites_before_outer_raise_can_consume():
+    """Lying: a false inner warning assertion must not become outer success."""
+    _inner, outer = _nested_assertion_boundaries(warning_pattern="never present")
+    routed = outer.desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_symbolic_warning_pattern_retains_both_faces():
+    """Undecided is neither success nor failure; both vendor faces survive."""
+    inner = _pattern_boundary(
+        semantics=WARNING_WITH_PATTERN,
+        expected=_ExpectedCategory(_identity("FutureWarning")),
+        pattern=_SymbolicPattern("diagnostic only"),
+        body=(_Fixed(_raise_after_warning()),),
+    )
+    routed = inner.desugar()
+    assert len(routed.exits) == 2
+    assert all(isinstance(face, Halted) for face in routed.exits)
+    assert {type(face.effect) for face in routed.exits} == {
+        RaiseEffect,
+        ExpectationNotMetEffect,
+    }

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -496,6 +496,37 @@ class SourceUnit:
         cache[cache_key] = result
         return result
 
+    def imported_exception_type_identity(self, node: "Expression"):
+        """Return the closed coordinate of an import-bound dotted type operand.
+
+        The context-manager contract authenticates the operand's role as an
+        exception type.  This method authenticates only its source identity:
+        the exact head occurrence must have one reaching import definition,
+        and every remaining component must be a static Attribute link.  A
+        shadowed, computed, or ambiguous head has no coordinate and stays loud.
+        """
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        link = node
+        attributes = []
+        while isinstance(link, Attribute):
+            attributes.append(link.attr)
+            link = link.value
+        if not isinstance(link, Name):
+            return None
+        span = link.line_col_span()
+        target = self.import_bound_name_target(
+            (span.start_line, span.start_col, span.end_line, span.end_col)
+        )
+        if target is None:
+            return None
+        module = target[len("python:") :] if target.startswith("python:") else target
+        qualified = ".".join([module, *reversed(attributes)])
+        return ctor(
+            "python:exception_type_identity",
+            [str_const("import"), str_const(qualified)],
+        )
+
     def _compute_exception_type_identity(
         self, node: "Name", span, builtin_names, ctor, str_const
     ):
@@ -5101,9 +5132,13 @@ class With(Statement):
             if index == selector.parameter_index:
                 actual, actual_location = value, location
                 break
-        if not isinstance(actual, Name):
+        if not isinstance(actual, (Name, Attribute)):
             return manager_sugar
-        identity = self.unit.exception_type_identity(actual)
+        identity = (
+            self.unit.exception_type_identity(actual)
+            if isinstance(actual, Name)
+            else self.unit.imported_exception_type_identity(actual)
+        )
         if identity is None:
             return manager_sugar
         if actual_location[0] == "arg":
@@ -8372,6 +8407,15 @@ class Name(Expression):
         bound = unwrap_binding_state(bound)
         if isinstance(bound, Node):
             return bound
+        span = self.line_col_span()
+        if self.unit.import_bound_name_target(
+            (span.start_line, span.start_col, span.end_line, span.end_col)
+        ) is not None:
+            # The sole lexical import pass proves that this exact use has one
+            # reaching import definition.  Preserve the source node so its
+            # consumer can project that coordinate; do not replace it with an
+            # unbound temporal read merely because imports are inert facts.
+            return self
         return self._make_binding_read(bound)
 
     def _make_binding_read(self, state: BindingState) -> "Node":

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -261,6 +261,147 @@ PINNED_INVALID_ARG_CID = (
     "blake3-512:1a2b00ed9faeb66823b5bf57d534f5ec309cdf5201045bf43b199fabd931e597f"
     "f0d207c885c936577ec06e599da93a29f8497c97c1e03b94f3224923e997889"
 )
+PINNED_IO_COMMON_CID = (
+    "blake3-512:bb8ffaae9d8a417b4054f7688905c4eb405c54ec80fe72daa62ba8394b2fde393"
+    "9e11e9ea25977d357b872820e3e46f6c8c267e7be3cf09889dbb9f04b83a3a9"
+)
+PINNED_ERRORS_CID = (
+    "blake3-512:e0c0e46661f4028ee20659af69bba7b9f87b047b6b1126491bfd5d5c941119c1"
+    "113df8ed9daeb5413832a45b7434689a4768068013d513dc0f634e683b212a33"
+)
+
+
+def _pinned_identity(relative_path: str, expected_cid: str):
+    root = PINNED_PANDAS_ROOT
+    if not root.is_dir():
+        import pandas
+
+        root = Path(pandas.__file__).resolve().parent
+    path = root / relative_path
+    source = path.read_bytes()
+    source_cid = blake3_512_of(source)
+    assert source_cid == expected_cid
+    return source.decode("utf-8"), str(path), source_cid
+
+
+def _raise_semantics():
+    return EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+
+
+def _warning_semantics():
+    return EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        WarningEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        WarningObservationBindingV1(),
+    )
+
+
+def _built_function(identity, name, rows):
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+    )
+    return next(
+        node
+        for node in SourceFile(identity, construction_context=context).functions()
+        if node.name == name
+    ).sugar()
+
+
+def _with_routers(sugar):
+    routers = []
+
+    def walk(node):
+        if isinstance(node, (WithEffectBoundarySugar, WithResourceSugar)):
+            routers.append(node)
+        for field in ("body", "statements", "entries", "then_body", "else_body"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return tuple(routers)
+
+
+def _real_three_deep_assertion_resource_chain():
+    identity = _pinned_identity("tests/io/test_common.py", PINNED_IO_COMMON_CID)
+    probe = SourceFile(identity)
+    function = next(node for node in probe.functions() if node.name == "test_close_on_error")
+    with_nodes = sorted(
+        (node for node in function.walk() if node.kind == "With"),
+        key=lambda node: node.line_col_span().start_line,
+    )
+    assert [node.line_col_span().start_line for node in with_nodes] == [638, 639, 640]
+    rows = {}
+    for index, node in enumerate(with_nodes):
+        coordinate = _coordinate(node.items[0].context_expr)
+        rows[coordinate] = (
+            _ref(coordinate, _raise_semantics(), "h")
+            if index == 0
+            else _resource_ref(coordinate, str(index))
+        )
+    return _with_routers(_built_function(identity, function.name, rows))
+
+
+def _real_juxtaposed_assertion_resource_chain():
+    identity = _pinned_identity("tests/test_errors.py", PINNED_ERRORS_CID)
+    probe = SourceFile(identity)
+    function = next(
+        node for node in probe.functions() if node.name == "test_pandas_warnings_filter"
+    )
+    with_nodes = [node for node in function.walk() if node.kind == "With"]
+    assert len(with_nodes) == 1
+    node = with_nodes[0]
+    assert node.line_col_span().start_line == 142
+    assert len(node.items) == 2
+    first = _coordinate(node.items[0].context_expr)
+    second = _coordinate(node.items[1].context_expr)
+    rows = {
+        first: _ref(first, _warning_semantics(), "w"),
+        second: _resource_ref(second, "z"),
+    }
+    return _with_routers(_built_function(identity, function.name, rows))
+
+
+def test_pinned_three_deep_assertion_over_two_resources_preserves_source_order():
+    """Truthful: the subject manager stays inside both outer boundaries."""
+    outer, middle, inner = _real_three_deep_assertion_resource_chain()
+    assert isinstance(outer, WithEffectBoundarySugar)
+    assert isinstance(middle, WithResourceSugar)
+    assert isinstance(inner, WithResourceSugar)
+    assert middle in outer.body
+    assert inner in middle.body
+
+
+def test_pinned_three_deep_chain_cannot_move_the_assertion_inside_cleanup():
+    """Lying: contract kind cannot reorder authenticated source occurrences."""
+    outer, middle, inner = _real_three_deep_assertion_resource_chain()
+    assert not isinstance(outer, WithResourceSugar)
+    assert not isinstance(middle, WithEffectBoundarySugar)
+    assert not isinstance(inner, WithEffectBoundarySugar)
+
+
+def test_pinned_juxtaposed_assertion_and_resource_nest_left_to_right():
+    """Two items use Python nesting and the same routers as nested source."""
+    outer, inner = _real_juxtaposed_assertion_resource_chain()
+    assert isinstance(outer, WithEffectBoundarySugar)
+    assert isinstance(outer.semantics.effect_kind, WarningEffectKindV1)
+    assert isinstance(inner, WithResourceSugar)
+    assert inner in outer.body
+
+
+def test_pinned_juxtaposition_cannot_swap_the_two_item_occurrences():
+    """Lying: the right-hand resource cannot become the outer assertion."""
+    outer, inner = _real_juxtaposed_assertion_resource_chain()
+    assert not isinstance(outer, WithResourceSugar)
+    assert not isinstance(inner, WithEffectBoundarySugar)
+
 def _real_resource_outer_boundary_inner():
     root = PINNED_PANDAS_ROOT
     if not root.is_dir():

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import MappingProxyType
 
 from sugar_lift_py_tests.context_manager_contract import (
     CallParameterV1,
     EffectBoundarySemanticsV1,
+    EnterResultContractV1,
     ExceptionInfoBindingV1,
+    ExitContractV1,
     ExpectsModeV1,
     FormalArgumentProjectionV1,
     KeywordOnlyV1,
     LiteralDefaultV1,
+    NeverSuppressesDispositionV1,
     NoDefaultV1,
     OptionalFormalArgumentProjectionV1,
     PositionalOrKeywordV1,
+    ProtocolResourceSemanticsV1,
     RaiseEffectKindV1,
     WarningEffectKindV1,
     WarningObservationBindingV1,
@@ -33,6 +38,8 @@ from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
 )
 from sugar_lift_py_tests.ir import PrimitiveSort
 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
@@ -116,6 +123,17 @@ def _ref(use_site, semantics, salt: str) -> ContextManagerContractRefV1:
         exit_testimony_cid=_cid("2"),
         import_signature=SIGNATURE,
         semantics=semantics,
+    )
+
+
+def _resource_ref(use_site, salt: str) -> ContextManagerContractRefV1:
+    return _ref(
+        use_site,
+        ProtocolResourceSemanticsV1(
+            enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+            exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+        ),
+        salt,
     )
 
 
@@ -230,3 +248,172 @@ def test_reassigned_local_import_head_has_no_exception_identity(tmp_path):
         if node.kind == "Attribute" and node.attr == "ArrowNotImplementedError"
     )
     assert tree.root.unit.imported_exception_type_identity(expected) is None
+
+
+PINNED_PANDAS_ROOT = Path(
+    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages/pandas"
+)
+PINNED_DATETIMELIKE_CID = (
+    "blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f39300"
+    "2003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00"
+)
+PINNED_INVALID_ARG_CID = (
+    "blake3-512:1a2b00ed9faeb66823b5bf57d534f5ec309cdf5201045bf43b199fabd931e597f"
+    "f0d207c885c936577ec06e599da93a29f8497c97c1e03b94f3224923e997889"
+)
+def _real_resource_outer_boundary_inner():
+    root = PINNED_PANDAS_ROOT
+    if not root.is_dir():
+        import pandas
+
+        root = Path(pandas.__file__).resolve().parent
+    path = root / "tests/arrays/test_datetimelike.py"
+    source = path.read_bytes()
+    source_cid = blake3_512_of(source)
+    assert source_cid == PINNED_DATETIMELIKE_CID
+    identity = (source.decode("utf-8"), str(path), source_cid)
+    probe = SourceFile(identity)
+    function = next(
+        node
+        for node in probe.functions()
+        if node.name == "test_searchsorted_castable_strings"
+    )
+    with_nodes = {
+        node.line_col_span().start_line: node
+        for node in function.walk()
+        if node.kind == "With"
+    }
+    assert set(with_nodes) == {327, 342, 343}
+    raise_semantics = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    rows = {}
+    for line, node in with_nodes.items():
+        coordinate = _coordinate(node.items[0].context_expr)
+        rows[coordinate] = (
+            _resource_ref(coordinate, "o")
+            if line == 342
+            else _ref(coordinate, raise_semantics, "e")
+        )
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+    )
+    built = next(
+        node
+        for node in SourceFile(identity, construction_context=context).functions()
+        if node.name == function.name
+    ).sugar()
+    outer = None
+
+    def walk(sugar):
+        nonlocal outer
+        if isinstance(sugar, WithResourceSugar) and sugar.site.line == 342:
+            outer = sugar
+            return
+        for field in ("body", "statements", "entries", "then_body", "else_body"):
+            for child in getattr(sugar, field, ()) or ():
+                walk(child)
+
+    walk(built)
+    assert outer is not None
+    inner = next(
+        child for child in outer.body if isinstance(child, WithEffectBoundarySugar)
+    )
+    return outer, inner
+
+
+def test_pinned_resource_outer_assertion_inner_uses_two_authenticated_demands():
+    """The concrete 3.0.3 site, never a historical or synthetic substitute."""
+    outer, inner = _real_resource_outer_boundary_inner()
+    assert isinstance(outer, WithResourceSugar)
+    assert isinstance(inner, WithEffectBoundarySugar)
+    assert inner in outer.body
+
+
+def test_pinned_resource_outer_order_is_not_assertion_outer():
+    """Lying: swapping the two structural roles must bite on the real site."""
+    outer, inner = _real_resource_outer_boundary_inner()
+    assert not isinstance(outer, WithEffectBoundarySugar)
+    assert not isinstance(inner, WithResourceSugar)
+
+
+def _real_assertion_outer_resource_inner():
+    root = PINNED_PANDAS_ROOT
+    if not root.is_dir():
+        import pandas
+
+        root = Path(pandas.__file__).resolve().parent
+    path = root / "tests/apply/test_invalid_arg.py"
+    source = path.read_bytes()
+    source_cid = blake3_512_of(source)
+    assert source_cid == PINNED_INVALID_ARG_CID
+    identity = (source.decode("utf-8"), str(path), source_cid)
+    probe = SourceFile(identity)
+    function = next(
+        node
+        for node in probe.functions()
+        if node.name == "test_transform_and_agg_err_agg"
+    )
+    with_nodes = {
+        node.line_col_span().start_line: node
+        for node in function.walk()
+        if node.kind == "With"
+    }
+    assert set(with_nodes) == {309, 310}
+    raise_semantics = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    rows = {}
+    for line, node in with_nodes.items():
+        coordinate = _coordinate(node.items[0].context_expr)
+        rows[coordinate] = (
+            _ref(coordinate, raise_semantics, "x")
+            if line == 309
+            else _resource_ref(coordinate, "r")
+        )
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+    )
+    built = next(
+        node
+        for node in SourceFile(identity, construction_context=context).functions()
+        if node.name == function.name
+    ).sugar()
+    outer = None
+
+    def walk(sugar):
+        nonlocal outer
+        if isinstance(sugar, WithEffectBoundarySugar) and sugar.site.line == 309:
+            outer = sugar
+            return
+        for field in ("body", "statements", "entries", "then_body", "else_body"):
+            for child in getattr(sugar, field, ()) or ():
+                walk(child)
+
+    walk(built)
+    assert outer is not None
+    inner = next(child for child in outer.body if isinstance(child, WithResourceSugar))
+    return outer, inner
+
+
+def test_pinned_assertion_outer_resource_inner_uses_two_authenticated_demands():
+    """The inverse order composes by nesting through the same constructors."""
+    outer, inner = _real_assertion_outer_resource_inner()
+    assert isinstance(outer, WithEffectBoundarySugar)
+    assert isinstance(inner, WithResourceSugar)
+    assert inner in outer.body
+
+
+def test_pinned_inverse_order_is_not_resource_outer():
+    """Lying: contract kind cannot reorder the two real source occurrences."""
+    outer, inner = _real_assertion_outer_resource_inner()
+    assert not isinstance(outer, WithResourceSugar)
+    assert not isinstance(inner, WithEffectBoundarySugar)

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -1,0 +1,232 @@
+"""Nested assertion managers compose in source order without vendor authority."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExceptionInfoBindingV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    KeywordOnlyV1,
+    LiteralDefaultV1,
+    NoDefaultV1,
+    OptionalFormalArgumentProjectionV1,
+    PositionalOrKeywordV1,
+    RaiseEffectKindV1,
+    WarningEffectKindV1,
+    WarningObservationBindingV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ImportSignatureV2,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.floor import CallSiteValue, StringValue
+from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+    AuthenticatedExceptionTypeValue,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+SOURCE = (
+    "from dependency import halting, observing\n"
+    "def f():\n"
+    '    msg = "unsupported operand type.+for &:"\n'
+    '    warn_msg = "deprecated operand"\n'
+    "    with halting(TypeError, match=msg):\n"
+    "        with observing(FutureWarning, match=warn_msg):\n"
+    '            raise TypeError("unsupported operand type for &:")\n'
+)
+
+STRESS_SOURCE = (
+    "from dependency import observing, halting\n"
+    "def f(using_feature):\n"
+    "    from dependency import pa\n"
+    "    warn = FutureWarning if using_feature else None\n"
+    "    if using_feature:\n"
+    '        with observing(warn, match="Operation between non"):\n'
+    "            with halting(\n"
+    "                pa.lib.ArrowNotImplementedError, match=\"has no kernel\"\n"
+    "            ):\n"
+    '                raise pa.lib.ArrowNotImplementedError("has no kernel")\n'
+)
+
+SIGNATURE = ImportSignatureV2(
+    (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("String"),
+            KeywordOnlyV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+)
+
+
+def _cid(char: str) -> str:
+    return "blake3-512:" + char * 128
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _ref(use_site, semantics, salt: str) -> ContextManagerContractRefV1:
+    return ContextManagerContractRefV1(
+        resolution_cid=_cid(salt),
+        demand_cid=_cid("d"),
+        use_site=use_site,
+        use_site_cid=_hash_json(use_site.wire()),
+        authenticated_import_use_cid=_cid("u"),
+        import_binding_cid=_cid("i"),
+        construction_context_generation_cid=_cid("g"),
+        contract_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        provenance_cid=_cid("v"),
+        distribution_artifact_cid=_cid("a"),
+        dependency_artifact_graph_cid=_cid("b"),
+        module_source_cid=_cid("s"),
+        resolved_definition_cid=_cid("f"),
+        manager_construction_cid=_cid("n"),
+        enter_testimony_cid=_cid("1"),
+        exit_testimony_cid=_cid("2"),
+        import_signature=SIGNATURE,
+        semantics=semantics,
+    )
+
+
+def _constructed_boundaries(tmp_path, source=SOURCE, *, warning_first=False):
+    path = tmp_path / "renamed.py"
+    path.write_text(source, encoding="utf-8")
+    identity = path_source(str(path))
+    probe = SourceFile(identity)
+    with_nodes = [node for node in probe.nodes() if node.kind == "With"]
+    assert len(with_nodes) == 2
+    coordinates = [_coordinate(node.items[0].context_expr) for node in with_nodes]
+    raise_semantics = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    warning_semantics = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        WarningEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        WarningObservationBindingV1(),
+    )
+    semantics = (
+        (warning_semantics, raise_semantics)
+        if warning_first
+        else (raise_semantics, warning_semantics)
+    )
+    rows = {
+        coordinate: _ref(coordinate, selected, salt)
+        for coordinate, selected, salt in zip(
+            coordinates, semantics, ("r", "q"), strict=True
+        )
+    }
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(
+            _cid("c"), _cid("t"), MappingProxyType(rows)
+        )
+    )
+    function = next(SourceFile(identity, construction_context=context).functions())
+    sugar = function.sugar()
+    boundaries = []
+
+    def walk(node):
+        if isinstance(node, WithEffectBoundarySugar):
+            boundaries.append(node)
+        for field in (
+            "body",
+            "statements",
+            "entries",
+            "then_body",
+            "else_body",
+        ):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return tuple(boundaries)
+
+
+def test_variable_patterns_reach_both_nested_boundaries(tmp_path):
+    """Truthful: Assign substitution supplies both real ``match=`` operands."""
+    outer, inner = _constructed_boundaries(tmp_path)
+    outer_call = outer.manager.desugar().value
+    inner_call = inner.manager.desugar().value
+    assert isinstance(outer_call, CallSiteValue)
+    assert isinstance(inner_call, CallSiteValue)
+    assert outer_call.arg_values[-1] == StringValue("unsupported operand type.+for &:")
+    assert inner_call.arg_values[-1] == StringValue("deprecated operand")
+
+
+def test_lying_variable_patterns_do_not_alias_between_boundaries(tmp_path):
+    """Lying: swapped expectations must fail; the two bindings stay distinct."""
+    outer, inner = _constructed_boundaries(tmp_path)
+    outer_pattern = outer.manager.desugar().value.arg_values[-1]
+    inner_pattern = inner.manager.desugar().value.arg_values[-1]
+    assert outer_pattern != inner_pattern
+
+
+def test_reverse_order_branch_constructs_both_native_boundaries(tmp_path):
+    """The stress shape stays source-ordered under a branch and local import."""
+    outer, inner = _constructed_boundaries(
+        tmp_path, STRESS_SOURCE, warning_first=True
+    )
+    assert isinstance(outer.semantics.effect_kind, WarningEffectKindV1)
+    assert isinstance(inner.semantics.effect_kind, RaiseEffectKindV1)
+    assert outer.manager.desugar().value.arg_values[-1] == StringValue(
+        "Operation between non"
+    )
+    inner_call = inner.manager.desugar().value
+    assert isinstance(inner_call.arg_values[0], AuthenticatedExceptionTypeValue)
+    assert inner_call.arg_values[-1] == StringValue(
+        "has no kernel"
+    )
+
+
+def test_reassigned_local_import_head_has_no_exception_identity(tmp_path):
+    """Lying: an intervening assignment defeats the import coordinate."""
+    source = STRESS_SOURCE.replace(
+        "    warn = FutureWarning if using_feature else None\n",
+        "    pa = replacement\n"
+        "    warn = FutureWarning if using_feature else None\n",
+    )
+    path = tmp_path / "shadowed.py"
+    path.write_text(source, encoding="utf-8")
+    tree = SourceFile(path_source(str(path)))
+    expected = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "Attribute" and node.attr == "ArrowNotImplementedError"
+    )
+    assert tree.root.unit.imported_exception_type_identity(expected) is None


### PR DESCRIPTION
## What changed

- route authenticated warning observations on halted as well as completed body faces, preserving the original halt for an enclosing assertion boundary
- construct `match=` warning predicates with ground truthful/lying decisions and retained symbolic faces
- authenticate dotted expected exception operands from their exact reaching import coordinate; shadowed/reassigned heads remain loud
- preserve the landed warning-producer bucket and exact-`None` no-warning contract from #6475/#6476
- add source-order twins for the clean nested shape and the reverse-order branch/local-import stress shape

No vendor/name admission, fallback contract, or warning-absence fabrication is added.

## Validation

Authenticated launcher (CPython 3.12.13, pandas 3.0.3, NumPy 2.5.1, corpus manifest `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`):

```text
50 passed in 33.16s
AUTHENTICATED_EXIT=0
```

The focused set includes:

- `test_nested_assertion_manager_composition.py`
- `test_with_effect_boundary_warning.py`
- import-bound callee discrimination
- construction invariant and side-door laws
- timeout and native-crash zero-tolerance laws

Mutation transaction: reintroducing the old halted-face bypass made `test_nested_warning_lie_bites_before_outer_raise_can_consume` fail; reverting the mutation restored both nested twins green.

An earlier broad probe also included two unrelated base-red modules: the construction-panic-catch scanner reports seven pre-existing loci outside this diff, and `test_structural_floor.py` has five CPython/source-tree incompatibility failures. They are unchanged by this branch and are not presented as green.

Base: `675c5de7b4a6556f85b848ddf8673815e7dcddc8`
Head: `d4d0f67fb0fe562cd953d7fe46ebaabbfcd75fa5`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compose nested assertion manager boundaries with authenticated exception identity and message-pattern matching
> - Adds `warning_effect_message_verdict` in [authenticated_exception_matching.py](https://github.com/TSavo/sugar/pull/6479/files#diff-b708c62aea2f4d18c3905c4cf348081f6c83d00d7864779eedc94b32ad948d03) to evaluate warning occurrences against an expected category and optional regex pattern, returning a decided or retained verdict.
> - Reworks `_route_warning_boundary` in [with_effect_boundary_sugar.py](https://github.com/TSavo/sugar/pull/6479/files#diff-0d372d766673042627a4eeab5612c75aa23cb49a85e1aa6866cfb0721be30780) to handle both `Completed` and `Halted` body faces, consuming warning observations and partitioning exits when a symbolic pattern match is retained.
> - Extends `SourceUnit` and `With` in [nodes.py](https://github.com/TSavo/sugar/pull/6479/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to authenticate exception type identities for dotted import references (e.g. `pa.lib.ArrowNotImplementedError`), and preserves import-bound `Name` nodes during substitution instead of replacing them with binding reads.
> - Adds tests in [test_nested_assertion_manager_composition.py](https://github.com/TSavo/sugar/pull/6479/files#diff-36e2bf5cd83aaf2e1fd4eddf63fd8a366307a0b6dee453a6532e38dcbd4365a1) covering nested boundary composition, argument substitution for patterns, and imported exception identity authentication including pinned pandas sources.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 166e258.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warning-based effect boundaries can now match both exception categories and message patterns.
  * Added support for recognizing imported, dotted exception types in context-manager boundaries.
  * Symbolic message patterns remain pending until their values can be resolved.

* **Bug Fixes**
  * Improved nested warning and raise boundary handling, including truthful and failed matches.

* **Tests**
  * Added coverage for nested boundaries, message-pattern matching, import resolution, reassigned imports, and symbolic patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->