### PR TITLE
Step past statements that owe nothing

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -56,6 +56,28 @@ class OpaqueStepV1:
 
 
 @dataclass(frozen=True)
+class InertStepV1:
+    """A body statement that owes NOTHING and is therefore stepped past.
+
+    The discriminating property is not the statement's spelling but what it
+    owes: no effect, no binding, no suspension. A bare ``Constant`` expression
+    -- a docstring, or any evaluated-and-discarded literal -- is the only shape
+    admitted today, because evaluating a literal and discarding it is
+    observationally nothing.
+
+    This is deliberately NARROWER than ``OpaqueStepV1``. An opaque step names a
+    real obligation the vocabulary cannot yet perform; an inert step names the
+    absence of one. Widening this row to any statement that merely *looks*
+    harmless would make the machine skip work it cannot do and report the wrong
+    blocker -- the failure this row must never cause. ``observed`` is retained
+    so a stepped-past statement is still nameable in testimony rather than
+    vanishing.
+    """
+
+    observed: str
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     statements: tuple[object, ...]
 
@@ -85,7 +107,9 @@ class IfStepV1:
     fragment_cid: str
 
 
-GeneratorStepV1 = YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | FinallyStepV1 | IfStepV1
+GeneratorStepV1 = (
+    YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | InertStepV1 | FinallyStepV1 | IfStepV1
+)
 
 
 @dataclass(frozen=True)
@@ -197,6 +221,13 @@ class GeneratorConstructionV1:
         step = self.steps[self.cursor]
         if isinstance(step, OpaqueStepV1):
             return self._gap(requested, step.gap_observed())
