### PR TITLE
Refuse undecided UnaryOp success faces at the producer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -739,9 +739,49 @@ class FloorValue:
         )
         construction_panic(info)
 
+    def _undecided_unary_law(self, site, operator: str):
+        """The ONE law for a unary operation with an undecided operand type.
+
+        ``-x``, ``+x``, and ``~x`` select ``__neg__`` / ``__pos__`` / ``__invert__``
+        (or raise TypeError) from the operand's runtime type.  When that type is
+        undecided, inventing a success coordinate (``py.neg``, identity, ``py.invert``)
+        erases the exceptional face, and inventing TypeError invents an exception
+        identity.  Both stay refused until source-visible type testimony decides.
+        """
+        denotes = getattr(self, "denotes_value", None)
+        decided = getattr(self, "runtime_type_is_decided", None)
+        if not callable(denotes) or not callable(decided):
+            return None
+        if not denotes() or decided():
+            return None
+
+        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="unary_operation_exception_floor",
+            blame=site,
+            observed=f"{type(self).__name__} {operator}",
+            requested=(
+                "source-visible native unary-operator testimony selecting "
+                "completion or an authenticated exceptional exit"
+            ),
+            fix=(
+                "preserve the undecided third value at the UnaryOp producer; "
+                "resolve the operand's runtime type and its unary operator body "
+                "from source, or retain this named refusal without inventing an "
+                "exception identity"
+            ),
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+
     def unary_minus(self, site):
-        # Default: no arithmetic negation floor. TermValue folds; SymbolicValue
-        # emits py.neg; absence is the honest "no".
+        # Default: no arithmetic negation floor. TermValue folds; an undecided
+        # operand type refuses (success versus TypeError is not source-decidable).
+        refused = self._undecided_unary_law(site, "-")
+        if refused is not None:
+            return refused
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 
@@ -758,7 +798,10 @@ class FloorValue:
         construction_panic(info)
 
     def unary_plus(self, site):
-        # Default: no unary-plus floor. TermValue / SymbolicValue implement.
+        # Default: no unary-plus floor. TermValue folds; undecided types refuse.
+        refused = self._undecided_unary_law(site, "+")
+        if refused is not None:
+            return refused
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 
@@ -778,6 +821,9 @@ class FloorValue:
         # Default: no bitwise-not floor. TermValue decides concrete operands;
         # an untyped symbol refuses because success versus TypeError is not
         # source-decidable.
+        refused = self._undecided_unary_law(site, "~")
+        if refused is not None:
+            return refused
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -258,12 +258,10 @@ class SymbolicValue(FloorValue):
         )
 
     def unary_minus(self, site):
-        # Symbolic arithmetic negation: emit py.neg(term) (LAW in symbolic_term).
-        del site
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(SymbolicValue(ctor("py.neg", [self.term])))
+        # The term does not state a runtime type, so it cannot decide whether
+        # ``-`` returns a value or raises TypeError.  A symbolic ``py.neg``
+        # coordinate for the success face would erase that exceptional face.
+        return super().unary_minus(site)
 
     def absolute(self, site):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
@@ -359,12 +357,10 @@ class SymbolicValue(FloorValue):
         return self._runtime_bitwise_refusal(other, site, "@")
 
     def unary_plus(self, site):
-        # Unary plus on a symbolic is identity (symbolic_term UAdd returns the
-        # operand). Match the LAW; do not invent a py.pos spelling.
-        del site
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(self)
+        # The term does not state a runtime type, so it cannot decide whether
+        # ``+`` is identity or raises TypeError (e.g. DatetimeArray).  Completing
+        # as the operand erases that exceptional face.
+        return super().unary_plus(site)
 
     def bitwise_invert(self, site):
         # The term does not state a runtime type, so it cannot decide whether

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -2,10 +2,10 @@
 
 Mirrors BinOpSugar: the node carries its operator, so recognition is the node's;
 this routes the reduced operand to the floor method that operator names, and the
