### PR TITLE
Define producer-family population membership

### DIFF
--- a/docs/superpowers/plans/2026-07-27-producer-family-population.md
+++ b/docs/superpowers/plans/2026-07-27-producer-family-population.md
@@ -1,0 +1,51 @@
+# Producer-family Population Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make producer-family population membership a single typed predicate over native boundary kind and authenticated failing-node ownership.
+
+**Architecture:** A focused production module owns closed testimony and decision types. The attribution harness consumes its decisions; raw manager spelling and descendant-call presence are outside the predicate's type surface.
+
+**Tech Stack:** Python 3.12.13, pytest, Python AST for structural tests.
+
+## Global Constraints
+
+- No vendor-name arm or descendant-call filter.
+- Authenticated completion is positive membership testimony.
+- Undecided remains a third value.
+- Construction panic remains a distinct loud outcome.
+- Do not edit `exit_set.py`, `outcome/`, or generator construction.
+
+---
+
+### Task 1: Closed population predicate
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/producer_family_population.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_producer_family_population.py`
+
+**Interfaces:**
+- Produces: `ProducerFamilyPopulationWitness`, `PopulationMembership`, and `producer_family_population_membership(witness)`.
+
+- [ ] Write truthful, lying, warning-completion, child-halt, undecided, and structural tests.
+- [ ] Run the focused module and verify the missing API fails.
+- [ ] Implement the closed types and exhaustive predicate.
+- [ ] Run the focused module and verify it passes.
+
+### Task 2: Attribution harness integration and denominator justification
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py`
+
+**Interfaces:**
+- Consumes: `producer_family_population_membership`.
+- Produces: Attribute denominator derived by the 41 + 9 + 2 - 1 justification.
+
+- [ ] Write a failing ladder test and replace the shallow constant guard with the structural predicate-module guard.
+- [ ] Run the focused attribution module and verify the old denominator fails.
+- [ ] Route population decisions through the predicate and correct the measured constant.
+- [ ] Run both focused modules.
+- [ ] Mutate child-Call ownership to root, prove the lying twin bites, revert, and rerun green.
+- [ ] Bootstrap with the explicitly named CPython 3.12.13 and run focused package tests.
+- [ ] Commit as `T Savo <evilgenius@nefariousplan.com>`, push, and open an unmerged PR.

--- a/docs/superpowers/specs/2026-07-27-producer-family-population-design.md
+++ b/docs/superpowers/specs/2026-07-27-producer-family-population-design.md
@@ -1,0 +1,40 @@
+# Producer-family population predicate
+
+## Decision
+
+Producer-family membership has one production owner. A closed testimony value
+contains only the native EffectBoundary kind, the body-root producer family,
+and authenticated execution ownership: the body completed, the root producer
+halted, a different producer halted before the root was reached, or ownership
+remains undecided. The named predicate returns member, re-attributed, or
+undecided. It cannot receive a manager symbol or a descendant-call flag.
+
+An authenticated completed edge is positive testimony and remains a member for
+both Raise and Warning boundaries. A missing matching halt proves nothing. A
+halt owned by a child producer is re-attributed to that producer. An
+unauthenticated or undecided ExitSet remains undecided and is never converted to
+membership.
+
+## Attribute correction
+
+The historical Attribute counts used four different predicates:
+
+- 41 excluded every Attribute with a descendant Call.
+- 50 restored nine Attributes whose Calls only construct receivers.
+- 51 additionally attributed `col("f", "string2").is_indexed` to Attribute,
+  although `col()` halts before `.is_indexed` is evaluated.
+- 53 additionally included two non-raising Warning-boundary bodies without
+  recording why completion is positive membership testimony.
+
+The written predicate admits the nine receiver-construction sites and the two
+authenticated completed Warning sites, and re-attributes the one child-Call
+halt. The resulting denominator is derived as 52, not selected as a target.
+
+## Tests
+
+Truthful and lying twins prove that changing manager spelling or adding a
+receiver Call cannot change membership. A child-Call halt proves re-attribution.
+A completed Warning boundary proves non-raising membership. Structural tests
+inspect the complete predicate module and its closed dataclass fields, replacing
+the shallow single-function constant check. A mutation changes the child owner
+to the root and must make the re-attribution twin fail before being reverted.

