### PR TITLE
Authenticate pandas corpus file contents

### DIFF
--- a/implementations/python/sugar-lift-py-tests/pyproject.toml
+++ b/implementations/python/sugar-lift-py-tests/pyproject.toml
@@ -48,10 +48,12 @@ test = [
 ]
 
 [tool.sugar.measured-corpus]
-# SourceTree(pandas_root).paths(), sorted and JSON-canonicalized before sha256.
-# This is the 1,421-file pandas 3.0.3 denominator in the immutable managed
-# closure. Older 1,415-file receipts have a different CID and cannot mix.
-pandas-manifest-cid = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+# Content manifest over SourceTree(pandas_root).paths(): each sorted relative
+# path is paired with the BLAKE3-512 CID of its file bytes, then the canonical
+# manifest is content-addressed by demand_table_identity.corpus_manifest_cid.
+# Identical paths with one changed byte MUST mismatch. This is the 1,421-file
+# pandas 3.0.3 denominator in the immutable managed closure.
+pandas-manifest-cid = "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 
 [project.scripts]
 sugar-lift-python = "sugar_lift_py_tests.lift_rpc:main"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 import sys
 import sysconfig
@@ -12,7 +10,9 @@ from dataclasses import dataclass
 from importlib import import_module, metadata
 from pathlib import Path
 from types import ModuleType
-from typing import Sequence
+from typing import Iterable, Sequence
+
+from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
 
 
 class ExecutionEnvironmentMismatch(RuntimeError):
@@ -95,14 +95,28 @@ def authenticate_lift(module: ModuleType, repo_root: Path) -> ImportIdentity:
     return ImportIdentity("sugar_lift_py_tests", "checkout-source", loaded_from)
 
 
-def corpus_manifest_cid(files: Sequence[str]) -> str:
-    ordered = sorted(str(path) for path in files)
-    if not ordered:
+def authenticate_corpus_manifest(
+    root: Path, paths: Iterable[Path], expected_cid: str
+) -> tuple[str, int]:
+    """Authenticate relative paths AND bytes using the shared manifest CID.
+
+    This deliberately reuses ``demand_table_identity.corpus_manifest_cid``.
+    The former path-only SHA-256 proved only which files existed, so identical
+    paths with edited, truncated, or partially synchronized bytes passed as an
+    authenticated corpus. Reading the pinned 1,421 files costs a measured
+    median 1.255 seconds (max 1.591 seconds over five workstation runs), which
+    is acceptable once before pytest collection; false authentication is not.
+    """
+    observed_cid, file_count = corpus_manifest_cid(root, paths)
+    if file_count == 0:
         raise ExecutionEnvironmentMismatch("pandas corpus manifest is empty")
-    if len(set(ordered)) != len(ordered):
-        raise ExecutionEnvironmentMismatch("pandas corpus manifest contains duplicates")
-    preimage = json.dumps(ordered, separators=(",", ":"), ensure_ascii=True)
-    return "sha256:" + hashlib.sha256(preimage.encode("utf-8")).hexdigest()
+    if observed_cid != expected_cid:
+        raise ExecutionEnvironmentMismatch(
+            "pandas corpus content manifest CID mismatch: "
+            f"observed {observed_cid} over {file_count} files; "
+            f"required {expected_cid}"
+        )
+    return observed_cid, file_count
 
 
 def activate_checkout_import_roots(repo_root: Path, search_path: list[str]) -> None:
