### PR TITLE
Require content manifest in subscript and BinOp producers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -14,10 +14,18 @@ from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_source_tree.nodes import BinOp
 from sugar_source_tree.tree import SourceFile
 
+# Content manifest (relative path + per-file BLAKE3-512). Path-shape
+# sha256:a223… is historical negative testimony only — never identity.
 PANDAS_MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+HISTORICAL_PATH_SHAPE_DIGEST = (
     "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 )
 FILE_SHA256 = "14698f3356d531b1cb87761c57be48737cb547b7ac97f7a6406c16336d5e2f5f"
+
+
 def _corpus_file() -> Path:
     corpus = authenticated_pandas_corpus()
     assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
@@ -25,6 +33,7 @@ def _corpus_file() -> Path:
         PANDAS_MANIFEST_CID,
         1421,
     )
+    assert corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST
     return corpus.root / "tests/series/test_logical_ops.py"
 
 
@@ -45,19 +54,36 @@ def _line_96_bitand(source: str, path: Path):
     return matches[0]
 
 
-def _assert_named_undecided_refusal(node, *, observed: str) -> None:
+def _assert_named_panic(
+    node,
+    *,
+    owner: str,
+    observed: str,
+    requested_contains: str,
+) -> None:
     with pytest.raises(ConstructionPanic) as raised:
         node.sugar().desugar(None)
     info = raised.value.info
-    assert info.owner == "binary_operation_exception_floor"
+    assert info.owner == owner
     assert info.observed == observed
-    assert "authenticated exceptional exit" in info.requested
+    assert requested_contains in info.requested
+    # Never invent a runtime TypeError / RuntimeEffect for undecided source.
     assert "TypeError" not in str(info)
     assert "RuntimeEffect" not in str(info)
 
 
 def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> None:
-    """Truthful/lying runtime twins cannot license invented source testimony."""
+    """Truthful/lying runtime twins cannot license invented source testimony.
+
+    Site: ``pandas/tests/series/test_logical_ops.py:96`` ``s_0123 & np.nan``.
+
+    Operand evaluation runs before the BinOp floor. On the truthful site the
+    right operand is ``np.nan`` — Attribute on an unresolved name — so the
+    named coordinate is ``SymbolicValue.attribute``. Replacing the right
+    operand with a term (``0``) removes that child gap and the panic lands on
+    ``binary_operation_exception_floor`` as ``SymbolicValue & TermValue``.
+    Neither arm invents TypeError.
+    """
     path = _corpus_file()
     truthful = path.read_text(encoding="utf-8")
     assert hashlib.sha256(truthful.encode("utf-8")).hexdigest() == FILE_SHA256
@@ -71,11 +97,19 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
     assert (series & 0).tolist() == [0, 0, 0, 0]
 
     lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
-    _assert_named_undecided_refusal(
+    _assert_named_panic(
         _line_96_bitand(truthful, path),
-        observed="SymbolicValue & SymbolicValue",
+        owner="SymbolicValue.attribute",
+        observed=(
+            "undecided receiver runtime type or member semantics: SymbolicValue.nan"
+        ),
+        requested_contains=(
+            "source-authenticated attribute success or exceptional exit"
+        ),
     )
-    _assert_named_undecided_refusal(
+    _assert_named_panic(
         _line_96_bitand(lying, path),
+        owner="binary_operation_exception_floor",
         observed="SymbolicValue & TermValue",
+        requested_contains="authenticated exceptional exit",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -26,7 +26,15 @@ from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.tree import SourceFile
 
 SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
-MANIFEST_CID = "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+# Content manifest (relative path + per-file BLAKE3-512). Path-shape
+# sha256:a223… is historical negative testimony only — never identity.
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+HISTORICAL_PATH_SHAPE_DIGEST = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+)
 
 
 @pytest.fixture(scope="module")
@@ -74,6 +82,9 @@ def test_launcher_authenticates_the_exact_corpus() -> None:
         MANIFEST_CID,
         1421,
     )
+    # Path-shape is refusal testimony, not an accepted corpus identity.
+    assert corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST
+
 
 def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> None:
     receiver = CallSiteValue(


### PR DESCRIPTION
## Summary

The two residual producer tests still treated historical path-shape `sha256:a223…` as the authenticated corpus identity after the launcher and demand table switched to content-addressed `blake3-512:6f317…`.

- **Subscript producer**: expect content manifest; refuse path-shape as identity.
- **BinOp floor producer**: same identity cut; name the truthful site's child coordinate (`SymbolicValue.attribute` on `np.nan`) and keep the lying twin on `binary_operation_exception_floor`.

Path-shape digest is retained only as negative testimony. No new environment, shelf, or census work.

## Validation

```text
runtime = CPython 3.12.13
canonical corpus manifest = blake3-512:6f317a5a…563530
demand-table identity = blake3-512:0ce7c645…75153ab0

pytest test_subscript_exceptional_exit_producer.py \
       test_pandas_binary_operation_exception_floor.py
→ 11 passed
```

## Owner reports (identity cut)

### Subscript
- concrete site: `pandas/tests/test_multilevel.py:158`
- before: accepted `sha256:a223…` path-shape as MANIFEST_CID
- after: requires content manifest; path-shape refused
- surviving gaps: undecided receiver remains `SymbolicValue.subscript` (named)

### BinOp floor
- concrete site: `pandas/tests/series/test_logical_ops.py:96` `s_0123 & np.nan`
- before: accepted path-shape as PANDAS_MANIFEST_CID
- after: content manifest; truthful arm names `SymbolicValue.attribute` (`np.nan`); lying arm names `binary_operation_exception_floor` (`SymbolicValue & TermValue`)
- surviving typed gap: Attribute child before BinOp floor on truthful site

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require blake3-512 content-manifest CIDs in subscript and BinOp producer tests
> - Updates manifest constants in both test modules to use blake3-512 content-manifest CIDs, replacing the prior sha256 path-shape digests retained as `HISTORICAL_PATH_SHAPE_DIGEST`.
> - Adds explicit assertions that authenticated corpora do not match the historical sha256 digest.
> - Replaces `_assert_named_undecided_refusal` with `_assert_named_panic` in the BinOp test, which verifies panic `owner`, `observed`, and a substring match on `requested` to distinguish truthful vs. instrumented source panics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cc6a50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->