### PR TITLE
Pin returned assertion manager classification boundary

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -1,132 +1,80 @@
+"""Authenticated returned-manager classification in the pinned pandas corpus.
+
+The truthful face intentionally stays red until ordinary returned-manager
+classification reaches the helper's authenticated manager.  On #6501 it stops
+at ``binary_operation_exception_floor:SymbolicValue + CallSiteValue``.  Moving
+past that point with receiver construction and nested ``__call__`` following is
+a separate general mechanism, not permission for a helper-name shortcut here.
+"""
+
 from __future__ import annotations
 
-import importlib.metadata
 from functools import cache
-from pathlib import Path
-from types import MappingProxyType
 
 import pytest
 
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import (
-    ContextManagerResolutionGapV1,
-    ResolvedContractRefsV1,
-    SourceFragmentCoordinateV1,
+    SourceDerivedContextManagerRefV1,
+    TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
-from sugar_lift_python_source.canonical import blake3_512_of
-
-
-_TABLE_CID = "blake3-512:" + "t" * 128
-_CATALOG_CID = "blake3-512:" + "c" * 128
-_DEMAND_CID = (
-    "blake3-512:6e13b2f2c9e67794d662ff357cf8c0ddc2a1509902c0130bfe1ee63377695a113"
-    "b6111d3e44accbd277c993149c8d9f7cabd5f63fc0f3707fc8a49a967abf523"
-)
-_OPAQUE_DEMAND_CID = (
-    "blake3-512:f299951a254712ea1fb53f4f9611aa80c9fe2dd92814cc28b4300540cbc5214d"
-    "7cf4b7d11832f7ba113be17d73b79a34d0fb7c4ddc1705ea1bfa272ecfa58c65"
-)
-_SOURCE_CID = (
-    "blake3-512:3a71aa9c523d26a6a541cb6fdc124d37c364245b959d41873619701b421fbe370"
-    "7b50d44f9d87083a783b17ec779000a4480863c8dc8435761e6f17238dd3ee0"
-)
-
-
-def _install_root() -> Path:
-    distribution = importlib.metadata.distribution("pandas")
-    package = Path(distribution.locate_file("pandas")).resolve()
-    assert package.is_dir()
-    return package.parent
 
 
 @cache
 def _feather_tree():
-    """The pandas helper is a named construction refusal, not an assertion.
-
-    The coordinate and CIDs are the exact row consumed from the authenticated
-    demand table at content key ``e225...3499``.  The local import and returned
-    ``pytest.raises(..., match=None)`` are behind a dynamic export: construction
-    may name that missing preimage, but must not invent it from the With head.
-    """
-    root = _install_root()
-    path = root / "pandas/tests/io/test_feather.py"
-    source_cid = blake3_512_of(path.read_bytes())
-    assert source_cid == _SOURCE_CID
-    external_site = SourceFragmentCoordinateV1(source_cid, 40, 13, 40, 48)
-    opaque_site = SourceFragmentCoordinateV1(source_cid, 33, 13, 33, 46)
-    external_gap = ContextManagerResolutionGapV1(
-        _DEMAND_CID,
-        external_site,
-        "pandas._testing.external_error_raised",
-        "runtime-selected",
-        (),
-    )
-    opaque_gap = ContextManagerResolutionGapV1(
-        _OPAQUE_DEMAND_CID,
-        opaque_site,
-        "pytest.raises",
-        "runtime-selected",
-        (),
-    )
-    refs = ResolvedContractRefsV1(
-        _CATALOG_CID,
-        _TABLE_CID,
-        MappingProxyType({external_site: external_gap, opaque_site: opaque_gap}),
-    )
-
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count) == ("3.0.3", 1421)
+    path = corpus.root / "tests/io/test_feather.py"
     return open_source_file_for_construction(
-        path, root=root, contract_refs=refs, populate_derived=True
+        path,
+        root=corpus.root.parent,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=True,
     )
 
 
