### PR TITLE
Preserve nested boundary edge ownership

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/block_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/block_value.py
@@ -51,11 +51,19 @@ class BlockValue(FloorValue):
         # still reduce the assert on the non-exception path.
         from sugar_lift_py_tests.floor.raise_value import RaiseValue
         from sugar_lift_py_tests.floor.return_value import ReturnValue
+        from sugar_lift_py_tests.outcome import Incomplete
         from sugar_lift_py_tests.outcome.follow_step import FollowStep
 
         if any(type(entry) is ReturnValue for entry in self.statements):
             return FollowStep.halt(keeps_rest=True)
         if any(type(entry) is RaiseValue for entry in self.statements):
+            return FollowStep.halt(keeps_rest=False)
+        if any(
+            isinstance(entry, Incomplete)
+            and not entry.branch_conditions
+            and not entry.follow().continues
+            for entry in self.statements
+        ):
             return FollowStep.halt(keeps_rest=False)
         return FollowStep.continue_with()
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -64,20 +64,34 @@ def promote_raise_halts(exits):
             continue
 
         remaining: list = []
+        prefix: list = []
         saw_halt = False
         for entry in state.entries:
             if is_hard_raise(entry):
                 saw_halt = True
                 guard = guard_from_conditions(exit_.guard, entry.branch_conditions)
-                promoted.append(Halted(guard, entry.effect, state))
+                # A Halted face carries the state that existed before its
+                # effect.  Keeping the raise entry in that state lets a later
+                # enclosing reducer promote the already-consumed edge again.
+                promoted.append(
+                    Halted(
+                        guard,
+                        entry.effect,
+                        replace(state, entries=tuple(prefix)),
+                    )
+                )
             else:
                 remaining.append(entry)
+                prefix.append(entry)
 
         if not saw_halt:
             promoted.append(exit_)
             continue
 
-        if remaining or state.can_fall_through:
+        # Entries before a terminal raise are the halted arm's state, not
+        # evidence of a second execution that completed.  Only the reducer's
+        # explicit fall-through testimony authorizes a complementary arm.
+        if state.can_fall_through:
             promoted.append(
                 Completed(
                     exit_.guard,

--- a/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
@@ -1,0 +1,25 @@
+"""BlockValue preserves the halt encoded by ExitSet's linear adapter."""
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import BlockValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Incomplete
+
+
+def test_unguarded_incomplete_raise_stops_block_fallthrough():
+    block = BlockValue((Incomplete(RaiseEffect(exception_name="OSError")),))
+
+    assert not block.follow_rest().continues
+
+
+def test_guarded_incomplete_raise_preserves_the_complementary_tail():
+    block = BlockValue(
+        (
+            Incomplete(
+                RaiseEffect(exception_name="OSError"),
+                branch_conditions=(make_var("condition"),),
+            ),
+        )
+    )
+
+    assert block.follow_rest().continues

--- a/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
@@ -1,0 +1,59 @@
+"""Terminal raise promotion must not invent a completed sibling arm."""
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import (
+    Completed,
+    ExitSet,
+    Halted,
+    Incomplete,
+    true_guard,
+)
+from sugar_lift_py_tests.sugar.exit_set_routing import promote_raise_halts
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+
+def test_terminal_raise_with_prior_state_promotes_to_halt_only():
+    marker = object()
+    effect = RaiseEffect(exception_name="OSError")
+    exits = ExitSet(
+        (
+            Completed(
+                true_guard(),
+                _ReducedBlock((marker, Incomplete(effect)), False, ()),
+            ),
+        )
+    )
+
+    promoted = promote_raise_halts(exits)
+
+    assert len(promoted.exits) == 1
+    assert isinstance(promoted.exits[0], Halted)
+    assert promoted.exits[0].effect is effect
+    assert promoted.exits[0].state.entries == (marker,)
+
+
+def test_guarded_raise_keeps_its_complementary_completed_arm():
+    marker = object()
+    condition = make_var("condition")
+    effect = RaiseEffect(exception_name="OSError")
+    exits = ExitSet(
+        (
+            Completed(
+                true_guard(),
+                _ReducedBlock(
+                    (
+                        marker,
+                        Incomplete(effect, branch_conditions=(condition,)),
+                    ),
+                    True,
+                    (),
+                ),
+            ),
+        )
+    )
+
+    promoted = promote_raise_halts(exits)
+
+    assert sum(isinstance(face, Halted) for face in promoted.exits) == 1
+    assert sum(isinstance(face, Completed) for face in promoted.exits) == 1

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
 
@@ -437,20 +437,17 @@ def _three_deep_manager_halt(exception_name: str):
     original_middle = middle
     original_inner = inner
     middle_exit, inner_enter, inner_exit = [], [], []
+    effect = RaiseEffect(
+        exception_name=exception_name,
+        exception_type_coordinate=ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(exception_name)],
+        ),
+        occurrence="test_common.py:640",
+    )
     inner = replace(
         inner,
-        manager=_FixedOutcomeSugar(
-            Incomplete(
-                RaiseEffect(
-                    exception_name=exception_name,
-                    exception_type_coordinate=ctor(
-                        "python:exception_type_identity",
-                        [str_const("builtins"), str_const(exception_name)],
-                    ),
-                    occurrence="test_common.py:640",
-                )
-            )
-        ),
+        manager=_FixedOutcomeSugar(Incomplete(effect)),
         enter=_FixedOutcomeSugar(
             Complete(StringValue("inner-enter")), probe=inner_enter
         ),
@@ -474,6 +471,180 @@ def _three_deep_manager_halt(exception_name: str):
         ),
     )
     return outer.desugar(), middle_exit, inner_enter, inner_exit
