### PR TITLE
Measure Subscript producer outcomes loudly

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -26,6 +26,11 @@ class RaiseEffect:
     # The handled occurrence active when this raise happened. This is Python's
     # ``__context__`` testimony and is distinct from an explicit ``from`` cause.
     context_effect: "RaiseEffect | None" = None
+    # The expression node that published this halted edge to its parent. This
+    # is distinct from ``blame``: a callee's Raise statement supplies the
+    # source locus, while the enclosing Call owns the failure observed by a
+    # parent expression such as ``make_receiver()[0]``.
+    producer_node_owner: str | None = None
 
     @property
     def occurrence_id(self) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -1261,8 +1261,16 @@ class CallSiteValue(FloorValue):
 
             return Complete(self)
 
+        from dataclasses import replace
+
+        from sugar_lift_py_tests.effect import RaiseEffect
         from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        def call_owned(effect):
+            if isinstance(effect, RaiseEffect):
+                return replace(effect, producer_node_owner="Call")
+            return effect
 
         outcome = self.reduce_source_outcome(ctx)
         if isinstance(outcome, Complete):
@@ -1280,7 +1288,7 @@ class CallSiteValue(FloorValue):
                     if isinstance(exit_, Completed)
                     else Halted(
                         exit_.guard,
-                        exit_.effect,
+                        call_owned(exit_.effect),
                         exit_.state,
                         exit_.faces,
                         exit_.pending_contracts,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -177,23 +177,28 @@ class AttributionReport:
         return "\n".join(lines)
 
 
-def _exceptional_exit_present(outcome: object) -> bool:
+def _exceptional_exit_effects(outcome: object) -> tuple[object, ...]:
     from sugar_lift_py_tests.effect import RaiseEffect
     from sugar_lift_py_tests.floor import RaiseValue
     from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
     from sugar_lift_py_tests.outcome.exit_set import Halted
 
     if isinstance(outcome, Incomplete):
-        return isinstance(outcome.effect, RaiseEffect)
+        return (outcome.effect,) if isinstance(outcome.effect, RaiseEffect) else ()
     if isinstance(outcome, Complete):
         value = outcome.value
-        return isinstance(value, RaiseValue) and isinstance(value.effect, RaiseEffect)
-    if isinstance(outcome, ExitSet):
-        return any(
-            isinstance(face, Halted) and isinstance(face.effect, RaiseEffect)
-            for face in outcome.exits
+        return (
+            (value.effect,)
+            if isinstance(value, RaiseValue) and isinstance(value.effect, RaiseEffect)
+            else ()
         )
-    return False
+    if isinstance(outcome, ExitSet):
+        return tuple(
+            face.effect
+            for face in outcome.exits
+            if isinstance(face, Halted) and isinstance(face.effect, RaiseEffect)
+        )
+    return ()
 
 
 def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
@@ -217,12 +222,23 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             panic.info.owner,
         )
 
-    if _exceptional_exit_present(outcome):
+    exceptional_effects = _exceptional_exit_effects(outcome)
+    if exceptional_effects:
+        owners = {
+            effect.producer_node_owner
+            for effect in exceptional_effects
+            if effect.producer_node_owner is not None
+        }
+        detail = (
+            next(iter(owners))
+            if len(owners) == 1
+            else getattr(probe.family, "value", str(probe.family))
+        )
         return BodyAttribution(
             probe.body_id,
             probe.family,
             AttributionOutcome.AUTHENTICATED_EXIT,
-            type(outcome).__name__,
+            detail,
         )
     raise AttributionInvariantError(
         f"{probe.body_id} "

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_exceptional_exit_producer.py
@@ -67,6 +67,7 @@ def test_authenticated_call_publishes_its_source_body_halt() -> None:
     assert isinstance(halted, Halted)
     assert isinstance(halted.effect, RaiseEffect)
     assert halted.effect.exception_name == "ValueError"
+    assert halted.effect.producer_node_owner == "Call"
 
 
 def test_completed_source_call_keeps_the_ordinary_call_coordinate() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -36,6 +36,14 @@ def _raise_value():
     return Complete(RaiseValue(RaiseEffect(exception_name="TypeError")))
 
 
+def _call_owned_raise_value():
+    return Complete(
+        RaiseValue(
+            RaiseEffect(exception_name="TypeError", producer_node_owner="Call")
+        )
+    )
+
+
 def _named_refusal():
     raise SugarNotWritten(
         owner="native-producer",
@@ -132,7 +140,7 @@ def test_report_keeps_all_six_families_separate() -> None:
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
-def test_escaped_construction_panic_remains_a_separate_loud_axis() -> None:
+def test_construction_panic_remains_a_separate_loud_axis() -> None:
     report = attribute_body_probes(
         (_probe(ProducerFamily.ATTRIBUTE, _construction_panic),)
     )
@@ -158,6 +166,85 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
         "OUTCOME TOTAL DISCREPANCY enrolled=1 threeOutcomeTotal=0 unaccounted=1"
         in report.render()
     )
+
+
+def test_construction_panics_are_rendered_with_site_and_failing_node_owner() -> None:
+    report = attribute_body_probes(
+        (_probe(ProducerFamily.SUBSCRIPT, _construction_panic),)
+    )
+
+    assert (
+        "constructionPanic body=pandas/example.py:1:Subscript "
+        "node=Subscript owner=producer-construction"
+    ) in report.render()
+    assert report.construction_panic_count == 1
+
+
+def test_join_collects_construction_panic_and_outcome_discrepancy_before_failing() -> None:
+    """#6540 + #6541: both loud axes survive one report transaction."""
+    report = attribute_body_probes(
+        (
+            _probe(ProducerFamily.SUBSCRIPT, _construction_panic),
+            _probe(ProducerFamily.BOOLOP, lambda: Complete(object())),
+        )
+    )
+
+    assert len(report.bodies) == 1
+    assert len(report.discrepancies) == 1
+    assert report.construction_panic_count == 1
+    assert report.outcome_total == 1
+    assert report.loud_failure_count == 2
+    assert "constructionPanic body=pandas/example.py:1:Subscript" in report.render()
+    assert (
+        "OUTCOME TOTAL DISCREPANCY enrolled=2 threeOutcomeTotal=1 unaccounted=1"
+        in report.render()
+    )
+
+
+def test_receiver_call_panic_is_owned_by_call_before_subscript_is_reached() -> None:
+    """Lying twin: root shape cannot steal a failure from its receiver Call."""
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
+
+    class RaisingCall:
+        def desugar(self, ctx=None):
+            construction_panic_gap(
+                owner="Call",
+                blame="pandas/example.py:1:receiver",
+                observed="receiver call raised before returning a value",
+                requested="a completed receiver before Subscript evaluation",
+                fix="attribute this failing edge to Call",
+            )
+
+    class UnreachedIndex:
+        def desugar(self, ctx=None):
+            raise AssertionError("Subscript index was evaluated after receiver halt")
+
+    expression = SubscriptSugar(
+        receiver=RaisingCall(), index=UnreachedIndex(), site="pandas/example.py:1"
+    )
+    body = attribute_body_probe(
+        BodyProbe(
+            body_id="pandas/example.py:1:Subscript",
+            family=ProducerFamily.SUBSCRIPT,
+            evaluator=expression.desugar,
+        )
+    )
+
+    assert body.family is ProducerFamily.SUBSCRIPT
+    assert body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
+    assert body.detail == "Call"
+
+
+def test_receiver_call_exceptional_exit_is_not_claimed_by_root_subscript() -> None:
+    report = attribute_body_probes(
+        (_probe(ProducerFamily.SUBSCRIPT, _call_owned_raise_value),)
+    )
+
+    body = report.bodies[0]
+    assert body.family is ProducerFamily.SUBSCRIPT
+    assert body.outcome is AttributionOutcome.AUTHENTICATED_EXIT
+    assert body.detail == "Call"
 
 
 def _table_payload() -> dict:

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 from pathlib import Path
 
@@ -48,10 +49,54 @@ SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
 MANIFEST_CID = CANONICAL_CORPUS_MANIFEST_CID
 MANIFEST_SHA256 = CANONICAL_CORPUS_MANIFEST_SHA256
 
+REJECTED_VENDOR_FILTER_SEEDS = (
+    (
+        "tests/indexes/multi/test_sorting.py",
+        147,
+        'dfm.loc[1, "z"]',
+        "assert_produces_warning",
+    ),
+    (
+        "tests/indexing/multiindex/test_multiindex.py",
+        29,
+        'df.loc[1, "z"]',
+        "assert_produces_warning",
+    ),
+    (
+        "tests/indexing/multiindex/test_multiindex.py",
+        33,
+        "df.loc[0,]",
+        "assert_produces_warning",
+    ),
+    (
+        "tests/series/accessors/test_list_accessor.py",
+        101,
+        "ser.list[1:None:0]",
+        "external_error_raised",
+    ),
+    (
+        "tests/series/accessors/test_list_accessor.py",
+        133,
+        "ser.list[-1]",
+        "external_error_raised",
+    ),
+    (
+        "tests/series/accessors/test_list_accessor.py",
+        135,
+        "ser.list[5]",
+        "external_error_raised",
+    ),
+)
+
 
 @pytest.fixture(scope="module")
-def authenticated_site():
-    corpus = authenticated_pandas_corpus()
+def authenticated_corpus():
+    return authenticated_pandas_corpus()
+
+
+@pytest.fixture(scope="module")
+def authenticated_site(authenticated_corpus):
+    corpus = authenticated_corpus
     assert corpus.manifest_cid == MANIFEST_CID
     site = corpus.root / "tests/test_multilevel.py"
     assert hashlib.sha256(site.read_bytes()).hexdigest() == SITE_SHA256
@@ -121,6 +166,53 @@ def test_historical_path_shape_digest_is_refused_as_corpus_identity() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "relative_path,line,expected_expression,expected_manager",
+    REJECTED_VENDOR_FILTER_SEEDS,
+)
+def test_non_vendor_subscript_seed_is_real_and_has_no_call_descendant(
+    authenticated_corpus,
+    relative_path,
+    line,
+    expected_expression,
+    expected_manager,
+) -> None:
+    corpus = authenticated_corpus
+    source = (corpus.root / relative_path).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=relative_path)
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.With, ast.AsyncWith))
+        and len(node.body) == 1
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Subscript)
+        and node.body[0].value.lineno == line
+    ]
+
+    assert len(matches) == 1
+    expression = matches[0].body[0].value
+    assert ast.dump(expression, include_attributes=False) == ast.dump(
+        ast.parse(expected_expression, mode="eval").body,
+        include_attributes=False,
+    )
+    assert not any(isinstance(node, ast.Call) for node in ast.walk(expression))
+    assert any(
+        isinstance(item.context_expr, ast.Call)
+        and (
+            (
+                isinstance(item.context_expr.func, ast.Name)
+                and item.context_expr.func.id == expected_manager
+            )
+            or (
+                isinstance(item.context_expr.func, ast.Attribute)
+                and item.context_expr.func.attr == expected_manager
+            )
+        )
+        for item in matches[0].items
+    )
+
+
 def test_authenticated_subscript_family_owns_no_construction_panics(
     tmp_path,
 ) -> None:
@@ -128,7 +220,12 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
     repo_root = Path(__file__).resolve().parents[4]
     payload = pull_shared_demand_table(repo_root, tmp_path / "python-demand-table.json")
     inventory = require_expected_denominators(
-        discover_no_call_body_probes(payload, corpus.root)
+        discover_no_call_body_probes(
+            payload,
+            corpus.root,
+            families=frozenset({ProducerFamily.SUBSCRIPT}),
+        ),
+        families=frozenset({ProducerFamily.SUBSCRIPT}),
     )
     probes = tuple(
         probe for probe in inventory if probe.family is ProducerFamily.SUBSCRIPT
@@ -140,22 +237,33 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
         for body in report.bodies
         if body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
     )
-    subscript_owned_panics = tuple(
-        gap
-        for gap in reattributed_gaps
-        if gap.detail == "subscript" or gap.detail.endswith(".subscript")
-    )
+    required_non_vendor_sites = {
+        "tests/indexes/multi/test_sorting.py:147:Subscript",
+        "tests/indexing/multiindex/test_multiindex.py:29:Subscript",
+        "tests/indexing/multiindex/test_multiindex.py:33:Subscript",
+        "tests/series/accessors/test_list_accessor.py:101:Subscript",
+        "tests/series/accessors/test_list_accessor.py:133:Subscript",
+        "tests/series/accessors/test_list_accessor.py:135:Subscript",
+    }
 
     print(row, flush=True)
