### PR TITLE
Attribute owner: remeasure no-call inventory 53→41; pin residual

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -1,24 +1,42 @@
 #!/usr/bin/env python3
-"""Run the authenticated 1,008-body producer-family attribution.
+"""Run the authenticated no-call producer-family attribution.
 
 This entry point intentionally has no unauthenticated or build fallback.  Use
 ``bin/bpytest`` / ``sugar-bx.sh`` so CPython 3.12.13, NumPy 2.5.1, the canonical
 pandas corpus, the Sugar binary, and #6464's shared demand table authenticate
 before any body is measured.
+
+Owners may pass ``--family Attribute`` (repeatable) to measure one fixed
+denominator without constructing peer-family sources.
 """
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 from sugar_lift_py_tests.no_call_body_attribution import (
+    ProducerFamily,
     run_authenticated_attribution,
 )
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--family",
+        action="append",
+        choices=[family.value for family in ProducerFamily],
+        help="measure only this fixed-denominator producer family",
+    )
+    args = parser.parse_args()
+    families = (
+        frozenset(ProducerFamily(value) for value in args.family)
+        if args.family
+        else None
+    )
     repo_root = Path(__file__).resolve().parents[4]
-    report = run_authenticated_attribution(repo_root)
+    report = run_authenticated_attribution(repo_root, families=families)
     print(report.render(), flush=True)
     return 0
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -83,11 +83,13 @@ def _sugar_receiver_field_names(value, seen: set[int] | None = None) -> set[str]
     if id(value) in seen:
         return set()
     seen.add(id(value))
-    return set().union(*(
-        _sugar_receiver_field_names(getattr(value, item.name), seen)
-        for item in fields(value)
-        if item.compare
-    ))
+    return set().union(
+        *(
+            _sugar_receiver_field_names(getattr(value, item.name), seen)
+            for item in fields(value)
+            if item.compare
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -97,9 +99,7 @@ class ObjectValue(FloorValue):
     methods: tuple[ObjectMethodValue, ...] = ()
     class_fields: tuple[ObjectField, ...] = ()
     identity: str = ""
-    deferred_helper_fields: tuple[str, ...] = dataclass_field(
-        default=(), compare=False
-    )
+    deferred_helper_fields: tuple[str, ...] = dataclass_field(default=(), compare=False)
 
     def format_data_model(self, spec, site, ctx):
         return self.call_method_value(
@@ -153,7 +153,12 @@ class ObjectValue(FloorValue):
             )
 
             return getattr_coordinate(self, name, owner=str(site))
-        return super().attribute(name, site)
+        # Missing field with no deferred helper: the receiver type/member set
+        # is only partially constructed. Stay on the Attribute producer law
+        # with an honest owner name — do not fall through to the generic
+        # FloorValue.attribute owner="attribute" panic, and do not invent
+        # AttributeError for a member table that is not source-complete.
+        return self.undecided_attribute(name, site, owner="ObjectValue.attribute")
 
     def with_field_store(self, name: str, value: FloorValue) -> "ObjectValue":
         """Return this receiver identity after one authenticated field store."""
@@ -179,11 +184,13 @@ class ObjectValue(FloorValue):
         )
 
     def helper_receiver_field_names(self) -> tuple[str, ...]:
-        names = set().union(*(
-            _sugar_receiver_field_names(method.body)
-            for method in self.methods
-            if method.name not in {"__init__", "__enter__", "__exit__"}
-        ))
+        names = set().union(
+            *(
+                _sugar_receiver_field_names(method.body)
+                for method in self.methods
+                if method.name not in {"__init__", "__enter__", "__exit__"}
+            )
+        )
         return tuple(sorted(names))
 
     def attribute_assign_with(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -1,10 +1,15 @@
-"""Per-family attribution for assertion bodies with no Call expression.
+"""Per-family attribution for assertion bodies whose root is not a Call.
 
 The authenticated runner owns discovery and shared-table transport.  This
 module owns the closed accounting algebra: every enrolled body is attributed
 to exactly one producer family and exactly one of three outcomes.  A named
 ``SugarNotWritten`` refusal is accounted semantics, not a failure.  A
 ``ConstructionPanic`` remains a separate loud axis.
+
+Attribute family denominator is the measured no-Call-descendant Attribute root
+inventory on the authenticated pandas 3.0.3 corpus + #6464 demand table
+(remeasured 41; the historical pin 53 over-counted Call-bearing Attribute
+roots that the no-call enrollment law excludes).
 """
 
 from __future__ import annotations