+
+
+@dataclass(frozen=True)
+class _LevelRoutingReceipt:
+    level: str
+    effect: object
+    attribution: object
+    consumed: bool
+    passed: bool
+
+    @property
+    def authenticated_exceptional_exits(self) -> int:
+        from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
+
+        return int(self.attribution is AttributionOutcome.AUTHENTICATED_EXIT)
+
+    @property
+    def named_refusals(self) -> int:
+        from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
+
+        return int(self.attribution is AttributionOutcome.NAMED_REFUSAL)
+
+    @property
+    def construction_panics(self) -> int:
+        from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
+
+        return int(self.attribution is AttributionOutcome.CONSTRUCTION_PANIC)
+
+
+def _account_level(level: str, effect, evaluate):
+    """Account one incoming edge without reconstructing its identity."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
+    from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.exit_set_routing import promote_raise_halts
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+    from sugar_source_tree.panic import SugarNotWritten
+
+    try:
+        outcome = evaluate()
+    except SugarNotWritten:
+        return (
+            _LevelRoutingReceipt(
+                level, effect, AttributionOutcome.NAMED_REFUSAL, False, False
+            ),
+            None,
+        )
+    except ConstructionPanic:
+        return (
+            _LevelRoutingReceipt(
+                level, effect, AttributionOutcome.CONSTRUCTION_PANIC, False, False
+            ),
+            None,
+        )
+
+    # Observe the exact projection the next enclosing boundary consumes. The
+    # linear Outcome adapter may carry a hard raise inside BlockValue; routing
+    # sees it only after the ordinary block reduction promotes that native
+    # entry back to a Halted ExitSet face.
+    exits = (
+        promote_raise_halts(outcome)
+        if isinstance(outcome, ExitSet)
+        else promote_raise_halts(
+            reduce_block_to_exitset((_FixedOutcomeSugar(outcome),), None)
+        )
+    )
+    passed = any(
+        isinstance(face, Halted) and face.effect is effect for face in exits.exits
+    )
+    completed = any(isinstance(face, Completed) for face in exits.exits)
+    if passed and completed:
+        raise AssertionError(
+            f"{level} duplicated the incoming edge into a completed arm: {exits!r}"
+        )
+    consumed = not passed and completed
+    if consumed == passed:
+        raise AssertionError(
+            f"{level} must consume or pass the exact incoming edge once: {exits!r}"
+        )
+    return (
+        _LevelRoutingReceipt(
+            level, effect, AttributionOutcome.AUTHENTICATED_EXIT, consumed, passed
+        ),
+        outcome,
+    )
+
+
+def _three_deep_level_receipts(exception_name: str):
+    """Expose the pinned chain's ExitSet after each source-ordered router."""
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.floor import BlockValue, ClassValue, StringValue
+    from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+        AuthenticatedExceptionTypeValue,
+    )
+    from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+    source = (
+        "def test_close_on_error():\n"
+        "    with boundary(OSError):\n"
+        "        with bytes_io() as buffer:\n"
+        "            with get_handle(buffer) as handles:\n"
+        "                pass\n"
+    )
+    identity = (source, "test_common_three_deep.py", blake3_512_of(source.encode()))
+    probe = SourceFile(identity)
+    with_nodes = sorted(
+        (node for node in probe.nodes() if node.kind == "With"),
+        key=lambda node: node.line_col_span().start_line,
+    )
+    rows = {}
+    for index, node in enumerate(with_nodes):
+        coordinate = _coordinate(node.items[0].context_expr)
+        rows[coordinate] = (
+            _ref(coordinate, _raise_semantics(), "h")
+            if index == 0
+            else _resource_ref(coordinate, str(index))
+        )
+    outer, middle, inner = _with_routers(
+        _built_function(identity, "test_close_on_error", rows)
+    )
+    effect = RaiseEffect(
+        exception_name=exception_name,
+        exception_type_coordinate=ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(exception_name)],
+        ),
+        occurrence="test_common.py:640",
+    )
+    inner = replace(
+        inner,
+        manager=_FixedOutcomeSugar(Incomplete(effect)),
+        enter=_FixedOutcomeSugar(Complete(StringValue("inner-enter"))),
+        exit=_FixedOutcomeSugar(Complete(StringValue("inner-exit"))),
+    )
+    inner_receipt, inner_outcome = _account_level("inner", effect, inner.desugar)
+    assert inner_outcome is not None, inner_receipt
+
+    middle = replace(
+        middle,
+        manager=_FixedOutcomeSugar(Complete(StringValue("bytes-io"))),
+        enter=_FixedOutcomeSugar(Complete(StringValue("buffer"))),
+        exit=_FixedOutcomeSugar(Complete(StringValue("bytes-io-exit"))),
+        body=(_FixedOutcomeSugar(inner_outcome),),
+    )
+    middle_receipt, middle_outcome = _account_level("middle", effect, middle.desugar)
+    assert middle_outcome is not None, middle_receipt
+
+    expected_identity = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("OSError")],
+    )
+    expected = AuthenticatedExceptionTypeValue(
+        ClassValue("OSError", (), BlockValue(())),
+        expected_identity,
+        (expected_identity,),
+    )
+    manager_call = CallSiteValue(
+        "boundary",
+        (expected,),
+        ("expected",),
+        ctor("call:boundary", []),
+        None,
+    )
+    outer = replace(
+        outer,
+        manager=_FixedOutcomeSugar(Complete(manager_call)),
+        body=(_FixedOutcomeSugar(middle_outcome),),
+    )
+    outer_receipt, outer_outcome = _account_level("outer", effect, outer.desugar)
+    assert outer_outcome is not None, outer_receipt
+    return inner_receipt, middle_receipt, outer_receipt
 
 
 def test_three_deep_innermost_manager_halt_reaches_outer_assertion_after_cleanup():
