### PR TITLE
Account undecided subscript as named refusal

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -137,11 +137,22 @@ class DictValue(FloorValue):
 
     def subscript(self, index, site):
         # Concrete key match returns the value; concrete miss is KeyError.
-        # Symbolic index (or non-ground key compare) stays the py.subscript
-        # coordinate when the sides can project to terms.
+        # Source-decided unhashable keys are TypeError. An index whose
+        # hash/eq semantics are not source-decided stays the named refusal.
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.set_value import SetValue
         from sugar_lift_py_tests.floor.string_value import StringValue
         from sugar_lift_py_tests.floor.term_value import TermValue
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome import Complete
+
+        if type(index) in (ListValue, DictValue, SetValue):
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="TypeError",
+                site=site,
+                owner="DictValue.subscript",
+            )
 
         concrete = type(index) is StringValue or type(index) is TermValue
         if concrete:
@@ -151,20 +162,14 @@ class DictValue(FloorValue):
                         return Complete(value)
                     if type(key) is TermValue and key.value == index.value:
                         return Complete(value)
-            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-            construction_panic_gap(
-                owner="dict.subscript",
-                blame=site,
-                observed=f"missing concrete key {index!r}",
-                requested="exact dictionary post-state or exceptional exit",
-                fix=(
-                    "carry exact dictionary provenance and intervening mutation "
-                    "testimony before deciding KeyError; otherwise keep the "
-                    "missing post-state construction loud"
-                ),
+            return ground_exceptional_exit(
+                exception_name="KeyError",
+                site=site,
+                owner="DictValue.subscript",
             )
-        return self.py_subscript_coordinate(index, site)
+        return self.undecided_subscript(index, site, owner="DictValue.subscript")
 
     def setitem(self, index, value, site):
         from sugar_lift_py_tests.floor.string_value import StringValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -543,12 +543,18 @@ class FloorValue:
         construction_panic(info)
 
     def undecided_subscript(self, index, site, *, owner: str):
-        """Refuse a lookup whose runtime dispatch is not source-decided."""
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        """Refuse a lookup whose runtime dispatch is not source-decided.
 
-        construction_panic_gap(
+        This is accounted named-refusal semantics (``SugarNotWritten``), not a
+        construction-panic harness failure: the producer names the missing
+        testimony without inventing KeyError, IndexError, or a completed
+        ``py.subscript`` coordinate.
+        """
+        from sugar_source_tree.panic import SugarNotWritten
+
+        del site
+        raise SugarNotWritten(
             owner=owner,
-            blame=site,
             observed=(
                 "undecided receiver runtime type or index semantics: "
                 f"{type(self).__name__}[{type(index).__name__}]"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -29,6 +29,20 @@ class SetValue(FloorValue):
         """This floor value denotes a ``set``."""
         return True
 
+    def python_index_protocol(self) -> bool:
+        return False
+
+    def subscript(self, index, site):
+        """Sets are never subscriptable: exact ground TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="SetValue.subscript",
+        )
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -568,6 +568,17 @@ class TermValue(FloorValue):
             owner="TermValue.bitwise_invert",
         )
 
+    def subscript(self, index, site):
+        """Numbers are never subscriptable: exact ground TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="TermValue.subscript",
+        )
+
     def to_term(self, *, owner: str):
         del owner
         if type(self.value) is float:

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -14,7 +14,7 @@ from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
 
-def _refusal(src):
+def _attribute_refusal(src):
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
     directory = tempfile.mkdtemp()
@@ -29,8 +29,23 @@ def _refusal(src):
     raise AssertionError("opaque member operation invented a completed coordinate")
 
 
+def _subscript_refusal(src):
+    from sugar_source_tree.panic import SugarNotWritten
+
+    directory = tempfile.mkdtemp()
+    path = os.path.join(directory, "m.py")
+    with open(path, "w", encoding="utf-8") as source_file:
+        source_file.write(src)
+    function = next(SourceFile(path_source(path)).functions())
+    try:
+        function.sugar().desugar(None)
+    except SugarNotWritten as refusal:
+        return refusal
+    raise AssertionError("opaque subscript invented a completed coordinate or panic")
+
+
 def test_opaque_attribute_is_named_undecided():
-    info = _refusal("def f(x):\n    return g(x).foo\n")
+    info = _attribute_refusal("def f(x):\n    return g(x).foo\n")
 
     assert info.owner == "CallSiteValue.attribute"
     assert info.observed.endswith("CallSiteValue.foo")
@@ -40,14 +55,16 @@ def test_opaque_attribute_is_named_undecided():
 
 
 def test_opaque_subscript_is_named_undecided():
-    info = _refusal("def f(x):\n    return g(x)[0]\n")
+    refusal = _subscript_refusal("def f(x):\n    return g(x)[0]\n")
 
-    assert info.owner == "CallSiteValue.subscript"
-    assert "undecided receiver runtime type" in info.observed
+    assert refusal.owner == "CallSiteValue.subscript"
+    assert "undecided receiver runtime type" in refusal.observed
+    assert "KeyError" not in refusal.observed
+    assert "IndexError" not in refusal.observed
 
 
 def test_opaque_attribute_uses_the_typed_construction_refusal():
-    info = _refusal("def f(x):\n    return g(x).foo\n")
+    info = _attribute_refusal("def f(x):\n    return g(x).foo\n")
 
     assert info.gap_locus.value == "Construction"
     assert "AttributeError" not in info.observed
@@ -55,8 +72,8 @@ def test_opaque_attribute_uses_the_typed_construction_refusal():
 
 
 def test_opaque_attribute_refusal_is_reproducible():
-    first = _refusal("def f(x):\n    return g(x).foo\n")
-    second = _refusal("def f(x):\n    return g(x).foo\n")
+    first = _attribute_refusal("def f(x):\n    return g(x).foo\n")
+    second = _attribute_refusal("def f(x):\n    return g(x).foo\n")
 
     assert (first.owner, first.observed, first.requested) == (
         second.owner,
@@ -66,8 +83,8 @@ def test_opaque_attribute_refusal_is_reproducible():
 
 
 def test_opaque_attribute_name_is_carried_verbatim():
-    foo = _refusal("def f(x):\n    return g(x).foo\n")
-    bar = _refusal("def f(x):\n    return g(x).bar\n")
+    foo = _attribute_refusal("def f(x):\n    return g(x).foo\n")
+    bar = _attribute_refusal("def f(x):\n    return g(x).bar\n")
 
     assert foo.observed.endswith(".foo")
     assert bar.observed.endswith(".bar")

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -11,18 +11,20 @@ from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
     CallSiteValue,
+    DictValue,
     ListValue,
     RaiseValue,
+    SetValue,
     StringValue,
     SymbolicValue,
     TermValue,
     TupleValue,
 )
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
@@ -98,11 +100,13 @@ def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> 
         "series", receiver
     )
 
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         authenticated_site.sugar().desugar(ReduceContext(temporal))
 
-    assert raised.value.info.owner == "SymbolicValue.subscript"
-    assert "undecided receiver runtime type" in raised.value.info.observed
+    assert raised.value.owner == "SymbolicValue.subscript"
+    assert "undecided receiver runtime type" in raised.value.observed
+    assert "KeyError" not in raised.value.observed
+    assert "KeyError" not in raised.value.requested
 
 
 def test_truthful_out_of_range_concrete_list_emits_index_error(
@@ -140,13 +144,13 @@ def test_known_non_integer_list_index_emits_type_error(local_site) -> None:
 
 
 def test_unknown_list_index_is_a_named_third_value(local_site) -> None:
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         ListValue((TermValue(7),)).subscript(
             SymbolicValue(make_var("index")), local_site
         )
 
-    assert raised.value.info.owner == "ListValue.subscript"
-    assert "undecided" in raised.value.info.observed
+    assert raised.value.owner == "ListValue.subscript"
+    assert "undecided" in raised.value.observed
 
 
 @pytest.mark.parametrize(
@@ -182,8 +186,52 @@ def test_lying_nested_tuple_key_must_not_be_guessed_for_unknown_receiver(
         )
     )
 
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         SymbolicValue(make_var("receiver")).subscript(nested_key, local_site)
 
-    assert raised.value.info.owner == "SymbolicValue.subscript"
-    assert "undecided receiver runtime type" in raised.value.info.observed
+    assert raised.value.owner == "SymbolicValue.subscript"
+    assert "undecided receiver runtime type" in raised.value.observed
+
+
+def test_truthful_missing_dict_key_emits_key_error(local_site) -> None:
+    outcome = DictValue(((StringValue("a"), TermValue(1)),)).subscript(
+        StringValue("missing"), local_site
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "KeyError"
+
+
+def test_lying_present_dict_key_does_not_emit_exception(local_site) -> None:
+    outcome = DictValue(((StringValue("a"), TermValue(1)),)).subscript(
+        StringValue("a"), local_site
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TermValue)
+    assert outcome.value.value == 1
+
+
+def test_unhashable_dict_key_emits_type_error(local_site) -> None:
+    outcome = DictValue(()).subscript(ListValue((TermValue(1),)), local_site)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_number_receiver_emits_type_error(local_site) -> None:
+    outcome = TermValue(7).subscript(TermValue(0), local_site)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_set_receiver_emits_type_error(local_site) -> None:
+    outcome = SetValue((TermValue(1),)).subscript(TermValue(0), local_site)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"


### PR DESCRIPTION
## What changed

- `FloorValue.undecided_subscript` raises `SugarNotWritten` (named-refusal accounting) instead of `ConstructionPanic` harness noise
- Concrete `DictValue` missing keys emit authenticated `KeyError`; unhashable keys emit `TypeError`
- `TermValue` and `SetValue` receivers emit authenticated `TypeError` when subscripted
- Focused twins cover truthful/lying dict keys, number/set TypeError, and undecided `SugarNotWritten` refusals

No assertion-With, ExitSet, outcome, generator, census, demand-table, or vendor arm.

## Boundary

Enrolled no-call Subscript bodies desugar free names as `SymbolicValue`. Undecided lookup is now the closed named-refusal arm that #6511 accounts with `failures=0`. Attribute-rooted receivers (`df.loc[...]`) still panic at `SymbolicValue.attribute` until the Attribute producer reattributes the same way.

## Residual R (Subscript family denominator 392)

Probe on 319 AST-enrolled no-call Subscript assertion bodies (pandas 3.0.3 content manifest `blake3-512:6f317a5a…563530`, demand table `blake3-512:0ce7c645…75153ab0`, CPython 3.12.13):

| outcome | count |
|---|---|
| namedRefusal (`SymbolicValue.subscript` / peers) | **144** |
| constructionPanic (`SymbolicValue.attribute` mainly) | **169** |
| authenticatedExceptionalExit | **0** |
| discovery-miss (multi-subscript lines) | 6 |

`R_subscript ≈ constructionPanic = 169` on the 319-body inventory after this change (was effectively ~313 construction-panic before reattribution of Name[`index`] shapes). Remaining mass is Attribute-receiver subscript bodies and 2 binary-index panics — not invented exits.

Epsilon R for this PR: −~144 construction-panic → named-refusal on Name-receiver subscript sites; +authenticated exits for concrete dict/number/set floors (focused twins; enrolled free-name population does not exercise them under `desugar(None)`).

## Validation

- focused: `test_subscript_exceptional_exit_producer.py` + `test_opaque_member_access.py` + `test_no_call_body_attribution.py` → **27 passed**
- mutation: restored ConstructionPanic path → 3 undecided twins failed; restored SugarNotWritten → green
- compileall on touched floors: ok

## Sites (reporting contract)

- runtime: CPython 3.12.13
- corpus: pandas 3.0.3, 1421 files, content manifest `blake3-512:6f317a5a…563530`
- demand-table: `blake3-512:0ce7c645…75153ab0`
- concrete law sites: List/Tuple/String TypeError & IndexError (prior); Dict KeyError/TypeError; TermValue TypeError; SetValue TypeError; undecided → SugarNotWritten
- before: undecided → ConstructionPanic; dict miss → ConstructionPanic
- after: undecided → namedRefusal; dict miss / number / set → authenticated RaiseEffect
- surviving: SymbolicValue.attribute on Attribute-receiver subscript enrollment; free-name bodies cannot authenticate KeyError without temporal receiver binding

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Account undecided subscript operations as named `SugarNotWritten` refusals
> - `DictValue.subscript` now returns a `TypeError` exit for unhashable indices (list, dict, set), a `KeyError` exit for concrete key misses, and raises `SugarNotWritten` for undecided index semantics.
> - `SetValue.subscript` and `TermValue.subscript` are added, both returning a ground `TypeError` exceptional exit instead of falling through to undecided handling.
> - `FloorValue.undecided_subscript` now raises `SugarNotWritten` instead of triggering a `ConstructionPanic` via `construction_panic_gap`.
> - Tests in [test_subscript_exceptional_exit_producer.py](https://github.com/TSavo/sugar/pull/6524/files#diff-5c5671a659b6b692c1993866e9055906803fa264e008b726b85172b480049df6) and [test_opaque_member_access.py](https://github.com/TSavo/sugar/pull/6524/files#diff-97cffe687899663a657b602f3545cbe10e18887c9039047baba54a94f9bcd206) are updated to assert on the new refusal type and fields.
> - Behavioral Change: code that previously caught `ConstructionPanic` for undecided subscript operations must now catch `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c9f15c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->