### PR TITLE
Refuse undecided Compare ordering and membership

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -45,13 +45,39 @@ _OPERATOR_COORDINATE = {
 
 
 def refuse_undecided_comparison(left, right, site, op_kind: str) -> None:
-    """Keep an unexecuted call result's native dispatch at its producer."""
-    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    """Keep undecided native comparison/containment dispatch at the producer.
 
-    if not (left.denotes_value() and right.denotes_value()):
+    Ordering and membership are not total over undecided runtime types:
+    Python may select a rich method that completes or raises (``Series`` vs
+    ``str`` raises ``TypeError``; unknown containers may raise from
+    ``__contains__``). Emitting ``py.lt`` / ``py.in`` invents completion;
+    inventing ``TypeError`` invents an exception identity. Both stay refused
+    until native operand types are source-authenticated — the same producer
+    law BinOp/BoolOp already own.
+
+    Equality is different: ``==`` / ``!=`` remain total solver coordinates for
+    symbolic and ground pairs (``py.eq``), so equality only refuses an
+    unexecuted call result whose ``__eq__`` body is itself undecided.
+    """
+    denotes_left = getattr(left, "denotes_value", None)
+    denotes_right = getattr(right, "denotes_value", None)
+    if not callable(denotes_left) or not callable(denotes_right):
         return
-    if not isinstance(left, CallSiteValue) and not isinstance(right, CallSiteValue):
+    if not (denotes_left() and denotes_right()):
         return
+
+    if op_kind in {"Eq", "NotEq"}:
+        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+
+        if not isinstance(left, CallSiteValue) and not isinstance(right, CallSiteValue):
+            return
+    else:
+        decided_left = getattr(left, "runtime_type_is_decided", None)
+        decided_right = getattr(right, "runtime_type_is_decided", None)
+        if not callable(decided_left) or not callable(decided_right):
+            return
+        if decided_left() and decided_right():
+            return
 
     from sugar_lift_py_tests.gap.info import GapKind, GapLocus
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
@@ -100,13 +126,13 @@ class ComparisonOpSugar(Sugar):
         return left.and_then(right)
 
     def _membership(self, container, item):
-        """Dispatch membership only when native receiver type is decided.
+        """Dispatch membership only when native operand types are decided.
 
-        An unexecuted call result denotes a Python value, but its runtime type
-        is a third value. Python may select ``__contains__``, fall back through
-        iteration, or raise from either native method. Emitting ``py.in`` there
-        invents completion; choosing TypeError invents an exit. Keep that
-        undecided dispatch loud at the Compare producer.
+        An undecided container or needle denotes a Python value, but which
+        ``__contains__`` / iteration path Python would select — and whether it
+        raises — is a third value. Emitting ``py.in`` invents completion;
+        inventing ``TypeError`` invents an exit. Keep that undecided dispatch
+        loud at the Compare producer.
         """
         refuse_undecided_comparison(item, container, self.site, self.op_kind)
         return container.contains(item, self.site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -1,4 +1,4 @@
-"""Compare is an effect producer; membership follows native source testimony."""
+"""Compare is an effect producer; undecided native dispatch stays named-loud."""
 
 from __future__ import annotations
 
@@ -10,35 +10,40 @@ from dataclasses import dataclass
 
 import pytest
 
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.floor import CallSiteValue, TermValue
+from sugar_lift_py_tests.floor import CallSiteValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
-from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
 from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Compare
 from sugar_source_tree.tree import SourceFile
 
-CORPUS_ROOT = Path("/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages")
-SITE = CORPUS_ROOT / "pandas/tests/test_col.py"
-SITE_SHA256 = "a86bcccd3f041ac81a1d6f349d537ee1049c6afa4d799b9293b410da4409f038"
-SOURCE_CID = (
-    "blake3-512:58f9629e47ef9bdb4137fbe31d1c322b22fd1918ec8da1b1725f344d0087d5a27"
-    "f69cb188d8d417d0f6490c6a9531191e789f9e5df14e5070f93455673bacdad"
-)
+# Content manifest (relative path + per-file BLAKE3-512). Path-shape
+# sha256:a223… is historical negative testimony only — never identity.
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+HISTORICAL_PATH_SHAPE_DIGEST = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 )
 DEMAND_TABLE_KEY = (
     "blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d"
     "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
 )
+COL_SITE_SHA256 = "a86bcccd3f041ac81a1d6f349d537ee1049c6afa4d799b9293b410da4409f038"
+COL_SOURCE_CID = (
+    "blake3-512:58f9629e47ef9bdb4137fbe31d1c322b22fd1918ec8da1b1725f344d0087d5a27"
+    "f69cb188d8d417d0f6490c6a9531191e789f9e5df14e5070f93455673bacdad"
+)
+NUMERIC_SITE_SHA256 = "ad382bdf9178c34fffa4762b4014a8ef64d02e548433adaa8aba414398d6e5d8"
+COMMON_SITE_SHA256 = "442441f4ea11ec95e361c54ddf5c599a49769928970af3daee3b9a482dce7754"
 
 
 @dataclass(frozen=True)
@@ -58,23 +63,48 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def _compare_at_365(source: str) -> Compare:
-    source_identity = (
-        workspace_path_source(str(SITE), root=str(CORPUS_ROOT))
-        if hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
-        else (source, str(SITE), blake3_512_of(source.encode()))
+def _corpus_root() -> Path:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        MANIFEST_CID,
+        1421,
     )
+    assert corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST
+    return corpus.root
+
+
+def _compare_at(path: Path, source: str, *, line: int) -> Compare:
     tree = SourceFile(
-        source_identity,
+        (source, str(path), blake3_512_of(source.encode())),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     matches = tuple(
         node
         for node in tree.nodes()
-        if isinstance(node, Compare) and node.line_col_span().start_line == 365
+        if isinstance(node, Compare) and node.line_col_span().start_line == line
     )
     assert len(matches) == 1
     return matches[0]
+
+
+def _assert_named_compare_panic(node, *, observed: str) -> None:
+    with pytest.raises(ConstructionPanic) as raised:
+        node.sugar().desugar(None)
+    info = raised.value.info
+    assert info.owner == "comparison_operation_exception_floor"
+    assert info.observed == observed
+    assert "source-visible native comparison testimony" in info.requested
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
+    assert "RuntimeEffect" not in str(info)
+
+
+def test_launcher_authenticates_content_manifest_not_path_shape() -> None:
+    corpus = authenticated_pandas_corpus()
+    assert corpus.manifest_cid == MANIFEST_CID
+    assert corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST
+    assert corpus.file_count == 1421
 
 
 def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> None:
@@ -97,6 +127,11 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
         capture_output=True,
         text=True,
         check=False,
+        env={
+            **dict(__import__("os").environ),
+            "SUGAR_BINARY_ALLOW_BUILD": "0",
+            "SUGAR_BINARY_PUBLISH": "0",
+        },
     )
     assert pulled.returncode == 0 and output.is_file(), (
         "the authenticated #6464 demand table is absent; do not rebuild it: "
@@ -107,6 +142,9 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
     assert table["authentication"]["authenticatedCorpusManifestCid"] == MANIFEST_CID
     assert table["authentication"]["pandas"] == "3.0.3"
     assert table["identity"]["fileCount"] == 1421
+    assert table["authentication"]["authenticatedCorpusManifestCid"] != (
+        HISTORICAL_PATH_SHAPE_DIGEST
+    )
     rows = tuple(
         row
         for row in table["rows"]
@@ -115,7 +153,7 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
         and row.get("gapKind") is None
         and row.get("useSite")
         == {
-            "sourceCid": SOURCE_CID,
+            "sourceCid": COL_SOURCE_CID,
             "startLine": 362,
             "startCol": 9,
             "endLine": 364,
@@ -126,25 +164,24 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
 
 
 def test_pandas_col_membership_refuses_to_invent_type_error() -> None:
-    source = SITE.read_text(encoding="utf-8")
-    assert hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
+    path = _corpus_root() / "tests/test_col.py"
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == COL_SITE_SHA256
+    assert blake3_512_of(source.encode()) == COL_SOURCE_CID
 
-    with pytest.raises(ConstructionPanic) as raised:
-        _compare_at_365(source).sugar().desugar(None)
-
-    info = raised.value.info
-    assert info.owner == "comparison_operation_exception_floor"
-    assert info.observed == "TermValue in CallSiteValue"
-    assert "source-visible native comparison testimony" in info.requested
-    assert "TypeError" not in str(info)
+    _assert_named_compare_panic(
+        _compare_at(path, source, line=365),
+        observed="TermValue in CallSiteValue",
+    )
 
 
 def test_literal_container_lying_twin_does_not_inherit_the_refusal() -> None:
-    source = SITE.read_text(encoding="utf-8")
+    path = _corpus_root() / "tests/test_col.py"
+    source = path.read_text(encoding="utf-8")
     lying = source.replace('1 in pd.col("a")', "1 in [1]")
     assert lying != source
 
-    outcome = _compare_at_365(lying).sugar().desugar(None)
+    outcome = _compare_at(path, lying, line=365).sugar().desugar(None)
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
@@ -167,8 +204,8 @@ def test_runtime_truthful_and_lying_twins_discriminate() -> None:
         assert raises_type_error(lambda: 1 in [1])
 
 
-@pytest.mark.parametrize("op_kind", ["Lt", "NotEq", "In", "NotIn"])
-def test_every_nonidentity_comparison_keeps_undecided_dispatch_loud(
+@pytest.mark.parametrize("op_kind", ["Lt", "NotEq", "In", "NotIn", "Eq"])
+def test_every_nonidentity_comparison_keeps_undecided_call_dispatch_loud(
     op_kind: str,
 ) -> None:
     call_result = _ValueSugar(
@@ -184,22 +221,128 @@ def test_every_nonidentity_comparison_keeps_undecided_dispatch_loud(
         )
     )
 
+    sugar = (
+        EqualityOpSugar(left, right, "compare-site")
+        if op_kind == "Eq"
+        else ComparisonOpSugar(op_kind, left, right, "compare-site")
+    )
+    with pytest.raises(ConstructionPanic) as raised:
+        sugar.desugar(None)
+
+    assert raised.value.info.owner == "comparison_operation_exception_floor"
+    assert "TypeError" not in str(raised.value.info)
+
+
+@pytest.mark.parametrize("op_kind", ["Lt", "Gt", "LtE", "GtE"])
+def test_undecided_symbolic_operands_refuse_invented_ordering(
+    op_kind: str,
+) -> None:
+    """``left < right`` cannot invent ``py.lt`` when operand types are undecided."""
+    left = _ValueSugar(SymbolicValue(make_var("left")))
+    right = _ValueSugar(SymbolicValue(make_var("right")))
     with pytest.raises(ConstructionPanic) as raised:
         ComparisonOpSugar(op_kind, left, right, "compare-site").desugar(None)
 
-    assert raised.value.info.owner == "comparison_operation_exception_floor"
-    assert "TypeError" not in str(raised.value.info)
+    info = raised.value.info
+    assert info.owner == "comparison_operation_exception_floor"
+    operator = {"Lt": "<", "Gt": ">", "LtE": "<=", "GtE": ">="}[op_kind]
+    assert info.observed == f"SymbolicValue {operator} SymbolicValue"
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
 
 
-def test_equality_keeps_undecided_native_dispatch_loud() -> None:
+def test_symbolic_equality_remains_solver_owned() -> None:
+    """Equality stays a total ``py.eq`` coordinate for symbolic/ground pairs."""
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+    outcome = EqualityOpSugar(
+        _ValueSugar(SymbolicValue(make_var("left"))),
+        _ValueSugar(TermValue(1)),
+        "compare-site",
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, PredicateValue)
+
+
+def test_undecided_symbolic_membership_refuses_invented_py_in() -> None:
     with pytest.raises(ConstructionPanic) as raised:
-        EqualityOpSugar(
-            _ValueSugar(
-                CallSiteValue("unknown", (), (), ctor("call:unknown", []), None)
-            ),
+        ComparisonOpSugar(
+            "In",
             _ValueSugar(TermValue(1)),
+            _ValueSugar(SymbolicValue(make_var("container"))),
             "compare-site",
         ).desugar(None)
 
-    assert raised.value.info.owner == "comparison_operation_exception_floor"
-    assert "TypeError" not in str(raised.value.info)
+    info = raised.value.info
+    assert info.owner == "comparison_operation_exception_floor"
+    assert info.observed == "TermValue in SymbolicValue"
+    assert "TypeError" not in str(info)
+
+
+def test_ground_decided_membership_still_completes() -> None:
+    """Lying twin: a decided finite container is not an undecided third value."""
+    from sugar_lift_py_tests.floor import ListValue
+
+    outcome = ComparisonOpSugar(
+        "In",
+        _ValueSugar(TermValue(1)),
+        _ValueSugar(ListValue((TermValue(1),))),
+        "compare-site",
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_pandas_series_string_ordering_stays_source_undecided() -> None:
+    """``obj < "a"``: string right is decided; left Series type is not.
+
+    Site: ``pandas/tests/arithmetic/test_numeric.py:146`` under
+    ``pytest.raises(TypeError)``. Source does not state Series type at the
+    Compare, so the producer cannot mint TypeError — only the named refusal.
+    """
+    path = _corpus_root() / "tests/arithmetic/test_numeric.py"
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == NUMERIC_SITE_SHA256
+    assert source.count('obj < "a"') == 1
+
+    import pandas
+
+    series = pandas.Series([1.0, 2.0], dtype="float64")
+    with pytest.raises(TypeError, match="Invalid comparison"):
+        series < "a"  # noqa: B015
+
+    _assert_named_compare_panic(
+        _compare_at(path, source, line=146),
+        observed="SymbolicValue < StringValue",
+    )
+
+
+@pytest.mark.parametrize(
+    ("line", "op", "observed"),
+    (
+        (144, "<", "SymbolicValue < SymbolicValue"),
+        (146, "<=", "SymbolicValue <= SymbolicValue"),
+        (148, ">", "SymbolicValue > SymbolicValue"),
+        (150, ">=", "SymbolicValue >= SymbolicValue"),
+        (152, "<", "SymbolicValue < SymbolicValue"),
+        (154, "<=", "SymbolicValue <= SymbolicValue"),
+        (156, ">", "SymbolicValue > SymbolicValue"),
+        (158, ">=", "SymbolicValue >= SymbolicValue"),
+    ),
+)
+def test_pandas_left_right_ordering_faces_stay_source_undecided(
+    line: int, op: str, observed: str
+) -> None:
+    """``left < right`` family in arithmetic/common.py: both sides undecided.
+
+    Eight faces of the same helper under TypeError expectations. Production
+    construction sees only name coordinates — refuse without inventing exits.
+    """
+    path = _corpus_root() / "tests/arithmetic/common.py"
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == COMMON_SITE_SHA256
+    _assert_named_compare_panic(
+        _compare_at(path, source, line=line),
+        observed=observed,
+    )
+    del op  # documented in parametrize for human readers of the tooth list


### PR DESCRIPTION
## Summary

- **Compare ordering / membership**: refuse when either operand denotes a value but its runtime type is undecided (`comparison_operation_exception_floor`). Emitting `py.lt` / `py.in` invents completion; inventing `TypeError` invents an exception identity.
- **Equality carve-out**: `==` / `!=` remain total solver `py.eq` coordinates for symbolic/ground pairs; only unexecuted `CallSiteValue` equality stays refused (unchanged from #6494).
- **Substrate pins**: content manifest `blake3-512:6f317a5a…` only; historical path-shape `sha256:a223…` is negative testimony; demand table `blake3-512:0ce7c645…`; runtime CPython 3.12.13 via `authenticated_pandas_corpus()`.
- **Production construction teeth**: `obj < "a"` and eight `left/right` ordering faces under `pytest.raises(TypeError)` refuse without inventing exits.

## Owner contract (measurement substrate)

| Axis | Value |
|---|---|
| runtime | `cpython-3.12.13` (`.venv-py312`) |
| executable | `/Users/tsavo/provekit/.venv-py312/bin/python` |
| content manifest | `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530` |
| demand table | `blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0` |
| path-shape | `sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0` **negative only** |
| family denominator | Compare **181** (instrument); AST/no-call discovery locally **169** (12 Compare-with-nested-Call bodies excluded by no-call filter; separate residual) |
| door | `SourceFile` + `TreeConstructionContextV1.for_source_call_construction` + `node.sugar().desugar(None)` |

## Measured R (before → after) on 169 no-call Compare bodies

| Outcome | Before | After | Δ |
|---|---:|---:|---:|
| authenticated-exceptional-exit | 0 | 0 | 0 |
| silent Complete(PredicateValue) | 153 | **34** | **−119** |
| construction-panic `comparison_operation_exception_floor` | 0 | **119** | **+119** |
| construction-panic child reattr (`SymbolicValue.attribute` / `.subscript`) | 16 | 16 | 0 |

- **Ordering + membership (129 sites)**: all now `comparison_operation_exception_floor` (was silent invent of `py.lt`/`py.in`).
- **Equality (40 sites)**: 34 still silent `py.eq` (solver-owned); 6 still child attribute/subscript panics.
- **Auth exits**: still 0 — no Series/Period type source testimony yet; refuse without inventing TypeError.

### Pinned sites (full contract)

| Site | Text | Before | After | Named gap |
|---|---|---|---|---|
| `tests/test_col.py:365` | `1 in pd.col("a")` | construction-panic `comparison_operation_exception_floor` / `TermValue in CallSiteValue` | same + content-manifest/demand 0ce7 pins | Call result containment undecided |
| `tests/arithmetic/test_numeric.py:146` | `obj < "a"` | **silent** `Complete(PredicateValue(py.lt))` | construction-panic `… / SymbolicValue < StringValue` | left Series type undecided |
| `tests/arithmetic/common.py:144–158` (8 faces) | `left < right` etc. | **silent** `py.lt`… | construction-panic `SymbolicValue <op> SymbolicValue` | both operand types undecided |

### Residual R

- **R_silent (equality invent)** = 34 (`Eq`/`NotEq` Symbolic pairs still complete `py.eq`)
- **R_panic_compare** = 119 (`comparison_operation_exception_floor`)
- **R_panic_child** = 16 (operand attribute/subscript)
- **R_auth_exit** = 0
- **R_inventory_gap** = 12 Compare-with-Call bodies (not in no-call 169; all panic under #6494 when constructed)
- **R_not_authenticated_exit** = 169 (of discovered 169) + 12 off-instrument = toward family 181

Epsilon for next shots: produce authenticated TypeError exits only when both operand types are source-decided ground unorderable pairs; equality family drain is a separate arm if pytest.raises equality bodies must stop completing.

## Validation

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv-py312/bin/python -m pytest --noconftest -q \
  tests/test_compare_exceptional_exit_producer.py \
  tests/test_bool_op_ground_operand.py \
  tests/test_sequence_membership_floor.py
# 47 passed
```

Broader focused set earlier: 121 passed including `test_undecided_binary_operand_law` + `test_no_call_body_attribution`.

## Constraints honored

- No new env/shelf/census
- No fabricated TypeError / RuntimeEffect
- Continuous small PR; production construction door only
- Path-shape a223 never accepted as identity

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse undecided Compare ordering and membership in comparison op sugar
> - Updates `refuse_undecided_comparison` in [comparison_op_sugar.py](https://github.com/TSavo/sugar/pull/6528/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) to raise a `construction_panic_gap` for non-equality comparisons when either operand's `runtime_type_is_decided` is unavailable or reports undecided, and guards all attribute access with `getattr`+callable checks to avoid `AttributeError`.
> - Equality comparisons (`Eq`/`NotEq`) continue to panic only when at least one operand is a `CallSiteValue`; ordering and membership comparisons now also panic when either operand is `SymbolicValue` or otherwise undecided.
> - Membership dispatch (`_membership`) is updated to require decided types for both container and needle before proceeding.
> - Extends the test suite with parametrized tests covering undecided symbolic operands for ordering, membership with `SymbolicValue` containers, and pandas `Series` ordering against strings and numeric types.
> - Behavioral Change: non-equality comparisons with undecided operands now produce a `ConstructionPanic` instead of silently completing or raising `AttributeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 919722c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->