### PR TITLE
Check semantic laws on merged PR trees

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/join_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/join_integrity.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import ast
 import importlib.util
+import itertools
+import json
 import subprocess
 import tarfile
 from collections import Counter
@@ -52,7 +54,50 @@ class SemanticFieldLossFinding:
         )
 
 
-JoinFinding = DroppedCallerFinding | SemanticFieldLossFinding
+@dataclass(frozen=True)
+class TextualConflictFinding:
+    path: str
+    hunk_header: str
+    marker_count: int
+
+    def render(self) -> str:
+        return (
+            "test=textual-conflict "
+            f"path={self.path} hunk={self.hunk_header!r} "
+            f"markerCount={self.marker_count}"
+        )
+
+
+@dataclass(frozen=True)
+class NamedLawLossFinding:
+    path: str
+    law: str
+
+    def render(self) -> str:
+        return f"test=named-law-survival path={self.path} missingLaw={self.law}"
+
+
+@dataclass(frozen=True)
+class StackedBaseFinding:
+    pull_request: int
+    base_ref: str
+    parent_pull_request: int
+
+    def render(self) -> str:
+        return (
+            "test=stacked-base-retarget "
+            f"pr={self.pull_request} baseRef={self.base_ref} "
+            f"openParentPr={self.parent_pull_request}"
+        )
+
+
+JoinFinding = (
+    DroppedCallerFinding
+    | SemanticFieldLossFinding
+    | TextualConflictFinding
+    | NamedLawLossFinding
+    | StackedBaseFinding
+)
 
 
 @dataclass(frozen=True)
@@ -60,7 +105,7 @@ class JoinIntegrityReport:
     base: str
     left: str
     right: str
-    merged_tree: str
+    merged_tree: str | None
     adjacent_packages: tuple[str, ...]
     findings: tuple[JoinFinding, ...]
 
@@ -76,15 +121,28 @@ class JoinIntegrityReport:
             "semantic-field-propagation": sum(
                 isinstance(item, SemanticFieldLossFinding) for item in self.findings
             ),
+            "textual-conflict": sum(
+                isinstance(item, TextualConflictFinding) for item in self.findings
+            ),
+            "named-law-survival": sum(
+                isinstance(item, NamedLawLossFinding) for item in self.findings
+            ),
+            "stacked-base-retarget": sum(
+                isinstance(item, StackedBaseFinding) for item in self.findings
+            ),
         }
 
     def render(self) -> str:
         counts = self.test_counts()
         header = (
             f"join base={self.base} left={self.left} right={self.right} "
-            f"mergedTree={self.merged_tree} measuredPackages={self.measured_packages} "
+            f"mergedTreeStatus={'constructed' if self.merged_tree else 'conflicted'} "
+            f"measuredPackages={self.measured_packages} "
             f"droppedCaller={counts['dropped-caller']} "
-            f"semanticFieldLoss={counts['semantic-field-propagation']}"
+            f"semanticFieldLoss={counts['semantic-field-propagation']} "
+            f"textualConflict={counts['textual-conflict']} "
+            f"namedLawLoss={counts['named-law-survival']} "
+            f"stackedBase={counts['stacked-base-retarget']}"
         )
         return "\n".join((header, *(item.render() for item in self.findings)))
 
@@ -113,7 +171,38 @@ def _changed_packages(repo: Path, base: str, tip: str) -> set[str]:
     return packages
 
 
-def _merge_tree(repo: Path, base: str, left: str, right: str) -> str:
+def _parse_conflicts(output: str) -> tuple[TextualConflictFinding, ...]:
+    findings = []
+    sections = output.split("changed in both\n")[1:]
+    for section in sections:
+        lines = section.splitlines()
+        path = "<unknown>"
+        for line in lines[:4]:
+            fields = line.split()
+            if line.startswith("  base ") and len(fields) >= 4:
+                path = fields[-1]
+                break
+        hunk_starts = [
+            index for index, line in enumerate(lines) if line.startswith("@@")
+        ]
+        for offset, start in enumerate(hunk_starts):
+            end = (
+                hunk_starts[offset + 1] if offset + 1 < len(hunk_starts) else len(lines)
+            )
+            hunk = lines[start:end]
+            marker_count = sum(
+                marker in line
+                for line in hunk
+                for marker in ("<<<<<<<", "=======", ">>>>>>>")
+            )
+            if marker_count:
+                findings.append(TextualConflictFinding(path, hunk[0], marker_count))
+    return tuple(findings)
+
+
+def _merge_tree(
+    repo: Path, base: str, left: str, right: str
+) -> tuple[str | None, tuple[TextualConflictFinding, ...]]:
     completed = _git(
         repo,
         "merge-tree",
@@ -125,12 +214,16 @@ def _merge_tree(repo: Path, base: str, left: str, right: str) -> str:
         check=False,
     )
     if completed.returncode != 0:
