### PR TITLE
Preserve unary and boolean operator exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -760,8 +760,9 @@ class FloorValue:
         construction_panic(info)
 
     def bitwise_invert(self, site):
-        # Default: no bitwise-not floor. TermValue folds ints; SymbolicValue
-        # emits py.invert; absence is the honest "no".
+        # Default: no bitwise-not floor. TermValue decides concrete operands;
+        # an untyped symbol refuses because success versus TypeError is not
+        # source-decidable.
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -367,12 +367,10 @@ class SymbolicValue(FloorValue):
         return Complete(self)
 
     def bitwise_invert(self, site):
-        # Symbolic bitwise NOT: emit py.invert(term).
-        del site
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(SymbolicValue(ctor("py.invert", [self.term])))
+        # The term does not state a runtime type, so it cannot decide whether
+        # ``~`` returns a value or raises TypeError.  A symbolic coordinate for
+        # the success face would erase that exceptional face.
+        return super().bitwise_invert(site)
 
     def subscript(self, index, site):
         if self.formal_coordinate is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -548,23 +548,21 @@ class TermValue(FloorValue):
         return Complete(TermValue(+self.value))
 
     def bitwise_invert(self, site):
-        # Bitwise NOT: fold ints; floats raise TypeError at runtime in Python.
-        if type(self.value) is int:
+        # Bitwise NOT: fold ints; a known float has a ground TypeError exit.
+        if isinstance(self.value, int):
             from sugar_lift_py_tests.outcome import Complete
 
-            return Complete(TermValue(~self.value))
-        from sugar_lift_py_tests.effect import (
-            TypeErrorRuntimeEffect,
-            runtime_effect_evidence,
-        )
-        from sugar_lift_py_tests.outcome import Incomplete
+            # ``bool`` is an int subtype and Python 3.14 still defines its
+            # inversion through the underlying integer.  Convert explicitly
+            # so construction does not emit CPython's runtime deprecation
+            # warning while calculating a source-decided result.
+            return Complete(TermValue(~int(self.value)))
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-        return Incomplete(
-            TypeErrorRuntimeEffect(
-                f"bad operand type for unary ~: "
-                f"'float'; owner=TermValue.bitwise_invert site={site}",
-                **runtime_effect_evidence("py.bitwise_invert", self, site),
-            )
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="TermValue.bitwise_invert",
         )
 
     def to_term(self, *, owner: str):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -39,50 +39,73 @@ class BoolOpSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from functools import reduce
-
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.outcome import Complete, ExitSet, outcome_to_exitset
         from sugar_lift_py_tests.outcome.exit_set import (
+            Completed,
             _and_guards,
             _or_guards,
+            complement_guard,
             factored_operand,
+            false_guard,
+            partition,
+            true_guard,
         )
         from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
-        # Operands thread through `and_then`, the one door every Outcome variant
-        # implements. An operand that halts propagates -- the boolean is not
-        # decidable once a conjunct halts -- and an operand that PARTITIONS
-        # (`a and (d[k] := f())`, a conjunct whose store can halt) keeps both
-        # arms: each completed arm folds its own formula under its own guard.
-        # Reading `.value` off the outcome assumed exactly one arm and was the
-        # `'ExitSet' object has no attribute 'value'` defect here.
-        def collect(operand, collected):
-            # One completed arm per operand (#6324): an unfactored partitioning
-            # conjunct multiplies the accumulated formula tuple, and k conjuncts
-            # distribute into m ** k arms.
-            return factored_operand(operand.desugar(ctx)).and_then(
-                # Same truth→formula projection as if/if-exp: symbolic formulas
-                # stand as themselves; ground True/False (including None.truth →
-                # False) fold through true_guard/false_guard. Never raise bare
-                # NotImplementedError on a constructible ground boolean.
-                lambda value: Complete(
-                    (*collected, predicate_formula(value, self.site))
-                )
-            )
-
-        outcome = Complete(())
-        for operand in self.values:
-            outcome = outcome.and_then(
-                lambda collected, operand=operand: collect(operand, collected)
-            )
-
-        # Fold with the shared guard algebra so ground identities absorb:
-        #   false ∧ φ → false,  true ∧ φ → φ,  true ∨ φ → true,  false ∨ φ → φ.
-        # Raw and_/or_ would leave and_([false, true]) as a connective and hide
-        # that None and True is false in boolean context.
         combine = _and_guards if self.op_kind == "And" else _or_guards