-def test_external_error_raised_follows_return_to_named_formal_refusal() -> None:
-    """The pandas helper is followed without inventing an assertion boundary.
-
-    The coordinate and CIDs are the exact row consumed from the authenticated
-    demand table at content key ``e225...3499``.  The local import and returned
-    ``pytest.raises(..., match=None)`` is followed from source.  Its returned
-    manager currently stops at an unspecialized formal, before semantics exist;
-    neither the With-head spelling nor the helper name may bridge that refusal.
-    """
-    from sugar_lift_py_tests.context_manager_resolution import (
-        ContextManagerResolutionGapV1,
-    )
-    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
-
-    tree = _feather_tree()
-    with_node = next(
+def _with_at(line: int):
+    return next(
         node
-        for node in tree.nodes()
-        if node.kind == "With" and node.line_col_span().start_line == 40
+        for node in _feather_tree().nodes()
+        if node.kind == "With" and node.line_col_span().start_line == line
     )
-    reference = tree.unit.construction_context.source_derived_contract_refs[
-        SourceFragmentCoordinateV1(_SOURCE_CID, 40, 13, 40, 48)
-    ]
-    assert isinstance(reference, ContextManagerResolutionGapV1)
-    assert reference.kind == "force-floor"
-    assert reference.detail == (
-        "BindingCoordinateRefSugar.desugar:unspecialized source-call formal"
+
+
+def test_external_error_raised_follows_authenticated_returned_manager() -> None:
+    """Truthful: local import plus returned manager supplies the classification."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        OptionalFormalArgumentProjectionV1,
     )
-    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
-        with_node.sugar()
-    assert caught.value.kind == "force-floor"
-    assert "unspecialized source-call formal" in caught.value.observed
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    with_node = _with_at(40)
+    reference = with_node._prebound_manager_resolution(with_node.items[0])
+
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    # ``match=None`` is written and therefore remains the optional formal
+    # projection; call construction must deliver the native NoneValue actual.
+    # Treating it as an absent NoMessagePatternV1 would erase that distinction.
+    assert isinstance(
+        reference.semantics.message_pattern_operand,
+        OptionalFormalArgumentProjectionV1,
+    )
+    assert isinstance(with_node.sugar(), WithEffectBoundarySugar)
 
 
 def test_adjacent_computed_class_raises_stays_typed_opaque() -> None:
-    """The adjacent direct raises call differs only by its computed operands."""
+    """Lying twin: an unfollowable computed class cannot borrow sibling proof."""
     from sugar_source_tree.panic import WithConstructionGap, WithConstructionGapKind
 
-    tree = _feather_tree()
-    with_node = next(
-        node
-        for node in tree.nodes()
-        if node.kind == "With" and node.line_col_span().start_line == 33
-    )
-
+    with_node = _with_at(33)
     with pytest.raises(WithConstructionGap) as caught:
         with_node.sugar()
 
     assert caught.value.coordinate.start_line == 33
     assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert "ExitSet with 4 arms" in caught.value.observed
+    assert "binary_operation_exception_floor" in caught.value.observed


### PR DESCRIPTION
## Outcome

Pins the authenticated `external_error_raised` returned-manager classification as a truthful red instrument and its adjacent computed-class `pytest.raises` sibling as the lying twin. The implementation diagnostics that require receiver construction, protocol execution, or nested `__call__` following are intentionally excluded.

Current truthful boundary: `force-floor:binary_operation_exception_floor:SymbolicValue + CallSiteValue`. Applying the excluded exploratory stack advances to `construction-panic:OpaqueSourceCallResolutionGap:call-target-source-absent:fail`, confirming the next mechanism is outside this classification cut.

## Authentication

- runtime: CPython 3.12.13
- pandas: 3.0.3, 1,421 files
- corpus: `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`
- demand table: `blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0`, 107,433 rows

## Validation

- `PYTHON312=/usr/local/opt/python@3.12/bin/python3.12 bash scripts/bootstrap-venv-py312.sh` — exit 0, pins verified
- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py -q -s` — 1 failed truthful instrument, 1 passed lying twin, exit 1
- `bin/bpytest implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py -q -s` — same 1 failed / 1 passed under authenticated battleaxe, exit 1
- demand artifact pull/validation — exit 0, 107,433 rows
- #6516 consumer testimony emission — exit 0
- Black check and `git diff --check` — exit 0


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin returned assertion manager classification boundary in feather tree tests
> - Replaces live pandas installation lookup and hardcoded CIDs with `authenticated_pandas_corpus()` in [test_returned_assertion_manager.py](https://github.com/TSavo/sugar/pull/6521/files#diff-ae95b2e3d9589f08dcd37a7451092b43741299d876a5c9b72987042097bfb795), asserting corpus version 3.0.3 with 1421 files.
> - Adds a `_with_at(line)` helper to locate `With` nodes by start line, reducing duplication across tests.
> - `test_external_error_raised_follows_authenticated_returned_manager` now expects the returned manager classification to succeed, asserting a `SourceDerivedContextManagerRefV1` with `EffectBoundarySemanticsV1` and `WithEffectBoundarySugar`, instead of a force-floor construction gap.
> - `test_adjacent_computed_class_raises_stays_typed_opaque` retains the forced floor gap expectation but updates the observed diagnostic string from "ExitSet with 4 arms" to "binary_operation_exception_floor".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b705387.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->