### PR TITLE
Freeze fatal triage construction context

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
@@ -63,8 +63,14 @@ def _typed_construction_row(error) -> dict[str, object] | None:
     return None
 
 
-def production_lift_testimony(path: Path, rel: str) -> dict[str, object]:
-    """Enumerate one file and construct each function once."""
+def production_lift_testimony(
+    path: Path,
+    rel: str,
+    *,
+    corpus_root: Path,
+    construction_context,
+) -> dict[str, object]:
+    """Enumerate one file with the caller's frozen corpus context."""
     from sugar_source_tree.reporter import CollectingReporter
     from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 
@@ -75,7 +81,10 @@ def production_lift_testimony(path: Path, rel: str) -> dict[str, object]:
         # SourceFile has no manager-resolution context and paints every With as
         # RuntimeSelectedContextManager, which is false typed-gap testimony.
         source_file = open_source_file_for_construction(
-            path, root=path.parent, reporter=reporter
+            path,
+            root=corpus_root,
+            reporter=reporter,
+            construction_context=construction_context,
         )
     except BaseException as error:
         row = _typed_construction_row(error)
@@ -121,13 +130,29 @@ def production_lift_bootstrap_error() -> str | None:
     return None
 
 
-def run_production_lift_child(path: Path, rel: str) -> int:
+def run_production_lift_child(
+    path: Path,
+    rel: str,
+    *,
+    corpus_root: Path,
+    construction_context,
+) -> int:
     """Enumerate one file, construct each function, emit one terminal row.
 
     Typed construction failures → ``typed-gap`` and exit 0.
     Any other exception propagates (bare-exception signal to the caller).
     """
-    print(json.dumps(production_lift_testimony(path, rel)), flush=True)
+    print(
+        json.dumps(
+            production_lift_testimony(
+                path,
+                rel,
+                corpus_root=corpus_root,
+                construction_context=construction_context,
+            )
+        ),
+        flush=True,
+    )
     return 0
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -47,6 +47,9 @@ class SupervisedEnumSupervisor:
         file_timeout: float = 30.0,
         python: str | None = None,
         env: Mapping[str, str] | None = None,
+        corpus_root: Path,
+        demand_table_path: Path | None = None,
+        allow_local_demand_derivation: bool = False,
     ) -> None:
         if file_timeout > 30:
             raise ValueError("per-file timeout may not exceed 30 seconds")
@@ -54,6 +57,11 @@ class SupervisedEnumSupervisor:
         self.python = python or sys.executable
         self.env = dict(env or os.environ)
         self.env.setdefault("PYTHONFAULTHANDLER", "1")
+        self.corpus_root = corpus_root.resolve()
+        self.demand_table_path = (
+            None if demand_table_path is None else demand_table_path.resolve()
+        )
+        self.allow_local_demand_derivation = allow_local_demand_derivation
         self._proc: subprocess.Popen[str] | None = None
         self.worker_restarts = 0
         self._current_file: str | None = None
@@ -86,6 +94,22 @@ class SupervisedEnumSupervisor:
         if ready.get("kind") != "ready":
             self._kill()
             raise RuntimeError(f"supervised enum worker bad handshake: {ready!r}")
+        assert self._proc.stdin is not None
+        initialize = {"kind": "initialize", "corpus_root": str(self.corpus_root)}
+        if self.demand_table_path is not None:
+            initialize["demand_table_path"] = str(self.demand_table_path)
+        initialize["allow_local_demand_derivation"] = (
+            self.allow_local_demand_derivation
+        )
+        self._proc.stdin.write(json.dumps(initialize) + "\n")
+        self._proc.stdin.flush()
+        initialized = self._readline(timeout=30.0)
+        if initialized is None or initialized.get("kind") != "context-ready":
+            self._kill()
+            raise RuntimeError(
+                "supervised enum worker context initialization refused: "
+                f"{initialized!r}"
+            )
 
     def stop(self) -> None:
         proc = self._proc
@@ -285,9 +309,15 @@ def scan_paths(
     *,
     root: Path,
     file_timeout: float = 30.0,
+    demand_table_path: Path | None = None,
 ) -> list[FileTerminal]:
     from _enum_floor_runtime import relative_to_root
 
     pairs = [(path, relative_to_root(path, root)) for path in paths]
