### PR TITLE
Enroll empty, ordinary, and accumulated match= pattern shapes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -156,9 +156,7 @@ def test_written_none_pattern_consumes_without_a_regex_obligation():
     """The helper's explicit ``match=None`` reaches the native None floor."""
     from sugar_lift_py_tests.floor import NoneValue, StringValue
 
-    body = ExitSet(
-        (_raise("ValueError", "written-none", message=StringValue("boom")),)
-    )
+    body = ExitSet((_raise("ValueError", "written-none", message=StringValue("boom")),))
 
     routed = _route(body, pattern=NoneValue())
 
@@ -171,14 +169,87 @@ def test_string_none_pattern_does_not_impersonate_written_none():
     """Lying twin: the string ``"None"`` remains an actual regex constraint."""
     from sugar_lift_py_tests.floor import StringValue
 
-    body = ExitSet(
-        (_raise("ValueError", "string-none", message=StringValue("boom")),)
-    )
+    body = ExitSet((_raise("ValueError", "string-none", message=StringValue("boom")),))
 
     routed = _route(body, pattern=StringValue("None"))
 
     assert len(routed.exits) == 1
     assert isinstance(routed.exits[0], Halted)
+
+
+def test_empty_pattern_decides_only_for_the_empty_message():
+    """Corpus shape: ``match="^$"`` at pandas json normalize line 175.
+
+    The boundary consumes a matching empty-message raise and leaves a
+    nonempty message halted -- never treats written ``^$`` as absence.
+    """
+    from sugar_lift_py_tests.floor import StringValue
+
+    empty_body = ExitSet((_raise("ValueError", "empty-msg", message=StringValue("")),))
+    nonempty_body = ExitSet(
+        (_raise("ValueError", "nonempty-msg", message=StringValue("boom")),)
+    )
+    pattern = StringValue("^$")
+
+    empty_routed = _route(empty_body, pattern=pattern)
+    nonempty_routed = _route(nonempty_body, pattern=pattern)
+
+    assert len(empty_routed.exits) == 1
+    assert isinstance(empty_routed.exits[0], Completed)
+    assert _marker(empty_routed.exits[0]) == "empty-msg"
+    assert len(nonempty_routed.exits) == 1
+    assert isinstance(nonempty_routed.exits[0], Halted)
+    assert _marker(nonempty_routed.exits[0]) == "nonempty-msg"
+
+
+def test_ordinary_pattern_decides_ground_re_search():
+    """Corpus shape: ``match="whoops"`` at pandas register_accessor line 103."""
+    from sugar_lift_py_tests.floor import StringValue
+
+    matching = ExitSet(
+        (_raise("ValueError", "ordinary-hit", message=StringValue("whoops")),)
+    )
+    missing = ExitSet(
+        (_raise("ValueError", "ordinary-miss", message=StringValue("other")),)
+    )
+    pattern = StringValue("whoops")
+
+    assert isinstance(_route(matching, pattern=pattern).exits[0], Completed)
+    assert isinstance(_route(missing, pattern=pattern).exits[0], Halted)
+
+
+def test_accumulated_alternation_retains_re_search_on_the_boundary():
+    """Corpus shape: ``msg = "|".join(msgs)`` at pandas indexing line 108/111.
+
+    A join-built alternation is a constructed call-site value. The boundary
+    retains ``py.re_search`` over both faces rather than inventing a decision.
+    """
+    from sugar_lift_py_tests.floor import StringValue
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.ir import ctor
+
+    pattern = CallSiteValue(
+        "join",
+        (StringValue("|"), SymbolicValue(make_var("msgs"))),
+        (),
+        ctor("call:join", []),
+        None,
+    )
+    body = ExitSet(
+        (
+            _raise(
+                "ValueError",
+                "accum-open",
+                message=StringValue("positional indexers are out-of-bounds"),
+            ),
+        )
+    )
+
+    routed = _route(body, pattern=pattern)
+
+    assert len(routed.exits) == 2
+    assert {type(face).__name__ for face in routed.exits} == {"Completed", "Halted"}
+    assert all("py.re_search" in str(face.guard) for face in routed.exits)
 
 
 @pytest.mark.parametrize("exception_name", ["ValueError", "TypeError"])

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -618,14 +618,222 @@ def test_construction_names_value_call_target_at_the_opaque_coordinate() -> None
     assert _CALL_TARGET_GAP_PRECEDENCE.index("value-call-target") == 1
 
 
