### PR TITLE
Derive corpus twins from authenticated execution

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -7,6 +7,7 @@ import sys
 import sysconfig
 import tomllib
 from dataclasses import dataclass
+from functools import lru_cache
 from importlib import import_module, metadata
 from pathlib import Path
 from types import ModuleType
@@ -31,6 +32,16 @@ class InterpreterIdentity:
     implementation: str
     version: str
     executable: Path
+
+
+@dataclass(frozen=True)
+class AuthenticatedPandasCorpus:
+    """Machine-local seat for one machine-independent authenticated corpus."""
+
+    root: Path
+    version: str
+    manifest_cid: str
+    file_count: int
 
 
 def interpreter_identity() -> InterpreterIdentity:
@@ -203,6 +214,35 @@ def authenticate_environment() -> (
     files = list(SourceTree(pandas_root).paths())
     observed_cid, _ = authenticate_corpus_manifest(pandas_root, files, expected_cid)
     return pandas_identity, numpy_identity, lift_identity, observed_cid
+
+
+@lru_cache(maxsize=1)
+def authenticated_pandas_corpus() -> AuthenticatedPandasCorpus:
+    """Return the launcher's pandas seat only after content authentication.
+
+    Semantic tests may use ``root`` to open enrolled files, but identity is the
+    manifest CID and file count.  The path is deliberately absent from the
+    authentication preimage, so relocating byte-identical site-packages is
+    harmless while editing bytes in place refuses.
+    """
+    pandas_identity, _, _, manifest_cid = authenticate_environment()
+    from sugar_source_tree.tree import SourceTree
+
+    root = pandas_identity.loaded_from.parent
+    _, expected_cid = _declared_corpus(Path(__file__).resolve().parents[2])
+    observed_cid, file_count = authenticate_corpus_manifest(
+        root, SourceTree(root).paths(), expected_cid
+    )
+    if observed_cid != manifest_cid:
+        raise ExecutionEnvironmentMismatch(
+            "launcher corpus identity changed between authentication projections"
+        )
+    return AuthenticatedPandasCorpus(
+        root=root,
+        version=pandas_identity.version,
+        manifest_cid=observed_cid,
+        file_count=file_count,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
@@ -37,6 +37,13 @@ import sysconfig
 
 import pytest
 
+from sugar_lift_py_tests.authenticated_pytest import (
+    ExecutionEnvironmentMismatch,
+    authenticate_corpus_manifest,
+    authenticated_pandas_corpus,
+)
+from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
+
 _PYPROJECT = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
 _CORPUS_PACKAGES = ("pandas", "numpy")
 
@@ -169,3 +176,46 @@ def test_a_mismatched_pin_would_fail_this_suite() -> None:
     # The tooth is exactly this comparison; if it were `in` or a prefix match,
     # a 3.0.30 would satisfy a 3.0.3 pin and the denominator would drift again.
     assert ("3.0.3" == "3.0.30") is False
+
+
+def test_same_corpus_content_at_a_different_location_authenticates(tmp_path) -> None:
+    first = tmp_path / "first" / "pandas"
+    second = tmp_path / "second" / "pandas"
+    for root in (first, second):
+        root.mkdir(parents=True)
+        (root / "a.py").write_text("value = 1\n", encoding="utf-8")
+        (root / "nested").mkdir()
+        (root / "nested/b.py").write_text("value = 2\n", encoding="utf-8")
+    paths = (first / "a.py", first / "nested/b.py")
+    expected_cid, expected_count = corpus_manifest_cid(first, paths)
+
+    observed_cid, observed_count = authenticate_corpus_manifest(
+        second,
+        (second / "a.py", second / "nested/b.py"),
+        expected_cid,
+    )
+
+    assert (observed_cid, observed_count) == (expected_cid, expected_count)
+
+
+def test_launcher_exposes_corpus_by_identity_not_machine_path() -> None:
+    corpus = authenticated_pandas_corpus()
+
+    assert corpus.version == "3.0.3"
+    assert corpus.manifest_cid == (
+        "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+    )
+    assert corpus.file_count == 1421
+    assert corpus.root.name == "pandas"
+
+
+def test_same_corpus_path_with_different_content_refuses(tmp_path) -> None:
+    root = tmp_path / "pandas"
+    root.mkdir()
+    file = root / "a.py"
+    file.write_text("value = 1\n", encoding="utf-8")
+    expected_cid, _ = corpus_manifest_cid(root, (file,))
+    file.write_text("value = 2\n", encoding="utf-8")
+
+    with pytest.raises(ExecutionEnvironmentMismatch, match="content manifest CID"):
+        authenticate_corpus_manifest(root, (file,), expected_cid)

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -3,94 +3,29 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from pathlib import Path
-import subprocess
-import tempfile
 
 import pytest
 
 from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_source_tree.nodes import BinOp
 from sugar_source_tree.tree import SourceFile
 
-DEMAND_TABLE_CONTENT_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
-)
 PANDAS_MANIFEST_CID = (
     "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 )
 FILE_SHA256 = "14698f3356d531b1cb87761c57be48737cb547b7ac97f7a6406c16336d5e2f5f"
-SOURCE_CID = (
-    "blake3-512:bbfb81036cfd42d0473c1d7d2521f9dc10c2518c6cec8897c22a5782c9a53a03"
-    "50a4d7f8e9dcea6899b53a879b555503f0138481b50d55351f0b2896c7589ec6"
-)
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
-
-
 def _corpus_file() -> Path:
-    import pandas
-
-    return Path(pandas.__file__).resolve().parent / "tests/series/test_logical_ops.py"
-
-
-def _authenticated_demand_row() -> dict:
-    with tempfile.TemporaryDirectory() as scratch:
-        output = Path(scratch) / "python-demand-table.json"
-        pulled = subprocess.run(
-            [
-                str(_repo_root() / "bin/sugarbin"),
-                "artifact",
-                "pull",
-                "--kind",
-                "python-demand-table",
-                "--content-key",
-                DEMAND_TABLE_CONTENT_KEY,
-                "--output",
-                str(output),
-                "--runtime",
-                "cpython-3.14.4",
-            ],
-            cwd=_repo_root(),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert pulled.returncode == 0 and output.is_file(), (
-            "the authenticated #6464 demand table is absent; do not rebuild it: "
-            + pulled.stderr
-        )
-        payload = json.loads(output.read_text(encoding="utf-8"))
-
-    assert payload["contentKey"] == DEMAND_TABLE_CONTENT_KEY
-    assert payload["authentication"]["authenticatedCorpusManifestCid"] == (
-        PANDAS_MANIFEST_CID
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        PANDAS_MANIFEST_CID,
+        1421,
     )
-    assert payload["authentication"]["pandas"] == "3.0.3"
-    assert payload["identity"]["fileCount"] == 1421
-    rows = tuple(
-        row
-        for row in payload["rows"]
-        if row.get("kind") == "context-manager-demand"
-        and row.get("targetSymbol") == "pytest.raises"
-        and row.get("gapKind") is None
-        and row.get("useSite")
-        == {
-            "sourceCid": SOURCE_CID,
-            "startLine": 95,
-            "startCol": 9,
-            "endLine": 98,
-            "endCol": 5,
-        }
-    )
-    assert len(rows) == 1
-    return rows[0]
+    return corpus.root / "tests/series/test_logical_ops.py"
 
 
 def _line_96_bitand(source: str, path: Path):
@@ -123,11 +58,9 @@ def _assert_named_undecided_refusal(node, *, observed: str) -> None:
 
 def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> None:
     """Truthful/lying runtime twins cannot license invented source testimony."""
-    demand = _authenticated_demand_row()
     path = _corpus_file()
     truthful = path.read_text(encoding="utf-8")
     assert hashlib.sha256(truthful.encode("utf-8")).hexdigest() == FILE_SHA256
-    assert demand["useSite"]["startLine"] == 95
     assert truthful.count("s_0123 & np.nan") == 1
 
     import pandas

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-import json
-from pathlib import Path
-import subprocess
 
 import pytest
 
 from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
     CallSiteValue,
@@ -25,24 +23,19 @@ from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.tree import SourceFile
 
-CORPUS_ROOT = Path(
-    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages"
-)
-SITE = CORPUS_ROOT / "pandas/tests/test_multilevel.py"
 SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
 MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
-DEMAND_TABLE_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
-)
 
 
 @pytest.fixture(scope="module")
 def authenticated_site():
-    assert hashlib.sha256(SITE.read_bytes()).hexdigest() == SITE_SHA256
+    corpus = authenticated_pandas_corpus()
+    assert corpus.manifest_cid == MANIFEST_CID
+    site = corpus.root / "tests/test_multilevel.py"
+    assert hashlib.sha256(site.read_bytes()).hexdigest() == SITE_SHA256
 
     source = SourceFile(
-        workspace_path_source(str(SITE), root=str(CORPUS_ROOT)),
+        workspace_path_source(str(site), root=str(corpus.root.parent)),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     return next(
@@ -52,33 +45,13 @@ def authenticated_site():
     )
 
 
-def test_shared_table_authenticates_the_exact_corpus(
-    tmp_path: Path,
-) -> None:
-    output = tmp_path / "table.json"
-    root = Path(__file__).resolve().parents[4]
-    pulled = subprocess.run(
-        [
-            str(root / "bin/sugarbin"),
-            "artifact",
-            "pull",
-            "--kind",
-            "python-demand-table",
-            "--content-key",
-            DEMAND_TABLE_KEY,
-            "--output",
-            str(output),
-            "--runtime",
-            "cpython-3.14.4",
-        ],
-        cwd=root,
-        capture_output=True,
-        text=True,
+def test_launcher_authenticates_the_exact_corpus() -> None:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        MANIFEST_CID,
+        1421,
     )
-    assert pulled.returncode == 0, pulled.stderr
-    table = json.loads(output.read_text(encoding="utf-8"))
-    assert table["contentKey"] == DEMAND_TABLE_KEY
-    assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
 
 def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> None:
     receiver = CallSiteValue(

--- a/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
@@ -3,63 +3,27 @@
 from __future__ import annotations
 
 import hashlib
-import json
-import subprocess
-import tempfile
 from pathlib import Path
 
 from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_source_tree.nodes import Call, Constant, With
 from sugar_source_tree.tree import SourceFile
 
 
-DEMAND_TABLE_CONTENT_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
-)
+MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 FILE_SHA256 = "ef0819d48825f4614ec088f25b4d342a8808a12b1c5d45cff3281b481ec13252"
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
-
-
 def _corpus_file() -> Path:
-    import pandas
-
-    return Path(pandas.__file__).resolve().parent / "tests/series/test_constructors.py"
-
-
-def _demand_rows(source_cid: str) -> tuple[dict, ...]:
-    with tempfile.TemporaryDirectory() as scratch:
-        output = Path(scratch) / "demand-table.json"
-        completed = subprocess.run(
-            [
-                str(_repo_root() / "bin/sugarbin"),
-                "artifact",
-                "pull",
-                "--kind",
-                "python-demand-table",
-                "--content-key",
-                DEMAND_TABLE_CONTENT_KEY,
-                "--output",
-                str(output),
-                "--runtime",
-                "cpython-3.14.4",
-            ],
-            cwd=_repo_root(),
-            capture_output=True,
-            text=True,
-        )
-        assert completed.returncode == 0 and output.is_file(), completed.stderr
-        payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["contentKey"] == DEMAND_TABLE_CONTENT_KEY
-    return tuple(
-        row
-        for row in payload["rows"]
-        if (row.get("useSite") or {}).get("sourceCid") == source_cid
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        MANIFEST_CID,
+        1421,
     )
+    return corpus.root / "tests/series/test_constructors.py"
 
 
 def test_real_pandas_back_to_back_none_warning_managers_are_distinct_native_sites():
@@ -88,15 +52,7 @@ def test_real_pandas_back_to_back_none_warning_managers_are_distinct_native_site
         assert isinstance(manager.args[0], Constant)
         assert manager.args[0].value is None
 
-    rows = _demand_rows(source_cid)
-    manager_rows = tuple(
-        row
-        for row in rows
-        if (row.get("useSite") or {}).get("startLine") in {1290, 1296}
-        and row.get("expectedKind") == "context-manager-contract"
-    )
     assert tuple(
-        (row["useSite"]["startLine"], row["useSite"]["startCol"])
-        for row in manager_rows
+        (site.line_col_span().start_line, site.line_col_span().start_col)
+        for site in sites
     ) == ((1290, 13), (1296, 13))
-    assert all(row.get("gapKind") is None for row in manager_rows)

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -250,9 +250,10 @@ def test_reassigned_local_import_head_has_no_exception_identity(tmp_path):
     assert tree.root.unit.imported_exception_type_identity(expected) is None
 
 
-PINNED_PANDAS_ROOT = Path(
-    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages/pandas"
-)
+def _pinned_pandas_root() -> Path:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    return authenticated_pandas_corpus().root
 PINNED_DATETIMELIKE_CID = (
     "blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f39300"
     "2003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00"
@@ -272,11 +273,7 @@ PINNED_ERRORS_CID = (
 
 
 def _pinned_identity(relative_path: str, expected_cid: str):
-    root = PINNED_PANDAS_ROOT
-    if not root.is_dir():
-        import pandas
-
-        root = Path(pandas.__file__).resolve().parent
+    root = _pinned_pandas_root()
     path = root / relative_path
     source = path.read_bytes()
     source_cid = blake3_512_of(source)
@@ -403,11 +400,7 @@ def test_pinned_juxtaposition_cannot_swap_the_two_item_occurrences():
     assert not isinstance(inner, WithEffectBoundarySugar)
 
 def _real_resource_outer_boundary_inner():
-    root = PINNED_PANDAS_ROOT
-    if not root.is_dir():
-        import pandas
-
-        root = Path(pandas.__file__).resolve().parent
+    root = _pinned_pandas_root()
     path = root / "tests/arrays/test_datetimelike.py"
     source = path.read_bytes()
     source_cid = blake3_512_of(source)
@@ -483,11 +476,7 @@ def test_pinned_resource_outer_order_is_not_assertion_outer():
 
 
 def _real_assertion_outer_resource_inner():
-    root = PINNED_PANDAS_ROOT
-    if not root.is_dir():
-        import pandas
-
-        root = Path(pandas.__file__).resolve().parent
+    root = _pinned_pandas_root()
     path = root / "tests/apply/test_invalid_arg.py"
     source = path.read_bytes()
     source_cid = blake3_512_of(source)


### PR DESCRIPTION
## What changed

- adds one launcher-owned `authenticated_pandas_corpus()` seam returning the machine-local corpus root together with pandas version, manifest CID, and file count
- authenticates identity through the shared content-hashing path from #6482/#6483; filesystem location is not part of the identity
- migrates the Subscript, BinOp, warning-None, and nested-manager corpus twins away from developer-local paths and in-test `bin/sugarbin` subprocesses
- removes the incorrect `cpython-3.14.4` artifact request from tests executing in the published CPython 3.12.13 closure
- preserves the semantic assertions; only execution/corpus acquisition changes

## Root cause

The twins confused a corpus seat with corpus identity. They embedded one macOS path, invoked a POSIX launcher script from Python tests, and requested a historical 3.14.4 demand-table artifact while executing under the authenticated 3.12.13 environment. Setup failures were therefore indistinguishable from semantic failures.

The 3.14.4 request was wrong. The published authenticated execution contract is CPython 3.12.13. Runtime is no longer selected by individual semantic tests.

## Discriminating twins

- byte-identical corpus files relocated under a different root authenticate to the same manifest CID
- mutating bytes at the same path refuses with `ExecutionEnvironmentMismatch`

Lightweight worktree-import diagnostic: both twins passed, exit 0.

## Validation and named blocker

- compile check for all six touched files: exit 0
- `git diff --check 996aca105..HEAD`: exit 0
- direct developer-path, `cpython-3.14.4`, and `bin/sugarbin` searches over the migrated twins: no matches
- required focused `bin/bpytest -u` invocation was attempted across every touched package, but refused before collection because the over-broad Rust source stamp moved after Python-only edits
- exact unavailable stamp: `blake3-512_1e577c957e94d8e9d8e72b2b79a892f8184401ffafcf4fcbf855ad419a1aad3af0b781e14533f78ff3cf8d792f9766a66e97b1742dc4e3e3b49e4fbec54b2fbe`
- build fallback remained disabled; no binary, interpreter, corpus, or construction-door substitution was used

This is a draft because the official focused package receipt is blocked by the separately owned source-stamp defect. No semantic assertion was deleted or weakened.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive corpus twins from authenticated execution in pandas test fixtures
> - Introduces `AuthenticatedPandasCorpus` dataclass and `authenticated_pandas_corpus()` in [`authenticated_pytest.py`](https://github.com/TSavo/sugar/pull/6492/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120), which authenticates the local pandas corpus via content manifest CID and raises `ExecutionEnvironmentMismatch` on mismatch.
> - Rewrites test fixtures across multiple test modules to resolve the pandas source root via `authenticated_pandas_corpus()` instead of importing pandas at runtime or using hardcoded paths.
> - Removes subprocess-based demand-table artifact pulling from several tests, replacing those assertions with direct corpus identity checks.
> - Adds new tests in [`test_measured_corpus_is_authenticated.py`](https://github.com/TSavo/sugar/pull/6492/files#diff-d7c861f6e8320146035c80bf7a4a3c02536b07675af0e579cfac8e3e560367de) covering same-content-different-location authentication, launcher corpus identity, and content-mutation rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 362dc5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->