### PR TITLE
Authenticate no-warning None twins

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -11,18 +12,34 @@ from sugar_lift_py_tests.context_manager_resolution import TreeConstructionConte
 from sugar_source_tree.nodes import Call, Constant, With
 from sugar_source_tree.tree import SourceFile
 
-
-MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+CONTENT_MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1"
+    "c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+MANIFEST_SHAPE_CID = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+)
 FILE_SHA256 = "ef0819d48825f4614ec088f25b4d342a8808a12b1c5d45cff3281b481ec13252"
+
+
+def _manifest_shape_cid(root: Path) -> str:
+    from sugar_source_tree.tree import SourceTree
+
+    paths = sorted(
+        path.relative_to(root).as_posix() for path in SourceTree(root).paths()
+    )
+    preimage = json.dumps(paths, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(preimage.encode("utf-8")).hexdigest()
 
 
 def _corpus_file() -> Path:
     corpus = authenticated_pandas_corpus()
     assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
         "3.0.3",
-        MANIFEST_CID,
+        CONTENT_MANIFEST_CID,
         1421,
     )
+    assert _manifest_shape_cid(corpus.root) == MANIFEST_SHAPE_CID
     return corpus.root / "tests/series/test_constructors.py"
 
 
@@ -40,8 +57,7 @@ def test_real_pandas_back_to_back_none_warning_managers_are_distinct_native_site
     sites = tuple(
         node
         for node in tree.nodes()
-        if isinstance(node, With)
-        and node.line_col_span().start_line in {1290, 1296}
+        if isinstance(node, With) and node.line_col_span().start_line in {1290, 1296}
     )
     assert len(sites) == 2
     assert tuple(len(site.body) for site in sites) == (2, 1)
@@ -52,7 +68,22 @@ def test_real_pandas_back_to_back_none_warning_managers_are_distinct_native_site
         assert isinstance(manager.args[0], Constant)
         assert manager.args[0].value is None
 
+    first_names = tuple(
+        node.id
+        for statement in sites[0].body
+        for node in statement.walk()
+        if node.kind == "Name"
+    )
+    assert first_names.count("middle") == 2
+
     assert tuple(
         (site.line_col_span().start_line, site.line_col_span().start_col)
+        for site in sites
+    ) == ((1290, 8), (1296, 8))
+    assert tuple(
+        (
+            site.items[0].context_expr.line_col_span().start_line,
+            site.items[0].context_expr.line_col_span().start_col,
+        )
         for site in sites
     ) == ((1290, 13), (1296, 13))


### PR DESCRIPTION
## Finding

The merged warning work already covers `assert_produces_warning(None)` correctly. Exact `NoneValue` selects the inverted completed-face contract; clean multi-statement bodies complete, an authenticated warning halts with `ExpectationNotMetEffect`, unresolved producers refuse by name, and two sequential boundaries do not share observations. No production mechanism changes are needed.

## What changed

- repair #6492's exact pandas-site tooth so it distinguishes the launcher's content manifest (`blake3-512:6f317...530`) from the pinned table's 1,421-path shape manifest (`sha256:a223...03d0`) and authenticates both independently
- correct the existing coordinate assertion: each `With` begins at column 8 and its manager call begins at column 13
- pin the real multi-statement data flow structurally: `middle` is both bound and consumed inside the first manager
- retain the two distinct back-to-back manager coordinates

The corpus root is obtained only from `authenticated_pandas_corpus()`; no developer path is embedded.

## Measured delta

One driven evidence site moved from an unusable identity/coordinate assertion to a passing authenticated witness for the exact pandas pair. This does not project a gain across the 101-site family.

## Validation

```text
implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
implementations/python/sugar-lift-py-tests/tests/test_warning_observation_producer.py

28 passed in 14.76s
```

Mutation transaction: clean 4/4; mutating the completed no-warning router to ignore an arriving observation made `test_warning_arriving_at_no_warning_contract_fails_assertion` fail because the face completed; reverted; clean 4/4.

Three pre-existing guarded-occurrence tests remain red on the base because the newer Attribute producer refuses earlier at `SymbolicValue.attribute`; this PR does not weaken either law.

`bin/bpytest` emitted no shelf-refusal stamp and started `Updating crates.io index`; it was interrupted immediately. No fallback was enabled and no substitute interpreter, corpus, demand-table build, or bare construction door was used.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shape manifest CID validation and fix `With` statement position assertions in warning-None twin tests
> - Adds a `_manifest_shape_cid` helper in [test_warning_none_argument_shape.py](https://github.com/TSavo/sugar/pull/6496/files#diff-902a070c7b66eb806eff3c8b3f46c389f3002cb4f1acbff2e9d576df9f6e64a0) that computes a sha256 digest over the corpus path listing to validate filesystem structure independently of content.
> - Replaces the single `MANIFEST_CID` constant with two: `CONTENT_MANIFEST_CID` (blake3-512) and `MANIFEST_SHAPE_CID` (sha256), so both content and shape are asserted separately.
> - Fixes `test_real_pandas_back_to_back_none_warning_managers_are_distinct_native_sites` to assert `With` statement positions at column 8 and context manager call positions at column 13 (previously both were asserted at column 13), and adds an assertion that `middle` appears exactly twice in the first with-body.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b9215a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation of corpus contents and source-tree structure.
  * Added deterministic checks for manifest shape and file layout.
  * Updated source-location expectations and structural assertions for warning-related syntax.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->