### PR TITLE
Prove except-as observes the same effect the handler routed

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
@@ -1,6 +1,8 @@
 """Sugar for tree-native EffectRef / ObservationRef coordinates.
 
-Always desugars to a pure coordinate. No ambient lookup. No sealing.
+Coordinates are pure by default. When reduction context carries an
+authenticated observed effect for the slot (handler routing deposited it),
+the projection is that exact effect — never a reconstructed E().
 """
 
 from __future__ import annotations
@@ -21,9 +23,20 @@ class EffectRefSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
-        from sugar_lift_py_tests.floor.effect_coordinate import EffectCoordinate
+        from sugar_lift_py_tests.floor.effect_coordinate import (
+            EffectCoordinate,
+            ObservedEffectValue,
+        )
 
+        # Observed-effect identity: the bound name projects the same RaiseEffect
+        # the handler (or effect boundary) routed into this slot. No ambient
+        # table — only the explicit context preimage deposited at the route.
+        reader = getattr(ctx, "observed_effect_for", None) if ctx is not None else None
+        effect = reader(self.slot_id) if reader is not None else None
+        if effect is not None:
+            return Complete(
+                ObservedEffectValue(slot_id=self.slot_id, effect=effect, site=self.site)
+            )
         return Complete(EffectCoordinate(slot_id=self.slot_id, site=self.site))
 
 
@@ -53,7 +66,9 @@ class ObservationRefSugar(Sugar):
                         slot_id=self.slot_id, effect=effect, site=self.site
                     )
                 )
