### PR TITLE
Isolate memo correctness from construction order

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_canonicalization_value_memo.py
@@ -19,7 +19,10 @@ speed never comes from skipping testimony.
 """
 
 import gc
+import json
 import os
+import subprocess
+import sys
 import tempfile
 import weakref
 from dataclasses import dataclass
@@ -228,7 +231,7 @@ def test_speed_never_comes_from_skipping_testimony():
             raise AssertionError("unsupported value went quiet")
 
 
-def test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer():
+def _real_construction_comparisons():
     # For EVERY semantic value a real function presents, mint its CID with the
     # memo warm and again with the memo emptied, and require them equal. Done
     # in ONE pass so no other warm cache (node shape, sugar() coordinate) can
@@ -270,7 +273,38 @@ def test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer():
         fn.sugar()
     finally:
         BS._constructed_preimage = original
+    return compared
+
+
+def _fresh_real_construction_comparisons() -> list[str]:
+    script = (
+        "import json, runpy; "
+        f"ns = runpy.run_path({__file__!r}); "
+        "print('comparisons=' + json.dumps(ns['_real_construction_comparisons']()))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    line = completed.stdout.strip().splitlines()[-1]
+    assert line.startswith("comparisons="), completed.stdout
+    return json.loads(line.removeprefix("comparisons="))
+
+
+def test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer():
+    compared = _fresh_real_construction_comparisons()
     # A real function presents several distinct values (8 measured here); a
     # silent zero comparisons would make this test prove nothing at all.
     assert len(compared) >= 8, len(compared)
     assert len(set(compared)) > 1, compared
+
+
+def test_real_construction_memo_floor_is_independent_of_prior_construction():
+    first = _fresh_real_construction_comparisons()
+    second = _fresh_real_construction_comparisons()
+
+    assert len(first) >= 8, len(first)
+    assert len(second) >= 8, len(second)


### PR DESCRIPTION
## Finding

The reported memo red is order-dependent, not merge-fixed and not uncollected. The exact node collected and passed in a cold process, while an authenticated battleaxe probe collected 41 executions: the first passed and the following 40 failed because the comparison denominator fell from 8 to 5. The compared CIDs did not disagree; three LoopBindingRefSugar presentations were already satisfied by process-lifetime construction state.

## Change

Run the real memoized-versus-unmemoized comparison in a fresh child of the authenticated interpreter. This preserves the original bit-for-bit assertions, the non-vacuous >= 8 denominator, and the distinct-CID floor. A two-run twin proves prior construction cannot change the result.

No production cache behavior changes, and no threshold is weakened.

## Validation

- Authenticated battleaxe module: 10 passed.
- Mutation present: 10 passed.
- Mutation replacing fresh-process isolation with the previous same-process path: the twin fails with second denominator 5 < 8.
- Mutation reverted: 10 passed.

Runtime testimony: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3; canonical pandas manifest blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate memo correctness tests from construction order by running in fresh subprocesses
> - Extracts the core comparison logic into `_real_construction_comparisons`, a helper that hooks `BS._constructed_preimage` to compare warm vs. cold CID computations and returns the results as a list.
> - Adds `_fresh_real_construction_comparisons`, which runs that helper in a fresh Python interpreter via `subprocess` to prevent interpreter state from leaking between test runs.
> - Refactors `test_real_construction_agrees_bit_for_bit_with_the_unmemoized_answer` to use the subprocess-isolated helper.
> - Adds `test_real_construction_memo_floor_is_independent_of_prior_construction`, which calls the helper twice and asserts each run produces at least 8 comparisons, verifying the memo floor resets cleanly between runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab7905e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->