### PR TITLE
Refuse undecided Attribute producer exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -145,17 +145,8 @@ class CallSiteValue(FloorValue):
         return self.exception_type_coordinate
 
     def attribute(self, name, site):
-        """Retain attribute lookup on this exact constructed call result.
-
-        Construction does not execute the call or invent the attribute value;
-        downstream source construction receives the stable projection term.
-        """
-        del site
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor, str_const
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(SymbolicValue(ctor("py.getattr", [self.term, str_const(name)])))
+        """Keep an unexecuted call result's member lookup a named third value."""
+        return self.undecided_attribute(name, site, owner="CallSiteValue.attribute")
 
     def _identity(self) -> tuple:
         """Authenticate this immutable callsite's finite coordinate once.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -581,6 +581,24 @@ class FloorValue:
         )
         construction_panic(info)
 
+    def undecided_attribute(self, name, site, *, owner: str):
+        """Refuse lookup when source testimony decides neither outgoing edge."""
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner=owner,
+            blame=site,
+            observed=(
+                "undecided receiver runtime type or member semantics: "
+                f"{type(self).__name__}.{name}"
+            ),
+            requested="a source-authenticated attribute success or exceptional exit",
+            fix=(
+                "carry receiver-type and member testimony to the attribute floor; "
+                "do not guess AttributeError or invent a completed projection"
+            ),
+        )
+
     def contains(self, item, site):
         # Default: this value does not stand on the membership floor -- it cannot
         # answer whether it holds `item`. A symbolic container stays the py.in

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -396,16 +396,7 @@ class SymbolicValue(FloorValue):
         )
 
     def attribute(self, name, site):
-        # A symbolic receiver stays the py.getattr coordinate: an opaque term
-        # `py.getattr(recv, "name")`, the same EUF vocabulary as py.subscript.
-        # The lift does not know the receiver's fields, so `.name` is an
-        # uninterpreted projection -- decidable only where it later meets an
-        # equality, never invented.
-        del site
-        from sugar_lift_py_tests.ir import ctor, str_const
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(SymbolicValue(ctor("py.getattr", [self.term, str_const(name)])))
+        return self.undecided_attribute(name, site, owner="SymbolicValue.attribute")
 
     def contains(self, item, site):
         # `item in self`: a symbolic container stays the py.in coordinate, a

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -1,0 +1,185 @@
+"""Attribute lookup is an effect producer; undecided lookup stays named-loud."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import hashlib
+import mmap
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import CallSiteValue, NoneValue, SymbolicValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor, make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.nodes import Attribute
+from sugar_source_tree.tree import SourceFile
+
+CORPUS_ROOT = Path("/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages")
+SITE = CORPUS_ROOT / "pandas/tests/test_register_accessor.py"
+SITE_SHA256 = "4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793"
+SOURCE_CID = (
+    "blake3-512:43cdd8a4f204ef75c77996a7e7a98b84bcd174de708cfe1e9e430415bbd636e2"
+    "186f44518e941e76854029b14db48605c43ff6c242c0750322c215eb7c646013"
+)
+MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+DEMAND_TABLE_KEY = (
+    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
+    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _site_attribute(source: str) -> Attribute:
+    assert blake3_512_of(source.encode()) == SOURCE_CID
+    tree = SourceFile(
+        workspace_path_source(str(SITE), root=str(CORPUS_ROOT)),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "bad"
+        and node.line_col_span().start_line == 104
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _call_result() -> CallSiteValue:
+    return CallSiteValue(
+        "source-constructor",
+        (),
+        (),
+        ctor("call:source-constructor", []),
+        None,
+    )
+
+
+@dataclass(frozen=True)
+class _ReceiverSugar(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _assert_undecided(node: Attribute, receiver, *, name: str | None = None) -> None:
+    operation = replace(
+        node.sugar(),
+        receiver=_ReceiverSugar(receiver),
+        name=node.attr if name is None else name,
+    )
+    with pytest.raises(ConstructionPanic) as raised:
+        operation.desugar(None)
+    info = raised.value.info
+    assert info.owner == f"{type(receiver).__name__}.attribute"
+    assert "undecided" in info.observed
+    assert "source-authenticated attribute success or exceptional exit" in (
+        info.requested
+    )
+    assert "AttributeError" not in info.observed
+    assert "AttributeError" not in info.requested
+    assert "RuntimeEffect" not in info.observed
+    assert "RuntimeEffect" not in info.requested
+
+
+def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) -> None:
+    output = tmp_path / "python-demand-table.json"
+    pulled = subprocess.run(
+        [
+            str(_repo_root() / "bin/sugarbin"),
+            "artifact",
+            "pull",
+            "--kind",
+            "python-demand-table",
+            "--content-key",
+            DEMAND_TABLE_KEY,
+            "--output",
+            str(output),
+            "--runtime",
+            "cpython-3.14.4",
+        ],
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert pulled.returncode == 0 and output.is_file(), (
+        "the authenticated #6464 demand table is absent; do not rebuild it: "
+        + pulled.stderr
+    )
+    with output.open("rb") as table_file, mmap.mmap(
+        table_file.fileno(), 0, access=mmap.ACCESS_READ
+    ) as table:
+        assert table.find(DEMAND_TABLE_KEY.encode()) >= 0
+        assert table.find(MANIFEST_CID.encode()) >= 0
+        assert table.find(b'"pandas": "3.0.3"') >= 0
+        assert table.find(b'"fileCount": 1421') >= 0
+        cursor = 0
+        rows = []
+        while True:
+            cursor = table.find(b'"startLine": 103', cursor)
+            if cursor < 0:
+                break
+            window = table[max(0, cursor - 5000) : cursor + 5000]
+            if (
+                SOURCE_CID.encode() in window
+                and b'"kind": "context-manager-demand"' in window
+                and b'"targetSymbol": "pytest.raises"' in window
+                and b'"gapKind": null' in window
+                and b'"startCol": 13' in window
+                and b'"endCol": 58' in window
+            ):
+                rows.append(cursor)
+            cursor += 1
+        assert len(rows) >= 1
+
+
+def test_real_pandas_constructed_receiver_attribute_is_named_undecided() -> None:
+    source = SITE.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
+    node = _site_attribute(source)
+
+    _assert_undecided(node, _call_result())
+
+
+def test_symbolic_receiver_attribute_is_the_same_named_third_value() -> None:
+    source = SITE.read_text(encoding="utf-8")
+    node = _site_attribute(source)
+
+    _assert_undecided(node, SymbolicValue(make_var("series")))
+
+
+def test_lying_known_member_does_not_license_blanket_attribute_error() -> None:
+    outcome = NoneValue().attribute("__class__", "lying-none-class")
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+
+
+def test_replacing_bad_with_known_member_still_cannot_invent_an_exit() -> None:
+    source = SITE.read_text(encoding="utf-8")
+    assert source.count("pd.Series([], dtype=object).bad") == 1
+    lying = source.replace(
+        "pd.Series([], dtype=object).bad",
+        "pd.Series([], dtype=object).__class__",
+    )
+    assert "pd.Series([], dtype=object).__class__" in lying
+
+    _assert_undecided(_site_attribute(source), _call_result(), name="__class__")

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
@@ -17,15 +17,19 @@ def _guard():
     return atomic("choose", [])
 
 
-def test_guarded_attribute_distributes_to_symbolic_faces():
+def test_guarded_attribute_keeps_symbolic_face_refusal_loud():
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
     true_face = SymbolicValue(make_var("t"))
     false_face = SymbolicValue(make_var("f"))
     guarded = GuardedValue(_guard(), true_face, false_face)
-    outcome = guarded.attribute("x", "site")
-    assert isinstance(outcome, Complete)
-    assert isinstance(outcome.value, GuardedValue)
-    assert outcome.value.when_true.term.name == "py.getattr"
-    assert outcome.value.when_false.term.name == "py.getattr"
+    try:
+        guarded.attribute("x", "site")
+    except ConstructionPanic as panic:
+        assert panic.info.owner == "SymbolicValue.attribute"
+        assert panic.info.observed.endswith("SymbolicValue.x")
+    else:
+        raise AssertionError("guarded symbolic attribute invented completion")
 
 
 def test_guarded_list_membership_opposite_faces_emit_predicate():

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -1,13 +1,10 @@
-"""Member access on an OPAQUE object is a symbolic read, not a gap.
+"""Opaque member operations refuse until a producer owns their runtime edges.
 
-`OpaqueObjectStateV1` is an authenticated call-result identity with no field
-testimony: statically we know only WHICH call produced it, never its fields.
-Attribute reads retain their honest coordinate. A subscript is also an effect
-producer, however, and an opaque result cannot authenticate whether lookup
-succeeds or which exception it raises, so that operation stays named-loud.
-
-A free-function call `g(x)` is the deterministic opaque receiver (no vendor,
-no numpy): its result has no field testimony, exactly like `np.asarray(...)`.
+An unexecuted call authenticates which call produced the receiver, but not its
+runtime type or members.  A completed ``py.getattr`` coordinate would silently
+choose the success edge; a guessed ``AttributeError`` would silently choose the
+failure edge.  Neither choice has source testimony, so both attribute and
+subscript operations remain named construction refusals.
 """
 
 import os
@@ -15,74 +12,66 @@ import tempfile
 
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
-from sugar_lift_py_tests.ir import (
-    atomic as _atomic,
-    ctor as _ctor,
-    make_var,
-    str_const,
-    eq as _eq,
-)
 
 
-def _post_of(src):
-    d = tempfile.mkdtemp()
-    p = os.path.join(d, "m.py")
-    open(p, "w").write(src)
-    fn = list(SourceFile(path_source(p)).functions())[0]
-    return fn.sugar().desugar(None).value.post()
+def _refusal(src):
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    directory = tempfile.mkdtemp()
+    path = os.path.join(directory, "m.py")
+    with open(path, "w", encoding="utf-8") as source_file:
+        source_file.write(src)
+    function = next(SourceFile(path_source(path)).functions())
+    try:
+        function.sugar().desugar(None)
+    except ConstructionPanic as panic:
+        return panic.info
+    raise AssertionError("opaque member operation invented a completed coordinate")
 
 
-def test_opaque_attribute_is_getattr_not_gap():
-    # `g(x).foo` -- attribute on an opaque call result -- projects the honest
-    # symbolic read, NOT SugarNotWritten and NOT a fabricated field value.
-    post = _post_of("def f(x):\n    return g(x).foo\n")
-    expected = _eq(
-        make_var("out"),
-        _ctor("py.getattr", [_ctor("call:g", [make_var("x")]), str_const("foo")]),
+def test_opaque_attribute_is_named_undecided():
+    info = _refusal("def f(x):\n    return g(x).foo\n")
+
+    assert info.owner == "CallSiteValue.attribute"
+    assert info.observed.endswith("CallSiteValue.foo")
+    assert "source-authenticated attribute success or exceptional exit" in (
+        info.requested
     )
-    assert post == expected, f"post was {post!r}"
 
 
 def test_opaque_subscript_is_named_undecided():
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    info = _refusal("def f(x):\n    return g(x)[0]\n")
 
-    try:
-        _post_of("def f(x):\n    return g(x)[0]\n")
-    except ConstructionPanic as panic:
-        assert panic.info.owner == "CallSiteValue.subscript"
-        assert "undecided receiver runtime type" in panic.info.observed
-    else:  # pragma: no cover - the lying arm
-        raise AssertionError("opaque subscript invented a completed coordinate")
+    assert info.owner == "CallSiteValue.subscript"
+    assert "undecided receiver runtime type" in info.observed
 
 
-def test_opaque_member_access_no_longer_raises():
-    # The discrimination against the OLD behavior: the guard used to raise
-    # SugarNotWritten on any opaque receiver. Construction must now complete.
-    from sugar_source_tree.panic import SugarNotWritten
+def test_opaque_attribute_uses_the_typed_construction_refusal():
+    info = _refusal("def f(x):\n    return g(x).foo\n")
 
-    try:
-        _post_of("def f(x):\n    return g(x).foo\n")
-    except SugarNotWritten as e:  # pragma: no cover - the regression tripwire
-        raise AssertionError(f"opaque member access wrongly withheld: {e}")
+    assert info.gap_locus.value == "Construction"
+    assert "AttributeError" not in info.observed
+    assert "AttributeError" not in info.requested
 
 
-def test_opaque_attribute_congruence():
-    # Same attribute on the SAME opaque call is the SAME term (equal-in-equal-out
-    # one level up). Two `g(x).foo` reads produce identical coordinates.
-    a = _post_of("def f(x):\n    return g(x).foo\n")
-    b = _post_of("def f(x):\n    return g(x).foo\n")
-    assert a == b
+def test_opaque_attribute_refusal_is_reproducible():
+    first = _refusal("def f(x):\n    return g(x).foo\n")
+    second = _refusal("def f(x):\n    return g(x).foo\n")
+
+    assert (first.owner, first.observed, first.requested) == (
+        second.owner,
+        second.observed,
+        second.requested,
+    )
 
 
 def test_opaque_attribute_name_is_carried_verbatim():
-    # The attribute name is a static identifier carried onto the coordinate,
-    # never desugared: `.bar` yields "bar", distinct from `.foo`.
-    post = _post_of("def f(x):\n    return g(x).bar\n")
-    expected = _eq(
-        make_var("out"),
-        _ctor("py.getattr", [_ctor("call:g", [make_var("x")]), str_const("bar")]),
-    )
-    assert post == expected, f"post was {post!r}"
+    foo = _refusal("def f(x):\n    return g(x).foo\n")
+    bar = _refusal("def f(x):\n    return g(x).bar\n")
+
+    assert foo.observed.endswith(".foo")
+    assert bar.observed.endswith(".bar")
+    assert foo.observed != bar.observed
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8321,11 +8321,10 @@ class Attribute(Expression):
         """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
         The attr name is a static identifier carried onto the coordinate.
 
-        An OpaqueObjectStateV1 receiver is NOT withheld: `.attr` on an opaque
-        call result is a symbolic read the witness resolves at runtime, not a
-        gap. It reduces to the honest `py.getattr(recv, "attr")` EUF coordinate
-        (SymbolicValue.attribute), carrying whatever the call term guarantees and
-        nothing invented. Withholding it here was the gap, not the construct."""
+        An opaque receiver still constructs this native operation. Its floor
+        decides whether source testimony supplies a value or exceptional exit;
+        when neither is known, the producer refuses instead of inventing a
+        completed ``py.getattr`` projection or guessing ``AttributeError``."""
         from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 
         return AttributeSugar(

--- a/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
@@ -2,8 +2,8 @@
 
 Each mirrors an existing dispatch: UnaryOp routes to the operand value's floor
 method (`not` composes truth+negate); BoolOp combines the operands' truthiness
-via and_/or_; Attribute asks the receiver for `.name` (a symbolic receiver stays
-the opaque py.getattr coordinate, like py.subscript).
+via and_/or_; Attribute asks the receiver for `.name` and a symbolic receiver
+refuses because source testimony decides neither lookup edge.
 """
 
 import tempfile
@@ -69,20 +69,26 @@ def test_bare_operands_use_py_truthy():
 # ---- Attribute ---------------------------------------------------------------
 
 
-def test_attribute_is_the_py_getattr_coordinate():
-    post = _post("def A(z):\n    return z.numerator\n")
-    getattr_term = post.args[1]
-    assert getattr_term.name == "py.getattr"
-    assert getattr_term.args[0].name == "z"
-    assert getattr_term.args[1].value == "numerator"
+def _attribute_refusal(source):
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    try:
+        _post(source)
+    except ConstructionPanic as panic:
+        return panic.info
+    raise AssertionError("symbolic attribute invented a completed projection")
 
 
-def test_attribute_chain_nests():
-    # z.a.b -> py.getattr(py.getattr(z, "a"), "b")
-    post = _post("def A(z):\n    return z.a.b\n")
-    outer = post.args[1]
-    assert outer.name == "py.getattr" and outer.args[1].value == "b"
-    assert outer.args[0].name == "py.getattr" and outer.args[0].args[1].value == "a"
+def test_attribute_is_named_undecided():
+    info = _attribute_refusal("def A(z):\n    return z.numerator\n")
+    assert info.owner == "SymbolicValue.attribute"
+    assert info.observed.endswith("SymbolicValue.numerator")
+
+
+def test_attribute_chain_refuses_at_the_first_unowned_lookup():
+    info = _attribute_refusal("def A(z):\n    return z.a.b\n")
+    assert info.owner == "SymbolicValue.attribute"
+    assert info.observed.endswith("SymbolicValue.a")
 
 
 if __name__ == "__main__":
@@ -91,6 +97,6 @@ if __name__ == "__main__":
     test_and_conjoins_operand_truthiness()
     test_or_disjoins_operand_truthiness()
     test_bare_operands_use_py_truthy()
-    test_attribute_is_the_py_getattr_coordinate()
-    test_attribute_chain_nests()
+    test_attribute_is_named_undecided()
+    test_attribute_chain_refuses_at_the_first_unowned_lookup()
     print("ok: UnaryOp, BoolOp, Attribute drained through the node")


### PR DESCRIPTION
## What changed

- audited the landed Attribute floors against pandas 3.0.3 `test_register_accessor.py:103-104`
- replaced completed `py.getattr` invention for unexecuted call results and symbolic receivers with one named third-value producer refusal
- retained concrete `NoneValue.__class__` completion as the lying twin that prevents blanket `AttributeError` invention
- strengthened the old opaque-member tests from completed-coordinate coverage to named-refusal laws
- left assertion-With, ExitSet/outcome, and generator construction untouched

## Root cause

`CallSiteValue.attribute` and `SymbolicValue.attribute` always returned `Complete(SymbolicValue(py.getattr(...)))`. For an assertion body consisting only of an Attribute operation, that silently chose the success edge even though source construction authenticated neither member existence nor an exceptional edge. The assertion consumer consequently saw body completion rather than a producer exit.

The repair does not guess `AttributeError`. Undecided member dispatch now raises a typed `ConstructionPanic` owned by the producer floor and asks for source-authenticated success or exceptional testimony.

## Evidence

- exact corpus: pandas 3.0.3, 1421 files, manifest `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`
- exact source: `pandas/tests/test_register_accessor.py`, SHA-256 `4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793`
- shared #6464 demand table authenticates the `pytest.raises` manager at line 103
- authenticated focused packages: `33 passed`
- mutation: restoring invented completed `py.getattr` caused `7 failed, 3 passed`; reverted; clean `33 passed`
- `bin/bpytest` refused before collection on missing stamp `blake3-512_0b244bdcedd009ccb8cfa53c5ff1484f8627dbb8171da82cf3f6b884c163c0da00df2d392515af1b4f64f69b1f3f7e19e31bd39af45bc0d63e93181b22e5d114`; build fallback remained disabled

Base: `18da8d5fb3461d9120b46f5a2e29b9deb9de1580`
Head: `75cf66c1c82ab503cdcb5fa0e1da6f5f9430deff`

Open for review. Do not merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse undecided attribute lookups with named `ConstructionPanic` instead of emitting symbolic `py.getattr` terms
> - `SymbolicValue.attribute` and `CallSiteValue.attribute` previously returned a completed `py.getattr` projection when the receiver's member semantics were unknown; they now raise a `ConstructionPanic` via a new `FloorValue.undecided_attribute` helper.
> - `FloorValue.undecided_attribute` centralizes the refusal, reporting the receiver type and attribute name and requesting source-authenticated testimony rather than guessing.
> - Tests in [`test_attribute_exceptional_exit_producer.py`](https://github.com/TSavo/sugar/pull/6491/files#diff-9d776645f85cbc6b9afbf85b90a31db44f6ff21e8756fb5ac24bc70d030bec67), [`test_opaque_member_access.py`](https://github.com/TSavo/sugar/pull/6491/files#diff-97cffe687899663a657b602f3545cbe10e18887c9039047baba54a94f9bcd206), and [`test_guarded_attribute_membership.py`](https://github.com/TSavo/sugar/pull/6491/files#diff-0307021d2c8e27daa1f6b5148c52c2112bbb5fccadbba7135731307217f75300) are updated to expect refusals instead of `py.getattr` terms.
> - Behavioral Change: code that previously received a completed symbolic `py.getattr` value from an undecided attribute lookup will now get a `ConstructionPanic` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25b9db6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->