### PR TITLE
Keep undecided subscript effects loud

### DIFF
--- a/docs/superpowers/plans/2026-07-27-subscript-exceptional-exit-producer.md
+++ b/docs/superpowers/plans/2026-07-27-subscript-exceptional-exit-producer.md
@@ -1,0 +1,95 @@
+# Subscript Exceptional-Exit Producer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit authenticated Subscript exceptional exits only from receiver floors whose source-visible semantics decide them, while keeping undecidable lookups named and loud.
+
+**Architecture:** `SubscriptSugar` remains a sequencing/delegation shell. Concrete receiver floor implementations own success and exceptional-exit construction; undecidable receiver/key combinations use the existing construction-gap boundary. Assertion-With remains an unrelated ExitSet consumer.
+
+**Tech Stack:** Python 3.14 AST/source construction, Sugar Floor/Outcome APIs, pytest through `bin/sugarbin run --task authenticated-python-lift`.
+
+## Global Constraints
+
+- Base exactly on main `675c5de7b`.
+- Corpus is pandas 3.0.3 at `/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages/pandas`, manifest CID `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`.
+- No vendor/name arm, assertion-With edit, side door, placeholder, sentinel, guessed exception type, generic runtime-effect fallback, ExitSet/outcome/generator edit, census, or demand-table rebuild.
+- Undecided is a named third value, never False or Complete.
+- Preserve construction panics, timeouts, native crashes, and unaccounted at zero.
+
+---
+
+### Task 1: Authenticate the concrete boundary
+
+**Files:**
+- Read: `pandas/tests/test_multilevel.py:157`
+- Test: existing authenticated single-site launcher path
+
+**Interfaces:**
+- Consumes: pandas 3.0.3 corpus and shared demand-table shelf artifact.
+- Produces: exact construct, panic, or typed-refusal boundary with inline exit status.
+
+- [ ] Run the real site through the authenticated launcher without a bare `SourceFile` lift.
+- [ ] Record whether Subscript construction emits `Completed`, `Halted(RaiseEffect)`, or a named refusal.
+- [ ] If the shelf binary is absent and fallback is disabled, record that blocker and continue only with focused verification that does not rebuild the demand table.
+
+### Task 2: Pin receiver-owned producer twins
+
+**Files:**
+- Test: the smallest existing focused Subscript floor test module under `implementations/python/sugar-lift-py-tests/tests/`.
+
+**Interfaces:**
+- Consumes: `SubscriptSugar.desugar`, concrete receiver `subscript` floors, `ExitSet`, and `RaiseEffect`.
+- Produces: truthful exceptional-exit, lying success, and undecidable-refusal assertions.
+
+- [ ] Add a 5-15 line reproducer derived from the verified pandas Subscript body.
+- [ ] Add a truthful concrete failing lookup asserting the exact authenticated exception coordinate.
+- [ ] Add a lying successful lookup asserting no exceptional edge; the assertion must fail if it observes the truthful edge.
+- [ ] Add an undecidable receiver/key twin asserting the named refusal rather than a generic effect or completed value.
+- [ ] Run the focused module with the repo-relative authenticated launcher and verify RED for the missing producer law.
+
+### Task 3: Implement the general Subscript floor law
+
+**Files:**
+- Modify only the concrete receiver floor file(s) demonstrated by Task 2.
+- Modify `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py` only if evidence shows delegation itself loses an operand outcome; do not add receiver semantics there.
+
+**Interfaces:**
+- Consumes: concrete receiver contents and authenticated index/key floor.
+- Produces: exact success, `Halted(RaiseEffect)` with native exception testimony, or named construction refusal.
+
+- [ ] Implement the smallest receiver-owned distinction that turns the truthful twin green.
+- [ ] Ensure symbolic/custom/opaque shapes take the named refusal path before any exception class is selected.
+- [ ] Run the Task 2 module and verify truthful, lying, and undecidable twins pass.
+- [ ] Search the production diff for vendor spellings, assertion-manager coupling, generic Subscript runtime effects, sentinels, and forbidden package edits.
+
+### Task 4: Verify every touched package and mutation transaction
+
+**Files:**
+- Test: every focused module in packages modified by Tasks 2-3.
+
+**Interfaces:**
+- Consumes: final production diff and focused tests.
+- Produces: fresh package results and clean/mutated/bites/reverted/clean evidence.
+
+- [ ] Stage and commit the intended implementation so the worktree is clean.
+- [ ] Apply the minimal inverse mutation to the producer law.
+- [ ] Run the exact truthful test and verify it fails for the missing authenticated exceptional edge.
+- [ ] Revert only that mutation, verify `git diff` is clean, and rerun the exact test green.
+- [ ] Run focused tests for every touched package through the authenticated launcher with inline exit statuses.
+- [ ] Confirm no timeout, construction panic, native crash, or unaccounted outcome occurred.
+
+### Task 5: Publish without merging
+
+**Files:**
+- Commit: only the approved spec, plan, focused tests, and Subscript producer implementation.
+
+**Interfaces:**
+- Consumes: clean verified branch and exact author identity.
+- Produces: pushed branch and open unmerged PR.
+
+- [ ] Inspect `git status`, staged diff, and forbidden-symbol searches.
+- [ ] Commit as `T Savo <evilgenius@nefariousplan.com>` with a terse producer-law message.
+- [ ] Push `fleet/subscript-floor-owner` to origin.
+- [ ] Open a ready-for-review PR against `main` describing the boundary, twins, mutation transaction, focused results, and preserved zeros.
+- [ ] Report branch head SHA and PR URL; do not merge.
+

