### PR TITLE
Require completed testimony for no-warning contracts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -435,6 +435,22 @@ def _route_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
     body_es = promote_raise_halts(reduce_block_to_exitset(body, ctx)).guarded(
         manager_exit.guard
     )
+    # The inverted contract is proved by a POSITIVE completed edge whose
+    # temporal record contains no matching warning observation.  An empty
+    # ExitSet says the body never resolved; it is not a vacuous proof of
+    # absence. Producer-family enrollment carries the same distinction as
+    # AuthenticatedCompletedOwnership versus UndecidedOwnership; keep that
+    # population predicate in its single owner rather than restating it here.
+    if not body_es.exits:
+        raise SugarNotWritten(
+            owner="WithEffectBoundarySugar.warning_observation",
+            observed="body has no authenticated exit edge",
+            requested="a resolved ExitSet containing a Completed edge",
+            fix=(
+                "construct and resolve the body before deciding warning absence; "
+                "absence of a halt is not completion testimony"
+            ),
+        )
     exits = []
     for face in body_es.exits:
         # Matching-category routing already reads both faces the same way:

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -334,6 +334,14 @@ def test_no_warning_both_edges_discriminate_absence_from_arrival():
     assert isinstance(exception_arrived.exits[0].effect, ExpectationNotMetEffect)
 
 
+def test_no_warning_empty_exit_set_cannot_pass_vacuously():
+    """No faces means the body never resolved, not that no warning occurred."""
+    with pytest.raises(SugarNotWritten) as raised:
+        _no_warning_from_exitset(ExitSet(())).desugar()
+    assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
+    assert raised.value.observed == "body has no authenticated exit edge"
+
+
 def test_no_warning_guarded_occurrence_is_undecided_on_exception_edge():
     """Guarded law is edge-independent: refuse on the halt face too."""
     guarded = WarningObservationValue(


### PR DESCRIPTION
## What changed

- Require a positive authenticated ExitSet edge before an inverted no-warning boundary can succeed.
- Refuse an empty ExitSet by name instead of treating absence of halted edges as a vacuous proof.
- Add the anti-vacuity twin alongside the existing truthful completed-edge and lying warning-arrival twins.

## Ruling and assumption

A non-raising observed body remains a member of its producer family when its ExitSet is authenticated. Membership follows the root expression and authenticated outcome, not exceptionality. This PR assumes the single shared population predicate remains owned by the producer-family population work and does not duplicate it here.

The 101-site outcome census is intentionally not claimed in this PR. The shared demand artifact contains the demand rows, but the re-exported generator context-manager sites do not yet mint a source-derived contract reference through the authenticated construction path. Selecting them by targetSymbol would be the prohibited vendor/name filter. That residual remains loud and separate from this ruling.

## Validation

- Runtime: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pytest 9.1.1
- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py`
- Result: 17 passed; `TEST_EXIT_STATUS=0`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `SugarNotWritten` when no-warning contract body produces an empty ExitSet
> Previously, `_route_no_warning_boundary` would silently succeed when the body produced an empty ExitSet, treating it as a vacuous proof of no exits. Now it raises `SugarNotWritten` in that case, requiring the body to produce a resolved ExitSet containing at least one `Completed` edge.
>
> - The check is added in [with_effect_boundary_sugar.py](https://github.com/TSavo/sugar/pull/6555/files#diff-0d372d766673042627a4eeab5612c75aa23cb49a85e1aa6866cfb0721be30780) immediately after the body ExitSet is constructed and guarded.
> - A new test in [test_with_effect_boundary_warning.py](https://github.com/TSavo/sugar/pull/6555/files#diff-8f0a59cf02b50d012e3ececbaa001b0fc5e65fe1794b8ca599b8152267f4d704) verifies the error owner and observed fields.
> - Behavioral Change: no-warning contracts that previously passed with an empty ExitSet will now fail at desugar time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a06a25e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or unresolved effect results from being treated as valid proof that no warning exists.
  * Added clear guidance to construct or resolve the body before deciding that warnings are absent.

* **Tests**
  * Added coverage ensuring empty exit results are rejected with an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->