### PR TITLE
Provision managed Battleaxe shelf artifacts

### DIFF
--- a/bin/brun
+++ b/bin/brun
@@ -19,6 +19,8 @@ Options:
 Environment (shared with bcargo so roots, caps and test harnesses apply):
   BCARGO_REMOTE_HOST   SSH host alias (default: battleaxe)
   BCARGO_REMOTE_ROOT   Remote scratch root (default: /home/tsavo/remote/sugar-bcargo-<checkout-hash>)
+  BCARGO_REMOTE_BINARY_SHELF  Exact binary shelf mounted into managed builders
+                              (default: /home/tsavo/.cache/sugar/binary-shelf-v2)
   BCARGO_CLEAN_REMOTE_ROOT        never | success | always (default: never)
   BCARGO_CLEAN_REMOTE_ROOT_UNSAFE Set to 1 to allow cleanup outside
                                   /home/tsavo/remote/sugar-bcargo-*

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -89,6 +89,7 @@ sugar_bx_init() {
     fi
   fi
   SUGAR_BX_BINARY_CACHE="${BCARGO_REMOTE_BINARY_CACHE:-/home/tsavo/.cache/sugar/binaries}"
+  SUGAR_BX_BINARY_SHELF="${BCARGO_REMOTE_BINARY_SHELF:-/home/tsavo/.cache/sugar/binary-shelf-v2}"
   SUGAR_BX_SSH="${BCARGO_SSH:-ssh}"; SUGAR_BX_RSYNC="${BCARGO_RSYNC:-rsync}"
   SUGAR_BX_CLEAN="${BCARGO_CLEAN_REMOTE_ROOT:-never}"
   case "$SUGAR_BX_CLEAN" in ""|0|false|no|never) SUGAR_BX_CLEAN=never;; 1|true|yes|success) SUGAR_BX_CLEAN=success;; always);; *) echo "sugarbin: BCARGO_CLEAN_REMOTE_ROOT must be never, success, or always" >&2; return 2;; esac
@@ -196,19 +197,29 @@ sugar_bx_docker_bind_source() {
 }
 
 sugar_bx_build_artifacts_docker() {
-  local image="$1" needs="$2" profile="$3"
+  local image="$1" needs="$2" profile="$3" provision_artifacts="${4:-0}"
   local image_digest="${image##*@sha256:}"
   local managed_target="${BCARGO_REMOTE_MANAGED_TARGET:-/home/tsavo/.cache/sugar/managed-targets/$image_digest}"
-  sugar_bx_ssh "rm -rf $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") && mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_BX_BINARY_CACHE") $(sugar_bx_quote "$managed_target")" || return $?
-  local workspace_source artifacts_source cache_source target_source
+  sugar_bx_ssh "rm -rf $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") && mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_BX_BINARY_CACHE") $(sugar_bx_quote "$SUGAR_BX_BINARY_SHELF") $(sugar_bx_quote "$managed_target")" || return $?
+  local workspace_source artifacts_source cache_source shelf_source target_source
   workspace_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_REPO")" || return $?
   artifacts_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_ROOT/artifacts")" || return $?
   cache_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_BINARY_CACHE")" || return $?
+  shelf_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_BINARY_SHELF")" || return $?
   target_source="$(sugar_bx_docker_bind_source "$managed_target")" || return $?
   local build_script
