### PR TITLE
Bootstrap authenticated CPython 3.12.13 venv

### DIFF
--- a/scripts/bootstrap-venv-py312.sh
+++ b/scripts/bootstrap-venv-py312.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Authenticated local macOS inner loop: CPython 3.12.13 plus corpus pins.
+#
+# A venv inherits its creator. Bare `python3` is 3.14.4 on this Mac and cannot
+# create authenticated demand-table testimony. The installed authority is:
+#   /usr/local/opt/python@3.12/bin/python3.12
+#
+# Feature worktrees must run this helper from their own checkout (or reinstall
+# its editable packages there), then re-pin NumPy and pandas as done below.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$repo_root"
+
+die() {
+  echo "bootstrap-venv-py312: $*" >&2
+  exit 2
+}
+
+py312="${PYTHON312:-}"
+if [[ -z "$py312" ]]; then
+  for candidate in \
+    /usr/local/opt/python@3.12/bin/python3.12 \
+    /usr/local/bin/python3.12 \
+    /opt/homebrew/bin/python3.12 \
+    "$(command -v python3.12 2>/dev/null || true)"
+  do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      py312="$candidate"
+      break
+    fi
+  done
+fi
+[[ -n "$py312" && -x "$py312" ]] || die \
+  "need exact CPython 3.12.13 at /usr/local/opt/python@3.12/bin/python3.12 or set PYTHON312"
+
+version="$("$py312" -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')"
+[[ "$version" == 3.12.13 ]] || die \
+  "required exact CPython 3.12.13; observed $version at $py312"
+
+venv_dir="${VENV_DIR:-$repo_root/.venv-py312}"
+echo "Creating $venv_dir from $py312 ($version)"
+"$py312" -m venv "$venv_dir"
+"$venv_dir/bin/python" -m pip install -U pip setuptools wheel
+
+"$venv_dir/bin/python" -m pip install \
+  -e "$repo_root/implementations/python/sugar-source-tree" \
+  -e "$repo_root/implementations/python/sugar-lift-python-source" \
+  -e "$repo_root/implementations/python/sugar-lift-py-tests[test]" \
+  "pytest==9.1.1"
+
+# This must follow the editable install: old worktree extras floated pandas to
+# 3.0.5. Re-pin the authenticated corpus before verifying what was imported.
+"$venv_dir/bin/python" -m pip install "numpy==2.5.1" "pandas==3.0.3"
+
+"$venv_dir/bin/python" - <<'PY'
+import pathlib
+import sys
+
+import numpy
+import pandas
+
+assert sys.version_info[:3] == (3, 12, 13), sys.version
+assert numpy.__version__ == "2.5.1", numpy.__version__
+assert pandas.__version__ == "3.0.3", pandas.__version__
+purelib = (
+    pathlib.Path(sys.prefix)
+    / "lib"
+    / f"python{sys.version_info[0]}.{sys.version_info[1]}"
+    / "site-packages"
+)
+assert purelib in pathlib.Path(numpy.__file__).resolve().parents
+assert purelib in pathlib.Path(pandas.__file__).resolve().parents
+print("interpreter", sys.version.split()[0], sys.executable)
+print("numpy", numpy.__version__)
+print("pandas", pandas.__version__)
+print("PINS_OK")
+PY
+
+echo "Use: $venv_dir/bin/python -m pytest ..."

