### PR TITLE
Authenticate pandas census corpus before selection

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -77,6 +77,13 @@ from __future__ import annotations
 # tests/test_one_authoritative_scoreboard.py: exactly one module may say True.
 SCOREBOARD_AUTHORITY = True
 
+_PANDAS_3_0_3_AGGREGATE_HASH = (
+    "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c"
+)
+_PANDAS_3_0_3_MANIFEST_SHAPE_CID = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+)
+
 import argparse
 import json
 import logging
@@ -94,6 +101,30 @@ def _git_commit(root: Path) -> str:
     return subprocess.check_output(
         ["git", "rev-parse", "HEAD"], cwd=root, text=True
     ).strip()
+
+
+def _authenticate_declared_pandas_corpus(observed_pin, manifest_shape_cid: str) -> None:
+    """Refuse a corpus before source selection on either named pin axis.
+
+    The aggregate covers distribution, version, relative paths, file bytes and
+    sizes.  The shape CID covers only relative path names; it is retained as a
+    separately named diagnostic, never presented as content authentication.
+    """
+    failures: list[str] = []
+    if observed_pin.aggregate_hash != _PANDAS_3_0_3_AGGREGATE_HASH:
+        failures.append(
+            "corpus aggregate hash mismatch: "
+            f"observed {observed_pin.aggregate_hash}; "
+            f"required {_PANDAS_3_0_3_AGGREGATE_HASH}"
+        )
+    if manifest_shape_cid != _PANDAS_3_0_3_MANIFEST_SHAPE_CID:
+        failures.append(
+            "corpus manifest shape CID mismatch: "
+            f"observed {manifest_shape_cid}; "
+            f"required {_PANDAS_3_0_3_MANIFEST_SHAPE_CID}"
+        )
+    if failures:
+        raise ValueError("; ".join(failures))
 
 
 def _silence_console_logging() -> None:
@@ -173,35 +204,103 @@ def _cm_resolution_bucket(resolution) -> str:
 
     kind = getattr(resolution, "kind", None)
     if not isinstance(kind, str) or not kind:
-        return "gap:unstated-kind"
-    # Normalize through the closed vocabulary; an unknown wire kind keeps its
-    # own spelling rather than crashing or collapsing (see #6243 dynamic-export).
+        raise ValueError("With resolution gap has no typed kind")
+    # Normalize through the closed vocabulary. Unknown wire kinds belong to
+    # the vocabulary's explicit sentinel; they never mint an escape bucket.
     parsed = WithConstructionGapKind.parse(kind)
-    if parsed is WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND and (
-        kind != WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND.value
-    ):
-        return f"gap:unrecognized:{kind}"
     return f"gap:{parsed.value}"
 
 
-def _tally_cm_resolutions(context) -> Counter[str]:
+def _tally_cm_resolutions(
+    context,
+) -> tuple[Counter[str], Counter[str]]:
     """Count derived-table rows by structural resolution kind."""
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
         SourceDerivedContextManagerRefV1,
     )
+    from sugar_source_tree.panic import WithConstructionGapKind
 
     buckets: Counter[str] = Counter()
+    unrecognized_kinds: Counter[str] = Counter()
     refs = getattr(context, "source_derived_contract_refs", None) or {}
     for resolution in refs.values():
         if isinstance(resolution, SourceDerivedContextManagerRefV1):
             buckets["derived-contract"] += 1
             continue
         if isinstance(resolution, ContextManagerResolutionGapV1):
-            buckets[_cm_resolution_bucket(resolution)] += 1
+            bucket = _cm_resolution_bucket(resolution)
+            buckets[bucket] += 1
+            if bucket == (
+                f"gap:{WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND.value}"
+            ):
+                unrecognized_kinds[str(resolution.kind)] += 1
             continue
