### PR TITLE
Name undecided attribute producer refusals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the authenticated 982 outer-body producer-family attribution.
+"""Run attribution for 1,008 assertion bodies whose root is not a Call.
 
 This entry point intentionally has no unauthenticated or build fallback.  Use
 ``bin/bpytest`` / ``sugar-bx.sh`` so CPython 3.12.13, NumPy 2.5.1, the canonical

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -598,11 +598,12 @@ class FloorValue:
 
     def undecided_attribute(self, name, site, *, owner: str):
         """Refuse lookup when source testimony decides neither outgoing edge."""
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_source_tree.panic import SugarNotWritten
 
-        construction_panic_gap(
+        del site
+
+        raise SugarNotWritten(
             owner=owner,
-            blame=site,
             observed=(
                 "undecided receiver runtime type or member semantics: "
                 f"{type(self).__name__}.{name}"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -6,10 +6,9 @@ to exactly one producer family and exactly one of three outcomes.  A named
 ``SugarNotWritten`` refusal is accounted semantics, not a failure.  A
 ``ConstructionPanic`` remains a separate loud axis.
 
-Family denominators are the authenticated outer-body inventory on the
-pandas 3.0.3 corpus + #6464 demand table under the outer-node-not-Call law
-(Subscript 386, BinOp 349, Compare 181, Attribute 51, UnaryOp 13, BoolOp 2;
-sum 982). Nested Call descendants do not reclassify an outer producer.
+The producer family is the body's root expression. Calls used to construct an
+Attribute receiver remain children of that Attribute producer; they do not
+reclassify the raising operation as a Call.
 """
 
 from __future__ import annotations
@@ -48,10 +47,10 @@ class ProducerFamily(str, Enum):
 
 
 FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
-    ProducerFamily.SUBSCRIPT: 386,
-    ProducerFamily.BINOP: 349,
+    ProducerFamily.SUBSCRIPT: 392,
+    ProducerFamily.BINOP: 367,
     ProducerFamily.COMPARE: 181,
-    ProducerFamily.ATTRIBUTE: 51,
+    ProducerFamily.ATTRIBUTE: 53,
     ProducerFamily.UNARYOP: 13,
     ProducerFamily.BOOLOP: 2,
 }