--- a/docs/superpowers/specs/2026-07-27-subscript-exceptional-exit-producer-design.md
+++ b/docs/superpowers/specs/2026-07-27-subscript-exceptional-exit-producer-design.md
@@ -1,0 +1,60 @@
+# Subscript Exceptional-Exit Producer Design
+
+## Goal
+
+Make the general Subscript floor emit authenticated exceptional exits exactly
+when source-visible receiver semantics decide them.  The concrete witness is
+`pandas/tests/test_multilevel.py:157` from pandas 3.0.3:
+
+```python
+with pytest.raises(KeyError, match=r"^\(\('foo', 'bar', 0\), 2\)$"):
+    series[("foo", "bar", 0), 2]
+```
+
+The assertion manager is outside this design.  It consumes halted ExitSet
+edges and never locates or interprets the expression that produced them.
+
+## Ownership and data flow
+
+`SubscriptSugar` sequences receiver and index construction and delegates to the
+receiver's existing Subscript floor.  Receiver floors own all decisions:
+
+- A concrete, source-visible container returns its exact stored value when the
+  key or index succeeds.
+- A concrete container emits a `RaiseEffect` with authenticated native type
+  testimony when its own semantics prove a missing key or invalid index.
+- An opaque, symbolic, custom-dispatch, or otherwise undecidable receiver/key
+  produces a named construction refusal.  It does not return a completed
+  `py.subscript` coordinate and does not guess `KeyError`, `IndexError`, or a
+  generic runtime effect.
+
+No assertion-With, ExitSet algebra, outcome, or generator file participates.
+Existing occurrence-authenticated subscript field coordinates remain the sole
+temporal identity mechanism; this change adds no parallel heap or selector.
+
+## Authentication boundary
+
+Exceptional exits use the receiver floor's native testimony.  Built-in literal
+container semantics may authenticate their language-defined exception class;
+vendor objects and operands without a decidable source-visible type may not.
+Partial knowledge remains undecidable: absence of one provable success is not
+proof of a particular failure.
+
+## Tests and mutation gate
+
+The authenticated pandas 3.0.3 site establishes the initial boundary.  Focused
+twins then pin both sides of the producer law:
+
+1. Truthful: a concrete missing-key or invalid-index lookup emits one halted
+   authenticated exceptional exit.
+2. Lying: a successful concrete lookup must not emit that exceptional exit.
+3. Undecided: the real symbolic pandas receiver remains a named refusal unless
+   its source-visible type becomes authenticated; it is never interpreted as
+   false or as a guessed exception.
+
+After green, revert the production law in a clean tree, prove the focused test
+fails for the intended missing exceptional edge, restore it, rerun green, and
+verify the tree is clean.  Run focused modules for every modified Python
+package through the repo-relative authenticated launcher.  Preserve zero
+construction panics, timeouts, native crashes, and unaccounted outcomes.
+

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -418,8 +418,9 @@ class CallSiteValue(FloorValue):
         )
 
     def subscript(self, index, site):
