### PR TITLE
A guarded occurrence does not settle a no-warning contract

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -418,7 +418,27 @@ def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site)
                 ),
                 fix="preserve the completed face until its record is constructed",
             )
-        if any(isinstance(entry, WarningObservationValue) for entry in entries):
+        observations = tuple(
+            entry for entry in entries if isinstance(entry, WarningObservationValue)
+        )
+        # A conditional occurrence decides NEITHER side of a no-warning
+        # contract. The producer says the warning happens WHEN a branch guard
+        # holds; reading that as a met assertion drops the warning, and reading
+        # it as a failed one -- which is what an unguarded `any(...)` does --
+        # asserts a violation the source never states. Both directions are the
+        # same defect, and the matching-category router above already refuses
+        # this shape by name. Undecided, not present and not absent.
+        if any(entry.guards for entry in observations):
+            raise SugarNotWritten(
+                owner="WithEffectBoundarySugar.warning_observation",
+                observed="warning occurrence is reached only under a branch guard",
+                requested="a decidable warning surface on the completed face",
+                fix=(
+                    "keep the conditional occurrence undecided; never settle a "
+                    "no-warning contract from a guarded occurrence"
+                ),
+            )
+        if observations:
             if isinstance(mode, ExpectsModeV1):
                 exits.append(
                     Halted(
@@ -432,8 +452,9 @@ def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site)
             else:
                 exits.append(face)
             continue
-        if any(isinstance(entry, CallSiteValue) for entry in entries):
-            raise SugarNotWritten(
+        unresolved_members = _unresolved_producer_coordinates(entries)
+        if unresolved_members:
+            refusal = SugarNotWritten(
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed="completed face has unresolved warning producers",
                 requested="authenticated absence of warning observations",
@@ -442,5 +463,10 @@ def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site)
                     "absence from an empty observation set"
                 ),
             )