-        buckets["unclassified"] += 1
-    return buckets
+        raise TypeError(
+            "With resolution table contains a value outside the closed "
+            f"derived-contract | ContextManagerResolutionGapV1 union: "
+            f"{type(resolution).__name__}"
+        )
+    return buckets, unrecognized_kinds
+
+
+def _with_census_partition(
+    cm_resolutions: Counter[str],
+    ast_sites: Counter[str],
+    unrecognized_kinds: Counter[str] | None = None,
+) -> dict[str, Any]:
+    """Conserve every synchronous With item into constructed or one typed gap."""
+    from sugar_source_tree.panic import WithConstructionGapKind
+
+    vocabulary = tuple(member.value for member in WithConstructionGapKind)
+    if len(vocabulary) != 39:
+        raise ValueError(
+            "WithConstructionGapKind vocabulary changed: "
+            f"expected 39 members, found {len(vocabulary)}"
+        )
+    allowed = {"derived-contract", *(f"gap:{kind}" for kind in vocabulary)}
+    unexpected = sorted(set(cm_resolutions) - allowed)
+    if unexpected:
+        raise ValueError(
+            "With census contains keys outside its closed vocabulary: "
+            + ", ".join(unexpected)
+        )
+
+    typed_gaps = {
+        kind: int(cm_resolutions.get(f"gap:{kind}", 0)) for kind in vocabulary
+    }
+    unrecognized_kinds = unrecognized_kinds or Counter()
+    unrecognized_total = typed_gaps[
+        WithConstructionGapKind.UNRECOGNIZED_RESOLUTION_KIND.value
+    ]
+    if sum(unrecognized_kinds.values()) != unrecognized_total:
+        raise ValueError(
+            "With census sentinel lacks preserved resolution kinds: "
+            f"sentinel={unrecognized_total} "
+            f"preserved={sum(unrecognized_kinds.values())}"
+        )
+    total = int(ast_sites.get("site:with-item", 0))
+    constructed = int(cm_resolutions.get("derived-contract", 0))
+    accounted = constructed + sum(typed_gaps.values())
+    if accounted != total:
+        raise ValueError(
+            "With census does not conserve: "
+            f"with_items_total={total} constructed={constructed} "
+            f"typed_gaps={sum(typed_gaps.values())} accounted={accounted}"
+        )
+    return {
+        "with_items_total": total,
+        "constructed": constructed,
+        "typed_gap_kinds_total": len(vocabulary),
+        "typed_gaps": typed_gaps,
+        "unrecognized_resolution_kinds": dict(sorted(unrecognized_kinds.items())),
+        "accounted": accounted,
+        "reconciliation": (
+            f"{total} = {constructed} constructed + "
+            f"{sum(typed_gaps.values())} typed gaps"
+        ),
+        "conserves": True,
+    }
 
 
 def _backend_defect_key(exc: object) -> str:
@@ -336,6 +435,7 @@ def _measure_file(
     construction_seen: set[tuple[str, str, object, object]] = set()
     backend_defects: Counter[str] = Counter()
     cm_resolutions: Counter[str] = Counter()
+    unrecognized_cm_kinds: Counter[str] = Counter()
     desugar_axis = DesugarAxis()
     if workspace_root is None:
         # No silent ``path.parent``. That default made a one-file run derive its
@@ -384,7 +484,11 @@ def _measure_file(
             return reporter
         # Resolution partition from the derived table (manager-expression
         # sites, not functions-blocked), keyed by authenticated gap kind.
-        cm_resolutions.update(_tally_cm_resolutions(construction_context))
+        file_cm_resolutions, file_unrecognized_kinds = _tally_cm_resolutions(
+            construction_context
+        )
+        cm_resolutions.update(file_cm_resolutions)
+        unrecognized_cm_kinds.update(file_unrecognized_kinds)
         for function in source_file.functions():
             functions_total += 1
             try:
@@ -430,6 +534,7 @@ def _measure_file(
     # site prevalence (denominator, never R).
     resolution_row = {
         "cmResolutions": dict(cm_resolutions),
+        "unrecognizedCmResolutionKinds": dict(unrecognized_cm_kinds),
         "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
         "astSites": dict(_ast_site_prevalence(path)),
     }
@@ -564,16 +669,6 @@ def main() -> int:
     if corpus != corpus_root and corpus_root not in corpus.parents:
         parser.error(f"corpus {corpus} is not inside --corpus-root {corpus_root}")
 
-    out = args.out_dir
-    out.mkdir(parents=True, exist_ok=True)
-    result_path = args.json or (out / "recensus.json")
-    checkpoint_path = args.checkpoint_jsonl or (out / "checkpoint.jsonl")
-    engine_path = args.engine_log or (out / "engine.jsonl")
-    progress_path = args.progress or (out / "progress.log")
-
-    _silence_console_logging()
-    _configure_engine_log(engine_path)
-
     from sugar_lift_py_tests.corpus_pin import (
         CorpusPinDefect,
         load_pin,
@@ -581,6 +676,7 @@ def main() -> int:
         require_pin,
         write_pin,
     )
+    from sugar_lift_py_tests.authenticated_pytest import corpus_manifest_cid
     from sugar_source_tree.tree import SourceTree
 
     # Pin FIRST. A run that cannot name its corpus has no denominator, and a
@@ -593,9 +689,28 @@ def main() -> int:
         )
         if args.require_corpus_pin is not None:
             require_pin(load_pin(args.require_corpus_pin), observed_pin)
+        manifest_shape_cid = corpus_manifest_cid(
+            [entry.path for entry in observed_pin.files]
+        )
+        _authenticate_declared_pandas_corpus(observed_pin, manifest_shape_cid)
     except CorpusPinDefect as defect:
         print(str(defect), file=sys.stderr, flush=True)
         return 2
+    except ValueError as defect:
+        print(str(defect), file=sys.stderr, flush=True)
+        return 2
+
+    # Authentication precedes every output artifact and every source-selection
+    # pass. A refused tree cannot leave a checkpoint that looks resumable.
+    out = args.out_dir
+    out.mkdir(parents=True, exist_ok=True)
+    result_path = args.json or (out / "recensus.json")
+    checkpoint_path = args.checkpoint_jsonl or (out / "checkpoint.jsonl")
+    engine_path = args.engine_log or (out / "engine.jsonl")
+    progress_path = args.progress or (out / "progress.log")
+
+    _silence_console_logging()
+    _configure_engine_log(engine_path)
     if args.write_corpus_pin is not None:
         write_pin(observed_pin, args.write_corpus_pin)
 
@@ -661,6 +776,7 @@ def main() -> int:
     desugar_by_category_owner: Counter[str] = Counter()
     backend_defects: Counter[str] = Counter()
     cm_resolutions: Counter[str] = Counter()
+    unrecognized_cm_kinds: Counter[str] = Counter()
     ast_sites: Counter[str] = Counter()
     # Three disjoint desugar-layer quantities; the two below are NEVER folded
     # into R_desugar and both make the run red.
@@ -949,6 +1065,7 @@ def main() -> int:
         desugar_by_category_owner.update(row.get("desugarByCategoryOwner") or {})
         backend_defects.update(row.get("backendDefects") or {})
         cm_resolutions.update(row.get("cmResolutions") or {})
+        unrecognized_cm_kinds.update(row.get("unrecognizedCmResolutionKinds") or {})
         ast_sites.update(row.get("astSites") or {})
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
         desugar_defects.extend(row.get("desugarDefects") or [])
@@ -1002,8 +1119,17 @@ def main() -> int:
     r_construction = sum(families.values())
     r_desugar = sum(desugar_families.values())
     r_backend = sum(backend_defects.values())
+    with_census = _with_census_partition(
+        cm_resolutions, ast_sites, unrecognized_cm_kinds
+    )
     result: dict[str, Any] = {
         "kind": "control-effect-construction-recensus",
+        "corpusAuthentication": {
+            "aggregateHash": observed_pin.aggregate_hash,
+            "requiredAggregateHash": _PANDAS_3_0_3_AGGREGATE_HASH,
+            "manifestShapeCid": manifest_shape_cid,
+            "requiredManifestShapeCid": _PANDAS_3_0_3_MANIFEST_SHAPE_CID,
+        },
         "authority": (
             "sole authoritative Python corpus scoreboard; every other census "
             "output is non-authoritative"
@@ -1087,6 +1213,7 @@ def main() -> int:
             sorted(cm_resolutions.items(), key=lambda item: (-item[1], item[0]))
         ),
         "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
+        "withCensus": with_census,
         # AST SITE PREVALENCE — a denominator, NEVER R. Different question,
         # different number: prevalence counts shapes present, R counts
         # authenticated occurrences that failed to construct. Quoting one as

--- a/implementations/python/sugar-lift-py-tests/tests/test_control_effect_with_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_control_effect_with_census.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts/control_effect_recensus.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("control_effect_recensus", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_with_census_emits_the_complete_closed_vocabulary_and_conserves():
+    from sugar_source_tree.panic import WithConstructionGapKind
+
+    module = _module()
+    partition = module._with_census_partition(
+        Counter(
+            {
+                "derived-contract": 2,
+                "gap:runtime-selected": 3,
+                "gap:force-floor": 5,
+            }
+        ),
+        Counter({"site:with-item": 10}),
+    )
+
+    assert tuple(partition["typed_gaps"]) == tuple(
+        member.value for member in WithConstructionGapKind
+    )
+    assert partition["typed_gap_kinds_total"] == len(WithConstructionGapKind)
+    assert partition["typed_gap_kinds_total"] == 39
+    assert partition["accounted"] == partition["with_items_total"] == 10
+    assert partition["unrecognized_resolution_kinds"] == {}
+    assert partition["reconciliation"] == "10 = 2 constructed + 8 typed gaps"
+    assert partition["conserves"] is True
+
+
+def test_with_census_refuses_an_escape_bucket():
+    module = _module()
+
+    with pytest.raises(ValueError, match="outside its closed vocabulary"):
+        module._with_census_partition(
+            Counter({"derived-contract": 1, "unclassified": 1}),
+            Counter({"site:with-item": 2}),
+        )
+
+
+def test_with_census_refuses_a_nonconserving_denominator():
+    module = _module()
+
+    with pytest.raises(ValueError, match="does not conserve"):
+        module._with_census_partition(
+            Counter({"derived-contract": 1}),
+            Counter({"site:with-item": 2}),
+        )
+
+
+def test_unknown_wire_kind_maps_to_the_typed_sentinel():
+    from types import SimpleNamespace
+
+    module = _module()
+
+    assert module._cm_resolution_bucket(SimpleNamespace(kind="future-kind")) == (
+        "gap:unrecognized-resolution-kind"
+    )
+
+
+def test_with_census_emits_preserved_unknown_wire_kinds_beside_sentinel():
+    module = _module()
+
+    partition = module._with_census_partition(
+        Counter({"gap:unrecognized-resolution-kind": 3}),
+        Counter({"site:with-item": 3}),
+        Counter({"future-kind": 2, "another-future-kind": 1}),
+    )
+
+    assert partition["unrecognized_resolution_kinds"] == {
+        "another-future-kind": 1,
+        "future-kind": 2,
+    }
+
+
+def test_with_census_refuses_sentinel_without_preserved_unknown_kinds():
+    module = _module()
+
+    with pytest.raises(ValueError, match="lacks preserved resolution kinds"):
+        module._with_census_partition(
+            Counter({"gap:unrecognized-resolution-kind": 1}),
+            Counter({"site:with-item": 1}),
+        )
+
+
+def test_driver_refuses_wrong_pandas_manifest_before_source_selection(
+    tmp_path, monkeypatch, capsys
+):
+    from sugar_lift_py_tests import lift_rpc
+
+    corpus = tmp_path / "pandas"
+    corpus.mkdir()
+    (corpus / "one.py").write_text("with manager():\n    pass\n", encoding="utf-8")
+
+    def source_selection_must_not_start(_root):
+        raise AssertionError("source selection ran before corpus authentication")
+
+    monkeypatch.setattr(
+        lift_rpc,
+        "provisional_contract_refs_from_demands",
+        source_selection_must_not_start,
+    )
+    module = _module()
+    saved = sys.argv
+    sys.argv = [
+        "control_effect_recensus.py",
+        str(corpus),
+        "--corpus-distribution",
+        "pandas",
+        "--corpus-version",
+        "3.0.3",
+        "--out-dir",
+        str(tmp_path / "out"),
+    ]
+    try:
+        result = module.main()
+    finally:
+        sys.argv = saved
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "corpus aggregate hash mismatch" in captured.err
+    assert (
+        "required "
+        "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c"
+    ) in captured.err
+    assert not (tmp_path / "out").exists()
+
+
+def test_declared_pandas_corpus_accepts_both_known_good_axes():
+    from types import SimpleNamespace
+
+    module = _module()
+    module._authenticate_declared_pandas_corpus(
+        SimpleNamespace(aggregate_hash=module._PANDAS_3_0_3_AGGREGATE_HASH),
+        module._PANDAS_3_0_3_MANIFEST_SHAPE_CID,
+    )
+
+
+def test_content_drift_refuses_even_when_manifest_shape_is_unchanged():
+    from types import SimpleNamespace
+
+    module = _module()
+    with pytest.raises(ValueError, match="corpus aggregate hash mismatch"):
+        module._authenticate_declared_pandas_corpus(
+            SimpleNamespace(aggregate_hash="0" * 64),
+            module._PANDAS_3_0_3_MANIFEST_SHAPE_CID,
+        )
+
+
+def test_shape_drift_is_a_separately_named_refusal():
+    from types import SimpleNamespace
+
+    module = _module()
+    with pytest.raises(ValueError, match="corpus manifest shape CID mismatch"):
+        module._authenticate_declared_pandas_corpus(
+            SimpleNamespace(aggregate_hash=module._PANDAS_3_0_3_AGGREGATE_HASH),
+            "sha256:" + "0" * 64,
+        )


### PR DESCRIPTION
## Summary

Authenticate the pandas 3.0.3 census corpus before the driver creates output artifacts or performs demand/source selection.

The driver now requires both named axes:

- content-authenticated `corpus_pin.aggregate_hash == bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c`
- diagnostic-only manifest-shape CID `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`

The manifest-shape CID hashes only sorted relative path strings. It remains a separate diagnostic so shape drift and byte drift are distinguishable, but it is not described as content authentication. The aggregate hash covers distribution, version, paths, bytes, and sizes. Failures on both axes are accumulated and reported together.

A refused run exits before `out.mkdir(...)`, engine-log setup, checkpoint creation, or `provisional_contract_refs_from_demands(...)`. Successful output carries observed and required values for both axes.

The same change completes the already-in-progress closed-vocabulary `With` census partition: 39 typed gap kinds, preservation of unknown wire spellings beside the typed sentinel, and exact constructed-plus-gap conservation.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | authentication changes admission, not construction semantics |
| `mandatory_panics` | 0 | no construction arm changes |
| `suppressed_descendants` | 0 | no suppression changes |
| `typed_effects` | 0 | no effect routing changes |
| `silent` | 0 | floor: must stay 0 |

The expected board change is refusal of an unauthenticated corpus before any site is emitted; no prevalence or residual mass is claimed by this PR.

## Validation

Merge-readiness before push:

```text
git status --porcelain
# empty

git rev-list --left-right --count HEAD...origin/main
1 0

git rev-parse HEAD
57c9f1f6cf46d13fdf4dbece4c6edafae68cb42b
```

Real installed pandas 3.0.3 acceptance receipt:

```text
files=1421
aggregateHash=bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c
manifestShapeCid=sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0
accepted=True
```

Focused source-tree verification after rebase:

```text
PYTHONPATH=src:../sugar-source-tree/src:../sugar-lift-python-source/src \
  python3 -m pytest --noconftest -q tests/test_control_effect_with_census.py
10 passed in 1.38s
```

The ordinary pytest startup after rebase was independently blocked by a sandbox-denied write under the Sugar binary build cache. Before rebase, a broader package run was interrupted at 19% after `343 passed / 22 failed`; these failures are unrelated to the corpus gate and were not treated as a green baseline:

- `test_assert_sugar_from_node.py::test_unbuilt_condition_child_preserves_its_own_gap`
- six `test_binary_handoff_policy.py` cases covering shelf fallback, exhausted rungs, source stamps, missing BLAKE3, and publish assets
- `test_black_format_gate.py::test_black_format_check_is_installed_and_required_by_ci`
- four `test_bound_var_memoization.py` cases
- two `test_call_contract_resolution.py` cases
- `test_canonicalization_value_memo.py::test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer`
- `test_cid_parser_census.py::test_hand_rolled_cid_parsers_are_zero`
- two `test_construction_gap_owner_is_a_name.py` cases
- `test_construction_law_gate.py::test_construction_law_ratchet`
- two `test_construction_law_instrument.py` cases
- `test_construction_panic_catch_law.py::test_current_repository_construction_panic_catch_law`

## Floors preserved

- `data_loss=0`
- no secret commit
- no test deleted for green
- `silent=0` remains the required floor
- no mass or prevalence claim is made from an unauthenticated tree
- no completed full-suite claim is made from the interrupted broad run