@@ -186,17 +200,8 @@ def authenticate_environment() -> (
     from sugar_source_tree.tree import SourceTree
 
     pandas_root = pandas_identity.loaded_from.parent
-    files = [
-        path.resolve().relative_to(pandas_root).as_posix()
-        for path in SourceTree(pandas_root).paths()
-    ]
-    observed_cid = corpus_manifest_cid(files)
-    if observed_cid != expected_cid:
-        raise ExecutionEnvironmentMismatch(
-            "pandas corpus manifest CID mismatch: "
-            f"observed {observed_cid} over {len(files)} files; "
-            f"required {expected_cid}"
-        )
+    files = list(SourceTree(pandas_root).paths())
+    observed_cid, _ = authenticate_corpus_manifest(pandas_root, files, expected_cid)
     return pandas_identity, numpy_identity, lift_identity, observed_cid
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
@@ -27,7 +27,8 @@ def render(value, width):
 # the decisive law, not merely its convenient conclusion: same corpus,
 # different parser output, byte-identical demand table.
 MEASURED_CORPUS_MANIFEST_CID = (
-    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 )
 MEASURED_DEMAND_TABLE_OUTPUT_CIDS = {
     "cpython-3.12.13": (

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -12,6 +12,7 @@ from sugar_lift_py_tests.authenticated_pytest import (
     ExecutionEnvironmentMismatch,
     activate_checkout_import_roots,
     authenticate_distribution,
+    authenticate_corpus_manifest,
     authenticate_lift,
     corpus_manifest_cid,
     interpreter_identity,
@@ -131,11 +132,28 @@ def test_lift_must_resolve_from_the_synced_checkout(tmp_path) -> None:
         authenticate_lift(foreign, repo)
 
 
-def test_manifest_cid_is_order_independent_and_path_bound() -> None:
-    assert corpus_manifest_cid(["pandas/b.py", "pandas/a.py"]) == (
-        "sha256:194cbd45be1fdf143d4ed8dca52fb946dc88b5a15198dbef26426ef514503ca6"
+def test_manifest_cid_is_order_independent_and_content_bound(tmp_path) -> None:
+    root = tmp_path / "pandas"
+    root.mkdir()
+    first = root / "a.py"
+    second = root / "b.py"
+    first.write_bytes(b"VALUE = 1\n")
+    second.write_bytes(b"VALUE = 2\n")
+
+    expected_cid, expected_count = corpus_manifest_cid(root, [second, first])
+    assert corpus_manifest_cid(root, [first, second]) == (
+        expected_cid,
+        expected_count,
     )
-    assert corpus_manifest_cid(["pandas/a.py"]) != corpus_manifest_cid(["pandas/b.py"])
+
+    # LYING TWIN: same two relative paths, one changed byte. Path-only
+    # authentication accepts this; corpus authentication must refuse it.
+    first.write_bytes(b"VALUE = 0\n")
+    with pytest.raises(
+        ExecutionEnvironmentMismatch,
+        match=r"pandas corpus content manifest CID mismatch.*over 2 files",
+    ):
+        authenticate_corpus_manifest(root, [first, second], expected_cid)
 
 
 def test_selected_interpreter_identity_is_named() -> None:


### PR DESCRIPTION
## Ruling

Environment authentication uses the content manifest CID, not the former path-only SHA-256. A path digest proves package shape but silently authenticates edited, truncated, partially synchronized, or same-path/different-byte corpora.

The stronger primitive already owned by `demand_table_identity.corpus_manifest_cid` addresses sorted relative paths paired with each file byte CID. The launcher now reuses that single implementation.

## Measured cost

Five complete hashes of the pinned 1,421-file pandas 3.0.3 corpus on the shared workstation took 0.826–1.591 seconds, median 1.255 seconds. This one-time pre-collection cost is bounded and acceptable; false corpus authentication is not.

Both authenticated CPython 3.12.13 on Battleaxe and CPython 3.14.4 locally independently produced:

`blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`

## Discrimination

- truthful managed Battleaxe corpus: 10 passed, exit 0
- truthful workstation corpus: 10 passed, exit 0
- identical paths plus one changed byte: loud content-manifest mismatch refusal
- ambient Battleaxe pandas 2.3.3: refused before pytest, exit 78

## Focused validation

- launcher/build/identity tests: 62 passed
- real CPython 3.14 demand-table consumer: 2 passed, output CID unchanged
- Black and `git diff --check`: clean
- independent review and independent CID recomputation: clean

The historical path CID remains only where it truthfully describes an already-published historical artifact. The live environment pin and current interpreter twin use the byte CID.

## Outstanding shelf status

Actual `bin/bpytest` still fails fast because current-main Sugar stamp `66a49f0d…c129` is absent from the binary shelf. It exits immediately with build fallback disabled and does not hang or build. Provisioning that exact binary remains a separate blocker.

This PR is intentionally draft, open, and unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate pandas corpus files by content using BLAKE3-512 manifest CIDs
> - Replaces the path-only SHA-256 manifest check with a content-bound BLAKE3-512 manifest that hashes both relative paths and file bytes, via a new `authenticate_corpus_manifest` function in [authenticated_pytest.py](https://github.com/TSavo/sugar/pull/6482/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120).
> - `corpus_manifest_cid` is now imported from `demand_table_identity` rather than computed locally; the old local SHA-256 implementation is removed.
> - `authenticate_environment` now enumerates files via `SourceTree(pandas_root).paths()` and delegates to `authenticate_corpus_manifest`, raising `ExecutionEnvironmentMismatch` with the message `'pandas corpus content manifest CID mismatch'` on empty manifests or CID mismatches.
> - Expected CID constants in [pyproject.toml](https://github.com/TSavo/sugar/pull/6482/files#diff-261ec8796a9b416fbd4a4be1c4d29020ef3e684186d192280285d81a390a3a94) and [test_demand_table_interpreter_twin.py](https://github.com/TSavo/sugar/pull/6482/files#diff-e38143f960e267cf09b853231140fa148d68d00865bdf9e770f2084dda863469) are updated to BLAKE3-512 values.
> - Behavioral Change: environments that previously passed the path-only SHA-256 check will now fail if file contents do not match the new content-bound CID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f4ddb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->