-        return outcome.and_then(
-            lambda formulas: Complete(
-                PredicateValue(reduce(combine, formulas), self.site)
+        stop_formula = false_guard() if self.op_kind == "And" else true_guard()
+
+        def reduce_from(index: int):
+            operand = self.values[index]
+            standing = factored_operand(operand.desugar(ctx)).and_then(
+                lambda value: Complete(predicate_formula(value, self.site))
             )
-        )
+
+            def continue_from(formula):
+                last = index == len(self.values) - 1
+                if last:
+                    return Complete(PredicateValue(formula, self.site))
+
+                # A decided stopping face never evaluates the RHS at all.
+                if formula == stop_formula:
+                    return Complete(PredicateValue(stop_formula, self.site))
+                if (self.op_kind == "And" and formula == true_guard()) or (
+                    self.op_kind == "Or" and formula == false_guard()
+                ):
+                    return reduce_from(index + 1)
+
+                tail = reduce_from(index + 1)
+                tail_es = outcome_to_exitset(tail)
+                halted = any(not isinstance(edge, Completed) for edge in tail_es.exits)
+
+                # If construction established that every RHS face completes,
+                # its truth formula is available and the ordinary boolean
+                # formula remains a single value.  No exceptional edge is being
+                # hidden in this arm.
+                if not halted and len(tail_es.exits) == 1:
+                    tail_value = tail_es.exits[0].value
+                    return Complete(
+                        PredicateValue(combine(formula, tail_value.formula), self.site)
+                    )
+
+                # Otherwise Python evaluates the tail only on this face.  The
+                # complementary face completes with the short-circuit result;
+                # the RHS halt is conditional, never promoted to unconditional
+                # and never discarded as absent.
+                rhs_guard = (
+                    formula if self.op_kind == "And" else complement_guard(formula)
+                )
+                rhs_face, stop_face = partition(
+                    ("BoolOpSugar", str(self.site), index, self.op_kind)
+                )
+                rhs = tail_es.guarded(rhs_guard, rhs_face)
+                stopped = ExitSet.completed(
+                    PredicateValue(stop_formula, self.site),
+                    complement_guard(rhs_guard),
+                ).guarded(true_guard(), stop_face)
+                return rhs.union(stopped)
+
+            return standing.and_then(continue_from)
+
+        return reduce_from(0)

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -1,0 +1,201 @@
+"""UnaryOp and BoolOp exceptional-exit producer laws.
+
+The corpus witnesses are pandas 3.0.3 source, while the discrimination twins
+exercise the native floors directly.  No assertion-manager spelling grants an
+operator an exception it cannot establish from source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.floor import RaiseValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import atomic, make_var, not_
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
+from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
+from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.temporal import TemporalContext
+from sugar_lift_py_tests.context import ReduceContext
+
+CORPUS = Path(
+    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages/pandas"
+)
+UNARY_SITE = CORPUS / "tests/extension/base/ops.py"
+BOOLOP_SITE = CORPUS / "tests/generic/test_generic.py"
+DEMAND_TABLE_KEY = (
+    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
+    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+)
+MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+UNARY_SOURCE_CID = (
+    "blake3-512:e67b3f17a16e69f16ea8d1e0b19eff3f27f8acb8beac1dcb923066ad5901c039"
+    "a6949846351444d20ec05e193006125a7781fe4ef2503e0f8eb6bfebffbc7fca"
+)
+BOOLOP_SOURCE_CID = (
+    "blake3-512:851b7839bb2cdb42bcb34227ea39b4c84e8324ca164a5875283b934ede5935cb4"
+    "ce94ecaf08a4e83d608f9c9a676760892b1be24f953f9a1999175d479a8075c"
+)
+
+
+class _Site:
+    filename = "pandas-producer-twin.py"
+    line = 1
+    col = 0
+    source = "operator"
+    unit = type("_Unit", (), {"source": "~value\n"})()
+
+
+def test_verified_pandas_303_reproducers_are_content_pinned() -> None:
+    assert hashlib.sha256(UNARY_SITE.read_bytes()).hexdigest() == (
+        "bd98339ca8660c94faf9afdd8900d382a27c88c7f179a71f2a165b278d2bb66e"
+    )
+    assert hashlib.sha256(BOOLOP_SITE.read_bytes()).hexdigest() == (
+        "cbc5383e8e1545537baedca85a6c62a487d3bea6942bb56e5e0c7479dd2f188d"
+    )
+    assert (
+        "with pytest.raises(TypeError):\n                ~ser" in UNARY_SITE.read_text()
+    )
+    source = BOOLOP_SITE.read_text()
+    assert (
+        "with pytest.raises(ValueError, match=msg):\n            obj1 and obj2"
+        in source
+    )
+    assert (
+        "with pytest.raises(ValueError, match=msg):\n            obj1 or obj2" in source
+    )
+
+
+def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -> None:
+    root = Path(__file__).resolve().parents[4]
+    output = tmp_path / "python-demand-table.json"
+    pulled = subprocess.run(
+        [
+            str(root / "bin/sugarbin"),
+            "artifact",
+            "pull",
+            "--kind",
+            "python-demand-table",
+            "--content-key",
+            DEMAND_TABLE_KEY,
+            "--output",
+            str(output),
+            "--runtime",
+            "cpython-3.14.4",
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    assert pulled.returncode == 0, pulled.stderr
+    table = json.loads(output.read_text(encoding="utf-8"))
+    assert table["contentKey"] == DEMAND_TABLE_KEY
+    assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
+    assert table["authentication"]["pandas"] == "3.0.3"
+    assert table["identity"]["fileCount"] == 1421
+    sites = {
+        (row["useSite"]["sourceCid"], row["useSite"]["startLine"])
+        for row in table["rows"]
+        if row.get("kind") == "context-manager-demand"
+        and row.get("gapKind") is None
+        and row.get("targetSymbol") == "pytest.raises"
+    }
+    assert (UNARY_SOURCE_CID, 257) in sites
+    assert {(BOOLOP_SOURCE_CID, 151), (BOOLOP_SOURCE_CID, 153)} <= sites
+
+
+def test_unary_invert_unknown_operand_is_named_undecided() -> None:
+    with pytest.raises(ConstructionPanic) as caught:
+        SymbolicValue(make_var("ser")).bitwise_invert(_Site())
+
+    assert caught.value.info.owner == "bitwise_invert"
+    assert caught.value.info.observed == "SymbolicValue"
+    assert "TypeError" not in str(caught.value.info)
+
+
+def test_unary_invert_concrete_integer_truthful_twin_folds() -> None:
+    outcome = TermValue(3).bitwise_invert(_Site())
+    assert outcome == Complete(TermValue(-4))
+
+
+def test_unary_invert_concrete_bool_truthful_twin_folds() -> None:
+    outcome = TermValue(True).bitwise_invert(_Site())
+    assert outcome == Complete(TermValue(-2))
+
+
+def test_unary_invert_concrete_float_lying_twin_has_typed_effect() -> None:
+    outcome = TermValue(3.5).bitwise_invert(_Site())
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+class _EffectSugar:
+    def __init__(self, effect):
+        self.effect = effect
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        return Incomplete(self.effect)
+
+
+def _boolop(kind: str, left, right, *, temporal=None):
+    return BoolOpSugar(kind, (left, right), _Site()).desugar(
+        ReduceContext(temporal or TemporalContext.empty())
+    )
+
+
+def test_and_false_short_circuits_rhs_effect_truthful_twin() -> None:
+    result = _boolop(
+        "And",
+        FalseBoolLiteralSugar(_Site()),
+        _EffectSugar(ExpectationNotMetEffect("rhs")),
+    )
+    assert result == Complete(result.value)
+    assert result.value.formula == false_guard()
+
+
+def test_or_true_short_circuits_rhs_effect_truthful_twin() -> None:
+    result = _boolop(
+        "Or",
+        TrueBoolLiteralSugar(_Site()),
+        _EffectSugar(ExpectationNotMetEffect("rhs")),
+    )
+    assert result == Complete(result.value)
+    assert result.value.formula == true_guard()
+
+
+@pytest.mark.parametrize(
+    ("kind", "rhs_guard"),
+    (
+        ("And", atomic("py.truthy", [make_var("left")])),
+        ("Or", not_(atomic("py.truthy", [make_var("left")]))),
+    ),
+)
+def test_undecided_left_makes_rhs_effect_conditional(kind, rhs_guard) -> None:
+    temporal = TemporalContext.empty().bind_value(
+        "left", SymbolicValue(make_var("left_truth"))
+    )
+    outcome = _boolop(
+        kind,
+        NameSugar("left", _Site()),
+        _EffectSugar(ExpectationNotMetEffect("rhs")),
+        temporal=temporal,
+    )
+
+    assert isinstance(outcome, ExitSet)
+    halted = [edge for edge in outcome.exits if isinstance(edge, Halted)]
+    assert len(halted) == 1
+    assert halted[0].guard == rhs_guard


### PR DESCRIPTION
## What changed

- refuse unresolved unary invert instead of fabricating a symbolic success coordinate
- turn ground unsupported unary invert into a source-cited TypeError exit
- preserve BoolOp short-circuit control flow so RHS halts are conditional on the left truth face
- pin the pandas 3.0.3 UnaryOp and complete BoolOp corpus family against the shared demand table

## Why

Assertion boundaries consume halted ExitSet edges. Operator producers must therefore publish only source-authenticated exits: unknown unary dispatch stays a named refusal, and an undecided BoolOp left operand guards rather than erases or forces its RHS effect.

## Validation

- `python -m black --check` on all five changed files
- `python -m pytest --noconftest -q test_unary_boolop_exception_producers.py test_bool_op_ground_operand.py` (20 passed)
- mutation transaction: restoring symbolic `py.invert` fails the UnaryOp refusal tooth
- mutation transaction: making BoolOp RHS unconditional fails both conditional-guard teeth

The authenticated launcher could not participate because the exact source-stamped binary is absent with build fallback disabled; direct focused tests used the pinned Python 3.14 environment and consumed the existing shared demand-table artifact.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve unary and boolean operator exits with short-circuit and ground exceptional exit semantics
> - `BoolOpSugar.desugar` now models Python short-circuit semantics: a decided false LHS short-circuits `and` (and vice versa for `or`) without evaluating the RHS, and undecided LHS conditionally evaluates RHS, preserving halted edges as guarded ExitSet edges rather than collapsing them.
> - `TermValue.bitwise_invert` now folds boolean operands as integers (e.g., `True → -2`) and returns a `Complete(RaiseValue(TypeError))` ground exceptional exit for non-integer operands instead of an `Incomplete(TypeErrorRuntimeEffect)`.
> - `SymbolicValue.bitwise_invert` now delegates to `FloorValue.bitwise_invert` (triggering a construction panic) instead of returning an unresolved `py.invert` symbolic term.
> - New tests in [test_unary_boolop_exception_producers.py](https://github.com/TSavo/sugar/pull/6493/files#diff-06bff2278db63ecf1b26d417311cee0c9ba5a6bec1e363833e81a08290ec62f6) pin and verify all three behaviors.
> - Behavioral Change: non-integer `~` operands and undecided `~` on symbolic values now exit via panic/raise paths rather than producing incomplete effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e5ad7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->