### PR TITLE
Construct bare-name option_context managers through reaching bindings

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -189,6 +189,11 @@ class TreeConstructionContextV1:
     # construction consumes the testimony only when execution reaches the call.
     opaque_source_call_obligations: dict = field(default_factory=dict)
     source_derived_contract_refs: dict = field(default_factory=dict)
+    # Reaching provider Calls for bare-Name manager uses, keyed by the immutable
+    # manager-use coordinate.  Binding coordinates own identity: the Name at the
+    # With head is not the provider; this table seats the authenticated Call
+    # that the Name reaches so With construction never re-resolves by spelling.
+    source_manager_provider_calls: dict = field(default_factory=dict)
     # Runtime-only, prebound class-base Sugar children keyed by the exact
     # subclass definition coordinate.  These are never serialized; the class
     # definition projects their sealed CIDs into its own preimage.

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -203,9 +203,7 @@ def _derive_effect_boundary(exit_set, protocol, behavior):
             and isinstance(face.value.statements[-1].value, PredicateValue)
         ):
             predicates.append(face.value.statements[-1].value.formula)
-    if predicates and all(
-        predicate == predicates[0] for predicate in predicates[1:]
-    ):
+    if predicates and all(predicate == predicates[0] for predicate in predicates[1:]):
         formula = predicates[0]
     else:
         formula = _guarded_literal_suppression_formula(exit_set)
@@ -338,9 +336,7 @@ def _guarded_literal_suppression_formula(exit_set):
                 if literal is None:
                     return None
                 if literal:
-                    resolved = _resolve_branch_result_guards(
-                        face.guard, authenticated
-                    )
+                    resolved = _resolve_branch_result_guards(face.guard, authenticated)
                     if resolved is None:
                         return None
                     saw_true = True
@@ -674,6 +670,12 @@ def populate_source_derived_resource_refs(
             frame, _ = frame_result
             if frame.generator_steps is not None:
                 _install_source_call_frame(context, call, frame)
+                # Seat the provider Call at the manager-use coordinate so a
+                # bare-Name With head resolves through its reaching binding
+                # rather than by spelling.  Direct Call heads already key the
+                # frame by their own span; the use-site seat is what carries
+                # assigned multi-manager projection.
+                context.source_manager_provider_calls[coordinate] = call
                 continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
         from sugar_lift_py_tests.temporal import builtin_name_temporal
@@ -807,9 +809,7 @@ def _projected_manager_call_uses(source_file):
                 if not projected_names and hasattr(item, "manager_use_site_start_line"):
                     continue
                 span = expr.line_col_span()
-                start_line, start_col, end_line, end_col = (
-                    item._manager_use_site_span()
-                )
+                start_line, start_col, end_line, end_col = item._manager_use_site_span()
                 if projected_names and (
                     start_line,
                     start_col,

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -7,6 +7,7 @@ import pytest
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     _projected_manager_call_uses,
@@ -30,7 +31,9 @@ def _pandas_root() -> Path:
         PANDAS_MANIFEST_CID,
         1421,
     )
-    return corpus.root
+    # Construction loci use the distribution-recorded seat (site-packages).
+    # Corpus identity is over the package root; import binding seats one level up.
+    return corpus.root.parent
 
 
 def _real_tree():
@@ -52,6 +55,12 @@ def _line_32_with(tree):
         for node in tree.nodes()
         if node.kind == "With" and node.line_col_span().start_line == 32
     )
+
+
+def _nested_manager_sugars(site):
+    """Both managers of a multi-item With, outer then inner, after nesting."""
+    nested = site._nest_items()
+    return nested.sugar(), nested.body[0].sugar()
 
 
 def test_local_two_name_managers_project_both_reaching_calls(tmp_path: Path) -> None:
@@ -112,18 +121,43 @@ def test_projection_is_a_transaction_and_does_not_mutate_the_source_tree() -> No
     assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
 
 