-    print(f"subscriptReattributedTypedGaps={len(reattributed_gaps)}", flush=True)
+    print(f"subscriptConstructionPanics={len(reattributed_gaps)}", flush=True)
     for gap in reattributed_gaps:
         print(
-            f"subscriptReattribution site={gap.body_id} owner={gap.detail}",
+            f"constructionPanic site={gap.body_id} owner={gap.detail}",
             flush=True,
         )
 
     assert row.enrolled == FAMILY_DENOMINATORS[ProducerFamily.SUBSCRIPT]
-    assert not subscript_owned_panics, subscript_owned_panics
+    assert {probe.body_id for probe in probes} >= required_non_vendor_sites
+    assert (
+        row.authenticated_exceptional_exits
+        + row.named_refusals
+        + row.construction_panics
+        == 392
+    )
+    assert report.discrepancies == ()
+    assert not reattributed_gaps, reattributed_gaps
 
 
 def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> None:


### PR DESCRIPTION
## What changed

- keeps the authenticated Subscript denominator fixed at 392 and pins the six real sites excluded by the rejected `targetSymbol == "pytest.raises"` filter
- records the node that actually publishes an exceptional edge, so a receiver Call that halts before Subscript evaluation remains Call-owned
- composes with #6540's collected-discrepancy report: panics, named refusals, and unaccounted outcomes are all rendered before `loud_failure_count` makes the runner non-zero
- adds a join regression proving one ConstructionPanic and one outcome discrepancy survive the same report transaction