--- a/tests/bootstrap_venv_py312.sh
+++ b/tests/bootstrap_venv_py312.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+bootstrap="$repo_root/scripts/bootstrap-venv-py312.sh"
+authority=/usr/local/opt/python@3.12/bin/python3.12
+
+[[ -x "$bootstrap" ]] || { echo "missing executable $bootstrap" >&2; exit 1; }
+[[ -x "$authority" ]]
+[[ "$($authority -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')" == 3.12.13 ]]
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/state"
+
+cat >"$tmp/fake-base" <<'FAKE_BASE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == -c ]]; then printf '3.12.13\n'; exit 0; fi
+if [[ "${1:-}" == -m && "${2:-}" == venv ]]; then
+  mkdir -p "$3/bin"
+  cp "$FAKE_VENV" "$3/bin/python"
+  chmod +x "$3/bin/python"
+  exit 0
+fi
+exit 97
+FAKE_BASE
+chmod +x "$tmp/fake-base"
+
+cat >"$tmp/fake-venv" <<'FAKE_VENV'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_STATE/commands"
+if [[ "${1:-}" == -m && "${2:-}" == pip ]]; then
+  saw_numpy=0
+  saw_pandas=0
+  for arg in "$@"; do
+    [[ "$arg" != numpy==2.5.1 ]] || saw_numpy=1
+    [[ "$arg" != pandas==3.0.3 ]] || saw_pandas=1
+  done
+  if [[ "$saw_numpy" == 1 && "$saw_pandas" == 1 ]]; then
+    printf '2.5.1\n' >"$FAKE_STATE/numpy"
+    printf '3.0.3\n' >"$FAKE_STATE/pandas"
+  fi
+  exit 0
+fi
+if [[ "${1:-}" == - ]]; then
+  [[ "$(cat "$FAKE_STATE/numpy")" == 2.5.1 ]]
+  [[ "$(cat "$FAKE_STATE/pandas")" == 3.0.3 ]]
+  printf 'PINS_OK\n'
+  exit 0
+fi
+exit 98
+FAKE_VENV
+chmod +x "$tmp/fake-venv"
+
+FAKE_STATE="$tmp/state" FAKE_VENV="$tmp/fake-venv" \
+  PYTHON312="$tmp/fake-base" VENV_DIR="$tmp/venv" \
+  bash "$bootstrap" >"$tmp/truthful.out"
+grep -Fq PINS_OK "$tmp/truthful.out"
+grep -Fq 'numpy==2.5.1 pandas==3.0.3' "$tmp/state/commands"
+
+rc=0
+PYTHON312=/usr/local/bin/python3 VENV_DIR="$tmp/lying-venv" \
+  bash "$bootstrap" >"$tmp/lying.out" 2>"$tmp/lying.err" || rc=$?
+[[ "$rc" -eq 2 ]]
+grep -Fq 'required exact CPython 3.12.13; observed 3.14.4 at /usr/local/bin/python3' "$tmp/lying.err"
+[[ ! -e "$tmp/lying-venv" ]]
+
+echo "PASS: exact CPython 3.12.13 venv bootstrap"


### PR DESCRIPTION
## Summary

Land the missing local macOS bootstrap for the declared CPython 3.12.13 runtime. The helper records `/usr/local/opt/python@3.12/bin/python3.12` as this machine’s authority, creates the venv from that executable, installs editable packages from the invoking checkout, then force-pins NumPy 2.5.1 and pandas 3.0.3 afterward.

The post-install verifier checks the exact interpreter patch, exact corpus package versions, and that both packages load from the created venv. Bare `/usr/local/bin/python3` is refused as observed CPython 3.14.4 before any placeholder venv is created.

Feature worktrees should run this helper from their own checkout, or reinstall the three editable packages from their tree and then reinstall `numpy==2.5.1 pandas==3.0.3`.

## Validation

- `bash tests/bootstrap_venv_py312.sh` — PASS, including truthful and lying twins
- `/Users/tsavo/provekit/.venv-py312/bin/python` reports CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3
- `bash -n scripts/bootstrap-venv-py312.sh tests/bootstrap_venv_py312.sh`
- `git diff --check HEAD^ HEAD`

Predicted epsilon: local-runtime-authentication blockers -9 when owners reinstall editables from their own worktrees. Floors preserved: exact runtime patch, exact corpus pins, no bare-python fallback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bootstrap authenticated CPython 3.12.13 venv with pinned numpy and pandas
> - Adds [scripts/bootstrap-venv-py312.sh](https://github.com/TSavo/sugar/pull/6508/files#diff-a22bd73dfaccdbcb19ad8940327c62df8c7d5f112e66d08ca65cdf2bccf65be9) to create a `.venv-py312` virtual environment using exactly CPython 3.12.13, installs three local editable packages, and pins `numpy==2.5.1` and `pandas==3.0.3`.
> - The script verifies the interpreter version and package pins at the end, exiting with code 2 if either invariant is not met.
> - Adds [tests/bootstrap_venv_py312.sh](https://github.com/TSavo/sugar/pull/6508/files#diff-dd30716d51f910dbf1ce4e1840b14bfe4a58f4439f582d60b02fcd1d6695e7e5) with a bash test harness that uses shims to assert correct pin installation and that a mismatched interpreter (e.g. 3.14.4) causes an exit code 2 with no venv created.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11c9441.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->