### PR TITLE
Serialize and reuse the authenticated py312 bootstrap

### DIFF
--- a/scripts/bootstrap-venv-py312.sh
+++ b/scripts/bootstrap-venv-py312.sh
@@ -68,22 +68,12 @@ if [[ "${BOOTSTRAP_CHECK_ONLY:-0}" == "1" ]]; then
 fi
 
 venv_dir="${VENV_DIR:-$repo_root/.venv-py312}"
-echo "Creating $venv_dir from $py312 (3.12.13)"
-"$py312" -m venv "$venv_dir"
-"$venv_dir/bin/python" -m pip install -U pip setuptools wheel
 
-# Editable Sugar packages always come from THIS checkout.
-"$venv_dir/bin/python" -m pip install \
-  -e "$repo_root/implementations/python/sugar-source-tree" \
-  -e "$repo_root/implementations/python/sugar-lift-python-source" \
-  -e "$repo_root/implementations/python/sugar-lift-py-tests[test]" \
-  "pytest==9.1.1"
-
-# AFTER the editable install: float was measured when extras resolved pandas
-# 3.0.5 while ledgers key to 3.0.3. Re-pin exactly, then verify load path.
-"$venv_dir/bin/python" -m pip install "numpy==2.5.1" "pandas==3.0.3"
-
-"$venv_dir/bin/python" - <<'PY'
+# The post-install discrimination, hoisted into one function. Used by BOTH the
+# reuse fast path and the full run, so reuse can never authenticate an
+# environment the full run would reject.
+verify_pins() {
+  "$1/bin/python" - <<'PY'
 """Post-install discrimination: version AND load path inside this venv."""
 from __future__ import annotations
 
@@ -107,6 +97,51 @@ print("pandas", pandas.__version__, pathlib.Path(pandas.__file__).resolve())
 print("pytest", md.version("pytest"))
 print("PINS_OK")
 PY
+}
+
+# SERIALIZE. Twelve agents bootstrapping at once drove a shared workstation to
+# load 200 and raced two pip installs onto one site-packages. mkdir is atomic;
+# the loser waits instead of corrupting the winner's install.
+lock_dir="$venv_dir.lock"
+lock_waited=0
+lock_timeout="${BOOTSTRAP_LOCK_TIMEOUT:-1800}"
+while ! mkdir "$lock_dir" 2>/dev/null; do
+  if (( lock_waited == 0 )); then
+    echo "bootstrap-venv-py312: another bootstrap holds $lock_dir; waiting" >&2
+  fi
+  if (( lock_waited >= lock_timeout )); then
+    die "timed out after ${lock_timeout}s waiting for $lock_dir (if no bootstrap is running: rmdir $lock_dir)"
+  fi
+  sleep 5
+  lock_waited=$(( lock_waited + 5 ))
+done
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+
+# Already authenticated? Then there is nothing to do. Recreating the venv and
+# reinstalling numpy+pandas on every invocation is what made this heavy.
+if [[ -x "$venv_dir/bin/python" ]] && verify_pins "$venv_dir" 2>/dev/null; then
+  echo
+  echo "$venv_dir already authenticates the declared pins; reusing it."
+  echo "Use:  $venv_dir/bin/python -m pytest …"
+  exit 0
+fi
+
+echo "Creating $venv_dir from $py312 (3.12.13)"
+"$py312" -m venv "$venv_dir"
+"$venv_dir/bin/python" -m pip install -U pip setuptools wheel
+
+# Editable Sugar packages always come from THIS checkout.
+"$venv_dir/bin/python" -m pip install \
+  -e "$repo_root/implementations/python/sugar-source-tree" \
+  -e "$repo_root/implementations/python/sugar-lift-python-source" \
+  -e "$repo_root/implementations/python/sugar-lift-py-tests[test]" \
+  "pytest==9.1.1"
+
+# AFTER the editable install: float was measured when extras resolved pandas
+# 3.0.5 while ledgers key to 3.0.3. Re-pin exactly, then verify load path.
+"$venv_dir/bin/python" -m pip install "numpy==2.5.1" "pandas==3.0.3"
+
+verify_pins "$venv_dir"
 
 echo
 echo "Use:  $venv_dir/bin/python -m pytest …"


### PR DESCRIPTION
Twelve agents bootstrapping concurrently drove the shared workstation to **load 200** and raced two `pip install` processes onto one `site-packages`, which also blocked all agent dispatch. Both causes are in this script.

**1. No mutex.** N concurrent invocations stampede. Now an atomic `mkdir` lock: the loser waits (default 1800s, `BOOTSTRAP_LOCK_TIMEOUT`) and `die()`s with instructions for clearing a stale lock, rather than corrupting the winner's install. Released via `trap ... EXIT`.

**2. Not idempotent.** It recreated the venv and reinstalled numpy+pandas on *every* invocation, even when the venv already authenticated. Now a fast path exits 0 if the pins already check out.

**The authentication is unchanged.** The post-install discrimination moved into one `verify_pins` function used by BOTH the fast path and the full run, so reuse cannot authenticate an environment the full run would reject. Exact-string 3.12.13 / 2.5.1 / 3.0.3 plus the `purelib` load-path assertions are untouched, and `die()`, `require_exact_cpython_31213` and `BOOTSTRAP_CHECK_ONLY` are preserved. Diff is +50/-15, additive.

**Verified, all three paths:**
- Fast path on an authenticated venv: prints `PINS_OK`, reuses, exit 0, no reinstall.
- Mutex with the lock held: refuses with the wait message, exit 2, no stampede.
- `BOOTSTRAP_CHECK_ONLY=1`: still exits 0 without touching a venv. Lock released by the trap.

Nothing heavy on the shared Mac — this is the fix for that class.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize and reuse the authenticated py312 bootstrap venv
> - Adds a lock-based serialization mechanism to [bootstrap-venv-py312.sh](https://github.com/TSavo/sugar/pull/6542/files#diff-a22bd73dfaccdbcb19ad8940327c62df8c7d5f112e66d08ca65cdf2bccf65be9) using a lock directory, with a configurable timeout (`BOOTSTRAP_LOCK_TIMEOUT`, default 1800s) and automatic cleanup on exit.
> - Introduces a fast-path reuse: if the venv's Python binary exists and pin/import verification passes, the script exits early without recreating the venv or reinstalling packages.
> - Extracts the post-install verification logic into a `verify_pins` function called both during the reuse check and after fresh installation.
> - Behavioral Change: concurrent bootstrap invocations now serialize rather than run in parallel; if the lock times out, the script exits with an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31b4a3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->