### PR TITLE
Require canonical consumer corpus identity

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
@@ -8,6 +8,7 @@ cell: Python runtime authority is testified by the demand cell and launcher.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
@@ -99,6 +100,17 @@ def _runtime_parser_identity(runtime: str) -> str:
     return f"{implementation}-{components[0]}.{components[1]}"
 
 
+def _is_primary_corpus_coordinate(value: str) -> bool:
+    """The demand identity owns one primary CID; SHA-256 is only an alias.
+
+    ``demand_table_identity.corpus_manifest_cid`` returns the BLAKE3-512
+    coordinate.  Artifact transport may authenticate the SHA-256 alias over
+    the same canonical bytes, but that alias does not replace the primary
+    coordinate consumed by the demand table and launcher.
+    """
+    return re.fullmatch(r"blake3-512:[0-9a-f]{128}", value) is not None
+
+
 def resolve_consumer_hit(
     request: ConsumerResolutionRequest,
     binary: BinaryCellTestimony,
@@ -138,7 +150,9 @@ def resolve_consumer_hit(
         (launcher.corpus_manifest_cid, launcher.corpus_files),
     )
     requested_corpus = (request.corpus_manifest_cid, request.corpus_files)
-    if any(coordinate != requested_corpus for coordinate in corpus_coordinates):
+    if not _is_primary_corpus_coordinate(request.corpus_manifest_cid) or any(
+        coordinate != requested_corpus for coordinate in corpus_coordinates
+    ):
         _miss("corpus identity", requested_corpus, corpus_coordinates)
 
     if launcher.selected_demand_content_key != demand.identity.content_key:

--- a/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
@@ -17,7 +17,13 @@ from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
 
 
 STAMP = "blake3-512_" + "b" * 128
-MANIFEST = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+MANIFEST = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604ed"
+    "a1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+HISTORICAL_PATH_SHAPE_DIGEST = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+)
 
 
 def _matching_testimony():
@@ -123,3 +129,22 @@ def test_consumer_refuses_unverified_artifact_instead_of_printing_a_hit():
             request, replace(binary, artifact_verified=False), demand, launcher
         )
     assert caught.value.coordinate == "artifact verification"
+
+
+def test_historical_path_shape_digest_is_a_named_corpus_identity_miss():
+    """Even unanimous testimony cannot upgrade a non-corpus preimage."""
+    request, binary, demand, launcher = _matching_testimony()
+    request = replace(request, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST)
+    demand = replace(
+        demand,
+        identity=replace(
+            demand.identity, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
+        ),
+    )
+    launcher = replace(
+        launcher, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
+    )
+    with pytest.raises(ConsumerResolutionMiss) as caught:
+        resolve_consumer_hit(request, binary, demand, launcher)
+    assert caught.value.coordinate == "corpus identity"
+    assert HISTORICAL_PATH_SHAPE_DIGEST in str(caught.value)


### PR DESCRIPTION
## What changed

- Makes the consumer corpus coordinate use the primary BLAKE3-512 manifest CID owned by `corpus_manifest_cid()`.
- Updates the truthful composite hit to the verified pandas 3.0.3 canonical BLAKE3 identity over 1,421 relative-path/content-CID rows.
- Adds a unanimous-testimony lying twin proving the historical `sha256:a223a449...` path-shape digest still refuses as `corpus identity`.
- Keeps SHA-256 as an artifact-level alias only; neither existing cell schema changes.

## Validation executed on this Mac

- Consumer and exact #6498 digest tests: 10 passed.
- The pinned-tree digest test independently recomputed 1,421 files, canonical BLAKE3 `6f317a5a...`, canonical SHA-256 `0ee4e945...`, and rejected historical `a223a449...`.
- Syntax compilation and diff checks passed.

No authenticated launcher receipt, crash/timeout zero, or corpus-wide delta is claimed from CPython 3.14.4. Battleaxe execution remains pending its authenticated CPython 3.12.13 cell.

Base: `761e067e39f63295ac4457fc3124b980a2c6d06b`
Head: `a01066aa89a77b8a4e1ef3ff26bc56a442e033e0`

Do not merge automatically.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject non-BLAKE3-512 corpus manifest CIDs in `resolve_consumer_hit`
> - Adds `_is_primary_corpus_coordinate` helper in [consumer_resolution_report.py](https://github.com/TSavo/sugar/pull/6502/files#diff-bd717e8aaa8a75626c402d2b396cc5fb2a57c5deac6ad5a85fcde6607d78f22a) that validates a string as a `blake3-512:` prefix followed by 128 lowercase hex characters.
> - `resolve_consumer_hit` now triggers a `'corpus identity'` miss if `corpus_manifest_cid` is not a primary BLAKE3-512 coordinate, even when demand and launcher testimonies otherwise match.
> - Adds a regression test covering the SHA-256 historical path-shape digest as a named miss case.
> - Behavioral Change: requests using SHA-256 (or any non-BLAKE3-512) corpus identities that previously may have resolved will now always miss.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a01066a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->