-        # A callsite receiver stays the py.subscript coordinate regardless of index.
-        return self.py_subscript_coordinate(index, site)
+        return self.undecided_subscript(
+            index, site, owner="CallSiteValue.subscript"
+        )
 
     def setitem(self, index, value, site):
         """Rebind an opaque mapping/list-shaped callsite after ``xs[k] = v``.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -542,6 +542,24 @@ class FloorValue:
         )
         construction_panic(info)
 
+    def undecided_subscript(self, index, site, *, owner: str):
+        """Refuse a lookup whose runtime dispatch is not source-decided."""
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner=owner,
+            blame=site,
+            observed=(
+                "undecided receiver runtime type or index semantics: "
+                f"{type(self).__name__}[{type(index).__name__}]"
+            ),
+            requested="a source-authenticated subscript success or exceptional exit",
+            fix=(
+                "carry receiver-type and index testimony to its native floor; "
+                "do not guess KeyError, IndexError, or a generic runtime effect"
+            ),
+        )
+
     def attribute(self, name, site):
         # Default: this value does not stand on the attribute floor -- it cannot
         # answer what it yields at `.name`. A symbolic receiver stays the

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
@@ -67,7 +67,9 @@ class ImportAliasValue(FloorValue):
         raise AssertionError("construction_panic_gap returned")
 
     def subscript(self, index, site):
-        return self.py_subscript_coordinate(index, site)
+        return self.undecided_subscript(
+            index, site, owner="ImportAliasValue.subscript"
+        )
 
     def getattr_static(self, name: str, site):
         from sugar_lift_py_tests.gap.info import GapKind, GapLocus

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -195,12 +195,12 @@ class ListValue(FloorValue):
         return super().matrix_multiply(other, site)
 
     def subscript(self, index, site):
-        # Concrete list + in-range TermValue int folds to the element; out of
-        # range is IndexError. Non-concrete index stays the py.subscript coordinate.
+        # Concrete list + integer index is fully decided. A known non-integer
+        # is TypeError; an index with undecided runtime semantics stays loud.
         from sugar_lift_py_tests.floor.term_value import TermValue
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome import Complete
 
-        if type(index) is TermValue and type(index.value) is int:
+        if type(index) is TermValue and isinstance(index.value, int):
             i = index.value
             n = len(self.elements)
             if -n <= i < n:
@@ -216,7 +216,13 @@ class ListValue(FloorValue):
                 length=n,
                 site=site,
             )
-        return self.py_subscript_coordinate(index, site)
+        if type(index) is TermValue:
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="TypeError", site=site, owner="ListValue.subscript"
+            )
+        return self.undecided_subscript(index, site, owner="ListValue.subscript")
 
     def setitem(self, index, value, site):
         from sugar_lift_py_tests.floor.term_value import TermValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -240,11 +240,11 @@ class StringValue(GuardStableValue):
         )
 
     def subscript(self, index, site):
-        # Concrete string + in-range TermValue int folds to the one-char string;
-        # out of range is IndexError. Non-concrete index stays py.subscript.
+        # Concrete string + integer index is fully decided. A known non-integer
+        # is TypeError; an index with undecided runtime semantics stays loud.
         from sugar_lift_py_tests.floor.slice_value import SliceValue
         from sugar_lift_py_tests.floor.term_value import TermValue
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome import Complete
 
         if type(index) is SliceValue:
             bounds = (index.lower, index.upper, index.step)
@@ -268,7 +268,7 @@ class StringValue(GuardStableValue):
                     )
                 return Complete(StringValue(self.value[slice(lower, upper, step)]))
 
-        if type(index) is TermValue and type(index.value) is int:
+        if type(index) is TermValue and isinstance(index.value, int):
             i = index.value
             n = len(self.value)
             if -n <= i < n:
@@ -284,7 +284,13 @@ class StringValue(GuardStableValue):
                 length=n,
                 site=site,
             )
-        return self.py_subscript_coordinate(index, site)
+        if type(index) is TermValue:
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="TypeError", site=site, owner="StringValue.subscript"
+            )
+        return self.undecided_subscript(index, site, owner="StringValue.subscript")
 
     def add(self, other, site):
         # A string's addition IS concatenation: two strings fold to their join.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -375,20 +375,24 @@ class SymbolicValue(FloorValue):
         return Complete(SymbolicValue(ctor("py.invert", [self.term])))
 
     def subscript(self, index, site):
-        built = self.py_subscript_coordinate(index, site)
-        if self.formal_coordinate is None:
-            return built
-        from sugar_lift_py_tests.caller_parameter_contract import (
-            ContractConditionalConstructionV1,
-        )
-        from sugar_lift_py_tests.ir import atomic
+        if self.formal_coordinate is not None:
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                ContractConditionalConstructionV1,
+            )
+            from sugar_lift_py_tests.ir import atomic
 
-        return ContractConditionalConstructionV1.mint(
-            site=site,
-            candidate=built.value.to_term(owner=str(site)),
-            demand_formula=atomic("python:indexable", [self.term]),
-            value=built.value,
-            coordinate=self.formal_coordinate,
+            built = self.py_subscript_coordinate(index, site)
+            return ContractConditionalConstructionV1.mint(
+                site=site,
+                candidate=built.value.to_term(owner=str(site)),
+                demand_formula=atomic("python:indexable", [self.term]),
+                value=built.value,
+                coordinate=self.formal_coordinate,
+            )
+        return self.undecided_subscript(
+            index,
+            site,
+            owner="SymbolicValue.subscript",
         )
 
     def attribute(self, name, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -286,12 +286,12 @@ class TupleValue(FloorValue):
         )
 
     def subscript(self, index, site):
-        # Concrete tuple + in-range TermValue int folds to the element; out of
-        # range is IndexError. Non-concrete index stays the py.subscript coordinate.
+        # Concrete tuple + integer index is fully decided. A known non-integer
+        # is TypeError; an index with undecided runtime semantics stays loud.
         from sugar_lift_py_tests.floor.term_value import TermValue
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome import Complete
 
-        if type(index) is TermValue and type(index.value) is int:
+        if type(index) is TermValue and isinstance(index.value, int):
             i = index.value
             n = len(self.elements)
             if -n <= i < n:
@@ -307,4 +307,10 @@ class TupleValue(FloorValue):
                 length=n,
                 site=site,
             )
-        return self.py_subscript_coordinate(index, site)
+        if type(index) is TermValue:
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="TypeError", site=site, owner="TupleValue.subscript"
+            )
+        return self.undecided_subscript(index, site, owner="TupleValue.subscript")

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -1,11 +1,10 @@
 """Member access on an OPAQUE object is a symbolic read, not a gap.
 
 `OpaqueObjectStateV1` is an authenticated call-result identity with no field
