### PR TITLE
Report bare-name manager outcomes per item

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 import json
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
 
 from sugar_lift_py_tests.canonicalizer import encode_jcs
 from sugar_lift_py_tests.context_manager_contract import (
@@ -76,6 +82,23 @@ class DerivedManagerSummaryGapV1:
         "opaque-exit-truthiness",
     ]
     protocol_construction_cid: str
+    detail: str
+
+
+class ManagerItemResolutionOutcomeV1(str, Enum):
+    """Closed result for one context-manager item; no item speaks for another."""
+
+    AUTHENTICATED_EXCEPTIONAL_EXIT = "authenticated-exceptional-exit"
+    NAMED_REFUSAL = "named-refusal"
+    CONSTRUCTION_PANIC = "construction-panic"
+
+
+@dataclass(frozen=True)
+class ManagerItemResolutionV1:
+    coordinate: SourceFragmentCoordinateV1
+    binding_coordinate: SourceFragmentCoordinateV1 | None
+    outcome: ManagerItemResolutionOutcomeV1
+    owner: str
     detail: str
 
 
@@ -203,9 +226,7 @@ def _derive_effect_boundary(exit_set, protocol, behavior):
             and isinstance(face.value.statements[-1].value, PredicateValue)
         ):
             predicates.append(face.value.statements[-1].value.formula)
-    if predicates and all(
-        predicate == predicates[0] for predicate in predicates[1:]
-    ):
+    if predicates and all(predicate == predicates[0] for predicate in predicates[1:]):
         formula = predicates[0]
     else:
         formula = _guarded_literal_suppression_formula(exit_set)
@@ -338,9 +359,7 @@ def _guarded_literal_suppression_formula(exit_set):
                 if literal is None:
                     return None
                 if literal:
-                    resolved = _resolve_branch_result_guards(
-                        face.guard, authenticated
-                    )
+                    resolved = _resolve_branch_result_guards(face.guard, authenticated)
                     if resolved is None:
                         return None
                     saw_true = True
@@ -781,6 +800,158 @@ def populate_source_derived_resource_refs(
         )
 
 