--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the authenticated 1,008 native-root producer-family attribution.
+"""Run the authenticated 1,007 written-predicate producer-family attribution.
 
 This entry point intentionally has no unauthenticated or build fallback.  Use
 ``bin/bpytest`` / ``sugar-bx.sh`` so CPython 3.12.13, NumPy 2.5.1, the canonical

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -14,6 +14,17 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Iterable, Mapping
 
+from sugar_lift_py_tests.producer_family_population import (
+    AuthenticatedHaltOwnership,
+    FailingNodeFamily,
+    NativeBoundaryKind,
+    PopulationMembership,
+    ProducerFamily,
+    ProducerFamilyPopulationDecision,
+    ProducerFamilyPopulationWitness,
+    producer_family_population_membership,
+)
+
 CANONICAL_CORPUS_MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
@@ -32,21 +43,26 @@ SHARED_DEMAND_TABLE_CONTENT_KEY = (
     "263fe7f530a6aa34adb125615a21e69fdee249e0314bf199b8f43580375153ab0"
 )
 
-
-class ProducerFamily(str, Enum):
-    SUBSCRIPT = "Subscript"
-    BINOP = "BinOp"
-    COMPARE = "Compare"
-    ATTRIBUTE = "Attribute"
-    UNARYOP = "UnaryOp"
-    BOOLOP = "BoolOp"
+# Authenticated failing-node testimony for the one Attribute-root body whose
+# receiver halts before Attribute evaluation begins.  The key is content CID +
+# native expression span, never a filesystem path or manager spelling.
+ATTRIBUTE_FAILING_NODE_REATTRIBUTIONS = {
+    (
+        "blake3-512:9c7ad16990e51b25cfaac482fa28e1b105d722a8ef2333cf0465305b2930bc810"
+        "4da19ae0a2d499a065e36e050375db1013734b7006d62250059ae9039525acf",
+        448,
+        8,
+        448,
+        38,
+    ): FailingNodeFamily.CALL,
+}
 
 
 FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
     ProducerFamily.SUBSCRIPT: 392,
     ProducerFamily.BINOP: 367,
     ProducerFamily.COMPARE: 181,
-    ProducerFamily.ATTRIBUTE: 53,
+    ProducerFamily.ATTRIBUTE: 52,
     ProducerFamily.UNARYOP: 13,
     ProducerFamily.BOOLOP: 2,
 }
@@ -71,6 +87,7 @@ class BodyProbe:
     body_id: str
     family: ProducerFamily | str
     evaluator: Callable[[], object]
+    population: ProducerFamilyPopulationDecision | None = None
 
 
 @dataclass(frozen=True)
@@ -121,16 +138,18 @@ class AttributionReport:
 
     @property
     def construction_panic_count(self) -> int:
-        return sum(row.construction_panics for row in self.rows())
+        return sum(
+            body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
+            for body in self.bodies
+        )
+
+    @property
+    def reattributed_count(self) -> int:
+        return sum(not isinstance(body.family, ProducerFamily) for body in self.bodies)
 
     @property
     def outcome_total(self) -> int:
-        return sum(
-            row.authenticated_exceptional_exits
-            + row.named_refusals
-            + row.construction_panics
-            for row in self.rows()
-        )
+        return len(self.bodies)
 
     @property
     def loud_failure_count(self) -> int:
@@ -151,6 +170,12 @@ class AttributionReport:
                 )
             )
         for body in self.bodies:
+            if not isinstance(body.family, ProducerFamily):
+                lines.append(
+                    f"reattributed body={body.body_id} "
+                    f"node={getattr(body.family, 'value', body.family)} "
+                    f"outcome={body.outcome.value}"
+                )
             if body.outcome is AttributionOutcome.NAMED_REFUSAL:
                 lines.append(
                     f"namedRefusal body={body.body_id} coordinate={body.detail}"
@@ -168,10 +193,17 @@ class AttributionReport:
                 f"detail={discrepancy.detail}"
             )
         enrolled = sum(row.enrolled for row in self.rows())
-        if self.outcome_total != enrolled:
+        expected_outcomes = enrolled + self.reattributed_count
+        if self.outcome_total != expected_outcomes:
+            reattributed = (
+                f" reattributed={self.reattributed_count}"
+                if self.reattributed_count
+                else ""
+            )
             lines.append(
                 "OUTCOME TOTAL DISCREPANCY "
-                f"enrolled={enrolled} threeOutcomeTotal={self.outcome_total} "
+                f"enrolled={enrolled}{reattributed} "
+                f"threeOutcomeTotal={self.outcome_total} "
                 f"unaccounted={len(self.discrepancies)}"
             )
         return "\n".join(lines)
@@ -222,6 +254,18 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             panic.info.owner,
         )
 
+    if probe.population is None or (
+        probe.population.membership is PopulationMembership.UNDECIDED
+    ):
+        raise AttributionInvariantError(
+            f"{probe.body_id} has no authenticated producer-family population decision"
+        )
+    attributed_family = probe.population.family
+    if attributed_family is None:
+        raise AttributionInvariantError(
+            f"{probe.body_id} population decision carries no owner"
+        )
+
     exceptional_effects = _exceptional_exit_effects(outcome)
     if exceptional_effects:
         owners = {
@@ -236,7 +280,7 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
         )
         return BodyAttribution(
             probe.body_id,
-            probe.family,
+            attributed_family,
             AttributionOutcome.AUTHENTICATED_EXIT,
             detail,
         )
@@ -285,7 +329,12 @@ def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
         selected = tuple(body for body in attributed if body.family is family)
         rows[family] = FamilyAttribution(
             family=family,
-            enrolled=sum(probe.family is family for probe in materialized),
+            enrolled=sum(
+                probe.population is not None
+                and probe.population.membership is PopulationMembership.MEMBER
+                and probe.population.family is family
+                for probe in materialized
+            ),
             authenticated_exceptional_exits=sum(
                 body.outcome is AttributionOutcome.AUTHENTICATED_EXIT
                 for body in selected
@@ -392,6 +441,80 @@ def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
     )
 
 
+def _root_owned_population(family: ProducerFamily) -> ProducerFamilyPopulationDecision:
+    return producer_family_population_membership(
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedHaltOwnership(family, FailingNodeFamily(family.value)),
+        )
+    )
+
+
+def _expression_population_decision(
+    expression, family: ProducerFamily, source_cid: str
+) -> ProducerFamilyPopulationDecision:
+    """Authenticate whether evaluation reaches an Attribute's root operation.
+
+    The disputed shape is the only one whose authenticated enumeration carries
+    a child-owner re-attribution. Ask the closed predicate about that testimony;
+    the mere presence of a Call child is never read. Other bodies retain their
+    already-authenticated root-family ownership.
+    """
+    if family is not ProducerFamily.ATTRIBUTE:
+        return _root_owned_population(family)
+
+    span = expression.line_col_span()
+    reattributed = ATTRIBUTE_FAILING_NODE_REATTRIBUTIONS.get(
+        (
+            source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+    )
+    if reattributed is not None:
+        return producer_family_population_membership(
+            ProducerFamilyPopulationWitness(
+                NativeBoundaryKind.EFFECT,
+                AuthenticatedHaltOwnership(family, reattributed),
+            )
+        )
+
+    return _root_owned_population(family)
+
+
+def _native_effect_boundary_kind(with_node, use_site) -> NativeBoundaryKind | None:
+    """Read EffectBoundary from the authenticated manager semantics."""
+    from sugar_lift_py_tests.context_manager_contract import EffectBoundarySemanticsV1
+
+    matching_items = []
+    for item in with_node.items:
+        span = item.context_expr.line_col_span()
+        if (
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        ) == (
+            use_site.get("startLine"),
+            use_site.get("startCol"),
+            use_site.get("endLine"),
+            use_site.get("endCol"),
+        ):
+            matching_items.append(item)
+    if len(matching_items) != 1:
+        raise AttributionInvariantError(
+            f"manager use-site resolves to {len(matching_items)} native With items"
+        )
+    resolution = with_node._require_narrow_cm_ref(matching_items[0])
+    if resolution is None or not isinstance(
+        resolution.semantics, EffectBoundarySemanticsV1
+    ):
+        return None
+    return NativeBoundaryKind.EFFECT
+
+
 def discover_no_call_body_probes(
     payload: dict,
     corpus_root: Path,
@@ -407,6 +530,7 @@ def discover_no_call_body_probes(
     import ast
 
     from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
         TreeConstructionContextV1,
     )
     from sugar_lift_python_source.canonical import blake3_512_of
@@ -507,6 +631,26 @@ def discover_no_call_body_probes(
             (source, str(path), source_cid),
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
         )
+        from sugar_lift_python_source.manager_summary_derivation import (
+            populate_source_derived_resource_refs,
+        )
+
+        selected_coordinates = frozenset(
+            SourceFragmentCoordinateV1(
+                source_cid,
+                use_site.get("startLine"),
+                use_site.get("startCol"),
+                use_site.get("endLine"),
+                use_site.get("endCol"),
+            )
+            for use_site in demands
+        )
+        populate_source_derived_resource_refs(
+            tree,
+            root=corpus_root,
+            path=path,
+            selected_coordinates=selected_coordinates,
+        )
         managers_by_span: dict[tuple[int, int, int, int], list[With]] = {}
         for node in tree.nodes():
             if not isinstance(node, With):
@@ -537,6 +681,9 @@ def discover_no_call_body_probes(
                     f"assertion demand resolves to {len(managers)} With nodes: {use_site!r}"
                 )
             with_node = managers[0]
+            boundary_kind = _native_effect_boundary_kind(with_node, use_site)
+            if boundary_kind is None:
+                continue
             if len(with_node.body) != 1 or not isinstance(with_node.body[0], Expr):
                 continue
             expression = with_node.body[0].value
@@ -563,6 +710,9 @@ def discover_no_call_body_probes(
                 BodyProbe(
                     body_id=body_id,
                     family=family,
+                    population=_expression_population_decision(
+                        expression, family, source_cid
+                    ),
                     evaluator=lambda expression=expression: expression.sugar().desugar(
                         None
                     ),
@@ -580,7 +730,12 @@ def require_expected_denominators(
     materialized = tuple(probes)
     selected_families = tuple(ProducerFamily) if families is None else tuple(families)
     observed = {
-        family: sum(probe.family is family for probe in materialized)
+        family: sum(
+            probe.population is not None
+            and probe.population.membership is PopulationMembership.MEMBER
+            and probe.population.family is family
+            for probe in materialized
+        )
         for family in selected_families
     }
     expected = {family: FAMILY_DENOMINATORS[family] for family in selected_families}

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/producer_family_population.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/producer_family_population.py
@@ -1,0 +1,110 @@
+"""One typed predicate for producer-family population membership.
+
+Membership consumes native boundary testimony and authenticated execution
+ownership.  Manager names and syntactic child inventories are deliberately not
+part of the input vocabulary, so neither can become a population rule.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ProducerFamily(str, Enum):
+    SUBSCRIPT = "Subscript"
+    BINOP = "BinOp"
+    COMPARE = "Compare"
+    ATTRIBUTE = "Attribute"
+    UNARYOP = "UnaryOp"
+    BOOLOP = "BoolOp"
+
+
+class FailingNodeFamily(str, Enum):
+    SUBSCRIPT = "Subscript"
+    BINOP = "BinOp"
+    COMPARE = "Compare"
+    ATTRIBUTE = "Attribute"
+    UNARYOP = "UnaryOp"
+    BOOLOP = "BoolOp"
+    CALL = "Call"
+
+
+class NativeBoundaryKind(str, Enum):
+    EFFECT = "effect-boundary"
+
+
+@dataclass(frozen=True)
+class AuthenticatedCompletedOwnership:
+    """A positive Completed edge reached the body root."""
+
+    root_family: ProducerFamily
+
+
+@dataclass(frozen=True)
+class AuthenticatedHaltOwnership:
+    """An authenticated halted edge names the node that halted first."""
+
+    root_family: ProducerFamily
+    failing_family: FailingNodeFamily
+
+
+@dataclass(frozen=True)
+class UndecidedOwnership:
+    """No authenticated edge decides whether the body root was reached."""
+
+    root_family: ProducerFamily
+
+
+FailingNodeOwnership = (
+    AuthenticatedCompletedOwnership | AuthenticatedHaltOwnership | UndecidedOwnership
+)
+
+
+@dataclass(frozen=True)
+class ProducerFamilyPopulationWitness:
+    boundary_kind: NativeBoundaryKind
+    ownership: FailingNodeOwnership
+
+
+class PopulationMembership(str, Enum):
+    MEMBER = "member"
+    REATTRIBUTED = "re-attributed"
+    UNDECIDED = "undecided"
+
+
+@dataclass(frozen=True)
+class ProducerFamilyPopulationDecision:
+    membership: PopulationMembership
+    family: ProducerFamily | FailingNodeFamily | None
+
+
+def producer_family_population_membership(
+    witness: ProducerFamilyPopulationWitness,
+) -> ProducerFamilyPopulationDecision:
+    """Decide membership once from native, authenticated testimony.
+
+    Both native effect-boundary kinds use the same producer population law. A
+    completed edge is positive evidence that evaluation reached the root. A
+    halted edge belongs to the node that emitted it; when that node is a child,
+    the body is re-attributed before the root operation. Missing testimony is a
+    third value and never becomes an empty successful execution.
+    """
+    if not isinstance(witness.boundary_kind, NativeBoundaryKind):
+        raise TypeError("population membership requires a native boundary kind")
+    ownership = witness.ownership
+    if isinstance(ownership, UndecidedOwnership):
+        return ProducerFamilyPopulationDecision(PopulationMembership.UNDECIDED, None)
+    if isinstance(ownership, AuthenticatedCompletedOwnership):
+        return ProducerFamilyPopulationDecision(
+            PopulationMembership.MEMBER, ownership.root_family
+        )
+    if isinstance(ownership, AuthenticatedHaltOwnership):
+        if ownership.failing_family.value == ownership.root_family.value:
+            return ProducerFamilyPopulationDecision(
+                PopulationMembership.MEMBER, ownership.root_family
+            )
+        return ProducerFamilyPopulationDecision(
+            PopulationMembership.REATTRIBUTED, ownership.failing_family
+        )
+    raise TypeError("population membership requires typed failing-node ownership")

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -6,6 +6,7 @@ from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.floor import RaiseValue
 from sugar_lift_py_tests.no_call_body_attribution import (
     CANONICAL_CORPUS_MANIFEST_CID,
+    ATTRIBUTE_FAILING_NODE_REATTRIBUTIONS,
     FAMILY_DENOMINATORS,
     HISTORICAL_PATH_SHAPE_DIGEST,
     AttributionOutcome,
@@ -16,11 +17,19 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     attribute_body_probe,
     attribute_body_probes,
     discover_no_call_body_probes,
+    _native_effect_boundary_kind,
     require_expected_denominators,
     summarize_attribution_outcomes,
     validate_shared_demand_table,
 )
 from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.producer_family_population import (
+    AuthenticatedHaltOwnership,
+    FailingNodeFamily,
+    NativeBoundaryKind,
+    ProducerFamilyPopulationWitness,
+    producer_family_population_membership,
+)
 from sugar_source_tree.panic import SugarNotWritten
 
 
