### PR TITLE
Authenticate assertion-With exception context observations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
@@ -33,6 +33,7 @@ class ReduceContext:
     # after opaque body dig started reducing vendor-bridged bodies.
     external_bridge_sink: Any = None
     in_flight_effects: tuple[tuple[str, object], ...] = ()
+    observed_effects: tuple[tuple[str, object], ...] = ()
 
     @classmethod
     def root(
@@ -67,6 +68,7 @@ class ReduceContext:
             dig_sink=source.dig_sink,
             external_bridge_sink=getattr(source, "external_bridge_sink", None),
             in_flight_effects=getattr(source, "in_flight_effects", ()),
+            observed_effects=getattr(source, "observed_effects", ()),
         )
 
     def record_operation(
@@ -104,6 +106,7 @@ class ReduceContext:
             dig_sink=self.dig_sink,
             external_bridge_sink=self.external_bridge_sink,
             in_flight_effects=self.in_flight_effects,
+            observed_effects=self.observed_effects,
         )
 
     def with_in_flight_effect(self, slot_id: str, effect: object) -> "ReduceContext":
@@ -122,10 +125,24 @@ class ReduceContext:
             dig_sink=self.dig_sink,
             external_bridge_sink=self.external_bridge_sink,
             in_flight_effects=(*self.in_flight_effects, (slot_id, effect)),
+            observed_effects=self.observed_effects,
         )
 
     def in_flight_effect_for(self, slot_id: str):
         for candidate_slot, effect in reversed(self.in_flight_effects):
+            if candidate_slot == slot_id:
+                return effect
+        return None
+
+    def with_observed_effect(self, slot_id: str, effect: object) -> "ReduceContext":
+        from dataclasses import replace
+
+        return replace(
+            self, observed_effects=(*self.observed_effects, (slot_id, effect))
+        )
+
+    def observed_effect_for(self, slot_id: str):
+        for candidate_slot, effect in reversed(self.observed_effects):
             if candidate_slot == slot_id:
                 return effect
         return None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -23,6 +23,9 @@ class RaiseEffect:
     # The constructed expression after an explicit ``from``. Host ``None``
     # means the clause was absent; explicit Python ``None`` is a NoneValue.
     cause_value: object | None = None
+    # The handled occurrence active when this raise happened. This is Python's
+    # ``__context__`` testimony and is distinct from an explicit ``from`` cause.
+    context_effect: "RaiseEffect | None" = None
 
     @property
     def occurrence_id(self) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -20,11 +20,23 @@ from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.inv_value import InvValue
+from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.ir import atomic, ctor, eq, str_const
 from sugar_lift_py_tests.outcome.incomplete import Incomplete
 
 _EFFECT_ABSENT_NAME = "py.effect.none"
 _EFFECT_EXPECTED_OBLIGATION = "py.effect.expected"
+
+
+@dataclass(frozen=True)
+class ObservedEffectBinding(FloorValue):
+    """Producer-owned preimage for projections from one consumed effect slot."""
+
+    slot_id: str
+    effect: RaiseEffect
+
+    def contribution(self):
+        return ()
 
 
 class RuntimeSelectedReachedRouter(RuntimeError):
@@ -90,6 +102,24 @@ class EffectBinding:
                     site=site,
                 )
             )
+        if isinstance(self.effect, RaiseEffect):
+            context = self.effect.context_effect
+            context_value = getattr(context, "raised_value", None)
+            if isinstance(context, RaiseEffect) and isinstance(
+                context_value, FloorValue
+            ):
+                facts.append(
+                    InvValue(
+                        eq(
+                            ctor("effect_slot_context", [slot]),
+                            context_value.to_term(
+                                owner="EffectBinding.context_preimage"
+                            ),
+                        ),
+                        site=site,
+                    )
+                )
+            facts.append(ObservedEffectBinding(self.slot_id, self.effect))
         return tuple(facts)
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/effect_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/effect_coordinate.py
@@ -26,6 +26,24 @@ class EffectCoordinate(FloorValue):
 
         return ctor("python:effect_slot", [str_const(self.slot_id)])
 
