### PR TITLE
Emit complete consumer resolution testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
@@ -12,6 +12,7 @@ import re
 from dataclasses import dataclass
 
 from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
 
 
 class ConsumerResolutionMiss(RuntimeError):
@@ -67,19 +68,65 @@ class LauncherSelectionTestimony:
 
 
 @dataclass(frozen=True)
+class CallerAttribution:
+    """Caller-owned surviving gap testimony using #6511's closed outcomes."""
+
+    outcome: AttributionOutcome
+    detail: str
+
+    def __post_init__(self) -> None:
+        if self.outcome not in (
+            AttributionOutcome.NAMED_REFUSAL,
+            AttributionOutcome.CONSTRUCTION_PANIC,
+        ):
+            raise ValueError(
+                "surviving testimony must be a named refusal or construction panic"
+            )
+        if not self.detail:
+            raise ValueError("surviving testimony requires caller detail")
+
+
+@dataclass(frozen=True)
+class CallerReportTestimony:
+    """Reported observations; never promoted to artifact verification."""
+
+    concrete_source_site: str
+    before_outcome: str
+    after_outcome: str
+    surviving: tuple[CallerAttribution, ...]
+
+    def __post_init__(self) -> None:
+        fields = (
+            self.concrete_source_site,
+            self.before_outcome,
+            self.after_outcome,
+        )
+        if any(not value for value in fields):
+            raise ValueError("caller testimony cannot contain an absent observation")
+
+
+@dataclass(frozen=True)
 class ConsumerHitReport:
     source_stamp: str
     runtime: str
-    corpus_files: int
     corpus_manifest_cid: str
+    demand_table_content_key: str
+    caller: CallerReportTestimony
 
     def lines(self) -> tuple[str, ...]:
+        surviving = ",".join(
+            f"{item.outcome.value}:{item.detail}" for item in self.caller.surviving
+        )
         return (
             f"sourceStamp {self.source_stamp}",
             f"runtime {self.runtime}",
-            f"corpusFiles {self.corpus_files}",
             f"corpusManifest {self.corpus_manifest_cid}",
-            "artifactVerification success",
+            f"demandTableIdentity {self.demand_table_content_key}",
+            f"concreteSourceSite reported {self.caller.concrete_source_site}",
+            f"beforeOutcome reported {self.caller.before_outcome}",
+            f"afterOutcome reported {self.caller.after_outcome}",
+            "survivingTypedGapsOrReattributions reported "
+            f"[{surviving}]",
         )
 
     def render(self) -> str:
