### PR TITLE
Distinguish written empty-message regex from absence

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -32,13 +32,17 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.authenticated_exception_matching import (
+    MatchDecided,
     MatchRetained,
     matches_raise_effect,
     raise_effect_message_verdict,
 )
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.ir import ctor, make_var, str_const
 from sugar_source_tree.panic import SugarNotWritten
 
 OCCURRENCE = "renamed_module.py:402:19"
@@ -212,3 +216,60 @@ def test_valueless_halt_cannot_use_occurrence_as_message_evidence() -> None:
 
     assert raised.value.owner == "authenticated_exception_matching._message_term"
     assert OCCURRENCE not in str(raised.value)
+
+
+def _effect_with_message(message: str) -> tuple[RaiseEffect, _AuthenticatedHandler]:
+    identity = TermValue(1).to_term(owner="exception identity")
+    raised_value = CallSiteValue(
+        "ValueError",
+        (StringValue(message),),
+        ("message",),
+        ctor("call:ValueError", []),
+        None,
+    )
+    return (
+        RaiseEffect(
+            exception_name="ValueError",
+            exception_type_coordinate=identity,
+            occurrence=OCCURRENCE,
+            raised_value=raised_value,
+        ),
+        _AuthenticatedHandler(identity),
+    )
+
+
+def test_written_empty_message_regex_is_not_an_absent_predicate() -> None:
+    """Truthful: ``^$`` decides true only for the ground empty message."""
+    effect, expected = _effect_with_message("")
+
+    verdict = raise_effect_message_verdict(effect, expected, StringValue("^$"))
+
+    assert verdict == MatchDecided(True)
+
+
+def test_written_empty_message_regex_rejects_a_nonempty_message() -> None:
+    """Lying twin: treating written ``^$`` as absent would consume this halt."""
+    effect, expected = _effect_with_message("boom")
+
+    constrained = raise_effect_message_verdict(
+        effect, expected, StringValue("^$")
+    )
+    absent = raise_effect_message_verdict(effect, expected, None)
+
+    assert constrained == MatchDecided(False)
+    assert absent == MatchDecided(True)
+
+
+def test_accumulated_pattern_remains_an_owed_regex_predicate() -> None:
+    """A branch-built alternation is a runtime value, not a false predicate."""
+    effect, expected = _effect_with_message("boom")
+    pattern = SymbolicValue(make_var("accumulated_pattern"))
+
+    verdict = raise_effect_message_verdict(effect, expected, pattern)
+
+    assert isinstance(verdict, MatchRetained)
+    assert verdict.obligation.name == "py.re_search"
+    assert verdict.obligation.args == (
+        make_var("accumulated_pattern"),
+        str_const("boom"),
+    )


### PR DESCRIPTION
## What changed

- pin the written `^$` message regex as distinct from an absent message predicate
- prove `^$` accepts the empty message and rejects a nonempty message
- prove an accumulated runtime pattern remains a retained `py.re_search` obligation

## Why

The originally supplied pandas coordinates were wrong. Content-pinned pandas 3.0.3 places the accumulated-pattern manager at `tests/indexing/test_indexing.py:111`, and the normalize manager at line 175 writes `match="^$"`, not `match=""`. A twin built on lines 118 or 203 would testify about unrelated syntax.

`^$` is a real constraint, not an omitted predicate and not a regex that matches every message. The matcher already implements the correct three-valued behavior; these tests make both possible conflations fail locally.

## Verification

- content pin: pandas 3.0.3, 1,421 files, aggregate `bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c`
- verified sites: indexing line 111, normalize line 175, analytics lines 242/247
- focused local tests: `20 passed`, exit 0
- mutation transaction: treating `^$` as absent made the lying twin fail, exit 1; restoration returned the focused tests to green
- `git diff --check`: exit 0

Authentication is intentionally not claimed. This Mac is outside the sole CPython 3.12.13 / NumPy 2.5.1 authority; Battleaxe execution remains pending provisioning.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests to distinguish a written empty-message regex from an absent predicate in `raise_effect_message_verdict`
> Adds three tests to [test_raise_matcher_subject_is_a_value.py](https://github.com/TSavo/sugar/pull/6500/files#diff-d0b0486bafe728847517ec06ae7e3695c27270c46f67be09c55fe95651401480) to cover previously untested edge cases in `raise_effect_message_verdict`:
> - Verifies that passing `StringValue("^$")` as the predicate yields `MatchDecided(True)` for an empty message, distinguishing it from a `None` predicate.
> - Verifies that `"^$"` rejects a non-empty message (`MatchDecided(False)`), while `None` (absent predicate) still yields `MatchDecided(True)`.
> - Verifies that a symbolic `SymbolicValue` predicate yields a `MatchRetained` result with an owed `py.re_search` obligation rather than an immediate decision.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45d3ae8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->