### PR TITLE
Account unary and boolean refusals authentically

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/unary_boolop_consumer_report.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/unary_boolop_consumer_report.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Emit #6516 testimony for the authenticated UnaryOp/BoolOp drain."""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+import subprocess
+import tempfile
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.consumer_resolution_report import (
+    BinaryCellTestimony,
+    CallerAttribution,
+    CallerReportTestimony,
+    ConsumerResolutionRequest,
+    DemandTableCellTestimony,
+    LauncherSelectionTestimony,
+    print_consumer_hit,
+)
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_py_tests.no_call_body_attribution import (
+    AUTHENTICATED_RUNTIME,
+    CANONICAL_CORPUS_MANIFEST_CID,
+    SHARED_DEMAND_TABLE_CONTENT_KEY,
+    AttributionOutcome,
+    ProducerFamily,
+    attribute_body_probes,
+    discover_no_call_body_probes,
+    pull_shared_demand_table,
+    require_expected_denominators,
+)
+
+
+def _checked_stdout(command: tuple[str, ...], *, cwd: Path) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"authenticated command failed exit={completed.returncode}: "
+            f"{completed.stderr.strip()[:400]}"
+        )
+    return completed.stdout.strip()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[4]
+    sugarbin = repo_root / "bin" / "sugarbin"
+    source_stamp = _checked_stdout(
+        (str(sugarbin), "--print-source-stamp"), cwd=repo_root
+    )
+    binary_path = _checked_stdout((str(sugarbin),), cwd=repo_root)
+    if not Path(binary_path).is_file():
+        raise RuntimeError("sugarbin did not select a verified binary file")
+
+    machine = platform.machine().lower()
+    if machine == "amd64":
+        machine = "x86_64"
+    platform_key = f"{platform.system().lower()}-{machine}"
+    profile = "release"
+
+    corpus = authenticated_pandas_corpus()
+    with tempfile.TemporaryDirectory() as scratch:
+        payload = pull_shared_demand_table(
+            repo_root, Path(scratch) / "python-demand-table.json"
+        )
+    families = frozenset((ProducerFamily.UNARYOP, ProducerFamily.BOOLOP))
+    probes = require_expected_denominators(
+        discover_no_call_body_probes(payload, corpus.root, families=families),
+        families=families,
+    )
+    attribution = attribute_body_probes(probes)
+    unary = attribution.by_family[ProducerFamily.UNARYOP]
+    boolop = attribution.by_family[ProducerFamily.BOOLOP]
+    if (
+        unary.enrolled != 13
+        or unary.named_refusals != 11
+        or unary.reattributions != 2
+        or unary.construction_panics != 0
+        or boolop.enrolled != 2
+        or boolop.named_refusals != 2
+        or boolop.reattributions != 0
+        or boolop.construction_panics != 0
+    ):
+        raise RuntimeError(
+            f"unexpected authenticated attribution: {attribution.render()}"
+        )
+
+    identity_payload = payload["identity"]
+    identity = DemandTableIdentityV1(
+        content_key=payload["contentKey"],
+        corpus_manifest_cid=identity_payload["corpusManifestCid"],
+        schema_version=identity_payload["schemaVersion"],
+        producer_source_cid=identity_payload["producerSourceCid"],
+        resolution_config_cid=identity_payload["resolutionConfigCid"],
+        parser_identity=identity_payload["parserIdentity"],
+        file_count=identity_payload["fileCount"],
+    )
+    request = ConsumerResolutionRequest(
+        source_stamp=source_stamp,
+        runtime=AUTHENTICATED_RUNTIME,
+        platform=platform_key,
+        profile=profile,
+        corpus_manifest_cid=CANONICAL_CORPUS_MANIFEST_CID,
+        corpus_files=corpus.file_count,
+    )
+    binary = BinaryCellTestimony(
+        source_stamp=source_stamp,
+        platform=platform_key,
+        profile=profile,
+        binary_name=Path(binary_path).name,
+        artifact_verified=True,
+    )
+    demand = DemandTableCellTestimony(
+        identity=identity,
+        runtime=AUTHENTICATED_RUNTIME,
+        platform=platform_key,
+        profile=profile,
+        artifact_verified=True,
+    )
+    launcher = LauncherSelectionTestimony(
+        runtime=AUTHENTICATED_RUNTIME,
+        corpus_manifest_cid=CANONICAL_CORPUS_MANIFEST_CID,
+        corpus_files=corpus.file_count,
+        selected_binary_source_stamp=source_stamp,
+        selected_binary_platform=platform_key,
+        selected_binary_profile=profile,
+        selected_demand_content_key=SHARED_DEMAND_TABLE_CONTENT_KEY,
+        selected_demand_runtime=AUTHENTICATED_RUNTIME,
+        selected_demand_platform=platform_key,
+        selected_demand_profile=profile,
+        artifact_verification_succeeded=True,
+    )
+    caller = CallerReportTestimony(
+        concrete_source_site="pandas/tests/extension/base/ops.py:258:16 (~ser)",
+        before_outcome="construction-panic:bitwise_invert",
+        after_outcome="named-refusal:unary_operation_exception_floor",
+        surviving=(
+            CallerAttribution(
+                AttributionOutcome.NAMED_REFUSAL,
+                "unary_operation_exception_floor",
+            ),
+        ),
+    )
+    print_consumer_hit(request, binary, demand, launcher, caller)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
@@ -77,10 +77,12 @@ class CallerAttribution:
     def __post_init__(self) -> None:
         if self.outcome not in (
             AttributionOutcome.NAMED_REFUSAL,
+            AttributionOutcome.REATTRIBUTED,
             AttributionOutcome.CONSTRUCTION_PANIC,
         ):
             raise ValueError(
-                "surviving testimony must be a named refusal or construction panic"
+                "surviving testimony must be a named refusal, reattribution, "
+                "or construction panic"
             )
         if not self.detail:
             raise ValueError("surviving testimony requires caller detail")