-    supervisor = SupervisedEnumSupervisor(file_timeout=file_timeout)
+    supervisor = SupervisedEnumSupervisor(
+        file_timeout=file_timeout,
+        corpus_root=root,
+        demand_table_path=demand_table_path,
+        allow_local_demand_derivation=demand_table_path is None,
+    )
     return supervisor.scan(pairs)

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -24,6 +24,9 @@ import json
 import sys
 from pathlib import Path
 
+_CORPUS_ROOT: Path | None = None
+_CONSTRUCTION_CONTEXT = None
+
 
 def _bootstrap() -> str | None:
     scripts = Path(__file__).resolve().parent
@@ -54,8 +57,69 @@ def _lift(path: str, rel: str) -> dict:
 
     from _production_lift_child import production_lift_testimony
 
-    terminal = production_lift_testimony(Path(path), rel)
+    if _CORPUS_ROOT is None or _CONSTRUCTION_CONTEXT is None:
+        return {
+            "kind": "lift-refusal",
+            "file": rel,
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": "authenticated frozen construction context was not initialized",
+        }
+    terminal = production_lift_testimony(
+        Path(path),
+        rel,
+        corpus_root=_CORPUS_ROOT,
+        construction_context=_CONSTRUCTION_CONTEXT,
+    )
     return {"kind": "lift-result", "file": rel, "terminal": terminal}
+
+
+def _initialize(
+    corpus_root: str,
+    demand_table_path: str | None,
+    *,
+    allow_local_demand_derivation: bool,
+) -> dict:
+    global _CONSTRUCTION_CONTEXT, _CORPUS_ROOT
+    if _CONSTRUCTION_CONTEXT is not None:
+        return {
+            "kind": "initialize-refusal",
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": "frozen construction context was already initialized",
+        }
+    from sugar_lift_py_tests.lift_rpc import (
+        provisional_contract_refs_from_demand_rows,
+        tree_construction_context_for_workspace,
+    )
+
+    root = Path(corpus_root).resolve()
+    contract_refs = None
+    demand_table_identity = None
+    if demand_table_path:
+        from sugar_lift_py_tests.no_call_body_attribution import (
+            SHARED_DEMAND_TABLE_CONTENT_KEY,
+            validate_shared_demand_table,
+        )
+
+        payload = validate_shared_demand_table(
+            json.loads(Path(demand_table_path).read_text(encoding="utf-8")),
+            expected_content_key=SHARED_DEMAND_TABLE_CONTENT_KEY,
+        )
+        contract_refs = provisional_contract_refs_from_demand_rows(payload["rows"])
+        demand_table_identity = SHARED_DEMAND_TABLE_CONTENT_KEY
+    elif not allow_local_demand_derivation:
+        raise RuntimeError(
+            "supervised-enum-worker.shared-demand-table: authenticated demand "
+            "table testimony is absent"
+        )
+    _CORPUS_ROOT = root
+    _CONSTRUCTION_CONTEXT = tree_construction_context_for_workspace(
+        root, contract_refs=contract_refs
+    )
+    return {
+        "kind": "context-ready",
+        "corpus_root": str(root),
+        "demand_table_identity": demand_table_identity,
+    }
 
 
 def main() -> int:
@@ -94,6 +158,25 @@ def main() -> int:
             return 0
         if kind == "ping":
             print(json.dumps({"kind": "pong"}), flush=True)
+            continue
+        if kind == "initialize":
+            try:
+                response = _initialize(
+                    str(msg.get("corpus_root") or ""),
+                    str(msg["demand_table_path"])
+                    if msg.get("demand_table_path")
+                    else None,
+                    allow_local_demand_derivation=bool(
+                        msg.get("allow_local_demand_derivation", False)
+                    ),
+                )
+            except Exception as error:
+                response = {
+                    "kind": "initialize-refusal",
+                    "coordinate": "supervised-enum-worker.construction-context",
+                    "reason": f"{type(error).__name__}: {error}",
+                }
+            print(json.dumps(response), flush=True)
             continue
         if kind == "lift":
             path = str(msg.get("path") or "")

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -15,6 +15,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
@@ -54,7 +55,13 @@ def _progress_logging_enabled() -> bool:
     return flag in {"1", "true", "yes", "on"}
 
 