-  build_script="set -euo pipefail; cd /workspace/sugar; printf '{\"artifacts\":[' >/out/required-artifacts.json; first=1; needs=$(sugar_bx_quote "$needs"); IFS=,; for b in \$needs; do [ -n \"\$b\" ] || continue; r=\$(env -u SUGAR_BIN -u SUGAR_BINARY_DIR SUGAR_BINARY_PUBLISH=0 bin/sugarbin --profile $(sugar_bx_quote "$profile") --platform linux-x86_64 --bin \"\$b\"); cp \"\$r\" /out/\"\$b\"; cp \"\$r.sugarbin.json\" /out/\"\$b.sugarbin.json\"; sum=\$(sha256sum /out/\"\$b\" | cut -d' ' -f1); [ \$first = 1 ] || printf ',' >>/out/required-artifacts.json; first=0; printf '{\"name\":\"%s\",\"sha256\":\"%s\"}' \"\$b\" \"\$sum\" >>/out/required-artifacts.json; done; printf ']}' >>/out/required-artifacts.json"
+  build_script="set -euo pipefail; cd /workspace/sugar; printf '{\"artifacts\":[' >/out/required-artifacts.json; first=1; needs=$(sugar_bx_quote "$needs"); IFS=,; for b in \$needs; do [ -n \"\$b\" ] || continue; r=\$(env -u SUGAR_BIN -u SUGAR_BINARY_DIR bin/sugarbin --profile $(sugar_bx_quote "$profile") --platform linux-x86_64 --bin \"\$b\"); cp \"\$r\" /out/\"\$b\"; cp \"\$r.sugarbin.json\" /out/\"\$b.sugarbin.json\"; sum=\$(sha256sum /out/\"\$b\" | cut -d' ' -f1); [ \$first = 1 ] || printf ',' >>/out/required-artifacts.json; first=0; printf '{\"name\":\"%s\",\"sha256\":\"%s\"}' \"\$b\" \"\$sum\" >>/out/required-artifacts.json; done; printf ']}' >>/out/required-artifacts.json"
+  local shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2,readonly"
+  local name
+  if [[ "$provision_artifacts" == 1 ]]; then
+    for name in ${SUGAR_BX_ENV_NAMES[@]+"${SUGAR_BX_ENV_NAMES[@]}"}; do
+      [[ "$name" != SUGAR_BINARY_PUBLISH || ${!name:-0} != 1 ]] \
+        || shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2"
+    done
+  fi
   local -a docker_args=(docker run --rm
     --workdir /workspace/sugar
+    --env SUGAR_BINARY_ALLOW_BUILD=0
     --env SUGAR_BINARY_PUBLISH=0
     --env CARGO_TARGET_DIR=/managed-target
     --env SUGAR_BINARY_TARGET_ROOT=/managed-target
@@ -216,12 +227,17 @@ sugar_bx_build_artifacts_docker() {
     --mount "type=bind,src=$workspace_source,dst=/workspace/sugar"
     --mount "type=bind,src=$artifacts_source,dst=/out"
     --mount "type=bind,src=$cache_source,dst=/root/.cache/sugar/binaries"
+    --mount "$shelf_mount"
     --mount "type=bind,src=$target_source,dst=/managed-target"
   )
-  local name
   for name in ${SUGAR_BX_ENV_NAMES[@]+"${SUGAR_BX_ENV_NAMES[@]}"}; do
-    [[ "$name" != SUGAR_BINARY_ALLOW_BUILD || ${!name+x} != x ]] \
-      || docker_args+=(--env "$name=${!name}")
+    case "$name" in
+      SUGAR_BINARY_ALLOW_BUILD|SUGAR_BINARY_PUBLISH|SUGAR_BINARY_REQUIRE_PUBLISH)
+        if [[ "$provision_artifacts" == 1 || ${!name:-0} == 0 ]]; then
+          [[ ${!name+x} != x ]] || docker_args+=(--env "$name=${!name}")
+        fi
+        ;;
+    esac
   done
   docker_args+=("$image" bash -lc "$build_script")
   local arg command=""
@@ -233,13 +249,16 @@ sugar_bx_run_docker() {
   local image="$1" network="$2" has_artifacts="$3"; shift 3
   local remote_cwd="/workspace/sugar"
   [[ -n "$SUGAR_BX_REL_CWD" ]] && remote_cwd="$remote_cwd/$SUGAR_BX_REL_CWD"
-  local workspace_source artifacts_source manifest_source
+  local workspace_source artifacts_source manifest_source shelf_source
   workspace_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_REPO")" || return $?
+  sugar_bx_ssh "mkdir -p $(sugar_bx_quote "$SUGAR_BX_BINARY_SHELF")" || return $?
+  shelf_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_BINARY_SHELF")" || return $?
   local -a docker_args=(docker run --rm
     --workdir "$remote_cwd"
     --env PATH=/opt/sugar/bin:/opt/java/bin:/root/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
     --env "SUGAR_BX_MOUNT_PROOF=$SUGAR_BX_MOUNT_PROOF"
-    --mount "type=bind,src=$workspace_source,dst=/workspace/sugar")
+    --mount "type=bind,src=$workspace_source,dst=/workspace/sugar"
+    --mount "type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2,readonly")
   [[ "$network" != none ]] || docker_args+=(--network none)
   if [[ "$has_artifacts" == 1 ]]; then
     artifacts_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_ROOT/artifacts")" || return $?

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -135,6 +135,20 @@ dispatch_execution_subcommand() {
     fi
   fi
 
+  if [[ "$subcommand" != build ]]; then
+    local elevated_name
+    for elevated_name in ${env_names[@]+"${env_names[@]}"}; do
+      case "$elevated_name" in
+        SUGAR_BINARY_ALLOW_BUILD|SUGAR_BINARY_PUBLISH|SUGAR_BINARY_REQUIRE_PUBLISH)
+          if [[ ${!elevated_name:-0} != 0 ]]; then
+            echo "sugarbin: provisioning authority requires explicit sugarbin build; refusing $subcommand with $elevated_name=${!elevated_name}" >&2
+            return 2
+          fi
+          ;;
+      esac
+    done
+  fi
+
   local route_env="${execution_env%%:*}" docker_image="" core_image=""
   if [[ "$route_env" == docker ]]; then
     local contract_python
