### PR TITLE
Fix no-warning inversion on completed and exception edges

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -281,7 +281,7 @@ def _route_warning_boundary(
     # Exact ``None`` is the manager's inverted contract: no warning may arrive.
     # NoneValue is the literal's floor type, not a placeholder warning class.
     if isinstance(expected, NoneValue):
-        return _route_completed_no_warning_boundary(
+        return _route_no_warning_boundary(
             body=body,
             ctx=ctx,
             manager_exit=manager_exit,
@@ -401,15 +401,28 @@ def _route_warning_boundary(
     return ExitSet(tuple(exits)).normalize()
 
 
-def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
-    """Accept a completed face only when warning absence is decidable."""
+def _route_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
+    """Invert Expects/Warning for literal ``None`` on both body edges.
+
+    ``assert_produces_warning(None)`` is not an empty category. Exact
+    ``NoneValue`` means no warning may arrive:
+
+    - completed edge: absence is success; an unguarded observation is
+      ``ExpectationNotMetEffect`` (never a fabricated ``WarningEffect``)
+    - exception edge: the same observation law applies to the pre-halt
+      record. Clean absence restores the original halt; an unguarded
+      observation still fails the assertion. A halt with no temporal
+      record is not a warning decision surface and is restored unchanged
+
+    Guarded occurrences and unresolved producers remain undecided on either
+    edge — the same refusals the matching-category router already names.
+    """
     from sugar_lift_py_tests.context_manager_contract import ExpectsModeV1
     from sugar_lift_py_tests.effect import ExpectationNotMetEffect
-    from sugar_lift_py_tests.floor import CallSiteValue
     from sugar_lift_py_tests.floor.warning_observation_value import (
         WarningObservationValue,
     )
-    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
     from sugar_lift_py_tests.sugar.exit_set_routing import promote_raise_halts
     from sugar_lift_py_tests.sugar.function_universe_sugar import (
         reduce_block_to_exitset,
@@ -421,15 +434,21 @@ def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site)
     )
     exits = []
     for face in body_es.exits:
-        if isinstance(face, Halted):
-            exits.append(face)
-            continue
-        entries = getattr(face.value, "entries", None)
+        # Matching-category routing already reads both faces the same way:
+        # Completed carries the reduced block as its value; Halted carries
+        # the pre-halt record as its state.
+        record = face.value if isinstance(face, Completed) else face.state
+        entries = getattr(record, "entries", None)
         if not isinstance(entries, tuple):
+            if isinstance(face, Halted):
+                # Exception edge without a temporal record: do not invent a
+                # warning verdict. Restore the halt as the body left it.
+                exits.append(face)
+                continue
             raise SugarNotWritten(
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed=(
-                    f"completed face carries {type(face.value).__name__}, "
+                    f"completed face carries {type(record).__name__}, "
                     "not a reduced block record"
                 ),
                 requested=(
@@ -459,11 +478,14 @@ def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site)
             )
         if observations:
             if isinstance(mode, ExpectsModeV1):
+                # Fail the inverted contract with the assertion effect only.
+                # Never mint a WarningEffect here — observations arrive only
+                # from the producer, and unmet is ExpectationNotMetEffect.
                 exits.append(
                     Halted(
                         face.guard,
                         ExpectationNotMetEffect("warning", site),
-                        face.value,
+                        record,
                         face.faces,
                         face.pending_contracts,
                     )
@@ -487,5 +509,7 @@ def _route_completed_no_warning_boundary(*, body, ctx, manager_exit, mode, site)
             # ever routed into.
             refusal.unresolved_warning_producers = unresolved_members
             raise refusal
+        # Decidable absence: completed stays completed; exception edge restores
+        # the original halt without inventing any warning effect.
         exits.append(face)
     return ExitSet(tuple(exits)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -203,6 +203,154 @@ def test_two_no_warning_boundaries_do_not_share_observations():
     assert isinstance(second.exits[0].effect, ExpectationNotMetEffect)
 
 
+def _no_warning_from_exitset(body_es):
+    """``assert_produces_warning(None)`` over a pre-built body ExitSet.
+
+    Used for exception-edge twins: the body already halted, and the temporal
+    record rides on ``Halted.state`` exactly as ``reduce_block_to_exitset``
+    leaves it.
+    """
+    manager_value = CallSiteValue(
+        target_name="scope",
+        arg_values=(NoneValue(),),
+        parameters=("expected",),
+        term=ctor("call", []),
+        body=None,
+    )
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    return WithEffectBoundarySugar(
+        manager=_Fixed(Complete(manager_value)),
+        body=(_Fixed(body_es),),
+        semantics=SEMANTICS,
+        contract_ref=SimpleNamespace(import_signature=signature),
+        context_manager_edge=None,
+        site=None,
+    )
+
+
+def _raise_with_entries(*entries):
+    """Exception edge: body statements then a real RaiseEffect halt."""
+    type_identity = _identity("TypeError")
+    raised_value = CallSiteValue(
+        target_name="raised",
+        arg_values=(StringValue("operand failed"),),
+        parameters=("message",),
+        term=ctor("call", []),
+        body=None,
+    )
+    state = _ReducedBlock(
+        entries=tuple(entries),
+        can_fall_through=False,
+        fall_through=(),
+    )
+    return ExitSet(
+        (
+            Halted(
+                true_guard(),
+                RaiseEffect(
+                    exception_name="TypeError",
+                    exception_type_coordinate=type_identity,
+                    occurrence="body.py:3:4",
+                    raised_value=raised_value,
+                ),
+                state,
+            ),
+        )
+    )
+
+
+def test_no_warning_exception_edge_without_warning_restores_the_halt():
+    """Completed-edge inversion's exception twin: clean halt is not unmet."""
+    routed = _no_warning_from_exitset(
+        _raise_with_entries(TermValue(1), TermValue(2))
+    ).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, RaiseEffect)
+    assert face.effect.exception_name == "TypeError"
+    # Absence decided without inventing a warning effect on the halt.
+    assert not isinstance(face.effect, WarningEffect)
+
+
+def test_no_warning_exception_edge_with_warning_fails_assertion():
+    """Exception edge carries the observation on pre-halt state — still unmet."""
+    routed = _no_warning_from_exitset(
+        _raise_with_entries(_warning("FutureWarning"), TermValue(1))
+    ).desugar()
+    assert len(routed.exits) == 1
+    face = routed.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+    # Failure is the assertion effect, never a fabricated WarningEffect halt.
+    assert not isinstance(face.effect, WarningEffect)
+    assert type(face.effect).__name__ == "ExpectationNotMetEffect"
+
+
+def test_no_warning_exception_edge_with_unresolved_producer_is_undecided():
+    unresolved = CallSiteValue(
+        target_name="f",
+        arg_values=(),
+        parameters=(),
+        term=ctor("call", []),
+        body=None,
+    )
+    with pytest.raises(SugarNotWritten) as raised:
+        _no_warning_from_exitset(_raise_with_entries(unresolved)).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert raised.value.observed == "completed face has unresolved warning producers"
+
+
+def test_no_warning_both_edges_discriminate_absence_from_arrival():
+    """One law, two edges: absence vs arrival must not collapse on either."""
+    completed_absent = _boundary(TermValue("ok"), expected=NoneValue()).desugar()
+    completed_arrived = _boundary(
+        _warning("FutureWarning"), expected=NoneValue()
+    ).desugar()
+    exception_absent = _no_warning_from_exitset(
+        _raise_with_entries(TermValue("ok"))
+    ).desugar()
+    exception_arrived = _no_warning_from_exitset(
+        _raise_with_entries(_warning("FutureWarning"))
+    ).desugar()
+
+    assert isinstance(completed_absent.exits[0], Completed)
+    assert isinstance(completed_arrived.exits[0], Halted)
+    assert isinstance(completed_arrived.exits[0].effect, ExpectationNotMetEffect)
+
+    assert isinstance(exception_absent.exits[0], Halted)
+    assert isinstance(exception_absent.exits[0].effect, RaiseEffect)
+    assert isinstance(exception_arrived.exits[0], Halted)
+    assert isinstance(exception_arrived.exits[0].effect, ExpectationNotMetEffect)
+
+
+def test_no_warning_guarded_occurrence_is_undecided_on_exception_edge():
+    """Guarded law is edge-independent: refuse on the halt face too."""
+    guarded = WarningObservationValue(
+        WarningEffect(
+            "UserWarning",
+            category_identity=_identity("UserWarning"),
+        ),
+        guards=(str_const("orient != tight"),),
+    )
+    with pytest.raises(SugarNotWritten) as raised:
+        _no_warning_from_exitset(_raise_with_entries(guarded)).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert raised.value.observed == (
+        "warning occurrence is reached only under a branch guard"
+    )
+
+
 WARNING_WITH_PATTERN = EffectBoundarySemanticsV1(
     ExpectsModeV1(),
     WarningEffectKindV1(),

--- a/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from pathlib import Path
 
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -12,24 +11,16 @@ from sugar_lift_py_tests.context_manager_resolution import TreeConstructionConte
 from sugar_source_tree.nodes import Call, Constant, With
 from sugar_source_tree.tree import SourceFile
 
+# Content manifest (relative path + per-file BLAKE3-512) is identity.
+# Path-shape sha256:a223… is historical negative testimony only — never identity.
 CONTENT_MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1"
     "c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 )
-MANIFEST_SHAPE_CID = (
+HISTORICAL_PATH_SHAPE_DIGEST = (
     "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 )
 FILE_SHA256 = "ef0819d48825f4614ec088f25b4d342a8808a12b1c5d45cff3281b481ec13252"
-
-
-def _manifest_shape_cid(root: Path) -> str:
-    from sugar_source_tree.tree import SourceTree
-
-    paths = sorted(
-        path.relative_to(root).as_posix() for path in SourceTree(root).paths()
-    )
-    preimage = json.dumps(paths, separators=(",", ":"), ensure_ascii=True)
-    return "sha256:" + hashlib.sha256(preimage.encode("utf-8")).hexdigest()
 
 
 def _corpus_file() -> Path:
@@ -39,7 +30,7 @@ def _corpus_file() -> Path:
         CONTENT_MANIFEST_CID,
         1421,
     )
-    assert _manifest_shape_cid(corpus.root) == MANIFEST_SHAPE_CID
+    assert corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST
     return corpus.root / "tests/series/test_constructors.py"
 
 


### PR DESCRIPTION
## What changed

`assert_produces_warning(None)` is the inverted Expects/Warning contract: no warning may arrive. #6476 routed that only on **completed** faces and restored every **halted** face unchanged. A body that warned and then raised therefore met the absence contract by silence.

This PR routes both edges from the same temporal record the matching-category router already reads (`Completed.value` / `Halted.state`):

| edge | no observation (decidable) | unguarded observation | guarded / unresolved |
|------|----------------------------|----------------------|----------------------|
| completed | stays `Completed` | `ExpectationNotMetEffect` | `SugarNotWritten` |
| exception | restores original halt | `ExpectationNotMetEffect` | `SugarNotWritten` |

No `WarningEffect` is invented: observations still come only from `warning_observation_producer`; unmet is always `ExpectationNotMetEffect`.

Also converts `test_warning_none_argument_shape.py` path-shape `sha256:a223…` from positive identity to negative testimony only (content manifest remains identity), matching #6515.

## Concrete site

**Before** (`_route_completed_no_warning_boundary`):

```python
for face in body_es.exits:
    if isinstance(face, Halted):
        exits.append(face)
        continue
    entries = getattr(face.value, "entries", None)
    # …observation law only on completed faces…
```

**After** (`_route_no_warning_boundary`):

```python
for face in body_es.exits:
    record = face.value if isinstance(face, Completed) else face.state
    entries = getattr(record, "entries", None)
    if not isinstance(entries, tuple):
        if isinstance(face, Halted):
            exits.append(face)  # no record → restore, do not invent
            continue
        raise SugarNotWritten(...)
    # same guarded / observation / unresolved law on both edges
```

## Twins

- exception edge, clean halt → restores `RaiseEffect`
- exception edge, pre-halt warning → `ExpectationNotMetEffect` (not `WarningEffect`)
- exception edge, unresolved producer → refused by name
- exception edge, guarded observation → undecided
- both-edge discrimination: absence vs arrival on completed and exception
- a223 path-shape: `corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST`

## Validation

```text
CPython 3.12.13 .venv-py312
implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
implementations/python/sugar-lift-python-source/tests/test_warning_none_argument_shape.py
17 passed
```

Mutation: re-inject early `if Halted: restore` →
`test_no_warning_exception_edge_with_warning_fails_assertion` and
`test_no_warning_both_edges_discriminate_absence_from_arrival` red
(RaiseEffect instead of ExpectationNotMetEffect); restore → green.

Three pre-existing guarded-occurrence arms remain red on main at
`SymbolicValue.attribute` (noted in #6496); unconditional / clean / unresolved
arms still green. No changes to exit_set, outcome disposition, or the producer.

History: #6476 completed faces · #6484 guarded · #6496 None twins · #6503 mixed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix no-warning inversion to apply on both completed and exception edges
> - `_route_completed_no_warning_boundary` is renamed to `_route_no_warning_boundary` and extended to handle both `Completed` and `Halted` faces, so `assert_produces_warning(None)` correctly evaluates the exception edge.
> - On the exception edge: a halted face with no warning in its pre-halt record preserves the original `RaiseEffect`; a warning in the record produces `ExpectationNotMetEffect`; a halted face with no temporal record is returned unchanged; guarded or unresolved producers raise `SugarNotWritten`.
> - Seven new tests in [test_with_effect_boundary_warning.py](https://github.com/TSavo/sugar/pull/6518/files#diff-8f0a59cf02b50d012e3ececbaa001b0fc5e65fe1794b8ca599b8152267f4d704) cover all exception-edge cases and a combined both-edges discriminating test.
> - The path-shape digest check in [test_warning_none_argument_shape.py](https://github.com/TSavo/sugar/pull/6518/files#diff-902a070c7b66eb806eff3c8b3f46c389f3002cb4f1acbff2e9d576df9f6e64a0) is changed from an equality assertion to a negative (non-identity) check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25db8b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->