-def test_name_pattern_reaches_authenticated_base_try_gap() -> None:
-    """The line-16 manager now reaches its generic base, then stays loud.
+#: The three ``match=`` *pattern* shapes -- what the predicate *means*, once a
+#: value is in hand. Distinct from the four argument *expression* shapes above.
+#:
+#: ``empty-pattern``
+#:     ``match="^$"`` -- written empty-message regex. Ground
+#:     ``StringValue("^$")`` decides true only for the empty message.
+#: ``ordinary-pattern``
+#:     ``match="whoops"`` -- an ordinary ground string. ``re.search`` settles
+#:     at lift against a ground message.
+#: ``accumulated-alternation``
+#:     ``msg = "|".join(msgs)`` bound into ``match=msg``. The join is a
+#:     constructed ``CallSiteValue``; the message half leaves as
+#:     ``MatchRetained(py.re_search(...))``, never as a false predicate.
+@dataclass(frozen=True)
+class MatchPatternSite:
+    """One enrolled pattern-semantic shape with a concrete corpus coordinate."""
+
+    shape: str
+    relative_path: str
+    line: int
+    expression: str
+    file_sha256: str
+    #: How the pattern value is obtained from the enrolled file.
+    construction: str
+    #: Authoritative message-predicate disposition for a ground raise.
+    disposition: str
+
+
+ENROLLED_PATTERN_SITES: tuple[MatchPatternSite, ...] = (
+    MatchPatternSite(
+        shape="empty-pattern",
+        relative_path="tests/io/json/test_normalize.py",
+        line=175,
+        expression='"^$"',
+        file_sha256="d8fe146f21dfe51e39b21aa233cdf416e5337efede0938d2930b783dd6a89909",
+        construction="literal-string-value",
+        disposition="match-decided",
+    ),
+    MatchPatternSite(
+        shape="ordinary-pattern",
+        relative_path="tests/test_register_accessor.py",
+        line=103,
+        expression='"whoops"',
+        file_sha256="4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793",
+        construction="literal-string-value",
+        disposition="match-decided",
+    ),
+    MatchPatternSite(
+        shape="accumulated-alternation",
+        relative_path="tests/indexing/test_indexing.py",
+        line=111,
+        expression="msg",
+        file_sha256="00d2e0ab8b75c16942df2c6cf7b3fc0a0aec02dfe39792d78b5c83d8f973e409",
+        construction="join-call-site-value",
+        disposition="match-retained",
+    ),
+)
+
+#: Binding site for the accumulated-alternation pattern: ``msg = "|".join(msgs)``.
+ACCUMULATED_ALTERNATION_BINDING_LINE = 108
+
+#: First named gap on the manager-construction path for enrolled match=
+#: managers. Soft-Try for ``re.compile`` is past; the live floor is the
+#: f-string binary pair inside an inherited method body. Named, not mere
+#: refusal -- BinOp owns the pair, Match owns the pattern half above.
+MANAGER_FORCE_FLOOR_DETAIL = (
+    "binary_operation_exception_floor:SymbolicValue + CallSiteValue"
+)
+
+
+def _pattern_value_for_site(site: MatchPatternSite):
+    """Construct the enrolled pattern value from the real corpus coordinate.
+
+    Empty and ordinary patterns desugar the ``match=`` keyword itself. The
+    accumulated alternation desugars the binding that produces ``msg`` -- the
+    keyword is a bare name, and the join that builds the alternation is the
+    shape under test.
+    """
+    from sugar_source_tree.nodes import Assign
+
+    path = _corpus_root() / site.relative_path
+    source_file = _source_file(path)
+    if site.shape == "accumulated-alternation":
+        binding = next(
+            node
+            for node in source_file.nodes()
+            if isinstance(node, Assign)
+            and node.line_col_span().start_line == ACCUMULATED_ALTERNATION_BINDING_LINE
+            and "join" in node.segment()
+        )
+        outcome = binding.value.sugar().desugar()
+    else:
+        argument = _match_argument(_raises_call_on_line(source_file, site.line))
+        outcome = argument.sugar().desugar()
+    assert type(outcome).__name__ == "Complete", (
+        f"{site.shape} at {site.relative_path}:{site.line} did not complete: "
+        f"{outcome!r}"
+    )
+    return outcome.value
+
+
+def _raise_effect_with_message(message: str):
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.floor.string_value import StringValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.ir import ctor
+
+    identity = TermValue(1).to_term(owner="match-pattern-identity")
+    raised = CallSiteValue(
+        "ValueError",
+        (StringValue(message),),
+        ("message",),
+        ctor("call:ValueError", []),
+        None,
+    )
+
+    class _Handler:
+        def exception_type_identity(self):
+            return identity
+
+    return (
+        RaiseEffect(
+            exception_name="ValueError",
+            exception_type_coordinate=identity,
+            occurrence=f"{message}@match-pattern",
+            raised_value=raised,
+        ),
+        _Handler(),
+    )
+
+
+@pytest.mark.parametrize(
+    "site",
+    ENROLLED_PATTERN_SITES,
+    ids=[site.shape for site in ENROLLED_PATTERN_SITES],
+)
+def test_enrolled_pattern_site_still_holds_its_match_argument(
+    site: MatchPatternSite,
+) -> None:
+    """Content pin: the enrolled pattern coordinate still spells this expression."""
+    path = _corpus_root() / site.relative_path
+    assert path.is_file(), f"enrolled pattern site missing: {path}"
+    observed = hashlib.sha256(path.read_bytes()).hexdigest()
+    assert observed == site.file_sha256, (
+        f"{site.relative_path} is not the file this pattern row enrolled "
+        f"(observed {observed}, enrolled {site.file_sha256})"
+    )
+    argument = _match_argument(_raises_call_on_line(_source_file(path), site.line))
+    assert argument.segment().strip() == site.expression
+
+
+@pytest.mark.parametrize(
+    "site",
+    ENROLLED_PATTERN_SITES,
+    ids=[site.shape for site in ENROLLED_PATTERN_SITES],
+)
+def test_enrolled_pattern_constructs_authoritative_message_verdict(
+    site: MatchPatternSite,
+) -> None:
+    """Each pattern shape produces a named verdict -- never mere silence.
+
+    Before this tooth, empty / ordinary / accumulated were only measured as
+    manager force-floor refusals. The pattern half is independent of that
+    floor: the real argument constructs a value, and
+    ``raise_effect_message_verdict`` settles or retains it.
+    """
+    from sugar_lift_py_tests.authenticated_exception_matching import (
+        MatchDecided,
+        MatchRetained,
+        raise_effect_message_verdict,
+    )
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.floor.string_value import StringValue
+
+    pattern = _pattern_value_for_site(site)
+    effect, expected = _raise_effect_with_message("whoops")
+
+    if site.shape == "empty-pattern":
+        assert isinstance(pattern, StringValue) and pattern.value == "^$"
+        empty_effect, _ = _raise_effect_with_message("")
+        assert raise_effect_message_verdict(
+            empty_effect, expected, pattern
+        ) == MatchDecided(True)
+        assert raise_effect_message_verdict(effect, expected, pattern) == MatchDecided(
+            False
+        )
+        return
+
+    if site.shape == "ordinary-pattern":
+        assert isinstance(pattern, StringValue) and pattern.value == "whoops"
+        assert raise_effect_message_verdict(effect, expected, pattern) == MatchDecided(
+            True
+        )
+        other, _ = _raise_effect_with_message("other")
+        assert raise_effect_message_verdict(other, expected, pattern) == MatchDecided(
+            False
+        )
+        return
+
+    assert site.shape == "accumulated-alternation"
+    assert isinstance(pattern, CallSiteValue)
+    assert pattern.target_name == "join"
+    verdict = raise_effect_message_verdict(effect, expected, pattern)
+    assert isinstance(verdict, MatchRetained)
+    assert verdict.obligation.name == "py.re_search"
+
+
+def test_name_pattern_reaches_authenticated_base_force_floor() -> None:
+    """The line-16 manager crosses the generic base, then names the live floor.
 
     ``RaisesExc(AbstractRaises[T])`` inherits its initializer from a local,