@@ -254,7 +268,9 @@ dispatch_execution_subcommand() {
     sugar_bx_write_mount_proof || return $?
     local remote_needs="$needs" has_artifacts=0
     if [[ -n "$remote_needs" ]]; then
-      sugar_bx_build_artifacts_docker "$core_image" "$remote_needs" "$profile" || return $?
+      local provision_artifacts=0
+      [[ "$subcommand" != build ]] || provision_artifacts=1
+      sugar_bx_build_artifacts_docker "$core_image" "$remote_needs" "$profile" "$provision_artifacts" || return $?
       has_artifacts=1
     fi
     if [[ "$subcommand" == build ]]; then

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -91,6 +91,8 @@ build_line="$(head -1 "$tmp/docker.log")"
 line="$(tail -1 "$tmp/docker.log")"
 [[ "$build_line" == *"'$core_ref'"* && "$build_line" == *"bin/sugarbin"* ]] || fail "artifact was not resolved inside managed core: $build_line"
 [[ "$build_line" == *"dst=/root/.cache/sugar/binaries"* ]] || fail "managed builder omitted persistent verified cache"
+[[ "$build_line" == *"dst=/root/.cache/sugar/binary-shelf-v2,readonly"* ]] || fail "ordinary managed resolution shelf is missing or writable"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_ALLOW_BUILD=0'"* ]] || fail "ordinary managed resolution retained an implicit build fallback"
 [[ "$build_line" == *"CARGO_TARGET_DIR=/managed-target"* ]] || fail "managed builder reused ambient Cargo target"
 [[ "$build_line" == *"SUGAR_BINARY_TARGET_ROOT=/managed-target"* ]] || fail "managed manifest root diverges from Cargo target"
 [[ "$build_line" == *"dst=/managed-target"* ]] || fail "managed target cache was not mounted"
@@ -116,6 +118,7 @@ line="$(tail -1 "$tmp/docker.log")"
 [[ "$line" == *"dst=/workspace/sugar"* ]] || fail "workspace mount missing"
 [[ "$line" == *"src=C:"* ]] || fail "WSL bind source was not translated"
 [[ "$line" == *"dst=/opt/sugar/bin,readonly"* ]] || fail "artifact mount not read-only"
+[[ "$line" == *"dst=/root/.cache/sugar/binary-shelf-v2,readonly"* ]] || fail "managed task cannot consume exact shelf payloads"
 [[ "$line" == *"required-artifacts.json,readonly"* ]] || fail "stamp mount not read-only"
 [[ "$line" != *"--env' 'SUGAR_BIN="* ]] || fail "orchestrator forged SUGAR_BIN before manifest verification"
 [[ "$entrypoint" == *'export SUGAR_BIN=/opt/sugar/bin/sugar'* ]] || fail "entrypoint does not inject verified sugar"
@@ -129,6 +132,28 @@ line="$(tail -1 "$tmp/docker.log")"
 run build --host bx --env docker:core --profile debug --needs sugar >/dev/null
 build_line="$(head -1 "$tmp/docker.log")"
 [[ "$build_line" == *"--profile"* && "$build_line" == *"debug"* ]] || fail "managed artifact profile did not reach the core builder"
+: >"$tmp/docker.log"
+
+SUGAR_BINARY_ALLOW_BUILD=1 SUGAR_BINARY_PUBLISH=1 SUGAR_BINARY_REQUIRE_PUBLISH=1 \
+  run build --host bx --env docker:core \
+    --env SUGAR_BINARY_ALLOW_BUILD --env SUGAR_BINARY_PUBLISH \
+    --env SUGAR_BINARY_REQUIRE_PUBLISH --needs sugar >/dev/null
+build_line="$(head -1 "$tmp/docker.log")"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_ALLOW_BUILD=1'"* ]] || fail "explicit managed publisher lost build authority"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_PUBLISH=1'"* ]] || fail "explicit managed publisher lost publish authority"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_REQUIRE_PUBLISH=1'"* ]] || fail "explicit managed publisher did not require a complete shelf cell"
+[[ "$build_line" != *"SUGAR_BINARY_PUBLISH=0 bin/sugarbin"* ]] || fail "managed build script overrode explicit publish authority"
+[[ "$build_line" == *"dst=/root/.cache/sugar/binary-shelf-v2"* && "$build_line" != *"dst=/root/.cache/sugar/binary-shelf-v2,readonly"* ]] || fail "explicit managed publisher did not receive the writable shelf"
+: >"$tmp/docker.log"
+
+status=0
+SUGAR_BINARY_ALLOW_BUILD=1 SUGAR_BINARY_PUBLISH=1 SUGAR_BINARY_REQUIRE_PUBLISH=1 \
+  run run --host bx --env SUGAR_BINARY_ALLOW_BUILD \
+    --env SUGAR_BINARY_PUBLISH --env SUGAR_BINARY_REQUIRE_PUBLISH \
+    --task python-unit -- -q >"$tmp/run-publish.out" 2>"$tmp/run-publish.err" || status=$?
+[[ "$status" == 2 ]] || fail "managed run accepted provisioning authority: status=$status"
+grep -Fq 'provisioning authority requires explicit sugarbin build' "$tmp/run-publish.err" || fail "managed run provisioning refusal was not named"
+[[ ! -s "$tmp/docker.log" ]] || fail "managed run provisioning refusal happened after Docker"
 : >"$tmp/docker.log"
 
 run run --host bx --env docker:core -- sh -c 'echo miss' >/dev/null