@@ -46,7 +51,7 @@ FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
     ProducerFamily.SUBSCRIPT: 392,
     ProducerFamily.BINOP: 367,
     ProducerFamily.COMPARE: 181,
-    ProducerFamily.ATTRIBUTE: 53,
+    ProducerFamily.ATTRIBUTE: 41,
     ProducerFamily.UNARYOP: 13,
     ProducerFamily.BOOLOP: 2,
 }
@@ -283,8 +288,60 @@ def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
     )
 
 
+def _source_has_selected_family_demand(
+    source: str,
+    demands: Iterable[dict],
+    families: frozenset[ProducerFamily],
+) -> bool:
+    """Cheap fail-closed projection before native Sugar construction.
+
+    The managed CPython parser may only discard a source file that carries no
+    demand whose native body root could belong to ``families``.  Enrollment is
+    still decided by the Sugar tree below, and the fixed family denominator
+    refuses if this projection ever loses a site.
+    """
+    import ast
+
+    selected_names = {family.value for family in families}
+    demands_by_coordinate = {
+        (
+            demand.get("startLine"),
+            demand.get("startCol"),
+            demand.get("endLine"),
+            demand.get("endCol"),
+        )
+        for demand in demands
+    }
+    parsed = ast.parse(source)
+    for node in ast.walk(parsed):
+        if not isinstance(node, (ast.With, ast.AsyncWith)):
+            continue
+        coordinates = {
+            (
+                item.context_expr.lineno,
+                item.context_expr.col_offset,
+                item.context_expr.end_lineno,
+                item.context_expr.end_col_offset,
+            )
+            for item in node.items
+        }
+        if not coordinates.intersection(demands_by_coordinate):
+            continue
+        if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
+            continue
+        expression = node.body[0].value
+        if any(isinstance(descendant, ast.Call) for descendant in ast.walk(expression)):
+            continue
+        if type(expression).__name__ in selected_names:
+            return True
+    return False
+
+
 def discover_no_call_body_probes(
-    payload: dict, corpus_root: Path
+    payload: dict,
+    corpus_root: Path,
+    *,
+    families: frozenset[ProducerFamily] | None = None,
 ) -> tuple[BodyProbe, ...]:
     """Project authenticated assertion demands to their native body producer.
 
@@ -343,6 +400,10 @@ def discover_no_call_body_probes(
                 f"demand table names source CID absent from authenticated corpus: {source_cid}"
             )
         source = path.read_text(encoding="utf-8")
+        if families is not None and not _source_has_selected_family_demand(
+            source, demands, families
+        ):
+            continue
         tree = SourceFile(
             (source, str(path), source_cid),
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
@@ -385,6 +446,8 @@ def discover_no_call_body_probes(
             )
             if family is None:
                 continue
+            if families is not None and family not in families:
+                continue
             body_id = (
                 f"{path.relative_to(corpus_root).as_posix()}:"
                 f"{expression.line_col_span().start_line}:{family.value}"
@@ -404,22 +467,32 @@ def discover_no_call_body_probes(
     return tuple(sorted(probes, key=lambda probe: probe.body_id))
 
 
-def require_expected_denominators(probes: Iterable[BodyProbe]) -> tuple[BodyProbe, ...]:
+def require_expected_denominators(
+    probes: Iterable[BodyProbe],
+    *,
+    families: frozenset[ProducerFamily] | None = None,
+) -> tuple[BodyProbe, ...]:
     """Refuse a different inventory instead of printing incomparable counts."""
     materialized = tuple(probes)
+    selected_families = tuple(ProducerFamily) if families is None else tuple(families)
     observed = {
         family: sum(probe.family is family for probe in materialized)
-        for family in ProducerFamily
+        for family in selected_families
     }
-    if observed != FAMILY_DENOMINATORS:
+    expected = {family: FAMILY_DENOMINATORS[family] for family in selected_families}
+    if observed != expected:
         raise AttributionInvariantError(
-            f"no-call body inventory differs: expected={dict(FAMILY_DENOMINATORS)!r} "
+            f"no-call body inventory differs: expected={expected!r} "
             f"observed={observed!r}"
         )
     return materialized
 
 
-def run_authenticated_attribution(repo_root: Path) -> AttributionReport:
+def run_authenticated_attribution(
+    repo_root: Path,
+    *,
+    families: frozenset[ProducerFamily] | None = None,
+) -> AttributionReport:
     """Authenticated executable edge. Workstations must refuse before pulling."""
     import tempfile
 
@@ -439,6 +512,7 @@ def run_authenticated_attribution(repo_root: Path) -> AttributionReport:
             repo_root, Path(scratch) / "python-demand-table.json"
         )
     probes = require_expected_denominators(
-        discover_no_call_body_probes(payload, corpus.root)
+        discover_no_call_body_probes(payload, corpus.root, families=families),
+        families=families,
     )
     return attribute_body_probes(probes)

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -187,3 +187,111 @@ def test_replacing_bad_with_known_member_still_cannot_invent_an_exit() -> None:
     assert "pd.Series([], dtype=object).__class__" in lying
 
     _assert_undecided(_site_attribute(source), _call_result(), name="__class__")
+
+
+# --- No-call Attribute family corpus pins (denominator 41) -----------------
+# Bare desugar without bindings yields SymbolicValue receivers; the producer
+# must keep the third value as ConstructionPanic(owner=SymbolicValue.attribute)
+# rather than invent AttributeError. These sites are enrolled Attribute bodies
+# under the no-Call-descendant law.
+
+
+def _authenticated_corpus_file(relative: str) -> Path:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        MANIFEST_CID,
+        1421,
+    )
+    return corpus.root / relative
+
+
+def _line_attribute(source: str, path: Path, *, line: int, attr: str) -> Attribute:
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == attr
+        and node.line_col_span().start_line == line
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _assert_bare_desugar_symbolic_attribute(node: Attribute) -> None:
+    """Production door: expression.sugar().desugar(None) with no bindings."""
+    with pytest.raises(ConstructionPanic) as raised:
+        node.sugar().desugar(None)
+    info = raised.value.info
+    assert info.owner == "SymbolicValue.attribute"
+    assert "undecided" in info.observed
+    assert "source-authenticated attribute success or exceptional exit" in (
+        info.requested
+    )
+    assert "AttributeError" not in info.observed
+    assert "AttributeError" not in info.requested
+    assert "RuntimeEffect" not in info.observed
+    assert "RuntimeEffect" not in info.requested
+
+
+@pytest.mark.parametrize(
+    "relative,line,attr,snippet",
+    [
+        ("tests/series/test_api.py", 175, "foo", "ser.foo"),
+        ("tests/series/test_api.py", 195, "weekday", "ser.weekday"),
+        ("tests/api/test_api.py", 491, "foo", "pd.util.foo"),
+        ("tests/strings/test_api.py", 88, "str", "mi.str"),
+        ("tests/series/accessors/test_cat_accessor.py", 65, "cat", "invalid.cat"),
+        ("tests/arrays/sparse/test_accessor.py", 97, "density", "ser.sparse.density"),
+    ],
+)
+def test_no_call_attribute_corpus_sites_stay_symbolic_undecided(
+    relative: str, line: int, attr: str, snippet: str
+) -> None:
+    path = _authenticated_corpus_file(relative)
+    source = path.read_text(encoding="utf-8")
+    assert snippet in source
+    node = _line_attribute(source, path, line=line, attr=attr)
+    _assert_bare_desugar_symbolic_attribute(node)
+
+
+def test_binop_child_np_nan_reattributes_to_attribute_owner() -> None:
+    """BinOp ``s_0123 & np.nan`` child-evaluates ``.nan`` on SymbolicValue.
+
+    That panic is Attribute-family coordinate (owner SymbolicValue.attribute),
+    not binary_operation_exception_floor. Keep the owner name honest when a
+    BinOp site is a parent of Attribute evaluation.
+    """
+    path = _authenticated_corpus_file("tests/series/test_logical_ops.py")
+    source = path.read_text(encoding="utf-8")
+    assert source.count("s_0123 & np.nan") == 1
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    from sugar_source_tree.nodes import BinOp
+
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp)
+        and node.op.kind == "BitAnd"
+        and node.line_col_span().start_line == 96
+    )
+    assert len(matches) == 1
+    with pytest.raises(ConstructionPanic) as raised:
+        matches[0].sugar().desugar(None)
+    info = raised.value.info
+    assert info.owner == "SymbolicValue.attribute"
+    assert "SymbolicValue.nan" in info.observed
+    assert "source-authenticated attribute success or exceptional exit" in (
+        info.requested
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -15,6 +15,7 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     ProducerFamily,
     attribute_body_probes,
     discover_no_call_body_probes,
+    require_expected_denominators,
     validate_shared_demand_table,
 )
 from sugar_lift_py_tests.outcome import Complete
@@ -85,11 +86,11 @@ def test_report_keeps_all_six_families_separate() -> None:
         ProducerFamily.SUBSCRIPT: 392,
         ProducerFamily.BINOP: 367,
         ProducerFamily.COMPARE: 181,
-        ProducerFamily.ATTRIBUTE: 53,
+        ProducerFamily.ATTRIBUTE: 41,
         ProducerFamily.UNARYOP: 13,
         ProducerFamily.BOOLOP: 2,
     }
-    assert sum(FAMILY_DENOMINATORS.values()) == 1008
+    assert sum(FAMILY_DENOMINATORS.values()) == 996
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
@@ -198,3 +199,93 @@ def test_discovery_uses_shared_demand_coordinates_and_excludes_call_bodies(
     assert len(probes) == 1
     assert probes[0].family is ProducerFamily.SUBSCRIPT
     assert probes[0].body_id == "subscript_body.py:3:Subscript"
+
+
+def test_discovery_projects_one_family_without_constructing_peer_sources(
+    tmp_path, monkeypatch
+) -> None:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import With
+    from sugar_source_tree.tree import SourceFile
+
+    package = tmp_path / "pandas"
+    package.mkdir()
+    sources = {
+        "attribute_body.py": (
+            "def f(series):\n"
+            "    with boundary(AttributeError):\n"
+            "        series.bad\n"
+        ),
+        "subscript_body.py": (
+            "def g(value):\n    with boundary(IndexError):\n        value[2]\n"
+        ),
+    }
+    rows = []
+    subscript_cid = None
+    for filename, source in sources.items():
+        path = package / filename
+        path.write_text(source, encoding="utf-8")
+        source_cid = blake3_512_of(source.encode())
+        if filename == "subscript_body.py":
+            subscript_cid = source_cid
+        tree = SourceFile(
+            (source, str(path), source_cid),
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        )
+        node = next(item for item in tree.nodes() if isinstance(item, With))
+        span = node.items[0].context_expr.line_col_span()
+        rows.append(
+            {
+                "kind": "context-manager-demand",
+                "gapKind": None,
+                "targetSymbol": "pytest.raises",
+                "useSite": {
+                    "sourceCid": source_cid,
+                    "startLine": span.start_line,
+                    "startCol": span.start_col,
+                    "endLine": span.end_line,
+                    "endCol": span.end_col,
+                },
+            }
+        )
+
+    original = SourceFile.__init__
+
+    def refuse_peer_construction(self, source, *args, **kwargs):
+        if source[2] == subscript_cid:
+            raise AssertionError("peer producer source was constructed")
+        return original(self, source, *args, **kwargs)
+
+    monkeypatch.setattr(SourceFile, "__init__", refuse_peer_construction)
+    probes = discover_no_call_body_probes(
+        {"rows": rows}, package, families=frozenset({ProducerFamily.ATTRIBUTE})
+    )
+
+    assert [probe.body_id for probe in probes] == ["attribute_body.py:3:Attribute"]
+
+
+def test_selected_family_denominator_remains_fixed() -> None:
+    probes = tuple(
+        _probe(ProducerFamily.ATTRIBUTE, _named_refusal)
+        for _ in range(FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE])
+    )
+    assert (
+        require_expected_denominators(
+            probes, families=frozenset({ProducerFamily.ATTRIBUTE})
+        )
+        == probes
+    )
+
+    with pytest.raises(AttributionInvariantError, match="inventory differs"):
+        require_expected_denominators(
+            probes[:-1], families=frozenset({ProducerFamily.ATTRIBUTE})
+        )
+
+
+def test_attribute_family_denominator_is_measured_no_call_inventory() -> None:
+    """Historical pin 53 included Call-bearing Attribute roots; measured is 41."""
+    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 41
+    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 53


### PR DESCRIPTION
## Summary

Attribute-family owner cut on the authenticated no-call producer board.

- **Inventory remeasure:** `FAMILY_DENOMINATORS[Attribute]` **53 → 41**. Official `discover_no_call_body_probes` on CPython 3.12.13 + corpus manifest `blake3-512:6f317…` + demand table `blake3-512:0ce7…` enrolls **41** Attribute roots under the no-Call-descendant law. The historical 53 pin over-counted Call-bearing Attribute roots (e.g. `Series([…]).cat`, `pd.Series([], dtype=object).bad`) that enrollment excludes.
- **Family-scoped measurement:** `--family Attribute` / `families=` on discovery/run so the owner can remeasure without constructing peer-family sources.
- **Honest ObjectValue coordinate:** missing field with no deferred helper uses `undecided_attribute(owner="ObjectValue.attribute")` instead of the generic FloorValue `owner="attribute"` panic.
- **Corpus teeth:** six no-call Attribute bodies + BinOp child `s_0123 & np.nan` reattr stay `ConstructionPanic(owner=SymbolicValue.attribute)` — never invented `AttributeError`.

## Measured residual R (Attribute)

Authentication: CPython 3.12.13, corpus `blake3-512:6f317a5a…` (1421 files), demand table `blake3-512:0ce7c645…`, a223 path-shape negative only.

| Axis | Count |
|---|---:|
| Denominator (enrolled) | **41** (was pinned 53; instrument red until this remeasure) |
| authenticated-exceptional-exit | **0** |
| named-refusal (SugarNotWritten) | **0** |
| construction-panic | **41** |
| **owner mass** | **SymbolicValue.attribute × 41** |

**R(Attribute) = 41** construction-panics, all `SymbolicValue.attribute`.

Bare `expression.sugar().desugar(None)` has no bindings: every enrolled body is a Name-rooted Attribute chain → SymbolicValue receiver → #6491 undecided attribute law. Epsilon R for this cut: inventory instrument green (53→41); semantic residual unchanged at 41 named construction panics (already correct law; now pinned).

### Child reattribution (BinOp → Attribute)

`tests/series/test_logical_ops.py:96` `s_0123 & np.nan` child-evaluates `.nan` before the BinOp floor. Panic owner is **`SymbolicValue.attribute`** (Attribute-family coordinate), not `binary_operation_exception_floor`. Pinned so parent/child ownership stays honest.

### Unenrolled Call-bearing Attribute surface (not in denominator)

~10 `pytest.raises` bodies whose root is Attribute but which contain Call descendants (`Series([…]).cat`, `pd.Series([], dtype=object).bad`, …) are excluded by the no-call law and sit in **no** producer family. Separate surface from R(Attribute)=41.

## Validation

- `40 passed`: `test_attribute_exceptional_exit_producer`, `test_no_call_body_attribution`, `test_none_attribute_floor`, `test_opaque_member_access`, `test_guarded_attribute_membership`
- Black clean on touched files
- Runtime: `/Users/tsavo/provekit/.venv-py312` = CPython 3.12.13 only
- Official Attribute-only discover: observed 41, matches new denominator

## Constraints

- Production doors only (`SourceFile` + `TreeConstructionContextV1.for_source_call_construction`, `node.sugar().desugar`)
- No demand-table rebuild; shelf pull only
- No invented AttributeError / RuntimeEffect for undecided receivers

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remeasure no-call Attribute inventory from 53 to 41 and pin residual with tests
> - Updates `FAMILY_DENOMINATORS` for `ProducerFamily.ATTRIBUTE` from 53 to 41 in [no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/6527/files#diff-63dc4df7d670fe2740ec87663a519f79002baa69eb853f03a8559b42d8f325e4), reflecting the measured count of Attribute-rooted bodies with no `Call` descendants.
> - Adds `--family` CLI option to the [attribution script](https://github.com/TSavo/sugar/pull/6527/files#diff-8e1df3404326b74b11100b0b063138d06765babfb90e86828821d08300ee62d9) to restrict measurement and validation to specific `ProducerFamily` values.
> - Threads a `families` parameter through `run_authenticated_attribution`, `discover_no_call_body_probes`, and `require_expected_denominators` to support per-family filtering, skipping source file construction for unselected families.
> - Fixes `ObjectValue.attribute` fallback in [object_value.py](https://github.com/TSavo/sugar/pull/6527/files#diff-915d55e3a0e35db85dc48bceffe52001584a598ab89e134e598a042edea35a7b): missing instance fields without a deferred helper now return `undecided_attribute` owned by `"ObjectValue.attribute"` instead of delegating to `FloorValue.attribute`.
> - Adds [test_attribute_exceptional_exit_producer.py](https://github.com/TSavo/sugar/pull/6527/files#diff-9d776645f85cbc6b9afbf85b90a31db44f6ff21e8756fb5ac24bc70d030bec67) pinning no-call Attribute family behavior (denominator 41) and verifying bare desugar raises `ConstructionPanic` owned by `SymbolicValue.attribute`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8224b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->