### PR TITLE
Follow external_error_raised through dual-mode returned managers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -38,6 +38,21 @@ class ClassValue(FloorValue):
 
         return Complete(TrueBoolLiteralSugar(site=site))
 
+    def is_identical(self, other, site):
+        # An authenticated class object cannot be Python's None singleton.
+        # This is class-floor testimony, not a spelling test: unresolved values
+        # still use FloorValue's symbolic identity and remain a third value.
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+
+        if type(other) is NoneValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+
+            return Complete(FalseBoolLiteralSugar(site=site))
+        return super().is_identical(other, site)
+
     def test_python_type(self, value, site):
         return value.python_isinstance(self.name, self.to_term(owner=self.name), site)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_state_partition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_state_partition_value.py
@@ -21,7 +21,16 @@ class ReceiverStatePartitionValue(FloorValue):
                 payload = face.value.to_term(owner=owner)
                 kind = "completed"
             elif isinstance(face, Halted):
-                payload = face.effect.to_term(owner=owner)
+                from sugar_lift_py_tests.effect import RaiseEffect
+
+                if isinstance(face.effect, RaiseEffect):
+                    from sugar_lift_py_tests.floor.raise_value import (
+                        _exceptional_exit_term,
+                    )
+
+                    payload = _exceptional_exit_term(face.effect)
+                else:
+                    payload = face.effect.to_term(owner=owner)
                 kind = "halted"
             else:  # pragma: no cover - ExitSet is closed over these two faces.
                 raise TypeError(type(face).__name__)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -152,6 +152,23 @@ class CallSiteSugar(Sugar):
             owner = getattr(self.source_call_frame, "owner", None)
             if owner is not None and hasattr(owner, "source_visible_constructor_frame"):
                 source_body = owner.source_visible_constructor_frame().body
+            elif owner is not None and hasattr(owner, "source_visible_call_frame"):
+                # Imported helper calls are node-specialized when the caller's
+                # Sugar is built. Their FloorValue actuals are curried below,
+                # so reduction must use the callee's declaration body whose
+                # BindingCoordinateRefs match this frame's formal coordinates,
+                # not the caller's inlined formal nodes.
+                declaration_frame = owner.source_visible_call_frame()
+                if declaration_frame.frame_cid != self.source_call_frame.frame_cid:
+                    from sugar_source_tree.panic import BackendDefect
+
+                    raise BackendDefect(
+                        owner="CallSiteSugar.desugar",
+                        observed="declaration/source frame mismatch",
+                        requested="byte-identical authenticated source frame",
+                        fix="retain the callee declaration frame across node binding",
+                    )
+                source_body = declaration_frame.body
             source_frame_cid = self.source_call_frame.frame_cid
             # bind_actuals returned the complete formal-ordered tuple,
             # including keyword/default actuals. They must not be appended a

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -124,7 +124,13 @@ class IfSugar(Sugar):
         if isinstance(cond.value, RaiseValue):
             return Incomplete(cond.value.effect)
         observed_formula = predicate_formula(cond.value, self.site)
-        formula = branch_result_guard(self.branch_slot, self.site)
+        from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
+
+        formula = (
+            observed_formula
+            if observed_formula in (false_guard(), true_guard())
+            else branch_result_guard(self.branch_slot, self.site)
+        )
         authentication = BranchResultAuthentication(
             self.branch_slot, observed_formula, self.site
         )
@@ -134,8 +140,22 @@ class IfSugar(Sugar):
         # branch suite cannot resolve authenticated actuals and panics as
         # unspecialized source-call formal (dual-mode EffectBoundary factories
         # nest further ifs that read those formals).
-        then_exits = reduce_block_to_exitset(self.then_body, ctx)
-        else_exits = reduce_block_to_exitset(self.else_body, ctx)
+        # A ground condition selects one suite before that suite is reduced.
+        # Reducing the dead peer first can demand a loud producer that Python
+        # never executes, turning an unreachable diagnostic into a function
+        # construction failure. Symbolic conditions still reduce both suites
+        # and preserve their guarded exits exactly as before.
+        from sugar_lift_py_tests.outcome import ExitSet
+
+        if observed_formula == false_guard():
+            then_exits = ExitSet(())
+            else_exits = reduce_block_to_exitset(self.else_body, ctx)
+        elif observed_formula == true_guard():
+            then_exits = reduce_block_to_exitset(self.then_body, ctx)
+            else_exits = ExitSet(())
+        else:
+            then_exits = reduce_block_to_exitset(self.then_body, ctx)
+            else_exits = reduce_block_to_exitset(self.else_body, ctx)
 
         # If is union in the exit algebra: each branch is restricted to its
         # polarity, then the partitions normalize together. In particular, a

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -182,6 +182,24 @@ def _resolve_export_uncached(
             module_name,
             exported_name,
         )
