### PR TITLE
Name returned manager outcome coordinates

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -71,6 +71,9 @@ class BodyProbe:
     body_id: str
     family: ProducerFamily | str
     evaluator: Callable[[], object]
+    consumer_coordinate: str
+    producer_coordinate: str
+    producer_call_descendants: int
 
 
 @dataclass(frozen=True)
@@ -79,6 +82,21 @@ class BodyAttribution:
     family: ProducerFamily | str
     outcome: AttributionOutcome
     detail: str
+    consumer_coordinate: str
+    producer_coordinate: str
+    producer_call_descendants: int
+
+    def render(self) -> str:
+        """One earned outcome with both sides of the manager/producer boundary."""
+        return " ".join(
+            (
+                f"outcome={self.outcome.value}",
+                f"consumer={self.consumer_coordinate}",
+                f"producer={self.producer_coordinate}",
+                f"producerCallDescendants={self.producer_call_descendants}",
+                f"detail={self.detail}",
+            )
+        )
 
 
 @dataclass(frozen=True)
@@ -207,14 +225,20 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             probe.body_id,
             probe.family,
             AttributionOutcome.NAMED_REFUSAL,
-            refusal.owner,
+            f"{refusal.owner}:{refusal.observed}",
+            probe.consumer_coordinate,
+            probe.producer_coordinate,
+            probe.producer_call_descendants,
         )
     except ConstructionPanic as panic:
         return BodyAttribution(
             probe.body_id,
             probe.family,
             AttributionOutcome.CONSTRUCTION_PANIC,
-            panic.info.owner,
+            f"{panic.info.owner}:{panic.info.observed}",
+            probe.consumer_coordinate,
+            probe.producer_coordinate,
+            probe.producer_call_descendants,
         )
 
     if _exceptional_exit_present(outcome):
@@ -223,6 +247,9 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             probe.family,
             AttributionOutcome.AUTHENTICATED_EXIT,
             type(outcome).__name__,
+            probe.consumer_coordinate,
+            probe.producer_coordinate,
+            probe.producer_call_descendants,
         )
     raise AttributionInvariantError(
         f"{probe.body_id} "
@@ -536,10 +563,10 @@ def discover_no_call_body_probes(
                 continue
             if families is not None and family not in families:
                 continue
-            body_id = (
-                f"{path.relative_to(corpus_root).as_posix()}:"
-                f"{expression.line_col_span().start_line}:{family.value}"
-            )
+            relative_path = path.relative_to(corpus_root).as_posix()
+            expression_span = expression.line_col_span()
+            manager_span = with_node.items[0].context_expr.line_col_span()
+            body_id = f"{relative_path}:{expression_span.start_line}:{family.value}"
             if body_id in seen:
                 raise AttributionInvariantError(f"duplicate body enrollment: {body_id}")
             seen.add(body_id)
@@ -549,6 +576,19 @@ def discover_no_call_body_probes(
                     family=family,
                     evaluator=lambda expression=expression: expression.sugar().desugar(
                         None
+                    ),
+                    consumer_coordinate=(
+                        f"{relative_path}:{manager_span.start_line}:"
+                        f"{manager_span.start_col}-{manager_span.end_line}:"
+                        f"{manager_span.end_col}"
+                    ),
+                    producer_coordinate=(
+                        f"{relative_path}:{expression_span.start_line}:"
+                        f"{expression_span.start_col}-{expression_span.end_line}:"
+                        f"{expression_span.end_col}"
+                    ),
+                    producer_call_descendants=sum(
+                        node.kind == "Call" for node in expression.walk()
                     ),
                 )
             )

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -20,7 +20,8 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     summarize_attribution_outcomes,
     validate_shared_demand_table,
 )
-from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome import Complete, ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Completed, true_guard
 from sugar_source_tree.panic import SugarNotWritten
 
 
@@ -29,6 +30,9 @@ def _probe(family: ProducerFamily, evaluator) -> BodyProbe:
         body_id=f"pandas/example.py:1:{family.value}",
         family=family,
         evaluator=evaluator,