+    def attribute(self, name, site):
+        if name != "__context__":
+            return super().attribute(name, site)
+        from sugar_lift_py_tests.gap.info import GapKind
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="EffectCoordinate.attribute.__context__",
+            blame=site,
+            observed="consumed raise carries no authenticated context preimage",
+            requested="the raised value of the in-flight RaiseEffect occurrence",
+            fix=(
+                "preserve Python exception chaining through the raise effect; "
+                "never fabricate an empty chained exception"
+            ),
+            gap_kind=GapKind.FLOOR,
+        )
+
 
 @dataclass(frozen=True)
 class ExceptionInfoCoordinate(FloorValue):
@@ -45,4 +63,41 @@ class ExceptionInfoCoordinate(FloorValue):
             from sugar_lift_py_tests.outcome import Complete
 
             return Complete(EffectCoordinate(slot_id=self.slot_id, site=site))
+        return super().attribute(name, site)
+
+
+@dataclass(frozen=True)
+class ObservedEffectValue(EffectCoordinate):
+    """Authenticated producer testimony for one consumed RaiseEffect."""
+
+    effect: object = dataclass_field(compare=False, default=None)
+
+    def attribute(self, name, site):
+        if name != "__context__":
+            return super().attribute(name, site)
+        from sugar_lift_py_tests.effect import RaiseEffect
+        from sugar_lift_py_tests.outcome import Complete
+
+        context = getattr(self.effect, "context_effect", None)
+        value = getattr(context, "raised_value", None)
+        if isinstance(context, RaiseEffect) and isinstance(value, FloorValue):
+            return Complete(value)
+        return super().attribute(name, site)
+
+
+@dataclass(frozen=True)
+class ObservedExceptionInfoValue(ExceptionInfoCoordinate):
+    """Authenticated assertion-manager observation that outlives its block."""
+
+    effect: object = dataclass_field(compare=False, default=None)
+
+    def attribute(self, name, site):
+        if name == "value":
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                ObservedEffectValue(
+                    slot_id=self.slot_id, effect=self.effect, site=site
+                )
+            )
         return super().attribute(name, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
@@ -38,16 +38,22 @@ class ObservationRefSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
         from sugar_lift_py_tests.floor.effect_coordinate import (
             EffectCoordinate,
             ExceptionInfoCoordinate,
+            ObservedExceptionInfoValue,
         )
 
         if self.projection == "exception_info":
-            return Complete(
-                ExceptionInfoCoordinate(slot_id=self.slot_id, site=self.site)
-            )
+            reader = getattr(ctx, "observed_effect_for", None)
+            effect = reader(self.slot_id) if reader is not None else None
+            if effect is not None:
+                return Complete(
+                    ObservedExceptionInfoValue(
+                        slot_id=self.slot_id, effect=effect, site=self.site
+                    )
+                )
+            return Complete(ExceptionInfoCoordinate(slot_id=self.slot_id, site=self.site))
         if self.projection == "enter_result":
             from sugar_lift_py_tests.floor.manager_coordinate import (
                 EnterResultCoordinate,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -241,7 +241,29 @@ def reduce_block_to_exitset(
                 # into a contradictory second post-state.
                 return ExitSet.completed(state)
             active_ctx = state.context if state.context is not None else ctx
-            outcome = head.desugar(active_ctx)
+            statement_ctx = active_ctx
+            from sugar_lift_py_tests.effect_router import ObservedEffectBinding
+
+            observed = tuple(
+                entry
+                for entry in state.entries
+                if isinstance(entry, ObservedEffectBinding)
+            )
+            if observed:
+                from sugar_lift_py_tests.context import ReduceContext
+
+                statement_ctx = (
+                    ReduceContext.root(owner="reduce_block_to_exitset")
+                    if statement_ctx is None
+                    else ReduceContext.derived(
+                        statement_ctx, owner="reduce_block_to_exitset"
+                    )
+                )
+                for binding in observed:
+                    statement_ctx = statement_ctx.with_observed_effect(
+                        binding.slot_id, binding.effect
+                    )
+            outcome = head.desugar(statement_ctx)
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 
             if (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -72,6 +72,13 @@ class RaiseSugar(Sugar):
             return Incomplete(resolve_in_flight_effect(ctx, self.in_flight_slot))
 
         def halt(raised_value, cause_value=None):
+            context_effect = None
+            if self.in_flight_slot is not None:
+                from sugar_lift_py_tests.in_flight_effect import (
+                    resolve_in_flight_effect,
+                )
+
+                context_effect = resolve_in_flight_effect(ctx, self.in_flight_slot)
             identity_reader = getattr(raised_value, "exception_type_identity", None)
             mro_reader = getattr(raised_value, "exception_type_mro", None)
             return Incomplete(
@@ -93,6 +100,7 @@ class RaiseSugar(Sugar):
                     ),
                     raised_value=raised_value,
                     cause_value=cause_value,
+                    context_effect=context_effect,
                 )
             )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 _ROOT = Path(__file__).resolve().parents[1]
 _SRC = _ROOT / "src" / "sugar_lift_py_tests"
 
@@ -84,6 +86,30 @@ def test_wrong_match_does_not_bind_slot() -> None:
     )
     assert out.bindings == ()
     assert any(isinstance(e, Incomplete) for e in out.entries)
+
+
+def test_observed_effect_projects_only_an_authenticated_context_preimage() -> None:
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.floor.effect_coordinate import (
+        EffectCoordinate,
+        ObservedEffectValue,
+    )
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    inner_value = TermValue(7)
+    inner = RaiseEffect(exception_name="ImportError", raised_value=inner_value)
+    outer = RaiseEffect(exception_name="ValueError", context_effect=inner)
+
+    projected = ObservedEffectValue(slot_id="S", effect=outer).attribute(
+        "__context__", site=None
+    )
+    assert projected.value is inner_value
+
+    with pytest.raises(ConstructionPanic) as caught:
+        EffectCoordinate(slot_id="S").attribute("__context__", site=None)
+    assert caught.value.info.owner == "EffectCoordinate.attribute.__context__"
+    assert "no authenticated context preimage" in caught.value.info.observed
 
 
 def test_no_process_identity_in_slot_fallback() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -89,6 +89,7 @@ from sugar_source_tree.nodes import (
     Constant,
     FunctionDef,
     Name,
+    With,
 )
 from sugar_source_tree.tree import SourceFile
 
@@ -513,6 +514,38 @@ def test_resolvable_call_drains_against_the_pinned_table() -> None:
     escape = escape_rows[0]
     assert escape.get("importSignature"), "the drained row carries no import signature"
     assert escape.get("gapKind") is None
+
+
+def test_real_name_ref_site_binds_and_reads_exception_context() -> None:
+    """The pinned name-ref site is also the real chained-observation reproducer."""
+    table = _pinned_demand_table()
+    site = next(s for s in ENROLLED_SITES if s.shape == "name-ref")
+    assert table["rows"]["name-ref"], "shared table has no rows for the real file"
+
+    source_file = _source_file(_corpus_root() / site.relative_path)
+    with_node = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, With) and node.line_col_span().start_line == site.line
+    )
+    item = with_node.items[0]
+    assert isinstance(item.optional_vars, Name)
+    assert item.optional_vars.id == "exc_info"
+    manager = item.context_expr
+    assert isinstance(manager, Call)
+    match_argument = next(
+        keyword.value for keyword in manager.keywords if keyword.arg == "match"
+    )
+    assert isinstance(match_argument, Name)
+
+    context_reads = [
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "__context__"
+        and "exc_info.value.__context__" in node.segment()
+    ]
+    assert len(context_reads) == 1
 
 
 def test_opaque_callee_is_absent_from_every_row_of_its_file() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import importlib.metadata
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -2230,18 +2231,25 @@ _BOUNDARY_IMPLEMENTATION = (
 
 
 def _route_boundary_with_binding(
-    tmp_path, *, body: str, as_clause: str = " as info", following: str = ""
+    tmp_path,
+    *,
+    body: str,
+    as_clause: str = " as info",
+    following: str = "",
+    implementation: str = _BOUNDARY_IMPLEMENTATION,
+    prefix: str = "",
+    manager: str = "arbitrary.boundary(ValueError)",
 ):
     distribution = _distribution(
-        tmp_path, _BOUNDARY_IMPLEMENTATION, exported="boundary"
+        tmp_path, implementation, exported="boundary"
     )
-    consumer = (
-        "import arbitrary\n"
-        "def use_boundary():\n"
-        f"    with arbitrary.boundary(ValueError){as_clause}:\n"
-        f"        {body}\n"
-        f"    {following}\n"
-    )
+    consumer = "import arbitrary\ndef use_boundary():\n"
+    if prefix:
+        consumer += textwrap.indent(textwrap.dedent(prefix), "    ")
+    consumer += f"    with {manager}{as_clause}:\n"
+    consumer += textwrap.indent(textwrap.dedent(body), "        ") + "\n"
+    if following:
+        consumer += textwrap.indent(textwrap.dedent(following), "    ") + "\n"
     path = tmp_path / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
     from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
@@ -2299,6 +2307,85 @@ def test_boundary_as_binding_never_reifies_a_nonmatching_halt(tmp_path):
     face = exits.exits[0]
     assert isinstance(face, Halted)
     assert _effect_slot_facts(face) == ()
+
+
+def test_boundary_as_binding_projects_authenticated_exception_context(tmp_path):
+    """Truthful chained twin: `.value.__context__` is the handled occurrence."""
+    from sugar_lift_py_tests.outcome import Completed
+
+    exits = _route_boundary_with_binding(
+        tmp_path,
+        body=(
+            "try:\n"
+            "    raise ImportError('inner')\n"
+            "except ImportError:\n"
+            "    raise ValueError('cannot convert')"
+        ),
+        following="assert isinstance(info.value.__context__, ImportError)",
+    )
+    completed = [face for face in exits.exits if isinstance(face, Completed)]
+    assert len(completed) == 1
+    face = completed[0]
+    assert len(_effect_binding_facts(face)) == 3
+    context_facts = tuple(
+        entry
+        for entry in _effect_slot_facts(face)
+        if "effect_slot_context" in str(entry.formula)
+    )
+    assert len(context_facts) == 1
+
+
+def test_boundary_context_binding_composes_with_variable_message_predicate(tmp_path):
+    """The binding survives a same-manager predicate supplied through Assign."""
+    implementation = (
+        "class Boundary:\n"
+        "    def __init__(self, expected, match):\n"
+        "        self.expected = expected\n"
+        "        self.match = match\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return (effect_type is self.expected) and (effect.message == self.match)\n\n"
+        "def boundary(expected, match):\n"
+        "    return Boundary(expected, match)\n"
+    )
+    from sugar_lift_py_tests.outcome import Completed
+
+    exits = _route_boundary_with_binding(
+        tmp_path,
+        implementation=implementation,
+        prefix="pattern = 'cannot convert'\n",
+        manager="arbitrary.boundary(ValueError, match=pattern)",
+        body=(
+            "try:\n"
+            "    raise ImportError('inner')\n"
+            "except ImportError:\n"
+            "    raise ValueError('cannot convert')"
+        ),
+        following="assert isinstance(info.value.__context__, ImportError)",
+    )
+    completed = [face for face in exits.exits if isinstance(face, Completed)]
+    assert len(completed) == 1
+    assert any(
+        "effect_slot_context" in str(entry.formula)
+        for entry in _effect_slot_facts(completed[0])
+    )
+
+
+def test_boundary_as_binding_refuses_missing_exception_context(tmp_path):
+    """Lying chained twin: no context preimage means no usable value."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic) as caught:
+        _route_boundary_with_binding(
+            tmp_path,
+            body="raise ValueError('cannot convert')",
+            following="assert isinstance(info.value.__context__, ImportError)",
+        )
+    assert caught.value.info.owner == "EffectCoordinate.attribute.__context__"
+    assert "no authenticated context preimage" in caught.value.info.observed
 
 
 def _effect_slot_facts(face) -> tuple:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5522,6 +5522,11 @@ class Raise(Statement):
             cause=self.cause.sugar() if self.cause is not None else None,
             exception_name=self._exception_name(),
             site=self.fragment,
+            in_flight_slot=(
+                self.control_context.exception_slots[-1]
+                if self.control_context.exception_slots
+                else None
+            ),
         )
 
 

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -449,6 +449,26 @@ def test_handler_halt_does_not_invent_post_try_fallthrough():
     assert reds[0].effect.exception_name == "RuntimeError"
 
 
+def test_handler_raise_carries_the_handled_occurrence_as_context():
+    """An explicit handler raise authenticates Python's chaining edge."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = _out(
+        "def A():\n"
+        "    try:\n"
+        "        raise ImportError('inner')\n"
+        "    except ImportError:\n"
+        "        raise ValueError('outer')\n"
+    )
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, RaiseEffect)
+    assert out.effect.exception_name == "ValueError"
+    assert isinstance(out.effect.context_effect, RaiseEffect)
+    assert out.effect.context_effect.exception_name == "ImportError"
+    assert out.effect.context_effect.occurrence.endswith(":6:8")
+
+
 # ---------------------------------------------------------------------------
 # except* separately loud (ordinary try path ≠ except*)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- preserve the handled `RaiseEffect` as authenticated Python `__context__` testimony on an explicit raise inside an exception handler
