### PR TITLE
Land bootstrap-venv-py312 on main with exact-runtime twins

### DIFF
--- a/scripts/bootstrap-venv-py312.sh
+++ b/scripts/bootstrap-venv-py312.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Authenticated local inner loop: CPython 3.12.13 venv + declared corpus pins.
+#
+# A venv does NOT install its own interpreter. It only inherits the executable
+# it was created from. Therefore:
+#
+#   python3 -m venv .venv-py312
+#
+# on a machine whose `python3` is 3.14.4 produces another 3.14.4 environment,
+# regardless of the directory name. That is the environment-layer placeholder
+# pattern: a label that does not name the runtime it carries.
+#
+# Declared pins (sugar-build.toml + sugar-lift-py-tests[test] on main):
+#   python 3.12.13, numpy 2.5.1, pandas 3.0.3, pytest 9.1.1
+#
+# Usage (from any checkout of this repository — the script must be IN the tree):
+#   bash scripts/bootstrap-venv-py312.sh
+#   .venv-py312/bin/python -m pytest …
+#
+# Environment:
+#   PYTHON312   exact 3.12.13 executable (default: search Homebrew / PATH)
+#   VENV_DIR    destination (default: <repo>/.venv-py312)
+#   BOOTSTRAP_CHECK_ONLY=1
+#               validate the interpreter only; do not create a venv or pip install
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$repo_root"
+
+die() {
+  echo "bootstrap-venv-py312: $*" >&2
+  exit 2
+}
+
+require_exact_cpython_31213() {
+  local exe="$1"
+  [[ -n "$exe" && -x "$exe" ]] || die "need an executable CPython 3.12.13 path"
+  local ver
+  ver="$("$exe" -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')"
+  # Exact triple — not 3.12.x, not a prefix. 3.12.0 and 3.12.30 both fail.
+  if [[ "$ver" != "3.12.13" ]]; then
+    die "required exact CPython 3.12.13; observed $ver at $exe"
+  fi
+}
+
+py312="${PYTHON312:-}"
+if [[ -z "$py312" ]]; then
+  for candidate in \
+    /usr/local/opt/python@3.12/bin/python3.12 \
+    /usr/local/bin/python3.12 \
+    /opt/homebrew/bin/python3.12 \
+    "$(command -v python3.12 2>/dev/null || true)"
+  do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      py312="$candidate"
+      break
+    fi
+  done
+fi
+[[ -n "$py312" && -x "$py312" ]] || die \
+  "need CPython 3.12.13 (local authority often /usr/local/opt/python@3.12/bin/python3.12); refuse bare python3"
+
+require_exact_cpython_31213 "$py312"
+
+if [[ "${BOOTSTRAP_CHECK_ONLY:-0}" == "1" ]]; then
+  echo "bootstrap-venv-py312: check-only OK ($py312 is CPython 3.12.13)"
+  exit 0
+fi
+
+venv_dir="${VENV_DIR:-$repo_root/.venv-py312}"
+echo "Creating $venv_dir from $py312 (3.12.13)"
+"$py312" -m venv "$venv_dir"
+"$venv_dir/bin/python" -m pip install -U pip setuptools wheel
+
+# Editable Sugar packages always come from THIS checkout.
+"$venv_dir/bin/python" -m pip install \
+  -e "$repo_root/implementations/python/sugar-source-tree" \
+  -e "$repo_root/implementations/python/sugar-lift-python-source" \
+  -e "$repo_root/implementations/python/sugar-lift-py-tests[test]" \
+  "pytest==9.1.1"
+
+# AFTER the editable install: float was measured when extras resolved pandas
+# 3.0.5 while ledgers key to 3.0.3. Re-pin exactly, then verify load path.
+"$venv_dir/bin/python" -m pip install "numpy==2.5.1" "pandas==3.0.3"
+
+"$venv_dir/bin/python" - <<'PY'
+"""Post-install discrimination: version AND load path inside this venv."""
+from __future__ import annotations
+
+import importlib.metadata as md
+import pathlib
+import sys
+import sysconfig
+
+import numpy
+import pandas
+
+assert sys.version_info[:3] == (3, 12, 13), sys.version
+assert numpy.__version__ == "2.5.1", numpy.__version__
+assert pandas.__version__ == "3.0.3", pandas.__version__
+purelib = pathlib.Path(sysconfig.get_paths()["purelib"]).resolve()
+assert purelib in pathlib.Path(numpy.__file__).resolve().parents, numpy.__file__
+assert purelib in pathlib.Path(pandas.__file__).resolve().parents, pandas.__file__
+print("interpreter", sys.version.split()[0], sys.executable)
+print("numpy", numpy.__version__, pathlib.Path(numpy.__file__).resolve())
+print("pandas", pandas.__version__, pathlib.Path(pandas.__file__).resolve())
+print("pytest", md.version("pytest"))
+print("PINS_OK")
+PY
+
+echo
+echo "Use:  $venv_dir/bin/python -m pytest …"
+echo "Feature worktree: reinstall its editable packages, then re-pin"
+echo "  numpy==2.5.1 pandas==3.0.3 (the post-editable step is load-bearing)."
+echo "Note: macOS cannot consume Battleaxe Linux Sugar binary cells."