-    source-authenticated generic base.  Construction must cross that edge and
-    name the first unsupported statement in the inherited body.  It must not
-    keep reporting the earlier synthetic ``ExitSet with 3 arms`` manager-face
-    gap, and it must not assume the regex-compilation ``try`` succeeds.
+    source-authenticated generic base. Soft-Try for ``re.compile`` is past;
+    construction now names the f-string binary pair inside an inherited
+    method body. It must not regress to the synthetic ``ExitSet with 3 arms``
+    manager-face gap.
     """
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
@@ -655,29 +863,23 @@ def test_name_pattern_reaches_authenticated_base_try_gap() -> None:
     )
     assert isinstance(row, ContextManagerResolutionGapV1)
     assert row.kind == "force-floor"
-    assert row.detail.startswith("Try.sugar:")
-    assert "has no sugar written" in row.detail
+    assert row.detail == MANAGER_FORCE_FLOOR_DETAIL
     assert "ExitSet with 3 arms" not in row.detail
 
 
 @pytest.mark.parametrize(
-    ("relative_path", "line", "expression"),
-    [
-        ("tests/indexing/test_indexing.py", 111, "msg"),
-        ("tests/io/json/test_normalize.py", 175, '"^$"'),
-        ("tests/indexes/multi/test_analytics.py", 247, "msg"),
-    ],
+    "site",
+    ENROLLED_PATTERN_SITES,
+    ids=[site.shape for site in ENROLLED_PATTERN_SITES],
 )
-def test_computed_class_patterns_cross_the_authenticated_generic_base(
-    relative_path: str, line: int, expression: str
+def test_pattern_sites_manager_floor_is_named_not_synthetic(
+    site: MatchPatternSite,
 ) -> None:
-    """Four-arm constructors cross ``AbstractRaises[T]`` and stop at Try.
+    """Manager construction at each pattern site names the live binary floor.
 
-    These real sites cover an accumulated alternation plus tuple exception
-    classes, a parametrized exception class plus the corpus's written ``^$``
-    predicate, and a source-bound constant exception class.  Their argument
-    values differ; their provider inherits through the same authenticated
-    generic base.  None may regress to the synthetic four-arm floor.
+    The pattern half above constructs authoritatively. The manager half still
+    stops at a named force-floor owned by BinOp's undecided pair law -- not at
+    a synthetic ExitSet arm count and not at an unnamed refusal.
     """
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
@@ -687,16 +889,16 @@ def test_computed_class_patterns_cross_the_authenticated_generic_base(
         populate_source_derived_resource_refs,
     )
 