### PR DESCRIPTION
## Outcome

Current-main Sugar stamp `blake3-512_306b3f8961a02ccd41671f0e26da79348c059a147958b30d4cc8653369dbb40f008216bcebc7bdf353bc75a65043e65c5de1cc1c113d87e4f083cc72629b66ca` is published with the immutable managed-core Cargo identity.

An isolated empty managed target resolved it from the filesystem shelf, then authenticated `bin/bpytest` ran 10 focused tests under CPython 3.12.13 / pandas 3.0.3 / NumPy 2.5.1, exit 0.

Exact shared demand table `blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d896cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499` is also consumable inside the final network-disabled managed container, exit 0.

## Root causes fixed

- managed artifact builders could not see Battleaxe filesystem shelf cells
- final managed task containers could not see exact payload artifacts such as the shared demand table
- explicit managed builds could not publish into the shared shelf
- ordinary managed runs implicitly inherited build-enabled behavior unless a wrapper remembered to disable it

## Authority boundary

- every ordinary managed artifact builder starts with `SUGAR_BINARY_ALLOW_BUILD=0` and `SUGAR_BINARY_PUBLISH=0`
- ordinary builder shelf mounts are read-only
- final task shelf mounts are read-only
- non-build commands requesting nonzero build/publish authority refuse before Docker
- only explicit `sugarbin build --host bx --env docker:core` may receive named build/publish authority and a writable shelf

The refusal is retained. No near-miss binary, fallback build, or substitute demand table is accepted.

## Focused validation

- `tests/sugarbin_docker_exec.sh`: pass, including authority lying twins and mount-mode assertions
- `tests/sugarbin_bx_exec.sh`: pass
- `tests/bpytest_authenticated_wrapper.sh`: pass
- shell syntax and `git diff --check`: pass
- independent review: clean

## Preserved incompatible cells

- ambient-Cargo binary cell moved intact to `/home/tsavo/.cache/sugar/quarantine/306b3f89-ambient-cargo-incompatible-20260727`
- Darwin-manifest table cell moved intact to `/home/tsavo/.cache/sugar/quarantine/e225-darwin-manifest-in-linux-cell-20260727`
- verified 232,235,473-byte table payload retained at `/home/tsavo/.cache/sugar/quarantine/e225-python-demand-table.json`

This PR is intentionally draft, open, and unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Provision managed Battleaxe shelf artifacts with binary shelf mounts in builder and task containers
> - Mounts a binary shelf directory (`/root/.cache/sugar/binary-shelf-v2`) into managed builder and task containers via `sugar_bx_build_artifacts_docker` and `sugar_bx_run_docker` in [sugar-bx.sh](https://github.com/TSavo/sugar/pull/6488/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc); task containers get a read-only mount, builder containers get read-only by default.
> - When the `build` subcommand runs with `SUGAR_BINARY_PUBLISH=1`, the shelf is mounted writable to allow artifact publishing.
> - Sets `SUGAR_BINARY_ALLOW_BUILD=0` by default in managed builder containers to prevent implicit builds; publish-related env vars are only forwarded when provisioning or when their value is 0.
> - Non-build subcommands in [sugarbin](https://github.com/TSavo/sugar/pull/6488/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) now fail fast with exit status 2 if any of `SUGAR_BINARY_ALLOW_BUILD`, `SUGAR_BINARY_PUBLISH`, or `SUGAR_BINARY_REQUIRE_PUBLISH` are set to nonzero.
> - Risk: the inner build script no longer forces `SUGAR_BINARY_PUBLISH=0`, so explicitly forwarded publish settings now take effect where they previously would have been suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c844aca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a managed binary shelf to improve binary reuse across remote builds and runs.
  * Added configuration for the remote binary shelf location.
  * Build operations can now provision and publish binaries with appropriate writable access.

* **Bug Fixes**
  * Prevented non-build commands from using provisioning or publishing authority.
  * Ensured ordinary managed runs use the binary shelf in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->