+        consumer_coordinate="pandas/example.py:1:9-1:30",
+        producer_coordinate="pandas/example.py:2:8-2:17",
+        producer_call_descendants=0,
     )
 
 
@@ -65,6 +69,15 @@ def test_truthful_authenticated_body_is_counted_as_an_exceptional_exit() -> None
     assert row.named_refusals == 0
     assert row.construction_panics == 0
     assert report.bodies[0].outcome is AttributionOutcome.AUTHENTICATED_EXIT
+    assert report.bodies[0].consumer_coordinate == "pandas/example.py:1:9-1:30"
+    assert report.bodies[0].producer_coordinate == "pandas/example.py:2:8-2:17"
+    assert report.bodies[0].producer_call_descendants == 0
+    assert report.bodies[0].render() == (
+        "outcome=authenticated-exceptional-exit "
+        "consumer=pandas/example.py:1:9-1:30 "
+        "producer=pandas/example.py:2:8-2:17 "
+        "producerCallDescendants=0 detail=Complete"
+    )
 
 
 def test_declared_typed_gap_is_a_named_refusal_not_a_failure() -> None:
@@ -77,6 +90,9 @@ def test_declared_typed_gap_is_a_named_refusal_not_a_failure() -> None:
     assert row.construction_panics == 0
     assert row.failures == 0
     assert report.bodies[0].outcome is AttributionOutcome.NAMED_REFUSAL
+    assert report.bodies[0].detail == (
+        "native-producer:source-visible operands do not decide the failure mode"
+    )
 
 
 def test_shared_outcome_summary_keeps_refusals_separate_from_panics() -> None:
@@ -142,6 +158,9 @@ def test_escaped_construction_panic_remains_a_separate_loud_axis() -> None:
     assert row.construction_panics == 1
     assert row.failures == 1
     assert report.bodies[0].outcome is AttributionOutcome.CONSTRUCTION_PANIC
+    assert report.bodies[0].detail == (
+        "producer-construction:missing native operand construction"
+    )
 
 
 def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
@@ -158,6 +177,17 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
         "OUTCOME TOTAL DISCREPANCY enrolled=1 threeOutcomeTotal=0 unaccounted=1"
         in report.render()
     )
+
+
+def test_empty_exitset_cannot_impersonate_an_authenticated_non_raising_body() -> None:
+    with pytest.raises(AttributionInvariantError, match="completed without"):
+        attribute_body_probe(_probe(ProducerFamily.SUBSCRIPT, lambda: ExitSet(())))
+
+
+def test_completed_only_exitset_cannot_impersonate_a_matching_halted_edge() -> None:
+    completed_only = ExitSet((Completed(true_guard(), object(), frozenset(), ()),))
+    with pytest.raises(AttributionInvariantError, match="completed without"):
+        attribute_body_probe(_probe(ProducerFamily.SUBSCRIPT, lambda: completed_only))
 
 
 def _table_payload() -> dict:

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -19,13 +19,16 @@ import subprocess
 import tempfile
 from functools import cache
 from pathlib import Path
+from types import MappingProxyType
 
 import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerResolutionGapV1,
+    ResolvedContractRefsV1,
     SourceDerivedContextManagerRefV1,
+    SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
@@ -37,7 +40,8 @@ from sugar_lift_py_tests.no_call_body_attribution import (
 )
 from sugar_lift_python_source.canonical import blake3_512_of
 
-
+_TABLE_CID = "blake3-512:" + "t" * 128
+_CATALOG_CID = "blake3-512:" + "c" * 128
 _SOURCE_CID = (
     "blake3-512:3a71aa9c523d26a6a541cb6fdc124d37c364245b959d41873619701b421fbe370"
     "7b50d44f9d87083a783b17ec779000a4480863c8dc8435761e6f17238dd3ee0"
@@ -157,9 +161,9 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
         reference.detail or ""
     )
     assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
-    # Current residual names the exit-face comparison on unfloored field state.
+    # Current residual names the exit-face negation on unfloored call state.
     assert reference.kind == "exit-may-halt"
