### PR TITLE
Pin two bare-name manager projection

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import importlib.metadata
 from pathlib import Path
 
 import pytest
 
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
@@ -17,14 +17,20 @@ PANDAS_SOURCE_CID = (
     "blake3-512:60e7b5ba2c971960e4d8edcaa85e916704dc8bfb977bc15dafb2f2b3e87458ff"
     "ba4b2f823e500c4c591a968b7c3e8ed436035aa171e8b3227055d9956147fae1"
 )
+PANDAS_MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1"
+    "c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
 
 
 def _pandas_root() -> Path:
-    distribution = importlib.metadata.distribution("pandas")
-    package = Path(distribution.locate_file("pandas")).resolve()
-    assert distribution.version == "3.0.3"
-    assert package.is_dir()
-    return package.parent
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        PANDAS_MANIFEST_CID,
+        1421,
+    )
+    return corpus.root
 
 
 def _real_tree():
@@ -46,6 +52,38 @@ def _line_32_with(tree):
         for node in tree.nodes()
         if node.kind == "With" and node.line_col_span().start_line == 32
     )
+
+
+def test_local_two_name_managers_project_both_reaching_calls(tmp_path: Path) -> None:
+    source = tmp_path / "truthful.py"
+    source.write_text(
+        "def exercise(make_manager):\n"
+        "    opt = make_manager()\n"
+        "    with_latex = make_manager()\n"
+        "    with opt, with_latex:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+    site = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 4
+    )
+
+    assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
+    projected = _projected_manager_call_uses(tree)
+    rows = sorted(
+        (call.line_col_span().start_line, coordinate.start_line, coordinate.start_col)
+        for coordinate, call, _exit_face in projected.values()
+        if coordinate.start_line == 4
+    )
+    assert rows == [(2, 4, 9), (3, 4, 14)]
 
 
 def test_pandas_303_two_name_managers_project_their_assignment_calls() -> None:


### PR DESCRIPTION
## Summary

- pin the local native `with first, second` shape where both manager heads are bare Names assigned from earlier calls
- prove both reaching calls are projected to the immutable manager-use coordinates, while an undecided rebinding refuses to invent the second preimage
- route the real pandas 3.0.3 reproducer through `authenticated_pandas_corpus()` and the canonical content-manifest CID instead of the workstation's installed-package location

## Finding

#6489 already implements this mechanism. Its transactional enclosing-function substitution projects reaching assignments for multi-item With nodes without mutating the source tree. #6503 independently pins ordered mixed-manager composition after construction; it complements this head projection but does not create it.

The unauthenticated shape-only check confirms file CID `blake3-512:60e7b5ba2c971960e4d8edcaa85e916704dc8bfb977bc15dafb2f2b3e87458ffba4b2f823e500c4c591a968b7c3e8ed436035aa171e8b3227055d9956147fae1`, With start line 32, manager kinds `Name,Name`, and names `opt,with_latex`. This is not presented as corpus authentication.

## Local validation

- local truthful/lying projection twins: `2 passed, 3 deselected`
- #6503 mixed-manager composition: `19 passed`
- mutation transaction: changing multi-item admission from `len(items) > 1` to `> 2` made both local projection teeth fail (`2 failed`, exit 1); reverting restored both (`2 passed`, exit 0)
- `black --check`: clean
- `git diff --check`: clean

## Deferred authenticated evidence

The three real-pandas tests now require `authenticated_pandas_corpus()` with canonical manifest CID `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`, pandas 3.0.3, and 1,421 files. They await battleaxe's sole CPython 3.12.13 / NumPy 2.5.1 authority.

No authenticated receipt, crash/timeout zero, or corpus delta is claimed. The 367-site BinOp attribution and Call population receipt remain pending the same battleaxe artifacts.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test for projecting two bare-name manager calls in a single `with` statement
> - Adds `test_local_two_name_managers_project_both_reaching_calls` to validate that two context managers assigned via separate calls and entered in one `with` block are correctly projected to their respective call sites (lines 2 and 3).
> - Replaces `importlib.metadata`-based pandas root discovery in `_pandas_root` with `authenticated_pandas_corpus()`, adding runtime assertions on version (`3.0.3`), manifest CID (`PANDAS_MANIFEST_CID`), and file count (1421).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba3fe7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->