-value owns the answer (a number folds, a symbol emits `py.neg`/`py.invert`, a
-type with no such floor hits its own loud gap). `not` is the one that composes
-two floor verbs: Python `not x` is `not bool(x)`, so it takes the operand's
-TRUTHINESS (`truth`) and negates that predicate -- never a bespoke boolean.
+value owns the answer (a number folds; an undecided type refuses rather than
+inventing ``py.neg`` / identity / ``py.invert``). `not` composes two floor verbs:
+Python `not x` is `not bool(x)`, so it takes a decided truthiness and negates
+that predicate -- never inventing ``py.truthy`` when ``bool(x)`` is undecided.
 """
 
 from __future__ import annotations
@@ -24,6 +24,45 @@ UNARYOP_METHODS: dict[str, str] = {
     "UAdd": "unary_plus",
     "Invert": "bitwise_invert",
 }
+
+
+def refuse_undecided_unary_truth(value, site) -> None:
+    """Keep undecided ``bool(operand)`` dispatch loud at the UnaryOp ``not`` producer.
+
+    Python evaluates ``not x`` by first taking ``bool(x)``.  When the operand
+    denotes a value but its runtime type is undecided, native ``__bool__`` /
+    ``__len__`` may complete or raise (``Series`` / ``NA`` raise ``TypeError`` /
+    ``ValueError``).  Emitting ``py.truthy`` invents a total completion; inventing
+    an exception identity invents the failure.  Both stay refused until
+    source-visible type testimony decides.
+    """
+    denotes = getattr(value, "denotes_value", None)
+    decided = getattr(value, "runtime_type_is_decided", None)
+    if not callable(denotes) or not callable(decided):
+        return
+    if not denotes() or decided():
+        return
+
+    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="unary_operation_exception_floor",
+        blame=site,
+        observed=f"{type(value).__name__} not",
+        requested=(
+            "source-visible native truth testimony selecting completion "
+            "or an authenticated exceptional exit"
+        ),
+        fix=(
+            "preserve the undecided third value at the UnaryOp producer; "
+            "resolve native operand types and their __bool__/__len__ bodies "
+            "from source, or retain this named refusal without inventing an "
+            "exception identity"
+        ),
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
 
 
 @dataclass(frozen=True)
@@ -46,8 +85,12 @@ class UnaryOpSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         operand = self.operand.desugar(ctx)
         if self.op_kind == "Not":
-            # `not x` = not bool(x): take the operand's truthiness, negate it.
-            return operand.and_then(lambda v: v.truth(self.site)).and_then(
+            # `not x` = not bool(x): only a decided truthiness may be negated.
+            def project_not(value):
+                refuse_undecided_unary_truth(value, self.site)
+                return value.truth(self.site)
+
+            return operand.and_then(project_not).and_then(
                 lambda predicate: predicate.negate()
             )
         method = UNARYOP_METHODS[self.op_kind]

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
@@ -4,7 +4,7 @@ import pytest
 
 from sugar_lift_py_tests.floor import GuardedValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
-from sugar_lift_py_tests.ir import atomic, ctor, make_var
+from sugar_lift_py_tests.ir import atomic, make_var
 from sugar_lift_py_tests.outcome import Complete
 
 
@@ -37,19 +37,18 @@ def test_guarded_arithmetic_preserves_an_undecided_arm_as_a_named_refusal(
     assert raised.value.info.observed == f"SymbolicValue {operator} TermValue"
 
 
-def test_guarded_unary_minus_distributes_to_both_faces() -> None:
+def test_guarded_unary_minus_preserves_an_undecided_arm_as_a_named_refusal() -> None:
     guard = atomic("choose", [])
     value = GuardedValue(
         guard,
         SymbolicValue(make_var("left")),
         SymbolicValue(make_var("right")),
     )
-    outcome = value.unary_minus("t.py:1")
-    assert outcome.value == GuardedValue(
-        guard,
-        SymbolicValue(ctor("py.neg", [make_var("left")])),
-        SymbolicValue(ctor("py.neg", [make_var("right")])),
-    )
+    with pytest.raises(ConstructionPanic) as raised:
+        value.unary_minus("t.py:1")
+
+    assert raised.value.info.owner == "unary_operation_exception_floor"
+    assert raised.value.info.observed == "SymbolicValue -"
 
 
 def test_guarded_bitwise_or_distributes_exact_set_union_to_both_faces() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_op_arithmetic.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_op_arithmetic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.floor import OpaqueOpCallsite, TermValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, num
 
 
@@ -27,12 +28,14 @@ def test_opaque_operator_arithmetic_cites_coordinates(method, operator) -> None:
     )
 
 
-def test_opaque_operator_unary_minus_cites_coordinate() -> None:
+def test_opaque_operator_unary_minus_is_named_refusal() -> None:
+    """An opaque call result has no decided runtime type for unary ``-``."""
     value = OpaqueOpCallsite("len", TermValue(9), computed=None)
-    outcome = value.unary_minus("t.py:1")
-    assert outcome.value.to_term(owner="test") == ctor(
-        "py.neg", [ctor("call:len", [num(9)])]
-    )
+    with pytest.raises(ConstructionPanic) as raised:
+        value.unary_minus("t.py:1")
+
+    assert raised.value.info.owner == "unary_operation_exception_floor"
+    assert raised.value.info.observed == "SymbolicValue -"
 
 
 def test_opaque_operator_declares_full_arithmetic_surface() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -119,13 +119,24 @@ def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -
     assert {(BOOLOP_SOURCE_CID, 151), (BOOLOP_SOURCE_CID, 153)} <= sites
 
 
-def test_unary_invert_unknown_operand_is_named_undecided() -> None:
+@pytest.mark.parametrize(
+    ("method", "operator"),
+    (
+        ("bitwise_invert", "~"),
+        ("unary_minus", "-"),
+        ("unary_plus", "+"),
+    ),
+)
+def test_undecided_unary_operand_is_named_refusal(method: str, operator: str) -> None:
+    """Success versus TypeError is undecidable without the operand's runtime type."""
     with pytest.raises(ConstructionPanic) as caught:
-        SymbolicValue(make_var("ser")).bitwise_invert(_Site())
+        getattr(SymbolicValue(make_var("ser")), method)(_Site())
 
-    assert caught.value.info.owner == "bitwise_invert"
-    assert caught.value.info.observed == "SymbolicValue"
-    assert "TypeError" not in str(caught.value.info)
+    info = caught.value.info
+    assert info.owner == "unary_operation_exception_floor"
+    assert info.observed == f"SymbolicValue {operator}"
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
 
 
 def test_unary_invert_concrete_integer_truthful_twin_folds() -> None:
@@ -143,6 +154,31 @@ def test_unary_invert_concrete_float_lying_twin_has_typed_effect() -> None:
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, RaiseValue)
     assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_unary_minus_concrete_integer_truthful_twin_folds() -> None:
+    outcome = TermValue(5).unary_minus(_Site())
+    assert outcome == Complete(TermValue(-5))
+
+
+def test_unary_plus_concrete_integer_truthful_twin_folds() -> None:
+    outcome = TermValue(5).unary_plus(_Site())
+    assert outcome == Complete(TermValue(5))
+
+
+def test_undecided_not_operand_refuses_invented_truth() -> None:
+    """``not obj`` cannot invent ``py.truthy`` when ``bool(obj)`` is undecided."""
+    from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
+
+    with pytest.raises(ConstructionPanic) as caught:
+        UnaryOpSugar("Not", NameSugar("obj1", _Site()), _Site()).desugar(None)
+
+    info = caught.value.info
+    assert info.owner == "unary_operation_exception_floor"
+    assert info.observed == "SymbolicValue not"
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
+    assert "ValueError" not in str(info)
 
 
 class _EffectSugar:
@@ -289,4 +325,60 @@ def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
         assert info.owner == "boolean_operation_exception_floor"
         assert info.observed == f"SymbolicValue {operator}"
         assert "authenticated exceptional exit" in info.requested
+        assert "ValueError" not in str(info)
+
+
+def test_pandas_unary_sites_stay_source_undecided() -> None:
+    """Truthful pandas unary raises at runtime; producer refuses without inventing.
+
+    Sites under authenticated pandas 3.0.3:
+    - ``tests/extension/base/ops.py`` ``~ser`` / ``~data`` (TypeError)
+    - ``tests/frame/test_unary.py`` ``-df`` / ``+df`` (TypeError)
+    - ``tests/generic/test_generic.py`` ``not obj1`` (ValueError)
+    - ``tests/scalar/test_na_scalar.py`` ``not NA`` (TypeError)
+    Source does not state the operand runtime type at the UnaryOp, so the
+    producer cannot mint the exception identity — only the named refusal.
+    """
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import UnaryOp
+    from sugar_source_tree.tree import SourceFile
+
+    corpus = authenticated_pandas_corpus()
+    assert corpus.manifest_cid == MANIFEST_CID
+
+    cases = (
+        ("tests/extension/base/ops.py", 258, "~"),
+        ("tests/extension/base/ops.py", 260, "~"),
+        ("tests/frame/test_unary.py", 56, "-"),
+        ("tests/frame/test_unary.py", 133, "+"),
+        ("tests/indexes/test_old_base.py", 861, "~"),
+        ("tests/scalar/timedelta/test_timedelta.py", 290, "~"),
+        ("tests/generic/test_generic.py", 156, "not"),
+        ("tests/scalar/test_na_scalar.py", 48, "not"),
+    )
+    for rel, line, operator in cases:
+        path = corpus.root / rel
+        source = path.read_text(encoding="utf-8")
+        source_cid = blake3_512_of(source.encode("utf-8"))
+        tree = SourceFile(
+            (source, str(path), source_cid),
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        )
+        matches = tuple(
+            node
+            for node in tree.nodes()
+            if isinstance(node, UnaryOp) and node.line_col_span().start_line == line
+        )
+        assert len(matches) == 1, (rel, line, matches)
+        with pytest.raises(ConstructionPanic) as raised:
+            matches[0].sugar().desugar(None)
+        info = raised.value.info
+        assert info.owner == "unary_operation_exception_floor", (rel, line, info.owner)
+        assert info.observed == f"SymbolicValue {operator}", (rel, line, info.observed)
+        assert "authenticated exceptional exit" in info.requested
+        assert "TypeError" not in str(info)
         assert "ValueError" not in str(info)