-testimony: statically we know only WHICH call produced it, never its fields --
-those come into existence at runtime, observed by the witness. So `opaque.attr`
-and `opaque[key]` must NOT raise SugarNotWritten (the old withhold); they
-construct the honest EUF coordinate `py.getattr(recv, "attr")` /
-`py.subscript(recv, key)`, carrying the opaque call term and nothing invented.
+testimony: statically we know only WHICH call produced it, never its fields.
+Attribute reads retain their honest coordinate. A subscript is also an effect
+producer, however, and an opaque result cannot authenticate whether lookup
+succeeds or which exception it raises, so that operation stays named-loud.
 
 A free-function call `g(x)` is the deterministic opaque receiver (no vendor,
 no numpy): its result has no field testimony, exactly like `np.asarray(...)`.
@@ -20,7 +19,6 @@ from sugar_lift_py_tests.ir import (
     atomic as _atomic,
     ctor as _ctor,
     make_var,
-    num,
     str_const,
     eq as _eq,
 )
@@ -45,14 +43,16 @@ def test_opaque_attribute_is_getattr_not_gap():
     assert post == expected, f"post was {post!r}"
 
 
-def test_opaque_subscript_is_subscript_not_gap():
-    # `g(x)[0]` -- subscript on an opaque call result -- projects py.subscript.
-    post = _post_of("def f(x):\n    return g(x)[0]\n")
-    expected = _eq(
-        make_var("out"),
-        _ctor("py.subscript", [_ctor("call:g", [make_var("x")]), num(0)]),
-    )
-    assert post == expected, f"post was {post!r}"
+def test_opaque_subscript_is_named_undecided():
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    try:
+        _post_of("def f(x):\n    return g(x)[0]\n")
+    except ConstructionPanic as panic:
+        assert panic.info.owner == "CallSiteValue.subscript"
+        assert "undecided receiver runtime type" in panic.info.observed
+    else:  # pragma: no cover - the lying arm
+        raise AssertionError("opaque subscript invented a completed coordinate")
 
 
 def test_opaque_member_access_no_longer_raises():

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -1,0 +1,143 @@
+"""Subscript is an effect producer; unknown receiver types stay undecided."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    ListValue,
+    RaiseValue,
+    SymbolicValue,
+    TermValue,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor, make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.temporal import TemporalContext
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+CORPUS_ROOT = Path(
+    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages"
+)
+SITE = CORPUS_ROOT / "pandas/tests/test_multilevel.py"
+SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
+MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+DEMAND_TABLE_KEY = (
+    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
+    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+)
+
+
+@pytest.fixture(scope="module")
+def authenticated_site():
+    assert hashlib.sha256(SITE.read_bytes()).hexdigest() == SITE_SHA256
+
+    source = SourceFile(
+        workspace_path_source(str(SITE), root=str(CORPUS_ROOT)),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(
+        node
+        for node in source.nodes()
+        if type(node).__name__ == "Subscript" and node.fragment.line == 158
+    )
+
+
+def test_shared_table_authenticates_the_exact_corpus(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "table.json"
+    root = Path(__file__).resolve().parents[4]
+    pulled = subprocess.run(
+        [
+            str(root / "bin/sugarbin"),
+            "artifact",
+            "pull",
+            "--kind",
+            "python-demand-table",
+            "--content-key",
+            DEMAND_TABLE_KEY,
+            "--output",
+            str(output),
+            "--runtime",
+            "cpython-3.14.4",
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    assert pulled.returncode == 0, pulled.stderr
+    table = json.loads(output.read_text(encoding="utf-8"))
+    assert table["contentKey"] == DEMAND_TABLE_KEY
+    assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
+
+def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> None:
+    receiver = CallSiteValue(
+        "source-constructor",
+        (),
+        (),
+        ctor("call:source-constructor", []),
+        None,
+    )
+    temporal = TemporalContext.empty().bind_value(
+        "series", receiver
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        authenticated_site.sugar().desugar(ReduceContext(temporal))
+
+    assert raised.value.info.owner == "SymbolicValue.subscript"
+    assert "undecided receiver runtime type" in raised.value.info.observed
+
+
+def test_truthful_out_of_range_concrete_list_emits_index_error(
+    authenticated_site,
+) -> None:
+    outcome = ListValue((TermValue(7),)).subscript(
+        TermValue(1), authenticated_site.fragment
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "IndexError"
+
+
+def test_lying_in_range_concrete_list_does_not_emit_exception(
+    authenticated_site,
+) -> None:
+    outcome = ListValue((TermValue(7),)).subscript(
+        TermValue(0), authenticated_site.fragment
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TermValue)
+    assert outcome.value.value == 7
+
+
+def test_known_non_integer_list_index_emits_type_error(authenticated_site) -> None:
+    outcome = ListValue((TermValue(7),)).subscript(
+        TermValue(1.5), authenticated_site.fragment
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_unknown_list_index_is_a_named_third_value(authenticated_site) -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        ListValue((TermValue(7),)).subscript(
+            SymbolicValue(make_var("index")), authenticated_site.fragment
+        )
+
+    assert raised.value.info.owner == "ListValue.subscript"
+    assert "undecided" in raised.value.info.observed


### PR DESCRIPTION
## What changed

- make opaque, imported, and plain-symbolic Subscript receivers take one named undecided floor instead of completing a `py.subscript` coordinate
- preserve enrolled formal `python:indexable` conditional construction
- emit exact native `IndexError` / `TypeError` exits for decidable list, tuple, and string indexes
- add the pandas 3.0.3 `test_multilevel.py:158` reproducer, truthful/lying twins, shared-demand-table authentication, and producer-only design/plan
- do not touch assertion-With, ExitSet, outcome, or generator construction

## Boundary

Before this branch, the concrete pandas Subscript constructed `Complete(CallSiteValue("py.subscript", ...))`. Its receiver runtime type is not source-decided at the producer boundary, so the branch returns the named `SymbolicValue.subscript` refusal rather than guessing `KeyError`.

## Validation

- local source-only focused modules: `15 passed, 1 deselected` (exit 0)
- mutation transaction: clean; replaced the named refusal with the old completed coordinate; the real-site test failed with `DID NOT RAISE ConstructionPanic` and exit 1; restored identical SHA-256; `5 passed, 1 deselected`; clean
- compileall exit 0; diff-check exit 0

## Authenticated launcher blocker

`bin/bpytest -u implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py -q` refuses before collection as designed: the shelf has no binary matching source stamp `blake3-512:a2ae84ce046c2ef5ace02da2754178a64a2d54f50c6357be662141d8a221bdf08765fb605617997ca330da0467ff89c7a6d04959bd3f0e1d531ee4fb0a17799f` and build fallback is disabled. Therefore authenticated twins and crash/timeout zeros remain unclaimed until that artifact is published.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make undecided subscript operations emit named construction refusals instead of coordinates
> - `subscript` methods across floor value types (`CallSiteValue`, `ImportAliasValue`, `SymbolicValue`, `ListValue`, `StringValue`, `TupleValue`) now call `undecided_subscript` when receiver runtime type or index semantics are undecidable, raising a `ConstructionPanic` gap instead of returning a `py.subscript` coordinate.
> - `ListValue`, `StringValue`, and `TupleValue` also gain a new branch that emits a `TypeError` `RaiseEffect` when the index is a `TermValue` with a known non-integer value.
> - A new `FloorValue.undecided_subscript` helper standardizes the named refusal path with an owner label and guidance not to guess exception classes.
> - New tests in [test_subscript_exceptional_exit_producer.py](https://github.com/TSavo/sugar/pull/6486/files#diff-5c5671a659b6b692c1993866e9055906803fa264e008b726b85172b480049df6) verify the producer law covering undecided refusals, `IndexError`, `TypeError`, and in-range element returns.
> - Behavioral Change: any code path that previously received a `py.subscript` coordinate for an undecidable subscript will now receive a construction panic instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08ebded.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->