### PR TITLE
Keep undecided unary and boolean outcomes named

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -755,12 +755,10 @@ class FloorValue:
         if not denotes() or decided():
             return None
 
-        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_source_tree.panic import SugarNotWritten
 
-        construction_panic_gap(
+        raise SugarNotWritten(
             owner="unary_operation_exception_floor",
-            blame=site,
             observed=f"{type(self).__name__} {operator}",
             requested=(
                 "source-visible native unary-operator testimony selecting "
@@ -772,8 +770,6 @@ class FloorValue:
                 "from source, or retain this named refusal without inventing an "
                 "exception identity"
             ),
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
         )
 
     def unary_minus(self, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -43,13 +43,12 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
     if not denotes() or decided():
         return
 
-    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    from sugar_source_tree.panic import SugarNotWritten
 
     operator = _BOOL_OPERATOR_COORDINATE[op_kind]
-    construction_panic_gap(
+    del site
+    raise SugarNotWritten(
         owner="boolean_operation_exception_floor",
-        blame=site,
         observed=f"{type(value).__name__} {operator}",
         requested=(
             "source-visible native truth testimony selecting completion "
@@ -61,8 +60,6 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
             "from source, or retain this named refusal without inventing an "
             "exception identity"
         ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -43,12 +43,11 @@ def refuse_undecided_unary_truth(value, site) -> None:
     if not denotes() or decided():
         return
 
-    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    from sugar_source_tree.panic import SugarNotWritten
 
-    construction_panic_gap(
+    del site
+    raise SugarNotWritten(
         owner="unary_operation_exception_floor",
-        blame=site,
         observed=f"{type(value).__name__} not",
         requested=(
             "source-visible native truth testimony selecting completion "
@@ -60,8 +59,6 @@ def refuse_undecided_unary_truth(value, site) -> None:
             "from source, or retain this named refusal without inventing an "
             "exception identity"
         ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
@@ -6,6 +6,7 @@ from sugar_lift_py_tests.floor import GuardedValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import atomic, make_var
 from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
 
 
 @pytest.mark.parametrize(
@@ -44,11 +45,11 @@ def test_guarded_unary_minus_preserves_an_undecided_arm_as_a_named_refusal() -> 
         SymbolicValue(make_var("left")),
         SymbolicValue(make_var("right")),
     )
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         value.unary_minus("t.py:1")
 
-    assert raised.value.info.owner == "unary_operation_exception_floor"
-    assert raised.value.info.observed == "SymbolicValue -"
+    assert raised.value.owner == "unary_operation_exception_floor"
+    assert raised.value.observed == "SymbolicValue -"
 
 
 def test_guarded_bitwise_or_distributes_exact_set_union_to_both_faces() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_op_arithmetic.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_op_arithmetic.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.floor import OpaqueOpCallsite, TermValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, num
+from sugar_source_tree.panic import SugarNotWritten
 
 
 @pytest.mark.parametrize(
@@ -31,11 +31,11 @@ def test_opaque_operator_arithmetic_cites_coordinates(method, operator) -> None:
 def test_opaque_operator_unary_minus_is_named_refusal() -> None:
     """An opaque call result has no decided runtime type for unary ``-``."""
     value = OpaqueOpCallsite("len", TermValue(9), computed=None)
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         value.unary_minus("t.py:1")
 
-    assert raised.value.info.owner == "unary_operation_exception_floor"
-    assert raised.value.info.observed == "SymbolicValue -"
+    assert raised.value.owner == "unary_operation_exception_floor"
+    assert raised.value.observed == "SymbolicValue -"
 
 
 def test_opaque_operator_declares_full_arithmetic_surface() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -14,11 +14,11 @@ import subprocess
 
 import pytest
 
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
 from sugar_lift_py_tests.floor import RaiseValue, SymbolicValue, TermValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import atomic, make_var, not_
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
 from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
@@ -28,10 +28,9 @@ from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_py_tests.context import ReduceContext
+from sugar_source_tree.panic import SugarNotWritten
 
-CORPUS = Path(
-    "/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages/pandas"
-)
+CORPUS = authenticated_pandas_corpus().root
 UNARY_SITE = CORPUS / "tests/extension/base/ops.py"
 BOOLOP_SITE = CORPUS / "tests/generic/test_generic.py"
 DEMAND_TABLE_KEY = (
@@ -129,14 +128,14 @@ def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -
 )
 def test_undecided_unary_operand_is_named_refusal(method: str, operator: str) -> None:
     """Success versus TypeError is undecidable without the operand's runtime type."""
-    with pytest.raises(ConstructionPanic) as caught:
+    with pytest.raises(SugarNotWritten) as caught:
         getattr(SymbolicValue(make_var("ser")), method)(_Site())
 
-    info = caught.value.info
-    assert info.owner == "unary_operation_exception_floor"
-    assert info.observed == f"SymbolicValue {operator}"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
+    refusal = caught.value
+    assert refusal.owner == "unary_operation_exception_floor"
+    assert refusal.observed == f"SymbolicValue {operator}"
+    assert "authenticated exceptional exit" in refusal.requested
+    assert "TypeError" not in str(refusal)
 
 
 def test_unary_invert_concrete_integer_truthful_twin_folds() -> None:
@@ -170,15 +169,15 @@ def test_undecided_not_operand_refuses_invented_truth() -> None:
     """``not obj`` cannot invent ``py.truthy`` when ``bool(obj)`` is undecided."""
     from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
 
-    with pytest.raises(ConstructionPanic) as caught:
+    with pytest.raises(SugarNotWritten) as caught:
         UnaryOpSugar("Not", NameSugar("obj1", _Site()), _Site()).desugar(None)
 
-    info = caught.value.info
-    assert info.owner == "unary_operation_exception_floor"
-    assert info.observed == "SymbolicValue not"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "ValueError" not in str(info)
+    refusal = caught.value
+    assert refusal.owner == "unary_operation_exception_floor"
+    assert refusal.observed == "SymbolicValue not"
+    assert "authenticated exceptional exit" in refusal.requested
+    assert "TypeError" not in str(refusal)
+    assert "ValueError" not in str(refusal)
 
 
 class _EffectSugar:
@@ -263,15 +262,15 @@ def test_predicate_left_makes_rhs_effect_conditional(kind, rhs_guard) -> None:
 @pytest.mark.parametrize("kind", ("And", "Or"))
 def test_undecided_operand_type_refuses_invented_truth(kind: str) -> None:
     """``obj and obj`` cannot invent ``py.truthy`` when ``bool(obj)`` is undecided."""
-    with pytest.raises(ConstructionPanic) as caught:
+    with pytest.raises(SugarNotWritten) as caught:
         _boolop(kind, NameSugar("obj1", _Site()), NameSugar("obj2", _Site()))
 
-    info = caught.value.info
-    assert info.owner == "boolean_operation_exception_floor"
-    assert info.observed == f"SymbolicValue {'and' if kind == 'And' else 'or'}"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "ValueError" not in str(info)
+    refusal = caught.value
+    assert refusal.owner == "boolean_operation_exception_floor"
+    assert refusal.observed == f"SymbolicValue {'and' if kind == 'And' else 'or'}"
+    assert "authenticated exceptional exit" in refusal.requested
+    assert "TypeError" not in str(refusal)
+    assert "ValueError" not in str(refusal)
 
 
 def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
@@ -319,13 +318,13 @@ def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
             if isinstance(node, BoolOp) and node.line_col_span().start_line == line
         )
         assert len(matches) == 1
-        with pytest.raises(ConstructionPanic) as raised:
+        with pytest.raises(SugarNotWritten) as raised:
             matches[0].sugar().desugar(None)
-        info = raised.value.info
-        assert info.owner == "boolean_operation_exception_floor"
-        assert info.observed == f"SymbolicValue {operator}"
-        assert "authenticated exceptional exit" in info.requested
-        assert "ValueError" not in str(info)
+        refusal = raised.value
+        assert refusal.owner == "boolean_operation_exception_floor"
+        assert refusal.observed == f"SymbolicValue {operator}"
+        assert "authenticated exceptional exit" in refusal.requested
+        assert "ValueError" not in str(refusal)
 
 
 def test_pandas_unary_sites_stay_source_undecided() -> None:
@@ -374,11 +373,19 @@ def test_pandas_unary_sites_stay_source_undecided() -> None:
             if isinstance(node, UnaryOp) and node.line_col_span().start_line == line
         )
         assert len(matches) == 1, (rel, line, matches)
-        with pytest.raises(ConstructionPanic) as raised:
+        with pytest.raises(SugarNotWritten) as raised:
             matches[0].sugar().desugar(None)
-        info = raised.value.info
-        assert info.owner == "unary_operation_exception_floor", (rel, line, info.owner)
-        assert info.observed == f"SymbolicValue {operator}", (rel, line, info.observed)
-        assert "authenticated exceptional exit" in info.requested
-        assert "TypeError" not in str(info)
-        assert "ValueError" not in str(info)
+        refusal = raised.value
+        assert refusal.owner == "unary_operation_exception_floor", (
+            rel,
+            line,
+            refusal.owner,
+        )
+        assert refusal.observed == f"SymbolicValue {operator}", (
+            rel,
+            line,
+            refusal.observed,
+        )
+        assert "authenticated exceptional exit" in refusal.requested
+        assert "TypeError" not in str(refusal)
+        assert "ValueError" not in str(refusal)


### PR DESCRIPTION
## Split scope

This is the non-colliding producer half of #6534. It touches six UnaryOp/BoolOp-owned files only. It does not modify either frozen file or any attribution denominator/report code.

## Behavior

- source-undecidable UnaryOp and BoolOp decisions raise actual `SugarNotWritten` named refusals, not `ConstructionPanic` mislabeled as refusal
- concrete unary folds and authenticated exceptional exits remain unchanged
- BoolOp preserves short-circuiting: RHS effects remain conditional on the left truth face; undecidable left truth remains a third value
- no exception type is invented

## Authenticated measurement

CPython 3.12.13, pandas 3.0.3, canonical 1,421-file corpus manifest, shared 107,433-row demand table:

- UnaryOp: enrolled 13, named refusal 13, construction panic 0
- BoolOp: enrolled 2, named refusal 2, construction panic 0
- the existing unmarked-root construction-panic twin remains unchanged and passes, so a producer defect still stays loud and red

## Validation

- bootstrap: exact CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pytest 9.1.1
- producer-focused tests: 31 passed
- loud-axis discrimination twin: 1 passed
- authenticated family harness: exit 0, UnaryOp 13/13 and BoolOp 2/2, zero construction panics
- Black and `git diff --check`: exit 0

## Held half

The attribution/report half remains held until the Attribute 41/53 population dispute names the twelve sites. No frozen-file resolution is attempted here.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `ConstructionPanic` with `SugarNotWritten` for undecided unary and boolean outcomes
> - `refuse_undecided_unary_truth` and `refuse_undecided_boolean_truth` now raise `SugarNotWritten` directly instead of going through `construction_panic_gap`, dropping gap kind/locus metadata and the `site` parameter from the exception.
> - Tests in [test_unary_boolop_exception_producers.py](https://github.com/TSavo/sugar/pull/6535/files#diff-06bff2278db63ecf1b26d417311cee0c9ba5a6bec1e363833e81a08290ec62f6), [test_guarded_arithmetic_total.py](https://github.com/TSavo/sugar/pull/6535/files#diff-85198e5ab0cee1bad8a133742b854aa8b53783c18e36e06e8527d666d5ee6341), and [test_opaque_op_arithmetic.py](https://github.com/TSavo/sugar/pull/6535/files#diff-71272a541f42abd1f2fb63561a5f9df599e8209114afa8bee8fc7d90f0e6fbec) are updated to catch `SugarNotWritten` and access fields directly rather than via `.info`.
> - Behavioral Change: callers that previously caught `ConstructionPanic` for undecided operands must now catch `SugarNotWritten`; the exception no longer carries `gap_kind`, `gap_locus`, or `site`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e0b39c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->