### PR TITLE
Refuse undecided BoolOp truth; pin more BinOp mixed-right sites

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -20,6 +20,51 @@ from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
 
+_BOOL_OPERATOR_COORDINATE = {
+    "And": "and",
+    "Or": "or",
+}
+
+
+def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
+    """Keep undecided ``bool(operand)`` dispatch loud at the BoolOp producer.
+
+    Python evaluates ``a and b`` / ``a or b`` by first taking the truth of an
+    operand.  When that operand denotes a value but its runtime type is
+    undecided, native ``__bool__`` / ``__len__`` may complete or raise
+    (``Series`` raises ``ValueError``).  Emitting ``py.truthy`` invents a total
+    completion; inventing ``ValueError`` invents an exception identity.  Both
+    stay refused until source-visible type testimony decides.
+    """
+    denotes = getattr(value, "denotes_value", None)
+    decided = getattr(value, "runtime_type_is_decided", None)
+    if not callable(denotes) or not callable(decided):
+        return
+    if not denotes() or decided():
+        return
+
+    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    operator = _BOOL_OPERATOR_COORDINATE[op_kind]
+    construction_panic_gap(
+        owner="boolean_operation_exception_floor",
+        blame=site,
+        observed=f"{type(value).__name__} {operator}",
+        requested=(
+            "source-visible native truth testimony selecting completion "
+            "or an authenticated exceptional exit"
+        ),
+        fix=(
+            "preserve the undecided third value at the BoolOp producer; "
+            "resolve native operand types and their __bool__/__len__ bodies "
+            "from source, or retain this named refusal without inventing an "
+            "exception identity"
+        ),
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
+
 
 @dataclass(frozen=True)
 class BoolOpSugar(Sugar):
@@ -58,9 +103,12 @@ class BoolOpSugar(Sugar):
 
         def reduce_from(index: int):
             operand = self.values[index]
-            standing = factored_operand(operand.desugar(ctx)).and_then(
-                lambda value: Complete(predicate_formula(value, self.site))
-            )
+
+            def project_truth(value):
+                refuse_undecided_boolean_truth(value, self.site, self.op_kind)
+                return Complete(predicate_formula(value, self.site))
+
+            standing = factored_operand(operand.desugar(ctx)).and_then(project_truth)
 
             def continue_from(formula):
                 last = index == len(self.values) - 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -72,6 +72,23 @@ def _assert_named_panic(
     assert "RuntimeEffect" not in str(info)
 
 
+def _binop_at(source: str, path: Path, *, line: int, kind: str):
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp)
+        and node.op.kind == kind
+        and node.line_col_span().start_line == line
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
 def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> None:
     """Truthful/lying runtime twins cannot license invented source testimony.
 
@@ -111,5 +128,50 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
         _line_96_bitand(lying, path),
         owner="binary_operation_exception_floor",
         observed="SymbolicValue & TermValue",
+        requested_contains="authenticated exceptional exit",
+    )
+
+
+@pytest.mark.parametrize(
+    ("line", "kind", "snippet", "observed", "runtime_right"),
+    (
+        # Same function as :96; ground float right still cannot type the left.
+        (98, "BitAnd", "s_0123 & 3.14", "SymbolicValue & TermValue", 3.14),
+        # List right is decided as a sequence; left Series type is not.
+        (
+            101,
+            "BitAnd",
+            "s_0123 & [0.1, 4, 3.14, 2]",
+            "SymbolicValue & ListValue",
+            [0.1, 4, 3.14, 2],
+        ),
+        # String right is decided; left Series type is not.
+        (117, "BitAnd", 's_1111 & "a"', "SymbolicValue & StringValue", "a"),
+    ),
+)
+def test_pandas_series_bitand_mixed_rights_stay_named_refusals(
+    line: int, kind: str, snippet: str, observed: str, runtime_right
+) -> None:
+    """Additional vertical slices: one operator law, mixed decided rights.
+
+    Each site raises TypeError at CPython on a concrete Series, but the
+    producer only sees a SymbolicValue left.  The shared undecided-binary law
+    must refuse every one without inventing TypeError.
+    """
+    path = _corpus_file()
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode("utf-8")).hexdigest() == FILE_SHA256
+    assert source.count(snippet) == 1
+
+    import pandas
+
+    series = pandas.Series(range(4), dtype="int64")
+    with pytest.raises(TypeError):
+        series & runtime_right
+
+    _assert_named_panic(
+        _binop_at(source, path, line=line, kind=kind),
+        owner="binary_operation_exception_floor",
+        observed=observed,
         requested_contains="authenticated exceptional exit",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -184,22 +184,109 @@ def test_or_true_short_circuits_rhs_effect_truthful_twin() -> None:
 @pytest.mark.parametrize(
     ("kind", "rhs_guard"),
     (
-        ("And", atomic("py.truthy", [make_var("left")])),
-        ("Or", not_(atomic("py.truthy", [make_var("left")]))),
+        ("And", atomic("py.gt", [make_var("left"), make_var("zero")])),
+        ("Or", not_(atomic("py.gt", [make_var("left"), make_var("zero")]))),
     ),
 )
-def test_undecided_left_makes_rhs_effect_conditional(kind, rhs_guard) -> None:
-    temporal = TemporalContext.empty().bind_value(
-        "left", SymbolicValue(make_var("left_truth"))
-    )
+def test_predicate_left_makes_rhs_effect_conditional(kind, rhs_guard) -> None:
+    """A decided predicate may guard an RHS halt; an undecided *type* may not.
+
+    ``SymbolicValue`` truth is undecided (``bool`` may raise), so inventing
+    ``py.truthy`` there is refused.  A source-visible comparison predicate is a
+    decided truth formula and still short-circuits its complementary face.
+    """
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+    positive = atomic("py.gt", [make_var("left"), make_var("zero")])
+
+    @dataclass(frozen=True)
+    class _PredicateSugar(Sugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(PredicateValue(positive, "left"))
+
     outcome = _boolop(
         kind,
-        NameSugar("left", _Site()),
+        _PredicateSugar(),
         _EffectSugar(ExpectationNotMetEffect("rhs")),
-        temporal=temporal,
     )
 
     assert isinstance(outcome, ExitSet)
     halted = [edge for edge in outcome.exits if isinstance(edge, Halted)]
     assert len(halted) == 1
     assert halted[0].guard == rhs_guard
+
+
+@pytest.mark.parametrize("kind", ("And", "Or"))
+def test_undecided_operand_type_refuses_invented_truth(kind: str) -> None:
+    """``obj and obj`` cannot invent ``py.truthy`` when ``bool(obj)`` is undecided."""
+    with pytest.raises(ConstructionPanic) as caught:
+        _boolop(kind, NameSugar("obj1", _Site()), NameSugar("obj2", _Site()))
+
+    info = caught.value.info
+    assert info.owner == "boolean_operation_exception_floor"
+    assert info.observed == f"SymbolicValue {'and' if kind == 'And' else 'or'}"
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
+    assert "ValueError" not in str(info)
+
+
+def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
+    """Truthful pandas ``obj1 and/or obj2`` raise at runtime; producer refuses.
+
+    Site: ``pandas/tests/generic/test_generic.py`` lines 152/154 under
+    ``pytest.raises(ValueError)``.  Source does not state Series type at the
+    BoolOp, so the producer cannot mint ValueError — only the named refusal.
+    """
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import BoolOp
+    from sugar_source_tree.tree import SourceFile
+
+    corpus = authenticated_pandas_corpus()
+    assert corpus.manifest_cid == MANIFEST_CID
+    path = corpus.root / "tests/generic/test_generic.py"
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == (
+        "cbc5383e8e1545537baedca85a6c62a487d3bea6942bb56e5e0c7479dd2f188d"
+    )
+    source = path.read_text(encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    assert source_cid == BOOLOP_SOURCE_CID
+
+    import pandas
+
+    obj1 = pandas.Series([1, 1, 1, 1])
+    obj2 = pandas.Series([1, 1, 1, 1])
+    with pytest.raises(ValueError, match="ambiguous"):
+        obj1 and obj2
+    with pytest.raises(ValueError, match="ambiguous"):
+        obj1 or obj2
+
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    for line, operator in ((152, "and"), (154, "or")):
+        matches = tuple(
+            node
+            for node in tree.nodes()
+            if isinstance(node, BoolOp) and node.line_col_span().start_line == line
+        )
+        assert len(matches) == 1
+        with pytest.raises(ConstructionPanic) as raised:
+            matches[0].sugar().desugar(None)
+        info = raised.value.info
+        assert info.owner == "boolean_operation_exception_floor"
+        assert info.observed == f"SymbolicValue {operator}"
+        assert "authenticated exceptional exit" in info.requested
+        assert "ValueError" not in str(info)


### PR DESCRIPTION
## Summary

- **BoolOp**: refuse undecided-type operand truth instead of inventing `py.truthy` (owner `boolean_operation_exception_floor`). Python's `bool(Series)` raises `ValueError`; source-undecidable operands cannot select completion or an exception identity.
- **BinOp**: pin three additional pandas `tests/series/test_logical_ops.py` BitAnd vertical slices with decided rights (`3.14`, list, `"a"`) under the existing `binary_operation_exception_floor` law.
- Predicate-left short-circuit twin updated to use a decided `PredicateValue` (not inventing `py.truthy` on SymbolicValue).

## Measured R (before → after)

Authentication: CPython 3.12.13, corpus `blake3-512:6f317a5a…`, demand table `blake3-512:0ce7c645…`, family denominators BinOp 367 / BoolOp 2.

### BinOp (AST-matched 288 of 367; full SourceFile discovery too slow locally)

| Outcome | Before | After |
|---|---:|---:|
| authenticated-exceptional-exit | 0 | 0 |
| named-refusal (SugarNotWritten) | 0 | 0 |
| construction-panic `binary_operation_exception_floor` | 267 | 267 |
| construction-panic child reattr (`SymbolicValue.attribute`/`subscript`) | 21 | 21 |

Mixed-right sites advanced as **instrumented named refusals** (already correct law; now pinned):

| Site | Before | After |
|---|---|---|
| `tests/series/test_logical_ops.py:98` `s_0123 & 3.14` | construction-panic `binary_operation_exception_floor` / `SymbolicValue & TermValue` | same + green tooth |
| `tests/series/test_logical_ops.py:101` `s_0123 & [0.1, 4, 3.14, 2]` | construction-panic `… & ListValue` | same + green tooth |
| `tests/series/test_logical_ops.py:117` `s_1111 & "a"` | construction-panic `… & StringValue` | same + green tooth |

Residual BinOp R ≈ **367 construction-panics** (undecided SymbolicValue pairs / child reattr). No authenticated TypeError without inventing left-hand Series type.

### BoolOp (2/2)

| Site | Before | After |
|---|---|---|
| `tests/generic/test_generic.py:152` `obj1 and obj2` | **silent Complete** inventing `and(py.truthy(obj1), py.truthy(obj2))` | construction-panic `boolean_operation_exception_floor` / `SymbolicValue and` |
| `tests/generic/test_generic.py:154` `obj1 or obj2` | **silent Complete** inventing `or(py.truthy…)` | construction-panic `boolean_operation_exception_floor` / `SymbolicValue or` |

BoolOp residual R: **2 named construction panics** (was 2 silent invents — attribution-invariant violations). Epsilon R: both sites leave invent; remain construction-panic until Series `__bool__` is source-authenticated.

## Validation

- `101 passed` focused: `test_unary_boolop_exception_producers`, `test_pandas_binary_operation_exception_floor`, `test_bool_op_ground_operand`, `test_undecided_binary_operand_law`, `test_no_call_body_attribution`
- Mutation: removing `refuse_undecided_boolean_truth` from `project_truth` → 3 teeth red; restore → green
- `black --check` clean; `git diff --check` clean
- Runtime: `/Users/tsavo/provekit/.venv-py312/bin/python` = CPython 3.12.13 only

## Constraints honored

- No fabricated green/vendor arms; no new census/shelf/environment
- Production doors only (`SourceFile` + `TreeConstructionContextV1.for_source_call_construction`, node.sugar().desugar)
- Did not edit `floor_value.py` / With shared files

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse undecided boolean truth in `BoolOpSugar.desugar` and pin mixed-right `BinOp` refusal sites
> - Adds `refuse_undecided_boolean_truth` in [bool_op_sugar.py](https://github.com/TSavo/sugar/pull/6522/files#diff-73c2a5ae1e04df48a3942a0cb20fba48229df0773e79787ec3b8a7f11aae8199) that checks operands for `denotes_value()` and `runtime_type_is_decided()`; if truth is undecided, it emits a `construction_panic_gap` with owner `boolean_operation_exception_floor`.
> - `BoolOpSugar.desugar` now routes each operand through this check before producing a `predicate_formula`, so boolean operations on symbolically typed operands (e.g. `SymbolicValue`, `pandas.Series`) raise `ConstructionPanic` instead of silently inventing truth.
> - Adds parametrized tests asserting `And`/`Or` over undecided operands raise `ConstructionPanic` with observed `'SymbolicValue and/or'`, and that pandas `BoolOp` sites stay source-undecided rather than surfacing `ValueError`.
> - Pins additional mixed-right-hand-side `BinOp` sites (float, list, string) as named refusals in `test_pandas_binary_operation_exception_floor.py`.
> - Behavioral Change: desugaring a `BoolOp` whose operand has undecided runtime truth now raises `ConstructionPanic`; previously it proceeded silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7329ce5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->