### PR TITLE
Compose authenticated consumer resolution testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
@@ -1,0 +1,175 @@
+"""Compose authenticated binary, demand-table, and launcher testimony.
+
+This module owns no artifact identity.  It compares the coordinates already
+owned by the three producers and emits a hit only when their testimony agrees
+with one request.  In particular, runtime remains absent from the Rust binary
+cell: Python runtime authority is testified by the demand cell and launcher.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+
+
+class ConsumerResolutionMiss(RuntimeError):
+    """A composite lookup failed at one named coordinate."""
+
+    def __init__(self, coordinate: str, detail: str):
+        self.coordinate = coordinate
+        self.detail = detail
+        super().__init__(f"consumer resolution MISS: {coordinate} differs: {detail}")
+
+
+@dataclass(frozen=True)
+class ConsumerResolutionRequest:
+    source_stamp: str
+    runtime: str
+    platform: str
+    profile: str
+    corpus_manifest_cid: str
+    corpus_files: int
+
+
+@dataclass(frozen=True)
+class BinaryCellTestimony:
+    source_stamp: str
+    platform: str
+    profile: str
+    binary_name: str
+    artifact_verified: bool
+
+
+@dataclass(frozen=True)
+class DemandTableCellTestimony:
+    identity: DemandTableIdentityV1
+    runtime: str
+    platform: str
+    profile: str
+    artifact_verified: bool
+
+
+@dataclass(frozen=True)
+class LauncherSelectionTestimony:
+    runtime: str
+    corpus_manifest_cid: str
+    corpus_files: int
+    selected_binary_source_stamp: str
+    selected_binary_platform: str
+    selected_binary_profile: str
+    selected_demand_content_key: str
+    selected_demand_runtime: str
+    selected_demand_platform: str
+    selected_demand_profile: str
+    artifact_verification_succeeded: bool
+
+
+@dataclass(frozen=True)
+class ConsumerHitReport:
+    source_stamp: str
+    runtime: str
+    corpus_files: int
+    corpus_manifest_cid: str
+
+    def lines(self) -> tuple[str, ...]:
+        return (
+            f"sourceStamp {self.source_stamp}",
+            f"runtime {self.runtime}",
+            f"corpusFiles {self.corpus_files}",
+            f"corpusManifest {self.corpus_manifest_cid}",
+            "artifactVerification success",
+        )
+
+    def render(self) -> str:
+        return "\n".join(self.lines())
+
+
+def _miss(coordinate: str, requested: object, observed: object) -> None:
+    raise ConsumerResolutionMiss(
+        coordinate, f"requested={requested!r} observed={observed!r}"
+    )
+
+
+def _runtime_parser_identity(runtime: str) -> str:
+    implementation, separator, version = runtime.rpartition("-")
+    components = version.split(".")
+    if not separator or len(components) < 2:
+        _miss("runtime", "<implementation-major.minor.patch>", runtime)
+    return f"{implementation}-{components[0]}.{components[1]}"
+
+
+def resolve_consumer_hit(
+    request: ConsumerResolutionRequest,
+    binary: BinaryCellTestimony,
+    demand: DemandTableCellTestimony,
+    launcher: LauncherSelectionTestimony,
+) -> ConsumerHitReport:
+    """Resolve one composite hit or refuse at its first differing coordinate."""
+    source_stamps = (
+        binary.source_stamp,
+        launcher.selected_binary_source_stamp,
+    )
+    if any(stamp != request.source_stamp for stamp in source_stamps):
+        _miss("source stamp", request.source_stamp, source_stamps)
+
+    runtimes = (demand.runtime, launcher.runtime, launcher.selected_demand_runtime)
+    parser_identities = (
+        demand.identity.parser_identity,
+        _runtime_parser_identity(request.runtime),
+    )
+    if any(runtime != request.runtime for runtime in runtimes) or len(
+        set(parser_identities)
+    ) != 1:
+        _miss("runtime", request.runtime, (runtimes, parser_identities))
+
+    cell_coordinates = (
+        (binary.platform, binary.profile),
+        (demand.platform, demand.profile),
+        (launcher.selected_binary_platform, launcher.selected_binary_profile),
+        (launcher.selected_demand_platform, launcher.selected_demand_profile),
+    )
+    requested_cell = (request.platform, request.profile)
+    if any(coordinate != requested_cell for coordinate in cell_coordinates):
+        _miss("profile/platform", requested_cell, cell_coordinates)
+
+    corpus_coordinates = (
+        (demand.identity.corpus_manifest_cid, demand.identity.file_count),
+        (launcher.corpus_manifest_cid, launcher.corpus_files),
+    )
+    requested_corpus = (request.corpus_manifest_cid, request.corpus_files)
+    if any(coordinate != requested_corpus for coordinate in corpus_coordinates):
+        _miss("corpus identity", requested_corpus, corpus_coordinates)
+
+    if launcher.selected_demand_content_key != demand.identity.content_key:
+        _miss(
+            "artifact verification",
+            demand.identity.content_key,
+            launcher.selected_demand_content_key,
+        )
+    verification = (
+        binary.artifact_verified,
+        demand.artifact_verified,
+        launcher.artifact_verification_succeeded,
+    )
+    if not all(verification):
+        _miss("artifact verification", True, verification)
+
+    return ConsumerHitReport(
+        source_stamp=request.source_stamp,
+        runtime=request.runtime,
+        corpus_files=request.corpus_files,
+        corpus_manifest_cid=request.corpus_manifest_cid,
+    )
+
+
+def print_consumer_hit(
+    request: ConsumerResolutionRequest,
+    binary: BinaryCellTestimony,
+    demand: DemandTableCellTestimony,
+    launcher: LauncherSelectionTestimony,
+) -> ConsumerHitReport:
+    """Resolve and print the composed testimony at the consumer edge."""
+    report = resolve_consumer_hit(request, binary, demand, launcher)
+    print(report.render(), flush=True)
+    return report

--- a/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.consumer_resolution_report import (
+    BinaryCellTestimony,
+    ConsumerResolutionMiss,
+    ConsumerResolutionRequest,
+    DemandTableCellTestimony,
+    LauncherSelectionTestimony,
+    print_consumer_hit,
+    resolve_consumer_hit,
+)
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+
+
+STAMP = "blake3-512_" + "b" * 128
+MANIFEST = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+
+
+def _matching_testimony():
+    demand_identity = DemandTableIdentityV1(
+        content_key="blake3-512:" + "d" * 128,
+        corpus_manifest_cid=MANIFEST,
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:" + "p" * 128,
+        resolution_config_cid="blake3-512:" + "r" * 128,
+        parser_identity="cpython-3.12",
+        file_count=1421,
+    )
+    binary = BinaryCellTestimony(
+        source_stamp=STAMP,
+        platform="linux-x86_64",
+        profile="release",
+        binary_name="sugar",
+        artifact_verified=True,
+    )
+    demand = DemandTableCellTestimony(
+        identity=demand_identity,
+        runtime="cpython-3.12.13",
+        platform="linux-x86_64",
+        profile="release",
+        artifact_verified=True,
+    )
+    launcher = LauncherSelectionTestimony(
+        runtime="cpython-3.12.13",
+        corpus_manifest_cid=MANIFEST,
+        corpus_files=1421,
+        selected_binary_source_stamp=STAMP,
+        selected_binary_platform="linux-x86_64",
+        selected_binary_profile="release",
+        selected_demand_content_key=demand_identity.content_key,
+        selected_demand_runtime="cpython-3.12.13",
+        selected_demand_platform="linux-x86_64",
+        selected_demand_profile="release",
+        artifact_verification_succeeded=True,
+    )
+    request = ConsumerResolutionRequest(
+        source_stamp=STAMP,
+        runtime="cpython-3.12.13",
+        platform="linux-x86_64",
+        profile="release",
+        corpus_manifest_cid=MANIFEST,
+        corpus_files=1421,
+    )
+    return request, binary, demand, launcher
+
+
+def test_matching_three_artifacts_print_composite_hit():
+    request, binary, demand, launcher = _matching_testimony()
+    report = resolve_consumer_hit(request, binary, demand, launcher)
+    assert report.lines() == (
+        f"sourceStamp {STAMP}",
+        "runtime cpython-3.12.13",
+        "corpusFiles 1421",
+        f"corpusManifest {MANIFEST}",
+        "artifactVerification success",
+    )
+
+
+def test_matching_three_artifacts_print_to_the_consumer_edge(capsys):
+    request, binary, demand, launcher = _matching_testimony()
+    print_consumer_hit(request, binary, demand, launcher)
+    assert capsys.readouterr().out.splitlines() == [
+        f"sourceStamp {STAMP}",
+        "runtime cpython-3.12.13",
+        "corpusFiles 1421",
+        f"corpusManifest {MANIFEST}",
+        "artifactVerification success",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("coordinate", "mutate"),
+    [
+        ("source stamp", lambda r: replace(r, source_stamp="blake3-512_" + "0" * 128)),
+        ("runtime", lambda r: replace(r, runtime="cpython-3.12.12")),
+        ("profile/platform", lambda r: replace(r, profile="debug")),
+        ("corpus identity", lambda r: replace(r, corpus_manifest_cid="sha256:" + "0" * 64)),
+    ],
+)
+def test_each_request_coordinate_misses_by_its_own_name(coordinate, mutate):
+    request, binary, demand, launcher = _matching_testimony()
+    with pytest.raises(ConsumerResolutionMiss) as caught:
+        resolve_consumer_hit(mutate(request), binary, demand, launcher)
+    assert caught.value.coordinate == coordinate
+    assert str(caught.value).startswith(f"consumer resolution MISS: {coordinate} differs:")
+
+
+def test_platform_difference_is_the_same_named_coordinate_as_profile():
+    request, binary, demand, launcher = _matching_testimony()
+    request = replace(request, platform="darwin-arm64")
+    with pytest.raises(ConsumerResolutionMiss, match=r"MISS: profile/platform differs"):
+        resolve_consumer_hit(request, binary, demand, launcher)
+
+
+def test_consumer_refuses_unverified_artifact_instead_of_printing_a_hit():
+    request, binary, demand, launcher = _matching_testimony()
+    with pytest.raises(ConsumerResolutionMiss) as caught:
+        resolve_consumer_hit(
+            request, replace(binary, artifact_verified=False), demand, launcher
+        )
+    assert caught.value.coordinate == "artifact verification"


### PR DESCRIPTION
## What changed

- Adds a consumer-owned composite resolution report over the existing Rust binary cell, demand-table identity/cell, and authenticated launcher testimony.
- Prints sourceStamp, runtime, corpusFiles, corpusManifest, and artifactVerification success only after all three artifacts match the request.
- Names source stamp, runtime, profile/platform, corpus identity, or artifact verification on every miss; there is no generic miss and no fallback build.
- Does not change either existing cell schema and does not put Python runtime identity on the Rust binary cell.

## Validation

- `python3 -m pytest --noconftest -q implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py` — 8 passed.
- `python3 -m py_compile ...consumer_resolution_report.py ...test_consumer_resolution_report.py` — passed.
- Adjacent authentication sweep: 36 passed, 5 inherited environment/main reds (host CPython 3.14.4 vs declared 3.12.13; NumPy 2.5.0 vs 2.5.1; existing parser-identity twin ineffective on main).

## Live testimony boundary

All five lines are executable from matching composed testimony. A live published-cell hit is not claimed: the current Mac is not the declared runtime, and the SHA-256 versus blake3 corpus-alias ruling remains external to this consumer. The consumer refuses rather than choosing an identity.

Base: `9d0e12b05ac4a4c88169af30fafe274eb5db7420`
Head: `7a65c58dbd8bafa029193f1edf0189b5ccdd5983`

Do not merge automatically.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated consumer resolution testimony module with composite verification checks
> - Adds [consumer_resolution_report.py](https://github.com/TSavo/sugar/pull/6497/files#diff-bd717e8aaa8a75626c402d2b396cc5fb2a57c5deac6ad5a85fcde6607d78f22a) with dataclasses for request/testimony inputs (`ConsumerResolutionRequest`, `BinaryCellTestimony`, `DemandTableCellTestimony`, `LauncherSelectionTestimony`) and a `ConsumerHitReport` output type.
> - `resolve_consumer_hit` performs a strict, fail-fast composite check across source stamp, runtime, platform/profile, corpus identity, content key, and artifact verification flags, raising `ConsumerResolutionMiss` at the first mismatch.
> - `print_consumer_hit` wraps `resolve_consumer_hit` and flushes the rendered report to stdout on success.
> - Adds [test_consumer_resolution_report.py](https://github.com/TSavo/sugar/pull/6497/files#diff-74ef15843c02df72315f2734c1c4c1d8fda47f317e665d20528ac853326f4c30) with parametrized tests covering all mismatch coordinates and the unverified-artifact case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2eefe0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->