### PR TITLE
Project assigned managers into multi-item With

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -565,13 +565,11 @@ def populate_source_derived_resource_refs(
 
     from sugar_lift_py_tests.context_manager_resolution import (
         SourceDerivedContextManagerRefV1,
-        SourceFragmentCoordinateV1,
     )
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
     from sugar_lift_py_tests.ir import _term_content_cid
     from sugar_lift_py_tests.outcome import Complete
     from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
-    from sugar_source_tree.nodes import Call, With
 
     from .dependency_artifact import (
         ResolvedPythonObjectV1,
@@ -595,27 +593,7 @@ def populate_source_derived_resource_refs(
         source_file.unit.source_cid,
         module_identities={},
     )
-    uses = {}
-    for node in source_file.nodes():
-        if not isinstance(node, With):
-            continue
-        for item in node.items:
-            expr = item.context_expr
-            if not isinstance(expr, Call):
-                continue
-            span = expr.line_col_span()
-            coordinate = SourceFragmentCoordinateV1(
-                expr.unit.source_cid,
-                span.start_line,
-                span.start_col,
-                span.end_line,
-                span.end_col,
-            )
-            uses[(span.start_line, span.start_col, span.end_line, span.end_col)] = (
-                coordinate,
-                expr,
-                item._exit_face_id(),
-            )
+    uses = _projected_manager_call_uses(source_file)
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
     for receipt in receipts:
         raw_site = receipt.use["useSite"]
@@ -757,6 +735,83 @@ def populate_source_derived_resource_refs(
                 protocol,
             )
         )
+
+
+def _projected_manager_call_uses(source_file):
+    """Project ordinary reaching assignments into context-manager call uses.
+
+    ``WithItem.substitute`` retains the consumer's immutable use coordinate
+    while the existing block substitution transaction replaces a bare Name
+    with its reaching value.  Reading that projection preserves shadowing and
+    undecided values without creating a second binding mechanism here.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_source_tree.nodes import Call, With
+
+    uses = {}
+
+    def collect(root, *, projected_names: bool) -> None:
+        for node in root.walk():
+            if not isinstance(node, With):
+                continue
+            for item in node.items:
+                expr = item.context_expr
+                if not isinstance(expr, Call):
+                    continue
+                if not projected_names and hasattr(item, "manager_use_site_start_line"):
+                    continue
+                span = expr.line_col_span()
+                start_line, start_col, end_line, end_col = (
+                    item._manager_use_site_span()
+                )
+                if projected_names and (
+                    start_line,
+                    start_col,
+                    end_line,
+                    end_col,
+                ) == (
+                    span.start_line,
+                    span.start_col,
+                    span.end_line,
+                    span.end_col,
+                ):
+                    # The projected frame also contains ordinary direct-call
+                    # managers.  Their existing source node is authoritative;
+                    # only a call borrowed from another locus is an assigned
+                    # manager projection.
+                    continue
+                coordinate = SourceFragmentCoordinateV1(
+                    expr.unit.source_cid,
+                    start_line,
+                    start_col,
+                    end_line,
+                    end_col,
+                )
+                uses[(span.start_line, span.start_col, span.end_line, span.end_col)] = (
+                    coordinate,
+                    expr,
+                    item._exit_face_id(),
+                )
+
+    # Preserve the original direct-call route exactly.
+    collect(source_file.root, projected_names=False)
+
+    # Project only frames that actually contain the new bare-Name shape.  A
+    # module-wide substitution would enter unrelated functions and demand
+    # contracts for sites outside this population pass.
+    for function in source_file.functions():
+        if not any(
+            isinstance(node, With)
+            and len(node.items) > 1
+            and any(item.context_expr.kind == "Name" for item in node.items)
+            for node in function.walk()
+        ):
+            continue
+        collect(function.substitute({}), projected_names=True)
+
+    return uses
 
 
 def _gap_kind_and_detail(gap) -> tuple[str, str | None]:

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_summary_derivation import (
+    _projected_manager_call_uses,
+    populate_source_derived_resource_refs,
+)
+
+PANDAS_SOURCE_CID = (
+    "blake3-512:60e7b5ba2c971960e4d8edcaa85e916704dc8bfb977bc15dafb2f2b3e87458ff"
+    "ba4b2f823e500c4c591a968b7c3e8ed436035aa171e8b3227055d9956147fae1"
+)
+
+
+def _pandas_root() -> Path:
+    distribution = importlib.metadata.distribution("pandas")
+    package = Path(distribution.locate_file("pandas")).resolve()
+    assert distribution.version == "3.0.3"
+    assert package.is_dir()
+    return package.parent
+
+
+def _real_tree():
+    root = _pandas_root()
+    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
+    assert path.is_file()
+    assert blake3_512_of(path.read_bytes()) == PANDAS_SOURCE_CID
+    return open_source_file_for_construction(
+        path,
+        root=root,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+
+
+def _line_32_with(tree):
+    return next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 32
+    )
+
+
+def test_pandas_303_two_name_managers_project_their_assignment_calls() -> None:
+    """The verified corpus site consumes two distinct acquired managers."""
+    tree = _real_tree()
+    site = _line_32_with(tree)
+    assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
+
+    projected = _projected_manager_call_uses(tree)
+    rows = sorted(
+        (call.line_col_span().start_line, coordinate.start_line, coordinate.start_col)
+        for coordinate, call, _exit_face in projected.values()
+        if coordinate.start_line == 32
+    )
+    assert rows == [(21, 32, 13), (30, 32, 18)]
+
+
+def test_projection_is_a_transaction_and_does_not_mutate_the_source_tree() -> None:
+    tree = _real_tree()
+    site = _line_32_with(tree)
+    before = tuple(item.context_expr for item in site.items)
+
+    _projected_manager_call_uses(tree)
+
+    assert tuple(item.context_expr for item in site.items) == before
+    assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
+
+
+def test_pandas_303_assigned_manager_keeps_provider_refusal_loud() -> None:
+    """Projection reaches the provider but never invents a resource value."""
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+    tree = _real_tree()
+    root = _pandas_root()
+    with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
+        populate_source_derived_resource_refs(
+            tree,
+            root=root,
+            path=root / "pandas/tests/io/formats/test_ipython_compat.py",
+        )
+
+
+def test_undecided_rebinding_does_not_invent_a_second_manager_call(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: the second Name no longer reaches acquired call state."""
+    source = tmp_path / "twin.py"
+    source.write_text(
+        "def exercise(make_manager, undecided):\n"
+        "    first = make_manager()\n"
+        "    second = make_manager()\n"
+        "    second = undecided\n"
+        "    with first, second:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+
+    projected = _projected_manager_call_uses(tree)
+    rows = [
+        (coordinate.start_line, coordinate.start_col, call.line_col_span().start_line)
+        for coordinate, call, _exit_face in projected.values()
+        if coordinate.start_line == 5
+    ]
+    assert rows == [(5, 9, 2)]


### PR DESCRIPTION
## What changed

- project ordinary Assign bindings into bare-Name items on native multi-item With nodes
- retain each manager consumer coordinate while authenticating the producer call coordinate
- keep undecided rebinding as a third value instead of inventing a manager
- pin the pandas 3.0.3 site at tests/io/formats/test_ipython_compat.py:32, transactional non-mutation, a lying twin, and the current named provider refusal

## Why

The pinned pandas corpus acquires two context managers before a single two-item With. The demand table authenticates the acquisition calls, while the With heads are bare Names. Construction must carry the ordinary assignment testimony to both items without a vendor spelling table or a second binding mechanism.

## Validation

- 3 passed, 1 deselected: real projection, transaction, lying twin
- 1 passed, 3 deselected: exact SourceCallBindingGap refusal
- existing returned-assertion test remains red identically on untouched 1ab800b75 with OpaqueSourceCallResolutionGap
- bin/bpytest refuses before collection: missing source-stamped shelf binary a667...d86e0f with build fallback disabled

The provider refusal is intentionally not repaired here because that belongs to the neighboring source-call subsystem. No exit_set.py, outcome, or generator construction files changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project assigned managers into bare-Name items in multi-item `with` statements
> - Adds `_projected_manager_call_uses()` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6489/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to collect context-manager call uses, including calls assigned to bare-Name items in multi-item `with` statements via a substitution transaction.
> - The projection runs without mutating the source tree; direct call sites are preserved and deduplicated.
> - `populate_source_derived_resource_refs` now delegates to this helper instead of building the `uses` mapping inline.
> - Tests in [test_assigned_multi_manager_with.py](https://github.com/TSavo/sugar/pull/6489/files#diff-39dfa4631059709fd6ce0d1d2335df9ea2678bcb05ffd238bf1633210c95f181) verify projection against a pinned pandas 3.0.3 file and guard against tree mutation and undecided rebinding inventing extra calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88da546.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->