-def test_pandas_303_assigned_manager_keeps_provider_refusal_loud() -> None:
-    """Projection reaches the provider but never invents a resource value."""
-    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+def test_pandas_303_both_option_context_managers_construct_through_bindings() -> None:
+    """Name → binding coordinate → provider Call → generator protocol edges.
 
+    Before: populate raised SourceCallBindingGap("unconsumed call actual") while
+    resolving OptionError constructors inside the provider module, so neither
+    manager seated a frame.  After: both bare-Name heads construct as
+    GeneratorWithSugar through their reaching option_context providers.
+    """
     tree = _real_tree()
     root = _pandas_root()
-    with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
-        populate_source_derived_resource_refs(
-            tree,
-            root=root,
-            path=root / "pandas/tests/io/formats/test_ipython_compat.py",
+    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
+    site = _line_32_with(tree)
+    context = tree.root.unit.construction_context
+
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+
+    seats = sorted(
+        (coordinate.start_line, coordinate.start_col)
+        for coordinate in context.source_manager_provider_calls
+        if coordinate.start_line == 32
+    )
+    assert seats == [(32, 13), (32, 18)]
+    frames = sorted(
+        (
+            coordinate.start_line,
+            coordinate.start_col,
+            frame.generator_steps is not None,
         )
+        for coordinate, frame in context.source_call_frames.items()
+        if coordinate.start_line in {21, 30}
+    )
+    assert frames == [(21, 14, True), (30, 21, True)]
+
+    outer, inner = _nested_manager_sugars(site)
+    assert isinstance(outer, GeneratorWithSugar)
+    assert isinstance(inner, GeneratorWithSugar)
+    assert isinstance(site.sugar(), GeneratorWithSugar)
 
 
 def test_undecided_rebinding_does_not_invent_a_second_manager_call(
@@ -154,3 +188,141 @@ def test_undecided_rebinding_does_not_invent_a_second_manager_call(
         if coordinate.start_line == 5
     ]
     assert rows == [(5, 9, 2)]
+
+
+def test_same_spelled_names_bound_elsewhere_do_not_authenticate(tmp_path: Path) -> None:
+    """Lying twin: names cannot authorize managers independently of bindings."""
+    source = tmp_path / "lying.py"
+    source.write_text(
+        "def exercise(opt_value, latex_value):\n"
+        "    opt = opt_value\n"
+        "    with_latex = latex_value\n"
+        "    with opt, with_latex:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+    site = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 4
+    )
+    context = tree.root.unit.construction_context
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=source)
+
+    assert context.source_manager_provider_calls == {}
+    assert _projected_manager_call_uses(tree) == {}
+    # No reaching provider Call: construction stays loud at the use coordinate.
+    with pytest.raises(Exception) as caught:
+        site.sugar()
+    assert "no context-manager derivation" in str(caught.value)
+
+
+def test_bare_name_construction_path_contains_no_vendor_name_literals() -> None:
+    """The structural constructor cannot admit this site by manager spelling."""
+    import ast
+    import inspect
+    import textwrap
+
+    import sugar_lift_python_source.manager_summary_derivation as derivation
+
+    module = ast.parse(textwrap.dedent(inspect.getsource(derivation)))
+    literals = {
+        node.value
+        for node in ast.walk(module)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert literals.isdisjoint(
+        {
+            "opt",
+            "with_latex",
+            "option_context",
+            "pytest.raises",
+            "external_error_raised",
+        }
+    )
+
+
+def test_exception_subclass_without_init_accepts_message_args(tmp_path: Path) -> None:
+    """Inherited BaseException constructor law — not an empty zero-formal lie."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
+    from sugar_source_tree.tree import SourceFile
+
+    source = (
+        "class RenamedFault(AttributeError, KeyError):\n"
+        "    pass\n"
+        "def exercise():\n"
+        '    raise RenamedFault("needle")\n'
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, str(tmp_path / "fault.py"), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    class_node = next(node for node in tree.nodes() if isinstance(node, ClassDef))
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    frame = class_node.source_visible_constructor_frame()
+    assert frame.parameters == ("args",)
+    assert frame.parameter_kinds == ("vararg",)
+    span = call.line_col_span()
+    context.source_call_frames[
+        SourceFragmentCoordinateV1(
+            tree.root.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+    ] = frame
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    # Must not raise SourceCallBindingGap("unconsumed call actual").
+    function.source_visible_call_frame()
+
+
+def test_non_exception_class_without_init_still_refuses_extra_actuals(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: object construction does not inherit exception *args."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+    from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
+    from sugar_source_tree.tree import SourceFile
+
+    source = (
+        "class RenamedPlain:\n"
+        "    pass\n"
+        "def exercise():\n"
+        "    return RenamedPlain(1)\n"
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, str(tmp_path / "plain.py"), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    class_node = next(node for node in tree.nodes() if isinstance(node, ClassDef))
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    frame = class_node.source_visible_constructor_frame()
+    assert frame.parameters == ()
+    span = call.line_col_span()
+    context.source_call_frames[
+        SourceFragmentCoordinateV1(
+            tree.root.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+    ] = frame
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
+        function.source_visible_call_frame()

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2831,12 +2831,7 @@ class ClassDef(Statement):
             ),
             None,
         )
-        params = () if initializer is None else initializer.params[1:]
         owner_cid = self.fragment.seal().cid
-        coordinates = tuple(
-            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
-            for index, param in enumerate(params)
-        )
         span = self.line_col_span()
         site = SourceFragmentCoordinateV1(
             self.unit.source_cid,
@@ -2844,6 +2839,37 @@ class ClassDef(Statement):
             span.start_col,
             span.end_line,
             span.end_col,
+        )
+        # A source class without ``__init__`` that is an exception type inherits
+        # BaseException's constructor law: ``(*args)``.  Ordinary new-style
+        # classes inherit ``object.__init__`` (zero formals).  Installing the
+        # empty frame at ``raise OptionError(msg)`` was minting
+        # SourceCallBindingGap("unconsumed call actual") for every argumented
+        # exception construction during module-wide frame resolution — and that
+        # silence blocked authenticated generator managers whose helpers only
+        # *mention* those raises.
+        if initializer is None and self._inherits_default_exception_constructor():
+            args_coordinate = BindingCoordinateV1.mint(
+                owner_cid, self.fragment, ("inherited-exception-args", 0)
+            )
+            return SourceVisibleCallFrameV1(
+                source_identity_cid=self.unit.source_cid,
+                definition_site=site,
+                definition_fragment_cid=owner_cid,
+                parameters=("args",),
+                formal_coordinates=(args_coordinate,),
+                parameter_kinds=("vararg",),
+                default_sugars=(None,),
+                default_nodes=(None,),
+                default_fragments=(None,),
+                default_fragment_cids=(None,),
+                body=self._source_visible_body({}),
+                owner=self,
+            )
+        params = () if initializer is None else initializer.params[1:]
+        coordinates = tuple(
+            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
+            for index, param in enumerate(params)
         )
         formal_scope = {
             param.name: self._make_constructor_coordinate_ref(param, coordinate)
@@ -2872,6 +2898,47 @@ class ClassDef(Statement):
             body=self._source_visible_body(formal_scope),
             owner=self,
         )
+
+    def _inherits_default_exception_constructor(self) -> bool:
+        """Whether this class inherits BaseException's ``(*args)`` constructor.
+
+        Identity is the authenticated base graph, never the class spelling.
+        A non-exception class without ``__init__`` still takes zero arguments
+        (object construction); only exception ancestry opens ``*args``.
+        """
+        from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+            BUILTIN_EXCEPTION_NAMES,
+        )
+
+        module = self.unit._require_typed_module(
+            "ClassDef._inherits_default_exception_constructor",
+            blame=self.fragment,
+        )
+        visiting: set[str] = set()
+
+        def base_is_exception(base) -> bool:
+            if not isinstance(base, Name):
+                return False
+            if base.id in BUILTIN_EXCEPTION_NAMES:
+                return True
+            if base.id in visiting:
+                return False
+            # Walk the same lexical ClassDef graph SourceUnit.exception_type_mro
+            # authenticates: one unique same-module definition, no guessed imports.
+            definitions = [
+                item
+                for item in module.body
+                if isinstance(item, ClassDef) and item.name == base.id
+            ]
+            if len(definitions) != 1:
+                return False
+            visiting.add(base.id)
+            try:
+                return any(base_is_exception(item) for item in definitions[0].bases)
+            finally:
+                visiting.remove(base.id)
+
+        return any(base_is_exception(base) for base in self.bases)
 
     def _make_constructor_coordinate_ref(self, param: "Param", coordinate) -> "Node":
         from .backend import Leaf, materialize
@@ -4775,8 +4842,38 @@ class With(Statement):
         self.reporter.report_gap(self, panic)
         raise panic
 
+    def _provider_manager_call(self, item: WithItem):
+        """The Call that authenticates this manager item, by binding not spelling.
+
+        A direct Call head is already the provider.  A bare Name head reaches
+        its provider only through the seat populate installed at the immutable
+        manager-use coordinate when projecting ordinary assignment testimony.
+        Same spelling elsewhere never authorizes a manager.
+        """
+        if isinstance(item.context_expr, Call):
+            return item.context_expr
+        context = self.unit.construction_context
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+
+        if not isinstance(context, TreeConstructionContextV1):
+            return None
+        start_line, start_col, end_line, end_col = item._manager_use_site_span()
+        coordinate = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        )
+        call = context.source_manager_provider_calls.get(coordinate)
+        return call if isinstance(call, Call) else None
+
     def _generator_manager_frame(self, item: WithItem):
-        if not isinstance(item.context_expr, Call):
+        call = self._provider_manager_call(item)
+        if call is None:
             return None
         context = self.unit.construction_context
         from sugar_lift_py_tests.context_manager_resolution import (
@@ -4786,7 +4883,7 @@ class With(Statement):
 
         if not isinstance(context, TreeConstructionContextV1):
             return None
-        span = item.context_expr.line_col_span()
+        span = call.line_col_span()
         coordinate = SourceFragmentCoordinateV1(
             self.unit.source_cid,
             span.start_line,
@@ -4802,7 +4899,12 @@ class With(Statement):
     def _generator_manager_sugar(self, item: WithItem):
         if self._generator_manager_frame(item) is None:
             return None
-        return item.context_expr.sugar()
+        call = self._provider_manager_call(item)
+        if call is None:
+            return None
+        # Always sugar the provider Call (with its installed frame), never the
+        # bare Name spelling at the With head.
+        return call.sugar()
 
     def _require_narrow_cm_ref(self, item: WithItem):
         resolution = self._prebound_manager_resolution(item)


### PR DESCRIPTION
## What changed

- carry authenticated construction through bare-Name multi-manager With heads via **binding coordinates**, not spelling
- seat each projected provider Call at the immutable manager-use coordinate (`source_manager_provider_calls`)
- resolve With generator protocol edges from that provider Call (`_provider_manager_call` → frame → `GeneratorWithSugar`)
- project BaseException's `(*args)` constructor onto exception subclasses that define no `__init__` (unblocks `OptionError("msg")` during provider-module frame resolution)
- pin pandas 3.0.3 `tests/io/formats/test_ipython_compat.py:32` both managers, plus lying twins

## Why (vs #6547)

#6547 was classification-only: it reported two independent `SourceCallBindingGap` refusals and explicitly declined provider construction. Same spelling is irrelevant — **binding coordinates own identity**. This PR implements the construction path #6547 deferred.

## Mechanism

```
Name (With head)
  → manager-use coordinate (immutable)
  → source_manager_provider_calls[use]  # seated by populate from reaching Assign
  → provider Call (option_context(...))
  → source_call_frames[call]            # generator frame from authenticated definition
  → GeneratorWithSugar enter/exit edges
```

Provider-module resolution previously crashed when sugaring helpers that `raise OptionError(msg)`: `OptionError` has no `__init__`, so its constructor frame had zero formals and `bind_node_actuals` raised `SourceCallBindingGap("unconsumed call actual")`. Exception subclasses without `__init__` now inherit BaseException's `*args` law. Ordinary non-exception classes still refuse extra actuals (lying twin).

## Verified corpus site

Pinned pandas 3.0.3 / manifest `blake3-512:6f317a5a…` / file CID `blake3-512:60e7b5ba…`

`pandas/tests/io/formats/test_ipython_compat.py:32` is `with opt, with_latex:`

| manager | use coord | provider Call | binding |
|---|---|---|---|
| `opt` | 32:13 | line 21 `cf.option_context(...)` | Assign → Call |
| `with_latex` | 32:18 | line 30 `cf.option_context(...)` | Assign → Call |

## Before / after (both managers)

| | **before** | **after** |
|---|---|---|
| `populate_source_derived_resource_refs` | raises `SourceCallBindingGap: unconsumed call actual` at `pandas/_config/config.py:131` (`raise OptionError(...)`) while resolving provider frames | completes; seats both providers |
| manager at 32:13 (`opt`) | no frame, no protocol edge | `source_manager_provider_calls[(32,13)]` → Call@21; frame@21:14 with `generator_steps`; constructs as **`GeneratorWithSugar`** |
| manager at 32:18 (`with_latex`) | no frame, no protocol edge | `source_manager_provider_calls[(32,18)]` → Call@30; frame@30:21 with `generator_steps`; constructs as **`GeneratorWithSugar`** |
| multi-item `With` sugar | `WithConstructionGap` / loud refusal | nested outer+inner both `GeneratorWithSugar` |

Defining source is present in the authenticated corpus (`pandas/_config/config.py:option_context`). Construction succeeds; refusal would only be lawful if that source were absent.

## Twins

- **truthful**: local two-name managers project both reaching calls; pandas site constructs both
- **lying (undecided rebinding)**: rebinding the second name drops its projection
- **lying (same spelling, no call binding)**: `opt`/`with_latex` bound to formals never seat providers; With stays loud
- **lying (non-exception empty constructor)**: `class RenamedPlain: pass` still refuses `RenamedPlain(1)` with `unconsumed call actual`
- **zero vendor literals**: derivation module contains no `opt` / `with_latex` / `option_context` string constants

## Validation

Authenticated interpreter: CPython 3.12.13; NumPy 2.5.1; pandas 3.0.3.

```
PYTHONUNBUFFERED=1 .venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py -q
# 9 passed

.venv-py312/bin/python -m pytest \
  implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py -q
# 10 passed

black --check: clean on touched files
```

No assertion-With, ExitSet, outcome, or generator machine vocabulary change beyond seating the provider Call and inherited exception constructor arity.

## Assumption / ruling applied

Binding coordinates own identity. A bare Name at a With head never authenticates a manager by spelling; only a reaching projected Call with an authenticated source-visible frame does. Exception subclasses without `__init__` inherit BaseException constructor arity from their base graph, not from leaf-name coincidence.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve bare-name `With` heads to provider calls through construction context bindings
> - Adds `source_manager_provider_calls` to `TreeConstructionContextV1`, mapping use-site coordinates to authenticated provider `Call`s reached via bare-`Name` `With` heads.
> - During derivation in `populate_source_derived_resource_refs`, resolved provider calls with generator frames are stored in this table, keyed by manager-use coordinate.
> - `With._provider_manager_call` looks up the table so `_generator_manager_frame` and `_generator_manager_sugar` can operate on the provider `Call` rather than the bare `Name` spelling.
> - Adds `ClassDef._inherits_default_exception_constructor` and updates `source_visible_constructor_frame` to return a vararg frame for exception subclasses without `__init__`, preventing `SourceCallBindingGap` when raising with message arguments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdfe852.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->