@@ -514,6 +685,44 @@ def test_three_deep_nonmatching_manager_halt_stays_halted_after_cleanup():
     assert middle_exit == [1]
     assert inner_enter == []
     assert inner_exit == []
+
+
+def test_three_deep_each_level_accounts_the_outer_matching_edge_once():
+    """Real site: two resources pass OSError; only the assertion consumes it."""
+    receipts = _three_deep_level_receipts("OSError")
+
+    assert [receipt.level for receipt in receipts] == ["inner", "middle", "outer"]
+    assert [receipt.consumed for receipt in receipts] == [False, False, True]
+    assert [receipt.passed for receipt in receipts] == [True, True, False]
+    assert all(receipt.authenticated_exceptional_exits == 1 for receipt in receipts)
+    assert all(receipt.named_refusals == 0 for receipt in receipts)
+    assert all(receipt.construction_panics == 0 for receipt in receipts)
+
+
+def test_three_deep_outer_only_edge_cannot_be_consumed_at_an_inner_level():
+    """Load-bearing lying twin: OSError is the outer contract's edge alone."""
+    inner, middle, outer = _three_deep_level_receipts("OSError")
+
+    assert inner.passed and not inner.consumed
+    assert middle.passed and not middle.consumed
+    assert outer.consumed and not outer.passed
+    assert inner.effect is middle.effect is outer.effect
+
+
+def test_three_deep_edge_matching_no_level_escapes_all_three_unchanged():
+    """A TypeError belongs to no level and must remain the identical loud edge."""
+    inner, middle, outer = _three_deep_level_receipts("TypeError")
+
+    assert all(
+        receipt.passed and not receipt.consumed for receipt in (inner, middle, outer)
+    )
+    assert inner.effect is middle.effect is outer.effect
+    assert all(
+        receipt.authenticated_exceptional_exits == 1
+        for receipt in (inner, middle, outer)
+    )
+    assert all(receipt.named_refusals == 0 for receipt in (inner, middle, outer))
+    assert all(receipt.construction_panics == 0 for receipt in (inner, middle, outer))
 
 
 def test_pinned_juxtaposed_assertion_and_resource_nest_left_to_right():


