### PR TITLE
Keep no-call attribution discrepancies loud

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -13,6 +13,7 @@ denominator without constructing peer-family sources.
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from sugar_lift_py_tests.no_call_body_attribution import (
@@ -36,9 +37,23 @@ def main() -> int:
         else None
     )
     repo_root = Path(__file__).resolve().parents[4]
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    import numpy
+    import pandas
+
+    corpus = authenticated_pandas_corpus()
+    print(
+        "authenticated execution environment: "
+        f"python={sys.implementation.name}-{sys.version_info.major}."
+        f"{sys.version_info.minor}.{sys.version_info.micro} "
+        f"numpy={numpy.__version__} pandas={pandas.__version__} "
+        f"corpusManifestCid={corpus.manifest_cid} fileCount={corpus.file_count}",
+        flush=True,
+    )
     report = run_authenticated_attribution(repo_root, families=families)
     print(report.render(), flush=True)
-    return 0
+    return int(report.loud_failure_count != 0)
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -82,6 +82,13 @@ class BodyAttribution:
 
 
 @dataclass(frozen=True)
+class AttributionDiscrepancy:
+    body_id: str
+    family: ProducerFamily | str
+    detail: str
+
+
+@dataclass(frozen=True)
 class FamilyAttribution:
     family: ProducerFamily
     enrolled: int
@@ -106,10 +113,28 @@ class AttributionOutcomeSummary:
 @dataclass(frozen=True)
 class AttributionReport:
     bodies: tuple[BodyAttribution, ...]
+    discrepancies: tuple[AttributionDiscrepancy, ...]
     by_family: Mapping[ProducerFamily, FamilyAttribution]
 
     def rows(self) -> tuple[FamilyAttribution, ...]:
         return tuple(self.by_family[family] for family in ProducerFamily)
+
+    @property
+    def construction_panic_count(self) -> int:
+        return sum(row.construction_panics for row in self.rows())
+
+    @property
+    def outcome_total(self) -> int:
+        return sum(
+            row.authenticated_exceptional_exits
+            + row.named_refusals
+            + row.construction_panics
+            for row in self.rows()
+        )
+
+    @property
+    def loud_failure_count(self) -> int:
+        return self.construction_panic_count + len(self.discrepancies)
 
     def render(self) -> str:
         lines = []
@@ -124,6 +149,30 @@ class AttributionReport:
                         f"constructionPanic={row.construction_panics}",
                     )
                 )
+            )
+        for body in self.bodies:
+            if body.outcome is AttributionOutcome.NAMED_REFUSAL:
+                lines.append(
+                    f"namedRefusal body={body.body_id} coordinate={body.detail}"
+                )
+            elif body.outcome is AttributionOutcome.CONSTRUCTION_PANIC:
+                lines.append(
+                    f"constructionPanic body={body.body_id} "
+                    f"node={getattr(body.family, 'value', body.family)} "
+                    f"owner={body.detail}"
+                )
+        for discrepancy in self.discrepancies:
+            lines.append(
+                f"unaccounted body={discrepancy.body_id} "
+                f"node={getattr(discrepancy.family, 'value', discrepancy.family)} "
+                f"detail={discrepancy.detail}"
+            )
+        enrolled = sum(row.enrolled for row in self.rows())
+        if self.outcome_total != enrolled:
+            lines.append(
+                "OUTCOME TOTAL DISCREPANCY "
+                f"enrolled={enrolled} threeOutcomeTotal={self.outcome_total} "
+                f"unaccounted={len(self.discrepancies)}"
             )
         return "\n".join(lines)
 