## Semantic join with #6540

Rebased onto `63686b6bf` (`Keep no-call attribution discrepancies loud`). The merged report retains `discrepancies`, `outcome_total`, `construction_panic_count`, and `loud_failure_count`; it does not restore the former raise-on-first-discrepancy behavior.

Named join tests, all passing:

- `test_construction_panic_remains_a_separate_loud_axis`
- `test_silent_completion_stays_a_separate_loud_discrepancy`
- `test_population_selection_never_reads_manager_target_symbol`
- `test_report_keeps_all_six_families_separate`
- `test_join_collects_construction_panic_and_outcome_discrepancy_before_failing`
- `test_receiver_call_exceptional_exit_is_not_claimed_by_root_subscript`

The denominators remain `392 + 367 + 181 + 53 + 13 + 2 = 1,008`.

## Validation

- exact pre-rebase Battleaxe focused selection: 26 collected/passed
- same post-rebase Battleaxe selection: 29 collected/passed; the three added tests are #6540's population/discrepancy coverage plus this PR's join test, with no removed collection and no new failure
- local authenticated CPython 3.12.13 focused selection: 43 passed, 1 heavy test deselected
- named semantic join selection: 6 collected/passed
- authenticated Battleaxe Subscript census: `0 authenticated exits + 390 named refusals + 2 ConstructionPanics = 392`, zero collected discrepancies, exit 1 as required

Compared with the pre-rebase census (`0 + 200 + 192 = 392`), landed main removed 190 ConstructionPanics by producing named third-value refusals. It revealed no new panic site. The two unchanged producer defects remain:

- `tests/extension/base/getitem.py:147:Subscript`, owner `binary_operation_exception_floor`
- `tests/series/indexing/test_getitem.py:595:Subscript`, owner `comparison_operation_exception_floor`

Runtime testimony: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, canonical BLAKE3 corpus manifest. The heavy census consumed the shared demand table on Battleaxe and did not rebuild it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track Subscript producer outcomes by propagating `producer_node_owner` through `RaiseEffect`
> - Adds an optional `producer_node_owner` field to `RaiseEffect` to distinguish which node published a halted edge from the blame/source locus.
> - `CallSiteValue` now wraps halted exit effects with `call_owned(...)`, stamping `producer_node_owner='Call'` on effects that originate from a call site.
> - `attribute_body_probe` in `no_call_body_attribution` now sets `detail` to the unique `producer_node_owner` from collected `RaiseEffect`s (e.g. `'Call'`) instead of a generic outcome type string for authenticated exceptional exits.
> - New and updated tests cover Subscript producer attribution, construction panics owned by `'Call'`, and the case where a receiver call's exceptional exit is not claimed by the root Subscript.
> - Behavioral Change: authenticated exceptional exit `AttributionOutcome.detail` now reflects the producing node owner when it is unique and non-`None`, changing previously recorded outcome type strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 230380a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->