### PR TITLE
Reconcile corpus manifest digest identities

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -51,11 +51,16 @@ authenticated at execution and artifact boundaries.
 
 from __future__ import annotations
 
+import hashlib
 import pathlib
 from dataclasses import dataclass
 from typing import Iterable, Mapping
 
-from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.canonical import (
+    blake3_512_of,
+    canonical_json_bytes,
+    cid_of_json,
+)
 
 # Bump when the demand table's SHAPE changes -- a new row kind, a changed
 # field, a different join. A consumer holding an artifact built under an older
@@ -102,13 +107,30 @@ class DemandTableIdentityV1:
         }
 
 
-def corpus_manifest_cid(
-    root: pathlib.Path, paths: Iterable[pathlib.Path]
-) -> tuple[str, int]:
-    """Content-address a corpus by its RELATIVE paths and file bytes.
+@dataclass(frozen=True)
+class CorpusManifestDigestAliasesV1:
+    """Digest aliases over one canonical path-plus-content manifest."""
 
-    Sorted by relative path so enumeration order cannot enter the address, and
-    relative so the same corpus at a different location is the same corpus.
+    sha256: str
+    blake3_512: str
+    file_count: int
+
+    def accepts(self, digest: str) -> bool:
+        return digest in (self.sha256, self.blake3_512)
+
+
+class CorpusManifestIdentityMismatch(ValueError):
+    """A presented digest is not an alias of the canonical corpus manifest."""
+
+
+def corpus_manifest_digest_aliases(
+    root: pathlib.Path, paths: Iterable[pathlib.Path]
+) -> CorpusManifestDigestAliasesV1:
+    """Hash one ordered relative-path/content-CID manifest two ways.
+
+    Algorithm choice does not create a second corpus identity. Both aliases
+    cover the exact same canonical bytes; ordering, path membership, file
+    count, or file bytes therefore move both together.
     """
     rows = []
     for path in sorted(paths, key=lambda item: item.relative_to(root).as_posix()):
@@ -118,7 +140,36 @@ def corpus_manifest_cid(
                 "contentCid": blake3_512_of(path.read_bytes()),
             }
         )
-    return cid_of_json({"kind": "corpus-manifest", "files": rows}), len(rows)
+    manifest = canonical_json_bytes({"kind": "corpus-manifest", "files": rows})
+    return CorpusManifestDigestAliasesV1(
+        sha256="sha256:" + hashlib.sha256(manifest).hexdigest(),
+        blake3_512=blake3_512_of(manifest),
+        file_count=len(rows),
+    )
+
+
+def require_corpus_manifest_alias(
+    aliases: CorpusManifestDigestAliasesV1, presented: str
+) -> None:
+    """Refuse artifact consumption under a digest from another preimage."""
+    if aliases.accepts(presented):
+        return
+    raise CorpusManifestIdentityMismatch(
+        f"{presented} is not an alias of canonical corpus manifest "
+        f"({aliases.sha256}, {aliases.blake3_512}); stop artifact consumption"
+    )
+
+
+def corpus_manifest_cid(
+    root: pathlib.Path, paths: Iterable[pathlib.Path]
+) -> tuple[str, int]:
+    """Content-address a corpus by its RELATIVE paths and file bytes.
+
+    Sorted by relative path so enumeration order cannot enter the address, and
+    relative so the same corpus at a different location is the same corpus.
+    """
+    aliases = corpus_manifest_digest_aliases(root, paths)
+    return aliases.blake3_512, aliases.file_count
 
 
 def producer_source_cid(source_root: pathlib.Path) -> str:

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -23,7 +23,12 @@ import shutil
 
 import pytest
 
-from sugar_lift_py_tests.demand_table_identity import demand_table_identity
+from sugar_lift_py_tests.demand_table_identity import (
+    CorpusManifestIdentityMismatch,
+    corpus_manifest_digest_aliases,
+    demand_table_identity,
+    require_corpus_manifest_alias,
+)
 
 _SOURCE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src"
 
@@ -304,3 +309,37 @@ def test_the_reason_the_first_answer_was_wrong_is_recorded() -> None:
 
     assert "version-dependent node stream" in doc
     assert "answered the wrong question" in doc
+
+
+def test_pandas_303_path_shape_digest_is_not_a_content_manifest_alias() -> None:
+    """Artifact consumption refuses the circulating path-only SHA-256.
+
+    Both accepted aliases are computed over one ordered manifest of relative
+    path plus content CID.  The historical ``a223...`` value covered path
+    shape only, so accepting it would make changed bytes look authenticated.
+    """
+    import importlib.metadata
+
+    from sugar_source_tree.tree import SourceTree
+
+    distribution = importlib.metadata.distribution("pandas")
+    root = pathlib.Path(distribution.locate_file("pandas")).resolve()
+    assert distribution.version == "3.0.3"
+
+    aliases = corpus_manifest_digest_aliases(root, SourceTree(root).paths())
+
+    assert aliases.file_count == 1421
+    assert aliases.sha256 == (
+        "sha256:0ee4e945d69e60941f74ad064215a44d9f02a0b23b081e2a507d893bdd22a938"
+    )
+    assert aliases.blake3_512 == (
+        "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604ed"
+        "a1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+    )
+    require_corpus_manifest_alias(aliases, aliases.sha256)
+    require_corpus_manifest_alias(aliases, aliases.blake3_512)
+    with pytest.raises(CorpusManifestIdentityMismatch, match="not an alias"):
+        require_corpus_manifest_alias(
+            aliases,
+            "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0",
+        )


### PR DESCRIPTION
## Verdict: TWO CORPORA

The circulating digests are not aliases of one canonical content manifest. Artifact consumers must refuse the historical `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0`; it does not authenticate the same preimage as the demand-table manifest. Already-verifiable consumers using the canonical BLAKE3-512 identity are not blocked.

Under the declared CPython 3.12.13 runtime, pandas 3.0.3 yielded 1,421 Python files. One sorted canonical manifest of `(relative path, BLAKE3-512 content CID)` produced both:

- SHA-256: `sha256:0ee4e945d69e60941f74ad064215a44d9f02a0b23b081e2a507d893bdd22a938`
- BLAKE3-512: `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`

The `a223...` SHA-256 covered the historical path-shape preimage, not the ordered relative-path-plus-content-CID manifest. This PR records the accepted pair explicitly, routes the existing corpus CID primitive through the shared manifest bytes, and adds a refusal twin for `a223...`.

## Validation

- CPython 3.12.13 pinned scientific-test image: recomputed 1,421 files and both full digests above from one manifest
- `PYTHONUNBUFFERED=1 /Users/tsavo/provekit/.venv/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py` (27 passed before rebase; rebase applied cleanly)
- `/Users/tsavo/provekit/.venv/bin/python -m black --check implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py`
- `git diff --check`

Base: `f17a43c92`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile corpus manifest digest identities with sha256 and blake3-512 aliases
> - Adds `CorpusManifestDigestAliasesV1` dataclass in [demand_table_identity.py](https://github.com/TSavo/sugar/pull/6498/files#diff-e2634b6c8c519b6db39aaaaf4c06749e13de74ddf792b909d25b5f74017f3165) holding `sha256`, `blake3_512`, and `file_count` fields, with an `accepts` method to validate a presented digest against either alias.
> - Adds `corpus_manifest_digest_aliases` function that serializes an ordered manifest of relative paths and content CIDs to canonical JSON bytes, then computes both a `sha256:` and blake3-512 digest over those same bytes.
> - Adds `require_corpus_manifest_alias` that raises the new `CorpusManifestIdentityMismatch` exception when a presented digest matches neither alias.
> - Refactors `corpus_manifest_cid` to delegate to `corpus_manifest_digest_aliases`, returning the blake3-512 alias instead of computing `cid_of_json` directly.
> - Behavioral Change: `corpus_manifest_cid` now returns a digest computed over canonical JSON bytes rather than via `cid_of_json`; a new test confirms that a legacy path-shape-only SHA-256 digest is rejected as not a content-manifest alias.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e173a7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->