+def resolve_bare_name_manager_items(
+    source_file,
+    *,
+    root,
+    path,
+    with_start_line: int,
+    distribution_index=None,
+) -> tuple[ManagerItemResolutionV1, ...]:
+    """Resolve each bare-name manager item independently through its binding.
+
+    A projected binding call is only a route to testimony.  It is not itself
+    testimony, and an item whose provider remains undecidable therefore keeps
+    its own coordinate-bearing refusal.  Construction panics stay on their
+    separate loud axis.
+    """
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+    from sugar_source_tree.nodes import Name, With
+    from sugar_source_tree.panic import OpaqueSourceCallResolutionGap, SugarNotWritten
+
+    site = next(
+        node
+        for node in source_file.root.walk()
+        if isinstance(node, With) and node.line_col_span().start_line == with_start_line
+    )
+    projected = _projected_manager_call_uses(source_file)
+    projected_by_use = {row[0]: row[1] for row in projected.values()}
+    context = source_file.root.unit.construction_context
+    rows = []
+    for item in site.items:
+        if not isinstance(item.context_expr, Name):
+            continue
+        start_line, start_col, end_line, end_col = item._manager_use_site_span()
+        coordinate = SourceFragmentCoordinateV1(
+            source_file.root.unit.source_cid,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        )
+        call = projected_by_use.get(coordinate)
+        binding_coordinate = None
+        if call is not None:
+            span = call.line_col_span()
+            binding_coordinate = SourceFragmentCoordinateV1(
+                source_file.root.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+        else:
+            rows.append(
+                ManagerItemResolutionV1(
+                    coordinate,
+                    None,
+                    ManagerItemResolutionOutcomeV1.NAMED_REFUSAL,
+                    "ManagerBindingProjectionGap",
+                    "bare manager binding did not project an authenticated call",
+                )
+            )
+            continue
+
+        if context is None:
+            rows.append(
+                ManagerItemResolutionV1(
+                    coordinate,
+                    binding_coordinate,
+                    ManagerItemResolutionOutcomeV1.NAMED_REFUSAL,
+                    "ManagerConstructionContextGap",
+                    "source file has no manager construction context",
+                )
+            )
+            continue
+        context.source_derived_contract_refs.pop(coordinate, None)
+        try:
+            populate_source_derived_resource_refs(
+                source_file,
+                root=root,
+                path=path,
+                distribution_index=distribution_index,
+                selected_coordinates=frozenset({coordinate}),
+            )
+        except ConstructionPanic as panic:
+            info = getattr(panic, "info", None)
+            rows.append(
+                ManagerItemResolutionV1(
+                    coordinate,
+                    binding_coordinate,
+                    ManagerItemResolutionOutcomeV1.CONSTRUCTION_PANIC,
+                    getattr(info, "owner", None) or "ConstructionPanic",
+                    getattr(info, "observed", None) or str(panic),
+                )
+            )
+            continue
+        except (
+            SourceCallBindingGap,
+            OpaqueSourceCallResolutionGap,
+            SugarNotWritten,
+        ) as exc:
+            rows.append(
+                ManagerItemResolutionV1(
+                    coordinate,
+                    binding_coordinate,
+                    ManagerItemResolutionOutcomeV1.NAMED_REFUSAL,
+                    type(exc).__name__,
+                    str(exc),
+                )
+            )
+            continue
+        reference = context.source_derived_contract_refs.get(coordinate)
+        if isinstance(reference, SourceDerivedContextManagerRefV1) and isinstance(
+            reference.semantics, EffectBoundarySemanticsV1
+        ):
+            rows.append(
+                ManagerItemResolutionV1(
+                    coordinate,
+                    binding_coordinate,
+                    ManagerItemResolutionOutcomeV1.AUTHENTICATED_EXCEPTIONAL_EXIT,
+                    "EffectBoundarySemanticsV1",
+                    reference.summary_cid,
+                )
+            )
+        else:
+            owner = (
+                type(reference).__name__
+                if reference is not None
+                else "ManagerContractResolutionGap"
+            )
+            detail = (
+                getattr(reference, "detail", None)
+                or "no authenticated exceptional exit"
+            )
+            rows.append(
+                ManagerItemResolutionV1(
+                    coordinate,
+                    binding_coordinate,
+                    ManagerItemResolutionOutcomeV1.NAMED_REFUSAL,
+                    owner,
+                    detail,
+                )
+            )
+    return tuple(rows)
+
+
 def _projected_manager_call_uses(source_file):
     """Project ordinary reaching assignments into context-manager call uses.
 
@@ -807,9 +978,7 @@ def _projected_manager_call_uses(source_file):
                 if not projected_names and hasattr(item, "manager_use_site_start_line"):
                     continue
                 span = expr.line_col_span()
-                start_line, start_col, end_line, end_col = (
-                    item._manager_use_site_span()
-                )
+                start_line, start_col, end_line, end_col = item._manager_use_site_span()
                 if projected_names and (
                     start_line,
                     start_col,

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -9,8 +9,10 @@ from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
+    ManagerItemResolutionOutcomeV1,
     _projected_manager_call_uses,
     populate_source_derived_resource_refs,
+    resolve_bare_name_manager_items,
 )
 
 PANDAS_SOURCE_CID = (
@@ -30,7 +32,9 @@ def _pandas_root() -> Path:
         PANDAS_MANIFEST_CID,
         1421,
     )
-    return corpus.root
+    # Construction loci use the distribution-recorded seat, which is rooted at
+    # site-packages even though corpus identity is over the pandas package root.
+    return corpus.root.parent
 
 
 def _real_tree():
@@ -154,3 +158,123 @@ def test_undecided_rebinding_does_not_invent_a_second_manager_call(
         if coordinate.start_line == 5
     ]
     assert rows == [(5, 9, 2)]
+
+
+def test_pandas_303_two_names_report_independent_named_refusals() -> None:
+    """Undecidable provider construction stays honest for each manager item."""
+    tree = _real_tree()
+    root = _pandas_root()
+
+    rows = resolve_bare_name_manager_items(
+        tree,
+        root=root,
+        path=root / "pandas/tests/io/formats/test_ipython_compat.py",
+        with_start_line=32,
+    )
+
+    assert [(row.coordinate.start_col, row.outcome) for row in rows] == [
+        (13, ManagerItemResolutionOutcomeV1.NAMED_REFUSAL),
+        (18, ManagerItemResolutionOutcomeV1.NAMED_REFUSAL),
+    ]
+    assert [row.binding_coordinate.start_line for row in rows] == [21, 30]
+    assert all(row.owner == "SourceCallBindingGap" for row in rows)
+    assert all("unconsumed call actual" in row.detail for row in rows)
+
+
+def test_same_spelled_names_bound_elsewhere_do_not_authenticate(tmp_path: Path) -> None:
+    """Lying twin: names cannot authorize managers independently of bindings."""
+    source = tmp_path / "lying.py"
+    source.write_text(
+        "def exercise(opt_value, latex_value):\n"
+        "    opt = opt_value\n"
+        "    with_latex = latex_value\n"
+        "    with opt, with_latex:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+
+    rows = resolve_bare_name_manager_items(
+        tree, root=tmp_path, path=source, with_start_line=4
+    )
+
+    assert [row.outcome for row in rows] == [
+        ManagerItemResolutionOutcomeV1.NAMED_REFUSAL,
+        ManagerItemResolutionOutcomeV1.NAMED_REFUSAL,
+    ]
+    assert all(row.owner == "ManagerBindingProjectionGap" for row in rows)
+
+
+def test_bare_name_resolution_path_contains_no_vendor_name_literals() -> None:
+    """The structural resolver cannot admit this site by manager spelling."""
+    import ast
+    import inspect
+    import textwrap
+
+    import sugar_lift_python_source.manager_summary_derivation as derivation
+
+    module = ast.parse(textwrap.dedent(inspect.getsource(derivation)))
+    literals = {
+        node.value
+        for node in ast.walk(module)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert literals.isdisjoint(
+        {
+            "opt",
+            "with_latex",
+            "option_context",
+            "pytest.raises",
+            "external_error_raised",
+        }
+    )
+
+
+def test_per_item_construction_panic_stays_on_its_loud_axis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A producer defect is never re-labelled as an honest named refusal."""
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    import sugar_lift_python_source.manager_summary_derivation as derivation
+
+    source = tmp_path / "panic.py"
+    source.write_text(
+        "from managers import acquire\n"
+        "def exercise():\n"
+        "    first = acquire()\n"
+        "    second = acquire()\n"
+        "    with first, second:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+
+    def panic(*_args, **_kwargs):
+        construction_panic_gap(
+            owner="test-provider",
+            blame="panic.py",
+            observed="provider defect",
+            requested="manager testimony",
+            fix="repair provider construction",
+        )
+
+    monkeypatch.setattr(derivation, "populate_source_derived_resource_refs", panic)
+    rows = resolve_bare_name_manager_items(
+        tree, root=tmp_path, path=source, with_start_line=5
+    )
+
+    assert [row.outcome for row in rows] == [
+        ManagerItemResolutionOutcomeV1.CONSTRUCTION_PANIC,
+        ManagerItemResolutionOutcomeV1.CONSTRUCTION_PANIC,
+    ]
+    assert [row.owner for row in rows] == ["test-provider", "test-provider"]


### PR DESCRIPTION
## What changed

- add a closed per-item result for bare-name manager lists: authenticated exceptional exit, named refusal, or construction panic
- resolve each item through its structural reaching-binding projection and preserve both the manager-use coordinate and binding coordinate
- keep undecidable `option_context` provider construction as two honest `SourceCallBindingGap` refusals; this PR deliberately does not extend provider construction
- add the same-spelling/different-binding lying twin, a module-wide zero-vendor-literal law, and a construction-panic axis twin

## Assumption / ruling applied

Provider construction is not extended to force authentication. Each undecidable item is independently reported as a coordinate-bearing named refusal; neither item decides the other. Absence of an authenticated exceptional edge does not satisfy the item.

## Verified corpus site

Pinned pandas 3.0.3 `pandas/tests/io/formats/test_ipython_compat.py:32` is `with opt, with_latex:`. Both context expressions are bare `Name` nodes. `opt` reaches its call binding at line 21; `with_latex` reaches its call binding at line 30.

## Validation

Authenticated interpreter: CPython 3.12.13; exact NumPy 2.5.1 and pandas 3.0.3.

```
PYTHON312=/usr/local/opt/python@3.12/bin/python3.12 bash scripts/bootstrap-venv-py312.sh .venv-py312/bin/python
PYTHONUNBUFFERED=1 .venv-py312/bin/python -m pytest implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py -q
# 9 passed, 2 warnings
```

Mutation transaction: changing an unprojected binding from named refusal to authenticated exceptional exit made `test_same_spelled_names_bound_elsewhere_do_not_authenticate` fail; restoration returned the lying twin and panic-axis tests to green.

macOS does not authenticate Battleaxe Linux Sugar binary cells, so this PR does not claim corpus-wide crash/timeout zeros.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report bare-name manager outcomes per item in manager summary derivation
> - Adds `ManagerItemResolutionOutcomeV1` enum with three outcomes (`AUTHENTICATED_EXCEPTIONAL_EXIT`, `NAMED_REFUSAL`, `CONSTRUCTION_PANIC`) and `ManagerItemResolutionV1` dataclass to [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6547/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c).
> - Adds `resolve_bare_name_manager_items` function that inspects a `with`-statement and returns a tuple of `ManagerItemResolutionV1` for each bare-name context manager item, recording the outcome, owner, and detail for each.
> - Resolution logic distinguishes missing binding projections, missing construction contexts, construction panics, and authenticated exceptional-exit references, recording a typed owner and detail for each failure mode.
> - New tests in [test_assigned_multi_manager_with.py](https://github.com/TSavo/sugar/pull/6547/files#diff-39dfa4631059709fd6ce0d1d2335df9ea2678bcb05ffd238bf1633210c95f181) cover pandas multi-item refusals, same-spelled-name refusals, construction panics, and a guard against vendor-name literals in the derivation module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad76897.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->