@@ -345,9 +344,10 @@ def discover_no_call_body_probes(
 ) -> tuple[BodyProbe, ...]:
     """Project authenticated assertion demands to their native body producer.
 
-    ``targetSymbol`` is consumed as authenticated import testimony from the
-    shared table.  It selects the measurement population only; it grants no
-    semantic behavior to a manager or producer.
+    A resolved ``context-manager-demand`` row is authenticated preconstruction
+    testimony from the shared table. ``targetSymbol`` is deliberately ignored:
+    it grants neither population membership nor semantic behavior to a manager
+    or producer.
     """
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
@@ -382,7 +382,6 @@ def discover_no_call_body_probes(
         if (
             row.get("kind") != "context-manager-demand"
             or row.get("gapKind") is not None
-            or row.get("targetSymbol") != "pytest.raises"
         ):
             continue
         use_site = row.get("useSite") or {}
@@ -467,7 +466,9 @@ def require_expected_denominators(
 ) -> tuple[BodyProbe, ...]:
     """Refuse a different inventory instead of printing incomparable counts."""
     materialized = tuple(probes)
-    selected_families = tuple(ProducerFamily) if families is None else tuple(families)
+    selected_families = tuple(
+        family for family in ProducerFamily if families is None or family in families
+    )
     observed = {
         family: sum(probe.family is family for probe in materialized)
         for family in selected_families

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -11,18 +11,16 @@ import subprocess
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.floor import CallSiteValue, NoneValue, SymbolicValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Attribute
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
-CORPUS_ROOT = Path("/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages")
-SITE = CORPUS_ROOT / "pandas/tests/test_register_accessor.py"
 SITE_SHA256 = "4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793"
 SOURCE_CID = (
     "blake3-512:43cdd8a4f204ef75c77996a7e7a98b84bcd174de708cfe1e9e430415bbd636e2"
@@ -42,10 +40,14 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
+def _site() -> Path:
+    return authenticated_pandas_corpus().root / "tests/test_register_accessor.py"
+
+
 def _site_attribute(source: str) -> Attribute:
     assert blake3_512_of(source.encode()) == SOURCE_CID
     tree = SourceFile(
-        workspace_path_source(str(SITE), root=str(CORPUS_ROOT)),
+        (source, str(_site()), SOURCE_CID),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     matches = tuple(
@@ -88,18 +90,18 @@ def _assert_undecided(node: Attribute, receiver, *, name: str | None = None) -> 
         receiver=_ReceiverSugar(receiver),
         name=node.attr if name is None else name,
     )
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         operation.desugar(None)
-    info = raised.value.info
-    assert info.owner == f"{type(receiver).__name__}.attribute"
-    assert "undecided" in info.observed
+    refusal = raised.value
+    assert refusal.owner == f"{type(receiver).__name__}.attribute"
+    assert "undecided" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (
-        info.requested
+        refusal.requested
     )
-    assert "AttributeError" not in info.observed
-    assert "AttributeError" not in info.requested
-    assert "RuntimeEffect" not in info.observed
-    assert "RuntimeEffect" not in info.requested
+    assert "AttributeError" not in refusal.observed
+    assert "AttributeError" not in refusal.requested
+    assert "RuntimeEffect" not in refusal.observed
+    assert "RuntimeEffect" not in refusal.requested
 
 
 def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) -> None:
@@ -156,7 +158,7 @@ def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) 
 
 
 def test_real_pandas_constructed_receiver_attribute_is_named_undecided() -> None:
-    source = SITE.read_text(encoding="utf-8")
+    source = _site().read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
     node = _site_attribute(source)
 
@@ -164,7 +166,7 @@ def test_real_pandas_constructed_receiver_attribute_is_named_undecided() -> None
 
 
 def test_symbolic_receiver_attribute_is_the_same_named_third_value() -> None:
-    source = SITE.read_text(encoding="utf-8")
+    source = _site().read_text(encoding="utf-8")
     node = _site_attribute(source)
 
     _assert_undecided(node, SymbolicValue(make_var("series")))
@@ -178,7 +180,7 @@ def test_lying_known_member_does_not_license_blanket_attribute_error() -> None:
 
 
 def test_replacing_bad_with_known_member_still_cannot_invent_an_exit() -> None:
-    source = SITE.read_text(encoding="utf-8")
+    source = _site().read_text(encoding="utf-8")
     assert source.count("pd.Series([], dtype=object).bad") == 1
     lying = source.replace(
         "pd.Series([], dtype=object).bad",
@@ -189,11 +191,9 @@ def test_replacing_bad_with_known_member_still_cannot_invent_an_exit() -> None:
     _assert_undecided(_site_attribute(source), _call_result(), name="__class__")
 
 
-# --- No-call Attribute family corpus pins (denominator 41) -----------------
+# --- Attribute-root family corpus pins (denominator 53) --------------------
 # Bare desugar without bindings yields SymbolicValue receivers; the producer
-# must keep the third value as ConstructionPanic(owner=SymbolicValue.attribute)
-# rather than invent AttributeError. These sites are enrolled Attribute bodies
-# under the no-Call-descendant law.
+# must keep the third value as a named refusal rather than invent AttributeError.
 
 
 def _authenticated_corpus_file(relative: str) -> Path:
@@ -227,18 +227,18 @@ def _line_attribute(source: str, path: Path, *, line: int, attr: str) -> Attribu
 
 def _assert_bare_desugar_symbolic_attribute(node: Attribute) -> None:
     """Production door: expression.sugar().desugar(None) with no bindings."""
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         node.sugar().desugar(None)
-    info = raised.value.info
-    assert info.owner == "SymbolicValue.attribute"
-    assert "undecided" in info.observed
+    refusal = raised.value
+    assert refusal.owner == "SymbolicValue.attribute"
+    assert "undecided" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (
-        info.requested
+        refusal.requested
     )
-    assert "AttributeError" not in info.observed
-    assert "AttributeError" not in info.requested
-    assert "RuntimeEffect" not in info.observed
-    assert "RuntimeEffect" not in info.requested
+    assert "AttributeError" not in refusal.observed
+    assert "AttributeError" not in refusal.requested
+    assert "RuntimeEffect" not in refusal.observed
+    assert "RuntimeEffect" not in refusal.requested
 
 
 @pytest.mark.parametrize(
@@ -265,7 +265,7 @@ def test_no_call_attribute_corpus_sites_stay_symbolic_undecided(
 def test_binop_child_np_nan_reattributes_to_attribute_owner() -> None:
     """BinOp ``s_0123 & np.nan`` child-evaluates ``.nan`` on SymbolicValue.
 
-    That panic is Attribute-family coordinate (owner SymbolicValue.attribute),
+    That refusal is Attribute-family coordinate (owner SymbolicValue.attribute),
     not binary_operation_exception_floor. Keep the owner name honest when a
     BinOp site is a parent of Attribute evaluation.
     """
@@ -287,11 +287,11 @@ def test_binop_child_np_nan_reattributes_to_attribute_owner() -> None:
         and node.line_col_span().start_line == 96
     )
     assert len(matches) == 1
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         matches[0].sugar().desugar(None)
-    info = raised.value.info
-    assert info.owner == "SymbolicValue.attribute"
-    assert "SymbolicValue.nan" in info.observed
+    refusal = raised.value
+    assert refusal.owner == "SymbolicValue.attribute"
+    assert "SymbolicValue.nan" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (
-        info.requested
+        refusal.requested
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
@@ -18,16 +18,16 @@ def _guard():
 
 
 def test_guarded_attribute_keeps_symbolic_face_refusal_loud():
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_source_tree.panic import SugarNotWritten
 
     true_face = SymbolicValue(make_var("t"))
     false_face = SymbolicValue(make_var("f"))
     guarded = GuardedValue(_guard(), true_face, false_face)
     try:
         guarded.attribute("x", "site")
-    except ConstructionPanic as panic:
-        assert panic.info.owner == "SymbolicValue.attribute"
-        assert panic.info.observed.endswith("SymbolicValue.x")
+    except SugarNotWritten as refusal:
+        assert refusal.owner == "SymbolicValue.attribute"
+        assert refusal.observed.endswith("SymbolicValue.x")
     else:
         raise AssertionError("guarded symbolic attribute invented completion")
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -83,14 +83,14 @@ def test_report_keeps_all_six_families_separate() -> None:
 
     assert tuple(report.by_family) == tuple(ProducerFamily)
     assert FAMILY_DENOMINATORS == {
-        ProducerFamily.SUBSCRIPT: 386,
-        ProducerFamily.BINOP: 349,
+        ProducerFamily.SUBSCRIPT: 392,
+        ProducerFamily.BINOP: 367,
         ProducerFamily.COMPARE: 181,
-        ProducerFamily.ATTRIBUTE: 51,
+        ProducerFamily.ATTRIBUTE: 53,
         ProducerFamily.UNARYOP: 13,
         ProducerFamily.BOOLOP: 2,
     }
-    assert sum(FAMILY_DENOMINATORS.values()) == 982
+    assert sum(FAMILY_DENOMINATORS.values()) == 1008
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
@@ -224,9 +224,7 @@ def test_discovery_projects_one_family_without_constructing_peer_sources(
     package.mkdir()
     sources = {
         "attribute_body.py": (
-            "def f(series):\n"
-            "    with boundary(AttributeError):\n"
-            "        series.bad\n"
+            "def f():\n    with boundary(AttributeError):\n        factory().bad\n"
         ),
         "subscript_body.py": (
             "def g(value):\n    with boundary(IndexError):\n        value[2]\n"
@@ -250,7 +248,11 @@ def test_discovery_projects_one_family_without_constructing_peer_sources(
             {
                 "kind": "context-manager-demand",
                 "gapKind": None,
-                "targetSymbol": "pytest.raises",
+                "targetSymbol": (
+                    "authenticated.boundary"
+                    if filename == "attribute_body.py"
+                    else "authenticated.resource"
+                ),
                 "useSite": {
                     "sourceCid": source_cid,
                     "startLine": span.start_line,
@@ -292,10 +294,3 @@ def test_selected_family_denominator_remains_fixed() -> None:
         require_expected_denominators(
             probes[:-1], families=frozenset({ProducerFamily.ATTRIBUTE})
         )
-
-
-def test_attribute_family_denominator_is_outer_body_inventory() -> None:
-    """Outer-body law measures Attribute 51 (historical no-Call-descendant pin was 41)."""
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 51
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 53
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] != 41

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -16,6 +16,7 @@ from sugar_source_tree.tree import SourceFile
 
 def _attribute_refusal(src):
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_source_tree.panic import SugarNotWritten
 
     directory = tempfile.mkdtemp()
     path = os.path.join(directory, "m.py")
@@ -24,6 +25,8 @@ def _attribute_refusal(src):
     function = next(SourceFile(path_source(path)).functions())
     try:
         function.sugar().desugar(None)
+    except SugarNotWritten as refusal:
+        return refusal
     except ConstructionPanic as panic:
         return panic.info
     raise AssertionError("opaque member operation invented a completed coordinate")
@@ -63,10 +66,12 @@ def test_opaque_subscript_is_named_undecided():
     assert "IndexError" not in refusal.observed
 
 
-def test_opaque_attribute_uses_the_typed_construction_refusal():
+def test_opaque_attribute_uses_the_named_refusal_arm():
     info = _attribute_refusal("def f(x):\n    return g(x).foo\n")
 
-    assert info.gap_locus.value == "Construction"
+    from sugar_source_tree.panic import SugarNotWritten
+
+    assert isinstance(info, SugarNotWritten)
     assert "AttributeError" not in info.observed
     assert "AttributeError" not in info.requested
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -89,6 +89,20 @@ def _binop_at(source: str, path: Path, *, line: int, kind: str):
     return matches[0]
 
 
+def _assert_named_refusal(node, *, owner: str, observed_contains: str) -> None:
+    from sugar_source_tree.panic import SugarNotWritten
+
+    with pytest.raises(SugarNotWritten) as raised:
+        node.sugar().desugar(None)
+    refusal = raised.value
+    assert refusal.owner == owner
+    assert observed_contains in refusal.observed
+    assert "AttributeError" not in refusal.observed
+    assert "AttributeError" not in refusal.requested
+    assert "RuntimeEffect" not in refusal.observed
+    assert "RuntimeEffect" not in refusal.requested
+
+
 def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> None:
     """Truthful/lying runtime twins cannot license invented source testimony.
 
@@ -114,14 +128,11 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
     assert (series & 0).tolist() == [0, 0, 0, 0]
 
     lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
-    _assert_named_panic(
+    _assert_named_refusal(
         _line_96_bitand(truthful, path),
         owner="SymbolicValue.attribute",
-        observed=(
+        observed_contains=(
             "undecided receiver runtime type or member semantics: SymbolicValue.nan"
-        ),
-        requested_contains=(
-            "source-authenticated attribute success or exceptional exit"
         ),
     )
     _assert_named_panic(


### PR DESCRIPTION
## Summary
- restore the authenticated Attribute-root denominator to 53, retaining Attribute receivers constructed by calls
- classify resolved context-manager demands structurally without a pytest/pandas/warnings spelling gate
- reattribute undecided Attribute producers from ConstructionPanic to named SugarNotWritten refusals without inventing AttributeError
- authenticate the concrete pandas site by corpus CID instead of the withdrawn local Python 3.14 path

## Validation
- authenticated Attribute attribution: enrolled=53, namedRefusal=53, constructionPanic=0, exit 0
- Battleaxe focused reproducer: 1 passed under CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3
- post-rebase focused suite: 45 passed
- mutation transaction: old construction panic restored -> concrete law failed; reverted -> passed
- black and git diff checks clean

Base supplied: 09d9cc800. Rebased onto current origin/main 984db5261. Do not merge automatically.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `construction_panic_gap` with `SugarNotWritten` for undecided attribute producer refusals
> - `FloorValue.undecided_attribute` now raises `SugarNotWritten(owner, observed, requested, fix)` directly instead of emitting a `ConstructionPanic` via `construction_panic_gap`.
> - All tests updated to catch `SugarNotWritten` and assert on `refusal.owner`, `refusal.observed`, and `refusal.requested` instead of accessing `panic.info`.
> - `no_call_body_attribution` probe discovery now includes any `context-manager-demand` row with `gapKind=None`, not only those with `targetSymbol=='pytest.raises'`; family denominators updated (SUBSCRIPT 392, BINOP 367, ATTRIBUTE 53, sum 1008).
> - Behavioral Change: code that previously caught `ConstructionPanic` from undecided attribute lookups must now catch `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c006a75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->