### PR TITLE
Classify native sequence index protocol

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -560,6 +560,15 @@ class FloorValue:
             ),
         )
 
+    def python_index_protocol(self) -> bool | None:
+        """Whether this value's source-decided type implements ``__index__``.
+
+        ``None`` is the third value: construction has not authenticated the
+        runtime type or its index protocol. Receiver floors may emit TypeError
+        only for ``False``; they must keep ``None`` named-loud.
+        """
+        return None
+
     def attribute(self, name, site):
         # Default: this value does not stand on the attribute floor -- it cannot
         # answer what it yields at `.name`. A symbolic receiver stays the

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -22,6 +22,9 @@ class ListValue(FloorValue):
         """This floor value denotes a ``list``."""
         return True
 
+    def python_index_protocol(self) -> bool:
+        return False
+
     def attribute(self, name, site):
         # Bound methods and fields on a constructed list (``[].append``, ``xs.index``) stay the
         # py.getattr coordinate -- one law, shared with StringValue and the
@@ -216,7 +219,7 @@ class ListValue(FloorValue):
                 length=n,
                 site=site,
             )
-        if type(index) is TermValue:
+        if index.python_index_protocol() is False:
             from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
             return ground_exceptional_exit(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -22,6 +22,9 @@ class StringValue(GuardStableValue):
         """This floor value denotes a ``str``."""
         return True
 
+    def python_index_protocol(self) -> bool:
+        return False
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete
@@ -284,7 +287,7 @@ class StringValue(GuardStableValue):
                 length=n,
                 site=site,
             )
-        if type(index) is TermValue:
+        if index.python_index_protocol() is False:
             from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
             return ground_exceptional_exit(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -16,6 +16,9 @@ class TermValue(FloorValue):
         """This floor value denotes a Python scalar it carries as its own payload."""
         return True
 
+    def python_index_protocol(self) -> bool:
+        return isinstance(self.value, int)
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -20,6 +20,9 @@ class TupleValue(FloorValue):
         """This floor value denotes a ``tuple``."""
         return True
 
+    def python_index_protocol(self) -> bool:
+        return False
+
     def attribute(self, name, site):
         # Bound methods and fields on a constructed tuple (``().count``, ``t.index``) stay the
         # py.getattr coordinate -- one law, shared with StringValue and the
@@ -307,7 +310,7 @@ class TupleValue(FloorValue):
                 length=n,
                 site=site,
             )
-        if type(index) is TermValue:
+        if index.python_index_protocol() is False:
             from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
             return ground_exceptional_exit(

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -13,8 +13,10 @@ from sugar_lift_py_tests.floor import (
     CallSiteValue,
     ListValue,
     RaiseValue,
+    StringValue,
     SymbolicValue,
     TermValue,
+    TupleValue,
 )
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, make_var
@@ -45,6 +47,26 @@ def authenticated_site():
     )
 
 
