### PR TITLE
Publish authenticated call exits at the producer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -409,9 +409,7 @@ class CallSiteValue(FloorValue):
         )
 
     def subscript(self, index, site):
-        return self.undecided_subscript(
-            index, site, owner="CallSiteValue.subscript"
-        )
+        return self.undecided_subscript(index, site, owner="CallSiteValue.subscript")
 
     def setitem(self, index, value, site):
         """Rebind an opaque mapping/list-shaped callsite after ``xs[k] = v``.
@@ -1246,6 +1244,51 @@ class CallSiteValue(FloorValue):
             self.formal_coordinate_cids,
         )
         return _reduce_callsite_body(self.body, reduce_ctx, blame=self.target_name)
+
+    def producer_outcome(self, ctx: Any = None):
+        """Publish authenticated source-body halts at the Call expression.
+
+        A completed source body still denotes this ordinary call coordinate;
+        later consumers may demand its returned floor exactly as before.  A
+        halted body is already the Call producer's authenticated exceptional
+        face and must not wait for an assertion (or any other consumer) to dig
+        it out.  Mixed bodies retain every guard and arm testimony while only
+        replacing completed block records with the call coordinate they
+        compute.
+        """
+        if self.body is None:
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(self)
+
+        from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        outcome = self.reduce_source_outcome(ctx)
+        if isinstance(outcome, Complete):
+            return Complete(self)
+        exits = outcome_to_exitset(outcome)
+        return ExitSet(
+            tuple(
+                (
+                    Completed(
+                        exit_.guard,
+                        self,
+                        exit_.faces,
+                        exit_.pending_contracts,
+                    )
+                    if isinstance(exit_, Completed)
+                    else Halted(
+                        exit_.guard,
+                        exit_.effect,
+                        exit_.state,
+                        exit_.faces,
+                        exit_.pending_contracts,
+                    )
+                )
+                for exit_ in exits.exits
+            )
+        ).normalize()
 
 
 def force_floor(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -19,9 +19,12 @@ class CallSiteSugar(Sugar):
     projects the callEdge -- and a cue is the signal that this call warrants a
     dig (reduce the callee into its universe; its call sites cue further digs).
 
-    The dig itself is NOT done here (`body=None`). Digging is cued, not eager:
-    an assertion cues digs, and digs cue digs, so the recursion is driven by the
-    cueing mechanism (the enumeration), not by inlining the callee at every call.
+    An opaque call keeps ``body=None`` and remains a dig cue.  When construction
+    carries a source-authenticated body, however, Call is an effect producer:
+    it reduces that already-constructed body once and publishes its halted
+    ExitSet faces at this expression.  Completed faces retain the CallSiteValue
+    coordinate, so ordinary return-floor digging is unchanged.  No assertion
+    or other consumer is consulted to decide whether the call may halt.
 
     Meaning-only, node-constructed. Plain positional calls to a named callee;
     method/attribute/computed callees and keyword args stay gaps (the tree node
@@ -167,31 +170,28 @@ class CallSiteSugar(Sugar):
                         steps=self.source_call_frame.generator_steps,
                     )
                 )
-        return Complete(
-            CallSiteValue(
-                target_name=self.target_name,
-                arg_values=positional + tuple(value for _, value in kw_values),
-                parameters=(
-                    self.source_call_frame.parameters
-                    if self.source_call_frame is not None
-                    else ()
-                ),
-                term=term,
-                body=source_body,
-                keyword_names=tuple(name for name, _ in kw_values),
-                site=self.site,
-                exception_type_coordinate=self.exception_type_coordinate,
-                exception_type_mro=self.exception_type_mro,
-                source_call_frame_cid=source_frame_cid,
-                formal_coordinate_cids=(
-                    tuple(
-                        item.cid for item in self.source_call_frame.formal_coordinates
-                    )
-                    if self.source_call_frame is not None
-                    else ()
-                ),
-            )
+        callsite = CallSiteValue(
+            target_name=self.target_name,
+            arg_values=positional + tuple(value for _, value in kw_values),
+            parameters=(
+                self.source_call_frame.parameters
+                if self.source_call_frame is not None
+                else ()
+            ),
+            term=term,
+            body=source_body,
+            keyword_names=tuple(name for name, _ in kw_values),
+            site=self.site,
+            exception_type_coordinate=self.exception_type_coordinate,
+            exception_type_mro=self.exception_type_mro,
+            source_call_frame_cid=source_frame_cid,
+            formal_coordinate_cids=(
+                tuple(item.cid for item in self.source_call_frame.formal_coordinates)
+                if self.source_call_frame is not None
+                else ()
+            ),
         )
+        return callsite.producer_outcome(ctx)
 
     def _collect_bridged(self, positional: tuple) -> Outcome:
         from sugar_lift_py_tests.floor.bridged_contract_value import (

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_exceptional_exit_producer.py
@@ -1,0 +1,111 @@
+"""Call is an ExitSet producer peer, never an assertion-boundary special case."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_file(source: str, context: TreeConstructionContextV1) -> SourceFile:
+    return SourceFile(
+        (source, "call_exceptional_exit_fixture.py", blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+
+
+def _coordinate(node: Call) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _call_outcome(function_body: str):
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        f"def producer():\n{function_body}\n\nproducer()\n",
+        context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+    context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
+    return call.sugar().desugar(None)
+
+
+def _parameterized_call_outcome(function_body: str):
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        f"def producer(flag):\n{function_body}\n\nproducer(flag)\n",
+        context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+    context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
+    return call.sugar().desugar(None)
+
+
+def test_authenticated_call_publishes_its_source_body_halt() -> None:
+    outcome = _call_outcome("    raise ValueError()")
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert isinstance(halted.effect, RaiseEffect)
+    assert halted.effect.exception_name == "ValueError"
+
+
+def test_completed_source_call_keeps_the_ordinary_call_coordinate() -> None:
+    outcome = _call_outcome("    return 7")
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+
+
+def test_guarded_source_call_preserves_completed_and_halted_faces() -> None:
+    outcome = _parameterized_call_outcome(
+        "    if flag:\n        raise ValueError()\n    return 7"
+    )
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 2
+    completed = next(face for face in outcome.exits if isinstance(face, Completed))
+    halted = next(face for face in outcome.exits if isinstance(face, Halted))
+    assert isinstance(completed.value, CallSiteValue)
+    assert isinstance(halted.effect, RaiseEffect)
+    assert halted.effect.exception_name == "ValueError"
+
+
+def test_runtime_truthful_and_lying_twins_discriminate() -> None:
+    def truthful():
+        raise ValueError()
+
+    def lying():
+        return 7
+
+    def raises_value_error(thunk) -> bool:
+        try:
+            thunk()
+        except ValueError:
+            return True
+        return False
+
+    with pytest.raises(ValueError):
+        truthful()
+    assert lying() == 7
+    with pytest.raises(AssertionError):
+        assert raises_value_error(lying)


### PR DESCRIPTION
## Summary

- make a source-authenticated `Call` publish its callee body's halted `ExitSet` faces at the expression producer
- retain the ordinary `CallSiteValue` coordinate on completed faces, including guarded completion/halt partitions
- add direct producer, completed twin, guarded-arm, and runtime truthful/lying discrimination laws

## Root cause

`CallSiteSugar` always returned `Complete(CallSiteValue)`, even when its authenticated source frame reduced to a `RaiseEffect`. That left Call privileged: later callsite digging had to discover the halt, while peer expression producers published their own exceptional faces. The assertion boundary is already an `ExitSet` consumer and is not consulted by this change.

## Validation

- focused bounded path: `48 passed in 8.99s`
- mutation transaction: restoring unconditional `Complete(CallSiteValue)` made both producer teeth fail (`2 failed`, exit 1); reverting restored them (`2 passed`, exit 0)
- `black --check`: 3 files unchanged
- `git diff --check`: clean

Authentication-dependent corpus attribution remains deferred to battleaxe. This Mac's CPython 3.14.4 / NumPy 2.5.0 environment is outside #6495's sole CPython 3.12.13 / NumPy 2.5.1 authority, so this PR claims no authenticated receipt, corpus-wide delta, crash zero, or timeout zero. It does not invoke the authenticated launcher, rebuild a demand table, enable binary fallback, or hardcode a corpus path.

Predicted local effect: the one source-frame Call completion side door is replaced by producer-owned completion/halt projection. Population `Delta R` remains unmeasured pending authenticated battleaxe execution.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish authenticated call exits at the producer via `CallSiteValue.producer_outcome`
> - Adds `producer_outcome` to [`CallSiteValue`](https://github.com/TSavo/sugar/pull/6501/files#diff-8c40ae10c3e0722cf284a5e0bb43d2d29524ce10b6eb590893ccfcab4785689a) which computes the exit outcome for a call expression: returning `Complete(self)` for opaque calls or a normalized `ExitSet` when the source-authenticated body halts or yields mixed exits.
> - Updates [`CallSiteSugar.desugar`](https://github.com/TSavo/sugar/pull/6501/files#diff-d7d594636ed207e69db76dd7b89c48760b0d3de93da23981143b3c45da88a3c7) to delegate to `producer_outcome` instead of always returning `Complete(CallSiteValue(...))`, so halted or guarded source bodies now surface their exits at the call expression.
> - Completed faces in the resulting `ExitSet` have their value replaced with the `CallSiteValue` coordinate; `Halted` faces are propagated unchanged.
> - Behavioral Change: `desugar` may now return an `ExitSet` for source-authenticated calls; callers that assumed a `Complete` result will need to handle the new exit type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b2cd5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->