- carry the consumed effect occurrence through assertion-With observation binding without putting payloads in pure effect coordinates
- project `.value.__context__` only from producer-authenticated observation values; missing testimony remains a named construction refusal
- cover the real pinned pandas `match=match` plus `as exc_info` site using the shared demand table

## Why

`with ... as exc_info` reifies an effect that already happened. A chained read such as `exc_info.value.__context__` must therefore use the exact handled exception occurrence as its preimage. Fabricating an empty exception-like value would turn missing authentication into a silent wrong answer.

## Validation

- authenticated post-rebase gate: 6 passed under CPython 3.12.13, pandas 3.0.3, numpy 2.5.1
- focused shared demand-table module: 15 passed against the exact published #6464 content key
- focused package run before rebase: 72 passed, with the single authenticated arm-count delta made exact and revalidated post-rebase
- full assertion-With construction module: 68 passed, 1 current-main baseline failure in the unrelated generator-manager test (`expected With`, observed `Expr`); the exact test reproduces unchanged on clean `origin/main` under the same authenticated launcher
- mutation transaction: severing `context_effect` made the truthful twin fail at `EffectCoordinate.attribute.__context__`; reverting restored 9 passing focused tests
- `git diff --check`

No corpus lift or demand-table build was run. Heavy construction stayed on the authenticated remote launcher.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate exception `__context__` access in raise-within-handler sugar
> - Implements Python-style exception chaining: when a `raise` occurs inside a handler, `RaiseSugar` now attaches the currently-handled `RaiseEffect` as `context_effect` on the new `RaiseEffect`.
> - Adds `ObservedEffectBinding` artifacts to effect routing so that downstream desugaring can retrieve the authenticated observed effect for a slot via the new `ReduceContext.observed_effect_for` lookup.
> - Introduces `ObservedEffectValue` and `ObservedExceptionInfoValue` floor-value subclasses that project `.value.__context__` only when a real `context_effect` preimage exists; accessing `__context__` on a plain `EffectCoordinate` now raises a `ConstructionPanic`.
> - `reduce_block_to_exitset` threads per-statement `ReduceContext` instances enriched with observed effects so that statement desugaring can authenticate chained exception access.
> - Behavioral Change: `exc_info.value.__context__` in a handler now fails at construction time (panic) rather than silently returning a fabricated value when no context preimage is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 970cea6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->