@@ -204,13 +253,23 @@ def summarize_attribution_outcomes(
 
 
 def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
-    bodies = tuple(attribute_body_probe(probe) for probe in probes)
+    materialized = tuple(probes)
+    bodies = []
+    discrepancies = []
+    for probe in materialized:
+        try:
+            bodies.append(attribute_body_probe(probe))
+        except AttributionInvariantError as error:
+            discrepancies.append(
+                AttributionDiscrepancy(probe.body_id, probe.family, str(error))
+            )
+    attributed = tuple(bodies)
     rows = {}
     for family in ProducerFamily:
-        selected = tuple(body for body in bodies if body.family is family)
+        selected = tuple(body for body in attributed if body.family is family)
         rows[family] = FamilyAttribution(
             family=family,
-            enrolled=len(selected),
+            enrolled=sum(probe.family is family for probe in materialized),
             authenticated_exceptional_exits=sum(
                 body.outcome is AttributionOutcome.AUTHENTICATED_EXIT
                 for body in selected
@@ -223,7 +282,11 @@ def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
                 for body in selected
             ),
         )
-    return AttributionReport(bodies=bodies, by_family=rows)
+    return AttributionReport(
+        bodies=attributed,
+        discrepancies=tuple(discrepancies),
+        by_family=rows,
+    )
 
 
 def validate_shared_demand_table(payload: dict, *, expected_content_key: str) -> dict:

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -94,6 +94,27 @@ def test_shared_outcome_summary_keeps_refusals_separate_from_panics() -> None:
     assert summary.construction_panics == 1
 
 
+def test_report_names_every_refusal_coordinate_and_panic_node_owner() -> None:
+    report = attribute_body_probes(
+        (
+            _probe(ProducerFamily.BINOP, _named_refusal),
+            _probe(ProducerFamily.SUBSCRIPT, _construction_panic),
+        )
+    )
+
+    rendered = report.render()
+
+    assert (
+        "namedRefusal body=pandas/example.py:1:BinOp "
+        "coordinate=native-producer" in rendered
+    )
+    assert (
+        "constructionPanic body=pandas/example.py:1:Subscript "
+        "node=Subscript owner=producer-construction" in rendered
+    )
+    assert report.construction_panic_count == 1
+
+
 def test_report_keeps_all_six_families_separate() -> None:
     probes = tuple(_probe(family, _named_refusal) for family in ProducerFamily)
     report = attribute_body_probes(probes)
@@ -123,11 +144,20 @@ def test_escaped_construction_panic_remains_a_separate_loud_axis() -> None:
     assert report.bodies[0].outcome is AttributionOutcome.CONSTRUCTION_PANIC
 
 
-def test_silent_completion_is_not_a_fourth_outcome() -> None:
-    with pytest.raises(AttributionInvariantError, match="completed without"):
-        attribute_body_probes(
-            (_probe(ProducerFamily.BOOLOP, lambda: Complete(object())),)
-        )
+def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
+    report = attribute_body_probes(
+        (_probe(ProducerFamily.BOOLOP, lambda: Complete(object())),)
+    )
+
+    assert report.by_family[ProducerFamily.BOOLOP].enrolled == 1
+    assert report.outcome_total == 0
+    assert report.loud_failure_count == 1
+    assert len(report.discrepancies) == 1
+    assert "completed without" in report.discrepancies[0].detail
+    assert (
+        "OUTCOME TOTAL DISCREPANCY enrolled=1 threeOutcomeTotal=0 unaccounted=1"
+        in report.render()
+    )
 
 
 def _table_payload() -> dict:

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -82,6 +82,12 @@ binaries = ["sugar"]
 command = ["python", "-m", "sugar_lift_py_tests.authenticated_pytest"]
 network = "none"
 
+[tasks.authenticated-no-call-body-attribution]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py"]
+network = "none"
+
 [tasks.datetime-claim-twins]
 capabilities = ["python-test", "solver-z3"]
 binaries = ["sugar"]


### PR DESCRIPTION
## What changed

- adds an authenticated Battleaxe task for the 1,008-body native-root attribution
- prints every named-refusal coordinate and every construction-panic file, line, root node, and owner
- preserves completed-without-outcome bodies as a separate loud discrepancy instead of relabeling them as refusals or panics
- exits red for construction panics or unaccounted bodies

## Authenticated result

CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, canonical 1,421-file corpus. The fixed denominators enroll 1,008 bodies; 974 enter the three outcomes, with 34 unaccounted Compare completions. The task exits 1 as required.

## Validation

- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py -q` — 12 passed
- mutation transaction: removing the refusal coordinate makes the focused lying twin fail; restored run passes
- `.venv-py312/bin/python -m black --check ...` — 3 files unchanged
- `SUGAR_BINARY_ALLOW_BUILD=0 PYTHONUNBUFFERED=1 bin/sugarbin run --host bx --env SUGAR_BINARY_ALLOW_BUILD --env PYTHONUNBUFFERED --task authenticated-no-call-body-attribution` — authenticated, exits 1 on 739 construction panics plus 34 unaccounted completions

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep no-call attribution discrepancies loud by recording them in the report instead of raising
> - `attribute_body_probes` in [no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/6540/files#diff-63dc4df7d670fe2740ec87663a519f79002baa69eb853f03a8559b42d8f325e4) now catches `AttributionInvariantError` (e.g. silent completions) and records them as `AttributionDiscrepancy` entries instead of raising, so the script always produces a full report.
> - `AttributionReport` gains a `discrepancies` field and new properties: `construction_panic_count`, `outcome_total`, and `loud_failure_count` (panics + discrepancies).
> - `render()` now emits per-body lines for named refusals and construction panics, lists unaccounted discrepancies with details, and appends an OUTCOME TOTAL DISCREPANCY line when totals don't match enrolled.
> - The [script entrypoint](https://github.com/TSavo/sugar/pull/6540/files#diff-8e1df3404326b74b11100b0b063138d06765babfb90e86828821d08300ee62d9) exits with a non-zero code when `loud_failure_count > 0`, making CI failures visible.
> - A new `authenticated-no-call-body-attribution` build task is added to [sugar-build.toml](https://github.com/TSavo/sugar/pull/6540/files#diff-b714a26a105f372af4929844b95deb54b1e2701396f192e8761d975086b49835) to run the script in a network-isolated environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f11726.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->