--- a/tests/bootstrap_venv_py312_twins.sh
+++ b/tests/bootstrap_venv_py312_twins.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Twins for scripts/bootstrap-venv-py312.sh — bankable on every worktree.
+#
+# Law: a venv only inherits the executable it was created from. A directory
+# named .venv-py312 built from bare `python3` (3.14.4) is still 3.14.4.
+# Exact CPython 3.12.13 is required; 3.12.x is not enough. Corpus pins are
+# re-applied AFTER editable install (pandas floated 3.0.5 otherwise).
+set -euo pipefail
+
+repo="${1:?usage: bootstrap_venv_py312_twins.sh REPO_ROOT}"
+cd "$repo"
+
+fail() {
+  echo "bootstrap_venv_py312_twins: $*" >&2
+  exit 1
+}
+
+script="$repo/scripts/bootstrap-venv-py312.sh"
+[[ -f "$script" ]] || fail "scripts/bootstrap-venv-py312.sh is not in the tree"
+[[ -x "$script" ]] || fail "scripts/bootstrap-venv-py312.sh is not executable"
+
+# -- script text teeth -------------------------------------------------------
+
+rg -q '3\.12\.13' "$script" || fail "bootstrap does not require exact 3.12.13"
+rg -q 'numpy==2\.5\.1' "$script" || fail "bootstrap missing numpy==2.5.1 pin"
+rg -q 'pandas==3\.0\.3' "$script" || fail "bootstrap missing pandas==3.0.3 pin"
+rg -q 'purelib|sysconfig' "$script" || fail "bootstrap does not verify load path / purelib"
+rg -q 'BOOTSTRAP_CHECK_ONLY' "$script" || fail "bootstrap missing BOOTSTRAP_CHECK_ONLY gate"
+
+editable_line="$(rg -n "sugar-lift-py-tests\[test\]" "$script" | head -1 | cut -d: -f1)"
+numpy_line="$(rg -n 'numpy==2\.5\.1' "$script" | head -1 | cut -d: -f1)"
+[[ -n "$editable_line" && -n "$numpy_line" ]] || fail "could not locate editable/pin order"
+[[ "$numpy_line" -gt "$editable_line" ]] || fail "corpus pins must run AFTER editable [test] install"
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-venv-py312.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+# -- lying twin: non-exact 3.12.x (3.12.0) ------------------------------------
+
+fake_3120="$tmp/fake-python-3.12.0"
+cat >"$fake_3120" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-c" ]]; then
+  printf '%s\n' "3.12.0"
+  exit 0
+fi
+echo "fake-python-3.12.0: unexpected: $*" >&2
+exit 1
+EOF
+chmod +x "$fake_3120"
+
+set +e
+PYTHON312="$fake_3120" BOOTSTRAP_CHECK_ONLY=1 bash "$script" \
+  >"$tmp/out-3120" 2>"$tmp/err-3120"
+status_3120=$?
+set -e
+[[ "$status_3120" -ne 0 ]] || fail "bootstrap accepted CPython 3.12.0"
+rg -q '3\.12\.13' "$tmp/err-3120" || fail "3.12.0 refusal did not name required 3.12.13"
+rg -q '3\.12\.0' "$tmp/err-3120" || fail "3.12.0 refusal did not name observed 3.12.0"
+
+# -- lying twin: bare python3 when it is not 3.12.13 -------------------------
+
+bare=""
+for candidate in /usr/local/bin/python3 /opt/homebrew/bin/python3 "$(command -v python3 2>/dev/null || true)"; do
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    bare="$candidate"
+    break
+  fi
+done
+if [[ -n "$bare" ]]; then
+  bare_ver="$("$bare" -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')"
+  if [[ "$bare_ver" != "3.12.13" ]]; then
+    set +e
+    PYTHON312="$bare" BOOTSTRAP_CHECK_ONLY=1 VENV_DIR="$tmp/must-not-exist" bash "$script" \
+      >"$tmp/out-bare" 2>"$tmp/err-bare"
+    status_bare=$?
+    set -e
+    [[ "$status_bare" -ne 0 ]] || fail "bootstrap accepted bare python3 ($bare_ver)"
+    rg -q '3\.12\.13' "$tmp/err-bare" || fail "bare-python3 refusal did not name required 3.12.13"
+    rg -Fq "$bare_ver" "$tmp/err-bare" || fail "bare-python3 refusal did not name observed $bare_ver"
+    [[ ! -e "$tmp/must-not-exist" ]] || fail "bootstrap created a venv after refusing the runtime"
+  fi
+fi
+
+# -- simulated full bootstrap: editable float then post-editable re-pin ------
+# Proves the pin step runs after [test] and that PINS_OK requires the re-pin.
+
+fake_base="$tmp/fake-python-3.12.13"
+fake_state="$tmp/state"
+mkdir -p "$fake_state"
+fake_venv_python="$tmp/fake-venv-python"
+
+cat >"$fake_base" <<'FAKE_BASE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == -c ]]; then
+  printf '3.12.13\n'
+  exit 0
+fi
+if [[ "${1:-}" == -m && "${2:-}" == venv ]]; then
+  venv_dir="${3:?missing venv directory}"
+  mkdir -p "$venv_dir/bin"
+  cp "$FAKE_VENV_PYTHON" "$venv_dir/bin/python"
+  chmod +x "$venv_dir/bin/python"
+  exit 0
+fi
+echo "unexpected base interpreter arguments: $*" >&2
+exit 97
+FAKE_BASE
+chmod +x "$fake_base"
+
+cat >"$fake_venv_python" <<'FAKE_VENV'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_STATE/commands"
+if [[ "${1:-}" == -m && "${2:-}" == pip ]]; then
+  # Editable [test] install historically floated pandas to 3.0.5.
+  case " $* " in
+    *"sugar-lift-py-tests[test]"*) printf '3.0.5\n' >"$FAKE_STATE/pandas" ;;
+  esac
+  saw_numpy=0
+  saw_pandas=0
+  for arg in "$@"; do
+    [[ "$arg" != numpy==2.5.1 ]] || saw_numpy=1
+    [[ "$arg" != pandas==3.0.3 ]] || saw_pandas=1
+  done
+  if [[ "$saw_numpy" == 1 && "$saw_pandas" == 1 ]]; then
+    printf '2.5.1\n' >"$FAKE_STATE/numpy"
+    printf '3.0.3\n' >"$FAKE_STATE/pandas"
+  fi
+  exit 0
+fi
+# Post-install verification heredoc: stdin mode (`python -`).
+if [[ "${1:-}" == - ]]; then
+  [[ "$(cat "$FAKE_STATE/numpy")" == 2.5.1 ]] || {
+    echo "post-editable pin missing: numpy not 2.5.1" >&2
+    exit 1
+  }
+  [[ "$(cat "$FAKE_STATE/pandas")" == 3.0.3 ]] || {
+    echo "post-editable pin missing: pandas still floated (not 3.0.3)" >&2
+    exit 1
+  }
+  printf 'PINS_OK\n'
+  exit 0
+fi
+echo "unexpected venv interpreter arguments: $*" >&2
+exit 98
+FAKE_VENV
+chmod +x "$fake_venv_python"
+
+truthful_out="$tmp/truthful.out"
+FAKE_STATE="$fake_state" FAKE_VENV_PYTHON="$fake_venv_python" \
+  PYTHON312="$fake_base" VENV_DIR="$tmp/venv" \
+  bash "$script" >"$truthful_out"
+rg -Fq PINS_OK "$truthful_out" || fail "simulated bootstrap did not reach PINS_OK"
+rg -Fq 'numpy==2.5.1' "$fake_state/commands" || fail "simulated bootstrap never pip-installed numpy==2.5.1"
+rg -Fq 'pandas==3.0.3' "$fake_state/commands" || fail "simulated bootstrap never pip-installed pandas==3.0.3"
+
+# -- truthful twin: real 3.12.13 when available --------------------------------
+
+real_312=""
+for candidate in \
+  /usr/local/opt/python@3.12/bin/python3.12 \
+  /usr/local/bin/python3.12 \
+  /opt/homebrew/bin/python3.12 \
+  "$(command -v python3.12 2>/dev/null || true)"
+do
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    cand_ver="$("$candidate" -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])' 2>/dev/null || true)"
+    if [[ "$cand_ver" == "3.12.13" ]]; then
+      real_312="$candidate"
+      break
+    fi
+  fi
+done
+
+if [[ -n "$real_312" ]]; then
+  PYTHON312="$real_312" BOOTSTRAP_CHECK_ONLY=1 bash "$script" \
+    >"$tmp/out-ok" 2>"$tmp/err-ok" \
+    || fail "bootstrap check-only refused real CPython 3.12.13 at $real_312"
+  rg -q 'check-only OK' "$tmp/out-ok" || fail "truthful twin did not print check-only OK"
+else
+  echo "bootstrap_venv_py312_twins: note: no local CPython 3.12.13; skipped real-executable twin"
+fi
+
+# -- runtime coordinate API (same required string as the shell gate) ----------
+
+python3 - <<'PY' || fail "runtime coordinate twin failed"
+from pathlib import Path
+import sys
+
+sys.path.insert(
+    0,
+    str(Path("implementations/python/sugar-lift-py-tests/src").resolve()),
+)
+from sugar_lift_py_tests.authenticated_pytest import (
+    ExecutionEnvironmentMismatch,
+    InterpreterIdentity,
+    authenticate_interpreter_runtime,
+    declared_interpreter_runtime,
+)
+
+assert declared_interpreter_runtime() == "cpython-3.12.13"
+authenticate_interpreter_runtime(
+    InterpreterIdentity("cpython", "3.12.13", Path("/declared"))
+)
+try:
+    authenticate_interpreter_runtime(
+        InterpreterIdentity("cpython", "3.14.4", Path("/bare-python3-venv"))
+    )
+except ExecutionEnvironmentMismatch as exc:
+    text = str(exc)
+    assert "cpython-3.12.13" in text and "cpython-3.14.4" in text, text
+else:
+    raise SystemExit("3.14.4 identity was not refused")
+print("runtime-coordinate twin OK")
+PY
+
+echo "PASS: bootstrap-venv-py312 twins (exact 3.12.13, post-editable pins, bare-python3 refuse, runtime coordinate)"

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -222,3 +222,22 @@ def test_bpytest_wrapper_contract_is_collected_by_pytest() -> None:
     )
     assert completed.returncode == 0, completed.stderr
     assert "PASS: authenticated bpytest wrapper" in completed.stdout
