### PR TITLE
Authenticate outer Subscript attribution

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the authenticated no-call producer-family attribution.
+"""Run the authenticated 982 outer-body producer-family attribution.
 
 This entry point intentionally has no unauthenticated or build fallback.  Use
 ``bin/bpytest`` / ``sugar-bx.sh`` so CPython 3.12.13, NumPy 2.5.1, the canonical

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -1,4 +1,4 @@
-"""Per-family attribution for assertion bodies whose root is not a Call.
+"""Per-family attribution for assertion bodies whose outer node is not Call.
 
 The authenticated runner owns discovery and shared-table transport.  This
 module owns the closed accounting algebra: every enrolled body is attributed
@@ -6,10 +6,10 @@ to exactly one producer family and exactly one of three outcomes.  A named
 ``SugarNotWritten`` refusal is accounted semantics, not a failure.  A
 ``ConstructionPanic`` remains a separate loud axis.
 
-Attribute family denominator is the measured no-Call-descendant Attribute root
-inventory on the authenticated pandas 3.0.3 corpus + #6464 demand table
-(remeasured 41; the historical pin 53 over-counted Call-bearing Attribute
-roots that the no-call enrollment law excludes).
+Family denominators are the authenticated outer-body inventory on the
+pandas 3.0.3 corpus + #6464 demand table under the outer-node-not-Call law
+(Subscript 386, BinOp 349, Compare 181, Attribute 51, UnaryOp 13, BoolOp 2;
+sum 982). Nested Call descendants do not reclassify an outer producer.
 """
 
 from __future__ import annotations
@@ -48,10 +48,10 @@ class ProducerFamily(str, Enum):
 
 
 FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
-    ProducerFamily.SUBSCRIPT: 392,
-    ProducerFamily.BINOP: 367,
+    ProducerFamily.SUBSCRIPT: 386,
+    ProducerFamily.BINOP: 349,
     ProducerFamily.COMPARE: 181,
-    ProducerFamily.ATTRIBUTE: 41,
+    ProducerFamily.ATTRIBUTE: 51,
     ProducerFamily.UNARYOP: 13,
     ProducerFamily.BOOLOP: 2,
 }
