### PR TITLE
Keep undecided comparisons loud

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -32,6 +32,49 @@ COMPARE_METHODS: dict[str, str] = {
 # operand: `x in xs` is `xs.contains(x)`).
 COMPARISON_KINDS = frozenset(COMPARE_METHODS) | {"NotEq", "Is", "IsNot", "In", "NotIn"}
 
+_OPERATOR_COORDINATE = {
+    "Eq": "==",
+    "NotEq": "!=",
+    "Lt": "<",
+    "LtE": "<=",
+    "Gt": ">",
+    "GtE": ">=",
+    "In": "in",
+    "NotIn": "not in",
+}
+
+
+def refuse_undecided_comparison(left, right, site, op_kind: str) -> None:
+    """Keep an unexecuted call result's native dispatch at its producer."""
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+
+    if not (left.denotes_value() and right.denotes_value()):
+        return
+    if not isinstance(left, CallSiteValue) and not isinstance(right, CallSiteValue):
+        return
+
+    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    operator = _OPERATOR_COORDINATE[op_kind]
+    construction_panic_gap(
+        owner="comparison_operation_exception_floor",
+        blame=site,
+        observed=(f"{type(left).__name__} {operator} {type(right).__name__}"),
+        requested=(
+            "source-visible native comparison testimony selecting completion "
+            "or an authenticated exceptional exit"
+        ),
+        fix=(
+            "preserve the undecided third value at the Compare producer; "
+            "resolve native operand types and their comparison/containment "
+            "bodies from source, or retain this named refusal without "
+            "inventing an exception identity"
+        ),
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
+
 
 @dataclass(frozen=True)
 class ComparisonOpSugar(Sugar):
@@ -56,7 +99,21 @@ class ComparisonOpSugar(Sugar):
         )
         return left.and_then(right)
 
+    def _membership(self, container, item):
+        """Dispatch membership only when native receiver type is decided.
+
+        An unexecuted call result denotes a Python value, but its runtime type
+        is a third value. Python may select ``__contains__``, fall back through
+        iteration, or raise from either native method. Emitting ``py.in`` there
+        invents completion; choosing TypeError invents an exit. Keep that
+        undecided dispatch loud at the Compare producer.
+        """
+        refuse_undecided_comparison(item, container, self.site, self.op_kind)
+        return container.contains(item, self.site)
+
     def _apply(self, left, right):
+        if self.op_kind not in {"Is", "IsNot", "In", "NotIn"}:
+            refuse_undecided_comparison(left, right, self.site, self.op_kind)
         if self.op_kind == "NotEq":
             # a != b is not (a == b): stand on the equals floor, negate.
             return left.equals(right, self.site).and_then(
@@ -72,10 +129,10 @@ class ComparisonOpSugar(Sugar):
             )
         if self.op_kind == "In":
             # a in b: the CONTAINER (right) owns membership -- b.contains(a).
-            return right.contains(left, self.site)
+            return self._membership(right, left)
         if self.op_kind == "NotIn":
             # a not in b is not (a in b): membership floor, negated.
-            return right.contains(left, self.site).and_then(
+            return self._membership(right, left).and_then(
                 lambda predicate: predicate.negate()
             )
         method = COMPARE_METHODS[self.op_kind]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -98,6 +98,11 @@ def _equals_and_refine(left, right, site, ctx, left_coordinate):
 
 
 def _equals_with_derived_residue(left, right, site, ctx):
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import (
+        refuse_undecided_comparison,
+    )
+
+    refuse_undecided_comparison(left, right, site, "Eq")
     outcome = left.equals(right, site)
 
     from sugar_lift_py_tests.floor import CallSiteValue, PredicateValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -1,0 +1,201 @@
+"""Compare is an effect producer; membership follows native source testimony."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import CallSiteValue, TermValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.nodes import Compare
+from sugar_source_tree.tree import SourceFile
+
+CORPUS_ROOT = Path("/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages")
+SITE = CORPUS_ROOT / "pandas/tests/test_col.py"
+SITE_SHA256 = "a86bcccd3f041ac81a1d6f349d537ee1049c6afa4d799b9293b410da4409f038"
+SOURCE_CID = (
+    "blake3-512:58f9629e47ef9bdb4137fbe31d1c322b22fd1918ec8da1b1725f344d0087d5a27"
+    "f69cb188d8d417d0f6490c6a9531191e789f9e5df14e5070f93455673bacdad"
+)
+MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+DEMAND_TABLE_KEY = (
+    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
+    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+)
+
+
+@dataclass(frozen=True)
+class _ValueSugar(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _compare_at_365(source: str) -> Compare:
+    source_identity = (
+        workspace_path_source(str(SITE), root=str(CORPUS_ROOT))
+        if hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
+        else (source, str(SITE), blake3_512_of(source.encode()))
+    )
+    tree = SourceFile(
+        source_identity,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Compare) and node.line_col_span().start_line == 365
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> None:
+    output = tmp_path / "table.json"
+    pulled = subprocess.run(
+        [
+            str(_repo_root() / "bin/sugarbin"),
+            "artifact",
+            "pull",
+            "--kind",
+            "python-demand-table",
+            "--content-key",
+            DEMAND_TABLE_KEY,
+            "--output",
+            str(output),
+            "--runtime",
+            "cpython-3.14.4",
+        ],
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert pulled.returncode == 0 and output.is_file(), (
+        "the authenticated #6464 demand table is absent; do not rebuild it: "
+        + pulled.stderr
+    )
+    table = json.loads(output.read_text(encoding="utf-8"))
+    assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
+    assert table["authentication"]["pandas"] == "3.0.3"
+    assert table["identity"]["fileCount"] == 1421
+    rows = tuple(
+        row
+        for row in table["rows"]
+        if row.get("kind") == "context-manager-demand"
+        and row.get("targetSymbol") == "pytest.raises"
+        and row.get("gapKind") is None
+        and row.get("useSite")
+        == {
+            "sourceCid": SOURCE_CID,
+            "startLine": 362,
+            "startCol": 9,
+            "endLine": 364,
+            "endCol": 5,
+        }
+    )
+    assert len(rows) == 1
+
+
+def test_pandas_col_membership_refuses_to_invent_type_error() -> None:
+    source = SITE.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _compare_at_365(source).sugar().desugar(None)
+
+    info = raised.value.info
+    assert info.owner == "comparison_operation_exception_floor"
+    assert info.observed == "TermValue in CallSiteValue"
+    assert "source-visible native comparison testimony" in info.requested
+    assert "TypeError" not in str(info)
+
+
+def test_literal_container_lying_twin_does_not_inherit_the_refusal() -> None:
+    source = SITE.read_text(encoding="utf-8")
+    lying = source.replace('1 in pd.col("a")', "1 in [1]")
+    assert lying != source
+
+    outcome = _compare_at_365(lying).sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_runtime_truthful_and_lying_twins_discriminate() -> None:
+    import pandas as pd
+
+    def raises_type_error(thunk) -> bool:
+        try:
+            thunk()
+        except TypeError:
+            return True
+        return False
+
+    with pytest.raises(TypeError, match="not .*iterable"):
+        1 in pd.col("a")
+    assert 1 in [1]
+    with pytest.raises(AssertionError):
+        assert raises_type_error(lambda: 1 in [1])
+
+
+@pytest.mark.parametrize("op_kind", ["Lt", "NotEq", "In", "NotIn"])
+def test_every_nonidentity_comparison_keeps_undecided_dispatch_loud(
+    op_kind: str,
+) -> None:
+    call_result = _ValueSugar(
+        CallSiteValue("unknown", (), (), ctor("call:unknown", []), None)
+    )
+    ground = _ValueSugar(TermValue(1))
+    left, right = (
+        (ground, call_result)
+        if op_kind in {"In", "NotIn"}
+        else (
+            call_result,
+            ground,
+        )
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        ComparisonOpSugar(op_kind, left, right, "compare-site").desugar(None)
+
+    assert raised.value.info.owner == "comparison_operation_exception_floor"
+    assert "TypeError" not in str(raised.value.info)
+
+
+def test_equality_keeps_undecided_native_dispatch_loud() -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        EqualityOpSugar(
+            _ValueSugar(
+                CallSiteValue("unknown", (), (), ctor("call:unknown", []), None)
+            ),
+            _ValueSugar(TermValue(1)),
+            "compare-site",
+        ).desugar(None)
+
+    assert raised.value.info.owner == "comparison_operation_exception_floor"
+    assert "TypeError" not in str(raised.value.info)


### PR DESCRIPTION
## What changed

- keep comparisons involving an unexecuted `CallSiteValue` at the Compare producer until native operand type and dispatch testimony are available
- emit the named `comparison_operation_exception_floor` construction refusal instead of completing an uninterpreted comparison or guessing an exception identity
- preserve identity comparisons, decided native containers, and established solver-owned symbolic coordinates
- authenticate the pandas 3.0.3 reproducer and shared demand-table row, with truthful and lying twins

## Why

At `pandas/tests/test_col.py:365`, `1 in pd.col("a")` previously constructed `Complete(PredicateValue(py.in(...)))`. The call result's runtime type is not decided by source-visible testimony, so that completion invents a successful native membership dispatch. The assertion boundary cannot consume an exceptional exit that Compare never produced.

The new boundary is an explicit refusal: decide native comparison or containment dispatch from source, or remain loud without inventing `TypeError`.

## Measurement

Post-build attribution is bounded to the authenticated reproducer: 1 verified Compare site moved from false completion to 1 named construction refusal. The supplied family denominator remains 181; this PR does not claim a full-corpus delta without running a heavy corpus sweep.

Predicted `Epsilon R`: one known false-completion site removed. Construction panics remain loud by design; timeouts, native crashes, and unaccounted outcomes remain zero in the focused instrument.

## Validation

```text
PYTHONPATH=<all implementations/python/*/src> \
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONUNBUFFERED=1 \
/Users/tsavo/sugar-defect-drain/.venv/bin/python -m pytest --noconftest -q \
  implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py \
  implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py \
  implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py \
  implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py

97 passed in 23.15s
```

Mutation transaction: clean passed; restoring silent completion caused the equality producer twin to fail with `DID NOT RAISE ConstructionPanic`; reverted; clean passed again.

No assertion-With, ExitSet/outcome, generator construction, CI, vendor dispatch, or demand-table construction file changed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise a ConstructionPanic for undecided comparison operands instead of proceeding
> - Adds `refuse_undecided_comparison` in [`comparison_op_sugar.py`](https://github.com/TSavo/sugar/pull/6494/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) that raises a `ConstructionPanic` gap (owner: `comparison_operation_exception_floor`) when either operand is a `CallSiteValue`, for all non-identity comparison kinds.
> - Equality comparisons in [`equality_op_sugar.py`](https://github.com/TSavo/sugar/pull/6494/files#diff-e84076b87cd75964f4dd373e3c1424c63e64ad01c466910cf516b2f408a9ff38) now call the same refusal helper before delegating to `left.equals`.
> - Membership checks route through a new `_membership` method that applies the same refusal before calling `container.contains`.
> - Adds tests in [`test_compare_exceptional_exit_producer.py`](https://github.com/TSavo/sugar/pull/6494/files#diff-fa2b8d1cb82b05e4512ec1bae4c7a4d961547ff92ac23924a9abf1ad25c75388) covering all affected comparison kinds and equality.
> - Behavioral Change: comparisons that previously proceeded with undecided `CallSiteValue` operands now fail at construction time rather than at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab51b67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->