### PR TITLE
Name undecided attribute producer refusals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -597,12 +597,17 @@ class FloorValue:
         construction_panic(info)
 
     def undecided_attribute(self, name, site, *, owner: str):
-        """Refuse lookup when source testimony decides neither outgoing edge."""
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        """Refuse lookup when source testimony decides neither outgoing edge.
 
-        construction_panic_gap(
+        This is an accounted named refusal, not a construction failure.  The
+        producer knows the native operation and the missing testimony, but it
+        cannot choose either the completed or AttributeError edge honestly.
+        """
+        from sugar_source_tree.panic import SugarNotWritten
+
+        del site
+        raise SugarNotWritten(
             owner=owner,
-            blame=site,
             observed=(
                 "undecided receiver runtime type or member semantics: "
                 f"{type(self).__name__}.{name}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -12,7 +12,7 @@ import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import CallSiteValue, NoneValue, SymbolicValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -21,8 +21,6 @@ from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Attribute
 from sugar_source_tree.tree import SourceFile
 
-CORPUS_ROOT = Path("/Users/tsavo/sugar-defect-drain/.venv/lib/python3.14/site-packages")
-SITE = CORPUS_ROOT / "pandas/tests/test_register_accessor.py"
 SITE_SHA256 = "4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793"
 SOURCE_CID = (
     "blake3-512:43cdd8a4f204ef75c77996a7e7a98b84bcd174de708cfe1e9e430415bbd636e2"
@@ -42,10 +40,10 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def _site_attribute(source: str) -> Attribute:
+def _site_attribute(source: str, site: Path) -> Attribute:
     assert blake3_512_of(source.encode()) == SOURCE_CID
     tree = SourceFile(
-        workspace_path_source(str(SITE), root=str(CORPUS_ROOT)),
+        workspace_path_source(str(site), root=str(site.parents[2])),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     matches = tuple(
@@ -88,18 +86,18 @@ def _assert_undecided(node: Attribute, receiver, *, name: str | None = None) -> 
         receiver=_ReceiverSugar(receiver),
         name=node.attr if name is None else name,
     )
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         operation.desugar(None)
-    info = raised.value.info
-    assert info.owner == f"{type(receiver).__name__}.attribute"
-    assert "undecided" in info.observed
+    refusal = raised.value
+    assert refusal.owner == f"{type(receiver).__name__}.attribute"
+    assert "undecided" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (
-        info.requested
+        refusal.requested
     )
-    assert "AttributeError" not in info.observed
-    assert "AttributeError" not in info.requested
-    assert "RuntimeEffect" not in info.observed
-    assert "RuntimeEffect" not in info.requested
+    assert "AttributeError" not in refusal.observed
+    assert "AttributeError" not in refusal.requested
+    assert "RuntimeEffect" not in refusal.observed
+    assert "RuntimeEffect" not in refusal.requested
 
 
 def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) -> None:
@@ -156,16 +154,18 @@ def test_shared_table_authenticates_the_exact_assertion_manager(tmp_path: Path) 
 
 
 def test_real_pandas_constructed_receiver_attribute_is_named_undecided() -> None:
-    source = SITE.read_text(encoding="utf-8")
+    site = _authenticated_corpus_file("tests/test_register_accessor.py")
+    source = site.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == SITE_SHA256
-    node = _site_attribute(source)
+    node = _site_attribute(source, site)
 
     _assert_undecided(node, _call_result())
 
 
 def test_symbolic_receiver_attribute_is_the_same_named_third_value() -> None:
-    source = SITE.read_text(encoding="utf-8")
-    node = _site_attribute(source)
+    site = _authenticated_corpus_file("tests/test_register_accessor.py")
+    source = site.read_text(encoding="utf-8")
+    node = _site_attribute(source, site)
 
     _assert_undecided(node, SymbolicValue(make_var("series")))
 
@@ -178,7 +178,8 @@ def test_lying_known_member_does_not_license_blanket_attribute_error() -> None:
 
 
 def test_replacing_bad_with_known_member_still_cannot_invent_an_exit() -> None:
-    source = SITE.read_text(encoding="utf-8")
+    site = _authenticated_corpus_file("tests/test_register_accessor.py")
+    source = site.read_text(encoding="utf-8")
     assert source.count("pd.Series([], dtype=object).bad") == 1
     lying = source.replace(
         "pd.Series([], dtype=object).bad",
@@ -186,12 +187,12 @@ def test_replacing_bad_with_known_member_still_cannot_invent_an_exit() -> None:
     )
     assert "pd.Series([], dtype=object).__class__" in lying
 
-    _assert_undecided(_site_attribute(source), _call_result(), name="__class__")
+    _assert_undecided(_site_attribute(source, site), _call_result(), name="__class__")
 
 
 # --- No-call Attribute family corpus pins (denominator 41) -----------------
 # Bare desugar without bindings yields SymbolicValue receivers; the producer
-# must keep the third value as ConstructionPanic(owner=SymbolicValue.attribute)
+# must keep the third value as SugarNotWritten(owner=SymbolicValue.attribute)
 # rather than invent AttributeError. These sites are enrolled Attribute bodies
 # under the no-Call-descendant law.
 
@@ -227,18 +228,18 @@ def _line_attribute(source: str, path: Path, *, line: int, attr: str) -> Attribu
 
 def _assert_bare_desugar_symbolic_attribute(node: Attribute) -> None:
     """Production door: expression.sugar().desugar(None) with no bindings."""
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         node.sugar().desugar(None)
-    info = raised.value.info
-    assert info.owner == "SymbolicValue.attribute"
-    assert "undecided" in info.observed
+    refusal = raised.value
+    assert refusal.owner == "SymbolicValue.attribute"
+    assert "undecided" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (
-        info.requested
+        refusal.requested
     )
-    assert "AttributeError" not in info.observed
-    assert "AttributeError" not in info.requested
-    assert "RuntimeEffect" not in info.observed
-    assert "RuntimeEffect" not in info.requested
+    assert "AttributeError" not in refusal.observed
+    assert "AttributeError" not in refusal.requested
+    assert "RuntimeEffect" not in refusal.observed
+    assert "RuntimeEffect" not in refusal.requested
 
 
 @pytest.mark.parametrize(
@@ -265,7 +266,7 @@ def test_no_call_attribute_corpus_sites_stay_symbolic_undecided(
 def test_binop_child_np_nan_reattributes_to_attribute_owner() -> None:
     """BinOp ``s_0123 & np.nan`` child-evaluates ``.nan`` on SymbolicValue.
 
-    That panic is Attribute-family coordinate (owner SymbolicValue.attribute),
+    That refusal is Attribute-family coordinate (owner SymbolicValue.attribute),
     not binary_operation_exception_floor. Keep the owner name honest when a
     BinOp site is a parent of Attribute evaluation.
     """
@@ -287,11 +288,11 @@ def test_binop_child_np_nan_reattributes_to_attribute_owner() -> None:
         and node.line_col_span().start_line == 96
     )
     assert len(matches) == 1
-    with pytest.raises(ConstructionPanic) as raised:
+    with pytest.raises(SugarNotWritten) as raised:
         matches[0].sugar().desugar(None)
-    info = raised.value.info
-    assert info.owner == "SymbolicValue.attribute"
-    assert "SymbolicValue.nan" in info.observed
+    refusal = raised.value
+    assert refusal.owner == "SymbolicValue.attribute"
+    assert "SymbolicValue.nan" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (
-        info.requested
+        refusal.requested
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_attribute_membership.py
@@ -1,6 +1,6 @@
 """GuardedValue distributes attribute and membership over both faces.
 
-Full-dump (pandas untruncated): attribute panics 229 with GuardedValue 197;
+Full-dump (pandas untruncated): attribute refusals 229 with GuardedValue 197;
 contains residual after sequence floors still names GuardedValue. These twins
 pin the distribution law so the default FloorValue.attribute/contains panics
 cannot reappear on a guarded receiver.
@@ -18,16 +18,16 @@ def _guard():
 
 
 def test_guarded_attribute_keeps_symbolic_face_refusal_loud():
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_source_tree.panic import SugarNotWritten
 
     true_face = SymbolicValue(make_var("t"))
     false_face = SymbolicValue(make_var("f"))
     guarded = GuardedValue(_guard(), true_face, false_face)
     try:
         guarded.attribute("x", "site")
-    except ConstructionPanic as panic:
-        assert panic.info.owner == "SymbolicValue.attribute"
-        assert panic.info.observed.endswith("SymbolicValue.x")
+    except SugarNotWritten as refusal:
+        assert refusal.owner == "SymbolicValue.attribute"
+        assert refusal.observed.endswith("SymbolicValue.x")
     else:
         raise AssertionError("guarded symbolic attribute invented completion")
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -235,6 +235,11 @@ def test_discovery_classifies_the_body_root_and_excludes_root_calls(
     ]
 
 
+def test_population_selection_never_reads_manager_target_symbol() -> None:
+    """All resolved managers enroll; manager spelling grants no membership."""
+    assert "targetSymbol" not in discover_no_call_body_probes.__code__.co_consts
+
+
 def test_discovery_projects_one_family_without_constructing_peer_sources(
     tmp_path, monkeypatch
 ) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_member_access.py
@@ -15,7 +15,7 @@ from sugar_source_tree.tree import SourceFile
 
 
 def _attribute_refusal(src):
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_source_tree.panic import SugarNotWritten
 
     directory = tempfile.mkdtemp()
     path = os.path.join(directory, "m.py")
@@ -24,8 +24,8 @@ def _attribute_refusal(src):
     function = next(SourceFile(path_source(path)).functions())
     try:
         function.sugar().desugar(None)
-    except ConstructionPanic as panic:
-        return panic.info
+    except SugarNotWritten as refusal:
+        return refusal
     raise AssertionError("opaque member operation invented a completed coordinate")
 
 
@@ -66,7 +66,7 @@ def test_opaque_subscript_is_named_undecided():
 def test_opaque_attribute_uses_the_typed_construction_refusal():
     info = _attribute_refusal("def f(x):\n    return g(x).foo\n")
 
-    assert info.gap_locus.value == "Construction"
+    assert type(info).__name__ == "SugarNotWritten"
     assert "AttributeError" not in info.observed
     assert "AttributeError" not in info.requested
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -11,6 +11,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.nodes import BinOp
 from sugar_source_tree.tree import SourceFile
 
@@ -72,6 +73,16 @@ def _assert_named_panic(
     assert "RuntimeEffect" not in str(info)
 
 
+def _assert_named_refusal(node, *, owner: str, observed: str) -> None:
+    with pytest.raises(SugarNotWritten) as raised:
+        node.sugar().desugar(None)
+    assert raised.value.owner == owner
+    assert raised.value.observed == observed
+    # Never invent a runtime TypeError / RuntimeEffect for undecided source.
+    assert "TypeError" not in str(raised.value)
+    assert "RuntimeEffect" not in str(raised.value)
+
+
 def _binop_at(source: str, path: Path, *, line: int, kind: str):
     source_cid = blake3_512_of(source.encode("utf-8"))
     tree = SourceFile(
@@ -114,14 +125,11 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
     assert (series & 0).tolist() == [0, 0, 0, 0]
 
     lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
-    _assert_named_panic(
+    _assert_named_refusal(
         _line_96_bitand(truthful, path),
         owner="SymbolicValue.attribute",
         observed=(
             "undecided receiver runtime type or member semantics: SymbolicValue.nan"
-        ),
-        requested_contains=(
-            "source-authenticated attribute success or exceptional exit"
         ),
     )
     _assert_named_panic(


### PR DESCRIPTION
## Outcome

Classify source-undecided Attribute producer edges as typed `SugarNotWritten` refusals instead of construction panics. The producer still refuses to choose a completed edge or invent `AttributeError`; decidable `None` members remain completed.

The concrete pandas 3.0.3 reproducer is `pandas/tests/test_register_accessor.py:104:12` (`pd.Series([], dtype=object).bad`). Its receiver is Call-built, but the native producer coordinate is `CallSiteValue.attribute`. The test now resolves the corpus through the authenticated CPython 3.12.13 corpus identity rather than the historical CPython 3.14 path.

The two frozen attribution/returned-manager test files are untouched.

## Validation

- `PYTHON312=/usr/local/opt/python@3.12/bin/python3.12 bash scripts/bootstrap-venv-py312.sh` (`PINS_OK`: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3)
- `.venv-py312/bin/python -m pytest ...` producer/floor focus: 62 passed
- shared demand-table identity test: 1 passed; consumed `blake3-512:0ce7c645...`, did not rebuild
- `PYTHONUNBUFFERED=1 bin/bpytest ...`: 2 passed in authenticated Battleaxe on CPython 3.12.13 / canonical pandas manifest
- mutation transaction: clean pass; old construction-panic behavior failed the concrete producer twin; revert passed
- `black --check` over all five changed files: clean
- `git diff --check`: clean
- live-tip `git merge-tree --write-tree origin/main HEAD`: exit 0

One read-only frozen integration test remains red identically on exact base `5c17725ee`: `test_external_error_raised_follows_authenticated_returned_manager` observes the unary residual while the frozen assertion expects a comparison residual. This PR does not alter that file.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `ConstructionPanic` with `SugarNotWritten` for undecided attribute producer refusals
> - Changes `FloorValue.undecided_attribute` in [floor_value.py](https://github.com/TSavo/sugar/pull/6536/files#diff-e465d9d796b4d8a065950433dc35b2a788306abfe91dab378d35f42a38a2cdd7) to raise `SugarNotWritten(owner, observed, requested, fix)` instead of calling `construction_panic_gap`.
> - Updates all related tests to expect `SugarNotWritten` and assert on its `owner`, `observed`, and `requested` fields rather than `ConstructionPanic.info`.
> - Renames terminology from "panics" to "refusals" in test module docstrings to match the new exception type.
> - Behavioral Change: undecided attribute lookups now raise `SugarNotWritten` instead of `ConstructionPanic`; any caller catching `ConstructionPanic` for this case will no longer intercept the error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c74f1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Attribute operations that cannot be resolved at runtime now report a named refusal with clearer ownership and observation details.
  - Opaque and pandas-related attribute operations now consistently expose the updated refusal behavior.
  - Error reporting avoids misleading construction-panic and runtime-effect details.

- **Tests**
  - Updated coverage verifies refusal details across attribute, guarded access, opaque member, and pandas operation scenarios.
  - Added coverage ensuring population selection does not inspect manager target symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->