### PR TITLE
Require canonical corpus manifest in launcher gate

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
@@ -226,7 +226,8 @@ def test_launcher_exposes_corpus_by_identity_not_machine_path() -> None:
 
     assert corpus.version == "3.0.3"
     assert corpus.manifest_cid == (
-        "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+        "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604ed"
+        "a1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
     )
     assert corpus.file_count == 1421
     assert corpus.root.name == "pandas"


### PR DESCRIPTION
The authenticated launcher now pins its corpus identity assertion to the canonical ordered BLAKE3-512 content manifest rather than the historical SHA-256 path-shape digest.

This closes the merged-main inconsistency exposed by the new local CPython 3.12.13 environment: authentication correctly returned the content manifest, while the focused launcher test still expected the historical path-only digest.

Validation:
- `bash tests/bootstrap_venv_py312_twins.sh "$PWD"`
- `/Users/tsavo/provekit/.venv-py312/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py`
- `git diff --check`

The Battleaxe Linux binary and genuine CPython 3.12.13 demand-table cells were provisioned separately; this PR changes no artifact identity or resolver behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require BLAKE3-512 CID in launcher corpus manifest gate
> Updates the expected `corpus.manifest_cid` in the launcher gate test from a SHA-256 prefixed CID to a BLAKE3-512 prefixed CID. The test in [test_measured_corpus_is_authenticated.py](https://github.com/TSavo/sugar/pull/6512/files#diff-d7c861f6e8320146035c80bf7a4a3c02536b07675af0e579cfac8e3e560367de) now asserts the canonical manifest uses BLAKE3-512 hashing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff83882.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->