### PR TITLE
Pin mixed no-warning resource composition

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_with_mixed_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_mixed_managers.py
@@ -27,6 +27,7 @@ Every law twin here is paired 1:1 with a discrimination arm.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import MappingProxyType
 
 import pytest
@@ -43,11 +44,17 @@ from sugar_lift_py_tests.context_manager_contract import (
     LiteralDefaultV1,
     NeverSuppressesDispositionV1,
     NoDefaultV1,
+    NoMessagePatternV1,
     OptionalFormalArgumentProjectionV1,
     PositionalOrKeywordV1,
     ProtocolResourceSemanticsV1,
     RaiseEffectKindV1,
+    WarningEffectKindV1,
+    WarningObservationBindingV1,
 )
+from sugar_lift_py_tests.effect import ExpectationNotMetEffect, WarningEffect
+from sugar_lift_py_tests.floor import BlockValue, NoneValue
+from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerContractRefV1,
     ImportSignatureV2,
@@ -57,7 +64,9 @@ from sugar_lift_py_tests.context_manager_resolution import (
     _hash_json,
 )
 from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 from sugar_lift_python_source.source_oracle import path_source
@@ -149,6 +158,31 @@ def _boundary_ref(use_site) -> ContextManagerContractRefV1:
     )
 
 
+def _no_warning_ref(use_site) -> ContextManagerContractRefV1:
+    """An inverted warning boundary: literal None means no warning may arrive."""
+    return _base_ref(
+        use_site,
+        signature=ImportSignatureV2(
+            (
+                CallParameterV1(
+                    "expected_warning",
+                    PrimitiveSort("Value"),
+                    PositionalOrKeywordV1(),
+                    True,
+                    NoDefaultV1(),
+                ),
+            )
+        ),
+        semantics=EffectBoundarySemanticsV1(
+            ExpectsModeV1(),
+            WarningEffectKindV1(),
+            FormalArgumentProjectionV1(0),
+            NoMessagePatternV1(),
+            WarningObservationBindingV1(),
+        ),
+    )
+
+
 HEADER = (
     "from dependency import manager\n"
     "from pytest import raises as expect_raises\n"
@@ -170,6 +204,14 @@ RESOURCE_ONLY = HEADER + (
     "def f():\n"
     "    with manager():\n"
     '        raise ValueError("boom")\n'
+)
+
+NO_WARNING_RESOURCE = (
+    "from dependency import no_warning, resource, configure, emit\n"
+    "def f(warn_category, filter_category):\n"
+    "    with no_warning(None), resource():\n"
+    '        configure(category=filter_category, action="ignore")\n'
+    '        emit("test", category=warn_category)\n'
 )
 
 
@@ -212,6 +254,34 @@ def _with_chain(sugar):
 
     walk(sugar)
     return chain
+
+
+class _Record(Sugar):
+    """A completed body carrying the producer entries selected by a twin."""
+
+    def __init__(self, entries):
+        self.entries = tuple(entries)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(BlockValue(self.entries))
+
+
+def _mixed_no_warning_sugar(tmp_path, *, entries=()):
+    """Construct the native two-item spelling, then select its body testimony."""
+    outer, inner = _with_chain(
+        _mixed_sugar(
+            tmp_path,
+            NO_WARNING_RESOURCE,
+            refs=(_no_warning_ref, _resource_ref),
+        )
+    )
+    routed_inner = replace(inner, body=(_Record(entries),))
+    return replace(outer, body=(routed_inner,)), routed_inner
 
 
 # ------------------------------------------------- LAW: both contracts retained
@@ -422,3 +492,66 @@ def test_discrimination_single_manager_site_builds_one_router(tmp_path):
     )
     assert len(chain) == 1
     assert isinstance(chain[0], WithResourceSugar)