-def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
+def _child_payload(
+    path: Path,
+    rel: str,
+    *,
+    corpus_root: Path,
+    construction_context,
+) -> tuple[dict[str, Any], int]:
     progress = _progress_logging_enabled()
     if not progress:
         logging.disable(logging.CRITICAL)
@@ -69,9 +76,19 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
 
         if progress:
             with reduction_span(sugar="production_lift", role="file", site=rel):
-                terminal = production_lift_testimony(path, rel)
+                terminal = production_lift_testimony(
+                    path,
+                    rel,
+                    corpus_root=corpus_root,
+                    construction_context=construction_context,
+                )
         else:
-            terminal = production_lift_testimony(path, rel)
+            terminal = production_lift_testimony(
+                path,
+                rel,
+                corpus_root=corpus_root,
+                construction_context=construction_context,
+            )
     except KeyboardInterrupt:
         raise
     except Exception as error:
@@ -86,9 +103,29 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
 
 
 def _run_child(args: argparse.Namespace) -> int:
-    terminal, returncode = _child_payload(Path(args.child_file), args.child_rel)
-    print(json.dumps(terminal, sort_keys=True), flush=True)
-    return returncode
+    print(
+        json.dumps(
+            {
+                "outcome": "typed-gap",
+                "file": args.child_rel,
+                "typed_gap_count": 1,
+                "typed_gaps": [
+                    {
+                        "exception_type": "FatalTriageContextProtocolRefusal",
+                        "gap": {
+                            "owner": "corpus_fatal_triage.child-protocol",
+                            "observed": "one-file child invocation has no shared frozen context",
+                            "requested": "persistent worker initialized from the authenticated shared demand table",
+                            "fix": "run fatal triage through its parent protocol",
+                        },
+                    }
+                ],
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+    return 0
 
 
 def _parse_child_stdout(stdout: str) -> dict[str, Any] | None:
@@ -187,11 +224,35 @@ def _run_parent(args: argparse.Namespace) -> int:
     representatives: dict[str, list[str]] = defaultdict(list)
     typed_gap_classes: Counter[str] = Counter()
     typed_gap_owners: Counter[str] = Counter()
-    script = Path(__file__).resolve()
     by_rel = {
         f"{package}/{path.relative_to(root).as_posix()}": (path, root)
         for package, root, path in paths
     }
+
+    # Authenticate the corpus seat before acquiring the shared demand table.
+    # The path is transport only; the manifest CID and demand-table content key
+    # are the identities.  One persistent worker freezes one context from that
+    # table and consumes it for every file in this run.
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.no_call_body_attribution import pull_shared_demand_table
+    from _supervised_enum_supervisor import SupervisedEnumSupervisor
+
+    authenticated = authenticated_pandas_corpus()
+    corpus_roots = {root.resolve() for _, root, _ in paths}
+    if authenticated.root.resolve() not in corpus_roots:
+        raise RuntimeError(
+            "fatal-triage.authenticated-corpus-root: canonical pandas corpus "
+            "is absent from the enrolled package roots"
+        )
+    workspace_root = Path(os.path.commonpath([str(root) for root in corpus_roots]))
+    demand_scratch = tempfile.TemporaryDirectory(prefix="fatal-triage-demand-")
+    demand_table_path = Path(demand_scratch.name) / "python-demand-table.json"
+    pull_shared_demand_table(Path(__file__).resolve().parents[4], demand_table_path)
+    supervisor = SupervisedEnumSupervisor(
+        file_timeout=float(args.file_timeout),
+        corpus_root=workspace_root,
+        demand_table_path=demand_table_path,
+    )
 
     def measure_unchecked(rel: str) -> dict[str, Any]:
         path, _root = by_rel[rel]
@@ -201,38 +262,14 @@ def _run_parent(args: argparse.Namespace) -> int:
             source = path.read_text(encoding="utf-8", errors="replace")
         tree = ast.parse(source, filename=rel)
         assertion_count = sum(isinstance(node, ast.Assert) for node in ast.walk(tree))
-        command = [
-            sys.executable,
-            str(script),
-            "--child-file",
-            str(path),
-            "--child-rel",
-            rel,
-        ]
-        env = dict(os.environ)
-        env["PYTHONFAULTHANDLER"] = "1"
-        try:
-            result = subprocess.run(
-                command,
-                text=True,
-                capture_output=True,
-                timeout=args.file_timeout,
-                env=env,
-                check=False,
-            )
-            row = _classify_child(
-                rel=rel,
-                result=result,
-                timed_out=False,
-                timeout_seconds=args.file_timeout,
-            )
-        except subprocess.TimeoutExpired:
-            row = _classify_child(
-                rel=rel,
-                result=None,
-                timed_out=True,
-                timeout_seconds=args.file_timeout,
-            )
+        terminal = supervisor.lift_file(path, rel)
+        row = {
+            "file": rel,
+            "category": terminal.category,
+            "returncode": terminal.returncode,
+            "testimony": terminal.terminal,
+            "reason": terminal.stderr_tail,
+        }
         return {"assertionCount": assertion_count, "terminal": row}
 
     def measure(rel: str) -> dict[str, Any]:
@@ -248,18 +285,22 @@ def _run_parent(args: argparse.Namespace) -> int:
                 },
             }
 
-    if args.checkpoint_jsonl:
-        from pandas_census_checkpoint import Checkpoint, run_pending
+    try:
+        if args.checkpoint_jsonl:
+            from pandas_census_checkpoint import Checkpoint, run_pending
 
-        checkpoint = Checkpoint(
-            floor="fatal-triage",
-            files=tuple(by_rel),
-            path=Path(args.checkpoint_jsonl),
-        )
-        journal_rows = run_pending(checkpoint, measure, workers=1)
-        measured = [dict(row["result"]) for row in journal_rows]
-    else:
-        measured = [measure(rel) for rel in sorted(by_rel)]
+            checkpoint = Checkpoint(
+                floor="fatal-triage",
+                files=tuple(by_rel),
+                path=Path(args.checkpoint_jsonl),
+            )
+            journal_rows = run_pending(checkpoint, measure, workers=1)
+            measured = [dict(row["result"]) for row in journal_rows]
+        else:
+            measured = [measure(rel) for rel in sorted(by_rel)]
+    finally:
+        supervisor.stop()
+        demand_scratch.cleanup()
 
     for index, (rel, measured_row) in enumerate(
         zip(sorted(by_rel), measured, strict=True), start=1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -120,20 +120,8 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
     return rows
 
 
-def provisional_contract_refs_from_demands(root: Path):
-    """One typed gap row per enrolled With demand — census / unbinded construct door.
-
-    Production replaces this table via ``bind_contract_refs`` with authenticated
-    resolutions. Until that table is installed (or for instruments that construct
-    without the Rust prebind), every With use-site must still appear so
-    ``With._prebound_manager_resolution`` does not treat missing context as
-    unconditional ``RuntimeSelectedContextManager`` (false red).
-
-    Each demand lands as ``ContextManagerResolutionGapV1`` with the demand's
-    ``gapKind`` (default ``runtime-selected``). Source-derived managers may still
-    win via ``populate_source_derived_resource_refs`` after the context is
-    installed — derived takes precedence over this provisional gap table.
-    """
+def provisional_contract_refs_from_demand_rows(rows):
+    """Project one already-authenticated demand table into construction refs."""
     from types import MappingProxyType
 
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -144,7 +132,7 @@ def provisional_contract_refs_from_demands(root: Path):
     )
 
     resolutions = {}
-    for row in _preconstruction_demand_rows(root):
+    for row in rows:
         if row.get("kind") != "context-manager-demand":
             continue
         site = SourceFragmentCoordinateV1.decode(row["useSite"])
@@ -162,6 +150,23 @@ def provisional_contract_refs_from_demands(root: Path):
     catalog_cid = "blake3-512:" + ("c" * 128)
     table_cid = "blake3-512:" + ("t" * 128)
     return ResolvedContractRefsV1(catalog_cid, table_cid, MappingProxyType(resolutions))
+
+
+def provisional_contract_refs_from_demands(root: Path):
+    """One typed gap row per enrolled With demand — census / unbinded construct door.
+
+    Production replaces this table via ``bind_contract_refs`` with authenticated
+    resolutions. Until that table is installed (or for instruments that construct
+    without the Rust prebind), every With use-site must still appear so
+    ``With._prebound_manager_resolution`` does not treat missing context as
+    unconditional ``RuntimeSelectedContextManager`` (false red).
+
+    Each demand lands as ``ContextManagerResolutionGapV1`` with the demand's
+    ``gapKind`` (default ``runtime-selected``). Source-derived managers may still
+    win via ``populate_source_derived_resource_refs`` after the context is
+    installed — derived takes precedence over this provisional gap table.
+    """
+    return provisional_contract_refs_from_demand_rows(_preconstruction_demand_rows(root))
 
 
 def tree_construction_context_for_workspace(

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -29,9 +29,27 @@ def _write(tmp_path: Path, source: str) -> Path:
     return path
 
 
+def _run(path: Path, rel: str) -> int:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+        empty_resolved_contract_refs,
+    )
+
+    root = path.parent
+    context = TreeConstructionContextV1(
+        empty_resolved_contract_refs(), workspace_root=str(root)
+    )
+    return _CHILD.run_production_lift_child(
+        path,
+        rel,
+        corpus_root=root,
+        construction_context=context,
+    )
+
+
 def test_clean_file_completes(tmp_path: Path, capsys) -> None:
     path = _write(tmp_path, "def a(z):\n    return z\n")
-    assert _CHILD.run_production_lift_child(path, "mod.py") == 0
+    assert _run(path, "mod.py") == 0
     terminal = _CHILD.terminal_outcome(capsys.readouterr().out)
     assert terminal == _CHILD.OUTCOME_COMPLETED
     assert terminal in _CHILD.NON_FAILURE_OUTCOMES
@@ -42,7 +60,7 @@ def test_intentional_typed_gap_is_typed_gap_not_failure(tmp_path: Path, capsys) 
     # typed loud gap. The child marks the file typed-gap and exits 0; the floors
     # must NOT count this as a bare exception.
     path = _write(tmp_path, "def a():\n    with open('x'):\n        pass\n")
-    assert _CHILD.run_production_lift_child(path, "mod.py") == 0
+    assert _run(path, "mod.py") == 0
     terminal = _CHILD.terminal_outcome(capsys.readouterr().out)
     assert terminal == _CHILD.OUTCOME_TYPED_GAP
     assert terminal in _CHILD.NON_FAILURE_OUTCOMES
@@ -70,7 +88,7 @@ def test_kit_construction_panic_is_typed_gap_not_failure(
 
     monkeypatch.setattr(nodes_mod.FunctionDef, "sugar", _boom)
     path = _write(tmp_path, "def a():\n    return 1\n")
-    assert _CHILD.run_production_lift_child(path, "mod.py") == 0
+    assert _run(path, "mod.py") == 0
     terminal = _CHILD.terminal_outcome(capsys.readouterr().out)
     assert terminal == _CHILD.OUTCOME_TYPED_GAP
     assert terminal in _CHILD.NON_FAILURE_OUTCOMES
@@ -99,7 +117,7 @@ def test_source_file_construction_panic_is_typed_gap(
     monkeypatch.setattr(tree_mod.SourceFile, "__init__", _typed_gap)
     path = _write(tmp_path, "def a():\n    return 1\n")
 
-    assert _CHILD.run_production_lift_child(path, "arbitrary.py") == 0
+    assert _run(path, "arbitrary.py") == 0
     assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
 
 
@@ -121,7 +139,7 @@ def test_source_file_unwritten_is_typed_gap(
     monkeypatch.setattr(tree_mod.SourceFile, "__init__", _typed_gap)
     path = _write(tmp_path, "def a():\n    return 1\n")
 
-    assert _CHILD.run_production_lift_child(path, "arbitrary.py") == 0
+    assert _run(path, "arbitrary.py") == 0
     assert _CHILD.terminal_outcome(capsys.readouterr().out) == _CHILD.OUTCOME_TYPED_GAP
 
 
@@ -134,11 +152,69 @@ def test_bare_exception_propagates_never_swallowed(tmp_path: Path, monkeypatch) 
     monkeypatch.setattr(tree_mod.SourceFile, "__init__", _boom)
     path = _write(tmp_path, "def a():\n    return 1\n")
     with pytest.raises(RuntimeError, match="planted bare exception"):
-        _CHILD.run_production_lift_child(path, "mod.py")
+        _run(path, "mod.py")
 
 
 def test_bootstrap_check_is_green_when_door_present() -> None:
     assert _CHILD.production_lift_bootstrap_error() is None
+
+
+def test_frozen_corpus_context_is_independent_of_launch_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sugar_lift_py_tests.lift_rpc as lift_rpc
+
+    root = tmp_path / "pkg"
+    source_dir = root / "sub"
+    source_dir.mkdir(parents=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    (root / "managers.py").write_text(
+        "import contextlib\n"
+        "@contextlib.contextmanager\n"
+        "def held():\n"
+        "    yield 1\n",
+        encoding="utf-8",
+    )
+    (source_dir / "__init__.py").write_text("", encoding="utf-8")
+    source = source_dir / "uses.py"
+    source.write_text(
+        "from pkg.managers import held\n"
+        "def run():\n"
+        "    with held() as value:\n"
+        "        return value\n",
+        encoding="utf-8",
+    )
+    context = object()
+    observed: list[tuple[Path, object]] = []
+
+    class Opened:
+        def functions(self):
+            return ()
+
+    def open_once(_path, *, root, construction_context, **_kwargs):
+        observed.append((root, construction_context))
+        return Opened()
+
+    monkeypatch.setattr(lift_rpc, "open_source_file_for_construction", open_once)
+
+    monkeypatch.chdir(root)
+    first = _CHILD.production_lift_testimony(
+        source,
+        "sub/uses.py",
+        corpus_root=root,
+        construction_context=context,
+    )
+    monkeypatch.chdir(source_dir)
+    second = _CHILD.production_lift_testimony(
+        source,
+        "sub/uses.py",
+        corpus_root=root,
+        construction_context=context,
+    )
+
+    assert first == second
+    assert first["outcome"] == _CHILD.OUTCOME_COMPLETED
+    assert observed == [(root, context), (root, context)]
 
 
 def test_terminal_outcome_none_is_the_silent_axis() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -9,6 +9,8 @@ import textwrap
 import pytest
 
 import sys
+import json
+import subprocess
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 _SPEC = importlib.util.spec_from_file_location(
@@ -48,12 +50,22 @@ def test_supervised_timeout_restarts_and_continues(tmp_path: Path, monkeypatch) 
     sleeper = _write(tmp_path, "sleep.py", "def a():\n    return 1\n")
     after = _write(tmp_path, "after.py", "def a(z):\n    return z\n")
     monkeypatch.setenv("SUGAR_SUPERVISOR_PLANT_TIMEOUT", "sleep.py")
-    rows = _SUP.scan_paths([sleeper, after], root=tmp_path, file_timeout=1.0)
-    assert rows[0].file == "sleep.py"
-    assert rows[0].category == "timeout"
-    assert rows[0].worker_restarts >= 1
-    assert rows[1].file == "after.py"
-    assert rows[1].category == "completed"
+    supervisor = _SUP.SupervisedEnumSupervisor(
+        corpus_root=tmp_path,
+        file_timeout=1.0,
+        allow_local_demand_derivation=True,
+    )
+    try:
+        timed_out = supervisor.lift_file(sleeper, "sleep.py")
+        supervisor.file_timeout = 30.0
+        completed = supervisor.lift_file(after, "after.py")
+    finally:
+        supervisor.stop()
+    assert timed_out.file == "sleep.py"
+    assert timed_out.category == "timeout"
+    assert timed_out.worker_restarts >= 1
+    assert completed.file == "after.py"
+    assert completed.category == "completed"
 
 
 def test_supervised_bare_exception_keeps_going(tmp_path: Path, monkeypatch) -> None:
@@ -64,3 +76,36 @@ def test_supervised_bare_exception_keeps_going(tmp_path: Path, monkeypatch) -> N
     assert rows[0].category == "bare-exception"
     assert "planted bare" in rows[0].stderr_tail
     assert rows[1].category == "completed"
+
+
+def test_worker_refuses_file_before_frozen_context_initialization(
+    tmp_path: Path,
+) -> None:
+    source = _write(tmp_path, "clean.py", "def a(z):\n    return z\n")
+    worker = subprocess.Popen(
+        [sys.executable, str(_SCRIPTS / "_supervised_enum_worker.py")],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert worker.stdin is not None and worker.stdout is not None
+    try:
+        assert json.loads(worker.stdout.readline())["kind"] == "ready"
+        worker.stdin.write(
+            json.dumps(
+                {"kind": "lift", "path": str(source), "rel": "clean.py"}
+            )
+            + "\n"
+        )
+        worker.stdin.flush()
+        refusal = json.loads(worker.stdout.readline())
+        assert refusal == {
+            "kind": "lift-refusal",
+            "file": "clean.py",
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": "authenticated frozen construction context was not initialized",
+        }
+    finally:
+        worker.stdin.write(json.dumps({"kind": "shutdown"}) + "\n")
+        worker.stdin.flush()
+        worker.wait(timeout=5)


### PR DESCRIPTION
## Supersedes

This replaces the implementation merged by #6537. That PR removed the bare `SourceFile`, but its `root=path.parent` call still derived a different context for every file. This PR closes both held defects rather than treating the smaller root as a typo.

## What changed

- Make production lift testimony require an explicit authenticated corpus root and an already-frozen construction context.
- Add a persistent-worker initialization handshake. A worker accepts no file until one context is installed, and refuses a second initialization by named coordinate.
- Authenticate and consume #6464's shared demand-table artifact for fatal triage, project its existing rows into contract refs, and freeze one context for the worker lifetime.
- Route fatal triage through that persistent protocol instead of spawning a context-free child per file.
- Preserve local developer floors through an explicit local-derivation mode; authenticated runs have no missing-artifact fallback.
- Keep the former one-file child mode loud as `FatalTriageContextProtocolRefusal`; it no longer fabricates per-file context testimony.

No vendor/name dispatch, cache, compatibility decoder, bare `SourceFile`, or per-file context producer was added.

## Teeth

- The same file is opened twice from different launch directories with the exact authenticated root and the identical frozen context object.
- A worker asked to lift before initialization emits the named `supervised-enum-worker.construction-context` refusal.
- The timeout/restart twin proves a restarted worker reinitializes before processing the next file.
- Mutation transaction: changing the production door back to `root=path.parent` makes the cwd/root twin fail, naming `pkg/sub` versus the authenticated `pkg`; reverting makes it green again.

Window 8865 retains ownership of `test_corpus_fatal_triage.py`; this PR does not edit that contested file.

## Validation

Runtime used for focused execution: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3.

- post-rebase `test_production_lift_child.py test_supervised_enum_supervisor.py`: `13 passed in 17.72s`, exit 0
- load-bearing root twin, clean: `1 passed`, exit 0
- root mutation (`root=path.parent`): exact twin failed, mutation harness exit 0
- restored root twin: `1 passed`, exit 0
- `construction_context_door_law.py --self-test`: PASS, exit 0
- exact CPython 3.12 `py_compile` over all changed Python modules: exit 0

No battleaxe corpus delta is claimed by this PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Freeze construction context before fatal triage lifts via a persistent supervised worker
> - The fatal triage parent mode now authenticates the corpus, fetches a shared demand table, and initializes a single persistent `SupervisedEnumSupervisor` worker with a frozen `construction_context` before running any lifts.
> - The worker (`_supervised_enum_worker.py`) stores the frozen `_CORPUS_ROOT` and `_CONSTRUCTION_CONTEXT` as module globals after an explicit `initialize` handshake, and rejects lift requests with a `lift-refusal` response until initialized.
> - `provisional_contract_refs_from_demand_rows` is added to `lift_rpc.py` so contract refs can be derived from already-loaded demand rows without filesystem access.
> - The child mode (`_run_child`) no longer performs lifting; it always returns a deterministic `typed-gap` refusal indicating the caller should use the parent protocol.
> - Behavioral Change: `run_production_lift_child` and `production_lift_testimony` now require explicit `corpus_root` and `construction_context` keyword arguments; callers omitting them will get a missing-argument error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7e61e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->