-    assert "comparison_operation_exception_floor" in (reference.detail or "")
+    assert reference.detail == "unary_operation_exception_floor:CallSiteValue not"
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:
@@ -233,9 +237,7 @@ def _external_error_attributions():
                 (),
             )
         context = TreeConstructionContextV1(
-            ResolvedContractRefsV1(
-                _CATALOG_CID, _TABLE_CID, MappingProxyType(refs)
-            ),
+            ResolvedContractRefsV1(_CATALOG_CID, _TABLE_CID, MappingProxyType(refs)),
             workspace_root=str(corpus.root.parent),
         )
         tree = SourceFile(
@@ -277,12 +279,30 @@ def _external_error_attributions():
                 return reduce_block_to_exitset(boundary.body, None)
 
             relative = path.relative_to(corpus.root).as_posix()
+            manager_span = manager.items[0].context_expr.line_col_span()
+            producer_node = manager.body[0]
+            if len(manager.body) == 1 and producer_node.kind == "Expr":
+                producer_node = producer_node.value
+            producer_span = producer_node.line_col_span()
             attributed.append(
                 attribute_body_probe(
                     BodyProbe(
                         body_id=f"{relative}:{site.start_line}",
-                        family="ReturnedManager",
+                        family=producer_node.kind,
                         evaluator=evaluate,
+                        consumer_coordinate=(
+                            f"{relative}:{manager_span.start_line}:"
+                            f"{manager_span.start_col}-{manager_span.end_line}:"
+                            f"{manager_span.end_col}"
+                        ),
+                        producer_coordinate=(
+                            f"{relative}:{producer_span.start_line}:"
+                            f"{producer_span.start_col}-{producer_span.end_line}:"
+                            f"{producer_span.end_col}"
+                        ),
+                        producer_call_descendants=sum(
+                            node.kind == "Call" for node in producer_node.walk()
+                        ),
                     )
                 )
             )
@@ -290,23 +310,69 @@ def _external_error_attributions():
 
 
 def test_external_error_raised_47_site_outcome_partition() -> None:
-    summary = summarize_attribution_outcomes(_external_error_attributions())
+    from collections import Counter
+
+    attributions = _external_error_attributions()
+    summary = summarize_attribution_outcomes(attributions)
 
     assert summary.enrolled == 47
     assert summary.authenticated_exceptional_exits == 0
-    assert summary.named_refusals == 42
-    assert summary.construction_panics == 5
+    assert summary.named_refusals == 47
+    assert summary.construction_panics == 0
+    assert len({body.consumer_coordinate for body in attributions}) == 47
+    assert all(body.consumer_coordinate.startswith("tests/") for body in attributions)
+    assert all(body.producer_coordinate.startswith("tests/") for body in attributions)
+    assert {body.outcome for body in attributions} == {AttributionOutcome.NAMED_REFUSAL}
+    rendered = tuple(body.render() for body in attributions)
+    assert len(set(rendered)) == 47
+    assert all(
+        line.startswith("outcome=named-refusal consumer=tests/") for line in rendered
+    )
+    assert Counter(body.detail for body in attributions) == {
+        "With._construct_sugar:authenticated preconstruction resolution gap: "
+        "exit-may-halt [unary_operation_exception_floor:CallSiteValue not]": 42,
+        "SymbolicValue.attribute:undecided receiver runtime type or member "
+        "semantics: SymbolicValue.ArrowInvalid": 4,
+        "SymbolicValue.attribute:undecided receiver runtime type or member "
+        "semantics: SymbolicValue.ArrowException": 1,
+    }
 
 
-def test_external_error_raised_refusal_and_gap_twins_are_concrete_sites() -> None:
+def test_external_error_raised_subscript_seeds_name_both_independent_coordinates():
+    """Three source sites expand independently of the returned manager route."""
+    by_producer = {
+        body.producer_coordinate: body for body in _external_error_attributions()
+    }
+    expected = {
+        "tests/series/accessors/test_list_accessor.py:101:8-101:26": "tests/series/accessors/test_list_accessor.py:100:9-100:50",
+        "tests/series/accessors/test_list_accessor.py:133:8-133:20": "tests/series/accessors/test_list_accessor.py:132:9-132:50",
+        "tests/series/accessors/test_list_accessor.py:135:8-135:19": "tests/series/accessors/test_list_accessor.py:134:9-134:50",
+    }
+
+    assert set(expected) <= set(by_producer)
+    for producer_coordinate, consumer_coordinate in expected.items():
+        attribution = by_producer[producer_coordinate]
+        assert attribution.consumer_coordinate == consumer_coordinate
+        assert attribution.family == "Subscript"
+        assert attribution.producer_call_descendants == 0
+
+
+def test_external_error_raised_former_panics_are_now_named_at_concrete_sites() -> None:
     by_id = {body.body_id: body for body in _external_error_attributions()}
 
     refusal = by_id["tests/io/test_feather.py:40"]
-    gap = by_id["tests/extension/test_arrow.py:1715"]
+    former_panic = by_id["tests/extension/test_arrow.py:1715"]
     assert refusal.outcome is AttributionOutcome.NAMED_REFUSAL
-    assert refusal.detail == "With._construct_sugar"
-    assert gap.outcome is AttributionOutcome.CONSTRUCTION_PANIC
-    assert gap.detail == "SymbolicValue.attribute"
+    assert former_panic.outcome is AttributionOutcome.NAMED_REFUSAL
+    assert refusal.consumer_coordinate == "tests/io/test_feather.py:40:13-40:48"
+    assert former_panic.consumer_coordinate == (
+        "tests/extension/test_arrow.py:1715:9-1715:50"
+    )
+    assert "exit-may-halt" in refusal.detail
+    assert former_panic.detail == (
+        "SymbolicValue.attribute:undecided receiver runtime type or member "
+        "semantics: SymbolicValue.ArrowInvalid"
+    )
 
 
 def test_external_error_raised_emits_complete_consumer_testimony() -> None:
@@ -331,8 +397,8 @@ def test_external_error_raised_emits_complete_consumer_testimony() -> None:
             surviving=(
                 CallerAttribution(
                     AttributionOutcome.NAMED_REFUSAL,
-                    "force-floor:binary_operation_exception_floor:"
-                    "SymbolicValue + CallSiteValue",
+                    "exit-may-halt:unary_operation_exception_floor:"
+                    "CallSiteValue not",
                 ),
             ),
         ),
