### PR TITLE
Require canonical manifest identity roles

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_manifest_identity_roles.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_manifest_identity_roles.py
@@ -1,0 +1,90 @@
+"""Manifest identity slots accept only the primary canonical coordinate."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+
+_PRIMARY_MANIFEST_COORDINATE = re.compile(r"blake3-512:[0-9a-f]{128}\Z")
+_PYTHON_IMPLEMENTATIONS = Path(__file__).resolve().parents[4] / "implementations/python"
+
+
+def _manifest_identity_slot_violations(source: str, label: str) -> tuple[str, ...]:
+    tree = ast.parse(source, filename=label)
+    violations = []
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+            value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            targets = (statement.target,)
+            value = statement.value
+        else:
+            continue
+        for target in targets:
+            if not isinstance(target, ast.Name) or not target.id.endswith(
+                "MANIFEST_CID"
+            ):
+                continue
+            try:
+                presented = ast.literal_eval(value)
+            except (TypeError, ValueError):
+                presented = None
+            if (
+                not isinstance(presented, str)
+                or _PRIMARY_MANIFEST_COORDINATE.fullmatch(presented) is None
+            ):
+                violations.append(
+                    f"{label}:{statement.lineno}: {target.id} presents {presented!r}; "
+                    "manifest identity slots require the canonical BLAKE3-512 coordinate"
+                )
+    return tuple(violations)
+
+
+def test_canonical_manifest_identity_is_accepted_by_role() -> None:
+    canonical = "blake3-512:" + "6" * 128
+
+    assert (
+        _manifest_identity_slot_violations(
+            f"MANIFEST_CID = {canonical!r}\n", "truthful.py"
+        )
+        == ()
+    )
+
+
+def test_path_shape_digest_in_manifest_identity_role_is_refused() -> None:
+    historical_shape = "sha256:" + "a" * 64
+
+    assert _manifest_identity_slot_violations(
+        f"MANIFEST_CID = {historical_shape!r}\n", "lying.py"
+    ) == (
+        "lying.py:1: MANIFEST_CID presents "
+        f"{historical_shape!r}; manifest identity slots require the canonical "
+        "BLAKE3-512 coordinate",
+    )
+
+
+def test_named_historical_and_shape_roles_remain_distinct() -> None:
+    historical_shape = "sha256:" + "a" * 64
+    source = (
+        f"HISTORICAL_PATH_SHAPE_DIGEST = {historical_shape!r}\n"
+        f"_PANDAS_3_0_3_MANIFEST_SHAPE_CID = {historical_shape!r}\n"
+    )
+
+    assert _manifest_identity_slot_violations(source, "honest-shape.py") == ()
+
+
+def test_python_modules_never_put_noncanonical_digest_in_manifest_identity_role() -> (
+    None
+):
+    violations = tuple(
+        violation
+        for path in sorted(_PYTHON_IMPLEMENTATIONS.rglob("*.py"))
+        for violation in _manifest_identity_slot_violations(
+            path.read_text(encoding="utf-8"),
+            str(path.relative_to(_PYTHON_IMPLEMENTATIONS)),
+        )
+    )
+
+    assert not violations, "\n".join(violations)


### PR DESCRIPTION
## What changed

The five acceptance sites are canonical on current main: Attribute, Compare, and Unary/BoolOp landed in #6513; Subscript and BinOp landed in #6515. This PR adds the structural ratchet that prevents the historical path-shape digest from returning to an accepted manifest-identity role.

The ratchet parses every Python module under `implementations/python`. Every module-level string binding whose identifier ends in `MANIFEST_CID` must carry the primary `blake3-512:<128 hex>` coordinate. This is role-derived, with no symbol whitelist and no vendor dispatch.

`HISTORICAL_PATH_SHAPE_DIGEST` and `*_MANIFEST_SHAPE_CID` remain untouched: their identifiers structurally distinguish refusal/shape testimony from accepted manifest identity. Truthful, lying, and honest-shape role twins pin all three cases.

## Root cause

`sha256:a223...03d0` covers the historical sorted path-list preimage. It can survive arbitrary file-byte changes, so placing it in a `MANIFEST_CID` acceptance slot authenticates no corpus content. The canonical pair covers the same sorted `(relative path, BLAKE3-512 content CID)` manifest:

- primary: `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`
- alias: `sha256:0ee4e945d69e60941f74ad064215a44d9f02a0b23b081e2a507d893bdd22a938`

## Composite report

- sourceStamp: `blake3-512_b536f988a64aa054491a35399fd25a8d5e296a07ab9c4738fcc64a8b05bb81163e06b79d35ec30ee58f4002a547fbf2382b45d1a72875e72d1105a4c1f5e0d05`
- runtime: `cpython-3.12.13`
- canonical corpus: pandas 3.0.3, 1,421 files, manifest identities above
- demand table: `blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0`, 107,433 rows
- artifactVerification: success

Concrete sites and outcomes after authentication:

- Attribute `pandas/tests/test_register_accessor.py:104`: named undecided `CallSiteValue.attribute`
- Compare `pandas/tests/test_col.py:365`: named undecided `comparison_operation_exception_floor`, observed `TermValue in CallSiteValue`
- Unary `pandas/tests/extension/base/ops.py:257`: named undecided `bitwise_invert`; BoolOp sites `pandas/tests/generic/test_generic.py:151,153` preserve conditional effects
- Subscript `pandas/tests/test_multilevel.py:158`: named undecided `SymbolicValue.subscript`
- BinOp `pandas/tests/series/test_logical_ops.py:96`: truthful `np.nan` stops at `SymbolicValue.attribute`; the lying `0` twin reaches `binary_operation_exception_floor` with `SymbolicValue & TermValue`

Before the five-site fix, these consumers stopped at false corpus authentication. After it, each reaches its named producer outcome or typed gap. No outcome is reported merely as “refused.”

## Validation

Exact authenticated environment:

```text
CPython 3.12.13
numpy 2.5.1
pandas 3.0.3
pytest 9.1.1
PINS_OK
```

Rebased focused producer, identity, ratchet, and composite run: `41 passed, 25 deselected in 162.92s`.

Mutation transaction: clean ratchet; mutate Subscript back to the path-shape digest; ratchet fails naming `test_subscript_exceptional_exit_producer.py:29`, `MANIFEST_CID`, and the presented value; revert; clean `4 passed`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require canonical BLAKE3-512 identity in `MANIFEST_CID` variable assignments
> Adds a test suite in [test_corpus_manifest_identity_roles.py](https://github.com/TSavo/sugar/pull/6517/files#diff-08df17ea7e89a922f66cf757f5cf1a2829ae4d688d0ee746d032296e4b34d3f0) that enforces `MANIFEST_CID` variables hold canonical BLAKE3-512 digest strings (`blake3-512:` prefix followed by 128 lowercase hex chars).
>
> - A `_manifest_identity_slot_violations` helper parses Python source via `ast`, finds all `MANIFEST_CID` assignments, and returns violation messages for any non-canonical values.
> - Unit tests cover acceptance of valid digests, rejection of legacy `sha256:` digests, and confirm that differently named variables (e.g. `HISTORICAL_PATH_SHAPE_DIGEST`) are unaffected.
> - An integration test recursively scans all Python files under `implementations/python` and fails the suite if any file assigns a non-canonical value to a `MANIFEST_CID` variable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 836258a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added validation to ensure Python modules use the canonical `blake3-512` format for manifest identity values.
  - Added coverage confirming historical digest formats remain distinct and are rejected in manifest identity fields.
  - Added repository-wide checks for non-canonical manifest identity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->