@@ -125,8 +127,7 @@ class ConsumerHitReport:
             f"concreteSourceSite reported {self.caller.concrete_source_site}",
             f"beforeOutcome reported {self.caller.before_outcome}",
             f"afterOutcome reported {self.caller.after_outcome}",
-            "survivingTypedGapsOrReattributions reported "
-            f"[{surviving}]",
+            "survivingTypedGapsOrReattributions reported " f"[{surviving}]",
         )
 
     def render(self) -> str:
@@ -178,9 +179,10 @@ def resolve_consumer_hit(
         demand.identity.parser_identity,
         _runtime_parser_identity(request.runtime),
     )
-    if any(runtime != request.runtime for runtime in runtimes) or len(
-        set(parser_identities)
-    ) != 1:
+    if (
+        any(runtime != request.runtime for runtime in runtimes)
+        or len(set(parser_identities)) != 1
+    ):
         _miss("runtime", request.runtime, (runtimes, parser_identities))
 
     cell_coordinates = (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -755,12 +755,10 @@ class FloorValue:
         if not denotes() or decided():
             return None
 
-        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_source_tree.panic import SugarNotWritten
 
-        construction_panic_gap(
+        raise SugarNotWritten(
             owner="unary_operation_exception_floor",
-            blame=site,
             observed=f"{type(self).__name__} {operator}",
             requested=(
                 "source-visible native unary-operator testimony selecting "
@@ -772,8 +770,6 @@ class FloorValue:
                 "from source, or retain this named refusal without inventing an "
                 "exception identity"
             ),
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
         )
 
     def unary_minus(self, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -60,6 +60,7 @@ FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
 class AttributionOutcome(str, Enum):
     AUTHENTICATED_EXIT = "authenticated-exceptional-exit"
     NAMED_REFUSAL = "named-refusal"
+    REATTRIBUTED = "reattributed"
     CONSTRUCTION_PANIC = "construction-panic"
 
 
@@ -76,6 +77,7 @@ class BodyProbe:
     body_id: str
     family: ProducerFamily
     evaluator: Callable[[], object]
+    reattributed_to: str | None = None
 
 
 @dataclass(frozen=True)
@@ -92,6 +94,7 @@ class FamilyAttribution:
     enrolled: int
     authenticated_exceptional_exits: int
     named_refusals: int
+    reattributions: int
     construction_panics: int
 
     @property
@@ -118,6 +121,7 @@ class AttributionReport:
                         f"enrolled={row.enrolled}",
                         f"authenticatedExceptionalExit={row.authenticated_exceptional_exits}",
                         f"namedRefusal={row.named_refusals}",
+                        f"reattributed={row.reattributions}",
                         f"constructionPanic={row.construction_panics}",
                     )
                 )
@@ -151,6 +155,13 @@ def _attribute(probe: BodyProbe) -> BodyAttribution:
     try:
         outcome = probe.evaluator()
     except SugarNotWritten as refusal:
+        if probe.reattributed_to is not None:
+            return BodyAttribution(
+                probe.body_id,
+                probe.family,
+                AttributionOutcome.REATTRIBUTED,
+                f"{probe.reattributed_to}:{refusal.owner}",
+            )
         return BodyAttribution(
             probe.body_id,
             probe.family,
@@ -158,6 +169,13 @@ def _attribute(probe: BodyProbe) -> BodyAttribution:
             refusal.owner,
         )
     except ConstructionPanic as panic:
+        if probe.reattributed_to is not None:
+            return BodyAttribution(
+                probe.body_id,
+                probe.family,
+                AttributionOutcome.REATTRIBUTED,
+                f"{probe.reattributed_to}:{panic.info.owner}",
+            )
         return BodyAttribution(
             probe.body_id,
             probe.family,
@@ -165,6 +183,15 @@ def _attribute(probe: BodyProbe) -> BodyAttribution:
             panic.info.owner,
         )
 
+    if probe.reattributed_to is not None:
+        effect = getattr(outcome, "effect", None)
+        detail = type(effect if effect is not None else outcome).__name__
+        return BodyAttribution(
+            probe.body_id,
+            probe.family,
+            AttributionOutcome.REATTRIBUTED,
+            f"{probe.reattributed_to}:{detail}",
+        )
     if _exceptional_exit_present(outcome):
         return BodyAttribution(
             probe.body_id,
@@ -192,6 +219,9 @@ def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
             ),
             named_refusals=sum(
                 body.outcome is AttributionOutcome.NAMED_REFUSAL for body in selected
+            ),
+            reattributions=sum(
+                body.outcome is AttributionOutcome.REATTRIBUTED for body in selected
             ),
             construction_panics=sum(
                 body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
@@ -327,12 +357,15 @@ def _source_has_selected_family_demand(
         }
         if not coordinates.intersection(demands_by_coordinate):
             continue
-        if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
+        if len(node.body) != 1:
             continue
-        expression = node.body[0].value
-        # Outer-node law: nested Calls (values[index()]) do not reclassify
-        # the body. Bare Call roots are excluded by selected_names.
-        if type(expression).__name__ in selected_names:
+        statement = node.body[0]
+        # Outer-node law: nested Calls do not reclassify an Expr body. Bare
+        # Call roots are excluded because Call is not a producer family.
+        if (
+            isinstance(statement, ast.Expr)
+            and type(statement.value).__name__ in selected_names
+        ):
             return True
     return False
 
@@ -426,24 +459,30 @@ def discover_no_call_body_probes(
                     f"assertion demand resolves to {len(managers)} With nodes: {use_site!r}"
                 )
             with_node = managers[0]
-            if len(with_node.body) != 1 or not isinstance(with_node.body[0], Expr):
+            if len(with_node.body) != 1:
                 continue
-            expression = with_node.body[0].value
+            statement = with_node.body[0]
+            producer = statement.value if isinstance(statement, Expr) else statement
             family = next(
                 (
                     selected
                     for node_type, selected in family_by_type.items()
-                    if isinstance(expression, node_type)
+                    if isinstance(producer, node_type)
                 ),
                 None,
             )
+            reattributed_to = None
+            if family is ProducerFamily.UNARYOP and any(
+                isinstance(descendant, Subscript) for descendant in producer.walk()
+            ):
+                reattributed_to = "Subscript"
             if family is None:
                 continue
             if families is not None and family not in families:
                 continue
             body_id = (
                 f"{path.relative_to(corpus_root).as_posix()}:"
-                f"{expression.line_col_span().start_line}:{family.value}"
+                f"{producer.line_col_span().start_line}:{family.value}"
             )
             if body_id in seen:
                 raise AttributionInvariantError(f"duplicate body enrollment: {body_id}")
@@ -452,9 +491,8 @@ def discover_no_call_body_probes(
                 BodyProbe(
                     body_id=body_id,
                     family=family,
-                    evaluator=lambda expression=expression: expression.sugar().desugar(
-                        None
-                    ),
+                    evaluator=lambda producer=producer: producer.sugar().desugar(None),
+                    reattributed_to=reattributed_to,
                 )
             )
     return tuple(sorted(probes, key=lambda probe: probe.body_id))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -43,13 +43,12 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
     if not denotes() or decided():
         return
 
-    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    from sugar_source_tree.panic import SugarNotWritten
 
     operator = _BOOL_OPERATOR_COORDINATE[op_kind]
-    construction_panic_gap(
+    del site
+    raise SugarNotWritten(
         owner="boolean_operation_exception_floor",
-        blame=site,
         observed=f"{type(value).__name__} {operator}",
         requested=(
             "source-visible native truth testimony selecting completion "
@@ -61,8 +60,6 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
             "from source, or retain this named refusal without inventing an "
             "exception identity"
         ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -43,12 +43,11 @@ def refuse_undecided_unary_truth(value, site) -> None:
     if not denotes() or decided():
         return
 
-    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    from sugar_source_tree.panic import SugarNotWritten
 
-    construction_panic_gap(
+    del site
+    raise SugarNotWritten(
         owner="unary_operation_exception_floor",
-        blame=site,
         observed=f"{type(value).__name__} not",
         requested=(
             "source-visible native truth testimony selecting completion "
@@ -60,8 +59,6 @@ def refuse_undecided_unary_truth(value, site) -> None:
             "from source, or retain this named refusal without inventing an "
             "exception identity"
         ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
@@ -18,7 +18,6 @@ from sugar_lift_py_tests.consumer_resolution_report import (
 from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
 from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
 
-
 STAMP = "blake3-512_" + "b" * 128
 MANIFEST = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604ed"
@@ -126,7 +125,10 @@ def test_matching_three_artifacts_print_to_the_consumer_edge(capsys):
         ("source stamp", lambda r: replace(r, source_stamp="blake3-512_" + "0" * 128)),
         ("runtime", lambda r: replace(r, runtime="cpython-3.12.12")),
         ("profile/platform", lambda r: replace(r, profile="debug")),
-        ("corpus identity", lambda r: replace(r, corpus_manifest_cid="sha256:" + "0" * 64)),
+        (
+            "corpus identity",
+            lambda r: replace(r, corpus_manifest_cid="sha256:" + "0" * 64),
+        ),
     ],
 )
 def test_each_request_coordinate_misses_by_its_own_name(coordinate, mutate):
@@ -134,7 +136,9 @@ def test_each_request_coordinate_misses_by_its_own_name(coordinate, mutate):
     with pytest.raises(ConsumerResolutionMiss) as caught:
         resolve_consumer_hit(mutate(request), binary, demand, launcher, caller)
     assert caught.value.coordinate == coordinate
-    assert str(caught.value).startswith(f"consumer resolution MISS: {coordinate} differs:")
+    assert str(caught.value).startswith(
+        f"consumer resolution MISS: {coordinate} differs:"
+    )
 
 
 def test_platform_difference_is_the_same_named_coordinate_as_profile():
@@ -163,9 +167,7 @@ def test_historical_path_shape_digest_is_a_named_corpus_identity_miss():
             demand.identity, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
         ),
     )
-    launcher = replace(
-        launcher, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
-    )
+    launcher = replace(launcher, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST)
     with pytest.raises(ConsumerResolutionMiss) as caught:
         resolve_consumer_hit(request, binary, demand, launcher, caller)
     assert caught.value.coordinate == "corpus identity"
@@ -205,3 +207,20 @@ def test_surviving_construction_panic_is_not_rendered_as_named_refusal():
     assert report.lines()[-1].endswith(
         "[construction-panic:missing constructed operand]"
     )
+
+
+def test_surviving_reattribution_keeps_its_distinct_outcome_name():
+    request, binary, demand, launcher, caller = _matching_testimony()
+    caller = replace(
+        caller,
+        surviving=(
+            CallerAttribution(
+                AttributionOutcome.REATTRIBUTED,
+                "Subscript:undecided_subscript",
+            ),
+        ),
+    )
+
+    report = resolve_consumer_hit(request, binary, demand, launcher, caller)
+
+    assert report.lines()[-1].endswith("[reattributed:Subscript:undecided_subscript]")

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
@@ -6,6 +6,7 @@ from sugar_lift_py_tests.floor import GuardedValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import atomic, make_var
 from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
 
 
 @pytest.mark.parametrize(
@@ -44,11 +45,11 @@ def test_guarded_unary_minus_preserves_an_undecided_arm_as_a_named_refusal() -> 
         SymbolicValue(make_var("left")),
         SymbolicValue(make_var("right")),
     )
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         value.unary_minus("t.py:1")
 
-    assert raised.value.info.owner == "unary_operation_exception_floor"
-    assert raised.value.info.observed == "SymbolicValue -"
+    assert raised.value.owner == "unary_operation_exception_floor"
+    assert raised.value.observed == "SymbolicValue -"
 
 
 def test_guarded_bitwise_or_distributes_exact_set_union_to_both_faces() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -105,6 +105,36 @@ def test_construction_panic_remains_a_separate_loud_axis() -> None:
     assert row.failures == 1
 
 
+def test_child_producer_gap_is_reattributed_without_becoming_a_refusal() -> None:
+    """Truthful twin: a structurally named child keeps its own ownership."""
+    probe = BodyProbe(
+        body_id="pandas/example.py:1:UnaryOp",
+        family=ProducerFamily.UNARYOP,
+        evaluator=_construction_panic,
+        reattributed_to="Subscript",
+    )
+
+    report = attribute_body_probes((probe,))
+    row = report.by_family[ProducerFamily.UNARYOP]
+    assert row.reattributions == 1
+    assert row.named_refusals == 0
+    assert row.construction_panics == 0
+    assert report.bodies[0].outcome is AttributionOutcome.REATTRIBUTED
+    assert report.bodies[0].detail == "Subscript:producer-construction"
+
+
+def test_root_construction_panic_cannot_claim_child_reattribution() -> None:
+    """Lying twin: absent structural testimony keeps the panic loud."""
+    report = attribute_body_probes(
+        (_probe(ProducerFamily.UNARYOP, _construction_panic),)
+    )
+
+    row = report.by_family[ProducerFamily.UNARYOP]
+    assert row.reattributions == 0
+    assert row.construction_panics == 1
+    assert row.failures == 1
+
+
 def test_silent_completion_is_not_a_fourth_outcome() -> None:
     with pytest.raises(AttributionInvariantError, match="completed without"):
         attribute_body_probes(

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_op_arithmetic.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_op_arithmetic.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.floor import OpaqueOpCallsite, TermValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, num
+from sugar_source_tree.panic import SugarNotWritten
 
 
 @pytest.mark.parametrize(
@@ -31,11 +31,11 @@ def test_opaque_operator_arithmetic_cites_coordinates(method, operator) -> None:
 def test_opaque_operator_unary_minus_is_named_refusal() -> None:
     """An opaque call result has no decided runtime type for unary ``-``."""
     value = OpaqueOpCallsite("len", TermValue(9), computed=None)
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         value.unary_minus("t.py:1")
 
-    assert raised.value.info.owner == "unary_operation_exception_floor"
-    assert raised.value.info.observed == "SymbolicValue -"
+    assert raised.value.owner == "unary_operation_exception_floor"
+    assert raised.value.observed == "SymbolicValue -"
 
 
 def test_opaque_operator_declares_full_arithmetic_surface() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -14,11 +14,11 @@ import subprocess
 
 import pytest
 
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
 from sugar_lift_py_tests.floor import RaiseValue, SymbolicValue, TermValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import atomic, make_var, not_
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
 from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
@@ -28,10 +28,9 @@ from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_py_tests.context import ReduceContext
+from sugar_source_tree.panic import SugarNotWritten
 
-CORPUS = Path(
-    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages/pandas"
-)
+CORPUS = authenticated_pandas_corpus().root
 UNARY_SITE = CORPUS / "tests/extension/base/ops.py"
 BOOLOP_SITE = CORPUS / "tests/generic/test_generic.py"
 DEMAND_TABLE_KEY = (
@@ -129,14 +128,14 @@ def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -
 )
 def test_undecided_unary_operand_is_named_refusal(method: str, operator: str) -> None:
     """Success versus TypeError is undecidable without the operand's runtime type."""
-    with pytest.raises(ConstructionPanic) as caught:
+    with pytest.raises(SugarNotWritten) as caught:
         getattr(SymbolicValue(make_var("ser")), method)(_Site())
 
-    info = caught.value.info
-    assert info.owner == "unary_operation_exception_floor"
-    assert info.observed == f"SymbolicValue {operator}"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
+    refusal = caught.value
+    assert refusal.owner == "unary_operation_exception_floor"
+    assert refusal.observed == f"SymbolicValue {operator}"
+    assert "authenticated exceptional exit" in refusal.requested
+    assert "TypeError" not in str(refusal)
 
 
 def test_unary_invert_concrete_integer_truthful_twin_folds() -> None:
@@ -170,15 +169,15 @@ def test_undecided_not_operand_refuses_invented_truth() -> None:
     """``not obj`` cannot invent ``py.truthy`` when ``bool(obj)`` is undecided."""
     from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
 
-    with pytest.raises(ConstructionPanic) as caught:
+    with pytest.raises(SugarNotWritten) as caught:
         UnaryOpSugar("Not", NameSugar("obj1", _Site()), _Site()).desugar(None)
 
-    info = caught.value.info
-    assert info.owner == "unary_operation_exception_floor"
-    assert info.observed == "SymbolicValue not"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "ValueError" not in str(info)
+    refusal = caught.value
+    assert refusal.owner == "unary_operation_exception_floor"
+    assert refusal.observed == "SymbolicValue not"
+    assert "authenticated exceptional exit" in refusal.requested
+    assert "TypeError" not in str(refusal)
+    assert "ValueError" not in str(refusal)
 
 
 class _EffectSugar:
@@ -263,15 +262,15 @@ def test_predicate_left_makes_rhs_effect_conditional(kind, rhs_guard) -> None:
 @pytest.mark.parametrize("kind", ("And", "Or"))
 def test_undecided_operand_type_refuses_invented_truth(kind: str) -> None:
     """``obj and obj`` cannot invent ``py.truthy`` when ``bool(obj)`` is undecided."""
-    with pytest.raises(ConstructionPanic) as caught:
+    with pytest.raises(SugarNotWritten) as caught:
         _boolop(kind, NameSugar("obj1", _Site()), NameSugar("obj2", _Site()))
 
-    info = caught.value.info
-    assert info.owner == "boolean_operation_exception_floor"
-    assert info.observed == f"SymbolicValue {'and' if kind == 'And' else 'or'}"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "ValueError" not in str(info)
+    refusal = caught.value
+    assert refusal.owner == "boolean_operation_exception_floor"
+    assert refusal.observed == f"SymbolicValue {'and' if kind == 'And' else 'or'}"
+    assert "authenticated exceptional exit" in refusal.requested
+    assert "TypeError" not in str(refusal)
+    assert "ValueError" not in str(refusal)
 
 
 def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
@@ -319,13 +318,13 @@ def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
             if isinstance(node, BoolOp) and node.line_col_span().start_line == line
         )
         assert len(matches) == 1
-        with pytest.raises(ConstructionPanic) as raised:
+        with pytest.raises(SugarNotWritten) as raised:
             matches[0].sugar().desugar(None)
-        info = raised.value.info
-        assert info.owner == "boolean_operation_exception_floor"
-        assert info.observed == f"SymbolicValue {operator}"
-        assert "authenticated exceptional exit" in info.requested
-        assert "ValueError" not in str(info)
+        refusal = raised.value
+        assert refusal.owner == "boolean_operation_exception_floor"
+        assert refusal.observed == f"SymbolicValue {operator}"
+        assert "authenticated exceptional exit" in refusal.requested
+        assert "ValueError" not in str(refusal)
 
 
 def test_pandas_unary_sites_stay_source_undecided() -> None:
@@ -374,11 +373,19 @@ def test_pandas_unary_sites_stay_source_undecided() -> None:
             if isinstance(node, UnaryOp) and node.line_col_span().start_line == line
         )
         assert len(matches) == 1, (rel, line, matches)
-        with pytest.raises(ConstructionPanic) as raised:
+        with pytest.raises(SugarNotWritten) as raised:
             matches[0].sugar().desugar(None)
-        info = raised.value.info
-        assert info.owner == "unary_operation_exception_floor", (rel, line, info.owner)
-        assert info.observed == f"SymbolicValue {operator}", (rel, line, info.observed)
-        assert "authenticated exceptional exit" in info.requested
-        assert "TypeError" not in str(info)
-        assert "ValueError" not in str(info)
+        refusal = raised.value
+        assert refusal.owner == "unary_operation_exception_floor", (
+            rel,
+            line,
+            refusal.owner,
+        )
+        assert refusal.observed == f"SymbolicValue {operator}", (
+            rel,
+            line,
+            refusal.observed,
+        )
+        assert "authenticated exceptional exit" in refusal.requested
+        assert "TypeError" not in str(refusal)
+        assert "ValueError" not in str(refusal)


### PR DESCRIPTION
## Summary

- turn source-undecidable UnaryOp and BoolOp decisions into actual `SugarNotWritten` named refusals instead of construction panics described as refusals
- extend #6511 attribution with a distinct reattribution outcome and structurally enroll the three assignment bodies that explain UnaryOp 10/13
- add an authenticated #6516 composite report executable for the concrete pandas `~ser` site

## Measured R

Authenticated CPython 3.12.13, pandas 3.0.3 canonical 1,421-file manifest, shared demand table `blake3-512:0ce7c645...`:

- UnaryOp: enrolled 13; named refusal 11; reattributed 2; construction panic 0
- BoolOp: enrolled 2; named refusal 2; reattributed 0; construction panic 0
- the two UnaryOp reattributions are child Subscript sites; assignment roots remain outside the family under #6529's outer-node law

Delta from the merged producer state: thirteen root construction panics become named refusals across UnaryOp and BoolOp; two child named gaps become explicitly Subscript-owned reattributions. No exception identity is invented.

## Validation

- authenticated family harness: exit 0 with UnaryOp 13/13 and BoolOp 2/2 accounted
- #6516 composite report: exit 0 with verified source stamp, CPython 3.12.13, canonical manifest, and exact demand-table identity
- focused package tests: 55 passed
- mutation transaction: restoring invented `py.neg` made the exact refusal tooth fail (`DID NOT RAISE SugarNotWritten`, exit 1); restored tree returned green
- Black check and `git diff --check`: exit 0

## Floors

- no vendor/name arm, fabricated exception type, assertion-With edit, demand-table rebuild, or runtime substitution
- construction panic remains a separate failure outcome and cannot render as a named refusal
- caller testimony does not inherit artifact verification


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Account for unary and boolean refusals by replacing `ConstructionPanic` with `SugarNotWritten`
> - `refuse_undecided_unary_truth` and `refuse_undecided_boolean_truth` now raise `SugarNotWritten` (with `owner`/`observed` fields) instead of `ConstructionPanic` for undecided operand types.
> - Probe discovery in `discover_no_call_body_probes` now supports structural reattribution: `UnaryOp` bodies containing a `Subscript` node are enrolled with `reattributed_to='Subscript'`, and a new `REATTRIBUTED` outcome is tracked separately from named refusals and construction panics.
> - `CallerAttribution` now accepts `REATTRIBUTED` as a valid surviving outcome, and `FamilyAttribution` tracks and renders a reattributions count.
> - A new CLI script [`unary_boolop_consumer_report.py`](https://github.com/TSavo/sugar/pull/6534/files#diff-637d8b5a10c88214d74f1db5796b1a78ad8c2e15b97c5eafc90533aeb0a7f331) constructs and prints an authenticated consumer resolution report for `UnaryOp`/`BoolOp` drains.
> - Behavioral Change: tests expecting `ConstructionPanic` for undecided unary/bool operations are updated to assert `SugarNotWritten` instead, with different exception fields (`owner`, `observed`) replacing the previous `info` fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 789cc38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->