@@ -340,9 +406,7 @@ def test_external_error_raised_emits_complete_consumer_testimony() -> None:
 
     assert len(report.lines()) == 8
     assert report.lines()[4].endswith("pandas/tests/io/test_feather.py:40:13")
-    assert report.lines()[-1].startswith(
-        "survivingTypedGapsOrReattributions reported"
-    )
+    assert report.lines()[-1].startswith("survivingTypedGapsOrReattributions reported")
 
 
 def test_adjacent_computed_class_raises_stays_typed_opaque() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1219,6 +1219,61 @@ def test_external_error_raised_spelling_cannot_replace_native_return_shape(tmp_p
     ), summary
 
 
+def test_deferred_import_cannot_override_the_manager_the_helper_returns(tmp_path):
+    """One-line return mutation decides the manager; the local import does not."""
+    from sugar_lift_py_tests.context_manager_contract import EffectBoundarySemanticsV1
+
+    implementation = (
+        "class ImportedBoundary:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        if effect_type is None:\n"
+        "            raise RuntimeError()\n"
+        "        return effect_type is self.expected\n"
+        "class OrdinaryResource:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "def external_error_raised(expected):\n"
+        "    import arbitrary.manager as deferred\n"
+        "    return {returned}(expected)\n"
+    )
+
+    def summary_for(label: str, returned: str):
+        root = tmp_path / label
+        root.mkdir()
+        graph, resolved, actual, call_site = _resolved_type_actual(
+            root,
+            implementation.format(returned=returned),
+            exported="external_error_raised",
+        )
+        behavior = construct_manager_behavior(
+            resolved, graph=graph, actuals=(actual,), call_site=call_site
+        )
+        assert isinstance(behavior, ConstructedManagerBehaviorV1)
+        protocol = construct_manager_protocol(
+            behavior, exit_face_id=f"deferred-import-{returned}"
+        )
+        assert isinstance(protocol, ConstructedManagerProtocolV1)
+        return derive_manager_summary(protocol, behavior=behavior)
+
+    truthful = summary_for("truthful", "deferred.ImportedBoundary")
+    lying = summary_for("lying", "OrdinaryResource")
+
+    assert isinstance(truthful, DerivedManagerSummaryV1)
+    assert isinstance(truthful.semantics, EffectBoundarySemanticsV1)
+    assert not (
+        isinstance(lying, DerivedManagerSummaryV1)
+        and isinstance(lying.semantics, EffectBoundarySemanticsV1)
+    ), lying
+
+
 def test_renamed_returned_assertion_manager_is_derived_from_protocol(tmp_path):
     """A source-authenticated returned manager is the truthful native twin."""
     graph, resolved, actual, call_site = _resolved_type_actual(


### PR DESCRIPTION
## Assumption

Per the ruling, this extends #6531 as the sole attribution authority. It does not add a parallel census, infer manager semantics from spelling, or enter Subscript production. If this ownership assumption is wrong, rebase this one concern rather than retaining two producers.

## Outcome

Preserves #6520 provenance: pandas 3.0.3 contains **51 textual mentions** and exactly **47 authenticated manager-demand sites**. Both denominators remain explicit.

The authenticated 47-site split on current main is:

- authenticated exceptional exit: **0**
- named refusal: **47**
- construction panic: **0**

Every attribution now carries and renders its exact consumer coordinate, independent producer coordinate, native producer root kind, Call-descendant count, and typed observed reason. The refusal detail partition is 42 returned-manager UnaryOp residuals, 4 `ArrowInvalid` Attribute refusals, and 1 `ArrowException` Attribute refusal. The five former construction panics remain visible but are correctly reattributed as named refusals after the merged producer work.

The verified Subscript seeds are producer lines 101, 133, and 135 in `tests/series/accessors/test_list_accessor.py`, paired with manager-consumer lines 100, 132, and 134. Each producer has zero Call descendants.

## Soundness teeth

- Empty ExitSet and completed-only ExitSet cannot satisfy the exceptional-exit arm; a positive authenticated halted edge is required.
- Truthful deferred-module import plus returned boundary derives EffectBoundary semantics.
- The one-line lying mutation returns `OrdinaryResource` while the same deferred import still binds the assertion boundary. It must not derive EffectBoundary semantics.
- Existing exact helper spelling returning an ordinary resource remains outside the assertion arm.

## Authentication and validation

Battleaxe Docker authenticated:

- Python: `cpython-3.12.13`
- NumPy: `2.5.1`
- pandas: `3.0.3`
- corpus manifest: `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`
- demand table: `blake3-512:0ce7c645a7525f1fe5189b808162b49d3fc3ba3d898bfb3d5086e0f295b8b8d263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0`

Focused Battleaxe receipt after the final rebase: **25 passed**, construction-panic axis **0**, timeout **0**, exit 0. Black and `git diff --check` pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add source coordinates and call descendant counts to manager outcome attribution
> - `BodyProbe` and `BodyAttribution` now carry `consumer_coordinate`, `producer_coordinate`, and `producer_call_descendants` fields derived from AST span data during probe discovery.
> - `BodyAttribution` gains a `render()` method that formats outcome, coordinates, call descendant count, and detail into a single string.
> - Detail strings for named refusal and construction panic outcomes change from `owner` to `owner:observed` format.
> - New tests in [test_returned_assertion_manager.py](https://github.com/TSavo/sugar/pull/6546/files#diff-ae95b2e3d9589f08dcd37a7451092b43741299d876a5c9b72987042097bfb795) validate coordinate uniqueness, prefix format, `render()` output, and per-detail-message counts across 47 attributions.
> - Behavioral Change: existing detail string comparisons expecting only `owner` will now fail; callers parsing detail strings must account for the colon-separated `owner:observed` format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f709cd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->