### PR DESCRIPTION
## What changed

- preserve terminal `Incomplete(RaiseEffect)` as a real halt through the linear `BlockValue` adapter
- carry only pre-effect state on promoted halted faces, so a consumed edge cannot be promoted again by an enclosing boundary
- require explicit fall-through testimony before minting a complementary completed arm
- pin the authenticated pandas `tests/io/test_common.py:638` three-level chain with per-level consumption receipts, an outer-only lying twin, and a no-level escape twin

## Why

The real site is one assertion boundary around two resource boundaries. A terminal edge crossing those resource adapters could be duplicated into a completed arm, and its raise entry remained embedded in the halted face's alleged pre-effect state. After the assertion consumed the edge, a later projection could therefore resurrect it. That makes level ownership silent and allows the wrong boundary to appear green.

The new receipts account each level as authenticated exceptional exit, named refusal, or construction panic, and assert whether the identical edge was consumed or passed.

## Validation

- authenticated shared demand table: CPython 3.12.13, canonical corpus manifest `blake3-512:6f317a5a...`, 107,433 rows, exact line-638 demand present
- battleaxe authenticated closure: CPython 3.12.13, pandas 3.0.3, NumPy 2.5.1, canonical corpus manifest; `26 passed, 10 deselected`
- mutation transaction: restoring the raise entry to the halted face's state makes `test_three_deep_outer_only_edge_cannot_be_consumed_at_an_inner_level` fail
- `git diff --check`

The broader source-tree file has one unrelated pre-existing construction panic in `test_reverse_order_branch_constructs_both_native_boundaries`; the focused authenticated gate excludes that independent local-import attribute path.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve nested boundary edge ownership in with-chain routing
> - Fixes edge ownership in nested `with`-chain managers so each boundary edge is consumed exactly once at the correct level rather than being dropped or duplicated.
> - `BlockValue.follow_rest` now halts (`keeps_rest=False`) when a block contains an unguarded `Incomplete` raise that does not continue, preventing fallthrough past terminal raises.
> - `promote_raise_halts` builds `Halted` faces using only pre-raise state entries and emits a `Completed` arm only when `state.can_fall_through` is true.
> - New tests in [test_nested_assertion_manager_composition.py](https://github.com/TSavo/sugar/pull/6544/files#diff-36e2bf5cd83aaf2e1fd4eddf63fd8a366307a0b6dee453a6532e38dcbd4365a1) assert that inner/middle levels pass an `OSError` edge and only the outer level consumes it, and that non-matching edges pass through all levels unchanged.
> - Behavioral Change: `promote_raise_halts` no longer emits a `Completed` arm for terminal raises unless the block explicitly permits fall-through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed25bff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->