### PR TITLE
Require blame coordinates on source tree panics

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -73,6 +73,7 @@ def matches_raise_effect(effect, expected) -> "MessageVerdict":
         # operands through their lexical coordinates", which invited exactly
         # that repair; it cost one owner three rounds and nearly landed.
         raise SugarNotWritten(
+            blame=effect.occurrence_id,
             owner="matches_raise_effect",
             observed="handler or raised exception has no term to state the test over",
             requested="an authenticated exception identity or an emittable VALUE term",
@@ -160,6 +161,7 @@ def _message_term(effect, *, owner):
     raised_term = _operand_term(raised, owner=owner, role="raised exception")
     if raised_term is None:
         raise SugarNotWritten(
+            blame=effect.occurrence_id,
             owner="authenticated_exception_matching._message_term",
             observed="raised exception has no value term to render as a message",
             requested="a message operand or an emittable raised VALUE term",
@@ -247,12 +249,11 @@ def warning_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
     from sugar_source_tree.panic import SugarNotWritten
 
     identity_projection = getattr(expected, "exception_type_identity", None)
-    expected_identity = (
-        identity_projection() if callable(identity_projection) else None
-    )
+    expected_identity = identity_projection() if callable(identity_projection) else None
     observed_identity = getattr(effect, "category_identity", None)
     if expected_identity is None or observed_identity is None:
         raise SugarNotWritten(
+            blame=effect.blame,
             owner="warning_effect_message_verdict",
             observed="warning category operand or occurrence has no authenticated identity",
             requested="two source-authenticated warning category coordinates",
@@ -268,6 +269,7 @@ def warning_effect_message_verdict(effect, expected, pattern) -> MessageVerdict:
     message = getattr(effect, "message", None)
     if not isinstance(message, str):
         raise SugarNotWritten(
+            blame=effect.blame,
             owner="warning_effect_message_verdict",
             observed="warning occurrence has no constructed message",
             requested="producer-carried warning message for the authenticated occurrence",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/grouped_raise_effect.py
@@ -80,6 +80,7 @@ def _leaf_matches(effect: RaiseEffect, expected, site) -> bool:
         operation = raised.test_python_subtype
     if operation is None:
         raise SugarNotWritten(
+            blame=site,
             owner="GroupedRaiseEffect.partition",
             observed="group leaf lacks an authenticated subtype floor",
             requested="RaiseEffect leaf with authenticated exception type testimony",
@@ -88,6 +89,7 @@ def _leaf_matches(effect: RaiseEffect, expected, site) -> bool:
     outcome = operation(expected, site)
     if not isinstance(outcome, Complete):
         raise SugarNotWritten(
+            blame=site,
             owner="GroupedRaiseEffect.partition",
             observed="symbolic subtype partition",
             requested="closed true/false subtype partition for group topology",
@@ -98,6 +100,7 @@ def _leaf_matches(effect: RaiseEffect, expected, site) -> bool:
     if isinstance(outcome.value, FalseBoolLiteralSugar):
         return False
     raise SugarNotWritten(
+        blame=site,
         owner="GroupedRaiseEffect.partition",
         observed=type(outcome.value).__name__,
         requested="closed boolean subtype partition",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
@@ -34,6 +34,7 @@ class AuthenticatedExceptionTypeValue(FloorValue):
 
         if not isinstance(supertype, AuthenticatedExceptionTypeValue):
             raise SugarNotWritten(
+                blame=site,
                 owner="AuthenticatedExceptionTypeValue.test_python_subtype",
                 observed=type(supertype).__name__,
                 requested="authenticated exception type operand",
@@ -47,6 +48,7 @@ class AuthenticatedExceptionTypeValue(FloorValue):
         )
         if not isinstance(leaf_class, ClassValue):
             raise SugarNotWritten(
+                blame=site,
                 owner="AuthenticatedExceptionTypeValue.test_python_subtype",
                 observed=type(leaf_class).__name__,
                 requested="authenticated ClassValue leaf",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bridged_contract_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bridged_contract_value.py
@@ -38,6 +38,7 @@ class BridgedContractValue(FloorValue):
         ):
             return Complete(SymbolicValue(self.term.args[index.value]))
         raise SugarNotWritten(
+            blame=site,
             owner="BridgedContractValue.subscript",
             observed="contract return does not warrant this projection",
             requested="ground in-range projection from an authenticated structural return",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -136,6 +136,7 @@ class ClassDefinitionValue(GuardStableValue):
                 continue
             if statement.receiver.identity != receiver.identity:
                 raise SugarNotWritten(
+                    blame=receiver_coordinate_cid,
                     owner="ClassDefinitionValue.construct_receiver_state",
                     observed="receiver coordinate mismatch",
                     requested="stores projected from this exact constructed receiver",
@@ -211,6 +212,7 @@ class ClassDefinitionValue(GuardStableValue):
             )
             if candidate is None:
                 raise SugarNotWritten(
+                    blame=self.class_definition_cid,
                     owner="ClassDefinitionValue._c3_tail",
                     observed="inconsistent authenticated local base order",
                     requested="one valid C3 linearization",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -552,8 +552,8 @@ class FloorValue:
         """
         from sugar_source_tree.panic import SugarNotWritten
 
-        del site
         raise SugarNotWritten(
+            blame=site,
             owner=owner,
             observed=(
                 "undecided receiver runtime type or index semantics: "
@@ -605,8 +605,8 @@ class FloorValue:
         """
         from sugar_source_tree.panic import SugarNotWritten
 
-        del site
         raise SugarNotWritten(
+            blame=site,
             owner=owner,
             observed=(
                 "undecided receiver runtime type or member semantics: "
@@ -763,6 +763,7 @@ class FloorValue:
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=site,
             owner="unary_operation_exception_floor",
             observed=f"{type(self).__name__} {operator}",
             requested=(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
@@ -90,6 +90,7 @@ class LambdaCallable(FloorValue):
         frame = self.source_call_frame
         if frame is None or len(self.parameters) != 1:
             raise SugarNotWritten(
+                blame=self.construction_identity,
                 owner="LambdaCallable.apply",
                 observed="lambda has no single-actual source frame",
                 requested="the ordinary SourceCallFrameV1 call door",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/in_flight_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/in_flight_effect.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-def bind_in_flight_effect(ctx, slot_id: str, effect):
+def bind_in_flight_effect(ctx, slot_id: str, effect, *, blame: object):
     if ctx is None:
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
 
@@ -13,6 +13,7 @@ def bind_in_flight_effect(ctx, slot_id: str, effect):
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=blame,
             owner="bind_in_flight_effect",
             observed="reduction context cannot carry authenticated in-flight effects",
             requested="the shared ReduceContext/FactoryBuildContext effect slot",
@@ -21,13 +22,14 @@ def bind_in_flight_effect(ctx, slot_id: str, effect):
     return binder(slot_id, effect)
 
 
-def resolve_in_flight_effect(ctx, slot_id: str):
+def resolve_in_flight_effect(ctx, slot_id: str, *, blame: object):
     reader = getattr(ctx, "in_flight_effect_for", None) if ctx is not None else None
     effect = reader(slot_id) if reader is not None else None
     if effect is None:
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=blame,
             owner="resolve_in_flight_effect",
             observed="bare raise has no authenticated in-flight effect testimony",
             requested="the exact RaiseEffect bound by its matching handler slot",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -116,6 +116,7 @@ def _boundary_halted_edge(disposition, incoming):
     # settled and the retained face. Demand it before either.
     if incoming.state is None:
         raise SugarNotWritten(
+            blame=incoming.effect.occurrence_id,
             owner="EffectBoundaryDisposition",
             observed="matching raise face omitted its pre-effect state",
             requested="ExitSet Halted face carrying the real pre-halt state",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
@@ -31,6 +31,7 @@ class BindingCoordinateRefSugar(Sugar):
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=self.site,
             owner="BindingCoordinateRefSugar.desugar",
             observed="unspecialized source-call formal",
             requested="runtime BindingEntryV1 substitution before Sugar construction",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -46,8 +46,8 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
     from sugar_source_tree.panic import SugarNotWritten
 
     operator = _BOOL_OPERATOR_COORDINATE[op_kind]
-    del site
     raise SugarNotWritten(
+        blame=site,
         owner="boolean_operation_exception_floor",
         observed=f"{type(value).__name__} {operator}",
         requested=(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -60,6 +60,7 @@ class CallSiteSugar(Sugar):
 
             raise OpaqueSourceCallResolutionGap(
                 owner="CallSiteSugar.desugar",
+                blame=self.site,
                 observed=self.contract_resolution_gap,
                 requested="authenticated resolved-call contract reference",
                 fix="publish and resolve the imported target contract or keep the call loud",
@@ -124,6 +125,7 @@ class CallSiteSugar(Sugar):
             if not isinstance(self.source_call_frame, SourceVisibleCallFrameV1):
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
+                    blame=self.site,
                     observed=type(self.source_call_frame).__name__,
                     requested="a closed SourceCallFrameV1 variant",
                     fix="construct a typed source frame or keep the call loud",
@@ -137,6 +139,7 @@ class CallSiteSugar(Sugar):
             except SourceCallBindingGap as exc:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
+                    blame=self.site,
                     observed=str(exc),
                     requested="actuals matching the authenticated source signature",
                     fix="supply a real actual/default/variadic occurrence or keep loud",
@@ -164,6 +167,7 @@ class CallSiteSugar(Sugar):
 
                     raise BackendDefect(
                         owner="CallSiteSugar.desugar",
+                        blame=self.site,
                         observed="declaration/source frame mismatch",
                         requested="byte-identical authenticated source frame",
                         fix="retain the callee declaration frame across node binding",
@@ -223,6 +227,7 @@ class CallSiteSugar(Sugar):
         if len(reference.formals) != len(positional):
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
+                blame=self.site,
                 observed="signature mismatch",
                 requested="actual arguments matching the authenticated import signature",
                 fix="correct the call signature or keep the call loud",
@@ -231,6 +236,7 @@ class CallSiteSugar(Sugar):
         if term is None:
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
+                blame=self.site,
                 observed="authenticated contract has no exact return equality",
                 requested="exact structural return testimony",
                 fix="strengthen the contract or keep the imported value loud",
@@ -238,6 +244,7 @@ class CallSiteSugar(Sugar):
         if not _free_vars_in_term(term) <= set(reference.formals):
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
+                blame=self.site,
                 observed="authenticated structural return contains an unbound projection",
                 requested="return variables authenticated by the target formal list",
                 fix="reject the stale or lying contract reference",
@@ -251,6 +258,7 @@ class CallSiteSugar(Sugar):
         }:
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
+                blame=self.site,
                 observed="authenticated contract has no exact structural return",
                 requested="structural return term carried by the target contract",
                 fix="strengthen the target contract or keep the imported value loud",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -93,6 +93,7 @@ class ClassConstructorBodySugar(Sugar):
                 isinstance(statement, EllipsisValue) for statement in block.statements
             ):
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="ClassConstructorBodySugar.desugar",
                     observed="initializer body is EllipsisValue only",
                     requested="one source-visible runtime initializer implementation",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -98,12 +98,14 @@ class ClassDefinitionSugar(Sugar):
                 from sugar_source_tree.panic import SugarNotWritten
 
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="ClassDefinitionSugar.desugar",
                     observed="class base did not construct to ClassDefinitionValue",
                     requested="one authenticated source-visible base definition",
                     fix="keep dynamic or opaque inheritance loud",
                 )
             base_values.append(outcome.value)
+
         def append_field(item):
             if isinstance(item, ConstructedClassConditionalFieldsV1):
                 condition = item.condition_sugar.desugar(ctx)
@@ -120,6 +122,7 @@ class ClassDefinitionSugar(Sugar):
                     from sugar_source_tree.panic import SugarNotWritten
 
                     raise SugarNotWritten(
+                        blame=self.site,
                         owner="ClassDefinitionSugar.desugar",
                         observed="class conditional guard is not a ground bool literal",
                         requested=(
@@ -141,6 +144,7 @@ class ClassDefinitionSugar(Sugar):
                 from sugar_source_tree.panic import SugarNotWritten
 
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="ClassDefinitionSugar.desugar",
                     observed=f"class field {item.name} did not construct completely",
                     requested="one exact constructed class-field value",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -98,6 +98,7 @@ class ComputedCallSugar(Sugar):
 
             if not isinstance(frame, SourceVisibleCallFrameV1):
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="ComputedCallSugar.desugar",
                     observed=type(frame).__name__,
                     requested="a closed SourceCallFrameV1 variant",
@@ -107,6 +108,7 @@ class ComputedCallSugar(Sugar):
                 positional = frame.bind_actuals(positional, kw_values, ctx)
             except SourceCallBindingGap as exc:
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="ComputedCallSugar.desugar",
                     observed=str(exc),
                     requested="actuals matching the authenticated lambda signature",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
@@ -142,11 +142,11 @@ class GeneratorWithSugar(Sugar):
             )
         )
 
-    @staticmethod
-    def _loud(observed: str, label: str):
+    def _loud(self, observed: str, label: str):
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=self.site,
             owner="GeneratorWithSugar.desugar",
             observed=f"{label}: {observed}",
             requested="an exhaustive GeneratorConstructionV1 transition",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
@@ -33,6 +33,7 @@ class GroupedRaiseSugar(Sugar):
                 outcome.effect, (RaiseEffect, GroupedRaiseEffect)
             ):
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="GroupedRaiseSugar.desugar",
                     observed=type(outcome).__name__,
                     requested="a constructed raise effect for every group child",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -108,6 +108,7 @@ class MethodCallSugar(Sugar):
             from sugar_source_tree.panic import SugarNotWritten
 
             raise SugarNotWritten(
+                blame=self.site,
                 owner="MethodCallSugar._collect_kwargs",
                 observed=type(receiver).__name__,
                 requested="authenticated constructed receiver matching the method frame",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -59,17 +59,20 @@ class RaiseSugar(Sugar):
             if self.in_flight_slot is None:
                 from sugar_source_tree.panic import SugarNotWritten
 
-                raise SugarNotWritten(
-                    owner="RaiseSugar.desugar",
-                    observed="bare raise lacks an authenticated in-flight effect slot",
-                    requested="the enclosing handler's effect-slot coordinate",
-                    fix="keep unowned bare raise loud",
-                )
+            raise SugarNotWritten(
+                blame=self.site,
+                owner="RaiseSugar.desugar",
+                observed="bare raise lacks an authenticated in-flight effect slot",
+                requested="the enclosing handler's effect-slot coordinate",
+                fix="keep unowned bare raise loud",
+            )
             from sugar_lift_py_tests.in_flight_effect import (
                 resolve_in_flight_effect,
             )
 
-            return Incomplete(resolve_in_flight_effect(ctx, self.in_flight_slot))
+            return Incomplete(
+                resolve_in_flight_effect(ctx, self.in_flight_slot, blame=self.site)
+            )
 
         def halt(raised_value, cause_value=None):
             context_effect = None
@@ -78,7 +81,9 @@ class RaiseSugar(Sugar):
                     resolve_in_flight_effect,
                 )
 
-                context_effect = resolve_in_flight_effect(ctx, self.in_flight_slot)
+                context_effect = resolve_in_flight_effect(
+                    ctx, self.in_flight_slot, blame=self.site
+                )
             identity_reader = getattr(raised_value, "exception_type_identity", None)
             mro_reader = getattr(raised_value, "exception_type_mro", None)
             return Incomplete(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -48,6 +48,7 @@ class TryStarSugar(Sugar):
                 continue
             if not isinstance(exit_.effect, GroupedRaiseEffect):
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="TryStarSugar.desugar",
                     observed=type(exit_.effect).__name__,
                     requested="GroupedRaiseEffect for except* routing",
@@ -72,6 +73,7 @@ class TryStarSugar(Sugar):
                     expected = matcher.desugar(ctx)
                     if not isinstance(expected, Complete):
                         raise SugarNotWritten(
+                            blame=self.site,
                             owner="TryStarSugar.desugar",
                             observed="symbolic except* type",
                             requested="authenticated subtype partition operand",
@@ -92,7 +94,9 @@ class TryStarSugar(Sugar):
                     continue
                 matched = regroup_except_star(residual, matched_parts)
                 residual = handler_residual
-                handler_ctx = bind_in_flight_effect(ctx, slot_id, matched)
+                handler_ctx = bind_in_flight_effect(
+                    ctx, slot_id, matched, blame=self.site
+                )
                 if slot_id is not None:
                     observer = getattr(handler_ctx, "with_observed_effect", None)
                     if observer is not None:
@@ -102,6 +106,7 @@ class TryStarSugar(Sugar):
                 )
                 if len(handler_exits.exits) != 1:
                     raise SugarNotWritten(
+                        blame=self.site,
                         owner="TryStarSugar.desugar",
                         observed="symbolically branching except* handler",
                         requested="one closed handler exit for exact regrouping",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -112,6 +112,7 @@ def _effect_match_verdict(effect, matcher, ctx=None):
     expected = matcher.desugar(ctx)
     if not isinstance(expected, Complete):
         raise SugarNotWritten(
+            blame=effect.occurrence_id,
             owner="TrySugar._effect_matches",
             observed="except type did not construct a completed type operand",
             requested="an authenticated exception-type value",
@@ -223,7 +224,7 @@ def _route_one_halt(exit_, handlers: tuple, *, site, ctx) -> list:
         # a reconstructed E(). Observed must be installed BEFORE the body
         # reduces; prepending facts after the fact cannot authenticate a read
         # that already desugared to a pure coordinate.
-        handler_ctx = bind_in_flight_effect(ctx, slot_id, exit_.effect)
+        handler_ctx = bind_in_flight_effect(ctx, slot_id, exit_.effect, blame=site)
         if slot_id is not None:
             observer = getattr(handler_ctx, "with_observed_effect", None)
             if observer is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -45,8 +45,8 @@ def refuse_undecided_unary_truth(value, site) -> None:
 
     from sugar_source_tree.panic import SugarNotWritten
 
-    del site
     raise SugarNotWritten(
+        blame=site,
         owner="unary_operation_exception_floor",
         observed=f"{type(value).__name__} not",
         requested=(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -62,6 +62,7 @@ class WithEffectBoundarySugar(Sugar):
             )
         ):
             raise SugarNotWritten(
+                blame=self.site,
                 owner="WithEffectBoundarySugar.desugar",
                 observed="unsupported authenticated EffectBoundary mode/effect",
                 requested="EffectBoundaryV1 Expects/Suppresses over Raise or Warning",
@@ -77,6 +78,7 @@ class WithEffectBoundarySugar(Sugar):
             manager_value = manager_exit.value
             if not isinstance(manager_value, CallSiteValue):
                 raise SugarNotWritten(
+                    blame=self.site,
                     owner="WithEffectBoundarySugar.desugar",
                     observed="manager did not construct a call-site value",
                     requested="one real call occurrence with authenticated formal binding",
@@ -144,6 +146,7 @@ class WithEffectBoundarySugar(Sugar):
 
         if not routed:
             raise SugarNotWritten(
+                blame=self.site,
                 owner="WithEffectBoundarySugar.desugar",
                 observed="manager produced no execution face",
                 requested="one completed or halted manager face",
@@ -238,9 +241,7 @@ def _unresolved_producer_coordinates(entries):
     return tuple(members)
 
 
-def _route_warning_boundary(
-    *, body, ctx, manager_exit, expected, pattern, mode, site
-):
+def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode, site):
     """Route warning testimony on every face while preserving body control.
 
     A warning observation can precede a later halt, so consuming the warning
@@ -298,6 +299,7 @@ def _route_warning_boundary(
         entries = getattr(record, "entries", None)
         if not isinstance(entries, tuple):
             raise SugarNotWritten(
+                blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed=f"body face carries {type(record).__name__}, not a reduced block record",
                 requested="reduced block carrying authenticated warning observations",
@@ -327,6 +329,7 @@ def _route_warning_boundary(
             else:
                 observed = "warning occurrence has no authenticated category identity"
             refusal = SugarNotWritten(
+                blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed=observed,
                 requested="one source-authenticated WarningObservationValue on the completed face",
@@ -446,6 +449,7 @@ def _route_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
                 exits.append(face)
                 continue
             raise SugarNotWritten(
+                blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed=(
                     f"completed face carries {type(record).__name__}, "
@@ -468,6 +472,7 @@ def _route_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
         # this shape by name. Undecided, not present and not absent.
         if any(entry.guards for entry in observations):
             raise SugarNotWritten(
+                blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed="warning occurrence is reached only under a branch guard",
                 requested="a decidable warning surface on the completed face",
@@ -496,6 +501,7 @@ def _route_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
         unresolved_members = _unresolved_producer_coordinates(entries)
         if unresolved_members:
             refusal = SugarNotWritten(
+                blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
                 observed="completed face has unresolved warning producers",
                 requested="authenticated absence of warning observations",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -84,12 +84,13 @@ class WithSourceResourceSugar(Sugar):
         if not parts:
             from sugar_source_tree.panic import SugarNotWritten
 
-            raise SugarNotWritten(
-                owner="WithSourceResourceSugar.desugar",
-                observed="constructed manager protocol produced no face",
-                requested="one completed or halted source-derived manager face",
-                fix="keep empty protocol testimony loud",
-            )
+        raise SugarNotWritten(
+            blame=self.site,
+            owner="WithSourceResourceSugar.desugar",
+            observed="constructed manager protocol produced no face",
+            requested="one completed or halted source-derived manager face",
+            fix="keep empty protocol testimony loud",
+        )
         result = parts[0]
         for part in parts[1:]:
             result = result.union(part)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/yield_from_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/yield_from_sugar.py
@@ -33,6 +33,7 @@ class YieldFromSugar(Sugar):
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=self.site,
             owner="YieldFromSugar.desugar",
             observed="yield from suspension reached eager expression reduction",
             requested="GeneratorConstructionV1 delegated-iteration consumption",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/yield_suspension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/yield_suspension_sugar.py
@@ -27,6 +27,7 @@ class YieldSuspensionSugar(Sugar):
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(
+            blame=self.site,
             owner="YieldSuspensionSugar.desugar",
             observed="yield suspension reached eager expression reduction",
             requested="GeneratorConstructionV1 transition consumption",

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -89,6 +89,10 @@ def _assert_undecided(node: Attribute, receiver, *, name: str | None = None) -> 
     with pytest.raises(SugarNotWritten) as raised:
         operation.desugar(None)
     refusal = raised.value
+    assert refusal.blame == node.fragment
+    assert f"{node.fragment.filename}:{node.fragment.line}:{node.fragment.col}" in str(
+        refusal
+    )
     assert refusal.owner == f"{type(receiver).__name__}.attribute"
     assert "undecided" in refusal.observed
     assert "source-authenticated attribute success or exceptional exit" in (

--- a/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
@@ -16,6 +16,7 @@ def test_census_returns_nonzero_when_construction_hits_backend_defect(
     def backend_crash(*args, **kwargs):
         del args, kwargs
         raise BackendDefect(
+            blame=tmp_path / "crash.py",
             owner="planted census tooth",
             observed="a malformed backend answer",
             requested="a valid constructed source tree",

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -167,6 +167,7 @@ def _script_roll_call(monkeypatch: pytest.MonkeyPatch, answer: str) -> None:
             reporter.report_gap(
                 absent,
                 SugarNotWritten(
+                    blame=absent.fragment,
                     owner="rpc-roll-call-twin",
                     observed=absent.kind,
                     requested="written tree sugar",

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -46,6 +46,7 @@ def _call_owned_raise_value():
 
 def _named_refusal():
     raise SugarNotWritten(
+        blame="test_no_call_body_attribution.py:native-producer",
         owner="native-producer",
         observed="source-visible operands do not decide the failure mode",
         requested="authenticated exceptional exit or retained refusal",

--- a/implementations/python/sugar-lift-py-tests/tests/test_node_shape_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_node_shape_v2_merkle.py
@@ -140,16 +140,37 @@ def test_a_leaf_carrying_a_cid_is_not_a_child():
 
 
 def test_operator_leaves_are_authenticated():
-    add = _H("BinOp", (("op", OpLeaf(operator_for("Add"))),))
-    sub = _H("BinOp", (("op", OpLeaf(operator_for("Sub"))),))
+    blame = "test_node_shape_v2_merkle.py:operator"
+    add = _H("BinOp", (("op", OpLeaf(operator_for("Add", blame=blame))),))
+    sub = _H("BinOp", (("op", OpLeaf(operator_for("Sub", blame=blame))),))
     assert _cid(add) != _cid(sub)
 
-    lt_gt = _H("Cmp", (("ops", OpsLeaf((operator_for("Lt"), operator_for("Gt")))),))
-    gt_lt = _H("Cmp", (("ops", OpsLeaf((operator_for("Gt"), operator_for("Lt")))),))
+    lt_gt = _H(
+        "Cmp",
+        (
+            (
+                "ops",
+                OpsLeaf(
+                    (operator_for("Lt", blame=blame), operator_for("Gt", blame=blame))
+                ),
+            ),
+        ),
+    )
+    gt_lt = _H(
+        "Cmp",
+        (
+            (
+                "ops",
+                OpsLeaf(
+                    (operator_for("Gt", blame=blame), operator_for("Lt", blame=blame))
+                ),
+            ),
+        ),
+    )
     assert _cid(lt_gt) != _cid(gt_lt)
 
-    ops_one = _H("Cmp", (("ops", OpsLeaf((operator_for("Lt"),))),))
-    op_one = _H("Cmp", (("ops", OpLeaf(operator_for("Lt"))),))
+    ops_one = _H("Cmp", (("ops", OpsLeaf((operator_for("Lt", blame=blame),))),))
+    op_one = _H("Cmp", (("ops", OpLeaf(operator_for("Lt", blame=blame))),))
     assert _cid(ops_one) != _cid(op_one)
 
 
@@ -202,7 +223,18 @@ def test_construction_is_bottom_up_and_never_embeds_a_subtree():
     # iteration encodes each node once, at its own arity.
     node = _name("a")
     for _ in range(2000):
-        node = _H("BinOp", (("left", Child(node)), ("op", OpLeaf(operator_for("Add")))))
+        node = _H(
+            "BinOp",
+            (
+                ("left", Child(node)),
+                (
+                    "op",
+                    OpLeaf(
+                        operator_for("Add", blame="test_node_shape_v2_merkle.py:deep")
+                    ),
+                ),
+            ),
+        )
     cid = backend_node_shape_cid_v2(node)
     assert cid.startswith("blake3-512:")
     # Every descendant is memoized -- each encoded exactly once, ever.

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -111,6 +111,7 @@ def test_source_file_unwritten_is_typed_gap(
 
     def _typed_gap(*_args, **_kwargs):
         raise SugarNotWritten(
+            blame=tmp_path / "fixture.py",
             owner="RenamedNode.sugar",
             observed="renamed node has no construction",
             requested="a constructed sugar object",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1557,6 +1557,7 @@ def _install_opaque_call_obligation(
     coordinate = _call_coordinate(call)
     if obligation.coordinate != coordinate:
         raise BackendDefect(
+            blame=call.fragment,
             owner="manager_construction._install_opaque_call_obligation",
             observed="obligation/call coordinate mismatch",
             requested="exact source-call coordinate testimony",
@@ -1564,6 +1565,7 @@ def _install_opaque_call_obligation(
         )
     if coordinate in context.source_call_frames:
         raise BackendDefect(
+            blame=call.fragment,
             owner="manager_construction._install_opaque_call_obligation",
             observed="frame/obligation collision",
             requested="one source-call classification at the exact coordinate",
@@ -1572,6 +1574,7 @@ def _install_opaque_call_obligation(
     existing = context.opaque_source_call_obligations.get(coordinate)
     if existing is not None and existing != obligation:
         raise BackendDefect(
+            blame=call.fragment,
             owner="manager_construction._install_opaque_call_obligation",
             observed="conflicting opaque-call obligation",
             requested="byte-identical duplicate testimony",
@@ -1590,6 +1593,7 @@ def _install_source_call_frame(
     coordinate = _call_coordinate(call)
     if coordinate in context.opaque_source_call_obligations:
         raise BackendDefect(
+            blame=call.fragment,
             owner="manager_construction._install_source_call_frame",
             observed="frame/obligation collision",
             requested="one source-call classification at the exact coordinate",
@@ -1598,6 +1602,7 @@ def _install_source_call_frame(
     existing = context.source_call_frames.get(coordinate)
     if existing is not None and existing != frame:
         raise BackendDefect(
+            blame=call.fragment,
             owner="manager_construction._install_source_call_frame",
             observed="conflicting source-call frame",
             requested="byte-identical duplicate frame testimony",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -74,7 +74,9 @@ class ConstructedManagerProtocolV1:
             enter = _call_protocol_method(
                 receiver, "__enter__", (), self.exit_face_id, ctx
             ).reduce_source_outcome(ctx)
-            entered = _receiver_state_after_enter(receiver, enter)
+            entered = _receiver_state_after_enter(
+                receiver, enter, blame=self.exit_face_id
+            )
             return _call_protocol_method(
                 entered,
                 "__exit__",
@@ -102,7 +104,7 @@ class ConstructedManagerProtocolV1:
             enter = _call_protocol_method(
                 receiver, "__enter__", (), self.exit_face_id, ctx
             ).reduce_source_outcome(ctx)
-            return _resource_enter_transitions(receiver, enter)
+            return _resource_enter_transitions(receiver, enter, blame=self.exit_face_id)
 
         if isinstance(self.receiver_state, ObjectValue):
             return run_enter(self.receiver_state)
@@ -155,6 +157,7 @@ def _call_protocol_method(receiver, name, arguments, exit_face_id, ctx):
     )
     if not isinstance(call, Complete) or not isinstance(call.value, CallSiteValue):
         raise SugarNotWritten(
+            blame=exit_face_id,
             owner="ConstructedManagerProtocolV1.protocol_method",
             observed=type(call).__name__,
             requested=f"authenticated {name} call over projected receiver state",
@@ -163,7 +166,9 @@ def _call_protocol_method(receiver, name, arguments, exit_face_id, ctx):
     return call.value
 
 
-def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectValue:
+def _receiver_state_after_enter(
+    receiver: ObjectValue, enter_outcome, *, blame: object
+) -> ObjectValue:
     from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
     from sugar_source_tree.panic import SugarNotWritten
 
@@ -180,6 +185,7 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
         return receiver
     if not exits or len(completed) != len(exits):
         raise SugarNotWritten(
+            blame=blame,
             owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
             observed="non-completed __enter__ face",
             requested="total completed enter testimony before __exit__",
@@ -190,6 +196,7 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
         block = face.value
         if not isinstance(block, BlockValue):
             raise SugarNotWritten(
+                blame=blame,
                 owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
                 observed=type(block).__name__,
                 requested="completed enter block carrying exact receiver stores",
@@ -201,6 +208,7 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
                 continue
             if statement.receiver.identity != receiver.identity:
                 raise SugarNotWritten(
+                    blame=blame,
                     owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
                     observed="receiver coordinate mismatch",
                     requested="stores from the exact authenticated manager receiver",
@@ -213,6 +221,7 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
     first = projected_faces[0]
     if any(fields != first for fields in projected_faces[1:]):
         raise SugarNotWritten(
+            blame=blame,
             owner="ConstructedManagerProtocolV1.receiver_state_after_enter",
             observed="guarded enter faces disagree on receiver fields",
             requested="one exact post-enter ObjectValue.fields projection",
@@ -228,7 +237,7 @@ def _receiver_state_after_enter(receiver: ObjectValue, enter_outcome) -> ObjectV
     )
 
 
-def _resource_enter_transitions(receiver: ObjectValue, enter_outcome):
+def _resource_enter_transitions(receiver: ObjectValue, enter_outcome, *, blame: object):
     from sugar_lift_py_tests.ir import and_, not_
     from sugar_lift_py_tests.outcome import (
         Completed,
@@ -246,6 +255,7 @@ def _resource_enter_transitions(receiver: ObjectValue, enter_outcome):
             continue
         if not isinstance(face.value, BlockValue):
             raise SugarNotWritten(
+                blame=blame,
                 owner="ConstructedManagerProtocolV1.enter_resource_outcome",
                 observed=type(face.value).__name__,
                 requested="completed enter block carrying exact acquisition stores",
@@ -262,7 +272,7 @@ def _resource_enter_transitions(receiver: ObjectValue, enter_outcome):
                     next_states.append(
                         (
                             and_([guard, statement.guard]),
-                            _apply_receiver_store(state, statement),
+                            _apply_receiver_store(state, statement, blame=blame),
                             faces | {then_face},
                         )
                     )
@@ -276,7 +286,11 @@ def _resource_enter_transitions(receiver: ObjectValue, enter_outcome):
                 states = next_states
             elif isinstance(statement, ReceiverFieldStoreValue):
                 states = [
-                    (guard, _apply_receiver_store(state, statement), faces)
+                    (
+                        guard,
+                        _apply_receiver_store(state, statement, blame=blame),
+                        faces,
+                    )
                     for guard, state, faces in states
                 ]
         projected.extend(
@@ -292,12 +306,13 @@ def _resource_enter_transitions(receiver: ObjectValue, enter_outcome):
 
 
 def _apply_receiver_store(
-    receiver: ObjectValue, statement: ReceiverFieldStoreValue
+    receiver: ObjectValue, statement: ReceiverFieldStoreValue, *, blame: object
 ) -> ObjectValue:
     from sugar_source_tree.panic import SugarNotWritten
 
     if statement.receiver.identity != receiver.identity:
         raise SugarNotWritten(
+            blame=blame,
             owner="ConstructedManagerProtocolV1.enter_resource_outcome",
             observed="receiver coordinate mismatch",
             requested="acquisition store from the exact authenticated receiver",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -431,6 +431,7 @@ class ConstructionTestimonyReporterV1:
         from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
 
         panic = ConstructedValueTestimonyNotWritten(
+            blame=node.fragment,
             owner="CollectingReporter.present_construction",
             observed=(
                 f"{canonicalized} of {type(value).__name__} at "

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
@@ -54,7 +54,7 @@ from .spans import Span
 
 
 def _op(node: ast.AST) -> Operator:
-    return operator_for(type(node).__name__)
+    return operator_for(type(node).__name__, blame=node)
 
 
 class _Handle(BackendNode):
@@ -66,7 +66,6 @@ class _Handle(BackendNode):
         self._unit = unit
         self._node = node
         self._desc: Optional[Description] = None
-
 
     @property
     def minting_unit(self):
@@ -99,7 +98,6 @@ class _ParamHandle(BackendNode):
         self._default = default
         self._kind = param_kind
         self._desc: Optional[Description] = None
-
 
     @property
     def minting_unit(self):
@@ -175,7 +173,6 @@ class _DictItemHandle(BackendNode):
         self._value = value
         self._desc: Optional[Description] = None
 
-
     @property
     def minting_unit(self):
         """Parsed out of this unit's text, so its span is that unit's."""
@@ -210,6 +207,7 @@ def _node_span(unit: SourceUnit, node: ast.AST) -> Span:
     end_lineno = getattr(node, "end_lineno", None)
     if lineno is None or end_lineno is None:
         vocabulary_missing(
+            blame=node,
             owner="cpython_adapter._node_span",
             observed=f"ast.{type(node).__name__} without a position",
             requested="a positioned node, or a describe() rule marking it envelope-spanned",
@@ -286,6 +284,7 @@ def _comprehension_for_anchor(unit: SourceUnit, comp: ast.comprehension) -> Span
         j -= 1
     if src[max(0, j - 3) : j] != "for":
         vocabulary_missing(
+            blame=comp,
             owner="cpython_adapter._comprehension_for_anchor",
             observed=f"no 'for' keyword immediately before comprehension target at {target_start}",
             requested="'for' (optionally 'async for') preceding the target",
@@ -382,6 +381,7 @@ def _describe(unit: SourceUnit, node: ast.AST) -> Description:
                 )
                 continue
             vocabulary_missing(
+                blame=node,
                 owner="cpython_adapter._describe",
                 observed=(
                     f"ast.{ast_kind}.{field_name} list with unhandled item "

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/libcst_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/libcst_adapter.py
@@ -116,6 +116,7 @@ class _Ctx:
             rng = self.positions[node]  # type: ignore[index]
         except KeyError:
             vocabulary_missing(
+                blame=node,
                 owner="libcst_adapter._Ctx.span",
                 observed=f"libcst {type(node).__name__} carries no position",
                 requested="a positioned node, or a rule marking it envelope-spanned",
@@ -219,6 +220,7 @@ def _asname_str(node: Optional[cst.AsName]) -> Optional[str]:
     if isinstance(target, cst.Name):
         return target.value
     vocabulary_missing(
+        blame=target,
         owner="libcst_adapter._asname_str",
         observed=f"AsName over {type(target).__name__}, not a Name",
         requested="a simple name binding",
@@ -236,6 +238,7 @@ def _dotted(node: cst.BaseExpression) -> str:
         cur = cur.value
     if not isinstance(cur, cst.Name):
         vocabulary_missing(
+            blame=cur,
             owner="libcst_adapter._dotted",
             observed=f"import target head is {type(cur).__name__}, not a Name",
             requested="a Name or a chain of Attribute over a Name",
@@ -275,6 +278,7 @@ def _statements(ctx: _Ctx, body: object) -> Tuple[BackendNode, ...]:
             out.append(_Handle(ctx, item))
             continue
         vocabulary_missing(
+            blame=item,
             owner="libcst_adapter._statements",
             observed=f"{type(item).__name__} in statement position",
             requested="a CST statement, suite, or block",
@@ -292,6 +296,7 @@ def _orelse(ctx: _Ctx, node: object) -> Tuple[BackendNode, ...]:
     if isinstance(node, cst.If):
         return (_Handle(ctx, node),)
     vocabulary_missing(
+        blame=node,
         owner="libcst_adapter._orelse",
         observed=f"{type(node).__name__} in orelse position",
         requested="an Else or a nested If",
@@ -358,13 +363,14 @@ def _op(table: dict[str, str], node: cst.CSTNode, where: str) -> Operator:
     kind = table.get(type(node).__name__)
     if kind is None:
         vocabulary_missing(
+            blame=node,
             owner=f"libcst_adapter._op[{where}]",
             observed=f"libcst operator {type(node).__name__} has no tree operator",
             requested="a mapping into the frozen operator vocabulary",
             fix="add the operator deliberately in operators.py and here; never guess",
         )
         raise AssertionError("unreachable")
-    return operator_for(kind)
+    return operator_for(kind, blame=node)
 
 
 # --------------------------------------------------------------------------
@@ -408,6 +414,7 @@ def _comp_for_anchor(ctx: _Ctx, node: cst.CompFor) -> Span:
         break
     if not (src.startswith("for", j) or src.startswith("async", j)):
         vocabulary_missing(
+            blame=node,
             owner="libcst_adapter._comp_for_anchor",
             observed=f"no 'for'/'async' keyword at comprehension clause start {j}",
             requested="'for' (optionally 'async for') opening the clause",
@@ -503,6 +510,7 @@ def _params(ctx: _Ctx, params: cst.Parameters) -> Children:
         pass  # bare ``*`` separator: a marker, not a parameter
     elif star_arg is not None and not isinstance(star_arg, cst.MaybeSentinel):
         vocabulary_missing(
+            blame=star_arg,
             owner="libcst_adapter._params",
             observed=f"star_arg is {type(star_arg).__name__}",
             requested="a Param, a ParamStar, or absent",
@@ -586,6 +594,7 @@ def _elements(ctx: _Ctx, elements: Sequence[cst.BaseElement]) -> Children:
             out.append(_Handle(ctx, el.value))
         else:
             vocabulary_missing(
+                blame=el,
                 owner="libcst_adapter._elements",
                 observed=f"{type(el).__name__} in element position",
                 requested="an Element or a StarredElement",
@@ -623,6 +632,7 @@ def _dict_items(ctx: _Ctx, elements: Sequence[cst.BaseDictElement]) -> Children:
             )
         else:
             vocabulary_missing(
+                blame=el,
                 owner="libcst_adapter._dict_items",
                 observed=f"{type(el).__name__} in dict element position",
                 requested="a DictElement or a StarredDictElement",
@@ -672,6 +682,7 @@ def _slice_element(ctx: _Ctx, element: cst.SubscriptElement) -> BackendNode:
     if isinstance(inner, cst.Slice):
         return _Handle(ctx, inner)
     vocabulary_missing(
+        blame=inner,
         owner="libcst_adapter._slice_element",
         observed=f"{type(inner).__name__} in subscript position",
         requested="an Index or a Slice",
@@ -696,6 +707,7 @@ def _format_spec(
     parts = list(spec)
     if not parts:
         vocabulary_missing(
+            blame=spec,
             owner="libcst_adapter._format_spec",
             observed="an empty format spec with no content to span",
             requested="a spec with at least one content node, or no spec at all",
@@ -721,6 +733,7 @@ def _conversion(value: Optional[str]) -> int:
     code = _CONVERSIONS.get(value)
     if code is None:
         vocabulary_missing(
+            blame=value,
             owner="libcst_adapter._conversion",
             observed=f"f-string conversion {value!r}",
             requested="one of !s, !r, !a, or none",
@@ -1105,6 +1118,7 @@ def _singleton(text: str) -> object:
     table: dict[str, object] = {"True": True, "False": False, "None": None}
     if text not in table:
         vocabulary_missing(
+            blame=text,
             owner="libcst_adapter._singleton",
             observed=f"match singleton {text!r}",
             requested="True, False, or None",
@@ -1131,6 +1145,7 @@ def _match_patterns(ctx: _Ctx, elements: Sequence[cst.CSTNode]) -> Children:
             out.append(_Handle(ctx, el))
         else:
             vocabulary_missing(
+                blame=el,
                 owner="libcst_adapter._match_patterns",
                 observed=f"{type(el).__name__} in match sequence position",
                 requested="a MatchSequenceElement or a MatchStar",
@@ -1260,6 +1275,7 @@ def _r_concatstring(ctx: _Ctx, n: cst.ConcatenatedString) -> Description:
         # (mixed str/bytes implicit concatenation): the backend's own
         # output is structurally invalid, not a vocabulary gap.
         backend_defect(
+            blame=n,
             owner="libcst_adapter._r_concatstring",
             observed="implicit concatenation mixing str and bytes pieces",
             requested="pieces of one literal type",
@@ -1524,6 +1540,7 @@ def _describe(ctx: _Ctx, node: cst.CSTNode) -> Description:
     rule = _RULES.get(type(node).__name__)
     if rule is None:
         vocabulary_missing(
+            blame=node,
             owner="libcst_adapter._describe",
             observed=f"libcst {type(node).__name__} has no adapter rule",
             requested="an explicit rule mapping this CST shape into tree terms",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -120,9 +120,10 @@ class ControlConstructionContextV1:
             raise LoopWireError("loop-control occurrence has no enclosing loop")
         return self.loop_targets[-1]
 
-    def nearest_exception_slot(self) -> str:
+    def nearest_exception_slot(self, *, blame: object) -> str:
         if not self.exception_slots:
             raise SugarNotWritten(
+                blame=blame,
                 owner="ControlConstructionContextV1.nearest_exception_slot",
                 observed="bare raise has no authenticated in-flight exception slot",
                 requested="an enclosing except handler effect-slot coordinate",
@@ -283,10 +284,11 @@ class SourceUnit:
             ),
         )
 
-    def _require_typed_module(self, owner: str) -> "Module":
+    def _require_typed_module(self, owner: str, *, blame: object) -> "Module":
         module = self.typed_module
         if module is None:
             raise SourceTreePanic(
+                blame=blame,
                 owner=owner,
                 observed="typed Module is not bound on this SourceUnit",
                 requested=(
@@ -315,6 +317,7 @@ class SourceUnit:
         visit(self.module_symtable)
         if len(matches) != 1:
             raise SourceTreePanic(
+                blame=f"{self.filename}:{lineno}:0",
                 owner="SourceUnit.function_symtable",
                 observed=(
                     f"{len(matches)} function symtables for {name!r} at line {lineno}"
@@ -331,7 +334,10 @@ class SourceUnit:
         ``FunctionDef`` / ``AsyncFunctionDef`` children only) — never a second
         parse of the source text as semantic authority.
         """
-        module = self._require_typed_module("SourceUnit.is_module_level_function")
+        module = self._require_typed_module(
+            "SourceUnit.is_module_level_function",
+            blame=f"{self.filename}:{lineno}:0",
+        )
         for statement in module.body:
             if statement.kind not in ("FunctionDef", "AsyncFunctionDef"):
                 continue
@@ -443,6 +449,7 @@ class SourceUnit:
         """
         if not isinstance(node, Call):
             raise SourceTreePanic(
+                blame=node.fragment,
                 owner="SourceUnit.construction_generation",
                 observed=type(node).__name__,
                 requested="one exact Call construction occurrence",
@@ -493,7 +500,9 @@ class SourceUnit:
             BUILTIN_EXCEPTION_NAMES,
         )
 
-        self._require_typed_module("SourceUnit.exception_type_identity")
+        self._require_typed_module(
+            "SourceUnit.exception_type_identity", blame=node.fragment
+        )
         span = node.line_col_span()
         cache_key = (
             node.id,
@@ -662,7 +671,9 @@ class SourceUnit:
         builtin_ancestry = self._builtin_exception_ancestry(identity)
         if builtin_ancestry is not None:
             return builtin_ancestry
-        module = self._require_typed_module("SourceUnit.exception_type_mro")
+        module = self._require_typed_module(
+            "SourceUnit.exception_type_mro", blame=node.fragment
+        )
         definitions = [
             statement
             for statement in module.body
@@ -716,6 +727,7 @@ class SourceUnit:
         mro = self.exception_type_mro(node)
         if identity is None or mro is None:
             raise SugarNotWritten(
+                blame=node.fragment,
                 owner="SourceUnit.exception_class_value",
                 observed="exception class lacks a closed authenticated base graph",
                 requested="source-authenticated ClassValue ancestry",
@@ -736,7 +748,9 @@ class SourceUnit:
                 cache[identity] = value
                 return value
 
-        module = self._require_typed_module("SourceUnit.exception_class_value")
+        module = self._require_typed_module(
+            "SourceUnit.exception_class_value", blame=node.fragment
+        )
         definitions = [
             statement
             for statement in module.body
@@ -744,6 +758,7 @@ class SourceUnit:
         ]
         if len(definitions) != 1:
             raise SugarNotWritten(
+                blame=node.fragment,
                 owner="SourceUnit.exception_class_value",
                 observed="authenticated identity has no unique source class",
                 requested="one lexical exception class definition",
@@ -805,6 +820,7 @@ class Typed(Typeable):
             # built an abstract instance. Raised as the common base directly
             # — deliberately, not a guess at which subclass fits.
             raise SourceTreePanic(
+                blame=tp,
                 owner="nodes.Typed.resolve_type",
                 observed=f"instance of abstract node class {tp.__name__}",
                 requested="a concrete grammar class",
@@ -937,6 +953,7 @@ class Node(Typed):
                 return value
         if name in _declared_fields(type(self)):
             vocabulary_missing(
+                blame=self.ref,
                 owner="nodes.Node.__getattr__",
                 observed=(
                     f"backend answer for {type(self).__name__} has no slot "
@@ -957,6 +974,7 @@ class Node(Typed):
             # Our own adapter's anchor-rule vocabulary is incomplete for a
             # kind it has not seen positioned before: a MISSING, not a defect.
             vocabulary_missing(
+                blame=self.ref,
                 owner="nodes.Node.span",
                 observed=(
                     f"{self.kind} with neither a backend position nor any spanned child"
@@ -993,6 +1011,7 @@ class Node(Typed):
         except SourceTreePanic:
             pass
         raise SubstituteNotWritten(
+            blame=self.fragment,
             owner=f"{type(self).__name__}.substitute",
             observed=f"{self.kind} at {where} has no substitution written",
             requested="a deliberate substitution (recurse, mask, bind, or inert)",
@@ -1120,6 +1139,7 @@ class Node(Typed):
 
         if not isinstance(left, Node) or not isinstance(right, Node):
             backend_defect(
+                blame=self.fragment,
                 owner="nodes.Node._make_binop",
                 observed=(
                     "a synthesized binary operation received non-Node "
@@ -1214,6 +1234,7 @@ class Node(Typed):
             lc = self.line_col_span()
         except SourceTreePanic as exc:
             raise SugarNotWritten(
+                blame=exc.blame,
                 owner=f"{type(self).__name__}._effect_slot_id",
                 observed=f"{self.kind} has no stable source span for an effect slot",
                 requested="a deterministic file:line:col extent for the binding site",
@@ -1535,6 +1556,7 @@ class Node(Typed):
         except SourceTreePanic:
             pass  # an unpositioned kind still panics usefully, by file
         panic = SugarNotWritten(
+            blame=self.fragment,
             owner=f"{type(self).__name__}.sugar",
             observed=f"{self.kind} at {where} has no sugar written",
             requested="a constructed sugar object",
@@ -2362,6 +2384,7 @@ class FunctionDef(Statement):
             from .panic import BackendDefect
 
             raise BackendDefect(
+                blame=parameter.fragment,
                 owner="FunctionDef._formal_coordinate",
                 observed=parameter.param_kind,
                 requested="one canonical Python parameter kind",
@@ -2541,6 +2564,7 @@ class FunctionDef(Statement):
                     relative = Path(self.unit.filename)
                     if relative.is_absolute():
                         raise SugarNotWritten(
+                            blame=self.fragment,
                             owner="FunctionDef.bridge_source_symbol",
                             observed=f"absolute source locus `{self.unit.filename}`",
                             requested="workspace-relative source locus",
@@ -2666,6 +2690,7 @@ class ClassDef(Statement):
             from sugar_source_tree.panic import SugarNotWritten
 
             raise SugarNotWritten(
+                blame=unsupported[0].fragment,
                 owner="ClassDef._construct_sugar",
                 observed=f"unsupported class member {unsupported[0].kind}",
                 requested="a total source-visible class member construction arm",
@@ -2730,6 +2755,7 @@ class ClassDef(Statement):
                 from sugar_source_tree.panic import SugarNotWritten
 
                 raise SugarNotWritten(
+                    blame=item.fragment,
                     owner="ClassDef._construct_sugar",
                     observed=f"unsupported conditional class member {item.kind}",
                     requested="a constructed field assignment or pass",
@@ -4045,6 +4071,7 @@ class For(Statement):
                     # case set `elements = None` above and falls through.)
                     raise SugarNotWritten(
                         owner="For.substitute",
+                        blame=self.target.fragment,
                         observed=(
                             f"concrete for-loop target {self.target.kind} does not "
                             "destructure its elements"
@@ -4642,6 +4669,7 @@ class If(Statement):
             slot = BranchResultSlot(self.branch_result_slot_id)
         except AttributeError:
             backend_defect(
+                blame=self.fragment,
                 owner="If._construct_sugar",
                 observed="If without a stored branch-result slot",
                 requested="consume the slot minted once by If.substitute",
@@ -4686,6 +4714,7 @@ class With(Statement):
 
         if not isinstance(context, TreeConstructionContextV1):
             backend_defect(
+                blame=self.fragment,
                 owner="With._construct_sugar",
                 observed="tree construction context is not TreeConstructionContextV1",
                 requested="the immutable prereq-2 contract-ref table",
@@ -4708,6 +4737,7 @@ class With(Statement):
             from .panic import WithConstructionGap, WithConstructionGapKind
 
             panic = WithConstructionGap(
+                blame=self.fragment,
                 gap_kind=WithConstructionGapKind.NO_DERIVED_CONTRACT,
                 coordinate=coordinate,
                 owner="With._construct_sugar",
@@ -4729,6 +4759,7 @@ class With(Statement):
         # fused `kind:detail` key used to smuggle into the key itself.
         detail = getattr(resolution, "detail", None)
         panic = ContextManagerResolutionConstructionGap(
+            blame=resolution.use_site,
             kind=resolution.kind,
             demand_cid=resolution.demand_cid,
             candidate_member_cids=resolution.candidate_member_cids,
@@ -4801,6 +4832,7 @@ class With(Statement):
             resolution, (ContextManagerContractRefV1, SourceDerivedContextManagerRefV1)
         ):
             backend_defect(
+                blame=self.fragment,
                 owner="With._construct_sugar",
                 observed=f"unexpected resolution value {type(resolution).__name__}",
                 requested="ContextManagerContractRefV1 or ContextManagerResolutionGapV1",
@@ -4827,6 +4859,7 @@ class With(Statement):
         )
         if not (admitted_resource or admitted_boundary):
             panic = UnsupportedContextManagerSemantics(
+                blame=self.fragment,
                 demand_cid=resolution.demand_cid,
                 member_cid=resolution.contract_cid,
                 owner="With._construct_sugar",
@@ -5053,6 +5086,7 @@ class With(Statement):
                     from .panic import UnsupportedWithBindingTarget
 
                     panic = UnsupportedWithBindingTarget(
+                        blame=item.optional_vars.fragment,
                         owner="With._construct_sugar",
                         observed=(
                             "EffectBoundary as-binding to a "
@@ -5088,6 +5122,7 @@ class With(Statement):
 
             if not isinstance(resolved_ref.semantics, ProtocolResourceSemanticsV1):
                 backend_defect(
+                    blame=self.fragment,
                     owner="With._construct_sugar",
                     observed="closed CM resolver returned an unknown semantics variant",
                     requested="ProtocolResourceSemanticsV1 or EffectBoundarySemanticsV1",
@@ -5112,6 +5147,7 @@ class With(Statement):
                 site=self.fragment,
             )
         panic = RuntimeSelectedContextManager(
+            blame=self.fragment,
             owner="With.sugar",
             observed="With manager has no injected authenticated preconstruction authority",
             requested="one resolved ContextManagerContractRefV1 at the exact use-site",
@@ -5273,6 +5309,7 @@ class With(Statement):
             from .panic import UnsupportedWithBindingTarget
 
             panic = UnsupportedWithBindingTarget(
+                blame=self.fragment,
                 owner="With._construct_sugar",
                 observed=(
                     "source binds an EffectBoundary result the authenticated "
@@ -5354,6 +5391,7 @@ class AsyncWith(Statement):
         from .panic import AsyncContextManagerUnsupported
 
         panic = AsyncContextManagerUnsupported(
+            blame=self.fragment,
             owner="AsyncWith._construct_sugar",
             observed="async context manager is outside the narrow synchronous arm",
             requested="one synchronous pre-resolved NeverSuppresses manager",
@@ -5419,7 +5457,9 @@ class Raise(Statement):
                 cause=None,
                 exception_name=None,
                 site=self.fragment,
-                in_flight_slot=self.control_context.nearest_exception_slot(),
+                in_flight_slot=self.control_context.nearest_exception_slot(
+                    blame=self.fragment
+                ),
             )
         from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
         from dataclasses import replace
@@ -5448,6 +5488,7 @@ class Raise(Statement):
                 leaf_name = node.id
             if leaf_identity is None:
                 raise SugarNotWritten(
+                    blame=node.fragment,
                     owner="Raise._construct_sugar",
                     observed="exception-group leaf lacks authenticated exception identity",
                     requested="a source-authenticated exception type",
@@ -5478,6 +5519,7 @@ class Raise(Statement):
                 or not isinstance(call.args[1], (List, Tuple))
             ):
                 raise SugarNotWritten(
+                    blame=call.fragment,
                     owner="Raise._construct_sugar",
                     observed="unsupported native exception-group construction",
                     requested="ExceptionGroup(message, finite list-or-tuple members)",
@@ -5498,6 +5540,7 @@ class Raise(Statement):
         if group_call(self.exc):
             if self.cause is not None:
                 raise SugarNotWritten(
+                    blame=self.fragment,
                     owner="Raise._construct_sugar",
                     observed="exception-group raise with explicit cause",
                     requested="group cause regroup semantics",
@@ -5942,6 +5985,7 @@ class Try(Statement):
                 if identity is None:
                     raise SugarNotWritten(
                         owner="Try._construct_sugar",
+                        blame=self.fragment,
                         observed="typed except handler lacks authenticated exception identity",
                         requested="a constructed exception-type coordinate",
                         fix="resolve the handler type lexically or keep the try loud",
@@ -6001,6 +6045,7 @@ class TryStar(Statement):
             # run an except* body twice on a group holding both.
             if handler.type_ is None:
                 raise SugarNotWritten(
+                    blame=self.fragment,
                     owner="TryStar._construct_sugar",
                     observed="unsupported except* handler type",
                     requested="one authenticated exception type operand",
@@ -6015,6 +6060,7 @@ class TryStar(Statement):
                 not isinstance(type_node, Name) for type_node in type_nodes
             ):
                 raise SugarNotWritten(
+                    blame=self.fragment,
                     owner="TryStar._construct_sugar",
                     observed="unsupported except* handler type",
                     requested="one authenticated exception type operand",
@@ -6026,6 +6072,7 @@ class TryStar(Statement):
                 if identity is None:
                     raise SugarNotWritten(
                         owner="TryStar._construct_sugar",
+                        blame=self.fragment,
                         observed="except* type lacks authenticated exception identity",
                         requested="a constructed exception-type coordinate",
                         fix="resolve the handler type lexically or keep it loud",
@@ -7437,6 +7484,7 @@ class Call(Expression):
                 from sugar_source_tree.panic import BackendDefect
 
                 raise BackendDefect(
+                    blame=self.fragment,
                     owner="Call._construct_sugar",
                     observed=type(source_call_resolution).__name__,
                     requested="closed source-call preconstruction result",
@@ -7450,6 +7498,7 @@ class Call(Expression):
                 from sugar_source_tree.panic import BackendDefect
 
                 raise BackendDefect(
+                    blame=self.fragment,
                     owner="Call._construct_sugar",
                     observed="source-call ref/frame mismatch",
                     requested="byte-identical prebound source frame CID",
@@ -7484,6 +7533,7 @@ class Call(Expression):
 
                     raise BackendDefect(
                         owner="Call._construct_sugar",
+                        blame=self.fragment,
                         observed=self.func.kind,
                         requested="attribute callee for authenticated method dispatch",
                         fix="bind the method ref to its exact attribute-call occurrence",
@@ -7547,6 +7597,7 @@ class Call(Expression):
 
                         raise BackendDefect(
                             owner="Call._construct_sugar",
+                            blame=self.fragment,
                             observed="enrolled call demand missing from resolution table",
                             requested="one typed resolution row for every enrolled imported call",
                             fix="repair call-contract preconstruction; never fall through to an ordinary call",
@@ -7848,6 +7899,7 @@ class FormattedValue(Expression):
             conversion = chr(self.conversion)
         else:
             backend_defect(
+                blame=self.fragment,
                 owner="FormattedValue._construct_sugar",
                 observed=f"unsupported f-string conversion slot {self.conversion!r}",
                 requested="-1 or the codepoint for 'a', 'r', or 's'",
@@ -7856,6 +7908,7 @@ class FormattedValue(Expression):
         format_spec = self.format_spec
         if format_spec is not None and not isinstance(format_spec, JoinedStr):
             backend_defect(
+                blame=self.fragment,
                 owner="FormattedValue._construct_sugar",
                 observed=f"format_spec constructed as {type(format_spec).__name__}",
                 requested="None or a nested JoinedStr",
@@ -8456,9 +8509,12 @@ class Name(Expression):
         if isinstance(bound, Node):
             return bound
         span = self.line_col_span()
-        if self.unit.import_bound_name_target(
-            (span.start_line, span.start_col, span.end_line, span.end_col)
-        ) is not None:
+        if (
+            self.unit.import_bound_name_target(
+                (span.start_line, span.start_col, span.end_line, span.end_col)
+            )
+            is not None
+        ):
             # The sole lexical import pass proves that this exact use has one
             # reaching import definition.  Preserve the source node so its
             # consumer can project that coordinate; do not replace it with an
@@ -9076,6 +9132,7 @@ def resolve_kind(kind: str, observed_at: str) -> type[Node]:
     cls = KIND_REGISTRY.get(kind)
     if cls is None or cls in _ABSTRACT:
         vocabulary_missing(
+            blame=observed_at,
             owner="nodes.resolve_kind",
             observed=f"backend kind {kind!r} at {observed_at} has no node class",
             requested="a concrete Node subclass for every constructible shape",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
@@ -35,6 +35,7 @@ class Operator:
             # abstract class directly. Not a vocabulary gap, not a backend
             # defect — raised as the common base deliberately.
             raise SourceTreePanic(
+                blame=cls,
                 owner="operators.Operator.instance",
                 observed=f"instance() on abstract {cls.__name__}",
                 requested="a concrete operator class",
@@ -216,11 +217,12 @@ _OPERATORS: dict[str, type[Operator]] = {
 }
 
 
-def operator_for(kind: str) -> Operator:
+def operator_for(kind: str, *, blame: object) -> Operator:
     """Frozen-vocabulary lookup: two arms — resolved, or panic."""
     cls = _OPERATORS.get(kind)
     if cls is None:
         vocabulary_missing(
+            blame=blame,
             owner="operators.operator_for",
             observed=f"operator kind {kind!r} not in the frozen vocabulary",
             requested="one of the declared Operator classes",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -42,11 +42,34 @@ from __future__ import annotations
 from enum import Enum
 
 
-class SourceTreePanic(Exception):
-    """Common base. Never raised directly — always one of the two below."""
+def _render_blame(blame: object) -> str:
+    """Project a native coordinate to actionable prose only at the panic edge."""
+    filename = getattr(blame, "filename", None)
+    line = getattr(blame, "line", None)
+    col = getattr(blame, "col", None)
+    if filename is not None and line is not None and col is not None:
+        return f"{filename}:{line}:{col}"
+    return str(blame)
 
-    def __init__(self, owner: str, observed: str, requested: str, fix: str) -> None:
-        super().__init__(owner, observed, requested, fix)
+
+class SourceTreePanic(Exception):
+    """Common base. Every refusal carries the native coordinate it blames."""
+
+    def __init__(
+        self,
+        *,
+        blame: object,
+        owner: str,
+        observed: str,
+        requested: str,
+        fix: str,
+    ) -> None:
+        if blame is None:
+            raise TypeError(
+                "blame must be a real source or backend coordinate, not None"
+            )
+        super().__init__(blame, owner, observed, requested, fix)
+        self.blame = blame
         self.owner = owner
         self.observed = observed
         self.requested = requested
@@ -57,6 +80,7 @@ class SourceTreePanic(Exception):
     def __str__(self) -> str:  # pragma: no cover - formatting only
         return (
             f"{self._LABEL} [{self.owner}]\n"
+            f"  blame:     {_render_blame(self.blame)}\n"
             f"  observed:  {self.observed}\n"
             f"  requested: {self.requested}\n"
             f"  fix:       {self.fix}"
@@ -306,14 +330,24 @@ class BackendDefect(SourceTreePanic):
 
 
 def vocabulary_missing(
-    owner: str, observed: str, requested: str, fix: str
+    *, blame: object, owner: str, observed: str, requested: str, fix: str
 ) -> "VocabularyMissing":
     raise VocabularyMissing(
-        owner=owner, observed=observed, requested=requested, fix=fix
+        blame=blame,
+        owner=owner,
+        observed=observed,
+        requested=requested,
+        fix=fix,
     )
 
 
 def backend_defect(
-    owner: str, observed: str, requested: str, fix: str
+    *, blame: object, owner: str, observed: str, requested: str, fix: str
 ) -> "BackendDefect":
-    raise BackendDefect(owner=owner, observed=observed, requested=requested, fix=fix)
+    raise BackendDefect(
+        blame=blame,
+        owner=owner,
+        observed=observed,
+        requested=requested,
+        fix=fix,
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
@@ -110,7 +110,6 @@ class _Handle(BackendNode):
         self._node = node
         self._desc: Optional[Description] = None
 
-
     @property
     def minting_unit(self):
         """Parsed out of this unit's text, so its span is that unit's."""
@@ -207,10 +206,11 @@ def _cmp_op(node: ParsoNode) -> Operator:
     if node.type == "comp_op":
         text = " ".join(c.value for c in _kids(node))
         if text == "not in":
-            return operator_for("NotIn")
+            return operator_for("NotIn", blame=node)
         if text == "is not":
-            return operator_for("IsNot")
+            return operator_for("IsNot", blame=node)
         vocabulary_missing(
+            blame=node,
             owner="parso_adapter._cmp_op",
             observed=f"comp_op token {text!r} not recognized",
             requested="one of: not in, is not",
@@ -218,18 +218,19 @@ def _cmp_op(node: ParsoNode) -> Operator:
         )
     text = node.value
     if text == "in":
-        return operator_for("In")
+        return operator_for("In", blame=node)
     if text == "is":
-        return operator_for("Is")
+        return operator_for("Is", blame=node)
     kind = _CMP_TOKEN.get(text)
     if kind is None:
         vocabulary_missing(
+            blame=node,
             owner="parso_adapter._cmp_op",
             observed=f"comparison token {text!r} not recognized",
             requested="a known comparison operator token",
             fix="extend _CMP_TOKEN deliberately",
         )
-    return operator_for(kind)
+    return operator_for(kind, blame=node)
 
 
 # --------------------------------------------------------------------------
@@ -250,6 +251,7 @@ def _fold_binop(unit: SourceUnit, node: ParsoNode) -> BackendNode:
         kind = _BIN_TOKEN.get(op_tok.value)
         if kind is None:
             vocabulary_missing(
+                blame=op_tok,
                 owner="parso_adapter._fold_binop",
                 observed=f"binary operator token {op_tok.value!r} not recognized",
                 requested="a known binary operator token",
@@ -262,7 +264,7 @@ def _fold_binop(unit: SourceUnit, node: ParsoNode) -> BackendNode:
             Span(first_start, end),
             (
                 ("left", Child(acc)),
-                ("op", OpLeaf(operator_for(kind))),
+                ("op", OpLeaf(operator_for(kind, blame=op_tok))),
                 ("right", Child(right)),
             ),
         )
@@ -277,7 +279,7 @@ def _boolop(unit: SourceUnit, node: ParsoNode, op_kind: str) -> Description:
         raw_span=_span(unit, node),
         anchors=(),
         slots=(
-            ("op", OpLeaf(operator_for(op_kind))),
+            ("op", OpLeaf(operator_for(op_kind, blame=node))),
             ("values", Children(values)),
         ),
     )
@@ -403,6 +405,7 @@ def _constant_leaf(unit: SourceUnit, node: ParsoNode) -> BackendNode:
     if node.type == "operator" and node.value == "...":
         return _fixed_constant(span, Ellipsis)
     vocabulary_missing(
+        blame=node,
         owner="parso_adapter._constant_leaf",
         observed=f"leaf {node.type}:{node.value!r} is not a recognized literal",
         requested="number, string, None/True/False, or Ellipsis",
@@ -423,6 +426,7 @@ def _fstring_values(unit: SourceUnit, node: ParsoNode) -> List[BackendNode]:
             continue
         else:
             vocabulary_missing(
+                blame=c,
                 owner="parso_adapter._fstring_values",
                 observed=f"fstring child {c.type!r} not recognized",
                 requested="fstring_string or fstring_expr",
@@ -458,6 +462,7 @@ def _describe_fstring_expr(unit: SourceUnit, node: ParsoNode) -> Description:
             i += 1
             continue
         vocabulary_missing(
+            blame=c,
             owner="parso_adapter._describe_fstring_expr",
             observed=f"fstring_expr trailing token {c!r} not recognized",
             requested="'!' conversion or format spec",
@@ -524,6 +529,7 @@ def _fold_trailers(
             )
         else:
             vocabulary_missing(
+                blame=trailer,
                 owner="parso_adapter._fold_trailers",
                 observed=f"trailer starting with {first.value!r} not recognized",
                 requested="'.', '(' or '['",
@@ -587,6 +593,7 @@ def _call_args(
                 )
             else:
                 vocabulary_missing(
+                    blame=item,
                     owner="parso_adapter._call_args",
                     observed=f"argument shape {[c.type for c in ik]!r} not recognized",
                     requested="*expr, **expr, name=expr, or a comprehension argument",
@@ -638,6 +645,7 @@ def _one_subscript_item(unit: SourceUnit, node: ParsoNode) -> BackendNode:
     for seg in (lower, upper, step):
         if len(seg) > 1:
             vocabulary_missing(
+                blame=seg[0],
                 owner="parso_adapter._one_subscript_item",
                 observed=f"slice segment with {len(seg)} nodes",
                 requested="zero or one expression per slice segment",
@@ -822,6 +830,7 @@ def _describe(unit: SourceUnit, node: ParsoNode) -> Description:
     if fn is not None:
         return fn(unit, node)
     vocabulary_missing(
+        blame=node,
         owner="parso_adapter._describe",
         observed=f"parso node type {t!r} has no translation rule",
         requested="a mapped statement/expression shape",
@@ -899,6 +908,7 @@ def _describe_leaf(unit: SourceUnit, node: ParsoNode) -> Description:
             ),
         )
     vocabulary_missing(
+        blame=node,
         owner="parso_adapter._describe_leaf",
         observed=f"leaf {node.type}:{node.value!r} has no translation rule",
         requested="a mapped leaf shape",
@@ -991,6 +1001,7 @@ def _atom(unit: SourceUnit, node: ParsoNode) -> Description:
     if first.type == "fstring":
         return _describe(unit, first)
     vocabulary_missing(
+        blame=node,
         owner="parso_adapter._atom",
         observed=f"atom starting with {getattr(first, 'value', first.type)!r} not recognized",
         requested="'(', '[', '{' grouping, or an fstring",
@@ -1099,6 +1110,7 @@ def _comp_clauses(
             continue
         else:
             vocabulary_missing(
+                blame=n,
                 owner="parso_adapter._comp_clauses",
                 observed=f"comprehension clause child {n.type!r} not recognized",
                 requested="comp_for/sync_comp_for or comp_if",
@@ -1127,6 +1139,7 @@ def _comprehension(unit: SourceUnit, node: ParsoNode) -> Description:
             # a comp_if may itself carry a further comp_iter (chained ifs/for)
             if len(ik) > 2:
                 vocabulary_missing(
+                    blame=r2,
                     owner="parso_adapter._comprehension",
                     observed="comp_if with a nested comp_iter tail not yet folded",
                     requested="a flattened ifs/for chain",
@@ -1134,6 +1147,7 @@ def _comprehension(unit: SourceUnit, node: ParsoNode) -> Description:
                 )
         elif r2.type in ("comp_for", "sync_comp_for"):
             vocabulary_missing(
+                blame=r2,
                 owner="parso_adapter._comprehension",
                 observed="chained 'for ... for ...' clause not yet folded into a flat generators list",
                 requested="each comp_for as its own top-level Comprehension",
@@ -1215,6 +1229,7 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
         )
     if not _is_leaf(op):
         vocabulary_missing(
+            blame=op,
             owner="parso_adapter._expr_stmt",
             observed=f"expr_stmt second child is a {op.type!r} node, not an operator leaf",
             requested="'=', an augmented-assignment operator, or annassign",
@@ -1235,6 +1250,7 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     aug_kind = _AUG_TOKEN.get(op.value)
     if aug_kind is None:
         vocabulary_missing(
+            blame=op,
             owner="parso_adapter._expr_stmt",
             observed=f"expr_stmt operator {op.value!r} not recognized",
             requested="'=' (chained) or an augmented-assignment token",
@@ -1246,7 +1262,7 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
         anchors=(),
         slots=(
             ("target", Child(_h(unit, kids[0]))),
-            ("op", OpLeaf(operator_for(aug_kind))),
+            ("op", OpLeaf(operator_for(aug_kind, blame=op))),
             ("value", Child(_h(unit, kids[2]))),
         ),
     )
@@ -1761,6 +1777,7 @@ def _async_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
             kind="AsyncWith", raw_span=span, anchors=(), slots=base.slots
         )
     vocabulary_missing(
+        blame=inner,
         owner="parso_adapter._async_stmt",
         observed=f"async_stmt wrapping {inner.type!r} not recognized",
         requested="funcdef, for_stmt, or with_stmt",
@@ -1819,7 +1836,7 @@ def _not_test(unit: SourceUnit, node: ParsoNode) -> Description:
         raw_span=_span(unit, node),
         anchors=(),
         slots=(
-            ("op", OpLeaf(operator_for("Not"))),
+            ("op", OpLeaf(operator_for("Not", blame=node))),
             ("operand", Child(_h(unit, kids[1]))),
         ),
     )
@@ -1830,6 +1847,7 @@ def _factor(unit: SourceUnit, node: ParsoNode) -> Description:
     kind = _UNARY_TOKEN.get(kids[0].value)
     if kind is None:
         vocabulary_missing(
+            blame=kids[0],
             owner="parso_adapter._factor",
             observed=f"unary token {kids[0].value!r} not recognized",
             requested="'+', '-', or '~'",
@@ -1840,7 +1858,7 @@ def _factor(unit: SourceUnit, node: ParsoNode) -> Description:
         raw_span=_span(unit, node),
         anchors=(),
         slots=(
-            ("op", OpLeaf(operator_for(kind))),
+            ("op", OpLeaf(operator_for(kind, blame=kids[0]))),
             ("operand", Child(_h(unit, kids[1]))),
         ),
     )
@@ -1856,7 +1874,7 @@ def _power(unit: SourceUnit, node: ParsoNode) -> Description:
         anchors=(),
         slots=(
             ("left", Child(left)),
-            ("op", OpLeaf(operator_for("Pow"))),
+            ("op", OpLeaf(operator_for("Pow", blame=node))),
             ("right", Child(right)),
         ),
     )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/spans.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/spans.py
@@ -97,6 +97,7 @@ class Span:
     def __post_init__(self) -> None:
         if self.start < 0 or self.end < self.start:
             backend_defect(
+                blame=self,
                 owner="spans.Span",
                 observed=f"degenerate span [{self.start}, {self.end})",
                 requested="0 <= start <= end",
@@ -143,6 +144,7 @@ class LineTable:
         """1-based line + 0-based codepoint column -> absolute offset."""
         if line < 1 or line > len(self._line_starts):
             backend_defect(
+                blame=(line, col),
                 owner="spans.LineTable.offset",
                 observed=f"line {line} outside 1..{len(self._line_starts)}",
                 requested="a position inside the source",
@@ -154,6 +156,7 @@ class LineTable:
         """Absolute codepoint offset -> (1-based line, 0-based codepoint col)."""
         if offset < 0 or offset > len(self.source):
             backend_defect(
+                blame=offset,
                 owner="spans.LineTable.line_col",
                 observed=f"offset {offset} outside 0..{len(self.source)}",
                 requested="an offset inside the source",
@@ -171,6 +174,7 @@ class LineTable:
         cp_col = self._byte_map(line).get(byte_col)
         if cp_col is None:
             backend_defect(
+                blame=(line, byte_col),
                 owner="spans.LineTable.offset_from_byte_col",
                 observed=f"byte col {byte_col} is not a codepoint boundary on line {line}",
                 requested="a byte column landing on a codepoint boundary",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -95,6 +95,7 @@ class SourceFile:
                 root = materialize(self.unit, backend_root, reporter)
             if not isinstance(root, Module):
                 backend_defect(
+                    blame=root.fragment,
                     owner="tree.SourceFile",
                     observed=f"backend root constructed as {type(root).__name__}",
                     requested="a Module at the root",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
@@ -119,7 +119,6 @@ class _Handle(BackendNode):
         self._node = node
         self._desc: Optional[Description] = None
 
-
     @property
     def minting_unit(self):
         """Parsed out of this unit's text, so its span is that unit's."""
@@ -261,6 +260,7 @@ def _expression_statement(unit: SourceUnit, node: TSNode) -> Description:
             slots=(("elts", Children(tuple(_h(unit, c) for c in kids))),),
         )
     vocabulary_missing(
+        blame=node,
         owner="tree_sitter_python_adapter._expression_statement",
         observed=f"expression_statement with {len(kids)} named children",
         requested="exactly one expression",
@@ -321,6 +321,7 @@ def _string_like(unit: SourceUnit, node: TSNode) -> Description:
             values.append(_interpolation(unit, c))
         else:
             vocabulary_missing(
+                blame=node,
                 owner="tree_sitter_python_adapter._string_like",
                 observed=f"f-string child {c.type!r} not recognized",
                 requested="string_content or interpolation",
@@ -437,6 +438,7 @@ def _binary_operator(unit: SourceUnit, node: TSNode) -> Description:
     kind = _BIN_TOKEN.get(op_node.type)
     if kind is None:
         vocabulary_missing(
+            blame=node,
             owner="tree_sitter_python_adapter._binary_operator",
             observed=f"binary operator token {op_node.type!r} not recognized",
             requested="a known binary operator token",
@@ -448,7 +450,7 @@ def _binary_operator(unit: SourceUnit, node: TSNode) -> Description:
         anchors=(),
         slots=(
             ("left", Child(_h(unit, left))),
-            ("op", OpLeaf(operator_for(kind))),
+            ("op", OpLeaf(operator_for(kind, blame=node))),
             ("right", Child(_h(unit, right))),
         ),
     )
@@ -463,7 +465,7 @@ def _boolean_operator(unit: SourceUnit, node: TSNode) -> Description:
         raw_span=_span(unit, node),
         anchors=(),
         slots=(
-            ("op", OpLeaf(operator_for(_bool_kind(op_type)))),
+            ("op", OpLeaf(operator_for(_bool_kind(op_type), blame=node))),
             ("values", Children(tuple(_h(unit, v) for v in values))),
         ),
     )
@@ -475,7 +477,10 @@ def _not_operator(unit: SourceUnit, node: TSNode) -> Description:
         kind="UnaryOp",
         raw_span=_span(unit, node),
         anchors=(),
-        slots=(("op", OpLeaf(operator_for("Not"))), ("operand", Child(_h(unit, arg)))),
+        slots=(
+            ("op", OpLeaf(operator_for("Not", blame=node))),
+            ("operand", Child(_h(unit, arg))),
+        ),
     )
 
 
@@ -485,6 +490,7 @@ def _unary_operator(unit: SourceUnit, node: TSNode) -> Description:
     kind = _UNARY_TOKEN.get(op_node.type)
     if kind is None:
         vocabulary_missing(
+            blame=node,
             owner="tree_sitter_python_adapter._unary_operator",
             observed=f"unary operator token {op_node.type!r} not recognized",
             requested="'+', '-', or '~'",
@@ -494,7 +500,10 @@ def _unary_operator(unit: SourceUnit, node: TSNode) -> Description:
         kind="UnaryOp",
         raw_span=_span(unit, node),
         anchors=(),
-        slots=(("op", OpLeaf(operator_for(kind))), ("operand", Child(_h(unit, arg)))),
+        slots=(
+            ("op", OpLeaf(operator_for(kind, blame=node))),
+            ("operand", Child(_h(unit, arg))),
+        ),
     )
 
 
@@ -510,12 +519,13 @@ def _comparison_operator(unit: SourceUnit, node: TSNode) -> Description:
         kind = _CMP_TOKEN.get(t.type)
         if kind is None:
             vocabulary_missing(
+                blame=node,
                 owner="tree_sitter_python_adapter._comparison_operator",
                 observed=f"comparison token {t.type!r} not recognized",
                 requested="a known comparison operator token",
                 fix="extend _CMP_TOKEN deliberately",
             )
-        ops.append(operator_for(kind))
+        ops.append(operator_for(kind, blame=node))
     return Description(
         kind="Compare",
         raw_span=_span(unit, node),
@@ -649,6 +659,7 @@ def _parenthesized_expression(unit: SourceUnit, node: TSNode) -> Description:
     inner = _named(node)
     if len(inner) != 1:
         vocabulary_missing(
+            blame=node,
             owner="tree_sitter_python_adapter._parenthesized_expression",
             observed=f"parenthesized_expression with {len(inner)} named children",
             requested="exactly one inner expression",
@@ -722,6 +733,7 @@ def _dictionary(unit: SourceUnit, node: TSNode) -> Description:
             )
         else:
             vocabulary_missing(
+                blame=node,
                 owner="tree_sitter_python_adapter._dictionary",
                 observed=f"dictionary child {c.type!r} not recognized",
                 requested="pair or dictionary_splat",
@@ -1057,6 +1069,7 @@ def _one_param(unit: SourceUnit, node: TSNode, after_star: bool) -> BackendNode:
             anchors=(_span(unit, name_node),),
         )
     vocabulary_missing(
+        blame=node,
         owner="tree_sitter_python_adapter._one_param",
         observed=f"parameter shape {node.type!r} not recognized",
         requested="a mapped parameter shape",
@@ -1145,6 +1158,7 @@ def _augmented_assignment(unit: SourceUnit, node: TSNode) -> Description:
     kind = _AUG_TOKEN.get(op_node.type)
     if kind is None:
         vocabulary_missing(
+            blame=node,
             owner="tree_sitter_python_adapter._augmented_assignment",
             observed=f"augmented assignment token {op_node.type!r} not recognized",
             requested="a known augmented assignment token",
@@ -1156,7 +1170,7 @@ def _augmented_assignment(unit: SourceUnit, node: TSNode) -> Description:
         anchors=(),
         slots=(
             ("target", Child(_h(unit, left))),
-            ("op", OpLeaf(operator_for(kind))),
+            ("op", OpLeaf(operator_for(kind, blame=node))),
             ("value", Child(_h(unit, right))),
         ),
     )
@@ -1930,6 +1944,7 @@ def _pattern(unit: SourceUnit, node: TSNode) -> BackendNode:
             ),
         )
     vocabulary_missing(
+        blame=node,
         owner="tree_sitter_python_adapter._pattern",
         observed=f"case pattern shape {node.type!r} not recognized",
         requested="a mapped match-pattern shape",
@@ -1963,6 +1978,7 @@ def _describe(unit: SourceUnit, node: TSNode) -> Description:
     t = node.type
     if not node.is_named:
         vocabulary_missing(
+            blame=node,
             owner="tree_sitter_python_adapter._describe",
             observed=f"unnamed/punctuation node {t!r} reached the dispatcher",
             requested="a named grammar node",
@@ -1977,6 +1993,7 @@ def _describe(unit: SourceUnit, node: TSNode) -> Description:
     if fn is not None:
         return fn(unit, node)
     vocabulary_missing(
+        blame=node,
         owner="tree_sitter_python_adapter._describe",
         observed=f"tree-sitter node type {t!r} has no translation rule",
         requested="a mapped statement/expression shape",
@@ -2066,7 +2083,7 @@ _DISPATCH = {
         anchors=(),
         slots=(
             ("left", Child(_h(u, _named(n)[0]))),
-            ("op", OpLeaf(operator_for("BitOr"))),
+            ("op", OpLeaf(operator_for("BitOr", blame=node))),
             ("right", Child(_h(u, _named(n)[1]))),
         ),
     ),

--- a/implementations/python/sugar-source-tree/tests/test_panic_taxonomy.py
+++ b/implementations/python/sugar-source-tree/tests/test_panic_taxonomy.py
@@ -32,6 +32,41 @@ def test_both_are_membrane_panic_but_distinct_from_each_other():
     assert not issubclass(BackendDefect, VocabularyMissing)
 
 
+def test_every_source_tree_refusal_renders_its_required_blame_coordinate():
+    blame = "tests/fixtures/refusal.py:17:4"
+    refusal = SugarNotWritten(
+        blame=blame,
+        owner="Attribute.sugar",
+        observed="member lookup stayed undecided",
+        requested="an authenticated completed or exceptional edge",
+        fix="carry member testimony to the attribute floor",
+    )
+
+    assert refusal.blame == blame
+    assert f"  blame:     {blame}" in str(refusal)
+
+
+def test_refusal_without_blame_coordinate_cannot_be_constructed():
+    with pytest.raises(TypeError, match="blame"):
+        SugarNotWritten(
+            owner="Attribute.sugar",
+            observed="member lookup stayed undecided",
+            requested="an authenticated completed or exceptional edge",
+            fix="carry member testimony to the attribute floor",
+        )
+
+
+def test_none_cannot_masquerade_as_a_blame_coordinate():
+    with pytest.raises(TypeError, match="blame"):
+        SugarNotWritten(
+            blame=None,
+            owner="Attribute.sugar",
+            observed="member lookup stayed undecided",
+            requested="an authenticated completed or exceptional edge",
+            fix="carry member testimony to the attribute floor",
+        )
+
+
 def test_unknown_backend_kind_is_a_missing_not_a_provider_defect():
     """resolve_kind: a shape the backend legitimately produced, but our
     vocabulary has no node class for it — the MISSING case."""
@@ -41,7 +76,7 @@ def test_unknown_backend_kind_is_a_missing_not_a_provider_defect():
 
 def test_unknown_operator_kind_is_a_missing_not_a_provider_defect():
     with pytest.raises(VocabularyMissing):
-        operator_for("NoSuchOperator")
+        operator_for("NoSuchOperator", blame="test_panic_taxonomy.py:operator")
 
 
 def test_degenerate_span_is_a_provider_defect_not_a_missing():
@@ -90,6 +125,7 @@ def test_runtime_selected_context_manager_is_named_sugar_gap():
     assert issubclass(RuntimeSelectedContextManager, SourceTreePanic)
     assert RuntimeSelectedContextManager is not SugarNotWritten
     panic = RuntimeSelectedContextManager(
+        blame="test_panic_taxonomy.py:runtime-selected",
         owner="With.sugar",
         observed="unauthenticated context manager — exit suppression runtime-selected",
         requested="typed exit contract",

--- a/implementations/python/sugar-source-tree/tests/test_raise_from_measurement.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_from_measurement.py
@@ -77,8 +77,9 @@ def test_measurement_surfaces_planted_construction_panic(tmp_path, monkeypatch) 
     )
     module = _module()
 
-    def planted(_path, *, reporter):
+    def planted(_path, **_kwargs):
         raise BackendDefect(
+            blame=path,
             owner="planted.raise",
             observed="construction panic",
             requested="loud census result",
@@ -95,6 +96,7 @@ def test_measurement_surfaces_planted_construction_panic(tmp_path, monkeypatch) 
             "type": "BackendDefect",
             "message": str(
                 BackendDefect(
+                    blame=path,
                     owner="planted.raise",
                     observed="construction panic",
                     requested="loud census result",
@@ -119,6 +121,7 @@ def test_gap_coordinate_failure_is_not_caught() -> None:
 
         def line_col_span(self):
             raise BackendDefect(
+                blame="test_raise_from_measurement.py:BrokenGapNode",
                 owner="planted gap coordinate",
                 observed="broken span",
                 requested="a valid normalized coordinate",

--- a/implementations/python/sugar-source-tree/tests/test_typed.py
+++ b/implementations/python/sugar-source-tree/tests/test_typed.py
@@ -55,4 +55,4 @@ def test_resolve_kind_never_returns_abstract():
 
 def test_unknown_operator_panics():
     with pytest.raises(SourceTreePanic):
-        operator_for("Frobnicate")
+        operator_for("Frobnicate", blame="test_typed.py:operator")

--- a/implementations/python/sugar-source-tree/tests/test_with_construction_gap_kind.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_construction_gap_kind.py
@@ -21,6 +21,7 @@ from sugar_source_tree.panic import (
 
 def test_dynamic_export_is_a_named_with_construction_gap_kind():
     panic = ContextManagerResolutionConstructionGap(
+        blame="demand:test",
         kind="dynamic-export",
         demand_cid="demand:test",
         candidate_member_cids=(),
@@ -37,6 +38,7 @@ def test_dynamic_export_is_a_named_with_construction_gap_kind():
 def test_static_export_absent_and_unsupported_statement_parse():
     for kind in ("static-export-absent", "unsupported-statement"):
         panic = ContextManagerResolutionConstructionGap(
+            blame="demand:test",
             kind=kind,
             demand_cid="demand:test",
             candidate_member_cids=(),
@@ -51,6 +53,7 @@ def test_static_export_absent_and_unsupported_statement_parse():
 def test_unknown_resolution_kind_stays_loud_not_valueerror():
     """A newly minted kind must not crash the census with ValueError."""
     panic = ContextManagerResolutionConstructionGap(
+        blame="demand:test",
         kind="brand-new-resolution-kind-2026",
         demand_cid="demand:test",
         candidate_member_cids=(),
@@ -66,6 +69,7 @@ def test_unknown_resolution_kind_stays_loud_not_valueerror():
 
 def test_known_runtime_selected_still_parses():
     panic = ContextManagerResolutionConstructionGap(
+        blame="demand:test",
         kind="runtime-selected",
         demand_cid="demand:test",
         candidate_member_cids=(),


### PR DESCRIPTION
## What changed

- make `blame` a required `SourceTreePanic` construction coordinate and render it on every refusal
- thread native source/backend coordinates through every `SugarNotWritten`, `VocabularyMissing`, `OpaqueSourceCallResolutionGap`, and `BackendDefect` construction
- restore the exact Attribute site on undecided attribute refusals
- add truthful, missing-coordinate, and `None` lying twins

## Validation

- authenticated battleaxe: CPython 3.12.13, NumPy 2.5.1, canonical pandas manifest `blake3-512:6f317a5a...563530`; 4 focused tests passed
- local CPython 3.12.13: sugar-source-tree focused 27 passed; sugar-lift-py-tests focused 28 passed
- mutation transaction: permissive default made both enforcement twins fail; revert returned 3 passed
- AST audit: every tracked panic construction carries `blame`; sole omission is the intentional lying twin

The broader lift-python-source slice retained 11 existing frontier/outcome expectation failures and passed 65 tests; no failing detector was weakened or skipped.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require blame coordinates on all `SourceTreePanic` subclasses raised during source tree parsing and sugar lifting
> - Makes `blame` a mandatory keyword argument on `SourceTreePanic` and its factory functions (`vocabulary_missing`, `backend_defect`), so every panic now carries and displays a source location.
> - Adds a `_render_blame` helper in [panic.py](https://github.com/TSavo/sugar/pull/6553/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb) that formats blame objects with filename/line/col attributes as `filename:line:col`.
> - Propagates `blame=` arguments through all parser adapters (cpython, libcst, parso, tree-sitter), node constructors, operator lookups, span utilities, and sugar desugaring methods across the codebase.
> - Updates `bind_in_flight_effect` and `resolve_in_flight_effect` to require a keyword-only `blame` parameter, threading blame through try/except/raise sugar paths.
> - Risk: constructing any `SourceTreePanic` subclass without a `blame` argument now raises `TypeError`; all call sites have been updated but third-party or test code that constructs these directly will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 628c026.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->