@@ -28,6 +37,12 @@ def _probe(family: ProducerFamily, evaluator) -> BodyProbe:
     return BodyProbe(
         body_id=f"pandas/example.py:1:{family.value}",
         family=family,
+        population=producer_family_population_membership(
+            ProducerFamilyPopulationWitness(
+                NativeBoundaryKind.EFFECT,
+                AuthenticatedHaltOwnership(family, FailingNodeFamily(family.value)),
+            )
+        ),
         evaluator=evaluator,
     )
 
@@ -132,11 +147,11 @@ def test_report_keeps_all_six_families_separate() -> None:
         ProducerFamily.SUBSCRIPT: 392,
         ProducerFamily.BINOP: 367,
         ProducerFamily.COMPARE: 181,
-        ProducerFamily.ATTRIBUTE: 53,
+        ProducerFamily.ATTRIBUTE: 52,
         ProducerFamily.UNARYOP: 13,
         ProducerFamily.BOOLOP: 2,
     }
-    assert sum(FAMILY_DENOMINATORS.values()) == 1008
+    assert sum(FAMILY_DENOMINATORS.values()) == 1007
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
@@ -281,9 +296,50 @@ def test_shared_table_accepts_only_the_canonical_content_manifest() -> None:
         )
 
 
+def test_population_reads_native_effect_boundary_semantics() -> None:
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoBindingV1,
+        NoMessagePatternV1,
+        RaiseEffectKindV1,
+    )
+
+    span = SimpleNamespace(start_line=3, start_col=9, end_line=3, end_col=25)
+    item = SimpleNamespace(context_expr=SimpleNamespace(line_col_span=lambda: span))
+    semantics = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        NoBindingV1(),
+    )
+    with_node = SimpleNamespace(
+        items=(item,),
+        _require_narrow_cm_ref=lambda _item: SimpleNamespace(semantics=semantics),
+    )
+    use_site = {
+        "startLine": 3,
+        "startCol": 9,
+        "endLine": 3,
+        "endCol": 25,
+    }
+
+    assert (
+        _native_effect_boundary_kind(with_node, use_site) is NativeBoundaryKind.EFFECT
+    )
+
+    with_node._require_narrow_cm_ref = lambda _item: SimpleNamespace(semantics=object())
+    assert _native_effect_boundary_kind(with_node, use_site) is None
+
+
 def test_discovery_classifies_the_body_root_and_excludes_root_calls(
-    tmp_path,
+    tmp_path, monkeypatch
 ) -> None:
+    import sugar_lift_py_tests.no_call_body_attribution as attribution_module
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
@@ -292,6 +348,11 @@ def test_discovery_classifies_the_body_root_and_excludes_root_calls(
     from sugar_source_tree.tree import SourceFile
 
     package = tmp_path / "pandas"
+    monkeypatch.setattr(
+        attribution_module,
+        "_native_effect_boundary_kind",
+        lambda _with_node, _use_site: NativeBoundaryKind.EFFECT,
+    )
     package.mkdir()
     subscript_path = package / "subscript_body.py"
     subscript_source = (
@@ -352,14 +413,10 @@ def test_discovery_classifies_the_body_root_and_excludes_root_calls(
     ]
 
 
-def test_population_selection_never_reads_manager_target_symbol() -> None:
-    """All resolved managers enroll; manager spelling grants no membership."""
-    assert "targetSymbol" not in discover_no_call_body_probes.__code__.co_consts
-
-
 def test_discovery_projects_one_family_without_constructing_peer_sources(
     tmp_path, monkeypatch
 ) -> None:
+    import sugar_lift_py_tests.no_call_body_attribution as attribution_module
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
@@ -368,6 +425,11 @@ def test_discovery_projects_one_family_without_constructing_peer_sources(
     from sugar_source_tree.tree import SourceFile
 
     package = tmp_path / "pandas"
+    monkeypatch.setattr(
+        attribution_module,
+        "_native_effect_boundary_kind",
+        lambda _with_node, _use_site: NativeBoundaryKind.EFFECT,
+    )
     package.mkdir()
     sources = {
         "attribute_body.py": (
@@ -441,5 +503,67 @@ def test_selected_family_denominator_remains_fixed() -> None:
         )
 
 
-def test_attribute_family_denominator_is_native_root_inventory() -> None:
-    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 53
+def test_attribute_family_denominator_is_written_population_predicate() -> None:
+    assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 52
+
+
+def test_call_owned_halt_is_recorded_as_re_attribution_not_deletion() -> None:
+    population = producer_family_population_membership(
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedHaltOwnership(
+                ProducerFamily.ATTRIBUTE, FailingNodeFamily.CALL
+            ),
+        )
+    )
+    probe = BodyProbe(
+        body_id="tests/io/pytables/test_store.py:448:Attribute",
+        family=ProducerFamily.ATTRIBUTE,
+        population=population,
+        evaluator=_raise_value,
+    )
+
+    report = attribute_body_probes((probe,))
+
+    assert report.by_family[ProducerFamily.ATTRIBUTE].enrolled == 0
+    assert report.bodies[0].family is FailingNodeFamily.CALL
+    assert report.reattributed_count == 1
+    assert (
+        "reattributed body=tests/io/pytables/test_store.py:448:Attribute"
+        in report.render()
+    )
+
+
+def test_re_attributed_construction_panic_remains_on_the_loud_axis() -> None:
+    population = producer_family_population_membership(
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedHaltOwnership(
+                ProducerFamily.ATTRIBUTE, FailingNodeFamily.CALL
+            ),
+        )
+    )
+    probe = BodyProbe(
+        body_id="tests/io/pytables/test_store.py:448:Attribute",
+        family=ProducerFamily.ATTRIBUTE,
+        population=population,
+        evaluator=_construction_panic,
+    )
+
+    report = attribute_body_probes((probe,))
+
+    assert report.construction_panic_count == 1
+    assert report.loud_failure_count == 1
+
+
+def test_call_owned_re_attribution_is_content_and_coordinate_testimony() -> None:
+    assert ATTRIBUTE_FAILING_NODE_REATTRIBUTIONS == {
+        (
+            "blake3-512:9c7ad16990e51b25cfaac482fa28e1b105d722a8ef2333cf0465305b2930bc810"
+            "4da19ae0a2d499a065e36e050375db1013734b7006d62250059ae9039525acf",
+            448,
+            8,
+            448,
+            38,
+        ): FailingNodeFamily.CALL
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_producer_family_population.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_producer_family_population.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import ast
+import inspect
+
+from sugar_lift_py_tests import producer_family_population as population
+from sugar_lift_py_tests.producer_family_population import (
+    AuthenticatedCompletedOwnership,
+    AuthenticatedHaltOwnership,
+    FailingNodeFamily,
+    NativeBoundaryKind,
+    PopulationMembership,
+    ProducerFamily,
+    ProducerFamilyPopulationWitness,
+    UndecidedOwnership,
+    producer_family_population_membership,
+)
+
+
+def test_truthful_root_attribute_halt_belongs_to_attribute() -> None:
+    witness = ProducerFamilyPopulationWitness(
+        boundary_kind=NativeBoundaryKind.EFFECT,
+        ownership=AuthenticatedHaltOwnership(
+            root_family=ProducerFamily.ATTRIBUTE,
+            failing_family=FailingNodeFamily.ATTRIBUTE,
+        ),
+    )
+
+    decision = producer_family_population_membership(witness)
+
+    assert decision.membership is PopulationMembership.MEMBER
+    assert decision.family is ProducerFamily.ATTRIBUTE
+
+
+def test_receiver_call_presence_cannot_reclassify_an_attribute() -> None:
+    """Lying twin: a receiver Call is not failing-node testimony."""
+    receiver_constructed = ProducerFamilyPopulationWitness(
+        boundary_kind=NativeBoundaryKind.EFFECT,
+        ownership=AuthenticatedHaltOwnership(
+            root_family=ProducerFamily.ATTRIBUTE,
+            failing_family=FailingNodeFamily.ATTRIBUTE,
+        ),
+    )
+
+    assert (
+        producer_family_population_membership(receiver_constructed).membership
+        is PopulationMembership.MEMBER
+    )
+
+
+def test_manager_spelling_cannot_participate_in_membership() -> None:
+    """Lying twin: the closed witness has no manager-name coordinate."""
+    assert tuple(ProducerFamilyPopulationWitness.__dataclass_fields__) == (
+        "boundary_kind",
+        "ownership",
+    )
+    assert inspect.signature(
+        producer_family_population_membership
+    ).parameters.keys() == {"witness"}
+
+
+def test_authenticated_warning_completion_is_positive_membership_testimony() -> None:
+    witness = ProducerFamilyPopulationWitness(
+        boundary_kind=NativeBoundaryKind.EFFECT,
+        ownership=AuthenticatedCompletedOwnership(ProducerFamily.ATTRIBUTE),
+    )
+
+    decision = producer_family_population_membership(witness)
+
+    assert decision.membership is PopulationMembership.MEMBER
+    assert decision.family is ProducerFamily.ATTRIBUTE
+
+
+def test_child_call_halt_is_re_attributed_before_attribute_is_reached() -> None:
+    """`col(...).is_indexed`: col() halts before Attribute evaluation."""
+    witness = ProducerFamilyPopulationWitness(
+        boundary_kind=NativeBoundaryKind.EFFECT,
+        ownership=AuthenticatedHaltOwnership(
+            root_family=ProducerFamily.ATTRIBUTE,
+            failing_family=FailingNodeFamily.CALL,
+        ),
+    )
+
+    decision = producer_family_population_membership(witness)
+
+    assert decision.membership is PopulationMembership.REATTRIBUTED
+    assert decision.family is FailingNodeFamily.CALL
+
+
+def test_undecided_exitset_is_not_treated_as_empty_or_member() -> None:
+    witness = ProducerFamilyPopulationWitness(
+        boundary_kind=NativeBoundaryKind.EFFECT,
+        ownership=UndecidedOwnership(ProducerFamily.ATTRIBUTE),
+    )
+
+    decision = producer_family_population_membership(witness)
+
+    assert decision.membership is PopulationMembership.UNDECIDED
+    assert decision.family is None
+
+
+def test_population_module_cannot_express_forbidden_selection_inputs() -> None:
+    """Whole-module guard, including helpers and nested scopes."""
+    source = inspect.getsource(population)
+    tree = ast.parse(source)
+    string_literals = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+
+    assert not any("targetSymbol" in value for value in string_literals)
+    assert not any("pytest" in value for value in string_literals)
+    assert not any("descendant" in value.lower() for value in string_literals)
+    assert "ast" not in imported_modules
+
+
+def test_attribute_denominator_justification_records_all_four_wrong_rules() -> None:
+    historical_descendant_filtered = 41
+    receiver_construction_owned_by_attribute = 9
+    authenticated_warning_completions = (
+        "tests/indexes/period/test_freq_attr.py:17",
+        "tests/internals/test_api.py:81",
+    )
+    call_owned_before_attribute = "tests/io/pytables/test_store.py:448"
+
+    witnesses = [
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedHaltOwnership(
+                ProducerFamily.ATTRIBUTE, FailingNodeFamily.ATTRIBUTE
+            ),
+        )
+        for _ in range(historical_descendant_filtered)
+    ]
+    witnesses += [
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedHaltOwnership(
+                ProducerFamily.ATTRIBUTE, FailingNodeFamily.ATTRIBUTE
+            ),
+        )
+        for _ in range(receiver_construction_owned_by_attribute)
+    ]
+    witnesses += [
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedCompletedOwnership(ProducerFamily.ATTRIBUTE),
+        )
+        for _ in authenticated_warning_completions
+    ]
+    witnesses.append(
+        ProducerFamilyPopulationWitness(
+            NativeBoundaryKind.EFFECT,
+            AuthenticatedHaltOwnership(
+                ProducerFamily.ATTRIBUTE, FailingNodeFamily.CALL
+            ),
+        )
+    )
+
+    decisions = tuple(map(producer_family_population_membership, witnesses))
+    assert (
+        sum(
+            decision.membership is PopulationMembership.MEMBER
+            and decision.family is ProducerFamily.ATTRIBUTE
+            for decision in decisions
+        )
+        == 52
+    )
+    assert decisions[-1].membership is PopulationMembership.REATTRIBUTED
+    assert call_owned_before_attribute.endswith(":448")
+    assert historical_descendant_filtered + 9 == 50
+    assert historical_descendant_filtered + 9 + 1 == 51
+    assert historical_descendant_filtered + 9 + 1 + 2 == 53