@@ -116,6 +163,7 @@ def resolve_consumer_hit(
     binary: BinaryCellTestimony,
     demand: DemandTableCellTestimony,
     launcher: LauncherSelectionTestimony,
+    caller: CallerReportTestimony,
 ) -> ConsumerHitReport:
     """Resolve one composite hit or refuse at its first differing coordinate."""
     source_stamps = (
@@ -172,8 +220,9 @@ def resolve_consumer_hit(
     return ConsumerHitReport(
         source_stamp=request.source_stamp,
         runtime=request.runtime,
-        corpus_files=request.corpus_files,
         corpus_manifest_cid=request.corpus_manifest_cid,
+        demand_table_content_key=demand.identity.content_key,
+        caller=caller,
     )
 
 
@@ -182,8 +231,9 @@ def print_consumer_hit(
     binary: BinaryCellTestimony,
     demand: DemandTableCellTestimony,
     launcher: LauncherSelectionTestimony,
+    caller: CallerReportTestimony,
 ) -> ConsumerHitReport:
     """Resolve and print the composed testimony at the consumer edge."""
-    report = resolve_consumer_hit(request, binary, demand, launcher)
+    report = resolve_consumer_hit(request, binary, demand, launcher, caller)
     print(report.render(), flush=True)
     return report

--- a/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
@@ -6,6 +6,8 @@ import pytest
 
 from sugar_lift_py_tests.consumer_resolution_report import (
     BinaryCellTestimony,
+    CallerAttribution,
+    CallerReportTestimony,
     ConsumerResolutionMiss,
     ConsumerResolutionRequest,
     DemandTableCellTestimony,
@@ -14,6 +16,7 @@ from sugar_lift_py_tests.consumer_resolution_report import (
     resolve_consumer_hit,
 )
 from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
 
 
 STAMP = "blake3-512_" + "b" * 128
@@ -71,30 +74,49 @@ def _matching_testimony():
         corpus_manifest_cid=MANIFEST,
         corpus_files=1421,
     )
-    return request, binary, demand, launcher
+    caller = CallerReportTestimony(
+        concrete_source_site="pandas/tests/example.py:41:8",
+        before_outcome="named-refusal:opaque-call",
+        after_outcome="authenticated-exceptional-exit:TypeError",
+        surviving=(
+            CallerAttribution(
+                AttributionOutcome.NAMED_REFUSAL,
+                "opaque native callback remains source-undecided",
+            ),
+        ),
+    )
+    return request, binary, demand, launcher, caller
 
 
 def test_matching_three_artifacts_print_composite_hit():
-    request, binary, demand, launcher = _matching_testimony()
-    report = resolve_consumer_hit(request, binary, demand, launcher)
+    request, binary, demand, launcher, caller = _matching_testimony()
+    report = resolve_consumer_hit(request, binary, demand, launcher, caller)
     assert report.lines() == (
         f"sourceStamp {STAMP}",
         "runtime cpython-3.12.13",
-        "corpusFiles 1421",
         f"corpusManifest {MANIFEST}",
-        "artifactVerification success",
+        "demandTableIdentity blake3-512:" + "d" * 128,
+        "concreteSourceSite reported pandas/tests/example.py:41:8",
+        "beforeOutcome reported named-refusal:opaque-call",
+        "afterOutcome reported authenticated-exceptional-exit:TypeError",
+        "survivingTypedGapsOrReattributions reported "
+        "[named-refusal:opaque native callback remains source-undecided]",
     )
 
 
 def test_matching_three_artifacts_print_to_the_consumer_edge(capsys):
-    request, binary, demand, launcher = _matching_testimony()
-    print_consumer_hit(request, binary, demand, launcher)
+    request, binary, demand, launcher, caller = _matching_testimony()
+    print_consumer_hit(request, binary, demand, launcher, caller)
     assert capsys.readouterr().out.splitlines() == [
         f"sourceStamp {STAMP}",
         "runtime cpython-3.12.13",
-        "corpusFiles 1421",
         f"corpusManifest {MANIFEST}",
-        "artifactVerification success",
+        "demandTableIdentity blake3-512:" + "d" * 128,
+        "concreteSourceSite reported pandas/tests/example.py:41:8",
+        "beforeOutcome reported named-refusal:opaque-call",
+        "afterOutcome reported authenticated-exceptional-exit:TypeError",
+        "survivingTypedGapsOrReattributions reported "
+        "[named-refusal:opaque native callback remains source-undecided]",
     ]
 
 
@@ -108,32 +130,32 @@ def test_matching_three_artifacts_print_to_the_consumer_edge(capsys):
     ],
 )
 def test_each_request_coordinate_misses_by_its_own_name(coordinate, mutate):
-    request, binary, demand, launcher = _matching_testimony()
+    request, binary, demand, launcher, caller = _matching_testimony()
     with pytest.raises(ConsumerResolutionMiss) as caught:
-        resolve_consumer_hit(mutate(request), binary, demand, launcher)
+        resolve_consumer_hit(mutate(request), binary, demand, launcher, caller)
     assert caught.value.coordinate == coordinate
     assert str(caught.value).startswith(f"consumer resolution MISS: {coordinate} differs:")
 
 
 def test_platform_difference_is_the_same_named_coordinate_as_profile():
-    request, binary, demand, launcher = _matching_testimony()
+    request, binary, demand, launcher, caller = _matching_testimony()
     request = replace(request, platform="darwin-arm64")
     with pytest.raises(ConsumerResolutionMiss, match=r"MISS: profile/platform differs"):
-        resolve_consumer_hit(request, binary, demand, launcher)
+        resolve_consumer_hit(request, binary, demand, launcher, caller)
 
 
 def test_consumer_refuses_unverified_artifact_instead_of_printing_a_hit():
-    request, binary, demand, launcher = _matching_testimony()
+    request, binary, demand, launcher, caller = _matching_testimony()
     with pytest.raises(ConsumerResolutionMiss) as caught:
         resolve_consumer_hit(
-            request, replace(binary, artifact_verified=False), demand, launcher
+            request, replace(binary, artifact_verified=False), demand, launcher, caller
         )
     assert caught.value.coordinate == "artifact verification"
 
 
 def test_historical_path_shape_digest_is_a_named_corpus_identity_miss():
     """Even unanimous testimony cannot upgrade a non-corpus preimage."""