+        if isinstance(step, InertStepV1):
+            # Owes nothing, so there is nothing to perform and nothing to
+            # refuse: advance and let the NEXT step answer. This is what makes
+            # the machine report its first real blocker instead of the first
+            # statement it happens to meet.
+            machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
         if isinstance(step, FinallyStepV1):
             cleanup = self._reduce_finally(step)
             from sugar_lift_py_tests.outcome import Completed, Halted

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1615,10 +1615,30 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
 def test_installed_pandas_warning_manager_names_opaque_generator_transition(tmp_path):
     """Real producer advances to its first still-opaque native transition.
 
-    The imported generator frame comes only from authenticated pandas source.
-    Its outer warning-capture ``With`` is not in the generator-step vocabulary,
-    so construction names that transition instead of inventing warning
-    testimony or collapsing the site to ``non-manager-result:BlockValue``.
+    The imported generator frame comes only from authenticated pandas source,
+    and construction names its first unconsumable step instead of inventing
+    warning testimony or collapsing the site to
+    ``non-manager-result:BlockValue``.
+
+    ``assert_produces_warning`` has a THREE-statement body::
+
+        0  Expr    (a ``Constant`` -- the docstring)
+        1  Assign  (``__tracebackhide__ = True``)
+        2  With    (the warning capture)
+
+    Statement 0 owes nothing -- no effect, no binding, no suspension -- so it
+    is stepped as an ``InertStepV1`` and is not the answer. Statement 1 is,
+    because a binding is real work the machine cannot yet perform.
+
+    This test previously asserted ``With``, which is statement TWO PAST where
+    the machine can reach; it was born red and never passed. ``With`` is the
+    KNOWN REMAINING DISTANCE, not a defect in this arm: naming it requires
+    stepping ``__tracebackhide__ = True``, and a binding step needs an
+    authenticated binding record that ``binding_state`` does not yet hold.
+    That is its own mechanism and its own PR.
+
+    Still a tooth: remove ``InertStepV1`` and the docstring blocks first, so
+    this node reports ``Expr`` and goes red.
     """
     consumer = (
         "import pandas._testing as tm\n"
@@ -1648,7 +1668,7 @@ def test_installed_pandas_warning_manager_names_opaque_generator_transition(tmp_
     with pytest.raises(SugarNotWritten) as caught:
         boundary.desugar()
     assert caught.value.owner == "GeneratorWithSugar.desugar"
-    assert caught.value.observed == "opaque generator transition: With"
+    assert caught.value.observed == "opaque generator transition: Assign"
 
 
 def test_imported_renamed_generator_manager_installs_native_frame(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2097,6 +2097,7 @@ class FunctionDef(Statement):
         from sugar_lift_py_tests.generator_construction import (
             FinallyStepV1,
             IfStepV1,
+            InertStepV1,
             OpaqueStepV1,
             ReturnStepV1,
             YieldStepV1,
@@ -2151,6 +2152,22 @@ class FunctionDef(Statement):
                 steps.append(
                     FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
                 )
+            elif (
+                isinstance(statement, Expr)
+                and isinstance(statement.value, Constant)
+                and not self._owns_yield((statement,))
+            ):
+                # EVALUATED AND DISCARDED IS NOTHING. A bare `Constant`
+                # expression -- the docstring case -- owes no effect, no
+                # binding and no suspension, so calling it opaque made the
+                # machine refuse at a statement that asks for nothing and name
+                # the WRONG blocker. It is stepped, not performed.
+                #
+                # The admission is structural (`Expr` holding `Constant`) and
+                # the suspension check is `_owns_yield`, the same authenticated
+                # predicate the rest of this producer reads -- never a judgement
+                # that a statement "looks harmless".
+                steps.append(InertStepV1(statement.kind))
             elif isinstance(statement, If) and self._owns_yield((statement,)):
                 # A BRANCH IS A TWO-FACE PARTITION and this producer owns it.
                 # Admitted only when BOTH branches are wholly nameable: a

--- a/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
@@ -150,3 +150,46 @@ def test_contextmanager_style_try_finally_resumes_cleanup_before_termination():
     assert outcome.value.statements[0].formula == eq(
         ctor("enter_result_value", [str_const(sugar.enter_slot_id)]), num(7)
     )
+
+
+def test_docstring_is_stepped_and_is_never_the_blocker():
+    """TRUTHFUL TWIN. A leading docstring owes nothing, so it is stepped.
+
+    The generator enters at its `yield` exactly as it does with no docstring
+    at all -- the `InertStepV1` row is the whole difference. Without it the
+    machine refuses at statement zero and names `Expr`, which is a blocker
+    that asks for nothing.
+    """
+    sugar = _with_sugar("    '''Real work happens below.'''\n    yield 7")
+
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+    assert outcome.value.statements[0].formula == eq(
+        ctor("enter_result_value", [str_const(sugar.enter_slot_id)]), num(7)
+    )
+
+
+def test_inert_step_does_not_swallow_a_call_expression():
+    """LYING TWIN. An `Expr` that is not a `Constant` still owes execution.
+
+    `record()` is spelled like the docstring -- a bare expression statement --
+    and is exactly what a spelling-based admission would step past. It owes a
+    call, so it stays opaque and loud. If this node goes green the inert row
+    has been widened past what it can prove.
+    """
+    sugar = _with_sugar("    record()\n    yield 7")
+
+    with pytest.raises(SugarNotWritten, match="opaque generator transition: Expr"):
+        sugar.desugar()
+
+
+def test_inert_step_does_not_swallow_a_binding():
+    """LYING TWIN. A binding is real work and must remain the named blocker.
+
+    This is the pandas `__tracebackhide__ = True` shape, and it is what the
+    machine must report once the docstring ahead of it is stepped.
+    """
+    sugar = _with_sugar("    '''Doc.'''\n    hidden = True\n    yield 7")
+
+    with pytest.raises(SugarNotWritten, match="opaque generator transition: Assign"):
+        sugar.desugar()


### PR DESCRIPTION
## What

A leading docstring is an `Expr` holding a `Constant`. It owes **nothing** — no effect, no binding, no suspension — but construction classified it as an opaque step and refused there. The machine named a blocker that asks for nothing and never reached the first statement that owes real work.

`InertStepV1` is a new generator-step row for exactly that shape: **stepped, not performed.** The cursor advances and the NEXT step answers.

The admission is **structural** (`Expr` holding `Constant`) and the suspension check is `_owns_yield` — the same authenticated predicate the rest of this producer already reads. It is never a judgement that a statement "looks harmless." Deliberately narrower than `OpaqueStepV1`: an opaque step names a real obligation the vocabulary cannot yet perform; an inert step names the *absence* of one.

## Reproducer

`pandas._testing._warnings.assert_produces_warning`, re-derived with `ast` on the interpreter under test — not read, and not resolved by filesystem glob:

```text
interpreter      /usr/local/opt/python@3.14/bin/python3.14
pandas.__file__  /usr/local/lib/python3.14/site-packages/pandas/__init__.py
version          3.0.3
read             .../pandas/_testing/_warnings.py
sha256           9a2e43ea6d0393c954e6008c38a9582f1b44a6e563775559b39b2becabfe8f35   10121 B
pin              docs/ledgers/pins/pandas-3.0.3.pin.json  _testing/_warnings.py
                 9a2e43ea6d0393c954e6008c38a9582f1b44a6e563775559b39b2becabfe8f35   10121 B   IDENTICAL

assert_produces_warning body, len 3
  0  Expr    Constant   <- docstring
  1  Assign  __tracebackhide__ = True
  2  With    warnings.catch_warnings(record=True)
```

Byte-identical to the pinned corpus entry, so **`With`-is-third is a fact about the corpus the gate authenticates**, not about whichever pandas a venv happened to resolve.

## The expectation correction

`test_installed_pandas_warning_manager_names_opaque_generator_transition` asserted `With` — statement **two past** where the machine can reach. It was born red at `3ea2e0d42` and has never been green. That is not a regression guard; it is an unbuilt expectation whose stated premise ("its outer warning-capture `With` is not in the generator-step vocabulary, so construction names that transition") is false about the source it runs on.

Corrected to `Assign`. **This is not weakening an assertion to match output** — the correct value is derivable from the pinned source *without running this fix*. The docstring was rewritten rather than edited around it, because the stale premise is what sent two reviewers at the wrong file.

`Assign` is the **honest current blocker, not a settled contract.** `With` is the known remaining distance: naming it requires stepping `__tracebackhide__ = True`, which owes a binding, which needs an authenticated binding record that `binding_state` does not hold. Filed separately — this body is the reproducer for it.

## The corrected expectation is still a tooth

Three distinct outcomes, all measured on this branch, verbatim:

| admission | `caught.value.observed` | result |
|---|---|---|
| **no fix** (`InertStepV1` absent, expectation corrected) | `opaque generator transition: Expr` | RED |
| **this fix** | `opaque generator transition: Assign` | GREEN |
| **skip-everything** (widened admission) | `opaque generator transition: With carrying a suspension` | RED |

```text
# no fix — measured in a detached worktree at a46d3219a, grep InertStepV1 = 0/0 in the same invocation
>       assert caught.value.observed == "opaque generator transition: Assign"
E       AssertionError: assert 'opaque gener...nsition: Expr' == 'opaque gener...ition: Assign'
E         - opaque generator transition: Assign
E         + opaque generator transition: Expr
1 failed in 15.22s

# skip-everything — admission widened to `not _owns_yield and not isinstance(statement, (If, Try))`
>       assert caught.value.observed == "opaque generator transition: Assign"
E       AssertionError: assert 'opaque gener... a suspension' == 'opaque gener...ition: Assign'
E         - opaque generator transition: Assign
E         + opaque generator transition: With carrying a suspension
1 failed in 9.78s
```

Note outcome C: the wrong-blocker failure mode is **self-labelling.** It reports `With carrying a suspension`, not a bare `With`, because `OpaqueStepV1.gap_observed()` was already discriminating there. A reviewer who ever sees a bare `With` in this position knows something upstream changed.

So `Assign` pins the discrimination that matters — *a docstring is inert, a real binding is not* — and cannot be vacuous. The original expectation pinned neither.

## Twins

- **Truthful** — `test_docstring_is_stepped_and_is_never_the_blocker`: a leading docstring enters at `yield` exactly as with no docstring at all. The `InertStepV1` row is the whole difference.
- **Lying** — `test_inert_step_does_not_swallow_a_call_expression`: `record()` is spelled identically to a docstring (bare expression statement) and is exactly what a *spelling*-based admission would step past. It owes a call, so it stays opaque and loud.
- **Lying** — `test_inert_step_does_not_swallow_a_binding`: the pandas `__tracebackhide__ = True` shape. A binding is real work and must remain the named blocker.

Both lying twins are chosen against the spelling-based admission, which is the easy wrong version of this row.

## A/B pair

One worktree per half, own venv each, base is a **detached worktree** at the same sha — nothing to revert, so baseline content is true by construction. Full owning-package suites for both packages, since the assertion lives in `sugar-lift-python-source` and `InertStepV1` in `sugar-source-tree`.

```text
HEAD  /Users/tsavo/.buzz/REPOS/sugar-wt-honey-gendoc        a46d3219a + this diff
BASE  /Users/tsavo/.buzz/REPOS/sugar-wt-honey-inert-base    a46d3219a, detached, 0 dirty paths

content guard, pre AND post each half     InertStepV1  nodes.py / generator_construction.py
  HEAD pre  2 / 3      HEAD post  2 / 3
  BASE pre  0 / 0      BASE post  0 / 0
interpreter resolution, in the same invocation as the run
  all three first-party packages resolve to their OWN half's worktree
  pandas 3.0.3 on both halves

                            collected     failed   passed   roster wc -l
sugar-source-tree     BASE       737         45      691        45
                      HEAD       740         45      694        45
sugar-lift-python-source BASE     742         26      716        26
                      HEAD       742         25      717        25
```

`wc -l` of each roster equals that half's reported failure count in all four legs.

**Delta**

```text
sugar-source-tree          node set IDENTICAL (45 = 45, diff empty)
                           collected +3 = the three new twins, all passing
sugar-lift-python-source   -1 failure, 0 new:
  - test_sole_path_manager_construction.py::test_installed_pandas_warning_manager_names_opaque_generator_transition
```

Exactly one node fixed, zero regressions, and every added node accounted for.

## Notes

- `black` is red on `nodes.py` and `test_sole_path_manager_construction.py` at the base rev already. Its reformat ranges (`nodes.py:8454`, test file `:1766`/`:2258`) are disjoint from every hunk here (`nodes.py:2100`/`:2155`, test file `:1618`–`:1671`), so my lines are clean and no formatting sweep rides along.
- Base `a46d3219a`; `git log a46d3219a..origin/main` touching these four files is **empty** at `37266f3d8`.

- Follow-on filed as #6510 (binding step), with this same body as its reproducer.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Step past bare constant expressions (docstrings) in generator desugaring
> - Adds `InertStepV1` to represent body statements that have no effect, binding, or suspension (e.g. docstrings), and includes it in the `GeneratorStepV1` union.
> - `FunctionDef._source_visible_generator_steps_from` now emits `InertStepV1` for `Expr` nodes holding a `Constant` with no owned yield, rather than treating them as opaque blockers.
> - `GeneratorConstructionV1._transition` skips `InertStepV1` entries by advancing the cursor and recursing, so the first real blocker or actionable step is reported correctly.
> - `Expr` nodes that are not `Constant` (e.g. call expressions) remain opaque and still raise `SugarNotWritten`.
> - Behavioral Change: the first named opaque transition for functions with a leading docstring is now the statement after the docstring (e.g. `Assign`) rather than the docstring itself.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67834d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->