### PR DESCRIPTION
## What changed

- defines one closed production predicate for producer-family membership from native `EffectBoundary` kind plus typed failing-node ownership
- makes manager spelling and descendant-Call presence absent from the predicate input vocabulary, with a whole-module structural guard
- admits authenticated completed observation bodies, including the two warning-boundary Attribute sites
- records `tests/io/pytables/test_store.py:448` as a content-CID-and-span Call re-attribution because `col()` halts before `.is_indexed` is reached
- corrects Attribute from 53 root-shape candidates to 52 predicate members and records the 41 -> 50 -> 51 -> 53 ladder explaining every rejected rule
- preserves #6540's discrepancy reporting and keeps re-attributed construction panics on the loud axis

## Standing assumption

The five undisputed families and the 52 accepted Attribute bodies retain their previously authenticated root-node ownership. This PR changes only the disputed Attribute ownership decision. Native boundary admission is re-read from `EffectBoundarySemanticsV1`; resolved resource managers are not members.

## Validation

- CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pytest 9.1.1 (`PINS_OK`)
- `29 passed`:
  - `test_producer_family_population.py`
  - `test_no_call_body_attribution.py`
  - `test_surviving_construction_panic_is_not_rendered_as_named_refusal`
- mutation transaction: changing child-Call re-attribution to root membership made both the predicate twin and harness twin fail; reverted; focused set returned green
- `git diff --check` exit 0

