### PR TITLE
Floor ObservedEffectBinding under guards; retain formal raise match

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -38,6 +38,17 @@ class ObservedEffectBinding(FloorValue):
     def contribution(self):
         return ()
 
+    def guarded(self, formula):
+        """Arm-scoped binding testimony rides under a guard unchanged.
+
+        The handler route already selected this slot under the arm's polarity.
+        Guarding does not invent a second occurrence and does not convert the
+        binding into an implication — it is the same RaiseEffect object the
+        router deposited for ``except ... as e`` / EffectRef projection.
+        """
+        del formula
+        return self
+
 
 class RuntimeSelectedReachedRouter(RuntimeError):
     """Raised when a ``RuntimeSelected`` contract reaches ``route``."""

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -177,15 +177,50 @@ def test_same_spelling_unresolved_handler_identity_stays_loud():
         ).sugar()
 
 
-def test_unresolved_raised_identity_stays_loud_at_the_router():
-    with pytest.raises(SugarNotWritten):
+def test_unresolved_raised_identity_is_retained_not_decided_at_the_router():
+    """Formal ``raise E`` vs typed ``except ValueError`` is MatchRetained.
+
+    ``matches_raise_effect`` retains ``adt.is_python_type(E, ValueError)`` when
+    both operands have value terms but no authenticated exception identity.
+    That is not a construction gap and not a silent match/miss: both faces of
+    the partition must survive. ObservedEffectBinding rides under the match
+    arm guard without inventing a second occurrence.
+    """
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.effect_router import ObservedEffectBinding
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+    out = (
         _fn(
             "def A(E):\n"
             "    try:\n"
             "        raise E\n"
             "    except ValueError:\n"
             "        pass\n"
-        ).sugar().desugar()
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)
+    record = out.value.record
+    # Residual halt under the open type test (miss face).
+    residual = tuple(
+        entry
+        for entry in record.statements
+        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect)
+    )
+    assert residual, "miss face of retained identity must remain a raise"
+    # Match-arm binding testimony must not invent TypeError / RuntimeEffect.
+    bindings = tuple(
+        entry for entry in record.statements if isinstance(entry, ObservedEffectBinding)
+    )
+    assert all(isinstance(b.effect, RaiseEffect) for b in bindings)
+    text = str(out)
+    assert "adt.is_python_type" in text
+    assert "TypeError" not in text
+    assert "RuntimeEffect" not in text
 
 
 def test_bare_reraise_reemits_the_exact_inflight_raise():


### PR DESCRIPTION
## Summary

Follow-up to #6519 (except-as observed-effect identity).

Handler routing deposits `ObservedEffectBinding` into ExitSet records. Under MatchRetained partitions those facts must ride under branch guards. Without `ObservedEffectBinding.guarded`, formal `raise E` vs typed `except` panics at the Floor default.

Also updates the stale SNW twin to pin the current law: `matches_raise_effect` **retains** `adt.is_python_type` when both operands have value terms but no authenticated exception identity.

## Owner report

```
sourceStamp: ObservedEffectBinding.guarded + MatchRetained formal raise
runtime = CPython 3.12.13
canonical corpus manifest = blake3-512:6f317a5a…563530
demand-table identity = blake3-512:0ce7c645…75153ab0
concrete source site: raise E / except ValueError (formal E)
before outcome: ConstructionPanic owner=guarded blame=ObservedEffectBinding
after outcome: Complete UniverseValue; residual Incomplete RaiseEffect on miss face; adt.is_python_type retained
surviving typed gaps: MatchRetained remains open (not decided; not SNW)
```

## Validation

```text
pytest test_effect_slot_binding_testimony.py test_try_sugar.py
→ 62 passed
```