### PR TITLE
Distinguish written None from regex message patterns

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -179,10 +179,13 @@ def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
     halves have THREE outcomes, and this function is their conjunction, so it
     is the conjunction of two three-valued verdicts and nothing here may
     collapse one. A contract that states no pattern asserts nothing about the
-    message (``MatchDecided(True)``). Two ground strings settle the message
-    predicate here. Anything else -- a symbolic message, a computed pattern --
-    leaves as ``MatchRetained`` carrying ``py.re_search(pattern, message)``,
-    the vendor's own predicate spelled on the membrane.
+    message (``MatchDecided(True)``). A written Python ``None`` arrives as the
+    distinct ``NoneValue`` floor and also states no regex constraint; it is not
+    reclassified as an absent operand or sent to ``re_search``. Two ground
+    strings settle the message predicate here. Anything else -- a symbolic
+    message, a computed pattern -- leaves as ``MatchRetained`` carrying
+    ``py.re_search(pattern, message)``, the vendor's own predicate spelled on
+    the membrane.
 
     A ``False`` on either half is ``False`` outright: a conjunct that is
     decidably false settles the conjunction without deciding the other half.
@@ -209,7 +212,9 @@ def raise_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
             return MatchRetained(retained_identity)
         return MatchRetained(and_([retained_identity, verdict.obligation]))
 
-    if pattern is None:
+    from sugar_lift_py_tests.floor.none_value import NoneValue
+
+    if pattern is None or isinstance(pattern, NoneValue):
         return _conjoin(MatchDecided(True))
 
     owner = "authenticated_exception_matching.raise_effect_message_verdict"

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -152,6 +152,35 @@ def test_match_predicate_remains_owed_without_message_evidence():
     assert all("py.re_search" in str(face.guard) for face in routed.exits)
 
 
+def test_written_none_pattern_consumes_without_a_regex_obligation():
+    """The helper's explicit ``match=None`` reaches the native None floor."""
+    from sugar_lift_py_tests.floor import NoneValue, StringValue
+
+    body = ExitSet(
+        (_raise("ValueError", "written-none", message=StringValue("boom")),)
+    )
+
+    routed = _route(body, pattern=NoneValue())
+
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Completed)
+    assert "py.re_search" not in str(routed.exits[0].guard)
+
+
+def test_string_none_pattern_does_not_impersonate_written_none():
+    """Lying twin: the string ``"None"`` remains an actual regex constraint."""
+    from sugar_lift_py_tests.floor import StringValue
+
+    body = ExitSet(
+        (_raise("ValueError", "string-none", message=StringValue("boom")),)
+    )
+
+    routed = _route(body, pattern=StringValue("None"))
+
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Halted)
+
+
 @pytest.mark.parametrize("exception_name", ["ValueError", "TypeError"])
 def test_nested_resource_cleanup_executes_on_matching_and_nonmatching_exits(
     exception_name,

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -260,6 +260,26 @@ def test_written_empty_message_regex_rejects_a_nonempty_message() -> None:
     assert absent == MatchDecided(True)
 
 
+def test_written_none_message_pattern_states_no_regex_obligation() -> None:
+    """A written Python ``None`` is a value, but not a regex pattern."""
+    from sugar_lift_py_tests.floor import NoneValue
+
+    effect, expected = _effect_with_message("boom")
+
+    verdict = raise_effect_message_verdict(effect, expected, NoneValue())
+
+    assert verdict == MatchDecided(True)
+
+
+def test_string_spelled_none_remains_a_real_message_constraint() -> None:
+    """Lying twin: spelling cannot turn the string ``"None"`` into None."""
+    effect, expected = _effect_with_message("boom")
+
+    verdict = raise_effect_message_verdict(effect, expected, StringValue("None"))
+
+    assert verdict == MatchDecided(False)
+
+
 def test_accumulated_pattern_remains_an_owed_regex_predicate() -> None:
     """A branch-built alternation is a runtime value, not a false predicate."""
     effect, expected = _effect_with_message("boom")


### PR DESCRIPTION
## What changed

- Treat the native Python None floor as an explicitly written no-regex message claim.
- Preserve absent pattern, written None, and written regex as distinct constructed inputs.
- Add truthful and lying twins at both matcher and ExitSet-consumer seams.

## Why

A written match=None was reaching the shared matcher as NoneValue and being retained as py.re_search(None, message). That invents a regex obligation the source did not state. The fix reads the native floor value only; it contains no pytest/helper/name/keyword spelling arm.

## Validation

- 49 passed: focused matcher, assertion-boundary consumer, and context-manager semantics modules.
- Mutation transaction: removing the NoneValue arm makes the truthful twin fail with retained py.re_search(None, boom); restoring it returns the focused set green.
- The pandas 3.0.3 coordinates were verified locally at tests/io/test_feather.py:33 and :40. The existing #6477 reproducer follows the helper return and local import but remains typed-loud before message semantics on this CPython 3.14.4 Mac. No authenticated corpus, crash, or timeout claim is made; those require the CPython 3.12.13 battleaxe authority.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish written `None` from regex message patterns in `raise_effect_message_verdict`
> Previously, only a Python `None` pattern bypassed regex matching. This change also treats a `NoneValue` instance (representing an explicitly written `None`) as absent, returning `MatchDecided(True)` without emitting a `py.re_search` obligation. A `StringValue('None')` is still treated as a real regex constraint. Two new test cases cover both behaviors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 848fc03.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->