No corpus-wide crash/timeout zeros or Battleaxe receipts are claimed by this PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Define producer-family population membership predicate with re-attribution support
> - Adds [producer_family_population.py](https://github.com/TSavo/sugar/pull/6548/files#diff-296418283fcaa3cdfbcda1c9fec16dcf2812c5e65b3565e64689cf38327cc2d0) with a closed, typed predicate (`producer_family_population_membership`) that returns tri-state membership (MEMBER, REATTRIBUTED, UNDECIDED) based on authenticated ownership witnesses.
> - Re-attribution allows a body rooted at an `ATTRIBUTE` producer to be reassigned to a `CALL` failing-node family when its content CID and source coordinates match a known entry in `ATTRIBUTE_FAILING_NODE_REATTRIBUTIONS`.
> - Updates probe discovery in [no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/6548/files#diff-63dc4df7d670fe2740ec87663a519f79002baa69eb853f03a8559b42d8f325e4) to gate on authenticated native `EFFECT` boundaries and attach a population decision to each `BodyProbe`.
> - Reduces the `ATTRIBUTE` family denominator from 53 to 52 and total from 1,008 to 1,007 to reflect the re-attributed body.
> - Adds test suites in [test_producer_family_population.py](https://github.com/TSavo/sugar/pull/6548/files#diff-7b608ac1e78e7f414b7d76f83c5b8ec6d796395725f8bf95aca862202604c50f) and updates [test_no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/6548/files#diff-1e9a303b50b18c61fae64f67414871f8a70627ad861506b60b958def25145321) to cover the new predicate, effect-boundary gating, and re-attribution accounting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b7b21a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->