-    request, binary, demand, launcher = _matching_testimony()
+    request, binary, demand, launcher, caller = _matching_testimony()
     request = replace(request, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST)
     demand = replace(
         demand,
@@ -145,6 +167,41 @@ def test_historical_path_shape_digest_is_a_named_corpus_identity_miss():
         launcher, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
     )
     with pytest.raises(ConsumerResolutionMiss) as caught:
-        resolve_consumer_hit(request, binary, demand, launcher)
+        resolve_consumer_hit(request, binary, demand, launcher, caller)
     assert caught.value.coordinate == "corpus identity"
     assert HISTORICAL_PATH_SHAPE_DIGEST in str(caught.value)
+
+
+def test_caller_testimony_cannot_inherit_or_override_artifact_verification():
+    request, binary, demand, launcher, caller = _matching_testimony()
+    caller = replace(
+        caller,
+        before_outcome="artifact verification success",
+        after_outcome="artifact verification success",
+    )
+    with pytest.raises(ConsumerResolutionMiss) as caught:
+        resolve_consumer_hit(
+            request,
+            replace(binary, artifact_verified=False),
+            demand,
+            launcher,
+            caller,
+        )
+    assert caught.value.coordinate == "artifact verification"
+
+
+def test_surviving_construction_panic_is_not_rendered_as_named_refusal():
+    request, binary, demand, launcher, caller = _matching_testimony()
+    caller = replace(
+        caller,
+        surviving=(
+            CallerAttribution(
+                AttributionOutcome.CONSTRUCTION_PANIC,
+                "missing constructed operand",
+            ),
+        ),
+    )
+    report = resolve_consumer_hit(request, binary, demand, launcher, caller)
+    assert report.lines()[-1].endswith(
+        "[construction-panic:missing constructed operand]"
+    )


### PR DESCRIPTION
## What changed

- Expands the composite consumer output to the architect-owned eight-line report: source stamp, actual runtime, canonical corpus manifest, demand-table identity, concrete source site, before outcome, after outcome, and surviving typed gaps or reattributions.
- Keeps artifact and caller provenance separate: caller-owned lines are explicitly marked `reported`, while artifact verification remains a prerequisite and cannot be supplied or overridden by caller testimony.
- Reuses #6511 `AttributionOutcome` so `named-refusal` remains accounted semantics and `construction-panic` remains the failure arm.
- Changes neither binary nor demand-table cell schema.

## Validation

- Exact CPython 3.12.13 focused tests: 18 passed (`test_consumer_resolution_report.py` and `test_no_call_body_attribution.py`).
- Shared demand table consumed from the filesystem shelf under `cpython-3.12.13`, darwin-x86_64, release with build fallback disabled; exit 0.
- Syntax compilation and diff checks passed.
- The branch-local bootstrap installed pins but its final import verifier hung on the shared Mac and was stopped; it is not claimed as a successful receipt.

Base: `ad759298d5adcd78dddaacda93d054dfca6af5b3`
Head: `d8a39cdeca00d2dd7fdd739b209525c8134aa464`

Do not merge automatically.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit complete consumer resolution testimony including caller-reported outcomes and surviving gaps
> - Adds `CallerAttribution` and `CallerReportTestimony` dataclasses to carry caller-reported resolution data (concrete source site, before/after outcomes, surviving typed gaps or reattributions) into the consumer hit report.
> - Replaces `corpus_files` in `ConsumerHitReport` with `demand_table_content_key` and a `CallerReportTestimony`; `lines()` now emits demand table identity and caller testimony lines instead of corpus file count and artifact verification status.
> - Updates `resolve_consumer_hit` and `print_consumer_hit` in [consumer_resolution_report.py](https://github.com/TSavo/sugar/pull/6516/files#diff-bd717e8aaa8a75626c402d2b396cc5fb2a57c5deac6ad5a85fcde6607d78f22a) to require a `CallerReportTestimony` argument.
> - Behavioral Change: callers of `resolve_consumer_hit` and `print_consumer_hit` must now supply a `CallerReportTestimony`; report output lines change shape entirely, dropping `corpusFiles` and `artifactVerification success`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8a39cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->