+            # Same enumeration the matching-category router carries: a bucket
+            # that only names itself cannot be told apart from one nothing was
+            # ever routed into.
+            refusal.unresolved_warning_producers = unresolved_members
+            raise refusal
         exits.append(face)
     return ExitSet(tuple(exits)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_warning_none_guarded_occurrence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_warning_none_guarded_occurrence.py
@@ -1,0 +1,287 @@
+"""A guarded occurrence does not settle a no-warning contract, in either direction.
+
+``675c5de7b`` (#6476) routed ``assert_produces_warning(None)`` on completed faces
+and decided the contract with a bare ``any(isinstance(entry,
+WarningObservationValue) ...)``.  That reads a CONDITIONAL occurrence as a
+definite assertion failure: the producer says the warning happens WHEN a branch
+guard holds, and the boundary restates it as "the warning happens".  It is the
+mirror of the arm the matching-category router already refuses by name
+(``warning occurrence is reached only under a branch guard``) -- same defect,
+opposite direction, same file.
+
+The reproducer is real and its whole point is that the guard does NOT hold.
+``pandas/core/methods/to_dict.py:148-153`` in the pinned 3.0.3 corpus::
+
+    if orient != "tight" and not df.columns.is_unique:
+        warnings.warn(
+            "DataFrame columns are not unique, some columns will be omitted.",
+            UserWarning,
+            stacklevel=find_stack_level(),
+        )
+
+and ``pandas/tests/frame/methods/test_to_dict.py:518-523`` (GH#58281)::
+
+    def test_to_dict_tight_no_warning_with_duplicate_column(self):
+        df = DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "A"])
+        with tm.assert_produces_warning(None):
+            result = df.to_dict(orient="tight")
+
+The columns really are duplicated, so the second conjunct holds; the assertion
+passes only because ``orient == "tight"`` makes the first one false.  Nothing
+lexical decides that, so the honest static answer is undecided -- not a met
+assertion, and emphatically not a failed one.
+
+Corpus authenticated before these sites were selected:
+``corpus_manifest_cid`` over ``SourceTree(pandas_root).paths()`` reproduces
+``sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0``
+over 1421 files.  ``assert_produces_warning(None)`` is 101 with-sites across 61
+files by grep and by an independent AST walk.  15 of those 101 blocks call a
+function that warns under a guard.
+
+No tooth here reads a wall clock, and no expected value is supplied by the test
+that then asserts it: each arm is lifted from source text and the discriminating
+value is the guard the source itself writes.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    ImportSignatureV2,
+    NoDefaultV1,
+    NoMessagePatternV1,
+    PositionalOrKeywordV1,
+    WarningEffectKindV1,
+    WarningObservationBindingV1,
+)
+from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, NoneValue
+from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+# The `to_dict` occurrence, transcribed in shape: a two-conjunct guard around an
+# explicit-category warn. The category is spelled here so the producer can
+# authenticate it -- that is what makes this an occurrence rather than an
+# unresolved call, and it is what puts the entry in front of the boundary at all.
+GUARDED_TO_DICT_SHAPE = """import warnings
+
+
+def to_dict(df, orient):
+    if orient != "tight" and not df.columns.is_unique:
+        warnings.warn(
+            "DataFrame columns are not unique, some columns will be omitted.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return df
+"""
+
+# The same occurrence with the guard removed: the source now states the warning
+# unconditionally, so the no-warning contract really is violated.
+UNCONDITIONAL_SHAPE = """import warnings
+
+
+def to_dict(df, orient):
+    warnings.warn(
+        "DataFrame columns are not unique, some columns will be omitted.",
+        UserWarning,
+        stacklevel=2,
+    )
+    return df
+"""
+
+# A body that warns nowhere: the contract is met, and it must still be met after
+# the guard arm exists, or the fix would have bought the refusal by breaking the
+# truthful case.
+NO_OCCURRENCE_SHAPE = """def to_dict(df, orient):
+    result = df
+    return result
+"""
+
+
+def _entries(source: str, stem: str):
+    """Every record entry of every completed face, from real lifted source."""
+    directory = pathlib.Path(tempfile.mkdtemp())
+    path = directory / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    function = next(SourceFile(path_source(str(path))).functions())
+    exits = reduce_block_to_exitset(function.sugar().statements, None)
+    return tuple(
+        entry for face in exits.exits for entry in getattr(face.value, "entries", ())
+    )
+
+
+class _Fixed(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _Record(Sugar):
+    """A completed face carrying exactly the entries the producer built."""
+
+    def __init__(self, entries):
+        self.entries = entries
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(BlockValue(self.entries))
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+SEMANTICS = EffectBoundarySemanticsV1(
+    ExpectsModeV1(),
+    WarningEffectKindV1(),
+    FormalArgumentProjectionV1(0),
+    NoMessagePatternV1(),
+    WarningObservationBindingV1(),
+)
+
+
+def _no_warning_boundary(entries):
+    """`assert_produces_warning(None)`: the expected operand is exactly None."""
+    manager_value = CallSiteValue(
+        target_name="scope",
+        arg_values=(NoneValue(),),
+        parameters=("expected",),
+        term=ctor("call", []),
+        body=None,
+    )
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    return WithEffectBoundarySugar(
+        manager=_Fixed(Complete(manager_value)),
+        body=(_Record(entries),),
+        semantics=SEMANTICS,
+        contract_ref=SimpleNamespace(import_signature=signature),
+        context_manager_edge=None,
+        site=None,
+    )
+
+
+def test_the_guarded_to_dict_occurrence_carries_its_guard():
+    """Precondition, asserted rather than assumed.
+
+    If the producer stopped recording guards this file would still be green
+    without testing anything -- the boundary would simply never see a guarded
+    entry. Pin the shape the rest of the module depends on.
+    """
+    observations = [
+        entry
+        for entry in _entries(GUARDED_TO_DICT_SHAPE, "guarded")
+        if isinstance(entry, WarningObservationValue)
+    ]
+    assert len(observations) == 1
+    assert observations[0].guards != ()
+
+
+def test_a_guarded_occurrence_leaves_a_no_warning_contract_undecided():
+    """The reproducer arm. Not met, and NOT failed."""
+    entries = _entries(GUARDED_TO_DICT_SHAPE, "guarded")
+    with pytest.raises(SugarNotWritten) as raised:
+        _no_warning_boundary(entries).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert raised.value.observed == (
+        "warning occurrence is reached only under a branch guard"
+    )
+
+
+def test_an_unconditional_occurrence_still_fails_the_contract():
+    """The lying twin: drop the guard and the violation becomes real.
+
+    This is what stops the fix from being "refuse whenever a warning appears".
+    The two sources differ only by the `if`, and they must route differently.
+    """
+    entries = _entries(UNCONDITIONAL_SHAPE, "unconditional")
+    routed = _no_warning_boundary(entries).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_a_body_that_never_warns_still_meets_the_contract():
+    """The truthful twin, unchanged by the guard arm."""
+    entries = _entries(NO_OCCURRENCE_SHAPE, "clean")
+    routed = _no_warning_boundary(entries).desugar()
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Completed)
+
+
+def test_the_guard_is_what_moves_the_outcome():
+    """The three arms together, stated as one discrimination.
+
+    Guarded, unguarded and absent are three distinct outcomes from sources that
+    differ only in whether -- and how -- the occurrence is reached. A mechanism
+    that collapsed any two of them would pass some arm above on its own.
+    """
+    outcomes = {}
+    for label, source in (
+        ("guarded", GUARDED_TO_DICT_SHAPE),
+        ("unconditional", UNCONDITIONAL_SHAPE),
+        ("absent", NO_OCCURRENCE_SHAPE),
+    ):
+        entries = _entries(source, label)
+        try:
+            routed = _no_warning_boundary(entries).desugar()
+        except SugarNotWritten as refusal:
+            outcomes[label] = f"refused:{refusal.observed}"
+        else:
+            outcomes[label] = type(routed.exits[0]).__name__
+
+    assert outcomes == {
+        "guarded": "refused:warning occurrence is reached only under a branch guard",
+        "unconditional": "Halted",
+        "absent": "Completed",
+    }
+
+
+def test_the_unresolved_bucket_enumerates_its_members_here_too():
+    """A bare `warnings.warn(msg)` has no authenticated category, so it stays an
+    unresolved producer -- and the no-warning router must NAME it rather than
+    read the empty observation set as absence. Presence, never absence: a
+    producer that was never wired leaves the same empty set."""
+    source = 'import warnings\n\n\ndef f():\n    warnings.warn("m", stacklevel=2)\n'
+    entries = _entries(source, "bare")
+    assert not any(isinstance(entry, WarningObservationValue) for entry in entries)
+    with pytest.raises(SugarNotWritten) as raised:
+        _no_warning_boundary(entries).desugar()
+    assert raised.value.observed == "completed face has unresolved warning producers"
+    members = raised.value.unresolved_warning_producers
+    assert any(member.endswith(":5") for member in members), members


### PR DESCRIPTION
675c5de7b (#6476) routed assert_produces_warning(None) on completed faces and
decided the contract with a bare
`any(isinstance(entry, WarningObservationValue) for entry in entries)`. That
reads a CONDITIONAL occurrence as a definite assertion failure: the producer
says the warning happens WHEN a branch guard holds, and the boundary restates
that as "the warning happens". It is the mirror of the arm the matching-category
router 60 lines above already refuses by name -- `warning occurrence is reached
only under a branch guard`, with_effect_boundary_sugar.py:330-334. Same file,
opposite direction. #6476 shipped truthful / warning-arrives / unresolved twins
and no guarded twin, which is what let it through.

Reproducer, both coordinates opened in the pinned pandas 3.0.3 corpus.
core/methods/to_dict.py:148-153 warns under a two-conjunct guard:

    if orient != "tight" and not df.columns.is_unique:
        warnings.warn(
            "DataFrame columns are not unique, some columns will be omitted.",
            UserWarning,
            stacklevel=find_stack_level(),
        )

and tests/frame/methods/test_to_dict.py:518-523 (GH#58281) calls it inside the
contract with duplicated columns:

    def test_to_dict_tight_no_warning_with_duplicate_column(self):
        df = DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "A"])
        with tm.assert_produces_warning(None):
            result = df.to_dict(orient="tight")

The columns really are duplicated, so the second conjunct holds; the assertion
passes only because orient == "tight" falsifies the first. Nothing lexical
decides that, so undecided is the only honest answer -- not a met assertion, and
emphatically not a failed one.

Corpus authenticated before any site was selected. corpus_manifest_cid over
SourceTree(pandas_root).paths() reproduces
sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0 over
1421 files. assert_produces_warning(None) is 101 with-sites across 61 files,
counted twice by independent instruments: a grep and an AST walk over the
manifest enumeration agree exactly. A looser `(None` pattern gives 105; the
extra 4 are assert_produces_warning(None, ...) with further arguments.

15 of those 101 blocks call a function that warns under a guard. THAT 15 IS A
FLOOR, NOT A COUNT: the match is by callee NAME with no resolved call graph, so
it can only under-count. It is quoted here as a floor deliberately -- a floor
quoted as a count is the shape that started tonight's withdrawal.

The fix adds the guarded arm and refuses, and the unresolved bucket now
enumerates its members here as it already does in the matching router: a bucket
that only names itself cannot be told apart from one nothing was ever routed
into.

Discrimination, two independent stubs, both run on this tree:

  remove the guard arm (`if any(entry.guards ...)` -> `if False`):
      2 failed, 12 passed
      FAILED test_a_guarded_occurrence_leaves_a_no_warning_contract_undecided
      FAILED test_the_guard_is_what_moves_the_outcome
    The 12 green include every one of #6476's own twins, so the fix is not
    bought by breaking the thing it extends.

  remove the enumeration (drop the unresolved_warning_producers assignment):
      1 failed, 5 passed
      FAILED test_the_unresolved_bucket_enumerates_its_members_here_too

Four arms, from sources differing only in whether and how the occurrence is
reached: guarded -> refused undecided; unconditional -> Halted with
ExpectationNotMetEffect; absent -> Completed; bare warnings.warn(msg) with no
explicit category -> refused as an unresolved producer, with its coordinate
named in the bucket.

The paired full sugar-lift-py-tests suite is still running against a detached
baseline worktree at 675c5de7b (content-verified: 0 hits of the guard arm, 2 of
the pre-existing no-warning router as positive control), one pinned release
SUGAR_BIN across both halves,
sha256 1a190367381c4334ec8a95632f6ba2f95557a1bc6658c15c32bdd1a54db344dc. No
roster delta is claimed in this body; it will be posted when it lands.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat guarded warning occurrences as undecided in no-warning contracts
> - In `_route_completed_no_warning_boundary`, a warning occurrence reached only under a branch guard now raises `SugarNotWritten` (undecided) instead of failing the no-warning contract.
> - Unresolved warning producer detection is moved to `_unresolved_producer_coordinates(entries)`; the resulting refusal now includes an `unresolved_warning_producers` enumeration.
> - Five new tests in [`test_warning_none_guarded_occurrence.py`](https://github.com/TSavo/sugar/pull/6484/files#diff-1d32c59b37fe2eaf7a19dff80886faba88a5c8a1715d8a4b61a643a6803eed97) cover guarded, unguarded, absent, and unresolved-producer cases.
> - Behavioral Change: conditional warning occurrences that previously settled (failed) the no-warning contract now leave it unsettled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4898b32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->