-            return Complete(ExceptionInfoCoordinate(slot_id=self.slot_id, site=self.site))
+            return Complete(
+                ExceptionInfoCoordinate(slot_id=self.slot_id, site=self.site)
+            )
         if self.projection == "enter_result":
             from sugar_lift_py_tests.floor.manager_coordinate import (
                 EnterResultCoordinate,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -153,9 +153,7 @@ def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
         if isinstance(exit_, Completed):
             enrolled.append(Completed(exit_.guard, widened, exit_.faces, ()))
         else:
-            enrolled.append(
-                Halted(exit_.guard, exit_.effect, widened, exit_.faces, ())
-            )
+            enrolled.append(Halted(exit_.guard, exit_.effect, widened, exit_.faces, ()))
     return ExitSet(tuple(enrolled)).normalize()
 
 
@@ -242,6 +240,12 @@ def reduce_block_to_exitset(
                 return ExitSet.completed(state)
             active_ctx = state.context if state.context is not None else ctx
             statement_ctx = active_ctx
+            # ObservedEffectBinding rows are producer testimony for a consumed
+            # slot (Try/With routing). Thread them into the next statement's
+            # reduction context so EffectRef / ObservationRef project the same
+            # RaiseEffect the boundary routed — not a pure unauthenticated
+            # coordinate. Handler bodies also receive this via
+            # TrySugar.with_observed_effect before their first statement.
             from sugar_lift_py_tests.effect_router import ObservedEffectBinding
 
             observed = tuple(
@@ -347,9 +351,7 @@ def reduce_block_to_exitset(
                         nested_fall_through = value.fall_through
                         nested_transforms = value.transforms
                         next_context = (
-                            value.context
-                            if value.context is not None
-                            else active_ctx
+                            value.context if value.context is not None else active_ctx
                         )
                     else:
                         linear = Complete(value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -93,6 +93,10 @@ class TryStarSugar(Sugar):
                 matched = regroup_except_star(residual, matched_parts)
                 residual = handler_residual
                 handler_ctx = bind_in_flight_effect(ctx, slot_id, matched)
+                if slot_id is not None:
+                    observer = getattr(handler_ctx, "with_observed_effect", None)
+                    if observer is not None:
+                        handler_ctx = observer(slot_id, matched)
                 handler_exits = promote_raise_halts(
                     reduce_block_to_exitset(handler_body, handler_ctx)
                 )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -218,7 +218,16 @@ def _route_one_halt(exit_, handlers: tuple, *, site, ctx) -> list:
             reduce_block_to_exitset,
         )
 
+        # In-flight: bare re-raise. Observed: ``except ... as e`` / EffectRef
+        # projects the same RaiseEffect this arm just matched — identity, not
+        # a reconstructed E(). Observed must be installed BEFORE the body
+        # reduces; prepending facts after the fact cannot authenticate a read
+        # that already desugared to a pure coordinate.
         handler_ctx = bind_in_flight_effect(ctx, slot_id, exit_.effect)
+        if slot_id is not None:
+            observer = getattr(handler_ctx, "with_observed_effect", None)
+            if observer is not None:
+                handler_ctx = observer(slot_id, exit_.effect)
         handler_es = reduce_block_to_exitset(handler_body, handler_ctx)
         facts = _binding_facts_for(slot_id, exit_.effect, site)
         return _prepend_facts(handler_es, facts) if facts else handler_es

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -112,6 +112,124 @@ def test_observed_effect_projects_only_an_authenticated_context_preimage() -> No
     assert "no authenticated context preimage" in caught.value.info.observed
 
 
+def test_effect_ref_observes_the_same_effect_the_route_deposited() -> None:
+    """``except ... as e`` → EffectRef: bound name is the routed RaiseEffect.
+
+    Truthful: observed context for slot S yields ObservedEffectValue whose
+    ``effect`` is the exact object deposited (identity, not type spelling).
+    Lying: without the observed preimage the projection is a pure coordinate
+    that cannot answer ``__context__``.
+    """
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.floor.effect_coordinate import (
+        EffectCoordinate,
+        ObservedEffectValue,
+    )
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.effect_ref_sugar import EffectRefSugar
+
+    inner_value = TermValue(11)
+    inner = RaiseEffect(
+        exception_name="ImportError",
+        raised_value=inner_value,
+        occurrence="inner.py:1:0",
+    )
+    routed = RaiseEffect(
+        exception_name="ValueError",
+        occurrence="outer.py:2:4",
+        context_effect=inner,
+    )
+    other = RaiseEffect(exception_name="ValueError", occurrence="other.py:9:0")
+
+    ctx = ReduceContext.root(owner="as-e-identity").with_observed_effect("S", routed)
+    out = EffectRefSugar(slot_id="S").desugar(ctx)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, ObservedEffectValue)
+    assert out.value.effect is routed
+    assert out.value.effect is not other
+    assert out.value.effect.occurrence_id == "outer.py:2:4"
+    # Same occurrence the boundary routed: context preimage is authentic.
+    projected = out.value.attribute("__context__", site=None)
+    assert projected.value is inner_value
+
+    # Unauthenticated twin: pure coordinate stays loud on the same projection.
+    bare = EffectRefSugar(slot_id="S").desugar(None)
+    assert isinstance(bare, Complete)
+    assert type(bare.value) is EffectCoordinate
+    with pytest.raises(ConstructionPanic) as caught:
+        bare.value.attribute("__context__", site=None)
+    assert "no authenticated context preimage" in caught.value.info.observed
+
+
+def test_function_universe_threads_observed_effect_binding_into_next_statement() -> (
+    None
+):
+    """ObservedEffectBinding in the prefix authenticates the next EffectRef.
+
+    ``reduce_block_to_exitset`` must install prior ObservedEffectBinding rows
+    onto the statement context before desugaring — the same seam With/Try use
+    after a consumed halt deposits producer testimony into the block record.
+    """
+    from sugar_lift_py_tests.context import ReduceContext
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.effect_router import ObservedEffectBinding
+    from sugar_lift_py_tests.floor.effect_coordinate import (
+        EffectCoordinate,
+        ObservedEffectValue,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+    from sugar_lift_py_tests.sugar.effect_ref_sugar import EffectRefSugar
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _ReducedBlock,
+        reduce_block_to_exitset,
+    )
+
+    routed = RaiseEffect(exception_name="ValueError", occurrence="route.py:3:0")
+
+    # Unauthenticated: no observed preimage → pure coordinate.
+    bare = reduce_block_to_exitset((EffectRefSugar(slot_id="S"),)).collapse()
+    assert isinstance(bare, Complete)
+    assert type(bare.value.entries[0]) is EffectCoordinate
+
+    # Authenticated via ctx (handler path): same RaiseEffect object.
+    via_ctx = reduce_block_to_exitset(
+        (EffectRefSugar(slot_id="S"),),
+        ReduceContext.root(owner="seed").with_observed_effect("S", routed),
+    ).collapse()
+    assert isinstance(via_ctx, Complete)
+    assert isinstance(via_ctx.value.entries[0], ObservedEffectValue)
+    assert via_ctx.value.entries[0].effect is routed
+
+    # Authenticated via prior entry (function_universe thread path).
+    # ObservedEffectBinding.contribution() is empty on purpose (preimage, not
+    # FOL); producers deposit it into _ReducedBlock.entries the way Try/With
+    # prepend facts after a consumed halt. The next statement must then see it.
+    class _Deposit:
+        def desugar(self, ctx):
+            del ctx
+            return ExitSet.completed(
+                _ReducedBlock(
+                    entries=(ObservedEffectBinding(slot_id="S", effect=routed),),
+                    can_fall_through=True,
+                    fall_through=(),
+                )
+            )
+
+    class _Read:
+        def desugar(self, ctx):
+            return EffectRefSugar(slot_id="S").desugar(ctx)
+
+    via_entries = reduce_block_to_exitset((_Deposit(), _Read())).collapse()
+    assert isinstance(via_entries, Complete)
+    read = via_entries.value.entries[-1]
+    assert isinstance(read, ObservedEffectValue)
+    assert read.effect is routed
+
+
 def test_no_process_identity_in_slot_fallback() -> None:
     """nodes._effect_slot_id must not call id(self) as a fallback."""
     import re

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -834,6 +834,37 @@ def test_except_as_binds_matching_raise_witness_in_handler():
     assert origins[0].args[1].name == "python:raise_effect_occurrence"
 
 
+def test_except_as_bound_name_observes_the_routed_effect_identity():
+    """``as error`` observes the same RaiseEffect the handler routed.
+
+    Nested raise under an active handler installs ``context_effect`` on the
+    inner halt. Returning ``error.__context__`` is only well-defined when
+    EffectRef projected that exact routed effect (ObservedEffectValue), not a
+    pure EffectCoordinate. The lying path (coordinate without preimage) is
+    pinned unit-side; here the truthful source path must complete.
+    """
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ImportError\n"
+        "    except ImportError:\n"
+        "        try:\n"
+        "            raise ValueError\n"
+        "        except ValueError as error:\n"
+        "            return error.__context__\n"
+    )
+    assert _incompletes(v) == []
+    post = v.post()
+    # __context__ of the routed ValueError is the handled ImportError's
+    # raised value — a constructed exception coordinate, not the slot itself.
+    assert post.args[0].name == "out"
+    assert post.args[1].name != "python:effect_slot"
+    # No residual incomplete from a missing context preimage.
+    assert not any(isinstance(e, Incomplete) for e in v.record.contribution())
+
+
 def test_except_as_does_not_bind_on_uncaught_path():
     # Wrong-type handler is unreachable; its EffectRef is never authenticated.
     # Body raise propagates (mismatch twin).


### PR DESCRIPTION
## What changed

`except ... as e` rewrites to `EffectRef(slot)`. Matching handler routing already deposited `ObservedEffectBinding` / `EffectBinding` facts, and `function_universe_sugar.reduce_block_to_exitset` already threaded those into `statement_ctx.with_observed_effect`. **EffectRefSugar ignored the context** (`del ctx`) and always projected a pure `EffectCoordinate`.

Assertion-With already closed the dual path for `ObservationRef` (`exception_info` → `ObservedExceptionInfoValue`). This PR closes the same identity law for except-as.

### Mechanism

1. **`EffectRefSugar.desugar`** — if `ctx.observed_effect_for(slot)` is set, project `ObservedEffectValue(slot, effect)` (same object the route deposited). Otherwise stay a pure coordinate.
2. **`TrySugar.handler_exits` / `TryStarSugar`** — call `with_observed_effect(slot, routed_effect)` **before** reducing the handler body. Facts prepended *after* reduction cannot authenticate a read that already desugared.
3. **`function_universe_sugar`** — document the ObservedEffectBinding thread (no behavior change; already present).

### Identity law

> Bound name observes the **same** `RaiseEffect` the handler (boundary) routed — not a type-derived reconstruction, not a pure unauthenticated slot.

## Classification

Incomplete path, not inventing green:
- BEFORE: `EffectRef` under observed ctx → pure `EffectCoordinate`; `error.__context__` panics (no preimage)
- AFTER: same ctx → `ObservedEffectValue` with `effect is routed`; `__context__` projects the authenticated chained preimage

Pre-existing reds left red (not this PR):
- `ObservedEffectBinding.guarded` missing on some conditional-raise faces
- `test_try_exitset_law` imports of renamed `_effect_matches`

## Proof sites (before → after)

| Site | BEFORE | AFTER |
| --- | --- | --- |
| `test_effect_ref_observes_the_same_effect_the_route_deposited` | would fail: pure coordinate, no `effect is routed` | **pass** — identity + `__context__` preimage |
| `test_function_universe_threads_observed_effect_binding_into_next_statement` | would fail on entry-thread read | **pass** — deposit via `_ReducedBlock.entries` then EffectRef |
| `test_except_as_bound_name_observes_the_routed_effect_identity` | would panic / residual on `error.__context__` | **pass** — source path completes, post ≠ bare `effect_slot` |
| Existing except-as slot/origin twins | pass | still pass |

## Validation

```text
PYTHONPATH=.../.venv-py312 substrate CPython 3.12.13
pytest test_effect_slot_binding_testimony.py          → 8 passed
pytest test_try_sugar.py -k 'except_as or matching...' → 6+ passed
pytest test_try_exitset_law.py::test_as_binds...       → pass
pytest test_try_handler_temporal_state.py::test_matched_as_binding... → pass
```

No vendor/name arm, no ambient auth table, no E() reconstruction.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prove except-as bindings observe the same routed effect identity in handler bodies
> - `except`/`except*` handler bodies now receive the routed `RaiseEffect` via `with_observed_effect` on the handler context, so `EffectRefSugar` returns an `ObservedEffectValue` instead of a bare `EffectCoordinate` when a matching observed effect is present.
> - `EffectRefSugar.desugar` consults `ctx.observed_effect_for(slot_id)` and, when found, returns `ObservedEffectValue(slot_id, effect, site)`; unauthenticated cases still return a pure `EffectCoordinate`.
> - `reduce_block_to_exitset` threads `ObservedEffectBinding` entries into the next statement's `ReduceContext` so subsequent `EffectRefSugar` reductions within the same block see the correct observed effect.
> - New tests in [`test_try_sugar.py`](https://github.com/TSavo/sugar/pull/6519/files#diff-e08e75c8aa18050f22f6a4f3eab47a900f9605097a7ac8dc38f92f9c906a7e07) and [`test_effect_slot_binding_testimony.py`](https://github.com/TSavo/sugar/pull/6519/files#diff-5ac1b2c19645db8c4c2cee0a9cd04113eaf23721e4ece70e622a88c273ead1f4) assert routed-effect identity and fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1be163.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->