+
+
+def test_bootstrap_venv_py312_twins_are_collected_by_pytest() -> None:
+    """The bootstrap script must live on main and refuse bare-python3 envs.
+
+    A prior session left scripts/bootstrap-venv-py312.sh only on one machine's
+    disk; other worktrees could not find it. These twins fail if the script is
+    absent, if pins are not post-editable, or if a non-exact 3.12.x / bare
+    python3 is accepted.
+    """
+    repo = Path(__file__).resolve().parents[1]
+    completed = subprocess.run(
+        ["bash", str(repo / "tests/bootstrap_venv_py312_twins.sh"), str(repo)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr + completed.stdout
+    assert "PASS: bootstrap-venv-py312 twins" in completed.stdout


### PR DESCRIPTION
## Why

The local 3.12.13 venv path was described but **not bankable**:

- `scripts/bootstrap-venv-py312.sh` was absent from `origin/main`
- other worktrees could not run what was only on one machine's disk
- a venv only inherits the executable it was created from — bare `python3` (3.14.4) cannot become 3.12.13 by directory name

## What ships

- `scripts/bootstrap-venv-py312.sh` in-tree (any checkout)
  - exact **CPython 3.12.13** only
  - editable Sugar packages from the checkout
  - **post-editable** `numpy==2.5.1` / `pandas==3.0.3` re-pin
  - load-path (purelib) verification
  - `BOOTSTRAP_CHECK_ONLY=1` for cheap twins
- `tests/bootstrap_venv_py312_twins.sh` + pytest collector in `test_authenticated_python_launcher.py`
  - lying: fake 3.12.0 refused
  - lying: bare `python3` when not 3.12.13 refused
  - truthful: real 3.12.13 check-only OK when present
  - runtime coordinate: 3.14.4 identity refused by `authenticate_interpreter_runtime`

## Local authority on this Mac

```
/usr/local/opt/python@3.12/bin/python3.12  → 3.12.13
/Users/tsavo/provekit/.venv-py312          → created from that executable
```

Owners in other worktrees:

```bash
bash scripts/bootstrap-venv-py312.sh
.venv-py312/bin/python -m pytest …
```

## Validation

```
bash tests/bootstrap_venv_py312_twins.sh "$PWD"   # PASS
pytest …test_bootstrap_venv_py312_twins…          # PASS
pytest …test_undeclared_cpython_3144…             # PASS
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CPython 3.12.13 bootstrap script with exact-runtime enforcement and twin tests
> - Adds [scripts/bootstrap-venv-py312.sh](https://github.com/TSavo/sugar/pull/6507/files#diff-a22bd73dfaccdbcb19ad8940327c62df8c7d5f112e66d08ca65cdf2bccf65be9), which creates a venv requiring exactly CPython 3.12.13, installs editable Sugar packages, then re-pins `numpy==2.5.1` and `pandas==3.0.3` after editable resolution, and verifies versions and load paths inside the venv.
> - Adds [tests/bootstrap_venv_py312_twins.sh](https://github.com/TSavo/sugar/pull/6507/files#diff-716f09c62f476680fc7f4b9fa8254bb13389356b7fd383cb2776b8343da6ddcd), a bash test harness that statically checks the bootstrap script's content, simulates lying/correct interpreters, and validates the `declared_interpreter_runtime()` API in `sugar_lift_py_tests.authenticated_pytest`.
> - Adds `test_bootstrap_venv_py312_twins_are_collected_by_pytest` in [tests/test_authenticated_python_launcher.py](https://github.com/TSavo/sugar/pull/6507/files#diff-4828ee1c7023051b0e295dd4542ed70f95a8cf4cfdd5130818336514e314d17a) to run the twins harness under pytest and assert a PASS sentinel in stdout.
> - Supports `BOOTSTRAP_CHECK_ONLY=1` to validate the interpreter without creating a venv, and `VENV_DIR` to override the default `.venv-py312` location.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 739e156.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a bootstrap utility for creating and validating a Python 3.12.13 virtual environment.
  - Added automated installation and verification of pinned development dependencies.
  - Added check-only validation for confirming the required Python interpreter.

- **Tests**
  - Added coverage for interpreter version validation, dependency pinning, runtime authentication, and successful bootstrap checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->