### PR TITLE
Key Sugar shelf on Rust build inputs

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -605,7 +605,8 @@ require_b3sum() {
 }
 
 rust_build_input_stream() {
-  # Shared preimage with tools/sugar_source_stamp.py (kit + binary identity).
+  # Shared preimage with tools/sugar_source_stamp.py: the Cargo package's
+  # local Rust dependency closure only.
   python3 "$repo_root/tools/sugar_source_stamp.py" --stream \
     --repo-root "$repo_root" \
     --rust-workspace "$rust_workspace" \

--- a/implementations/rust/sugar-cli/build.rs
+++ b/implementations/rust/sugar-cli/build.rs
@@ -4,16 +4,7 @@ fn main() {
     for path in git_paths_to_watch() {
         println!("cargo:rerun-if-changed={path}");
     }
-    // Rebuild when protocol Python sources change (they are part of sourceStamp
-    // for sugar-cli via tools/sugar_source_stamp.py).
-    for rel in [
-        "../../python/sugar-lift-py-tests/src",
-        "../../python/sugar-lift-python-source/src",
-        "../../python/sugar-source-tree/src",
-        "../../../tools/sugar_source_stamp.py",
-    ] {
-        println!("cargo:rerun-if-changed={rel}");
-    }
+    println!("cargo:rerun-if-changed=../../../tools/sugar_source_stamp.py");
     println!("cargo:rerun-if-env-changed=SUGAR_BUILD_STAMP");
     println!("cargo:rerun-if-env-changed=SUGAR_BUILD_GIT_HEAD");
     // Git HEAD is informational attestation only — never default for identity.

--- a/tests/source_stamp_compat_twins.sh
+++ b/tests/source_stamp_compat_twins.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Twins for sourceStamp-only kit/binary compatibility (#4577 redo).
+# Twins for Rust build sourceStamp and kit/binary agreement (#4577 redo).
 set -euo pipefail
 repo="${1:?usage: source_stamp_compat_twins.sh REPO_ROOT}"
 cd "$repo"
@@ -23,22 +23,28 @@ docs_stamp="$(stamp)"
 rm -f "$tmp_doc"
 [[ "$base" == "$docs_stamp" ]] || { echo "docs-only change altered sourceStamp" >&2; exit 1; }
 
-# Twin: protocol Python change must alter stamp.
+# Twin: Python sources are runtime inputs, not Rust build inputs. The shelf
+# identity must survive Python-only merges so one Rust artifact is reusable.
 py_touch="$(mktemp "$repo/implementations/python/sugar-lift-py-tests/src/.stamp-twin.XXXXXX")"
 echo "# twin" >"$py_touch"
 py_stamp="$(stamp)"
 rm -f "$py_touch"
-[[ "$base" != "$py_stamp" ]] || { echo "python protocol change did not alter sourceStamp" >&2; exit 1; }
+[[ "$base" == "$py_stamp" ]] || { echo "python-only change altered Rust sourceStamp" >&2; exit 1; }
 
 # Twin: after remove, stamp returns.
 restored="$(stamp)"
 [[ "$base" == "$restored" ]] || { echo "stamp did not restore after python twin cleanup" >&2; exit 1; }
 
-# Twin: relevant Rust source change alters stamp.
-rs_touch="$(mktemp "$repo/implementations/rust/sugar-cli/src/.stamp-twin.XXXXXX.rs")"
-echo "// twin" >"$rs_touch"
+# Opposite twin: changing one byte in an existing Rust source changes stamp.
+rs_target="$repo/implementations/rust/sugar-cli/src/main.rs"
+rs_backup="$(mktemp /tmp/source-stamp-rust-byte.XXXXXX.rs)"
+cp -p "$rs_target" "$rs_backup"
+trap 'cp -p "$rs_backup" "$rs_target"; rm -f "$rs_backup"' EXIT
+printf '\n// sourceStamp byte twin\n' >>"$rs_target"
 rs_stamp="$(stamp)"
-rm -f "$rs_touch"
+cp -p "$rs_backup" "$rs_target"
+rm -f "$rs_backup"
+trap - EXIT
 [[ "$base" != "$rs_stamp" ]] || { echo "rust source change did not alter sourceStamp" >&2; exit 1; }
 
 # Compatibility gate: mismatch is loud.
@@ -65,4 +71,4 @@ for provenance in implementations/python/*/src/*/source_provenance.py; do
     || { echo "$provenance does not compute the sugar-cli sourceStamp (#6224)" >&2; exit 1; }
 done
 
-echo "PASS: sourceStamp twins (docs stable, rust/python protocol matter, gate uses SUGAR_BUILD_STAMP, every python kit testifies sourceStamp)"
+echo "PASS: sourceStamp twins (docs/Python stable, Rust bytes matter, gate uses SUGAR_BUILD_STAMP, every python kit testifies sourceStamp)"

--- a/tests/sugarbin_build_identity_target.sh
+++ b/tests/sugarbin_build_identity_target.sh
@@ -2,6 +2,17 @@
 set -euo pipefail
 
 repo="${1:?usage: sugarbin_build_identity_target.sh REPO_ROOT}"
+
+# The executable cell is keyed by Rust build matter only. Keep this source
+# ratchet beside sugarbin's identity tests because bin/sugarbin delegates the
+# preimage to this tool; Python runtime sources must never re-enter that stream.
+stamp_tool="$repo/tools/sugar_source_stamp.py"
+grep -Fq "cargo package local dependency FS" "$stamp_tool"
+if grep -Eq 'PYTHON_PROTOCOL_SRC|protocol-python-(root|path)' "$stamp_tool"; then
+  echo 'Rust sourceStamp still includes Python runtime sources' >&2
+  exit 1
+fi
+
 tmp_root="${SUGARBIN_EXEC_TMPDIR:-$repo/.sugar/test-tmp}"
 mkdir -p "$tmp_root"
 tmp="$(mktemp -d "$tmp_root/sugarbin-build-identity.XXXXXX")"

--- a/tools/python_test_environment_identity.py
+++ b/tools/python_test_environment_identity.py
@@ -10,8 +10,8 @@ Fields (all load-bearing, all hashed into `environmentIdentityHash`):
 
   pythonImplementation / pythonVersion / pythonAbi   the interpreter
   platform                                            the machine + libc/OS
-  sourceStamp                                         the Rust+Python build
-                                                      inputs, from the same
+  sourceStamp                                         the Rust build inputs,
+                                                      from the same
                                                       preimage `bin/sugarbin`
                                                       hashes (tools/sugar_source_stamp.py)
   testExtraInputHash                                  hash of the [test] table
@@ -20,8 +20,8 @@ Fields (all load-bearing, all hashed into `environmentIdentityHash`):
                                                       -- the SOLE dependency
                                                       authority (#6275)
   packageBuildInputHash                               hash of every packaged
-                                                      source file of the
-                                                      packages installed
+                                                      Python source file of
+                                                      the packages installed
 
 Usage:
     python tools/python_test_environment_identity.py \

--- a/tools/sugar_source_stamp.py
+++ b/tools/sugar_source_stamp.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-"""Authenticated sourceStamp for sugar-cli (and kit/binary compatibility).
+"""Authenticated Rust build sourceStamp for a Cargo package.
 
 Emits the same labeled byte stream sugarbin hashes into sourceStamp:
 
   - cargo package local dependency FS (under implementations/rust)
-  - when package is sugar-cli: Python enumeration/protocol sources under
-    implementations/python/{sugar-lift-py-tests,sugar-lift-python-source,
-    sugar-source-tree}/src
 
-Excludes docs, .git, and other repository state. Path coordinates use
-underscore form: blake3-512_<hex>.
+Python, repository docs, .git, build output, and other non-Rust-package state
+are deliberately excluded: this stamp keys the compiled Rust artifact, not the
+whole runtime composition. Path coordinates use underscore form:
+blake3-512_<hex>.
 
 Usage:
   tools/sugar_source_stamp.py --repo-root ROOT --package sugar-cli
@@ -39,14 +38,6 @@ SKIP_DIRS = {
     "__pycache__",
 }
 SKIP_FILES = {".DS_Store"}
-
-# Python packages that own enumeration / kit protocol behavior for mint.
-PYTHON_PROTOCOL_SRC = (
-    "implementations/python/sugar-lift-py-tests/src",
-    "implementations/python/sugar-lift-python-source/src",
-    "implementations/python/sugar-source-tree/src",
-)
-
 
 def emit(label: bytes, value: bytes) -> None:
     out = sys.stdout.buffer
@@ -97,7 +88,6 @@ def write_stream(
     cargo: str,
 ) -> None:
     root = rust_workspace.resolve()
-    repo = repo_root.resolve()
     if not root.is_dir():
         raise SystemExit(f"rust workspace not found: {root}")
 
@@ -188,17 +178,6 @@ def write_stream(
 
     for package_root in local_roots:
         seen |= walk_emit(root, package_root)
-
-    # Protocol sources that change kit/binary compatibility without living in
-    # the Rust package graph (sugar.enumerate lives here).
-    if package == "sugar-cli":
-        for rel in PYTHON_PROTOCOL_SRC:
-            py_root = repo / rel
-            if not py_root.is_dir():
-                continue
-            emit(b"protocol-python-root", rel.encode())
-            walk_emit(repo, py_root, path_label=b"protocol-python-path")
-
 
 def stamp_from_stream() -> str:
     import hashlib


### PR DESCRIPTION
## Root cause

`tools/sugar_source_stamp.py` appended 430 files from three Python package source trees after walking the Cargo local-dependency closure. Python-only merges therefore minted new Rust artifact cells even when no Rust build input changed.

## Fix

- restrict the source stamp to the Cargo package local dependency filesystem closure
- remove matching Python `rerun-if-changed` watches from the Rust build script
- keep Python environment authentication in the existing byte-hashing `packageBuildInputHash`
- pin same-Rust/different-Python stability and changed-Rust-byte discrimination twins
- ratchet `sugarbin` identity tests against reintroducing Python runtime paths

## Validation

- `tests/source_stamp_compat_twins.sh "$PWD"`
- `/Users/tsavo/sugar-defect-drain/.venv/bin/python -m pytest -q tests/test_python_suite_identity_gate_twins.py` (8 passed)
- `tests/sugarbin_build_identity_target.sh "$PWD"`
- `bash tests/sugarbin_shelf_immutability.sh "$PWD"`
- two worktrees at the same commit, one with an untracked Python test, produced the identical Rust-only stamp

The artifact refusal and exact-stamp lookup remain unchanged; this makes the claimed Rust identity stable instead of accepting a near miss.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude Python protocol sources from Rust build `sourceStamp` in `sugar_source_stamp.py`
> - Removes the block in [`sugar_source_stamp.py`](https://github.com/TSavo/sugar/pull/6490/files#diff-3fd8d991eebf8874468c4f7380950ac16544b396c37a8af13a7c0c421e53a35d) that emitted Python protocol source paths for `sugar-cli`, so the computed `sourceStamp` now reflects only the Cargo package's local Rust dependency closure.
> - Updates [`build.rs`](https://github.com/TSavo/sugar/pull/6490/files#diff-5bf266285b7f0c7e9ed2a3b8efdc7693d33840588cf8d7865fb13495274a5a7b) to replace multiple `cargo:rerun-if-changed` directives for Python source directories with a single directive for `tools/sugar_source_stamp.py`.
> - Updates [`source_stamp_compat_twins.sh`](https://github.com/TSavo/sugar/pull/6490/files#diff-03efd12a87f0f1d29d7b6cab01c47e194485a74d592aabf7d5cdabc664f7b7c2) to assert that `sourceStamp` is stable across Python-only changes and changes when any Rust source file byte changes.
> - Adds pre-test assertions to [`sugarbin_build_identity_target.sh`](https://github.com/TSavo/sugar/pull/6490/files#diff-f723da7bd4ea671ebfa49bd0db49229a5d488c823f137e942daa0725f1a9775d) that fail early if the stamp tool references Python sources or omits mention of local Cargo dependency FS.
> - Behavioral Change: `sugar-cli` will no longer rebuild when Python protocol source files change; it rebuilds only on Rust source or `sugar_source_stamp.py` changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32dd2de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->