### PR TITLE
Keep undecided binary dispatch loud

### DIFF
--- a/docs/superpowers/plans/2026-07-27-binary-operation-exception-floor.md
+++ b/docs/superpowers/plans/2026-07-27-binary-operation-exception-floor.md
@@ -1,0 +1,68 @@
+# Binary-operation Exceptional Floor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep authenticated binary-operation exception exits and refuse every source-undecidable native dispatch instead of completing it symbolically.
+
+**Architecture:** The existing binary floor remains the sole producer owner. Ground operand pairs continue through their type-specific arms; the shared undecided-operand law becomes a named construction refusal, and direct SymbolicValue/CallSiteValue paths delegate to it rather than minting a completion. Assertion consumers remain unchanged.
+
+**Tech Stack:** Python 3.14, pytest, Sugar Python floor/outcome APIs, #6462 authenticated launcher, #6464 demand-table shelf.
+
+## Global Constraints
+
+- Base is exactly `675c5de7b4a6556f85b848ddf8673815e7dcddc8`.
+- No vendor/name/spelling dispatch and no invented exception identity or generic runtime effect.
+- Do not edit assertion-With, Compare, UnaryOp, Subscript, Attribute, `outcome/`, `exit_set.py`, or generator construction.
+- Preserve construction panic, timeout, native crash, and unaccounted zeros.
+
+---
+
+### Task 1: Pin the undecided binary producer law
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py`
+- Modify if its direct bypass is reached: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py`
+- Modify if its direct bypass is reached: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py`
+
+**Interfaces:**
+- Consumes: `FloorValue.denotes_value()`, `FloorValue.runtime_type_is_decided()`, existing guarded-operation distribution.
+- Produces: one named `ConstructionPanic` at the binary producer when native dispatch is undecidable; existing decided pair outcomes are unchanged.
+
+- [ ] Add a test asserting an undecided value pair raises the named producer gap and never returns `Complete(SymbolicValue)`.
+- [ ] Run that exact test and record the pre-change failure caused by symbolic completion.
+- [ ] Change the shared undecided-binary law to call `construction_panic_gap` with operator, operand categories, and the requested native testimony.
+- [ ] Route any measured direct symbolic/callsite bypass through the shared law.
+- [ ] Run the complete undecided-binary and guarded-operation focused test files.
+
+### Task 2: Authenticate the pandas producer reproducer
+
+**Files:**
+- Test: `implementations/python/sugar-lift-python-source/tests/test_binary_operation_exception_floor.py`
+
+**Interfaces:**
+- Consumes: #6464 demand-table artifact key `blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d896cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499` and #6462 authenticated pytest environment.
+- Produces: a producer-only real-site test that never asks the assertion manager to locate a call or effect.
+
+- [ ] Pull the shared table by content key and authenticate its pandas manifest CID.
+- [ ] Construct the exact pandas file through the production construction context and select the line-95 BinOp producer directly.
+- [ ] Assert runtime discrimination: `Series & nan` raises and `Series & 0` completes.
+- [ ] Assert both source-undecidable producer shapes take the named refusal without naming `TypeError` in the produced semantics.
+- [ ] Run the exact test through `PYTHONUNBUFFERED=1 ../../../bin/bpytest`; report a shelf binary refusal without workaround if collection cannot start.
+
+### Task 3: Mutation transaction and publication
+
+**Files:**
+- Modify: only the Task 1 implementation line during the temporary mutation; revert it before commit.
+
+**Interfaces:**
+- Consumes: focused tests from Tasks 1 and 2.
+- Produces: clean / mutated / bites / reverted / clean receipts, one requested-author commit, and an unmerged draft PR.
+
+- [ ] Record clean focused tests.
+- [ ] Mutate the undecided door back to completed symbolic output using `apply_patch`.
+- [ ] Run the teeth and record the intended failure plus inline exit status.
+- [ ] Revert the mutation using `apply_patch`.
+- [ ] Rerun focused tests and record clean status.
+- [ ] Inspect the exact diff and stable-zero axes; commit as `T Savo <evilgenius@nefariousplan.com>`.
+- [ ] Push `binary-operation-floor-owner`, open a draft PR against main, and do not merge.

--- a/docs/superpowers/specs/2026-07-27-binary-operation-exception-floor-design.md
+++ b/docs/superpowers/specs/2026-07-27-binary-operation-exception-floor-design.md
@@ -1,0 +1,46 @@
+# Binary-operation exceptional-floor design
+
+## Scope
+
+Repair only the Python BinOp producer.  Assertion boundaries consume the
+resulting `ExitSet`; they never inspect expression syntax.  This change does not
+touch assertion-With, Compare, UnaryOp, Subscript, Attribute, `outcome/`,
+`exit_set.py`, or generator construction.
+
+## Producer law
+
+A binary operation may publish an exceptional exit only when its operands and
+native source-visible operation authenticate that exit.  Existing ground floor
+arms retain their cited `RaiseEffect` exits for overflow, type, and division
+failures.  An operation with an operand whose runtime type is undecidable cannot
+select `__op__`, `__rop__`, or an exception identity.  That is a third value:
+the BinOp producer raises a named construction gap instead of returning a
+completed symbolic value or manufacturing an effect.
+
+The general undecided-binary door owns this refusal.  Direct symbolic and
+call-result binary helpers must route through that same door so no side path can
+launder undecided dispatch into `Complete(SymbolicValue(...))`.  Guarded
+operations continue to distribute through their existing floor law; each arm
+then either constructs, emits its authenticated ground exit, or refuses.
+
+## Authentication and tests
+
+The real reproducer is pandas 3.0.3
+`tests/series/test_logical_ops.py`, manager beginning at line 95, body
+`s_0123 & np.nan`.  Tests run through #6462's authenticated launcher and pull
+#6464's content-addressed demand table.  They authenticate manifest CID
+`sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`.
+The truthful runtime shape raises; the lying `s_0123 & 0` shape completes at
+runtime, but both remain source-undecidable to the producer and therefore both
+must take the same named refusal rather than inventing `TypeError`.
+
+Focused floor laws additionally prove that a decided ground exceptional face
+still carries its authenticated exception, an undecided operand refuses, and a
+guarded operation retains per-arm behavior.
+
+## Verification
+
+Run the focused tests for every touched Python package.  Prove the regression
+test's teeth with a clean / mutated / bites / reverted / clean transaction.
+Use the shared shelf only; an absent source-stamped binary is reported as a
+blocker and is never worked around by rebuilding the demand table.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -135,9 +135,9 @@ class CallSiteValue(FloorValue):
         """Undecided: no citation fixes an unexecuted call's result type.
 
         Which ``__op__``/``__rop__`` Python would select for an operation
-        over this value is undecided too, so a binary operation with it
-        constructs a symbolic coordinate rather than standing on a ground
-        field law.
+        over this value is undecided too, so a binary operation reaches the
+        named producer refusal rather than standing on a ground field law or
+        claiming completion.
         """
         return False
 
@@ -784,60 +784,35 @@ class CallSiteValue(FloorValue):
         return Complete(self.linear_method_call("__format__", (spec,), site))
 
     def add(self, other, site):
-        """Addition floor via interface dispatch: dig then redispatch, else EUF +.
+        """Addition floor via interface dispatch: dig, redispatch, or refuse.
 
         AddOpSugar calls left.add(right) — not binary_operator_with. Without this
         totalizer, dig of `want_bytes(x) + self.sep` construction_panics mid-body.
         """
-        return self._dig_or_symbolic_binop(other, site, op="+", floor_method="add")
+        return self._dig_or_refuse_binop(other, site, op="+", floor_method="add")
 
     def subtract(self, other, site):
-        return self._dig_or_symbolic_binop(other, site, op="-", floor_method="subtract")
+        return self._dig_or_refuse_binop(other, site, op="-", floor_method="subtract")
 
     def multiply(self, other, site):
-        return self._dig_or_symbolic_binop(other, site, op="*", floor_method="multiply")
+        return self._dig_or_refuse_binop(other, site, op="*", floor_method="multiply")
 
     def power(self, other, site):
-        """Dig a proved return body, otherwise retain runtime ``__pow__`` dispatch."""
-        dug = self._dig_floor_or_none(None, owner="CallSiteValue.power")
-        if dug is not None and dug is not self:
-            return dug.power(other, site)
-
-        from sugar_lift_py_tests.effect import (
-            PowerRuntimeEffect,
-            runtime_effect_evidence,
-        )
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Incomplete
-
-        operand = ctor(
-            "**",
-            [
-                self.to_term(owner=str(site)),
-                other.to_term(owner=str(site)),
-            ],
-        )
-        return Incomplete(
-            PowerRuntimeEffect(
-                "power dispatch depends on the runtime call result's __pow__; "
-                f"owner=CallSiteValue.power site={site}",
-                **runtime_effect_evidence("py.power", operand, site),
-            )
-        )
+        return self._dig_or_refuse_binop(other, site, op="**", floor_method="power")
 
     def divide(self, other, site):
-        return self._dig_or_symbolic_binop(other, site, op="/", floor_method="divide")
+        return self._dig_or_refuse_binop(other, site, op="/", floor_method="divide")
 
     def modulo(self, other, site):
-        return self._dig_or_symbolic_binop(other, site, op="%", floor_method="modulo")
+        return self._dig_or_refuse_binop(other, site, op="%", floor_method="modulo")
 
     def floor_divide(self, other, site):
-        return self._dig_or_symbolic_binop(
+        return self._dig_or_refuse_binop(
             other, site, op="//", floor_method="floor_divide"
         )
 
     def left_shift(self, other, site):
-        return self._dig_or_symbolic_binop(
+        return self._dig_or_refuse_binop(
             other, site, op="<<", floor_method="left_shift"
         )
 
@@ -845,48 +820,37 @@ class CallSiteValue(FloorValue):
         # Base64 / alphabet index math: `ord(c) >> 2` on call results.
         # Without this, FloorValue.right_shift panics (A2 mint-failed on
         # python-literal-base64 / base64-federation).
-        return self._dig_or_symbolic_binop(
+        return self._dig_or_refuse_binop(
             other, site, op=">>", floor_method="right_shift"
         )
 
     def bitwise_and(self, other, site):
         # Same family as left_shift / bitwise_or: dig then redispatch, else
-        # EUF `&`. Base20 / base64 nibble masks (`b0 & 15`) hit CallSiteValue.
-        return self._dig_or_symbolic_binop(
+        # retain the named undecided-dispatch refusal.
+        return self._dig_or_refuse_binop(
             other, site, op="&", floor_method="bitwise_and"
         )
 
     def bitwise_xor(self, other, site):
-        dug = self._dig_floor_or_none(None, owner="CallSiteValue.bitwise_xor")
-        if dug is not None and dug is not self:
-            return dug.bitwise_xor(other, site)
-        if self.body is not None:
-            return super().bitwise_xor(other, site)
-
-        from sugar_lift_py_tests.effect import runtime_bitwise_xor
-
-        return runtime_bitwise_xor(self, other, site)
-
-    def bitwise_or(self, other, site):
-        return self._dig_or_symbolic_binop(
-            other, site, op="|", floor_method="bitwise_or"
+        return self._dig_or_refuse_binop(
+            other, site, op="^", floor_method="bitwise_xor"
         )
 
+    def bitwise_or(self, other, site):
+        return self._dig_or_refuse_binop(other, site, op="|", floor_method="bitwise_or")
+
     def matrix_multiply(self, other, site):
-        return self._dig_or_symbolic_binop(
+        return self._dig_or_refuse_binop(
             other, site, op="@", floor_method="matrix_multiply"
         )
 
-    def _dig_or_symbolic_binop(self, other, site, *, op: str, floor_method: str):
-        """Dig body when present; redispatch op on dug floor; else SymbolicValue join.
+    def _dig_or_refuse_binop(self, other, site, *, op: str, floor_method: str):
+        """Dig source body when present; otherwise retain undecided dispatch.
 
         No invent of concrete sums. Ctx is None-tolerant (add(site) has no ctx).
         Mid-dig ConstructionPanic propagates (process-terminal; never dig opacity).
         """
         from sugar_lift_py_tests.floor.guarded_value import GuardedValue
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
 
         if isinstance(other, GuardedValue):
             return other.map_from_left(floor_method, self, site)
@@ -900,17 +864,10 @@ class CallSiteValue(FloorValue):
             if callable(method):
                 return method(other, site)
 
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    op,
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        refused = self._undecided_binary_law(other, site, op)
+        if refused is not None:
+            return refused
+        return getattr(super(), floor_method)(other, site)
 
     def edge_contribution(self, source_contract):
         # Project one call-edge row: the coordinates this value already carries.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -879,10 +879,10 @@ class FloorValue:
         THIS right operand, falling through to the pair gap. Most of those
         pairs are not eight separate arms to write. They are one law: when at
         least one operand's runtime TYPE is undecided, Python's own operator
-        dispatch for the pair is undecided, so the exact denotation of the
-        operation is the symbolic coordinate ``operator(left, right)`` -- the
-        same coordinate ``SymbolicValue`` already constructs, hoisted off that
-        one class and onto the law it was always stating.
+        dispatch for the pair is undecided. That is a third value, not a
+        completed symbolic coordinate: without source-visible native dispatch
+        testimony this law refuses to choose completion or manufacture an
+        exception identity.
 
         Two refusals are deliberate and stay loud:
 
@@ -901,20 +901,25 @@ class FloorValue:
         if self.runtime_type_is_decided() and other.runtime_type_is_decided():
             return None
 
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    operator,
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
+        construction_panic_gap(
+            owner="binary_operation_exception_floor",
+            blame=site,
+            observed=f"{type(self).__name__} {operator} {type(other).__name__}",
+            requested=(
+                "source-visible native operator testimony selecting completion "
+                "or an authenticated exceptional exit"
+            ),
+            fix=(
+                "preserve the undecided third value at the BinOp producer; "
+                "resolve native operand types and their operator bodies from "
+                "source, or retain this named refusal without inventing an "
+                "exception identity"
+            ),
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
         )
 
     def _binary_floor_gap(self, other, site, owner, floor):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from sugar_lift_py_tests.gap.info import GapKind, GapLocus
 from sugar_lift_py_tests.ir import Term
 
-from .floor_value import FloorValue
+from .floor_value import _BINARY_OPERATOR_COORDINATE, FloorValue
 
 
 def _pep604_type_union_leaves(term: Term) -> tuple[Term, ...] | None:
@@ -53,9 +53,9 @@ class SymbolicValue(FloorValue):
         """Undecided: this is an unresolved term: nothing names its Python type.
 
         Which ``__op__``/``__rop__`` Python would select for an
-        operation over this value is therefore undecided too, so a
-        binary operation with it constructs a symbolic coordinate
-        rather than standing on a ground field law.
+        operation over this value is therefore undecided too, so a binary
+        operation reaches the named producer refusal rather than standing on a
+        ground field law or claiming completion.
         """
         return False
 
@@ -294,147 +294,69 @@ class SymbolicValue(FloorValue):
         if type(other) is ListValue:
             return other.multiply(self, site)
 
-        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        if isinstance(other, GuardedValue):
-            return other.map_from_left("multiply", self, site)
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "*",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return self._runtime_binary_refusal(other, site, "*")
 
     def power(self, other, site):
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "**",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return self._runtime_binary_refusal(other, site, "**")
 
     def add(self, other, site):
-        # Symbolic / EUF addition: emit ``+(self, other)``. CallSiteValue dig
-        # redispatches here when body is opaque; never invent a concrete sum.
-        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        if isinstance(other, GuardedValue):
-            return other.map_from_left("add", self, site)
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "+",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return self._runtime_binary_refusal(other, site, "+")
 
     def subtract(self, other, site):
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "-",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return self._runtime_binary_refusal(other, site, "-")
 
     def divide(self, other, site):
-        return self._arithmetic_coordinate(other, site, "/")
+        return self._arithmetic_refusal(other, site, "/")
 
     def floor_divide(self, other, site):
-        return self._arithmetic_coordinate(other, site, "//")
+        return self._arithmetic_refusal(other, site, "//")
 
     def modulo(self, other, site):
-        return self._arithmetic_coordinate(other, site, "%")
+        return self._arithmetic_refusal(other, site, "%")
 
-    def _arithmetic_coordinate(self, other, site, operator):
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    operator,
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+    def _arithmetic_refusal(self, other, site, operator):
+        return self._runtime_binary_refusal(other, site, operator)
 
     def right_shift(self, other, site):
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    ">>",
-                    [
-                        self.to_term(owner=str(site)),
-                        other.to_term(owner=str(site)),
-                    ],
-                )
-            )
-        )
+        return self._runtime_binary_refusal(other, site, ">>")
 
     def bitwise_and(self, other, site):
-        return self._runtime_bitwise_coordinate(other, site, "&")
+        return self._runtime_bitwise_refusal(other, site, "&")
 
     def bitwise_xor(self, other, site):
-        return self._runtime_bitwise_coordinate(other, site, "^")
+        return self._runtime_bitwise_refusal(other, site, "^")
 
     def bitwise_or(self, other, site):
-        return self._runtime_bitwise_coordinate(other, site, "|")
+        return self._runtime_bitwise_refusal(other, site, "|")
 
     def left_shift(self, other, site):
-        return self._runtime_bitwise_coordinate(other, site, "<<")
+        return self._runtime_bitwise_refusal(other, site, "<<")
 
-    def _runtime_bitwise_coordinate(self, other, site, operator):
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
+    def _runtime_bitwise_refusal(self, other, site, operator):
+        return self._runtime_binary_refusal(other, site, operator)
 
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    operator,
-                    [self.to_term(owner=str(site)), other.to_term(owner=str(site))],
-                )
-            )
+    def _runtime_binary_refusal(self, other, site, operator):
+        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+
+        owner = next(
+            method
+            for method, coordinate in _BINARY_OPERATOR_COORDINATE.items()
+            if coordinate == operator
+        )
+        if isinstance(other, GuardedValue):
+            return other.map_from_left(owner, self, site)
+        refused = self._undecided_binary_law(other, site, operator)
+        if refused is not None:
+            return refused
+        return self._binary_floor_gap(
+            other,
+            site,
+            owner,
+            f"runtime binary operator {operator}",
         )
 
     def matrix_multiply(self, other, site):
-        return self._runtime_bitwise_coordinate(other, site, "@")
+        return self._runtime_bitwise_refusal(other, site, "@")
 
     def unary_plus(self, site):
         # Unary plus on a symbolic is identity (symbolic_term UAdd returns the

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
@@ -211,19 +211,15 @@ def test_no_folded_result_ever_projects_a_non_numeric_real() -> None:
         assert abs(float(arg.value)) != float("inf")
 
 
-def test_a_symbolic_operand_keeps_its_own_symbolic_door() -> None:
+def test_an_opaque_operand_keeps_the_undecided_third_value_loud() -> None:
     """A complex plus an opaque callsite is not a field member; the complex
     floor must not swallow it into a fabricated concrete complex.
 
     What this arm pinned was the REFUSAL to fabricate a complex, and that is
     unchanged: the outcome below is not a ``ComplexValue``. What it also
-    asserted -- that the pair panics -- was the state before the undecided
-    binary-operand law existed, and is superseded by it. An unexecuted call's
-    result type is undecided, so Python's own operator dispatch for the pair is
-    undecided, and the exact denotation is the symbolic coordinate. This is the
-    SAME answer ``test_an_integer_plus_a_symbolic_operand_is_still_symbolic``
-    below already pinned for ``int + symbolic``; the law states it once for
-    every field member instead of once per left class.
+    asserted -- a completed symbolic coordinate -- erased the exceptional face.
+    An unexecuted call's result type is undecided, so Python's own operator
+    dispatch for the pair is undecided and remains a named producer gap.
 
     See ``tests/test_undecided_binary_operand_law.py``.
     """
@@ -231,21 +227,18 @@ def test_a_symbolic_operand_keeps_its_own_symbolic_door() -> None:
 
     assert complex_field_coordinate(opaque) is None
 
-    outcome = ComplexValue(0.0, 1.0).add(opaque, SITE)
-
-    assert isinstance(outcome, Complete)
-    assert type(outcome.value) is SymbolicValue
-    assert outcome.value.term.name == "+"
+    with pytest.raises(ConstructionPanic) as raised:
+        ComplexValue(0.0, 1.0).add(opaque, SITE)
+    assert raised.value.info.owner == "binary_operation_exception_floor"
 
 
-def test_an_integer_plus_a_symbolic_operand_is_still_symbolic() -> None:
+def test_an_integer_plus_a_symbolic_operand_is_still_undecided() -> None:
     """The complex arm sits AFTER the symbolic arms and stole none of them."""
     symbolic = SymbolicValue(TermValue(2).to_term(owner=SITE))
 
-    outcome = TermValue(1).add(symbolic, SITE)
-
-    assert isinstance(outcome, Complete)
-    assert type(outcome.value) is SymbolicValue
+    with pytest.raises(ConstructionPanic) as raised:
+        TermValue(1).add(symbolic, SITE)
+    assert raised.value.info.owner == "binary_operation_exception_floor"
 
 
 # -- the field coordinate is read from the value, not from a name -------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.floor import GuardedValue, SymbolicValue, TermValue
-from sugar_lift_py_tests.ir import atomic, ctor, make_var, num
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import atomic, ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 
 
@@ -20,20 +21,20 @@ from sugar_lift_py_tests.outcome import Complete
         ("right_shift", ">>"),
     ),
 )
-def test_guarded_arithmetic_distributes_to_both_faces(method, operator) -> None:
+def test_guarded_arithmetic_preserves_an_undecided_arm_as_a_named_refusal(
+    method, operator
+) -> None:
     guard = atomic("choose", [])
     value = GuardedValue(
         guard,
         SymbolicValue(make_var("left")),
         SymbolicValue(make_var("right")),
     )
-    outcome = getattr(value, method)(TermValue(2), "t.py:1")
+    with pytest.raises(ConstructionPanic) as raised:
+        getattr(value, method)(TermValue(2), "t.py:1")
 
-    assert outcome.value == GuardedValue(
-        guard,
-        SymbolicValue(ctor(operator, [make_var("left"), num(2)])),
-        SymbolicValue(ctor(operator, [make_var("right"), num(2)])),
-    )
+    assert raised.value.info.owner == "binary_operation_exception_floor"
+    assert raised.value.info.observed == f"SymbolicValue {operator} TermValue"
 
 
 def test_guarded_unary_minus_distributes_to_both_faces() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -1,0 +1,148 @@
+"""Authenticated producer law for pandas' no-call BinOp assertion body."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_source_tree.nodes import BinOp
+from sugar_source_tree.tree import SourceFile
+
+DEMAND_TABLE_CONTENT_KEY = (
+    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
+    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+)
+PANDAS_MANIFEST_CID = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+)
+FILE_SHA256 = "14698f3356d531b1cb87761c57be48737cb547b7ac97f7a6406c16336d5e2f5f"
+SOURCE_CID = (
+    "blake3-512:bbfb81036cfd42d0473c1d7d2521f9dc10c2518c6cec8897c22a5782c9a53a03"
+    "50a4d7f8e9dcea6899b53a879b555503f0138481b50d55351f0b2896c7589ec6"
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _corpus_file() -> Path:
+    import pandas
+
+    return Path(pandas.__file__).resolve().parent / "tests/series/test_logical_ops.py"
+
+
+def _authenticated_demand_row() -> dict:
+    with tempfile.TemporaryDirectory() as scratch:
+        output = Path(scratch) / "python-demand-table.json"
+        pulled = subprocess.run(
+            [
+                str(_repo_root() / "bin/sugarbin"),
+                "artifact",
+                "pull",
+                "--kind",
+                "python-demand-table",
+                "--content-key",
+                DEMAND_TABLE_CONTENT_KEY,
+                "--output",
+                str(output),
+                "--runtime",
+                "cpython-3.14.4",
+            ],
+            cwd=_repo_root(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert pulled.returncode == 0 and output.is_file(), (
+            "the authenticated #6464 demand table is absent; do not rebuild it: "
+            + pulled.stderr
+        )
+        payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert payload["contentKey"] == DEMAND_TABLE_CONTENT_KEY
+    assert payload["authentication"]["authenticatedCorpusManifestCid"] == (
+        PANDAS_MANIFEST_CID
+    )
+    assert payload["authentication"]["pandas"] == "3.0.3"
+    assert payload["identity"]["fileCount"] == 1421
+    rows = tuple(
+        row
+        for row in payload["rows"]
+        if row.get("kind") == "context-manager-demand"
+        and row.get("targetSymbol") == "pytest.raises"
+        and row.get("gapKind") is None
+        and row.get("useSite")
+        == {
+            "sourceCid": SOURCE_CID,
+            "startLine": 95,
+            "startCol": 9,
+            "endLine": 98,
+            "endCol": 5,
+        }
+    )
+    assert len(rows) == 1
+    return rows[0]
+
+
+def _line_96_bitand(source: str, path: Path):
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp)
+        and node.op.kind == "BitAnd"
+        and node.line_col_span().start_line == 96
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _assert_named_undecided_refusal(node, *, observed: str) -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        node.sugar().desugar(None)
+    info = raised.value.info
+    assert info.owner == "binary_operation_exception_floor"
+    assert info.observed == observed
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
+    assert "RuntimeEffect" not in str(info)
+
+
+def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> None:
+    """Truthful/lying runtime twins cannot license invented source testimony."""
+    demand = _authenticated_demand_row()
+    path = _corpus_file()
+    truthful = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(truthful.encode("utf-8")).hexdigest() == FILE_SHA256
+    assert demand["useSite"]["startLine"] == 95
+    assert truthful.count("s_0123 & np.nan") == 1
+
+    import pandas
+
+    series = pandas.Series(range(4), dtype="int64")
+    with pytest.raises(TypeError):
+        series & float("nan")
+    assert (series & 0).tolist() == [0, 0, 0, 0]
+
+    lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
+    _assert_named_undecided_refusal(
+        _line_96_bitand(truthful, path),
+        observed="SymbolicValue & SymbolicValue",
+    )
+    _assert_named_undecided_refusal(
+        _line_96_bitand(lying, path),
+        observed="SymbolicValue & TermValue",
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -8,9 +8,8 @@ named for THIS right operand, falling to the (owner x pair) gap.
 
 Most of those pairs are not eight arms to write. When at least one operand's
 runtime TYPE is undecided, Python's own operator dispatch for the pair is
-undecided, so the exact denotation is the symbolic coordinate
-``operator(left, right)`` -- the coordinate ``SymbolicValue`` already
-constructed, hoisted off that one class onto the law it was always stating.
+undecided.  That is a third value: the producer cannot claim completion and
+cannot invent an exception identity, so the shared law emits one named gap.
 
 The category is read from each value's own testimony (``denotes_value`` /
 ``runtime_type_is_decided``), never from a lexical type name.
@@ -36,7 +35,6 @@ from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, _Lambda, ctor, make_var
-from sugar_lift_py_tests.outcome import Complete
 
 SITE = "undecided-binary-site"
 
@@ -66,13 +64,80 @@ def _comprehension() -> ComprehensionValue:
     )
 
 
-def _coordinate(outcome, operator: str):
-    assert isinstance(outcome, Complete), outcome
-    assert type(outcome.value) is SymbolicValue
-    term = outcome.value.term
-    assert term.name == operator
-    assert len(term.args) == 2
-    return term
+def _refusal(left, right, method: str, operator: str):
+    with pytest.raises(ConstructionPanic) as raised:
+        getattr(left, method)(right, SITE)
+    info = raised.value.info
+    assert info.owner == "binary_operation_exception_floor"
+    assert info.observed == f"{type(left).__name__} {operator} {type(right).__name__}"
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
+    assert "RuntimeEffect" not in str(info)
+    return info
+
+
+def test_undecided_native_bitwise_dispatch_refuses_in_the_producer() -> None:
+    """The producer cannot choose ``__and__``/``__rand__`` or an exception."""
+    with pytest.raises(ConstructionPanic) as raised:
+        _symbolic().bitwise_and(TermValue(0), SITE)
+
+    info = raised.value.info
+    assert info.owner == "binary_operation_exception_floor"
+    assert info.observed == "SymbolicValue & TermValue"
+    assert info.requested == (
+        "source-visible native operator testimony selecting completion or an "
+        "authenticated exceptional exit"
+    )
+    assert "TypeError" not in str(info)
+    assert "RuntimeEffect" not in str(info)
+
+
+@pytest.mark.parametrize(
+    ("method", "operator"),
+    (
+        ("add", "+"),
+        ("subtract", "-"),
+        ("multiply", "*"),
+        ("divide", "/"),
+        ("floor_divide", "//"),
+        ("modulo", "%"),
+        ("power", "**"),
+        ("matrix_multiply", "@"),
+        ("bitwise_and", "&"),
+        ("bitwise_or", "|"),
+        ("bitwise_xor", "^"),
+        ("left_shift", "<<"),
+        ("right_shift", ">>"),
+    ),
+)
+def test_undecided_call_result_has_no_completion_or_effect_side_door(
+    method: str, operator: str
+) -> None:
+    _refusal(_callsite(), TermValue(2), method, operator)
+
+
+@pytest.mark.parametrize(
+    ("method", "operator"),
+    (
+        ("add", "+"),
+        ("subtract", "-"),
+        ("multiply", "*"),
+        ("divide", "/"),
+        ("floor_divide", "//"),
+        ("modulo", "%"),
+        ("power", "**"),
+        ("matrix_multiply", "@"),
+        ("bitwise_and", "&"),
+        ("bitwise_or", "|"),
+        ("bitwise_xor", "^"),
+        ("left_shift", "<<"),
+        ("right_shift", ">>"),
+    ),
+)
+def test_symbolic_left_operand_has_no_completed_binary_side_door(
+    method: str, operator: str
+) -> None:
+    _refusal(_symbolic(), TermValue(2), method, operator)
 
 
 # -- positive arm: the pairs the pinned census actually found -----------------
@@ -99,13 +164,13 @@ def _coordinate(outcome, operator: str):
         (NoneValue(), _callsite(), "add", "+"),
     ),
 )
-def test_an_undecided_operand_constructs_the_symbolic_coordinate(
+def test_an_undecided_operand_keeps_the_third_value_loud(
     left, right, method, operator
 ) -> None:
-    _coordinate(getattr(left, method)(right, SITE), operator)
+    _refusal(left, right, method, operator)
 
 
-def test_the_law_covers_every_operator_it_names_from_one_place() -> None:
+def test_the_law_refuses_every_operator_it_names_from_one_place() -> None:
     """Eight operator names, one law -- so a ninth costs no new arm."""
     for method, operator in (
         ("add", "+"),
@@ -122,18 +187,15 @@ def test_the_law_covers_every_operator_it_names_from_one_place() -> None:
         ("left_shift", "<<"),
         ("right_shift", ">>"),
     ):
-        _coordinate(getattr(BytesValue(b"x"), method)(_symbolic(), SITE), operator)
+        _refusal(BytesValue(b"x"), _symbolic(), method, operator)
 
 
-def test_both_operands_are_conserved_in_the_coordinate() -> None:
-    """One output arm conserves exactly its two input arms, in order."""
+def test_both_operand_categories_are_conserved_in_the_refusal() -> None:
+    """The gap names the actual pair and operator; no operand becomes a value."""
     left = BytesValue(b"ab")
     right = _symbolic()
-
-    term = _coordinate(left.add(right, SITE), "+")
-
-    assert term.args[0] == left.to_term(owner=SITE)
-    assert term.args[1] == right.to_term(owner=SITE)
+    info = _refusal(left, right, "add", "+")
+    assert info.observed == "BytesValue + SymbolicValue"
 
 
 # -- the real reproducers: whole functions, lifted from source ---------------
@@ -154,23 +216,20 @@ def test_both_operands_are_conserved_in_the_coordinate() -> None:
         ("set_minus_call", "def f(g):\n    return {1, 2} - g()\n"),
     ),
 )
-def test_the_whole_function_lifts_where_it_construction_panicked(
+def test_the_whole_function_refuses_undecided_native_dispatch(
     tmp_path, name, source
 ) -> None:
-    """Each of these construction_panicked on the tree before the law: a
-    snippet flip is not the acceptance, the whole function is."""
+    """Whole-function construction cannot launder the third value."""
     from sugar_lift_python_source.source_oracle import path_source
-    from sugar_lift_py_tests.floor.universe_value import UniverseValue
     from sugar_source_tree.tree import SourceFile
 
     path = tmp_path / f"{name}.py"
     path.write_text(source, encoding="utf-8")
 
     fn = next(SourceFile(path_source(str(path))).functions())
-    outcome = fn.sugar().desugar(None)
-
-    assert isinstance(outcome, Complete)
-    assert type(outcome.value) is UniverseValue
+    with pytest.raises(ConstructionPanic) as raised:
+        fn.sugar().desugar(None)
+    assert raised.value.info.owner == "binary_operation_exception_floor"
 
 
 # -- discriminating arm: the law refuses, loudly, everywhere else -------------
@@ -321,8 +380,8 @@ def test_the_field_law_is_consulted_before_the_base_law() -> None:
         # A pair the field law REFUSES -- it decides, then falls through.
         with pytest.raises(ConstructionPanic):
             TermValue(10**400).add(ComplexValue(0.0, 1.0), SITE)
-        # The pair this law answers -- the field law still got asked first.
-        _coordinate(ComplexValue(0.0, 1.0).add(_symbolic(), SITE), "+")
+        # The pair this law refuses -- the field law still got asked first.
+        _refusal(ComplexValue(0.0, 1.0), _symbolic(), "add", "+")
     finally:
         complex_arithmetic.complex_add = original
 
@@ -448,6 +507,6 @@ def test_no_value_class_states_testimony_the_base_class_lost() -> None:
     assert orphaned == []
 
 
-def test_the_undecided_pair_still_answers_end_to_end() -> None:
+def test_the_undecided_pair_still_refuses_end_to_end() -> None:
     """The one shape that proves the law is wired, not merely present."""
-    _coordinate(BytesValue(b"x").add(_symbolic(), SITE), "+")
+    _refusal(BytesValue(b"x"), _symbolic(), "add", "+")


### PR DESCRIPTION
## Summary

- keep undecidable binary dispatch as a named construction refusal instead of a completed symbolic value
- route `SymbolicValue` and opaque `CallSiteValue` through the shared producer law for all 13 binary operators
- authenticate the pandas 3.0.3 `s_0123 & np.nan` reproducer from the shared #6464 demand table, with truthful and lying runtime twins

## Why

The BinOp producer cannot authenticate completion or an exception identity when source-visible operand types and native dispatch are undecidable. The previous symbolic completion, power runtime effect, and xor runtime-effect side doors collapsed that third value or invented an effect. This change keeps the uncertainty loud at construction and leaves assertion-boundary consumption entirely out of scope.

## Validation

- `115 passed in 21.49s` across the five focused `sugar-lift-py-tests` files
- clean/mutated/bites/reverted/clean: replacing the shared refusal with symbolic completion made both the CallSite side-door tooth and authenticated pandas tooth fail (`2 failed`, exit 1); reverting restored both (`2 passed`, exit 0)
- `black --check`: 7 files unchanged
- `git diff --check`: clean

Authenticated `bin/bpytest` remains blocked before collection because the required source-stamped Sugar binary is absent while build fallback is disabled. No fallback build or private demand-table reconstruction was used.

The 367-site population delta is therefore intentionally unmeasured in this PR; the build began with the single authenticated reproducer as required.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise a named construction refusal for undecidable binary dispatch instead of returning symbolic values
> - All binary operators (`+`, `-`, `*`, `/`, `//`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `@`) now raise a `ConstructionPanic` with owner `binary_operation_exception_floor` when at least one operand's runtime type is undecidable, replacing the previous behavior of returning a `SymbolicValue` or emitting a `RuntimeEffect`.
> - `FloorValue._undecided_binary_law` and a new `_dig_or_refuse_binop` helper in `CallSiteValue` centralize the refusal, reporting operator and operand categories in the gap's `observed` field.
> - `SymbolicValue` binary methods are updated to call refusal helpers (`_runtime_binary_refusal`, `_arithmetic_refusal`, `_runtime_bitwise_refusal`) instead of constructing symbolic coordinates.
> - Tests in [test_undecided_binary_operand_law.py](https://github.com/TSavo/sugar/pull/6487/files#diff-9998d1328333d54a7b5c59ca17ab35198a7558b224afbe0df116ce7b9e33fb0b) and related files are updated to assert `ConstructionPanic` rather than symbolic completions, and a new pandas integration test verifies the behavior against a real-world reproducer.
> - Behavioral Change: code that previously received a `SymbolicValue` or `Complete` result from an undecidable binary operation will now see a `ConstructionPanic` at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 131e165.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->