### PR TITLE
Declare CPython 3.12.13 runtime authority

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -1151,16 +1151,17 @@ filesystem_shelf_root() {
 }
 
 filesystem_shelf_cell() {
-  local kind="$1" stamp="$2" name="$3"
+  local kind="$1" stamp="$2" name="$3" runtime="${4:-}"
   if [[ "$kind" == binary ]]; then
     printf '%s/%s/%s/%s/%s\n' \
       "$(filesystem_shelf_root)" "$(platform_key)" "$profile" \
       "$(stamp_for_filename "$stamp")" "$name"
     return 0
   fi
-  printf '%s/%s/%s/%s/%s/%s\n' \
+  [[ -n "$runtime" ]] || { log "artifact shelf cell requires an authenticated runtime"; return 2; }
+  printf '%s/%s/%s/%s/%s/%s/%s\n' \
     "$(filesystem_shelf_root)" "$kind" "$(platform_key)" "$profile" \
-    "$(stamp_for_filename "$stamp")" "$name"
+    "$runtime" "$(stamp_for_filename "$stamp")" "$name"
 }
 
 filesystem_shelf_complete() {
@@ -1171,10 +1172,10 @@ filesystem_shelf_complete() {
 }
 
 publish_to_filesystem_shelf() {
-  local bin="$1" stamp="$2" name="$3" kind="${4:-binary}" manifest cell parent tmp actor sha meta
+  local bin="$1" stamp="$2" name="$3" kind="${4:-binary}" runtime="${5:-}" manifest cell parent tmp actor sha meta
   manifest="$(artifact_manifest_path "$bin")"
   [[ "${SUGAR_BINARY_PUBLISH:-1}" != "0" ]] || { log "publish disabled by SUGAR_BINARY_PUBLISH=0"; return 0; }
-  cell="$(filesystem_shelf_cell "$kind" "$stamp" "$name")"
+  cell="$(filesystem_shelf_cell "$kind" "$stamp" "$name" "$runtime")"
   if filesystem_shelf_complete "$cell" "$name"; then
     log "filesystem shelf already has $name"
     return 0
@@ -1373,7 +1374,7 @@ publish_payload_artifact() {
   payload="$staging/$name"
   cp "$input" "$payload"
   write_payload_artifact_manifest "$payload" "$kind" "$key" "$runtime" || { status=$?; rm -rf "$staging"; return "$status"; }
-  publish_to_filesystem_shelf "$payload" "$key" "$name" "$kind"
+  publish_to_filesystem_shelf "$payload" "$key" "$name" "$kind" "$runtime"
   status=$?
   rm -rf "$staging"
   return "$status"
@@ -1381,7 +1382,7 @@ publish_payload_artifact() {
 
 pull_payload_artifact() {
   local kind="$1" key="$2" runtime="$3" output="$4" name="$5" cell staging payload manifest output_manifest
-  cell="$(filesystem_shelf_cell "$kind" "$key" "$name")"
+  cell="$(filesystem_shelf_cell "$kind" "$key" "$name" "$runtime")"
   if ! filesystem_shelf_complete "$cell" "$name"; then
     log "filesystem shelf miss for $kind key $key"
     return 1
@@ -1412,6 +1413,14 @@ dispatch_artifact_subcommand() {
   [[ "$artifact_kind" == python-demand-table ]] || { log "unknown artifact kind: $artifact_kind"; return 2; }
   [[ "$artifact_key" =~ ^blake3-512[:_][0-9a-f]{128}$ ]] || { log "artifact --content-key must be a blake3-512 content key"; return 2; }
   [[ "$artifact_runtime" =~ ^[A-Za-z0-9._-]+$ ]] || { log "artifact --runtime must be a path-safe name"; return 2; }
+  local declared_python runtime
+  declared_python="$(awk -F ' *= *' '$1 == "python" { gsub(/"/, "", $2); print $2 }' "$repo_root/sugar-build.toml")"
+  [[ -n "$declared_python" ]] || { log "crime=missing-runtime-authority owner=sugar-build.toml replacement=declare tools.python exactly once"; return 78; }
+  runtime="cpython-$declared_python"
+  if [[ "$artifact_runtime" != "$runtime" ]]; then
+    log "crime=undeclared-python-runtime owner=bin/sugarbin required=$runtime requested=$artifact_runtime replacement=request the runtime declared by sugar-build.toml or publish a distinct declared cell"
+    return 78
+  fi
   [[ -z "$artifact_shelf_root" ]] || SUGAR_BINARY_SHELF_ROOT="$artifact_shelf_root"
   local name="$artifact_kind"
   case "$artifact_subcommand" in

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -53,6 +53,30 @@ def interpreter_identity() -> InterpreterIdentity:
     )
 
 
+def declared_interpreter_runtime() -> str:
+    """Read the one managed Python authority from the build manifest."""
+    repo_root = Path(__file__).resolve().parents[5]
+    manifest = tomllib.loads(
+        (repo_root / "sugar-build.toml").read_text(encoding="utf-8")
+    )
+    version = str(manifest["tools"]["python"])
+    return f"cpython-{version}"
+
+
+def authenticate_interpreter_runtime(
+    identity: InterpreterIdentity,
+) -> InterpreterIdentity:
+    """Refuse execution testimony minted outside the declared runtime."""
+    observed = f"{identity.implementation}-{identity.version}"
+    required = declared_interpreter_runtime()
+    if observed != required:
+        raise ExecutionEnvironmentMismatch(
+            "Python runtime authority mismatch: "
+            f"required {required}; observed {observed} at {identity.executable}"
+        )
+    return identity
+
+
 def _inside(path: Path, root: Path) -> bool:
     return path == root or root in path.parents
 
@@ -179,6 +203,7 @@ def _declared_corpus(package_root: Path) -> tuple[dict[str, str], str]:
 def authenticate_environment() -> (
     tuple[ImportIdentity, ImportIdentity, ImportIdentity, str]
 ):
+    authenticate_interpreter_runtime(interpreter_identity())
     package_root = Path(__file__).resolve().parents[2]
     repo_root = Path(__file__).resolve().parents[5]
     activate_checkout_import_roots(repo_root, sys.path)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -15,7 +15,7 @@ the shelf."* Same discipline, second artifact kind:
                 + demand-table schema version
                 + producer source CID
                 + resolution-affecting configuration
-    CELL PATH     platform, interpreter identity, anything situational
+    CELL PATH     platform, exact interpreter patch, anything situational
     EXCLUDED      checkout path, package spelling, monorepo HEAD, docs
 
 RELATIVE PATHS ARE THE WHOLE POINT. Two byte-identical corpora at different
@@ -24,7 +24,7 @@ per-checkout cache wearing a CID. That is the discriminating face, and it is
 the one that proves the key was taken over the preimage rather than the
 location.
 
-RUNTIME IS REPORTED, BUT A MEASURED TWIN REMOVED IT FROM THE CONTENT KEY.
+PARSER IDENTITY IS IN THE CONTENT KEY.
 
 An earlier version of this module excluded runtime identity, on two
 independently-traced verdicts that demand production never CALLS anything
@@ -42,19 +42,11 @@ tree, says so:
 per interpreter for that reason, and it names 3.12 and 3.14 -- which is the
 offload host versus the workstations exactly.
 
-So runtime joined the content key until a measurement said it could leave. The
-two failures are not symmetric: a key that is too SPECIFIC costs a rebuild per
-interpreter and announces itself as a cache miss; a key that is too LOOSE
-silently shares a table built under a different parser behind a valid-looking
-CID, and announces nothing. Loudly-lossy over silently-wrong was the correct
-default while the comparison was absent.
-
-MEASURED RELAXATION. The authenticated producer was run on the same small
-corpus and the same pinned pandas manifest under Battleaxe CPython 3.12.13 and
-workstation CPython 3.14.4. Both produced three demand rows with output CID
-``blake3-512:171cb05a5903a2d929596d9ea33b35432c4f5721f37c5553d2b012063495ee183b0e0281f23f3dbf9ceeadc4d1fb107163e78bfe4d570d457b4a0ae2867fe7fb``.
-The acceptance test pins that output. Runtime therefore stays in the receipt
-and cell-path testimony, but no longer enters the content preimage.
+The managed runtime authority is CPython 3.12.13. A workstation measurement
+under 3.14.4 cannot relax this identity: it is testimony from an undeclared
+runtime, not a second supported cell. The parser's major/minor fingerprint
+therefore remains in the content preimage, while the exact patch identity is
+authenticated at execution and artifact boundaries.
 """
 
 from __future__ import annotations
@@ -105,6 +97,7 @@ class DemandTableIdentityV1:
             "corpusManifestCid": self.corpus_manifest_cid,
             "producerSourceCid": self.producer_source_cid,
             "resolutionConfigCid": self.resolution_config_cid,
+            "parserIdentity": self.parser_identity,
             "fileCount": self.file_count,
         }
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -30,8 +30,8 @@ SOURCE_CID = (
 )
 MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 DEMAND_TABLE_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+    "blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d"
+    "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
 )
 
 
@@ -113,7 +113,7 @@ def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) 
             "--output",
             str(output),
             "--runtime",
-            "cpython-3.14.4",
+            "cpython-3.12.13",
         ],
         cwd=_repo_root(),
         capture_output=True,
@@ -128,6 +128,7 @@ def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) 
         table_file.fileno(), 0, access=mmap.ACCESS_READ
     ) as table:
         assert table.find(DEMAND_TABLE_KEY.encode()) >= 0
+        assert table.find(b'"python": "cpython-3.12.13"') >= 0
         assert table.find(MANIFEST_CID.encode()) >= 0
         assert table.find(b'"pandas": "3.0.3"') >= 0
         assert table.find(b'"fileCount": 1421') >= 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -33,8 +33,8 @@ SOURCE_CID = (
 )
 MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 DEMAND_TABLE_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+    "blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d"
+    "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
 )
 
 
@@ -88,7 +88,7 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
             "--output",
             str(output),
             "--runtime",
-            "cpython-3.14.4",
+            "cpython-3.12.13",
         ],
         cwd=_repo_root(),
         capture_output=True,
@@ -100,6 +100,7 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
         + pulled.stderr
     )
     table = json.loads(output.read_text(encoding="utf-8"))
+    assert table["authentication"]["python"] == "cpython-3.12.13"
     assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
     assert table["authentication"]["pandas"] == "3.0.3"
     assert table["identity"]["fileCount"] == 1421

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -248,11 +248,10 @@ def test_the_named_exception_is_not_a_producer() -> None:
         )
 
 
-# -- measured relaxation: runtime is testimony, not content identity ----------
+# -- parser identity is authenticated content identity -----------------------
 
 
-def test_the_parser_identity_is_reported_but_not_in_the_preimage(tmp_path) -> None:
-    """The measured 3.12/3.14 twin earned runtime's removal from content."""
+def test_the_parser_identity_is_in_the_preimage(tmp_path) -> None:
     import sys
 
     identity = _identity(_corpus(tmp_path / "corpus", _FILES))
@@ -261,37 +260,36 @@ def test_the_parser_identity_is_reported_but_not_in_the_preimage(tmp_path) -> No
         f"{sys.implementation.name}-{sys.version_info.major}."
         f"{sys.version_info.minor}"
     )
-    assert "parserIdentity" not in identity.preimage()
+    assert identity.preimage()["parserIdentity"] == identity.parser_identity
 
 
-def test_a_different_parser_identity_preserves_the_measured_content_key(
+def test_a_different_parser_identity_changes_the_content_key(
     tmp_path,
 ) -> None:
-    """3.12 and 3.14 share only after the real output twin proved equality."""
+    """An undeclared 3.14 parser cannot share the authoritative 3.12 key."""
     import sugar_lift_py_tests.demand_table_identity as module
 
     root = _corpus(tmp_path / "corpus", _FILES)
     here = _identity(root).content_key
 
     original = module.parser_identity
-    module.parser_identity = lambda: "cpython-3.12"
+    module.parser_identity = lambda: "cpython-3.14"
     try:
         elsewhere = _identity(root).content_key
     finally:
         module.parser_identity = original
 
-    assert elsewhere == here
+    assert elsewhere != here
 
 
-def test_the_runtime_relaxation_is_bound_to_the_measured_twin() -> None:
-    """Runtime left only after two authenticated producers matched exactly."""
+def test_the_runtime_authority_reason_is_recorded() -> None:
     from sugar_lift_py_tests import demand_table_identity as module
 
     doc = " ".join((module.__doc__ or "").split())
 
-    assert "MEASURED RELAXATION" in doc
-    assert "3.12" in doc and "3.14" in doc
-    assert "171cb05a5903" in doc
+    assert "PARSER IDENTITY IS IN THE CONTENT KEY" in doc
+    assert "CPython 3.12.13" in doc and "3.14.4" in doc
+    assert "undeclared runtime" in doc
 
 
 def test_the_reason_the_first_answer_was_wrong_is_recorded() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
@@ -1,4 +1,4 @@
-"""Measured 3.12/3.14 demand-table output twin on one small corpus."""
+"""Demand-table testimony minted on the declared CPython 3.12.13 runtime."""
 
 from __future__ import annotations
 
@@ -8,8 +8,12 @@ from pathlib import Path
 
 from sugar_lift_py_tests.authenticated_pytest import (
     authenticate_environment,
+    authenticated_pandas_corpus,
+    declared_interpreter_runtime,
     interpreter_identity,
 )
+from sugar_lift_py_tests.demand_table_identity import demand_table_identity
+from sugar_source_tree.tree import SourceTree
 from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 from sugar_source_tree.cpython_adapter import CPythonAstBackend
@@ -22,10 +26,9 @@ def render(value, width):
         return rendered
 """
 
-# Independently produced from base 964dbf95d under authenticated CPython
-# 3.12.13 on Battleaxe and CPython 3.14.4 on the workstation. The receipts pin
-# the decisive law, not merely its convenient conclusion: same corpus,
-# different parser output, byte-identical demand table.
+# Produced under authenticated CPython 3.12.13 on Battleaxe. CPython 3.14.4 is
+# not a declared cell, so its historical workstation receipt is deliberately
+# not accepted as managed testimony.
 MEASURED_CORPUS_MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
@@ -35,31 +38,35 @@ MEASURED_DEMAND_TABLE_OUTPUT_CIDS = {
         "blake3-512:171cb05a5903a2d929596d9ea33b35432c4f5721f37c5553d2b012063495ee18"
         "3b0e0281f23f3dbf9ceeadc4d1fb107163e78bfe4d570d457b4a0ae2867fe7fb"
     ),
-    "cpython-3.14.4": (
-        "blake3-512:171cb05a5903a2d929596d9ea33b35432c4f5721f37c5553d2b012063495ee18"
-        "3b0e0281f23f3dbf9ceeadc4d1fb107163e78bfe4d570d457b4a0ae2867fe7fb"
-    ),
 }
 MEASURED_PARSER_AST_CIDS = {
     "cpython-ast-cpython-3.12": (
         "blake3-512:9981672e8b2c342a55f1c6f9e063bb4df7ae79b705aebf5c8c13c351d0574cf"
         "bf632e8cfab087382857bdf2582e73e92e02e2d0ba9dc4ba0fd0ab68e64f66910"
     ),
-    "cpython-ast-cpython-3.14": (
-        "blake3-512:3bb9334b3359eeb822259f977144f1d05bc5ed5854efa92fd2cb28372a94c3d7"
-        "f1ff3b249358ac7dfd87af98c013c114ab01060515b71c110d2d34514088ff96"
-    ),
 }
+DECLARED_PANDAS_TABLE_CONTENT_KEY = (
+    "blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d"
+    "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
+)
 
 
-def test_measured_runtime_receipts_earn_parser_identity_removal() -> None:
-    """Runtime leaves the key only because the authenticated twin matched."""
-    assert set(MEASURED_DEMAND_TABLE_OUTPUT_CIDS) == {
-        "cpython-3.12.13",
-        "cpython-3.14.4",
-    }
-    assert len(set(MEASURED_PARSER_AST_CIDS.values())) == 2
-    assert len(set(MEASURED_DEMAND_TABLE_OUTPUT_CIDS.values())) == 1
+def test_runtime_derived_testimony_names_only_the_declared_authority() -> None:
+    assert declared_interpreter_runtime() == "cpython-3.12.13"
+    assert set(MEASURED_DEMAND_TABLE_OUTPUT_CIDS) == {"cpython-3.12.13"}
+    assert set(MEASURED_PARSER_AST_CIDS) == {"cpython-ast-cpython-3.12"}
+
+
+def test_pinned_corpus_table_key_is_minted_under_declared_parser() -> None:
+    corpus = authenticated_pandas_corpus()
+    source_root = Path(__file__).resolve().parents[1] / "src"
+    identity = demand_table_identity(
+        corpus.root,
+        SourceTree(corpus.root).paths(),
+        source_root=source_root,
+    )
+
+    assert identity.content_key == DECLARED_PANDAS_TABLE_CONTENT_KEY
 
 
 def test_demand_table_output_interpreter_twin(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
@@ -39,13 +39,36 @@ import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import (
     ExecutionEnvironmentMismatch,
+    InterpreterIdentity,
     authenticate_corpus_manifest,
+    authenticate_interpreter_runtime,
     authenticated_pandas_corpus,
+    declared_interpreter_runtime,
 )
 from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
 
 _PYPROJECT = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
 _CORPUS_PACKAGES = ("pandas", "numpy")
+
+
+def test_managed_runtime_authority_is_cpython_31213() -> None:
+    assert declared_interpreter_runtime() == "cpython-3.12.13"
+
+
+def test_declared_runtime_authenticates() -> None:
+    identity = InterpreterIdentity("cpython", "3.12.13", pathlib.Path("/python"))
+
+    assert authenticate_interpreter_runtime(identity) == identity
+
+
+def test_undeclared_cpython_3144_refuses_loudly() -> None:
+    identity = InterpreterIdentity("cpython", "3.14.4", pathlib.Path("/python"))
+
+    with pytest.raises(
+        ExecutionEnvironmentMismatch,
+        match=r"required cpython-3\.12\.13; observed cpython-3\.14\.4",
+    ):
+        authenticate_interpreter_runtime(identity)
 
 
 def _declared_pins() -> dict[str, str]:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -35,8 +35,8 @@ CORPUS = Path(
 UNARY_SITE = CORPUS / "tests/extension/base/ops.py"
 BOOLOP_SITE = CORPUS / "tests/generic/test_generic.py"
 DEMAND_TABLE_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+    "blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d"
+    "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
 )
 MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 UNARY_SOURCE_CID = (
@@ -92,7 +92,7 @@ def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -
             "--output",
             str(output),
             "--runtime",
-            "cpython-3.14.4",
+            "cpython-3.12.13",
         ],
         cwd=root,
         capture_output=True,
@@ -101,6 +101,7 @@ def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -
     assert pulled.returncode == 0, pulled.stderr
     table = json.loads(output.read_text(encoding="utf-8"))
     assert table["contentKey"] == DEMAND_TABLE_KEY
+    assert table["authentication"]["python"] == "cpython-3.12.13"
     assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
     assert table["authentication"]["pandas"] == "3.0.3"
     assert table["identity"]["fileCount"] == 1421

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -336,12 +336,13 @@ def test_the_two_call_shapes_are_not_the_same_condition() -> None:
 # wearing a pin's clothes; a content key returns one artifact or nothing.
 # --------------------------------------------------------------------------
 
-#: The first authenticated ``python-demand-table``, published through the
-#: ``ee50531eb`` shelf path. Producer ``964dbf95d``, corpus pandas 3.0.3 /
-#: 1,421 files, runtime ``cpython-3.14.4``.
+#: The declared authenticated ``python-demand-table`` identity: producer
+#: ``964dbf95d``, corpus pandas 3.0.3 / 1,421 files, parser
+#: ``cpython-3.12`` and runtime ``cpython-3.12.13``. The runtime cell must be
+#: genuinely re-minted; the former 3.14.4 bytes cannot satisfy this address.
 DEMAND_TABLE_CONTENT_KEY = (
-    "blake3-512:e225fcd0991f7c9011107521516e513390e448cc78ec4ce2da5eceb7116e1d89"
-    "6cba3f8d9f19c1b5375692117a8395aa9f1529a63b768387ce9aeb43d8323499"
+    "blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d"
+    "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
 )
 
 #: The CONTENT identity of the enrolled corpus: ``corpus_pin.aggregate_hash``
@@ -415,7 +416,7 @@ def _pinned_demand_table() -> dict:
                 "--output",
                 str(output),
                 "--runtime",
-                "cpython-3.14.4",
+                "cpython-3.12.13",
             ],
             cwd=root,
             capture_output=True,
@@ -436,6 +437,7 @@ def _pinned_demand_table() -> dict:
     # The shelf is content-addressed, but the artifact says who it is and that
     # is what gets checked -- never the filename it arrived under.
     assert payload["contentKey"] == DEMAND_TABLE_CONTENT_KEY
+    assert payload["authentication"]["python"] == "cpython-3.12.13"
     assert (
         payload["authentication"]["authenticatedCorpusManifestCid"]
         == DEMAND_TABLE_CORPUS_MANIFEST_SHAPE_CID

--- a/tests/sugarbin_python_demand_table_fixture.sh
+++ b/tests/sugarbin_python_demand_table_fixture.sh
@@ -35,7 +35,7 @@ publish() {
     --kind python-demand-table \
     --content-key "$content_key" \
     --input "$input" \
-    --runtime python-test-runtime \
+    --runtime cpython-3.12.13 \
     --platform test-platform \
     --profile test-profile \
     --shelf-root "$shelf"
@@ -47,10 +47,38 @@ pull() {
     --kind python-demand-table \
     --content-key "$content_key" \
     --output "$output" \
-    --runtime python-test-runtime \
+    --runtime cpython-3.12.13 \
     --platform test-platform \
     --profile test-profile \
     --shelf-root "$shelf"
+}
+
+# The managed closure declares exactly one Python authority. A shelf request
+# for workstation 3.14 testimony must refuse before looking for an artifact;
+# accepting both would claim a second authenticated runtime cell exists.
+set +e
+"$repo/bin/sugarbin" artifact pull \
+  --kind python-demand-table \
+  --content-key "$content_key" \
+  --output "$tmp/wrong-runtime.json" \
+  --runtime cpython-3.14.4 \
+  --platform test-platform \
+  --profile test-profile \
+  --shelf-root "$tmp/seed-shelf" \
+  2>"$tmp/wrong-runtime.err"
+wrong_runtime_status=$?
+set -e
+[[ "$wrong_runtime_status" == 78 ]] || {
+  echo "undeclared runtime request returned $wrong_runtime_status; expected refusal 78" >&2
+  exit 1
+}
+grep -Fq 'required=cpython-3.12.13 requested=cpython-3.14.4' "$tmp/wrong-runtime.err" || {
+  echo 'undeclared runtime refusal did not name required and requested identities' >&2
+  exit 1
+}
+[[ ! -e "$tmp/wrong-runtime.json" ]] || {
+  echo 'undeclared runtime request materialized an artifact' >&2
+  exit 1
 }
 
 # Obtain a real completed cell through the production publisher, then remove


### PR DESCRIPTION
## Outcome

Outcome A: CPython 3.12.13 is the sole declared managed runtime. `sugar-build.toml`, the managed image/entrypoint, and the authenticated Python action all agree on that exact patch runtime; 3.14.4 existed only in workstation-derived consumers and receipts.

## Changes

- authenticate the launcher interpreter against the runtime declared by `sugar-build.toml` before corpus imports
- refuse `python-demand-table` publish/pull requests for undeclared runtimes with exit 78
- put runtime identity in artifact cell paths so an old 3.14 cell cannot occupy the 3.12 seat
- restore parser identity to the demand-table content preimage
- remint the focused 3.12.13 runtime receipt and pin the declared pandas table address as `blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0`
- move all current consumers to request 3.12.13 and authenticate the payload runtime, so relabeling 3.14 bytes still fails

## Validation

- `bin/bpytest -u ...test_measured_corpus_is_authenticated.py -k ...`: 3 passed
- `bin/bpytest -u ...test_demand_table_identity.py ...test_demand_table_interpreter_twin.py`: 17 passed
- combined runtime/identity focus: 21 passed, 12 deselected
- `bash tests/sugarbin_shelf_immutability.sh "$PWD"`: pass
- `bash -n bin/sugarbin tests/sugarbin_python_demand_table_fixture.sh`: pass
- `git diff --check`: pass

## Named publication blocker

The full-corpus consumer tests correctly remain red because no genuine CPython 3.12.13 demand-table cell has yet been published at the new authenticated key. The shelf currently contains only the former 3.14.4 testimony. Focused consumer evidence reports a filesystem shelf miss at `blake3-512:0ce7c645...53ab0`. This PR does not copy, relabel, widen, or substitute that artifact; the table must be produced by the authenticated 3.12.13 publisher before these consumers can go green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Declare CPython 3.12.13 as the authoritative runtime for artifact shelf paths and environment authentication
> - Non-binary artifact shelf paths now include a `runtime` segment (`root/kind/platform/profile/runtime/stamp/name`); calls without a runtime fail with exit code 2.
> - The artifact CLI (`dispatch_artifact_subcommand`) reads `tools.python` from `sugar-build.toml`, constructs `cpython-<version>`, and rejects `--runtime` mismatches with exit code 78.
> - `authenticate_environment` in [authenticated_pytest.py](https://github.com/TSavo/sugar/pull/6495/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120) now validates the running interpreter matches the declared runtime, raising `ExecutionEnvironmentMismatch` on mismatch.
> - `DemandTableIdentityV1.preimage` embeds `parserIdentity`, changing the derived content key for all demand table identities.
> - Test fixtures across multiple packages updated to use `cpython-3.12.13` and new blake3-512 demand table keys.
> - Risk: the `parserIdentity`-in-preimage change breaks any cached demand table keys derived under the old layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa105dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->