--- a/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
@@ -30,9 +30,22 @@ def _invs(src):
 # ---- UnaryOp -----------------------------------------------------------------
 
 
-def test_unary_minus_and_invert_emit_symbolic_ops():
-    assert _post("def A(z):\n    return -z\n").args[1].name == "py.neg"
-    assert _post("def A(z):\n    return ~z\n").args[1].name == "py.invert"
+def test_undecided_unary_ops_are_named_refusals():
+    """``-z`` / ``~z`` / ``+z`` cannot invent a success face without z's type."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    for source, operator in (
+        ("def A(z):\n    return -z\n", "-"),
+        ("def A(z):\n    return ~z\n", "~"),
+        ("def A(z):\n    return +z\n", "+"),
+    ):
+        try:
+            _post(source)
+        except ConstructionPanic as panic:
+            assert panic.info.owner == "unary_operation_exception_floor"
+            assert panic.info.observed == f"SymbolicValue {operator}"
+        else:
+            raise AssertionError(f"undecided unary {operator} invented a completion")
 
 
 def test_not_is_truth_then_negate():
@@ -60,10 +73,17 @@ def test_or_disjoins_operand_truthiness():
     assert invs[0].kind == "or"
 
 
-def test_bare_operands_use_py_truthy():
-    invs = _invs("def A(a, b):\n    assert a and b\n    return a\n")
-    assert invs[0].kind == "and"
-    assert all(op.name == "py.truthy" for op in invs[0].operands)
+def test_bare_operands_refuse_undecided_truth():
+    """``a and b`` cannot invent ``py.truthy`` when operand runtime types are open."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    try:
+        _invs("def A(a, b):\n    assert a and b\n    return a\n")
+    except ConstructionPanic as panic:
+        assert panic.info.owner == "boolean_operation_exception_floor"
+        assert panic.info.observed == "SymbolicValue and"
+    else:
+        raise AssertionError("undecided BoolOp invented py.truthy")
 
 
 # ---- Attribute ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

UnaryOp owner continuous PR: drain silent invents of `py.neg` / identity / `py.invert` / `py.truthy` when the operand runtime type is undecided.

- **Floor law** `unary_operation_exception_floor` on `FloorValue._undecided_unary_law` for `-` / `+` / `~`
- **SymbolicValue** routes all three unaries through that law (no success-face invent)
- **UnaryOpSugar `not`**: `refuse_undecided_unary_truth` before `truth()` + negate
- Ground `TermValue` folds and TypeError exits preserved
- Teeth updated for guarded/opaque/source-tree paths that previously expected invents

## Measured R (before → after)

Authentication: CPython 3.12.13, corpus manifest `blake3-512:6f317a5a…`, demand table `blake3-512:0ce7c645…`, a223 path-shape negative only. Family denominator UnaryOp **13** (AST-matched **10** of 13; full SourceFile discovery too slow locally on BindTypedModule).

### UnaryOp (AST-matched 10)

| Outcome | Before | After |
|---|---:|---:|
| authenticated-exceptional-exit | 0 | 0 |
| named-refusal (`SugarNotWritten`) | 0 | 0 |
| construction-panic `unary_operation_exception_floor` | 4 (`bitwise_invert` only) | **8** |
| construction-panic child reattr (`SymbolicValue.subscript`) | 2 | 2 |
| **silent Complete invent** | **4** (`-df`, `+df`, `not obj1`, `not NA`) | **0** |