-        detail = (completed.stdout + completed.stderr).strip()
-        raise JoinIntegrityError(f"test=merged-tree conflict {detail}")
+        legacy = _git(repo, "merge-tree", base, left, right)
+        conflicts = _parse_conflicts(legacy.stdout)
+        if not conflicts:
+            detail = (completed.stdout + completed.stderr).strip()
+            raise JoinIntegrityError(f"test=merged-tree unparsed-conflict {detail}")
+        return None, conflicts
     tree = completed.stdout.splitlines()[0].strip()
     if not tree:
         raise JoinIntegrityError("test=merged-tree produced no tree coordinate")
-    return tree
+    return tree, ()
 
 
 def _package_sources(repo: Path, revision: str, package: str) -> dict[str, str]:
@@ -208,7 +301,9 @@ def _calls(sources: Mapping[str, str]) -> tuple[_CallSite, ...]:
                     line=node.lineno,
                     constructor=node.func.id,
                     keywords=frozenset(
-                        keyword.arg for keyword in node.keywords if keyword.arg is not None
+                        keyword.arg
+                        for keyword in node.keywords
+                        if keyword.arg is not None
                     ),
                     shape=ast.dump(node, include_attributes=False),
                 )
@@ -258,6 +353,73 @@ def _semantic_losses(
     return tuple(findings)
 
 
+_ATTRIBUTION_TEST = (
+    "implementations/python/sugar-lift-py-tests/tests/"
+    "test_no_call_body_attribution.py"
+)
+_ATTRIBUTION_SOURCE = (
+    "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/"
+    "no_call_body_attribution.py"
+)
+_REQUIRED_ATTRIBUTION_LAWS = (
+    "test_escaped_construction_panic_remains_a_separate_loud_axis",
+    "test_silent_completion_stays_a_separate_loud_discrepancy",
+    "test_population_selection_never_reads_manager_target_symbol",
+)
+
+
+def _named_law_losses(
+    package: str, sources: Mapping[str, str]
+) -> tuple[NamedLawLossFinding, ...]:
+    if package != "sugar-lift-py-tests":
+        return ()
+    findings = []
+    test_source = sources.get(_ATTRIBUTION_TEST)
+    if test_source is None:
+        findings.append(NamedLawLossFinding(_ATTRIBUTION_TEST, "test-file-present"))
+    else:
+        names = {
+            node.name
+            for node in ast.parse(test_source, filename=_ATTRIBUTION_TEST).body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        findings.extend(
+            NamedLawLossFinding(_ATTRIBUTION_TEST, law)
+            for law in _REQUIRED_ATTRIBUTION_LAWS
+            if law not in names
+        )
+    source = sources.get(_ATTRIBUTION_SOURCE)
+    denominator_sum = None
+    if source is not None:
+        for node in ast.parse(source, filename=_ATTRIBUTION_SOURCE).body:
+            if isinstance(node, (ast.Assign, ast.AnnAssign)) and (
+                (
+                    isinstance(node, ast.Assign)
+                    and any(
+                        isinstance(t, ast.Name) and t.id == "FAMILY_DENOMINATORS"
+                        for t in node.targets
+                    )
+                )
+                or (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and node.target.id == "FAMILY_DENOMINATORS"
+                )
+            ):
+                value = node.value
+                if isinstance(value, ast.Dict) and all(
+                    isinstance(item, ast.Constant) and isinstance(item.value, int)
+                    for item in value.values
+                ):
+                    denominator_sum = sum(item.value for item in value.values)
+                break
+    if denominator_sum != 1008:
+        findings.append(
+            NamedLawLossFinding(_ATTRIBUTION_SOURCE, "FAMILY_DENOMINATORS.sum==1008")
+        )
+    return tuple(findings)
+
+
 def check_git_join(
     repo: Path, *, base: str, left: str, right: str
 ) -> JoinIntegrityReport:
@@ -265,21 +427,34 @@ def check_git_join(
     repo = repo.resolve()
     adjacent = tuple(
         sorted(
-            _changed_packages(repo, base, left)
-            & _changed_packages(repo, base, right)
+            _changed_packages(repo, base, left) & _changed_packages(repo, base, right)
         )
     )
-    merged_tree = _merge_tree(repo, base, left, right)
+    if not adjacent:
+        conflicts = _parse_conflicts(_git(repo, "merge-tree", base, left, right).stdout)
+        return JoinIntegrityReport(
+            base,
+            left,
+            right,
+            "textual-merge-clean" if not conflicts else None,
+            (),
+            conflicts,
+        )
+    merged_tree, conflicts = _merge_tree(repo, base, left, right)
+    if conflicts:
+        return JoinIntegrityReport(base, left, right, None, adjacent, conflicts)
+    assert merged_tree is not None
     findings: list[JoinFinding] = []
     detector_path = (
-        Path(__file__).resolve().parents[2]
-        / "scripts/private_orphan_transition.py"
+        Path(__file__).resolve().parents[2] / "scripts/private_orphan_transition.py"
     )
     spec = importlib.util.spec_from_file_location(
         "sugar_private_orphan_transition", detector_path
     )
     if spec is None or spec.loader is None:
-        raise JoinIntegrityError(f"dropped-caller detector unavailable: {detector_path}")
+        raise JoinIntegrityError(
+            f"dropped-caller detector unavailable: {detector_path}"
+        )
     detector = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(detector)
 
@@ -309,6 +484,7 @@ def check_git_join(
                 merged_sources,
             )
         )
+        findings.extend(_named_law_losses(package, merged_sources))
     return JoinIntegrityReport(
         base=base,
         left=left,
@@ -319,21 +495,123 @@ def check_git_join(
     )
 
 
+@dataclass(frozen=True)
+class OpenPullRequest:
+    number: int
+    head_ref: str
+    base_ref: str
+    files: frozenset[str]
+
+
+def _open_pull_requests(repo: Path) -> tuple[OpenPullRequest, ...]:
+    limit = 10_000
+    completed = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,headRefName,baseRefName,files",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    rows = json.loads(completed.stdout)
+    if len(rows) == limit:
+        raise JoinIntegrityError(
+            f"coverage=incomplete reason=open-pr-limit limit={limit}"
+        )
+    return tuple(
+        OpenPullRequest(
+            row["number"],
+            row["headRefName"],
+            row["baseRefName"],
+            frozenset(item["path"] for item in row["files"]),
+        )
+        for row in rows
+    )
+
+
+def _adjacent_pairs(
+    pulls: tuple[OpenPullRequest, ...],
+) -> tuple[tuple[OpenPullRequest, OpenPullRequest], ...]:
+    return tuple(
+        (left, right)
+        for left, right in itertools.combinations(pulls, 2)
+        if left.files & right.files
+    )
+
+
+def check_open_pr_joins(repo: Path) -> tuple[JoinIntegrityReport, ...]:
+    pulls = _open_pull_requests(repo)
+    parents = {pull.head_ref: pull for pull in pulls}
+    stacked = tuple(
+        StackedBaseFinding(pull.number, pull.base_ref, parents[pull.base_ref].number)
+        for pull in pulls
+        if pull.base_ref in parents
+    )
+    if stacked:
+        raise JoinIntegrityError("\n".join(item.render() for item in stacked))
+    pairs = _adjacent_pairs(pulls)
+    print(
+        f"openPrs={len(pulls)} commonFilePairs={len(pairs)} droppedPairs=0 coverage=complete",
+        flush=True,
+    )
+    reports = []
+    for left, right in pairs:
+        left_ref = f"refs/join-audit/open-{left.number}"
+        right_ref = f"refs/join-audit/open-{right.number}"
+        _git(
+            repo,
+            "fetch",
+            "--force",
+            "origin",
+            f"refs/pull/{left.number}/head:{left_ref}",
+        )
+        _git(
+            repo,
+            "fetch",
+            "--force",
+            "origin",
+            f"refs/pull/{right.number}/head:{right_ref}",
+        )
+        base = _git(repo, "merge-base", left_ref, right_ref).stdout.strip()
+        reports.append(check_git_join(repo, base=base, left=left_ref, right=right_ref))
+    return tuple(reports)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="check laws on the synthesized merge of two adjacent tips"
     )
     parser.add_argument("--repo", type=Path, default=Path.cwd())
-    parser.add_argument("--base", required=True)
-    parser.add_argument("--left", required=True)
-    parser.add_argument("--right", required=True)
+    parser.add_argument("--base")
+    parser.add_argument("--left")
+    parser.add_argument("--right")
+    parser.add_argument("--open-prs", action="store_true")
     args = parser.parse_args(argv)
     try:
-        report = check_git_join(
-            args.repo, base=args.base, left=args.left, right=args.right
-        )
-        print(report.render(), flush=True)
-        report.require_clean()
+        if args.open_prs:
+            reports = check_open_pr_joins(args.repo)
+            for report in reports:
+                print(report.render(), flush=True)
+                report.require_clean()
+        else:
+            if not all((args.base, args.left, args.right)):
+                parser.error(
+                    "--base, --left, and --right are required without --open-prs"
+                )
+            report = check_git_join(
+                args.repo, base=args.base, left=args.left, right=args.right
+            )
+            print(report.render(), flush=True)
+            report.require_clean()
     except JoinIntegrityError as error:
         print(str(error), flush=True)
         return 1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/join_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/join_integrity.py
@@ -1,0 +1,344 @@
+"""Check laws on the synthetic merge tree, never on either tip alone."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import subprocess
+import tarfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+class JoinIntegrityError(RuntimeError):
+    """The merged tree lost a law or a live production caller."""
+
+
+@dataclass(frozen=True)
+class DroppedCallerFinding:
+    package: str
+    path: str
+    line: int
+    symbol: str
+    lost_reference_count: int
+
+    def render(self) -> str:
+        return (
+            "test=dropped-caller "
+            f"package={self.package} path={self.path}:{self.line} "
+            f"symbol={self.symbol} ZERO_REFERENCES_AFTER "
+            f"lostReferences={self.lost_reference_count}"
+        )
+
+
+@dataclass(frozen=True)
+class SemanticFieldLossFinding:
+    package: str
+    path: str
+    line: int
+    constructor: str
+    field: str
+    introducing_tip: str
+
+    def render(self) -> str:
+        return (
+            "test=semantic-field-propagation "
+            f"package={self.package} path={self.path}:{self.line} "
+            f"constructor={self.constructor} missingField={self.field} "
+            f"introducedBy={self.introducing_tip}"
+        )
+
+
+JoinFinding = DroppedCallerFinding | SemanticFieldLossFinding
+
+
+@dataclass(frozen=True)
+class JoinIntegrityReport:
+    base: str
+    left: str
+    right: str
+    merged_tree: str
+    adjacent_packages: tuple[str, ...]
+    findings: tuple[JoinFinding, ...]
+
+    @property
+    def measured_packages(self) -> int:
+        return len(self.adjacent_packages)
+
+    def test_counts(self) -> Mapping[str, int]:
+        return {
+            "dropped-caller": sum(
+                isinstance(item, DroppedCallerFinding) for item in self.findings
+            ),
+            "semantic-field-propagation": sum(
+                isinstance(item, SemanticFieldLossFinding) for item in self.findings
+            ),
+        }
+
+    def render(self) -> str:
+        counts = self.test_counts()
+        header = (
+            f"join base={self.base} left={self.left} right={self.right} "
+            f"mergedTree={self.merged_tree} measuredPackages={self.measured_packages} "
+            f"droppedCaller={counts['dropped-caller']} "
+            f"semanticFieldLoss={counts['semantic-field-propagation']}"
+        )
+        return "\n".join((header, *(item.render() for item in self.findings)))
+
+    def require_clean(self) -> None:
+        if self.findings:
+            raise JoinIntegrityError(self.render())
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def _changed_packages(repo: Path, base: str, tip: str) -> set[str]:
+    completed = _git(repo, "diff", "--name-only", base, tip)
+    packages = set()
+    for path in completed.stdout.splitlines():
+        parts = path.split("/")
+        if len(parts) >= 4 and parts[:2] == ["implementations", "python"]:
+            packages.add(parts[2])
+    return packages
+
+
+def _merge_tree(repo: Path, base: str, left: str, right: str) -> str:
+    completed = _git(
+        repo,
+        "merge-tree",
+        "--write-tree",
+        "--merge-base",
+        base,
+        left,
+        right,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stdout + completed.stderr).strip()
+        raise JoinIntegrityError(f"test=merged-tree conflict {detail}")
+    tree = completed.stdout.splitlines()[0].strip()
+    if not tree:
+        raise JoinIntegrityError("test=merged-tree produced no tree coordinate")
+    return tree
+
+
+def _package_sources(repo: Path, revision: str, package: str) -> dict[str, str]:
+    root = f"implementations/python/{package}"
+    sources = {}
+    process = subprocess.Popen(
+        ["git", "archive", "--format=tar", revision, root],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    with tarfile.open(fileobj=process.stdout, mode="r|") as archive:
+        for member in archive:
+            if not member.isfile() or not member.name.endswith(".py"):
+                continue
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            try:
+                sources[member.name] = extracted.read().decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+    stderr = process.communicate()[1]
+    if process.returncode != 0:
+        raise JoinIntegrityError(
+            f"test=merged-tree archive failed revision={revision} "
+            f"detail={stderr.decode(errors='replace').strip()}"
+        )
+    return sources
+
+
+def _dataclass_fields(sources: Mapping[str, str]) -> dict[str, frozenset[str]]:
+    fields: dict[str, set[str]] = {}
+    for path, source in sources.items():
+        tree = ast.parse(source, filename=path)
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            decorators = {
+                decorator.id
+                for decorator in node.decorator_list
+                if isinstance(decorator, ast.Name)
+            }
+            if "dataclass" not in decorators:
+                continue
+            fields[node.name] = {
+                statement.target.id
+                for statement in node.body
+                if isinstance(statement, ast.AnnAssign)
+                and isinstance(statement.target, ast.Name)
+            }
+    return {name: frozenset(names) for name, names in fields.items()}
+
+
+@dataclass(frozen=True)
+class _CallSite:
+    path: str
+    line: int
+    constructor: str
+    keywords: frozenset[str]
+    shape: str
+
+
+def _calls(sources: Mapping[str, str]) -> tuple[_CallSite, ...]:
+    calls = []
+    for path, source in sources.items():
+        tree = ast.parse(source, filename=path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            calls.append(
+                _CallSite(
+                    path=path,
+                    line=node.lineno,
+                    constructor=node.func.id,
+                    keywords=frozenset(
+                        keyword.arg for keyword in node.keywords if keyword.arg is not None
+                    ),
+                    shape=ast.dump(node, include_attributes=False),
+                )
+            )
+    return tuple(calls)
+
+
+def _semantic_losses(
+    package: str,
+    base: Mapping[str, str],
+    left: Mapping[str, str],
+    right: Mapping[str, str],
+    merged: Mapping[str, str],
+) -> tuple[SemanticFieldLossFinding, ...]:
+    base_fields = _dataclass_fields(base)
+    left_fields = _dataclass_fields(left)
+    right_fields = _dataclass_fields(right)
+    base_calls = Counter(call.shape for call in _calls(base))
+    merged_calls = _calls(merged)
+    findings = []
+    for introducing_tip, introduced_fields, other_calls in (
+        ("left", left_fields, _calls(right)),
+        ("right", right_fields, _calls(left)),
+    ):
+        for constructor, fields in introduced_fields.items():
+            added = fields - base_fields.get(constructor, frozenset())
+            for field in added:
+                candidates = Counter(call.shape for call in other_calls)
+                candidates.subtract(base_calls)
+                new_shapes = {shape for shape, count in candidates.items() if count > 0}
+                for call in merged_calls:
+                    if (
+                        call.constructor == constructor
+                        and call.shape in new_shapes
+                        and field not in call.keywords
+                    ):
+                        findings.append(
+                            SemanticFieldLossFinding(
+                                package,
+                                call.path,
+                                call.line,
+                                constructor,
+                                field,
+                                introducing_tip,
+                            )
+                        )
+    return tuple(findings)
+
+
+def check_git_join(
+    repo: Path, *, base: str, left: str, right: str
+) -> JoinIntegrityReport:
+    """Measure adjacent Python packages on the actual synthesized merge tree."""
+    repo = repo.resolve()
+    adjacent = tuple(
+        sorted(
+            _changed_packages(repo, base, left)
+            & _changed_packages(repo, base, right)
+        )
+    )
+    merged_tree = _merge_tree(repo, base, left, right)
+    findings: list[JoinFinding] = []
+    detector_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts/private_orphan_transition.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "sugar_private_orphan_transition", detector_path
+    )
+    if spec is None or spec.loader is None:
+        raise JoinIntegrityError(f"dropped-caller detector unavailable: {detector_path}")
+    detector = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(detector)
+
+    for package in adjacent:
+        base_sources = _package_sources(repo, base, package)
+        left_sources = _package_sources(repo, left, package)
+        right_sources = _package_sources(repo, right, package)
+        merged_sources = _package_sources(repo, merged_tree, package)
+        for orphan in detector.compare_package_sources(
+            package, base_sources, merged_sources
+        ):
+            findings.append(
+                DroppedCallerFinding(
+                    package=package,
+                    path=orphan.definition.path,
+                    line=orphan.definition.line,
+                    symbol=orphan.definition.name,
+                    lost_reference_count=len(orphan.lost_references),
+                )
+            )
+        findings.extend(
+            _semantic_losses(
+                package,
+                base_sources,
+                left_sources,
+                right_sources,
+                merged_sources,
+            )
+        )
+    return JoinIntegrityReport(
+        base=base,
+        left=left,
+        right=right,
+        merged_tree=merged_tree,
+        adjacent_packages=adjacent,
+        findings=tuple(findings),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="check laws on the synthesized merge of two adjacent tips"
+    )
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--left", required=True)
+    parser.add_argument("--right", required=True)
+    args = parser.parse_args(argv)
+    try:
+        report = check_git_join(
+            args.repo, base=args.base, left=args.left, right=args.right
+        )
+        print(report.render(), flush=True)
+        report.require_clean()
+    except JoinIntegrityError as error:
+        print(str(error), flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_join_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_join_integrity.py
@@ -9,6 +9,11 @@ from sugar_lift_py_tests.join_integrity import (
     DroppedCallerFinding,
     JoinIntegrityError,
     SemanticFieldLossFinding,
+    TextualConflictFinding,
+    OpenPullRequest,
+    _adjacent_pairs,
+    _named_law_losses,
+    _parse_conflicts,
     check_git_join,
     main,
 )
@@ -117,7 +122,9 @@ def test_dropped_caller_in_merged_tree_is_red(tmp_path: Path) -> None:
         report.require_clean()
 
 
-def test_auto_merge_new_constructor_must_carry_other_branch_field(tmp_path: Path) -> None:
+def test_auto_merge_new_constructor_must_carry_other_branch_field(
+    tmp_path: Path,
+) -> None:
     """#6439/#6445 twin: both tips are green; their clean join is red."""
     repo, base = _repo(tmp_path)
     _branch(repo, base, "field-law")
@@ -188,9 +195,7 @@ def test_nonadjacent_code_tips_do_not_claim_a_join_measurement(tmp_path: Path) -
     assert report.measured_packages == 0
 
 
-def test_cli_exits_red_and_prints_test_names_and_counts(
-    tmp_path: Path, capsys
-) -> None:
+def test_cli_exits_red_and_prints_test_names_and_counts(tmp_path: Path, capsys) -> None:
     repo, base = _repo(tmp_path)
     _write(
         repo,
@@ -226,3 +231,101 @@ def test_cli_exits_red_and_prints_test_names_and_counts(
     assert status == 1
     assert "droppedCaller=1 semanticFieldLoss=0" in output
     assert "test=dropped-caller" in output
+
+
+def test_live_6540_6541_conflict_testimony_names_hunks_and_markers() -> None:
+    """Fixture captured from the live pair; every marker is counted."""
+    path = (
+        "implementations/python/sugar-lift-py-tests/src/"
+        "sugar_lift_py_tests/no_call_body_attribution.py"
+    )
+    testimony = f"""changed in both
+  base   100644 000000 {path}
+  our    100644 111111 {path}
+  their  100644 222222 {path}
+@@ -106,11 +113,29 @@ class AttributionOutcomeSummary:
++<<<<<<< .our
++=======
++>>>>>>> .their
+@@ -125,6 +150,30 @@ class AttributionReport:
++<<<<<<< .our
++=======
++>>>>>>> .their
+"""
+
+    findings = _parse_conflicts(testimony)
+
+    assert [item.path for item in findings] == [path, path]
+    assert [item.hunk_header for item in findings] == [
+        "@@ -106,11 +113,29 @@ class AttributionOutcomeSummary:",
+        "@@ -125,6 +150,30 @@ class AttributionReport:",
+    ]
+    assert sum(item.marker_count for item in findings) == 6
+
+
+def test_textual_conflict_join_is_red_with_exact_file_and_hunk(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    target = "implementations/python/demo/src/demo/builders.py"
+    _branch(repo, base, "left")
+    _write(
+        repo,
+        target,
+        "from .model import Step\n\ndef build_plain():\n    return Step('left')\n",
+    )
+    left = _commit(repo, "left")
+    _branch(repo, base, "right")
+    _write(
+        repo,
+        target,
+        "from .model import Step\n\ndef build_plain():\n    return Step('right')\n",
+    )
+    right = _commit(repo, "right")
+
+    report = check_git_join(repo, base=base, left=left, right=right)
+
+    conflicts = [
+        item for item in report.findings if isinstance(item, TextualConflictFinding)
+    ]
+    assert report.merged_tree is None
+    assert len(conflicts) == 1
+    assert conflicts[0].path == target
+    assert conflicts[0].hunk_header.startswith("@@")
+    assert conflicts[0].marker_count == 3
+    with pytest.raises(JoinIntegrityError, match="test=textual-conflict"):
+        report.require_clean()
+
+
+def test_named_laws_and_denominator_survive_as_one_join_contract() -> None:
+    test_source = "\n".join(
+        f"def {name}():\n    pass"
+        for name in (
+            "test_escaped_construction_panic_remains_a_separate_loud_axis",
+            "test_silent_completion_stays_a_separate_loud_discrepancy",
+            "test_population_selection_never_reads_manager_target_symbol",
+        )
+    )
+    sources = {
+        "implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py": test_source,
+        "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py": "FAMILY_DENOMINATORS = {'a': 1000, 'b': 8}\n",
+    }
+    assert _named_law_losses("sugar-lift-py-tests", sources) == ()
+
+    mutated = dict(sources)
+    mutated[next(iter(mutated))] = test_source.replace(
+        "test_silent_completion_stays_a_separate_loud_discrepancy", "deleted_law"
+    )
+    losses = _named_law_losses("sugar-lift-py-tests", mutated)
+    assert [loss.law for loss in losses] == [
+        "test_silent_completion_stays_a_separate_loud_discrepancy"
+    ]
+
+
+def test_every_common_file_open_pr_pair_is_selected_without_a_cap() -> None:
+    pulls = (
+        OpenPullRequest(1, "one", "main", frozenset({"shared.py", "one.py"})),
+        OpenPullRequest(2, "two", "main", frozenset({"shared.py"})),
+        OpenPullRequest(3, "three", "main", frozenset({"other.py"})),
+    )
+    assert [(left.number, right.number) for left, right in _adjacent_pairs(pulls)] == [
+        (1, 2)
+    ]

--- a/implementations/python/sugar-lift-py-tests/tests/test_join_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_join_integrity.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.join_integrity import (
+    DroppedCallerFinding,
+    JoinIntegrityError,
+    SemanticFieldLossFinding,
+    check_git_join,
+    main,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args], cwd=repo, text=True, stderr=subprocess.STDOUT
+    ).strip()
+
+
+def _write(repo: Path, relative: str, source: str) -> None:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        "-c",
+        "user.name=T Savo",
+        "-c",
+        "user.email=evilgenius@nefariousplan.com",
+        "commit",
+        "-m",
+        message,
+    )
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/model.py",
+        "from dataclasses import dataclass\n\n@dataclass\nclass Step:\n    kind: str\n",
+    )
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/builders.py",
+        "from .model import Step\n\ndef build_plain():\n    return Step('plain')\n",
+    )
+    return repo, _commit(repo, "base")
+
+
+def _branch(repo: Path, base: str, name: str) -> None:
+    _git(repo, "switch", "-q", "-C", name, base)
+
+
+def test_clean_adjacent_join_has_zero_findings(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    _branch(repo, base, "left")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/left.py",
+        "def left():\n    return 1\n",
+    )
+    left = _commit(repo, "left")
+    _branch(repo, base, "right")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/right.py",
+        "def right():\n    return 2\n",
+    )
+    right = _commit(repo, "right")
+
+    report = check_git_join(repo, base=base, left=left, right=right)
+
+    assert report.adjacent_packages == ("demo",)
+    assert report.findings == ()
+
+
+def test_dropped_caller_in_merged_tree_is_red(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/helper.py",
+        "def _helper():\n    return 1\n\ndef caller():\n    return _helper()\n",
+    )
+    base = _commit(repo, "live helper")
+    _branch(repo, base, "left")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/left.py",
+        "VALUE = 1\n",
+    )
+    left = _commit(repo, "left adjacent")
+    _branch(repo, base, "right")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/helper.py",
+        "def _helper():\n    return 1\n",
+    )
+    right = _commit(repo, "drop caller")
+
+    report = check_git_join(repo, base=base, left=left, right=right)
+
+    assert len(report.findings) == 1
+    assert isinstance(report.findings[0], DroppedCallerFinding)
+    assert report.findings[0].symbol == "_helper"
+    with pytest.raises(JoinIntegrityError, match=r"_helper.*ZERO_REFERENCES_AFTER"):
+        report.require_clean()
+
+
+def test_auto_merge_new_constructor_must_carry_other_branch_field(tmp_path: Path) -> None:
+    """#6439/#6445 twin: both tips are green; their clean join is red."""
+    repo, base = _repo(tmp_path)
+    _branch(repo, base, "field-law")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/model.py",
+        "from dataclasses import dataclass\n\n@dataclass\nclass Step:\n"
+        "    kind: str\n    carries_suspension: bool = False\n",
+    )
+    left = _commit(repo, "thread suspension field")
+    _branch(repo, base, "new-shape")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/builders.py",
+        "from .model import Step\n\ndef build_plain():\n    return Step('plain')\n\n"
+        "def build_if():\n    return Step('If')\n",
+    )
+    right = _commit(repo, "add If constructor")
+
+    report = check_git_join(repo, base=base, left=left, right=right)
+
+    losses = [f for f in report.findings if isinstance(f, SemanticFieldLossFinding)]
+    assert len(losses) == 1
+    assert losses[0].constructor == "Step"
+    assert losses[0].field == "carries_suspension"
+    assert losses[0].path.endswith("builders.py")
+    with pytest.raises(JoinIntegrityError, match="carries_suspension"):
+        report.require_clean()
+
+
+def test_semantic_twin_bites_only_at_the_join(tmp_path: Path) -> None:
+    """The instrument must not falsely claim either individual tip is the join."""
+    repo, base = _repo(tmp_path)
+    _branch(repo, base, "field-law")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/model.py",
+        "from dataclasses import dataclass\n\n@dataclass\nclass Step:\n"
+        "    kind: str\n    carries_suspension: bool = False\n",
+    )
+    left = _commit(repo, "field")
+    _branch(repo, base, "new-shape")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/builders.py",
+        "from .model import Step\n\ndef build_plain():\n    return Step('plain')\n\n"
+        "def build_if():\n    return Step('If')\n",
+    )
+    right = _commit(repo, "shape")
+
+    assert check_git_join(repo, base=base, left=left, right=base).findings == ()
+    assert check_git_join(repo, base=base, left=base, right=right).findings == ()
+    assert check_git_join(repo, base=base, left=left, right=right).findings
+
+
+def test_nonadjacent_code_tips_do_not_claim_a_join_measurement(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    _branch(repo, base, "left")
+    _write(repo, "implementations/python/one/src/one/a.py", "A = 1\n")
+    left = _commit(repo, "one")
+    _branch(repo, base, "right")
+    _write(repo, "implementations/python/two/src/two/b.py", "B = 2\n")
+    right = _commit(repo, "two")
+
+    report = check_git_join(repo, base=base, left=left, right=right)
+
+    assert report.adjacent_packages == ()
+    assert report.measured_packages == 0
+
+
+def test_cli_exits_red_and_prints_test_names_and_counts(
+    tmp_path: Path, capsys
+) -> None:
+    repo, base = _repo(tmp_path)
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/helper.py",
+        "def _helper():\n    return 1\n\ndef caller():\n    return _helper()\n",
+    )
+    base = _commit(repo, "live helper")
+    _branch(repo, base, "left")
+    _write(repo, "implementations/python/demo/src/demo/left.py", "VALUE = 1\n")
+    left = _commit(repo, "left")
+    _branch(repo, base, "right")
+    _write(
+        repo,
+        "implementations/python/demo/src/demo/helper.py",
+        "def _helper():\n    return 1\n",
+    )
+    right = _commit(repo, "right")
+
+    status = main(
+        [
+            "--repo",
+            str(repo),
+            "--base",
+            base,
+            "--left",
+            left,
+            "--right",
+            right,
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert status == 1
+    assert "droppedCaller=1 semanticFieldLoss=0" in output
+    assert "test=dropped-caller" in output


### PR DESCRIPTION
## What changed

- Adds one merged-tree join instrument for adjacent Python-package PR tips.
- Synthesizes the actual Git merge tree, then runs the landed #6474 referenced-before to zero-after detector on base -> merged.
- Detects the #6439/#6445 class structurally: a dataclass field introduced on one tip must be explicitly carried by constructor occurrences newly introduced on the other tip.
- Emits named test counts (`dropped-caller`, `semantic-field-propagation`) and exits red for findings or textual merge conflicts.
- Nonadjacent tips report zero measured packages rather than claiming a join result.

## Validation

- Authenticated interpreter: CPython 3.12.13; NumPy 2.5.1.
- Focused join tests: 6 passed.
- Mutation transaction: disabling semantic-field detection made both semantic join twins fail; restored and clean.
- Shared demand table consumed from the existing shelf, exit 0; never rebuilt.
- `git show --stat` used for #6439, #6445, #6454, and #6474 orientation.

## Honest boundary

- The synthetic semantic reproducer creates two real Git branches whose textual merge is conflict-free and whose merged tree loses `carries_suspension`; the instrument reports exactly one semantic loss.
- The archived #6439/#6445 full-package replay exceeded the shared-Mac resource boundary and was stopped. That replay is UNKNOWN, not a receipt.
- No crash/timeout-zero or corpus-wide claim is made.

Base: `d8a047aaed21ee7a12b39d01bee91c0b4f0c6785`
Head: `cdc188d7b09d4d1ea01b613dcb5d30973e576269`

Do not merge automatically.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add semantic law checker for merged PR trees in Python packages
> - Adds [join_integrity.py](https://github.com/TSavo/sugar/pull/6538/files#diff-12bf4baa2bb5225ae469451b5ba598485c1c1d1c6b64275b6316b6c3d3d0033d), a CLI-capable analyzer that synthesizes a git merge tree from base/left/right SHAs and reports two classes of issues: dropped callers (symbols with zero references after merge) and semantic field propagation losses (dataclass constructor calls missing a field added on the opposite branch).
> - Uses `git merge-tree --write-tree` to produce the merged tree without a checkout, reads Python sources via `git archive`, and analyzes them with the `ast` module.
> - Exits with code 1 and prints a formatted report if any findings exist; exits 0 on a clean join.
> - Adds tests in [test_join_integrity.py](https://github.com/TSavo/sugar/pull/6538/files#diff-732c0ab61448b6991755412c707192cffb82d2e2473f09c61ff3dc6a9f8c3a9c) covering clean joins, dropped-caller detection, semantic field loss, adjacency filtering, and CLI exit codes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdc188d. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git join integrity checks for adjacent branches and open pull requests.
  * Reports dropped references, semantic field loss, merge conflicts, missing required symbols, and stacked-base issues.
  * Added a command-line mode that summarizes findings and returns a failing status for invalid joins.

* **Tests**
  * Added comprehensive coverage for clean joins, semantic regressions, conflicts, contract violations, branch adjacency, and CLI reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->