-    path = _corpus_root() / relative_path
+    path = _corpus_root() / site.relative_path
     source = path.read_text(encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     source_file = SourceFile(
         (source, str(path), blake3_512_of(source.encode("utf-8"))),
         construction_context=context,
     )
-    call = _raises_call_on_line(source_file, line)
+    call = _raises_call_on_line(source_file, site.line)
     argument = _match_argument(call)
-    assert argument.segment().strip() == expression
+    assert argument.segment().strip() == site.expression
 
     populate_source_derived_resource_refs(
         source_file, root=_corpus_root().parent, path=path
@@ -705,12 +907,13 @@ def test_computed_class_patterns_cross_the_authenticated_generic_base(
     row = next(
         result
         for coordinate, result in context.source_derived_contract_refs.items()
-        if coordinate.start_line == line
+        if coordinate.start_line == site.line
     )
     assert isinstance(row, ContextManagerResolutionGapV1)
     assert row.kind == "force-floor"
-    assert row.detail.startswith("Try.sugar:")
+    assert row.detail == MANAGER_FORCE_FLOOR_DETAIL
     assert "ExitSet with 4 arms" not in row.detail
+    assert "ExitSet with 3 arms" not in row.detail
 
 
 def test_corpus_identity_is_checked_on_content_not_on_the_file_list() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1572,7 +1572,12 @@ def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
         with_node.sugar()
 
     assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert "Try.sugar:Try at _pytest/raises.py:" in caught.value.observed
+    # Soft-Try for re.compile is past; the live named floor is the f-string
+    # binary pair inside an inherited RaisesExc method body (BinOp-owned).
+    assert (
+        "binary_operation_exception_floor:SymbolicValue + CallSiteValue"
+        in caught.value.observed
+    )
     assert "ExitSet with 3 arms" not in caught.value.observed
     assert (
         caught.value.coordinate.start_line,
@@ -1602,7 +1607,10 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
         with_node.sugar()
 
     assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert "Try.sugar:Try at _pytest/raises.py:" in caught.value.observed
+    assert (
+        "binary_operation_exception_floor:SymbolicValue + CallSiteValue"
+        in caught.value.observed
+    )
     assert "ExitSet with 4 arms" not in caught.value.observed
     assert (
         caught.value.coordinate.start_line,
@@ -1768,9 +1776,7 @@ def test_installed_plain_expected_halt_completes(tmp_path):
     """TRUTHFUL: the expected native halt is the assertion's passing face."""
     from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
 
-    outcome = _installed_plain_expected_halt(
-        tmp_path, "raise ValueError('expected')"
-    )
+    outcome = _installed_plain_expected_halt(tmp_path, "raise ValueError('expected')")
     exits = outcome_to_exitset(outcome).exits
     assert len(exits) == 1
     assert isinstance(exits[0], Completed), exits
@@ -2260,9 +2266,7 @@ def _route_boundary_with_binding(
     prefix: str = "",
     manager: str = "arbitrary.boundary(ValueError)",
 ):
-    distribution = _distribution(
-        tmp_path, implementation, exported="boundary"
-    )
+    distribution = _distribution(tmp_path, implementation, exported="boundary")
     consumer = "import arbitrary\ndef use_boundary():\n"
     if prefix:
         consumer += textwrap.indent(textwrap.dedent(prefix), "    ")


### PR DESCRIPTION
## What changed

- enroll three `match=` *pattern-semantic* shapes from real pandas 3.0.3 coordinates:
  - **empty-pattern** `tests/io/json/test_normalize.py:175` `match=\"^$\"`
  - **ordinary-pattern** `tests/test_register_accessor.py:103` `match=\"whoops\"`
  - **accumulated-alternation** `tests/indexing/test_indexing.py:111` (`msg = \"|\".join(msgs)` at line 108)
- construct each pattern value from the real argument / binding and prove authoritative message verdicts:
  - empty → `MatchDecided(True/False)` on empty vs nonempty messages
  - ordinary → `MatchDecided(True/False)` via ground `re.search`
  - accumulated → `MatchRetained(py.re_search)` over the constructed join `CallSiteValue`
- route the same three shapes through the EffectBoundary ExitSet consumer
- repin manager force-floor from stale `Try.sugar:` to the live named coordinate
  `binary_operation_exception_floor:SymbolicValue + CallSiteValue` (soft-Try for `re.compile` is past)

## Owner report (per enrolled pattern shape)

```
sourceStamp blake3-512_b536f988a64aa054491a35399fd25a8d5e296a07ab9c4738fcc64a8b05bb81163e06b79d35ec30ee58f4002a547fbf2382b45d1a72875e72d1105a4c1f5e0d05
runtime = CPython 3.12.13
canonical corpus manifest blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530
demand-table identity blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0
```

| shape | concrete source site | before | after | surviving gap |
|---|---|---|---|---|
| empty-pattern | `pandas/tests/io/json/test_normalize.py:175` `match=\"^$\"` | manager force-floor only (`Try.sugar` pin, no pattern verdict) | pattern → `StringValue(\"^$\")`; `MatchDecided(True)` empty / `False` nonempty; EffectBoundary consumes/rejects | manager: `force-floor [binary_operation_exception_floor:SymbolicValue + CallSiteValue]` (BinOp-owned f-string pair in RaisesExc method body) |
| ordinary-pattern | `pandas/tests/test_register_accessor.py:103` `match=\"whoops\"` | same — expression enrolled as literal, no pattern disposition | pattern → `StringValue(\"whoops\")`; `MatchDecided` hit/miss; EffectBoundary consumes/rejects | same manager floor |
| accumulated-alternation | `pandas/tests/indexing/test_indexing.py:111` (`msg = \"|\".join(msgs)` @108) | manager force-floor only | join binding → `CallSiteValue(join)`; `MatchRetained(py.re_search)`; EffectBoundary retains both faces | same manager floor |

Path-shape `sha256:a223…` remains **negative-only** (`HISTORICAL_PATH_SHAPE_DIGEST`).

## Validation

- CPython 3.12.13 `.venv-py312`, pandas 3.0.3, numpy 2.5.1
- `test_match_argument_shapes` pattern + shape + force-floor teeth: green (shelf-dependent byte-identical twin is env-bound to table `pandasPath`)
- `test_assertion_boundary_exitset_consumer`: 3 new pattern routes green
- sole-path installed pytest.raises force-floor pins updated and green
- Black 26.x reformatted touched files; `git diff --check` clean

No production module changed. No new environment/shelf/census. Manager floor remains named for BinOp follow-up; Match pattern half is authoritative.

Base: `origin/main` after rebase
Head: `c92266fd31d01ef1882de47894ada8711d30ff14`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll empty, ordinary, and accumulated `match=` pattern shapes with verdict and content-pin tests
> - Adds parametrized tests in [test_match_argument_shapes.py](https://github.com/TSavo/sugar/pull/6525/files#diff-f35f1e634d9f6f1d1cb89bf9424a58e274bed29385a256bbf244d343789b7a9f) covering three `match=` pattern shapes: empty (`'^$'`), ordinary (literal string), and accumulated alternation (`join('|', msgs)`).
> - Each shape is tested for correct routing verdict: empty pattern completes only for empty messages, ordinary pattern uses `re.search`, and accumulated alternation retains a `py.re_search` obligation as a `MatchRetained`.
> - Adds a content-pin test asserting enrolled pattern coordinates still match the source file and argument segment.
> - Adds supporting tests in [test_assertion_boundary_exitset_consumer.py](https://github.com/TSavo/sugar/pull/6525/files#diff-1eef89ac962ea3806e71cf518816ac0a8d7dddb20212b1d3d9f392e721986474) asserting `ExitSet` routing for each pattern shape at the assertion boundary.
> - Updates expected force-floor detail strings in [test_sole_path_manager_construction.py](https://github.com/TSavo/sugar/pull/6525/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) and [test_match_argument_shapes.py](https://github.com/TSavo/sugar/pull/6525/files#diff-f35f1e634d9f6f1d1cb89bf9424a58e274bed29385a256bbf244d343789b7a9f) from `Try.sugar` references to `binary_operation_exception_floor:SymbolicValue + CallSiteValue`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0991c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->