@@ -330,8 +330,8 @@ def _source_has_selected_family_demand(
         if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
             continue
         expression = node.body[0].value
-        if any(isinstance(descendant, ast.Call) for descendant in ast.walk(expression)):
-            continue
+        # Outer-node law: nested Calls (values[index()]) do not reclassify
+        # the body. Bare Call roots are excluded by selected_names.
         if type(expression).__name__ in selected_names:
             return True
     return False
@@ -357,7 +357,6 @@ def discover_no_call_body_probes(
         Attribute,
         BinOp,
         BoolOp,
-        Call,
         Compare,
         Expr,
         Subscript,
@@ -427,12 +426,6 @@ def discover_no_call_body_probes(
                     f"assertion demand resolves to {len(managers)} With nodes: {use_site!r}"
                 )
             with_node = managers[0]
-            if any(
-                isinstance(descendant, Call)
-                for statement in with_node.body
-                for descendant in statement.walk()
-            ):
-                continue
             if len(with_node.body) != 1 or not isinstance(with_node.body[0], Expr):
                 continue
             expression = with_node.body[0].value

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -83,14 +83,14 @@ def test_report_keeps_all_six_families_separate() -> None:
 
     assert tuple(report.by_family) == tuple(ProducerFamily)
     assert FAMILY_DENOMINATORS == {
-        ProducerFamily.SUBSCRIPT: 392,
-        ProducerFamily.BINOP: 367,
+        ProducerFamily.SUBSCRIPT: 386,
+        ProducerFamily.BINOP: 349,
         ProducerFamily.COMPARE: 181,
-        ProducerFamily.ATTRIBUTE: 41,
+        ProducerFamily.ATTRIBUTE: 51,
         ProducerFamily.UNARYOP: 13,
         ProducerFamily.BOOLOP: 2,
     }
-    assert sum(FAMILY_DENOMINATORS.values()) == 996
+    assert sum(FAMILY_DENOMINATORS.values()) == 982
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
@@ -146,7 +146,7 @@ def test_shared_table_accepts_only_the_canonical_content_manifest() -> None:
         )
 
 
-def test_discovery_uses_shared_demand_coordinates_and_excludes_call_bodies(
+def test_discovery_uses_outer_body_producer_and_excludes_bare_call_bodies(
     tmp_path,
 ) -> None:
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -166,11 +166,17 @@ def test_discovery_uses_shared_demand_coordinates_and_excludes_call_bodies(
     call_path = package / "call_body.py"
     call_source = "def g():\n    with boundary(TypeError):\n        opaque()\n"
     call_path.write_text(call_source, encoding="utf-8")
+    nested_call_path = package / "nested_call_subscript_body.py"
+    nested_call_source = (
+        "def h(values):\n" "    with boundary(TypeError):\n" "        values[index()]\n"
+    )
+    nested_call_path.write_text(nested_call_source, encoding="utf-8")
 
     rows = []
     for path, source in (
         (subscript_path, subscript_source),
         (call_path, call_source),
+        (nested_call_path, nested_call_source),
     ):
         source_cid = blake3_512_of(source.encode())
         tree = SourceFile(
@@ -196,9 +202,12 @@ def test_discovery_uses_shared_demand_coordinates_and_excludes_call_bodies(
 
     probes = discover_no_call_body_probes({"rows": rows}, package)
 
-    assert len(probes) == 1
-    assert probes[0].family is ProducerFamily.SUBSCRIPT
-    assert probes[0].body_id == "subscript_body.py:3:Subscript"
+    assert len(probes) == 2
+    assert all(probe.family is ProducerFamily.SUBSCRIPT for probe in probes)
+    assert [probe.body_id for probe in probes] == [
+        "nested_call_subscript_body.py:3:Subscript",
+        "subscript_body.py:3:Subscript",
+    ]
 
 
 def test_discovery_projects_one_family_without_constructing_peer_sources(
@@ -285,7 +294,8 @@ def test_selected_family_denominator_remains_fixed() -> None:
         )
 
 
-def test_attribute_family_denominator_is_measured_no_call_inventory() -> None:
-    """Historical pin 53 included Call-bearing Attribute roots; measured is 41."""
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 41
+def test_attribute_family_denominator_is_outer_body_inventory() -> None:
+    """Outer-body law measures Attribute 51 (historical no-Call-descendant pin was 41)."""
+    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 51
     assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 53
+    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 41

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from pathlib import Path
 
 import pytest
 
@@ -21,6 +22,20 @@ from sugar_lift_py_tests.floor import (
     TupleValue,
 )
 from sugar_lift_py_tests.ir import ctor, make_var
+from sugar_lift_py_tests.no_call_body_attribution import (
+    CANONICAL_CORPUS_MANIFEST_CID,
+    CANONICAL_CORPUS_MANIFEST_SHA256,
+    FAMILY_DENOMINATORS,
+    HISTORICAL_PATH_SHAPE_DIGEST,
+    AttributionOutcome,
+    DemandTableRefusal,
+    ProducerFamily,
+    attribute_body_probes,
+    discover_no_call_body_probes,
+    pull_shared_demand_table,
+    require_expected_denominators,
+    validate_shared_demand_table,
+)
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_python_source.source_oracle import workspace_path_source
@@ -30,13 +45,8 @@ from sugar_source_tree.tree import SourceFile
 SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
 # Content manifest (relative path + per-file BLAKE3-512). Path-shape
 # sha256:a223… is historical negative testimony only — never identity.
-MANIFEST_CID = (
-    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
-    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
-)
-HISTORICAL_PATH_SHAPE_DIGEST = (
-    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
-)
+MANIFEST_CID = CANONICAL_CORPUS_MANIFEST_CID
+MANIFEST_SHA256 = CANONICAL_CORPUS_MANIFEST_SHA256
 
 
 @pytest.fixture(scope="module")
@@ -62,7 +72,7 @@ def local_site(tmp_path):
     source_path = tmp_path / "nested_tuple_subscript.py"
     source_path.write_text(
         "def nested_tuple_lookup(values):\n"
-        "    key = ((\"foo\", \"bar\", 0), 2)\n"
+        '    key = (("foo", "bar", 0), 2)\n'
         "    return values[key]\n"
         "\n"
         "def control(values):\n"
@@ -76,7 +86,6 @@ def local_site(tmp_path):
     return next(function.fragment for function in source.functions())
 
 
-
 def test_launcher_authenticates_the_exact_corpus() -> None:
     corpus = authenticated_pandas_corpus()
     assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
@@ -86,6 +95,67 @@ def test_launcher_authenticates_the_exact_corpus() -> None:
     )
     # Path-shape is refusal testimony, not an accepted corpus identity.
     assert corpus.manifest_cid != HISTORICAL_PATH_SHAPE_DIGEST
+    assert MANIFEST_SHA256 == (
+        "sha256:0ee4e945d69e60941f74ad064215a44d9f02a0b23b081e2a507d893bdd22a938"
+    )
+
+
+def test_historical_path_shape_digest_is_refused_as_corpus_identity() -> None:
+    payload = {
+        "contentKey": "blake3-512:" + "d" * 128,
+        "authentication": {
+            "python": "cpython-3.12.13",
+            "authenticatedCorpusManifestCid": HISTORICAL_PATH_SHAPE_DIGEST,
+            "pandas": "3.0.3",
+        },
+        "identity": {
+            "corpusManifestCid": HISTORICAL_PATH_SHAPE_DIGEST,
+            "fileCount": 1421,
+        },
+        "rows": [],
+    }
+
+    with pytest.raises(DemandTableRefusal, match="historical path-shape"):
+        validate_shared_demand_table(
+            payload, expected_content_key=payload["contentKey"]
+        )
+
+
+def test_authenticated_subscript_family_owns_no_construction_panics(
+    tmp_path,
+) -> None:
+    corpus = authenticated_pandas_corpus()
+    repo_root = Path(__file__).resolve().parents[4]
+    payload = pull_shared_demand_table(repo_root, tmp_path / "python-demand-table.json")
+    inventory = require_expected_denominators(
+        discover_no_call_body_probes(payload, corpus.root)
+    )
+    probes = tuple(
+        probe for probe in inventory if probe.family is ProducerFamily.SUBSCRIPT
+    )
+    report = attribute_body_probes(probes)
+    row = report.by_family[ProducerFamily.SUBSCRIPT]
+    reattributed_gaps = tuple(
+        body
+        for body in report.bodies
+        if body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
+    )
+    subscript_owned_panics = tuple(
+        gap
+        for gap in reattributed_gaps
+        if gap.detail == "subscript" or gap.detail.endswith(".subscript")
+    )
+
+    print(row, flush=True)
+    print(f"subscriptReattributedTypedGaps={len(reattributed_gaps)}", flush=True)
+    for gap in reattributed_gaps:
+        print(
+            f"subscriptReattribution site={gap.body_id} owner={gap.detail}",
+            flush=True,
+        )
+
+    assert row.enrolled == FAMILY_DENOMINATORS[ProducerFamily.SUBSCRIPT]
+    assert not subscript_owned_panics, subscript_owned_panics
 
 
 def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> None:
@@ -96,9 +166,7 @@ def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> 
         ctor("call:source-constructor", []),
         None,
     )
-    temporal = TemporalContext.empty().bind_value(
-        "series", receiver
-    )
+    temporal = TemporalContext.empty().bind_value("series", receiver)
 
     with pytest.raises(SugarNotWritten) as raised:
         authenticated_site.sugar().desugar(ReduceContext(temporal))
@@ -112,9 +180,7 @@ def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> 
 def test_truthful_out_of_range_concrete_list_emits_index_error(
     local_site,
 ) -> None:
-    outcome = ListValue((TermValue(7),)).subscript(
-        TermValue(1), local_site
-    )
+    outcome = ListValue((TermValue(7),)).subscript(TermValue(1), local_site)
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, RaiseValue)
@@ -124,9 +190,7 @@ def test_truthful_out_of_range_concrete_list_emits_index_error(
 def test_lying_in_range_concrete_list_does_not_emit_exception(
     local_site,
 ) -> None:
-    outcome = ListValue((TermValue(7),)).subscript(
-        TermValue(0), local_site
-    )
+    outcome = ListValue((TermValue(7),)).subscript(TermValue(0), local_site)
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, TermValue)
@@ -134,9 +198,7 @@ def test_lying_in_range_concrete_list_does_not_emit_exception(
 
 
 def test_known_non_integer_list_index_emits_type_error(local_site) -> None:
-    outcome = ListValue((TermValue(7),)).subscript(
-        TermValue(1.5), local_site
-    )
+    outcome = ListValue((TermValue(7),)).subscript(TermValue(1.5), local_site)
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, RaiseValue)


### PR DESCRIPTION
## What changed

- repairs #6511 discovery to classify the outer body producer, so `values[index()]` remains a Subscript while a bare `opaque()` remains Call
- replaces the never-executed 392 pin with the authenticated canonical-corpus result: 386 Subscript, 349 BinOp, 181 Compare, 51 Attribute, 13 UnaryOp, 2 BoolOp
- retains the historical path-shape digest only as explicit refusal testimony and asserts the canonical BLAKE3/SHA-256 identity pair
- adds an authenticated Subscript-family gate that separates Subscript-owned refusals from child-producer reattributions

No vendor arm, assertion-With change, demand-table rebuild, generic runtime effect, guessed exception type, or ExitSet/outcome/generator edit. #6524 already landed the producer-side `SugarNotWritten` law and richer concrete dict/number/set floors; this PR preserves it rather than duplicating it.

## Authenticated report

```text
sourceStamp blake3-512_b536f988a64aa054491a35399fd25a8d5e296a07ab9c4738fcc64a8b05bb81163e06b79d35ec30ee58f4002a547fbf2382b45d1a72875e72d1105a4c1f5e0d05
runtime CPython 3.12.13
canonical corpus manifest blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530 / sha256:0ee4e945d69e60941f74ad064215a44d9f02a0b23b081e2a507d893bdd22a938
demand-table identity blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0
concrete source site pandas/tests/test_multilevel.py:158 series[("foo", "bar", 0), 2]
before outcome ConstructionPanic owner=SymbolicValue.subscript
after outcome SugarNotWritten owner=SymbolicValue.subscript
surviving typed gaps or reattributions 186 child-producer gaps; named coordinate tests/base/test_misc.py:189:Subscript owner=SymbolicValue.attribute
```

Authenticated Subscript result: enrolled=386, authenticatedExceptionalExit=0, namedRefusal=200, Subscript-owned constructionPanic=0, child-producer reattribution=186. The historical 392 was not an authenticated denominator: CPython 3.12 over the canonical bytes finds exactly 386 syntactic outer Expr(Subscript) sites, all 386 present in authenticated demand testimony.

## Validation

- authenticated focused package modules: 24 passed in 190.28s
- black: 6 files unchanged before the final rebase; rebased diff formatted
- mutation transaction: clean; restored old ConstructionPanic mouth; lying nested-tuple twin failed; reverted; tracked clean; twin passed
- shared demand table pulled read-only with build/publish disabled; no rebuild
- no timeout, native crash, silent/unaccounted outcome, or Subscript-owned construction panic


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate outer Subscript attribution by classifying With-body expressions on their outer node type
> - Removes the fail-closed check in `_source_has_selected_family_demand` that excluded any body whose expression subtree contained an `ast.Call`; nested Calls no longer reclassify the outer producer.
> - Updates `FAMILY_DENOMINATORS` to reflect the outer-body inventory: Subscript 386, BinOp 349, Compare 181, Attribute 51, UnaryOp 13, BoolOp 2 (total 982, down from 996).
> - Adds tests asserting that nested-call subscript bodies are discovered as SUBSCRIPT probes, historical path-shape digests are refused as corpus identity, and authenticated subscript bodies have no CONSTRUCTION_PANIC outcomes.
> - Behavioral Change: bodies such as `values[index()]` that were previously excluded are now included in attribution as SUBSCRIPT family.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 438db79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated attribution accounting to recognize valid nested-call and outer-body expressions.
  * Corrected producer-family inventory totals and discovery results for nested subscripts and attributes.

* **Tests**
  * Expanded coverage for nested expression attribution and exceptional subscript cases.
  * Added validation that outdated corpus identity data is rejected.
  * Updated test fixtures and expectations to reflect the revised attribution inventories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->