### PR TITLE
Route fatal triage through construction context

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
@@ -65,15 +65,18 @@ def _typed_construction_row(error) -> dict[str, object] | None:
 
 def production_lift_testimony(path: Path, rel: str) -> dict[str, object]:
     """Enumerate one file and construct each function once."""
-    from sugar_lift_python_source.source_oracle import path_source
     from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 
     gaps: list[dict[str, object]] = []
     reporter = CollectingReporter()
     try:
-        # Enumeration protocol: one file identity → one SourceFile → functions.
-        source_file = SourceFile(path_source(str(path)), reporter=reporter)
+        # Enumeration protocol: one authenticated construction door. A bare
+        # SourceFile has no manager-resolution context and paints every With as
+        # RuntimeSelectedContextManager, which is false typed-gap testimony.
+        source_file = open_source_file_for_construction(
+            path, root=path.parent, reporter=reporter
+        )
     except BaseException as error:
         row = _typed_construction_row(error)
         if row is None:


### PR DESCRIPTION
## Cause

`_production_lift_child` opened a bare `SourceFile` and then drove `.sugar()`. Without construction context every `with` is painted `RuntimeSelectedContextManager`, so fatal triage emitted false typed-gap testimony instead of the source-derived `ContextManagerResolutionConstructionGap`.

## Fix

Route the production child through the existing `open_source_file_for_construction` door. No name/vendor dispatch and no new construction path.

## Authenticated validation

CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3:

- focused truthful/lying set: `3 passed, 4 deselected`
- mutation present: passing
- mutation removed: target fails with `RuntimeSelectedContextManager`
- mutation restored: `3 passed, 4 deselected`

The child returns typed-gap with exit 0; a planted Python `RuntimeError` remains a bare exception. No detector was weakened.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route source file construction through `open_source_file_for_construction` in fatal triage
> In [`_production_lift_child.py`](https://github.com/TSavo/sugar/pull/6537/files#diff-40b5d58b4641d2e3c119f17e75b64bc367a9047ba78859dd063e72fd7041126e), `production_lift_testimony` now calls `lift_rpc.open_source_file_for_construction(path, root=path.parent, reporter=reporter)` instead of directly constructing a `SourceFile` via `SourceFile(path_source(str(path)), reporter=reporter)`. This passes the `Path` object and its parent as `root`, routing construction through the shared RPC helper rather than the lower-level constructor. Behavioral Change: the construction routine and its parameters differ from the previous direct instantiation, which may affect how the source file is prepared before processing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d660ed7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->