+
+
+# ------------------ LAW: inverted warning assertion + resource juxtaposition
+
+
+def test_no_warning_resource_site_retains_both_routers_in_source_order(tmp_path):
+    outer, inner = _mixed_no_warning_sugar(tmp_path)
+
+    assert isinstance(outer, WithEffectBoundarySugar)
+    assert isinstance(inner, WithResourceSugar)
+    assert outer.body == (inner,)
+
+
+def test_no_warning_expected_operand_remains_literal_none(tmp_path):
+    outer, _inner = _mixed_no_warning_sugar(tmp_path)
+
+    manager = outer.manager.desugar(None)
+    assert isinstance(manager, Complete)
+    assert len(manager.value.arg_values) == 1
+    assert isinstance(manager.value.arg_values[0], NoneValue)
+
+
+def test_parametrized_warning_classes_survive_native_multi_item_construction(
+    tmp_path,
+):
+    path = tmp_path / "computed_categories.py"
+    path.write_text(NO_WARNING_RESOURCE, encoding="utf-8")
+    source = SourceFile(path_source(str(path)))
+    with_node = next(node for node in source.nodes() if node.kind == "With")
+
+    assert len(with_node.items) == 2
+    calls = [node for node in with_node.body if node.kind == "Expr"]
+    assert [call.value.keywords[0].value.id for call in calls] == [
+        "filter_category",
+        "warn_category",
+    ]
+
+
+def test_clean_inner_resource_satisfies_inverted_warning_boundary(tmp_path):
+    outer, _inner = _mixed_no_warning_sugar(tmp_path)
+
+    routed = outer.desugar()
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Completed)
+
+
+def test_warning_arriving_through_inner_resource_fails_inverted_boundary(tmp_path):
+    warning = WarningObservationValue(WarningEffect("computed-warning"))
+    outer, _inner = _mixed_no_warning_sugar(tmp_path, entries=(warning,))
+
+    routed = outer.desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_lying_warning_arrival_cannot_be_reported_as_clean_completion(tmp_path):
+    warning = WarningObservationValue(WarningEffect("computed-warning"))
+    outer, _inner = _mixed_no_warning_sugar(tmp_path, entries=(warning,))
+
+    with pytest.raises(AssertionError):
+        assert isinstance(outer.desugar().exits[0], Completed)


### PR DESCRIPTION
## Result

#6489 already supplies the required production mechanism: native multi-item `With` is structurally rewritten into one single-item `With` per participant, preserving source/exit order and routing every participant through the shared ExitSet algebra. This PR adds the previously missing law for an inverted warning assertion juxtaposed with a resource manager.

## Added laws

- one `Expects/Warning` router remains outer and one resource router remains inner
- literal `None` remains `NoneValue`, never an empty-but-present warning class
- both computed category operands survive native source construction
- a clean inner resource satisfies the no-warning boundary
- a warning observation routed through the resource fails the no-warning boundary
- the lying completion twin fails

No assertion-With, ExitSet/outcome, producer, or generator construction code changed.

## Local evidence only

The locally installed source was checked and the mixed item list is at `pandas/tests/test_errors.py:142-144`, with `warn_category` and `filter_category` both parameters. This is not claimed as authenticated corpus evidence.

- local focused source-tree suite: `19 passed`
- mutation dropping the second manager: `14 failed, 5 passed`
- reverted mutation: `19 passed`

Authenticated execution is intentionally pending. The sole authority is CPython 3.12.13 / NumPy 2.5.1 through battleaxe, requiring the linux-x86_64 binary cell and CPython-3.12.13 demand table. No crash/timeout zeros, corpus delta, or authenticated receipt is claimed here.

Canonical corpus identity to be checked by battleaxe:

- BLAKE3-512: `6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`
- SHA-256: `0ee4e945d69e60941f74ad064215a44d9f02a0b23b081e2a507d893bdd22a938`

Base: `46aa8a2953190fe514eea1c335013be2b74a7a51`
Head: `29dae25f1d57f77dba673e1891b8d8d5db3dd248`

Open for review. Do not merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin mixed no-warning resource composition tests for warning boundary sugar
> Adds tests to [test_with_mixed_managers.py](https://github.com/TSavo/sugar/pull/6503/files#diff-af3fdf69cec15a34cee51947cbf129e527957fcb37852922a5e42a8e855841f5) covering the composition of a `no_warning` boundary with a resource in a two-item `with` statement.
>
> - Introduces `NO_WARNING_RESOURCE` source snippet, `_no_warning_ref` helper, `_Record` sugar subclass, and `_mixed_no_warning_sugar` builder to support the new test scenarios.
> - Adds five tests asserting router ordering, literal `None` operand preservation, parameter name survival through native multi-item construction, clean completion under an inverted warning boundary, and halting with `ExpectationNotMetEffect` when a warning is injected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29dae25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->