### PR TITLE
Bind fixture resources at authenticated formals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py
@@ -1,0 +1,143 @@
+"""Construction law for resources supplied through a formal parameter.
+
+The source frame contains no acquisition boundary for such a resource.  Its
+construction obligation therefore attaches to the formal binding and is
+discharged only by constructed-value testimony for the actual bound there.
+This type deliberately cannot mint ``__enter__``/``__exit__`` work: doing so
+would claim a local manager that the source never contained.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_source_tree.binding_provenance import BindingCoordinateV1
+from sugar_source_tree.binding_state import BindingEntryV1, BindingStateWireGap
+
+
+class FixtureResourceBindingRefusal(ValueError):
+    """A named formal coordinate lacks authenticated actual-value testimony."""
+
+    def __init__(self, coordinate: str, detail: str):
+        self.coordinate = coordinate
+        self.detail = detail
+        super().__init__(
+            f"fixture resource binding refused at {coordinate}: {detail}"
+        )
+
+
+@dataclass(frozen=True)
+class FixtureSuppliedResourceDischargeV1:
+    obligation_cid: str
+    formal_coordinate_cid: str
+    constructed_value_testimony_cid: str
+
+
+@dataclass(frozen=True)
+class FixtureSuppliedResourceObligationV1:
+    """One externally acquired resource owed at one authenticated formal."""
+
+    formal_coordinate_cid: str
+    obligation_cid: str
+    kind: str = "fixture-supplied-resource-obligation"
+    schema_version: str = "1"
+
+    @classmethod
+    def mint(
+        cls, coordinate: BindingCoordinateV1
+    ) -> "FixtureSuppliedResourceObligationV1":
+        # Decode the wire before accepting the coordinate.  A stale or invented
+        # CID cannot become an obligation merely by occupying this field.
+        authenticated = BindingCoordinateV1.decode(coordinate.wire())
+        preimage = {
+            "kind": "fixture-supplied-resource-obligation",
+            "schemaVersion": "1",
+            "formalCoordinateCid": authenticated.cid,
+        }
+        return cls(authenticated.cid, cid_of_json(preimage))
+
+    def discharge(
+        self, binding: BindingEntryV1
+    ) -> FixtureSuppliedResourceDischargeV1:
+        if binding.coordinate.cid != self.formal_coordinate_cid:
+            raise FixtureResourceBindingRefusal(
+                self.formal_coordinate_cid,
+                "formal binding coordinate mismatch: "
+                f"observed {binding.coordinate.cid}",
+            )
+        try:
+            testimony = binding.require_constructed_value_testimony()
+            # The round trip authenticates the testimony preimage and CID.
+            testimony_type = type(testimony)
+            testimony_type.decode(testimony.wire())
+        except (BindingStateWireGap, ValueError) as gap:
+            raise FixtureResourceBindingRefusal(
+                self.formal_coordinate_cid, str(gap)
+            ) from gap
+        return FixtureSuppliedResourceDischargeV1(
+            obligation_cid=self.obligation_cid,
+            formal_coordinate_cid=self.formal_coordinate_cid,
+            constructed_value_testimony_cid=testimony.cid,
+        )
+
+
+class FixtureResourceOutcome(str, Enum):
+    AUTHENTICATED_EXCEPTIONAL_EXIT = "authenticated-exceptional-exit"
+    NAMED_REFUSAL = "named-refusal"
+    CONSTRUCTION_PANIC = "construction-panic"
+
+
+@dataclass(frozen=True)
+class FixtureResourceAttribution:
+    coordinate: str
+    outcome: FixtureResourceOutcome
+    detail: str
+
+
+def classify_fixture_resource_outcome(
+    obligation: FixtureSuppliedResourceObligationV1,
+    binding: BindingEntryV1,
+    evaluator: Callable[[], object],
+) -> FixtureResourceAttribution:
+    """Classify one formal-bound resource into the closed three-way result.
+
+    Discharging the binding is necessary but not sufficient.  Satisfaction
+    requires a positive authenticated exceptional edge from the evaluated
+    body; ordinary or empty completion is a named refusal, never success by
+    absence.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.no_call_body_attribution import (
+        _exceptional_exit_present,
+    )
+
+    try:
+        obligation.discharge(binding)
+    except FixtureResourceBindingRefusal as refusal:
+        return FixtureResourceAttribution(
+            refusal.coordinate,
+            FixtureResourceOutcome.NAMED_REFUSAL,
+            refusal.detail,
+        )
+    try:
+        evaluated = evaluator()
+    except ConstructionPanic as panic:
+        return FixtureResourceAttribution(
+            obligation.formal_coordinate_cid,
+            FixtureResourceOutcome.CONSTRUCTION_PANIC,
+            panic.info.owner,
+        )
+    if _exceptional_exit_present(evaluated):
+        return FixtureResourceAttribution(
+            obligation.formal_coordinate_cid,
+            FixtureResourceOutcome.AUTHENTICATED_EXCEPTIONAL_EXIT,
+            type(evaluated).__name__,
+        )
+    return FixtureResourceAttribution(
+        obligation.formal_coordinate_cid,
+        FixtureResourceOutcome.NAMED_REFUSAL,
+        "positive-authenticated-exceptional-exit-absent",
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import ast
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.tree import SourceFile
+from sugar_source_tree.tree import SourceTree
+
+from sugar_lift_py_tests.fixture_resource_obligation import (
+    FixtureResourceOutcome,
+    FixtureResourceBindingRefusal,
+    FixtureSuppliedResourceObligationV1,
+    classify_fixture_resource_outcome,
+)
+
+
+@dataclass(frozen=True)
+class _FormalResourceSite:
+    relative_path: str
+    function_name: str
+    line: int
+    has_with: bool
+    load_references: int
+
+    @property
+    def coordinate(self) -> str:
+        return f"{self.relative_path}:{self.line}:{self.function_name}"
+
+
+@dataclass(frozen=True)
+class _FormalResourceCensus:
+    lexical_mentions: int
+    formal_declarations: int
+    load_references: int
+    formal_functions: int
+    functions_with_with: int
+    bare_parameter_functions: int
+    sites: tuple[_FormalResourceSite, ...]
+
+    def render(self) -> str:
+        return " ".join(
+            (
+                f"lexicalMentions={self.lexical_mentions}",
+                f"formalDeclarations={self.formal_declarations}",
+                f"loadReferences={self.load_references}",
+                f"formalFunctions={self.formal_functions}",
+                f"functionsWithWith={self.functions_with_with}",
+                f"bareParameterFunctions={self.bare_parameter_functions}",
+            )
+        )
+
+
+def _owned_function_nodes(function):
+    owned = []
+    stack = list(function.body)
+    while stack:
+        node = stack.pop()
+        owned.append(node)
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return tuple(owned)
+
+
+def _census_formal_parameter_resources(
+    corpus_root: Path, formal_name: str
+) -> _FormalResourceCensus:
+    """Measurement-only spelling filter; it grants no construction semantics."""
+    word = re.compile(rf"\b{re.escape(formal_name)}\b")
+    lexical_mentions = formal_declarations = load_references = 0
+    sites = []
+    for path in SourceTree(corpus_root).paths():
+        source = path.read_text(encoding="utf-8")
+        lexical_mentions += len(word.findall(source))
+        tree = ast.parse(source, filename=str(path))
+        formal_declarations += sum(
+            isinstance(node, ast.arg) and node.arg == formal_name
+            for node in ast.walk(tree)
+        )
+        load_references += sum(
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id == formal_name
+            for node in ast.walk(tree)
+        )
+        for function in ast.walk(tree):
+            if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            declarations = (
+                *function.args.posonlyargs,
+                *function.args.args,
+                *function.args.kwonlyargs,
+                *((function.args.vararg,) if function.args.vararg else ()),
+                *((function.args.kwarg,) if function.args.kwarg else ()),
+            )
+            if not any(parameter.arg == formal_name for parameter in declarations):
+                continue
+            owned = _owned_function_nodes(function)
+            sites.append(
+                _FormalResourceSite(
+                    path.relative_to(corpus_root).as_posix(),
+                    function.name,
+                    function.lineno,
+                    any(isinstance(node, (ast.With, ast.AsyncWith)) for node in owned),
+                    sum(
+                        isinstance(node, ast.Name)
+                        and isinstance(node.ctx, ast.Load)
+                        and node.id == formal_name
+                        for node in owned
+                    ),
+                )
+            )
+    ordered = tuple(sorted(sites, key=lambda site: site.coordinate))
+    with_with = sum(site.has_with for site in ordered)
+    return _FormalResourceCensus(
+        lexical_mentions,
+        formal_declarations,
+        load_references,
+        len(ordered),
+        with_with,
+        len(ordered) - with_with,
+        ordered,
+    )
+
+
+def _function_and_actual():
+    source = "def consume(resource):\n    return resource\nactual = 'ready'\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    tree = SourceFile(path_source(path))
+    function = next(tree.functions())
+    actual = next(node for node in tree.nodes() if node.kind == "Constant")
+    return function, actual
+
+
+def test_fixture_resource_is_discharged_at_authenticated_formal_binding():
+    """No local manager is invented: the caller-bound formal is the boundary."""
+    function, actual = _function_and_actual()
+    frame = function.source_visible_call_frame()
+    testimony = ConstructedValueTestimonyV1.mint(
+        actual.fragment,
+        cid_of_json({"kind": "external-resource", "state": "ready"}),
+    )
+    bound = frame.bind_node_actuals((actual,), (), (testimony,))
+    obligation = FixtureSuppliedResourceObligationV1.mint(
+        bound.formal_coordinates[0]
+    )
+
+    discharge = obligation.discharge(bound.runtime_entries[0])
+
+    assert discharge.formal_coordinate_cid == bound.formal_coordinates[0].cid
+    assert discharge.constructed_value_testimony_cid == testimony.cid
+    assert discharge.obligation_cid == obligation.obligation_cid
+
+
+def test_fixture_resource_without_binding_testimony_is_a_named_refusal():
+    """LYING TWIN: a supplied-looking formal cannot discharge itself."""
+    function, actual = _function_and_actual()
+    frame = function.source_visible_call_frame()
+    bound = frame.bind_node_actuals((actual,), ())
+    obligation = FixtureSuppliedResourceObligationV1.mint(
+        bound.formal_coordinates[0]
+    )
+
+    with pytest.raises(FixtureResourceBindingRefusal) as caught:
+        obligation.discharge(bound.runtime_entries[0])
+
+    assert caught.value.coordinate == bound.formal_coordinates[0].cid
+    assert "constructed-value testimony unavailable" in caught.value.detail
+
+
+def test_fixture_resource_obligation_refuses_a_different_formal_coordinate():
+    function, actual = _function_and_actual()
+    frame = function.source_visible_call_frame()
+    testimony = ConstructedValueTestimonyV1.mint(
+        actual.fragment,
+        cid_of_json({"kind": "external-resource", "state": "ready"}),
+    )
+    bound = frame.bind_node_actuals((actual,), (), (testimony,))
+    other = function.source_visible_call_frame().formal_coordinates[0]
+    obligation = FixtureSuppliedResourceObligationV1.mint(other)
+
+    # Minting the same structural frame is deliberately the same coordinate;
+    # mutate only the occurrence identity to model testimony from another formal.
+    from dataclasses import replace
+
+    wrong_entry = replace(
+        bound.runtime_entries[0],
+        coordinate=replace(
+            bound.runtime_entries[0].coordinate,
+            cid="blake3-512:" + "f" * 128,
+        ),
+    )
+    with pytest.raises(FixtureResourceBindingRefusal) as caught:
+        obligation.discharge(wrong_entry)
+    assert caught.value.coordinate == obligation.formal_coordinate_cid
+    assert "coordinate mismatch" in caught.value.detail
+
+
+def _authenticated_obligation_and_entry():
+    function, actual = _function_and_actual()
+    frame = function.source_visible_call_frame()
+    testimony = ConstructedValueTestimonyV1.mint(
+        actual.fragment,
+        cid_of_json({"kind": "external-resource", "state": "ready"}),
+    )
+    bound = frame.bind_node_actuals((actual,), (), (testimony,))
+    return (
+        FixtureSuppliedResourceObligationV1.mint(bound.formal_coordinates[0]),
+        bound.runtime_entries[0],
+    )
+
+
+def test_population_outcomes_require_a_positive_authenticated_exceptional_exit():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+    obligation, entry = _authenticated_obligation_and_entry()
+    positive = classify_fixture_resource_outcome(
+        obligation, entry, lambda: Incomplete(RaiseEffect("ValueError", "site"))
+    )
+    absent = classify_fixture_resource_outcome(
+        obligation, entry, lambda: Complete("ordinary completion")
+    )
+
+    assert positive.outcome is FixtureResourceOutcome.AUTHENTICATED_EXCEPTIONAL_EXIT
+    assert absent.outcome is FixtureResourceOutcome.NAMED_REFUSAL
+    assert absent.coordinate == obligation.formal_coordinate_cid
+    assert absent.detail == "positive-authenticated-exceptional-exit-absent"
+
+
+def test_population_keeps_construction_panic_separate_from_named_refusal():
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    obligation, entry = _authenticated_obligation_and_entry()
+
+    def panic():
+        construction_panic_gap(
+            owner="fixture-resource-test",
+            blame="fixture.py:2:4",
+            observed="missing producer",
+            requested="authenticated exceptional exit",
+            fix="implement the producer",
+        )
+
+    result = classify_fixture_resource_outcome(obligation, entry, panic)
+
+    assert result.outcome is FixtureResourceOutcome.CONSTRUCTION_PANIC
+    assert result.coordinate == obligation.formal_coordinate_cid
+    assert result.detail == "fixture-resource-test"
+
+
+def test_authenticated_pandas_303_temp_file_population_is_partitioned_by_formal():
+    """Measurement-only spelling filter; it grants no production semantics."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.no_call_body_attribution import (
+        CANONICAL_CORPUS_MANIFEST_CID,
+        SHARED_DEMAND_TABLE_CONTENT_KEY,
+        pull_shared_demand_table,
+    )
+
+    corpus = authenticated_pandas_corpus()
+    assert corpus.manifest_cid == CANONICAL_CORPUS_MANIFEST_CID
+    with tempfile.TemporaryDirectory() as scratch:
+        demand_table = pull_shared_demand_table(
+            Path(__file__).resolve().parents[4],
+            Path(scratch) / "python-demand-table.json",
+        )
+    assert demand_table["contentKey"] == SHARED_DEMAND_TABLE_CONTENT_KEY
+    assert len(demand_table["rows"]) == 107_433
+    census = _census_formal_parameter_resources(corpus.root, "temp_file")
+
+    assert census.lexical_mentions == 1_002
+    assert census.formal_declarations == 391
+    assert census.load_references == 596
+    assert census.formal_functions == 391
+    assert census.functions_with_with == 149
+    assert census.bare_parameter_functions == 242
+    assert 391 == 149 + 242
+    feather = [
+        site
+        for site in census.sites
+        if site.relative_path == "tests/io/test_feather.py"
+        and site.function_name == "check_error_on_write"
+    ]
+    assert len(feather) == 1
+    assert feather[0].line == 29
+    assert feather[0].has_with is True
+    assert feather[0].load_references == 1
+    print(census.render(), flush=True)
+    print(f"concreteSite={feather[0].coordinate}", flush=True)


### PR DESCRIPTION
## What changed

- add `FixtureSuppliedResourceObligationV1`, keyed only by an authenticated formal-coordinate CID
- discharge the obligation only with constructed-value testimony from the bound actual
- retain a closed three-way attribution: authenticated exceptional exit, named refusal, or construction panic
- require positive exceptional-edge presence; ordinary or empty completion is a named refusal
- pin an authenticated pandas 3.0.3 census and the concrete `tests/io/test_feather.py:29:check_error_on_write` site

## Ruling and assumption

A fixture-supplied resource enters the frame as a formal. Its acquisition happened outside the frame, so this mechanism does not synthesize local manager acquisition or cleanup. The obligation is non-vacuous: missing actual-value testimony refuses at the exact formal coordinate.

The census treats a construction site as a function declaration carrying the formal. It reports lexical mentions separately so the prior approximate mention count cannot become the construction denominator silently.

Authenticated CPython 3.12.13 / pandas 3.0.3 / 1,421-file canonical manifest result:

- 1,002 lexical `temp_file` mentions
- 391 formal declarations/functions
- 149 formal-bearing functions containing a source-owned `with`
- 242 formal-bearing functions containing no `with`
- 596 load references

The test pulls and authenticates the existing 107,433-row shared demand table; it does not rebuild it.

## Validation

- `bin/bpytest -q implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py` — 11 passed on battleaxe
- mutation transaction: clean hash `f3d158c6...`; altered discharge to accept missing testimony; lying twin failed with `DID NOT RAISE FixtureResourceBindingRefusal`; reverted to the identical hash; lying twin passed
- broader focused run: 26 passed, 1 unrelated baseline failure in `test_corpus_manifest_identity_roles.py`, which reports the separately owned `test_subscript_exceptional_exit_producer.py:48` alias. This PR does not edit or weaken that ratchet.

No assertion-With, ExitSet, outcome, generator, fixture-vendor dispatch, or manager-name behavior is changed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind fixture resources at authenticated formals with obligation discharge and outcome classification
> - Adds `FixtureSuppliedResourceObligationV1` in [`fixture_resource_obligation.py`](https://github.com/TSavo/sugar/pull/6545/files#diff-bef8ee352d6e9f8b3834a271723ab539117c6e19edb6fa48d12e549ea6a5a9b5) with `mint()` and `discharge()` methods that authenticate a formal coordinate via CID and validate constructed-value testimony before returning a `FixtureSuppliedResourceDischargeV1`.
> - Adds `classify_fixture_resource_outcome` to classify binding results into `NAMED_REFUSAL`, `CONSTRUCTION_PANIC`, or `AUTHENTICATED_EXCEPTIONAL_EXIT` using a closed `FixtureResourceOutcome` enum.
> - Raises `FixtureResourceBindingRefusal` (a `ValueError` subclass) on coordinate mismatch or missing/invalid testimony during discharge.
> - Adds tests covering the successful discharge path, refusal cases, construction panic, and an AST-based census over the authenticated pandas corpus for the `temp_file` formal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d57fc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->