| Site | Before | After |
|---|---|---|
| `tests/extension/base/ops.py:258` `~ser` | construction-panic `bitwise_invert` | construction-panic `unary_operation_exception_floor` / `SymbolicValue ~` |
| `tests/extension/base/ops.py:260` `~data` | construction-panic `bitwise_invert` | same family owner |
| `tests/indexes/test_old_base.py:861` `~idx` | construction-panic `bitwise_invert` | same family owner |
| `tests/scalar/timedelta/test_timedelta.py:290` `~td` | construction-panic `bitwise_invert` | same family owner |
| `tests/frame/test_unary.py:56` `-df` | **silent** `Complete(py.neg(df))` | construction-panic `unary_operation_exception_floor` / `SymbolicValue -` |
| `tests/frame/test_unary.py:133` `+df` | **silent** `Complete(df)` | construction-panic `unary_operation_exception_floor` / `SymbolicValue +` |
| `tests/generic/test_generic.py:156` `not obj1` | **silent** `Complete(not(py.truthy))` | construction-panic `unary_operation_exception_floor` / `SymbolicValue not` |
| `tests/scalar/test_na_scalar.py:48` `not NA` | **silent** invent | construction-panic `unary_operation_exception_floor` / `SymbolicValue not` |
| `tests/frame/test_unary.py:58` `-df["a"]` | child reattr `SymbolicValue.subscript` | same (operand undecided first) |
| `tests/frame/test_unary.py:135` `+df["a"]` | child reattr `SymbolicValue.subscript` | same |

### Residual R

- **Residual UnaryOp R (measured 10) = 10 construction-panics**
  - 8 named `unary_operation_exception_floor` (was 4 invert panics + 4 silent invents → all named)
  - 2 child reattr `SymbolicValue.subscript` on `-df["a"]` / `+df["a"]`
- **Silent invent residual = 0** (attribution-invariant violations cleared on measured set)
- **Epsilon R**: no authenticated TypeError/ValueError without inventing Series/DatetimeArray/NA type; residual stays construction-panic until source-visible operand types land
- Full sugar denominator 13: 3 additional bodies not AST-matched in local scan; remeasure after full `run_authenticated_attribution` on battleaxe

BoolOp 2 already drained on main by #6522 (`boolean_operation_exception_floor`); UnaryOp stable here so BoolOp handoff remains BinOp-owned.

## Validation

- `45 passed` focused: `test_unary_boolop_exception_producers`, `test_guarded_arithmetic_total`, opaque unary refusal, `test_unary_bool_attribute_sugar`, `test_no_call_body_attribution`
- Mutation: restore inventing `SymbolicValue.unary_minus` → teeth red (`unary_minus` + pandas sites); restore → green
- `black --check` clean; `git diff --check` clean
- Runtime: `/Users/tsavo/provekit/.venv-py312/bin/python` = CPython 3.12.13 only

## Constraints honored

- No fabricated green/vendor arms; no new census/shelf/environment
- Production doors only (`SourceFile` + `TreeConstructionContextV1.for_source_call_construction`, `node.sugar().desugar`)
- a223 path-shape remains negative testimony only

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse undecided UnaryOp success faces at the producer with named construction panics
> - Adds a shared `_undecided_unary_law` helper in [`floor_value.py`](https://github.com/TSavo/sugar/pull/6530/files#diff-e465d9d796b4d8a065950433dc35b2a788306abfe91dab378d35f42a38a2cdd7) and `refuse_undecided_unary_truth` in [`unary_op_sugar.py`](https://github.com/TSavo/sugar/pull/6530/files#diff-9701dc81d02d5c66bf2d96792b742e8df06dde7a5027b3d5e0c354b49b74d893) that detect when an operand denotes a runtime value with an undecided type.
> - When triggered, these helpers raise a `ConstructionPanic` with owner `unary_operation_exception_floor` and observed `<ClassName> <operator>`, replacing prior method-specific gaps (e.g. `unary_minus`, `unary_plus`, `bitwise_invert`).
> - `SymbolicValue.unary_minus` and `unary_plus` now delegate to `super()` instead of inventing symbolic success coordinates, since doing so would erase the exceptional face.
> - Unary `not` desugaring in `UnaryOpSugar` now calls `refuse_undecided_unary_truth` before attempting truth extraction on operands with undecided runtime types.
> - Behavioral Change: operators `-`, `+`, `~`, and `not` on undecided-type values now raise a named `ConstructionPanic` instead of completing with a symbolic term or a method-specific gap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17eb712.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->