+@pytest.fixture
+def local_site(tmp_path):
+    source_path = tmp_path / "nested_tuple_subscript.py"
+    source_path.write_text(
+        "def nested_tuple_lookup(values):\n"
+        "    key = ((\"foo\", \"bar\", 0), 2)\n"
+        "    return values[key]\n"
+        "\n"
+        "def control(values):\n"
+        "    return values[0]\n",
+        encoding="utf-8",
+    )
+    source = SourceFile(
+        workspace_path_source(str(source_path), root=str(tmp_path)),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(function.fragment for function in source.functions())
+
+
+
 def test_launcher_authenticates_the_exact_corpus() -> None:
     corpus = authenticated_pandas_corpus()
     assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
@@ -73,10 +95,10 @@ def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> 
 
 
 def test_truthful_out_of_range_concrete_list_emits_index_error(
-    authenticated_site,
+    local_site,
 ) -> None:
     outcome = ListValue((TermValue(7),)).subscript(
-        TermValue(1), authenticated_site.fragment
+        TermValue(1), local_site
     )
 
     assert isinstance(outcome, Complete)
@@ -85,10 +107,10 @@ def test_truthful_out_of_range_concrete_list_emits_index_error(
 
 
 def test_lying_in_range_concrete_list_does_not_emit_exception(
-    authenticated_site,
+    local_site,
 ) -> None:
     outcome = ListValue((TermValue(7),)).subscript(
-        TermValue(0), authenticated_site.fragment
+        TermValue(0), local_site
     )
 
     assert isinstance(outcome, Complete)
@@ -96,9 +118,9 @@ def test_lying_in_range_concrete_list_does_not_emit_exception(
     assert outcome.value.value == 7
 
 
-def test_known_non_integer_list_index_emits_type_error(authenticated_site) -> None:
+def test_known_non_integer_list_index_emits_type_error(local_site) -> None:
     outcome = ListValue((TermValue(7),)).subscript(
-        TermValue(1.5), authenticated_site.fragment
+        TermValue(1.5), local_site
     )
 
     assert isinstance(outcome, Complete)
@@ -106,11 +128,51 @@ def test_known_non_integer_list_index_emits_type_error(authenticated_site) -> No
     assert outcome.value.effect.exception_name == "TypeError"
 
 
-def test_unknown_list_index_is_a_named_third_value(authenticated_site) -> None:
+def test_unknown_list_index_is_a_named_third_value(local_site) -> None:
     with pytest.raises(ConstructionPanic) as raised:
         ListValue((TermValue(7),)).subscript(
-            SymbolicValue(make_var("index")), authenticated_site.fragment
+            SymbolicValue(make_var("index")), local_site
         )
 
     assert raised.value.info.owner == "ListValue.subscript"
     assert "undecided" in raised.value.info.observed
+
+
+@pytest.mark.parametrize(
+    "receiver",
+    (
+        ListValue((TermValue(7),)),
+        TupleValue((TermValue(7),)),
+        StringValue("x"),
+    ),
+)
+def test_truthful_nested_tuple_index_emits_type_error(local_site, receiver) -> None:
+    nested_key = TupleValue(
+        (
+            TupleValue((StringValue("foo"), StringValue("bar"), TermValue(0))),
+            TermValue(2),
+        )
+    )
+
+    outcome = receiver.subscript(nested_key, local_site)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_lying_nested_tuple_key_must_not_be_guessed_for_unknown_receiver(
+    local_site,
+) -> None:
+    nested_key = TupleValue(
+        (
+            TupleValue((StringValue("foo"), StringValue("bar"), TermValue(0))),
+            TermValue(2),
+        )
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        SymbolicValue(make_var("receiver")).subscript(nested_key, local_site)
+
+    assert raised.value.info.owner == "SymbolicValue.subscript"
+    assert "undecided receiver runtime type" in raised.value.info.observed


### PR DESCRIPTION
## What changed

- add receiver-independent three-valued `python_index_protocol` testimony: supported, unsupported, or undecided
- let concrete list, tuple, and string receivers emit authenticated native `TypeError` for source-decided non-index values
- keep unknown index semantics on the existing named refusal path
- cover the verified nested-tuple key shape from pandas `tests/test_multilevel.py:158`
- separate local native-floor twins from the battleaxe-only corpus fixture introduced by #6492

No vendor/name arm, assertion-With, ExitSet, outcome, or generator change.

## Twins

- truthful: the nested tuple `(("foo", "bar", 0), 2)` emits `TypeError` when indexing concrete list, tuple, and string receivers
- lying: the identical key against an unknown receiver must remain `SymbolicValue.subscript` undecided; it may not guess an exception

## Local validation

- focused Python package tests: `18 passed, 2 deselected`, exit 0
- compileall: exit 0
- diff check: exit 0
- mutation: clean commit; changed `TupleValue.python_index_protocol()` from `False` to undecided; all three truthful cases failed for the missing `TypeError`, exit 1; restored identical SHA-256; `18 passed, 2 deselected`; clean

## Awaiting battleaxe

This Mac is CPython 3.14.4 / NumPy 2.5.0 and is undeclared by #6495. These two tests require the authenticated battleaxe environment and were not claimed locally:

- `test_launcher_authenticates_the_exact_corpus`
- `test_real_pandas_unknown_receiver_is_named_undecided`

No corpus delta or crash/timeout zeros are claimed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify native sequence index protocol across floor value types
> - Adds a `python_index_protocol()` method to all floor value types ([FloorValue](https://github.com/TSavo/sugar/pull/6499/files#diff-e465d9d796b4d8a065950433dc35b2a788306abfe91dab378d35f42a38a2cdd7), [TermValue](https://github.com/TSavo/sugar/pull/6499/files#diff-e121752ef29c0271aaddd03d641288ad242e0daed95686a07feb339efc29a9ea), [ListValue](https://github.com/TSavo/sugar/pull/6499/files#diff-eeacaa87aa5806ebb12e29086e825199b416c15725bb8735d0c4c86c747515bf), [TupleValue](https://github.com/TSavo/sugar/pull/6499/files#diff-ee02935e29cc93521433e8c8341cbad2b784d9c95c3a9cee1451a2e504318945), [StringValue](https://github.com/TSavo/sugar/pull/6499/files#diff-7f7cef79e8741c9f5ef0a7a75ab1e3f73d2cf58f59cc5d53870d530f4ffcbda5)) returning `True`, `False`, or `None` to indicate index protocol support.
> - Replaces narrow `TermValue` type checks in `subscript()` with protocol-based checks (`index.python_index_protocol() is False`) in `ListValue`, `TupleValue`, and `StringValue`.
> - Behavioral Change: `subscript()` now emits `TypeError` for any index type that explicitly reports no `__index__` support (e.g. tuples, strings), not just non-integer `TermValue` instances; indices with unknown protocol (`None`) still produce an undecided gap rather than a `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9cc965.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->