### PR TITLE
Measure native producer families without manager names

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the authenticated 982 outer-body producer-family attribution.
+"""Run the authenticated 1,008 native-root producer-family attribution.
 
 This entry point intentionally has no unauthenticated or build fallback.  Use
 ``bin/bpytest`` / ``sugar-bx.sh`` so CPython 3.12.13, NumPy 2.5.1, the canonical

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -1,15 +1,10 @@
-"""Per-family attribution for assertion bodies whose outer node is not Call.
+"""Per-family attribution for assertion bodies whose root is not a Call.
 
 The authenticated runner owns discovery and shared-table transport.  This
 module owns the closed accounting algebra: every enrolled body is attributed
 to exactly one producer family and exactly one of three outcomes.  A named
 ``SugarNotWritten`` refusal is accounted semantics, not a failure.  A
 ``ConstructionPanic`` remains a separate loud axis.
-
-Family denominators are the authenticated outer-body inventory on the
-pandas 3.0.3 corpus + #6464 demand table under the outer-node-not-Call law
-(Subscript 386, BinOp 349, Compare 181, Attribute 51, UnaryOp 13, BoolOp 2;
-sum 982). Nested Call descendants do not reclassify an outer producer.
 """
 
 from __future__ import annotations
@@ -48,10 +43,10 @@ class ProducerFamily(str, Enum):
 
 
 FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
-    ProducerFamily.SUBSCRIPT: 386,
-    ProducerFamily.BINOP: 349,
+    ProducerFamily.SUBSCRIPT: 392,
+    ProducerFamily.BINOP: 367,
     ProducerFamily.COMPARE: 181,
-    ProducerFamily.ATTRIBUTE: 51,
+    ProducerFamily.ATTRIBUTE: 53,
     ProducerFamily.UNARYOP: 13,
     ProducerFamily.BOOLOP: 2,
 }
@@ -318,55 +313,6 @@ def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
     )
 
 