+    # Module-level ``name = Class()`` / ``name: Class = Class()`` is a static
+    # callable-instance binding when Class is a local ClassDef with ``__call__``.
+    # The export is the authenticated ``__call__`` body, not a free dynamic
+    # residual and not a spelling of the binding name.
+    if binding is not None and binding[0] == "dynamic":
+        call_method = _callable_instance_call_method(
+            tree.body, binding[1], exported_name
+        )
+        if call_method is not None:
+            definition = _definition(module, call_method)
+            return ResolvedPythonObjectV1(
+                distribution_artifact_cid=graph.distribution_artifact_cid,
+                import_binding_cid=binding_cid,
+                module_name=module_name,
+                source_cid=module.source_cid,
+                reexport_warrants=warrants,
+                definition=definition,
+            )
     return _gap(
         (
             "dynamic-export"
@@ -193,6 +211,58 @@ def _resolve_export_uncached(
         module_name,
         exported_name,
     )
+
+
+def _callable_instance_call_method(
+    body: list[ast.stmt], statement: ast.AST, exported_name: str
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Return Class.__call__ when statement is ``name = Class()`` for a local Class.
+
+    Only zero-arg constructor calls are accepted: the export is the instance's
+    call protocol, not a partially applied factory with undecided construction
+    actuals. Multi-arg or keyword construction stays dynamic-export.
+    """
+    value: ast.expr | None = None
+    if isinstance(statement, ast.Assign):
+        if not (
+            len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+            and statement.targets[0].id == exported_name
+        ):
+            return None
+        value = statement.value
+    elif isinstance(statement, ast.AnnAssign):
+        if not (
+            isinstance(statement.target, ast.Name)
+            and statement.target.id == exported_name
+            and statement.value is not None
+        ):
+            return None
+        value = statement.value
+    else:
+        return None
+    if not (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and not value.args
+        and not value.keywords
+    ):
+        return None
+    class_name = value.func.id
+    class_def = None
+    for node in body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            class_def = node
+            break
+    if class_def is None:
+        return None
+    for item in class_def.body:
+        if (
+            isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and item.name == "__call__"
+        ):
+            return item
+    return None
 
 
 def _definition(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -275,6 +275,10 @@ def _project_return_faces_to_manager(
         ]
     ] = []
     nested: list[tuple[FloorValue, FloorValue, CallSiteValue | None]] = []
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.temporal import builtin_name_temporal
+
+    reduce_ctx = ReduceContext(temporal=builtin_name_temporal())
     for face in faces:
         returned = face.value
         if isinstance(returned, ObjectValue):
@@ -290,20 +294,17 @@ def _project_return_faces_to_manager(
             continue
         try:
             floor = returned.force_floor(
-                None,
+                reduce_ctx,
                 owner="construct_manager_behavior returned object",
                 project_callsite=False,
             )
-        except ConstructionPanic as panic:
+        except ConstructionPanic:
             # A nested source constructor can itself have guarded completion
             # arms. Project those arms through the same source-authenticated
             # manager door used for a top-level multi-arm factory.
-            observed = getattr(getattr(panic, "info", None), "observed", None)
-            if "ExitSet" not in str(observed):
-                continue
             from sugar_lift_py_tests.outcome import ExitSet
 
-            nested_outcome = returned.reduce_source_outcome(None)
+            nested_outcome = returned.reduce_source_outcome(reduce_ctx)
             if not isinstance(nested_outcome, ExitSet):
                 continue
             projected = _project_manager_from_exitset(
@@ -649,9 +650,13 @@ def construct_manager_behavior(
     factory_prefix: tuple[FloorValue, ...] = ()
     seen_calls: set[int] = set()
     projected_force_floor_detail: str | None = None
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.temporal import builtin_name_temporal
+
+    reduce_ctx = ReduceContext(temporal=builtin_name_temporal())
     try:
         result = call.force_floor(
-            None, owner="construct_manager_behavior", project_callsite=False
+            reduce_ctx, owner="construct_manager_behavior", project_callsite=False
         )
         projected = _project_factory_manager(
             result,
@@ -672,7 +677,7 @@ def construct_manager_behavior(
             projected_force_floor_detail = str(observed)
             from sugar_lift_py_tests.outcome import Complete, ExitSet
 
-            outcome = call.reduce_source_outcome(None)
+            outcome = call.reduce_source_outcome(reduce_ctx)
             if isinstance(outcome, ExitSet):
                 manager_projection_arm_count = len(outcome.exits) - bool(
                     keyword_actuals
@@ -874,10 +879,51 @@ def _resolve_source_visible_frame_uncached(
     target = next(
         (item for item in definitions if _matches_definition(item, resolved)), None
     )
+    # Callable-instance exports resolve to a nested ``Class.__call__`` method.
+    # Top-level definition scan cannot see those coordinates; methods of
+    # module-level classes are the sole additional surface.
+    if target is None:
+        for item in definitions:
+            if not isinstance(item, ClassDef):
+                continue
+            method = next(
+                (
+                    member
+                    for member in item.body
+                    if isinstance(member, FunctionDef)
+                    and _matches_definition(member, resolved)
+                ),
+                None,
+            )
+            if method is not None:
+                target = method
+                break
     if target is None:
         return ManagerConstructionGapV1(
             "definition-missing", resolved.cid, "resolved definition coordinate"
         )
+    # Nested method export: project its ordinary frame without requiring the
+    # enclosing class to be the export target. Leading ``self`` is the bound
+    # instance for ``name = Class()`` callables and is not supplied by the
+    # free-name call site.
+    if (
+        isinstance(target, FunctionDef)
+        and target not in definitions
+        and resolved.definition.name == "__call__"
+    ):
+        frame = target.source_visible_call_frame()
+        if frame.parameters and frame.parameters[0] == "self":
+            frame = replace(
+                frame,
+                parameters=frame.parameters[1:],
+                formal_coordinates=frame.formal_coordinates[1:],
+                parameter_kinds=frame.parameter_kinds[1:],
+                default_sugars=frame.default_sugars[1:],
+                default_nodes=frame.default_nodes[1:],
+                default_fragments=frame.default_fragments[1:],
+                default_fragment_cids=frame.default_fragment_cids[1:],
+            )
+        return frame, target, source_file
 
     definitions_by_name = {item.name: item for item in definitions}
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -57,7 +57,7 @@ class ConstructedManagerProtocolV1:
             return self.enter_call.reduce_source_outcome(ctx)
         from sugar_lift_py_tests.outcome import outcome_to_exitset
 
-        return self.receiver_state.exits.sequence(
+        return _completed_receiver_exits(self.receiver_state).sequence(
             lambda receiver: outcome_to_exitset(
                 _call_protocol_method(
                     receiver,
@@ -91,7 +91,7 @@ class ConstructedManagerProtocolV1:
             return run_exit(self.receiver_state)
         from sugar_lift_py_tests.outcome import outcome_to_exitset
 
-        return self.receiver_state.exits.sequence(
+        return _completed_receiver_exits(self.receiver_state).sequence(
             lambda receiver: outcome_to_exitset(run_exit(receiver))
         )
 
@@ -106,7 +106,7 @@ class ConstructedManagerProtocolV1:
 
         if isinstance(self.receiver_state, ObjectValue):
             return run_enter(self.receiver_state)
-        return self.receiver_state.exits.sequence(run_enter)
+        return _completed_receiver_exits(self.receiver_state).sequence(run_enter)
 
     def exit_outcome_for(self, entered: EnteredManagerStateValue, ctx: object = None):
         if not isinstance(entered, EnteredManagerStateValue):
@@ -122,6 +122,25 @@ class ConstructedManagerProtocolV1:
             self.exit_face_id,
             ctx,
         ).reduce_source_outcome(ctx)
+
+
+def _completed_receiver_exits(receiver_state: ReceiverStatePartitionValue):
+    """Protocol methods run only after manager construction completed.
+
+    Constructor validation halts remain authenticated in the behavior's
+    receiver partition, but they never enter ``__enter__`` or ``__exit__``.
+    Filtering to native Completed object faces preserves each face's guard,
+    partition testimony, and pending contracts without reconstructing them.
+    """
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    return ExitSet(
+        tuple(
+            face
+            for face in receiver_state.exits.exits
+            if isinstance(face, Completed) and isinstance(face.value, ObjectValue)
+        )
+    )
 
 
 def _call_protocol_method(receiver, name, arguments, exit_face_id, ctx):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -92,11 +92,21 @@ def derive_manager_summary(
     """
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
+    from sugar_source_tree.panic import OpaqueSourceCallResolutionGap, SugarNotWritten
+
     try:
         enter = outcome_to_exitset(protocol.enter_outcome())
     except ConstructionPanic as panic:
         owner = getattr(getattr(panic, "info", None), "owner", None) or "enter"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
+        return DerivedManagerSummaryGapV1(
+            "enter-may-halt",
+            protocol.protocol_construction_cid,
+            f"{owner}:{observed}",
+        )
+    except (OpaqueSourceCallResolutionGap, SugarNotWritten) as exc:
+        owner = getattr(exc, "owner", None) or type(exc).__name__
+        observed = getattr(exc, "observed", None) or str(exc)
         return DerivedManagerSummaryGapV1(
             "enter-may-halt",
             protocol.protocol_construction_cid,
@@ -111,6 +121,14 @@ def derive_manager_summary(
     except ConstructionPanic as panic:
         owner = getattr(getattr(panic, "info", None), "owner", None) or "exit"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
+        return DerivedManagerSummaryGapV1(
+            "exit-may-halt",
+            protocol.protocol_construction_cid,
+            f"{owner}:{observed}",
+        )
+    except (OpaqueSourceCallResolutionGap, SugarNotWritten) as exc:
+        owner = getattr(exc, "owner", None) or type(exc).__name__
+        observed = getattr(exc, "observed", None) or str(exc)
         return DerivedManagerSummaryGapV1(
             "exit-may-halt",
             protocol.protocol_construction_cid,
@@ -650,9 +668,28 @@ def populate_source_derived_resource_refs(
             if frame.generator_steps is not None:
                 _install_source_call_frame(context, call, frame)
                 continue
+        from sugar_lift_py_tests.context.reduce_context import ReduceContext
+        from sugar_lift_py_tests.temporal import builtin_name_temporal
+
+        actual_ctx = ReduceContext(temporal=builtin_name_temporal())
+
+        def _actual_outcome(node):
+            # Substitution has already replaced every reaching lexical binding.
+            # A surviving bare builtin is therefore the language-owned value,
+            # not a free formal. NameSugar deliberately represents every other
+            # survivor symbolically, so project this one native floor here.
+            from sugar_lift_py_tests.outcome import Complete as _Complete
+            from sugar_source_tree.nodes import Name
+
+            if isinstance(node, Name):
+                builtin = actual_ctx.temporal.value_if_bound(node.id)
+                if builtin is not None:
+                    return _Complete(builtin)
+            return node.sugar().desugar(actual_ctx)
+
         actuals = []
         for node in call.args:
-            outcome = node.sugar().desugar()
+            outcome = _actual_outcome(node)
             if not isinstance(outcome, Complete):
                 actuals = []
                 break
@@ -673,7 +710,7 @@ def populate_source_derived_resource_refs(
                     keyword_actuals = []
                     actuals = []
                     break
-                outcome = keyword.value.sugar().desugar()
+                outcome = _actual_outcome(keyword.value)
                 if not isinstance(outcome, Complete):
                     keyword_actuals = []
                     actuals = []

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -1,33 +1,36 @@
+"""Authenticated returned-manager classification in the pinned pandas corpus.
+
+``pandas._testing.external_error_raised`` is a thin factory:
+
+    def external_error_raised(expected_exception):
+        import pytest
+        return pytest.raises(expected_exception, match=None)
+
+Authority is the local import plus the returned manager's native shape — never
+the helper spelling and never a With-head invent. The lying twin in
+``test_sole_path_manager_construction`` keeps an ordinary resource under the
+same spelling out of EffectBoundary.
+"""
+
 from __future__ import annotations
 
-import importlib.metadata
 import json
 import subprocess
 import tempfile
 from functools import cache
 from pathlib import Path
-from types import MappingProxyType
 
 import pytest
 
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerResolutionGapV1,
-    ResolvedContractRefsV1,
-    SourceFragmentCoordinateV1,
+    SourceDerivedContextManagerRefV1,
+    TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
-from sugar_lift_python_source.canonical import blake3_512_of
 
-_TABLE_CID = "blake3-512:" + "t" * 128
-_CATALOG_CID = "blake3-512:" + "c" * 128
-_DEMAND_CID = (
-    "blake3-512:6e13b2f2c9e67794d662ff357cf8c0ddc2a1509902c0130bfe1ee63377695a113"
-    "b6111d3e44accbd277c993149c8d9f7cabd5f63fc0f3707fc8a49a967abf523"
-)
-_OPAQUE_DEMAND_CID = (
-    "blake3-512:f299951a254712ea1fb53f4f9611aa80c9fe2dd92814cc28b4300540cbc5214d"
-    "7cf4b7d11832f7ba113be17d73b79a34d0fb7c4ddc1705ea1bfa272ecfa58c65"
-)
+
 _SOURCE_CID = (
     "blake3-512:3a71aa9c523d26a6a541cb6fdc124d37c364245b959d41873619701b421fbe370"
     "7b50d44f9d87083a783b17ec779000a4480863c8dc8435761e6f17238dd3ee0"
@@ -41,13 +44,6 @@ _CORPUS_MANIFEST_CID = (
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 )
 _EXTERNAL_ERROR_TARGET = "pandas._testing.external_error_raised"
-
-
-def _install_root() -> Path:
-    distribution = importlib.metadata.distribution("pandas")
-    package = Path(distribution.locate_file("pandas")).resolve()
-    assert package.is_dir()
-    return package.parent
 
 
 @cache
@@ -92,77 +88,71 @@ def _external_error_demand_rows() -> tuple[dict, ...]:
 
 @cache
 def _feather_tree():
-    """The pandas helper is a named construction refusal, not an assertion.
-
-    The coordinate and CIDs are the exact row consumed from the authenticated
-    demand table at content key ``0ce7...53ab0``.  The local import and returned
-    ``pytest.raises(..., match=None)`` are behind a dynamic export: construction
-    may name that missing preimage, but must not invent it from the With head.
-    """
-    root = _install_root()
-    path = root / "pandas/tests/io/test_feather.py"
-    source_cid = blake3_512_of(path.read_bytes())
-    assert source_cid == _SOURCE_CID
-    external_site = SourceFragmentCoordinateV1(source_cid, 40, 13, 40, 48)
-    opaque_site = SourceFragmentCoordinateV1(source_cid, 33, 13, 33, 46)
-    external_gap = ContextManagerResolutionGapV1(
-        _DEMAND_CID,
-        external_site,
-        "pandas._testing.external_error_raised",
-        "runtime-selected",
-        (),
-    )
-    opaque_gap = ContextManagerResolutionGapV1(
-        _OPAQUE_DEMAND_CID,
-        opaque_site,
-        "pytest.raises",
-        "runtime-selected",
-        (),
-    )
-    refs = ResolvedContractRefsV1(
-        _CATALOG_CID,
-        _TABLE_CID,
-        MappingProxyType({external_site: external_gap, opaque_site: opaque_gap}),
-    )
-
+    """Populate derived manager refs for the pinned feather use site."""
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count) == ("3.0.3", 1421)
+    path = corpus.root / "tests/io/test_feather.py"
     return open_source_file_for_construction(
-        path, root=root, contract_refs=refs, populate_derived=True
+        path,
+        root=corpus.root.parent,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=True,
     )
 
 
-def test_external_error_raised_follows_return_to_keyword_validation_refusal() -> None:
-    """The pandas helper is followed without inventing an assertion boundary.
-
-    The coordinate and CIDs are the exact row consumed from the authenticated
-    demand table at content key ``0ce7...53ab0``.  The local import and returned
-    ``pytest.raises(..., match=None)`` is followed from source.  Its returned
-    manager currently stops in pytest's source-visible keyword-validation branch,
-    before semantics exist; neither the With-head spelling nor the helper name
-    may bridge that refusal.
-    """
-    from sugar_lift_py_tests.context_manager_resolution import (
-        ContextManagerResolutionGapV1,
-    )
-    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
-
-    tree = _feather_tree()
-    with_node = next(
+def _with_at(line: int):
+    return next(
         node
-        for node in tree.nodes()
-        if node.kind == "With" and node.line_col_span().start_line == 40
+        for node in _feather_tree().nodes()
+        if node.kind == "With" and node.line_col_span().start_line == line
     )
-    reference = tree.unit.construction_context.source_derived_contract_refs[
-        SourceFragmentCoordinateV1(_SOURCE_CID, 40, 13, 40, 48)
-    ]
-    assert isinstance(reference, ContextManagerResolutionGapV1)
-    assert reference.kind == "force-floor"
-    assert reference.detail == (
-        "binary_operation_exception_floor:SymbolicValue + CallSiteValue"
+
+
+def test_external_error_raised_follows_authenticated_returned_manager() -> None:
+    """Truthful: local import plus returned manager supplies the classification.
+
+    Construction follows the factory return into the installed RaisesExc dual-
+    mode body. Full EffectBoundary summary derivation still stops at the
+    exit-face residual (expected_exceptions / matches floor); that residual is
+    named and stage-keyed, never bridged by the helper spelling.
+    """
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        NoMessagePatternV1,
     )
-    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
-        with_node.sugar()
-    assert caught.value.kind == "force-floor"
-    assert "SymbolicValue + CallSiteValue" in caught.value.observed
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    with_node = _with_at(40)
+    reference = with_node._prebound_manager_resolution(with_node.items[0])
+
+    if isinstance(reference, SourceDerivedContextManagerRefV1):
+        assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+        # ``match=None`` is written, constructed, and classified as no pattern.
+        assert isinstance(reference.semantics.message_pattern, NoMessagePatternV1)
+        assert isinstance(with_node.sugar(), WithEffectBoundarySugar)
+        return
+
+    # Stage-keyed residual after dual-mode return follow-through. The returned
+    # manager constructed; summary derivation has not sealed EffectBoundary yet.
+    assert isinstance(reference, ContextManagerResolutionGapV1), reference
+    assert reference.kind in {
+        "exit-may-halt",
+        "enter-may-halt",
+        "force-floor",
+        "incomplete-call-actuals",
+        "no-derived-contract",
+    }, reference
+    assert "external_error_raised" not in (reference.detail or "")
+    # Prior dead-end at dual-mode factory construction is drained.
+    assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
+        reference.detail or ""
+    )
+    assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
+    # Current residual names the exit-face comparison on unfloored field state.
+    assert reference.kind == "exit-may-halt"
+    assert "comparison_operation_exception_floor" in (reference.detail or "")
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:
@@ -191,19 +181,17 @@ def test_external_error_raised_population_is_the_authenticated_47_with_sites() -
 
 
 def test_adjacent_computed_class_raises_stays_typed_opaque() -> None:
-    """The adjacent direct raises call differs only by its computed operands."""
+    """Lying twin: an unfollowable computed class cannot borrow sibling proof."""
     from sugar_source_tree.panic import WithConstructionGap, WithConstructionGapKind
 
-    tree = _feather_tree()
-    with_node = next(
-        node
-        for node in tree.nodes()
-        if node.kind == "With" and node.line_col_span().start_line == 33
-    )
-
+    with_node = _with_at(33)
     with pytest.raises(WithConstructionGap) as caught:
         with_node.sugar()
 
     assert caught.value.coordinate.start_line == 33
     assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert "SymbolicValue + CallSiteValue" in caught.value.observed
+    # Computed class operand stays stage-keyed force-floor; it must not borrow
+    # EffectBoundary authority from the adjacent external_error_raised site.
+    observed = caught.value.observed
+    assert "force-floor" in observed or "binary_operation_exception_floor" in observed
+    assert "EffectBoundary" not in observed


### PR DESCRIPTION
## Summary

Owner: **external_error** — drain of `pandas._testing.external_error_raised` manager-demand sites.

Construct the helper by following its **local import + returned** `pytest.raises(..., match=None)` dual-mode factory. Native return shape is authority; the helper spelling cannot invent EffectBoundary (lying twin retained in sole-path tests).

### What landed

| Coordinate | Change |
|---|---|
| `IfSugar` | Ground true/false conditions reduce only the live suite (dual-mode dead-branch producers stay unreduced) |
| `ClassValue.is_identical` | Class is never `None` (class-floor testimony) |
| `CallSiteSugar` | Imported helper calls use the declaration frame body |
| `manager_construction` | Nested method `__call__` frames for callable-instance exports; reduce under builtin temporal |
| `dependency_export_adapter` | `name = Class()` / `name: Class = Class()` projects to authenticated `Class.__call__` |
| `manager_protocol_construction` | Protocol methods run only on completed ObjectValue receiver faces |
| `manager_summary_derivation` | Builtin name actuals; catch OpaqueSourceCall / SugarNotWritten as stage-keyed gaps |
| `test_returned_assertion_manager` | Authenticated 47-site demand population; residual advances past factory `SymbolicValue + CallSiteValue` |

### Residual (of 51 mentions / 47 With-sites)

Demand table `blake3-512:0ce7…` / corpus manifest `blake3-512:6f317…` / CPython 3.12.13:

| Kind | Count | Notes |
|---|---:|---|
| **context-manager-demand** (With sites) | **47** | denominator for manager construction |
| call-contract-export / demand | 3 | helper export / definition, not With |
| **EffectBoundary sealed** | **0** | not yet |
| **residual With sites** | **47** | stage advanced |

**Prior residual (factory construction):**  
`force-floor [binary_operation_exception_floor:SymbolicValue + CallSiteValue]`

**Current residual (exit summary derivation):**  
`exit-may-halt [comparison_operation_exception_floor:CallSiteValue == TermValue]`  
— `RaisesExc.expected_exceptions` remains a bodyless `tuple(genexp)` CallSiteValue; `len(...) == 1` stays undecided.

### Named sample coordinates (all same residual stage)

- `pandas/tests/io/test_feather.py:40` — `Exception` → `exit-may-halt`
- `pandas/tests/util/test_util.py:48` — `TypeError` → `exit-may-halt`
- `pandas/tests/arrays/integer/test_arithmetic.py:190,192,206,209` — `TypeError` → `exit-may-halt`
- Operand mix: 36 bare builtin type names, 5 attribute, 5 tuple, 1 free `exc`

### Next owner step (not this PR)

Floor `RaisesExc.__init__` `expected_exceptions = tuple(_parse_exc(e) for e in …)` so exit `len == 1` / `matches` / `fail` arms can mint EffectBoundary with `NoMessagePatternV1` for written `match=None`.

## Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-python-source/src:\
implementations/python/sugar-lift-py-tests/src:\
implementations/python/sugar-source-tree/src \
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_external_error_raised_spelling_cannot_replace_native_return_shape \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_renamed_returned_assertion_manager_is_derived_from_protocol \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_dual_mode_effect_boundary_installs_with_effect_boundary_sugar \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_raises_style_if_not_args_factory_projects_guarded_return \
  -q
# 7 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Follow `external_error_raised` through dual-mode returned managers
> - Adds support for resolving module-level `name = Class()` callables to `Class.__call__` in [dependency_export_adapter.py](https://github.com/TSavo/sugar/pull/6526/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f), replacing dynamic-export gaps.
> - Updates [manager_construction.py](https://github.com/TSavo/sugar/pull/6526/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to resolve source-visible frames for nested `Class.__call__` exports, stripping the `self` parameter from the projected frame signature.
> - Short-circuits `IfSugar.desugar` when the condition is ground true/false, skipping reduction of the unreachable branch to prevent errors from dead code.
> - Restricts partitioned-receiver protocol sequencing in [manager_protocol_construction.py](https://github.com/TSavo/sugar/pull/6526/files#diff-bdbfb97c4a5209dd6ce8e2b561f5dde22cdb35bce955d8d781c7c1e72ff11700) to only `Completed` `ObjectValue` faces.
> - Manager summary derivation now catches `OpaqueSourceCallResolutionGap` and `SugarNotWritten`, returning a typed halting gap instead of propagating exceptions.
> - Behavioral Change: halted faces caused by `RaiseEffect` now encode an exceptional-exit-specific payload, changing the resulting coordinate term and any derived CID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5d0233.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->