-def _source_has_selected_family_demand(
-    source: str,
-    demands: Iterable[dict],
-    families: frozenset[ProducerFamily],
-) -> bool:
-    """Cheap fail-closed projection before native Sugar construction.
-
-    The managed CPython parser may only discard a source file that carries no
-    demand whose native body root could belong to ``families``.  Enrollment is
-    still decided by the Sugar tree below, and the fixed family denominator
-    refuses if this projection ever loses a site.
-    """
-    import ast
-
-    selected_names = {family.value for family in families}
-    demands_by_coordinate = {
-        (
-            demand.get("startLine"),
-            demand.get("startCol"),
-            demand.get("endLine"),
-            demand.get("endCol"),
-        )
-        for demand in demands
-    }
-    parsed = ast.parse(source)
-    for node in ast.walk(parsed):
-        if not isinstance(node, (ast.With, ast.AsyncWith)):
-            continue
-        coordinates = {
-            (
-                item.context_expr.lineno,
-                item.context_expr.col_offset,
-                item.context_expr.end_lineno,
-                item.context_expr.end_col_offset,
-            )
-            for item in node.items
-        }
-        if not coordinates.intersection(demands_by_coordinate):
-            continue
-        if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
-            continue
-        expression = node.body[0].value
-        # Outer-node law: nested Calls (values[index()]) do not reclassify
-        # the body. Bare Call roots are excluded by selected_names.
-        if type(expression).__name__ in selected_names:
-            return True
-    return False
-
-
 def discover_no_call_body_probes(
     payload: dict,
     corpus_root: Path,
@@ -375,10 +321,12 @@ def discover_no_call_body_probes(
 ) -> tuple[BodyProbe, ...]:
     """Project authenticated assertion demands to their native body producer.
 
-    ``targetSymbol`` is consumed as authenticated import testimony from the
-    shared table.  It selects the measurement population only; it grants no
-    semantic behavior to a manager or producer.
+    Every resolved context-manager demand participates.  The native body root
+    selects the producer family; no manager or vendor spelling selects it or
+    grants semantic behavior to a producer.
     """
+    import ast
+
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
@@ -403,6 +351,23 @@ def discover_no_call_body_probes(
         UnaryOp: ProducerFamily.UNARYOP,
         BoolOp: ProducerFamily.BOOLOP,
     }
+    selected_families = families or frozenset(ProducerFamily)
+    family_by_type = {
+        node_type: family
+        for node_type, family in family_by_type.items()
+        if family in selected_families
+    }
+    native_type_by_family = {
+        ProducerFamily.SUBSCRIPT: ast.Subscript,
+        ProducerFamily.BINOP: ast.BinOp,
+        ProducerFamily.COMPARE: ast.Compare,
+        ProducerFamily.ATTRIBUTE: ast.Attribute,
+        ProducerFamily.UNARYOP: ast.UnaryOp,
+        ProducerFamily.BOOLOP: ast.BoolOp,
+    }
+    selected_native_types = tuple(
+        native_type_by_family[family] for family in selected_families
+    )
     paths_by_cid = {}
     for path in SourceTree(corpus_root).paths():
         paths_by_cid[blake3_512_of(path.read_bytes())] = path
@@ -412,7 +377,6 @@ def discover_no_call_body_probes(
         if (
             row.get("kind") != "context-manager-demand"
             or row.get("gapKind") is not None
-            or row.get("targetSymbol") != "pytest.raises"
         ):
             continue
         use_site = row.get("useSite") or {}
@@ -429,28 +393,66 @@ def discover_no_call_body_probes(
                 f"demand table names source CID absent from authenticated corpus: {source_cid}"
             )
         source = path.read_text(encoding="utf-8")
-        if families is not None and not _source_has_selected_family_demand(
-            source, demands, families
-        ):
+        candidate_spans = set()
+        for node in ast.walk(ast.parse(source, filename=str(path))):
+            if not isinstance(node, (ast.With, ast.AsyncWith)):
+                continue
+            if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
+                continue
+            if not isinstance(node.body[0].value, selected_native_types):
+                continue
+            for item in node.items:
+                manager = item.context_expr
+                candidate_spans.add(
+                    (
+                        manager.lineno,
+                        manager.col_offset,
+                        manager.end_lineno,
+                        manager.end_col_offset,
+                    )
+                )
+        demands = [
+            use_site
+            for use_site in demands
+            if (
+                use_site.get("startLine"),
+                use_site.get("startCol"),
+                use_site.get("endLine"),
+                use_site.get("endCol"),
+            )
+            in candidate_spans
+        ]
+        if not demands:
             continue
         tree = SourceFile(
             (source, str(path), source_cid),
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
         )
+        managers_by_span: dict[tuple[int, int, int, int], list[With]] = {}
+        for node in tree.nodes():
+            if not isinstance(node, With):
+                continue
+            for item in node.items:
+                span = item.context_expr.line_col_span()
+                managers_by_span.setdefault(
+                    (
+                        span.start_line,
+                        span.start_col,
+                        span.end_line,
+                        span.end_col,
+                    ),
+                    [],
+                ).append(node)
         for use_site in demands:
-            managers = []
-            for node in tree.nodes():
-                if not isinstance(node, With):
-                    continue
-                for item in node.items:
-                    span = item.context_expr.line_col_span()
-                    if (
-                        span.start_line == use_site.get("startLine")
-                        and span.start_col == use_site.get("startCol")
-                        and span.end_line == use_site.get("endLine")
-                        and span.end_col == use_site.get("endCol")
-                    ):
-                        managers.append(node)
+            managers = managers_by_span.get(
+                (
+                    use_site.get("startLine"),
+                    use_site.get("startCol"),
+                    use_site.get("endLine"),
+                    use_site.get("endCol"),
+                ),
+                (),
+            )
             if len(managers) != 1:
                 raise AttributionInvariantError(
                     f"assertion demand resolves to {len(managers)} With nodes: {use_site!r}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -67,8 +67,8 @@ def test_truthful_authenticated_body_is_counted_as_an_exceptional_exit() -> None
     assert report.bodies[0].outcome is AttributionOutcome.AUTHENTICATED_EXIT
 
 
-def test_named_refusal_is_not_counted_as_a_failure() -> None:
-    """Lying twin: refusing honestly must not inflate the failure frontier."""
+def test_declared_typed_gap_is_a_named_refusal_not_a_failure() -> None:
+    """Lying twin: declared refusal must not inflate the failure frontier."""
     report = attribute_body_probes((_probe(ProducerFamily.BINOP, _named_refusal),))
 
     row = report.by_family[ProducerFamily.BINOP]
@@ -100,18 +100,18 @@ def test_report_keeps_all_six_families_separate() -> None:
 
     assert tuple(report.by_family) == tuple(ProducerFamily)
     assert FAMILY_DENOMINATORS == {
-        ProducerFamily.SUBSCRIPT: 386,
-        ProducerFamily.BINOP: 349,
+        ProducerFamily.SUBSCRIPT: 392,
+        ProducerFamily.BINOP: 367,
         ProducerFamily.COMPARE: 181,
-        ProducerFamily.ATTRIBUTE: 51,
+        ProducerFamily.ATTRIBUTE: 53,
         ProducerFamily.UNARYOP: 13,
         ProducerFamily.BOOLOP: 2,
     }
-    assert sum(FAMILY_DENOMINATORS.values()) == 982
+    assert sum(FAMILY_DENOMINATORS.values()) == 1008
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
-def test_construction_panic_remains_a_separate_loud_axis() -> None:
+def test_escaped_construction_panic_remains_a_separate_loud_axis() -> None:
     report = attribute_body_probes(
         (_probe(ProducerFamily.ATTRIBUTE, _construction_panic),)
     )
@@ -120,6 +120,7 @@ def test_construction_panic_remains_a_separate_loud_axis() -> None:
     assert row.named_refusals == 0
     assert row.construction_panics == 1
     assert row.failures == 1
+    assert report.bodies[0].outcome is AttributionOutcome.CONSTRUCTION_PANIC
 
 
 def test_silent_completion_is_not_a_fourth_outcome() -> None:
@@ -163,7 +164,7 @@ def test_shared_table_accepts_only_the_canonical_content_manifest() -> None:
         )
 
 
-def test_discovery_uses_outer_body_producer_and_excludes_bare_call_bodies(
+def test_discovery_classifies_the_body_root_and_excludes_root_calls(
     tmp_path,
 ) -> None:
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -183,17 +184,17 @@ def test_discovery_uses_outer_body_producer_and_excludes_bare_call_bodies(
     call_path = package / "call_body.py"
     call_source = "def g():\n    with boundary(TypeError):\n        opaque()\n"
     call_path.write_text(call_source, encoding="utf-8")
-    nested_call_path = package / "nested_call_subscript_body.py"
-    nested_call_source = (
-        "def h(values):\n" "    with boundary(TypeError):\n" "        values[index()]\n"
+    binop_path = package / "binop_body.py"
+    binop_source = (
+        "def h():\n" "    with boundary(TypeError):\n" "        opaque() + 1\n"
     )
-    nested_call_path.write_text(nested_call_source, encoding="utf-8")
+    binop_path.write_text(binop_source, encoding="utf-8")
 
     rows = []
     for path, source in (
         (subscript_path, subscript_source),
         (call_path, call_source),
-        (nested_call_path, nested_call_source),
+        (binop_path, binop_source),
     ):
         source_cid = blake3_512_of(source.encode())
         tree = SourceFile(
@@ -206,7 +207,9 @@ def test_discovery_uses_outer_body_producer_and_excludes_bare_call_bodies(
             {
                 "kind": "context-manager-demand",
                 "gapKind": None,
-                "targetSymbol": "pytest.raises",
+                "targetSymbol": (
+                    "native.boundary" if path == binop_path else "pytest.raises"
+                ),
                 "useSite": {
                     "sourceCid": source_cid,
                     "startLine": span.start_line,
@@ -219,11 +222,16 @@ def test_discovery_uses_outer_body_producer_and_excludes_bare_call_bodies(
 
     probes = discover_no_call_body_probes({"rows": rows}, package)
 
-    assert len(probes) == 2
-    assert all(probe.family is ProducerFamily.SUBSCRIPT for probe in probes)
-    assert [probe.body_id for probe in probes] == [
-        "nested_call_subscript_body.py:3:Subscript",
-        "subscript_body.py:3:Subscript",
+    assert [(probe.family, probe.body_id) for probe in probes] == [
+        (ProducerFamily.BINOP, "binop_body.py:3:BinOp"),
+        (ProducerFamily.SUBSCRIPT, "subscript_body.py:3:Subscript"),
+    ]
+
+    binop_only = discover_no_call_body_probes(
+        {"rows": rows}, package, families=frozenset({ProducerFamily.BINOP})
+    )
+    assert [(probe.family, probe.body_id) for probe in binop_only] == [
+        (ProducerFamily.BINOP, "binop_body.py:3:BinOp")
     ]
 
 
@@ -311,8 +319,5 @@ def test_selected_family_denominator_remains_fixed() -> None:
         )
 
 
-def test_attribute_family_denominator_is_outer_body_inventory() -> None:
-    """Outer-body law measures Attribute 51 (historical no-Call-descendant pin was 41)."""
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 51
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 53
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 41
+def test_attribute_family_denominator_is_native_root_inventory() -> None:
+    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 53


### PR DESCRIPTION
## What changed

- classify no-call producer populations by the native body-root shape, independent of manager/vendor spelling
- keep nested calls inside a BinOp/Attribute/etc. in that root producer family
- count typed `ConstructionPanic` gaps as named refusals (`panic = gap`)
- add fixed-denominator family selection and prefilter irrelevant sources before authenticated construction
- index manager spans once per source to avoid repeated full-tree scans

## Why

The initial #6511 instrument filtered on `pytest.raises` and excluded any body containing a descendant Call. Against the authenticated pandas 3.0.3 corpus, that enrolled only 288 of the verified 367 BinOp roots. The producer-family boundary is the root native expression, and the manager spelling grants no semantic behavior.

## Authenticated result

Under CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, canonical corpus `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`, and shared demand table #6464:

`family=BinOp enrolled=367 authenticatedExceptionalExit=0 namedRefusal=367 constructionPanic=0`

The authenticated Call peer-law suite passes. A corpus-wide Call assertion-boundary delta remains refused because the table does not structurally distinguish assertion consumers from ordinary resource managers; selecting the apparent subset by symbol would be a vendor side door.

## Validation

- exact runtime pins: Python 3.12.13 / NumPy 2.5.1 / pandas 3.0.3
- local focused: `10 passed`
- authenticated focused via `bin/bpytest`: `14 passed`
- mutation transaction: clean / manager-symbol mutation / intended test failure / reverted / clean
- authenticated BinOp/367 attribution: exit 0, 367 named refusals, 0 construction panics


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Measure native producer families without manager names in no-call body attribution
> - Updates `discover_no_call_body_probes` to accept any context-manager demand with `gapKind` None, rather than filtering to `pytest.raises` targets; the native body root expression type now determines the producer family.
> - Replaces the deleted `_source_has_selected_family_demand` pre-filter with an AST-based scan that finds `With`/`AsyncWith` nodes whose bodies are a single `Expr` of a selected native type, excluding root `Call` expressions.
> - Reclassifies `ConstructionPanic` exceptions as `NAMED_REFUSAL` outcomes (using `panic.info.owner`) instead of `CONSTRUCTION_PANIC`.
> - Updates the `ATTRIBUTE` family denominator from 41 to 53 to reflect the expanded inventory.
> - Behavioral Change: discovery can now return multiple probes per source and covers non-`pytest.raises` context-manager demands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1856096. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->