### PR TITLE
Construct ground TypeError RaiseValue for source-decided no-call pairs

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -62,29 +62,76 @@ class ComplexValue(FloorValue):
     # any field member. See floor/complex_arithmetic.py for the one law; a
     # non-member right operand falls through to this floor's own loud gap.
 
+    def _decided_non_field_type_error(self, other, site, *, owner: str):
+        """Complex with a source-decided non-field peer is TypeError.
+
+        Undecided peers stay on the shared third-value law (``__r*__`` may
+        exist).  A numeric TermValue that fails to enter the field (overflow)
+        or a non-finite product remains a loud construction gap — those are
+        not TypeError identities.
+        """
+        if not (other.denotes_value() and other.runtime_type_is_decided()):
+            return None
+        from sugar_lift_py_tests.floor.complex_arithmetic import (
+            complex_field_coordinate,
+        )
+        from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if complex_field_coordinate(other) is not None:
+            return None
+        # Field members that refused entry (overflow) stay loud, not TypeError.
+        if type(other) is TermValue and type(other.value) in (int, float, bool):
+            return None
+        if type(other) in (TrueBoolLiteralSugar, FalseBoolLiteralSugar, type(self)):
+            return None
+        from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+        return ground_type_error(site=site, owner=owner)
+
     def add(self, other, site):
         from sugar_lift_py_tests.floor.complex_arithmetic import complex_add
 
         folded = complex_add(self, other, site)
-        if folded is None:
-            return super().add(other, site)
-        return folded
+        if folded is not None:
+            return folded
+        constructed = self._decided_non_field_type_error(
+            other, site, owner="ComplexValue.add"
+        )
+        if constructed is not None:
+            return constructed
+        return super().add(other, site)
 
     def subtract(self, other, site):
         from sugar_lift_py_tests.floor.complex_arithmetic import complex_subtract
 
         folded = complex_subtract(self, other, site)
-        if folded is None:
-            return super().subtract(other, site)
-        return folded
+        if folded is not None:
+            return folded
+        constructed = self._decided_non_field_type_error(
+            other, site, owner="ComplexValue.subtract"
+        )
+        if constructed is not None:
+            return constructed
+        return super().subtract(other, site)
 
     def multiply(self, other, site):
         from sugar_lift_py_tests.floor.complex_arithmetic import complex_multiply
 
         folded = complex_multiply(self, other, site)
-        if folded is None:
-            return super().multiply(other, site)
-        return folded
+        if folded is not None:
+            return folded
+        constructed = self._decided_non_field_type_error(
+            other, site, owner="ComplexValue.multiply"
+        )
+        if constructed is not None:
+            return constructed
+        return super().multiply(other, site)
 
     def to_term(self, *, owner: str):
         del owner

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -80,3 +80,17 @@ def ground_exceptional_exit(*, exception_name: str, site, owner: str) -> Outcome
             exception=ExceptionValue(exception_name, (), site),
         )
     )
+
+
+def ground_type_error(*, site, owner: str) -> Outcome:
+    """Authenticated TypeError partition for a source-decided ground pair.
+
+    Ground cross-type operations that Python rejects (``1 < "a"``, ``None + 1``,
+    ``[] + 0``, ``~3.5`` for bitwise invert on float) are not RuntimeEffects:
+    both operand types are lift-time decided, so the exceptional face is a
+    completed RaiseValue.  Undecided native dispatch stays on the named-refusal
+    / construction-panic laws; this door is only for the decided TypeError.
+    """
+    return ground_exceptional_exit(
+        exception_name="TypeError", site=site, owner=owner
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -178,6 +178,12 @@ class ListValue(FloorValue):
 
         if type(other) in (CallSiteValue, ImportAliasValue, SymbolicValue):
             return SymbolicValue(self.to_term(owner=str(site))).add(other, site)
+        if other.denotes_value() and other.runtime_type_is_decided():
+            # ``list + <decided non-list>`` is Python's TypeError.  Undecided
+            # rights stay on the shared third-value law via super().
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="ListValue.add")
         return super().add(other, site)
 
     def multiply(self, other, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from sugar_lift_py_tests.effect import runtime_effect_evidence
 
 from .floor_value import FloorValue
 
@@ -51,8 +50,8 @@ class NoneValue(FloorValue):
         )
 
     def less_than(self, other, site):
-        # None orders against nothing: any ground comparison is TypeError -- a
-        # recognized runtime halt. Symbolic falls to super() emit.
+        # None orders against nothing: any ground comparison is authenticated
+        # TypeError. Symbolic falls to super() emit.
         from sugar_lift_py_tests.floor.list_value import ListValue
         from sugar_lift_py_tests.floor.set_value import SetValue
         from sugar_lift_py_tests.floor.string_value import StringValue
@@ -67,16 +66,9 @@ class NoneValue(FloorValue):
             TupleValue,
             SetValue,
         ):
-            from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
-            from sugar_lift_py_tests.outcome import Incomplete
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
-            return Incomplete(
-                TypeErrorRuntimeEffect(
-                    f"unorderable types runtime boundary: "
-                    f"NoneValue and {type(other).__name__}; site={site}",
-                    **runtime_effect_evidence("py.lt", other, site),
-                )
-            )
+            return ground_type_error(site=site, owner="NoneValue.less_than")
         return super().less_than(other, site)
 
     def equals(self, other, site):
@@ -107,46 +99,59 @@ class NoneValue(FloorValue):
             return Complete(FalseBoolLiteralSugar(site=site))
         return super().equals(other, site)
 
-    def subtract(self, other, site):
-        # None - x is TypeError: the None-ness IS the type. Ground rights are
-        # lift-time decidable, so they cannot mint RuntimeEffect evidence as a
-        # bare constant; cite the data-model dunder call (call: is runtime by
-        # law) so the boundary is witnessed rather than a floor panic.
-        from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
-        from sugar_lift_py_tests.effect.runtime_effect import genuine_runtime_operand
-        from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.outcome import Incomplete
+    def _none_arithmetic_type_error(self, other, site, *, owner: str):
+        """``None <op> x`` is TypeError when the right type is source-decided.
 
-        try:
-            genuine_runtime_operand("py.subtract", other)
-            operand = other
-        except TypeError:
-            operand = ctor(
-                "call:NoneType.__sub__",
-                [
-                    self.to_term(owner=str(site)),
-                    other.to_term(owner=str(site)),
-                ],
-            )
-        return Incomplete(
-            TypeErrorRuntimeEffect(
-                "unsupported operand type(s) for -: 'NoneType' and "
-                f"{type(other).__name__}; site={site}",
-                **runtime_effect_evidence("py.subtract", operand, site),
-            )
+        An undecided right may still implement ``__r*__``, so that pair stays
+        on the shared undecided-binary law rather than inventing an exit.
+        """
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner=owner)
+        return None
+
+    def add(self, other, site):
+        constructed = self._none_arithmetic_type_error(
+            other, site, owner="NoneValue.add"
         )
+        if constructed is not None:
+            return constructed
+        return super().add(other, site)
+
+    def subtract(self, other, site):
+        # None - x is TypeError when the right type is source-decided.  Undecided
+        # rights stay on the shared binary-operation third-value law.
+        constructed = self._none_arithmetic_type_error(
+            other, site, owner="NoneValue.subtract"
+        )
+        if constructed is not None:
+            return constructed
+        return super().subtract(other, site)
+
+    def multiply(self, other, site):
+        constructed = self._none_arithmetic_type_error(
+            other, site, owner="NoneValue.multiply"
+        )
+        if constructed is not None:
+            return constructed
+        return super().multiply(other, site)
+
+    def divide(self, other, site):
+        constructed = self._none_arithmetic_type_error(
+            other, site, owner="NoneValue.divide"
+        )
+        if constructed is not None:
+            return constructed
+        return super().divide(other, site)
 
     def floor_divide(self, other, site):
-        from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
-        from sugar_lift_py_tests.outcome import Incomplete
-
-        return Incomplete(
-            TypeErrorRuntimeEffect(
-                "unsupported floor division runtime boundary: NoneType // "
-                f"{type(other).__name__}; site={site}",
-                **runtime_effect_evidence("py.floor_divide", other, site),
-            )
+        constructed = self._none_arithmetic_type_error(
+            other, site, owner="NoneValue.floor_divide"
         )
+        if constructed is not None:
+            return constructed
+        return super().floor_divide(other, site)
 
     def is_identical(self, other, site):
         # None is a singleton: None is None folds True. Against anything else,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -90,11 +90,26 @@ class StringValue(GuardStableValue):
     # decides it, matching the 1==1 doctrine that equality is stated, not
     # pre-decided.
 
+    def _unorderable_ground_peer(self, other) -> bool:
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.floor.set_value import SetValue
+        from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+        return type(other) in (
+            TermValue,
+            NoneValue,
+            ListValue,
+            TupleValue,
+            SetValue,
+        )
+
     def less_than(self, other, site):
         # A string stands on the ordering floor: two strings order by Python's
         # lexicographic rule and fold to the True/False literal. Ground
-        # cross-type is TypeError -- a named runtime effect, not an emit.
-        # Symbolic falls to super() emit.
+        # cross-type is authenticated TypeError, not an emit. Symbolic falls
+        # to super() emit.
         if type(other) is StringValue:
             from sugar_lift_py_tests.outcome import Complete
             from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
@@ -109,26 +124,10 @@ class StringValue(GuardStableValue):
                 if self.value < other.value
                 else FalseBoolLiteralSugar(site=site)
             )
-        from sugar_lift_py_tests.floor.list_value import ListValue
-        from sugar_lift_py_tests.floor.none_value import NoneValue
-        from sugar_lift_py_tests.floor.set_value import SetValue
-        from sugar_lift_py_tests.floor.term_value import TermValue
-        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
-        if type(other) in (TermValue, NoneValue, ListValue, TupleValue, SetValue):
-            from sugar_lift_py_tests.effect import (
-                TypeErrorRuntimeEffect,
-                runtime_effect_evidence,
-            )
-            from sugar_lift_py_tests.outcome import Incomplete
-
-            return Incomplete(
-                TypeErrorRuntimeEffect(
-                    f"unorderable types runtime boundary: "
-                    f"StringValue and {type(other).__name__}; site={site}",
-                    **runtime_effect_evidence("py.less_than", other, site),
-                )
-            )
+            return ground_type_error(site=site, owner="StringValue.less_than")
         return super().less_than(other, site)
 
     def length(self, site):
@@ -330,15 +329,19 @@ class StringValue(GuardStableValue):
             )
         if type(other) in (CallSiteValue, ImportAliasValue, SymbolicValue):
             return SymbolicValue(self.to_term(owner=str(site))).add(other, site)
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.add")
         return super().add(other, site)
 
     def subtract(self, other, site):
-        """Dispatch subtraction only when the right operand is runtime-opaque.
+        """``str - x``: undecided rights stay third-valued; decided rights TypeError.
 
         A body-less call result has no lift-time value, so Python's
-        ``__sub__``/``__rsub__`` choice is genuinely runtime-dependent.  A
-        call with a body is decidable machinery work and ground strings are a
-        Python TypeError; both stay on the loud subtraction floor.
+        ``__sub__``/``__rsub__`` choice is genuinely runtime-dependent.  Two
+        source-decided ground types never select a string subtraction — that
+        is authenticated TypeError, not a coordinate and not a RuntimeEffect.
         """
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 
@@ -346,6 +349,10 @@ class StringValue(GuardStableValue):
             from sugar_lift_py_tests.effect import runtime_subtract
 
             return runtime_subtract(self, other, site)
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.subtract")
         return super().subtract(other, site)
 
     def multiply(self, other, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -79,11 +79,31 @@ class TermValue(FloorValue):
             return Complete(FalseBoolLiteralSugar(site=site))
         return super().is_identical(other, site)
 
+    def _unorderable_ground_peer(self, other) -> bool:
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.floor.set_value import SetValue
+        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+        return type(other) in (
+            StringValue,
+            NoneValue,
+            ListValue,
+            TupleValue,
+            SetValue,
+        )
+
+    def _ground_ordering_type_error(self, site, *, owner: str):
+        from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+        return ground_type_error(site=site, owner=owner)
+
     def less_than(self, other, site):
         # A number stands on the ordering floor: two numbers are ordered or not, and
         # it gives back the True or False literal -- the boolean IS the type.
-        # Ground cross-type is TypeError (Python defines no ordering) -- a named
-        # runtime effect, not an unconstrained py.lt emit. Symbolic falls to emit.
+        # Ground cross-type is authenticated TypeError (Python defines no
+        # ordering). Symbolic falls to emit.
         if type(other) is TermValue:
             from sugar_lift_py_tests.outcome import Complete
             from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
@@ -98,26 +118,9 @@ class TermValue(FloorValue):
                 if self.value < other.value
                 else FalseBoolLiteralSugar(site=site)
             )
-        from sugar_lift_py_tests.floor.list_value import ListValue
-        from sugar_lift_py_tests.floor.none_value import NoneValue
-        from sugar_lift_py_tests.floor.set_value import SetValue
-        from sugar_lift_py_tests.floor.string_value import StringValue
-        from sugar_lift_py_tests.floor.tuple_value import TupleValue
-        from sugar_lift_py_tests.floor.tuple_value import TupleValue
-
-        if type(other) in (StringValue, NoneValue, ListValue, TupleValue, SetValue):
-            from sugar_lift_py_tests.effect import (
-                TypeErrorRuntimeEffect,
-                runtime_effect_evidence,
-            )
-            from sugar_lift_py_tests.outcome import Incomplete
-
-            return Incomplete(
-                TypeErrorRuntimeEffect(
-                    f"unorderable types runtime boundary: "
-                    f"TermValue and {type(other).__name__}; site={site}",
-                    **runtime_effect_evidence("py.less_than", other, site),
-                )
+        if self._unorderable_ground_peer(other):
+            return self._ground_ordering_type_error(
+                site, owner="TermValue.less_than"
             )
         return super().less_than(other, site)
 
@@ -136,6 +139,10 @@ class TermValue(FloorValue):
                 if self.value <= other.value
                 else FalseBoolLiteralSugar(site=site)
             )
+        if self._unorderable_ground_peer(other):
+            return self._ground_ordering_type_error(
+                site, owner="TermValue.less_equal"
+            )
         return super().less_equal(other, site)
 
     def greater_than(self, other, site):
@@ -153,6 +160,10 @@ class TermValue(FloorValue):
                 if self.value > other.value
                 else FalseBoolLiteralSugar(site=site)
             )
+        if self._unorderable_ground_peer(other):
+            return self._ground_ordering_type_error(
+                site, owner="TermValue.greater_than"
+            )
         return super().greater_than(other, site)
 
     def greater_equal(self, other, site):
@@ -169,6 +180,10 @@ class TermValue(FloorValue):
                 TrueBoolLiteralSugar(site=site)
                 if self.value >= other.value
                 else FalseBoolLiteralSugar(site=site)
+            )
+        if self._unorderable_ground_peer(other):
+            return self._ground_ordering_type_error(
+                site, owner="TermValue.greater_equal"
             )
         return super().greater_equal(other, site)
 
@@ -406,7 +421,75 @@ class TermValue(FloorValue):
             )
         return super().floor_divide(other, site)
 
+    def _bitwise_int_pair(self, other):
+        """Python bitwise ops accept int/bool; float is decided TypeError."""
+        return type(other) is TermValue and all(
+            isinstance(value, int) for value in (self.value, other.value)
+        )
+
+    def _bitwise_float_type_error(self, other, site, *, owner: str):
+        if type(other) is TermValue and (
+            type(self.value) is float or type(other.value) is float
+        ):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner=owner)
+        return None
+
+    def bitwise_and(self, other, site):
+        float_error = self._bitwise_float_type_error(
+            other, site, owner="TermValue.bitwise_and"
+        )
+        if float_error is not None:
+            return float_error
+        if self._bitwise_int_pair(other):
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(TermValue(self.value & other.value))
+        return self._symbolic_or_bv32_bitwise(other, site, "&", "bv32.and")
+
+    def bitwise_xor(self, other, site):
+        float_error = self._bitwise_float_type_error(
+            other, site, owner="TermValue.bitwise_xor"
+        )
+        if float_error is not None:
+            return float_error
+        if self._bitwise_int_pair(other):
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(TermValue(self.value ^ other.value))
+        return self._symbolic_or_bv32_bitwise(other, site, "^", "bv32.xor")
+
+    def bitwise_or(self, other, site):
+        float_error = self._bitwise_float_type_error(
+            other, site, owner="TermValue.bitwise_or"
+        )
+        if float_error is not None:
+            return float_error
+        if self._bitwise_int_pair(other):
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(TermValue(self.value | other.value))
+        return self._symbolic_or_bv32_bitwise(other, site, "|", "bv32.or")
+
+    def left_shift(self, other, site):
+        float_error = self._bitwise_float_type_error(
+            other, site, owner="TermValue.left_shift"
+        )
+        if float_error is not None:
+            return float_error
+        if self._bitwise_int_pair(other):
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(TermValue(self.value << other.value))
+        return self._symbolic_or_bv32_bitwise(other, site, "<<", "bv32.shl")
+
     def right_shift(self, other, site):
+        float_error = self._bitwise_float_type_error(
+            other, site, owner="TermValue.right_shift"
+        )
+        if float_error is not None:
+            return float_error
         if (
             type(other) is TermValue
             and type(self.value) is int
@@ -416,42 +499,6 @@ class TermValue(FloorValue):
 
             return Complete(TermValue(self.value >> other.value))
         return self._symbolic_or_bv32_bitwise(other, site, ">>", "bv32.lshr")
-
-    def bitwise_and(self, other, site):
-        if type(other) is TermValue and all(
-            type(value) is int for value in (self.value, other.value)
-        ):
-            from sugar_lift_py_tests.outcome import Complete
-
-            return Complete(TermValue(self.value & other.value))
-        return self._symbolic_or_bv32_bitwise(other, site, "&", "bv32.and")
-
-    def bitwise_xor(self, other, site):
-        if type(other) is TermValue and all(
-            type(value) is int for value in (self.value, other.value)
-        ):
-            from sugar_lift_py_tests.outcome import Complete
-
-            return Complete(TermValue(self.value ^ other.value))
-        return self._symbolic_or_bv32_bitwise(other, site, "^", "bv32.xor")
-
-    def bitwise_or(self, other, site):
-        if type(other) is TermValue and all(
-            type(value) is int for value in (self.value, other.value)
-        ):
-            from sugar_lift_py_tests.outcome import Complete
-
-            return Complete(TermValue(self.value | other.value))
-        return self._symbolic_or_bv32_bitwise(other, site, "|", "bv32.or")
-
-    def left_shift(self, other, site):
-        if type(other) is TermValue and all(
-            type(value) is int for value in (self.value, other.value)
-        ):
-            from sugar_lift_py_tests.outcome import Complete
-
-            return Complete(TermValue(self.value << other.value))
-        return self._symbolic_or_bv32_bitwise(other, site, "<<", "bv32.shl")
 
     def _symbolic_or_bv32_bitwise(self, other, site, operator, bv32_operator):
         from sugar_lift_py_tests.floor.bv32_value import Bv32Value
@@ -512,22 +559,9 @@ class TermValue(FloorValue):
                 blame=str(site),
             )
         if type(other) is TermValue:
-            from sugar_lift_py_tests.effect import (
-                TypeErrorRuntimeEffect,
-                runtime_effect_evidence,
-            )
-            from sugar_lift_py_tests.outcome import Incomplete
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
-            left_ty = type(self.value).__name__
-            right_ty = type(other.value).__name__
-            return Incomplete(
-                TypeErrorRuntimeEffect(
-                    f"unsupported operand type(s) for @: "
-                    f"'{left_ty}' and '{right_ty}'; "
-                    f"owner=TermValue.matrix_multiply site={site}",
-                    **runtime_effect_evidence("py.matmul", other, site),
-                )
-            )
+            return ground_type_error(site=site, owner="TermValue.matrix_multiply")
         return super().matrix_multiply(other, site)
 
     def unary_minus(self, site):

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -317,6 +317,45 @@ def test_pandas_series_string_ordering_stays_source_undecided() -> None:
     )
 
 
+def test_source_decided_number_string_ordering_emits_type_error() -> None:
+    """Truthful twin of the enrolled ``obj < "a"`` site with decided types.
+
+    When both operands are source-visible ground values Python refuses to
+    order, Compare constructs an authenticated TypeError RaiseValue — not
+    ``py.lt`` and not a RuntimeEffect.  The enrolled pandas site still
+    refuses because ``obj`` is undecided; this twin isolates the floor law
+    on a workspace-relative locus the ground exit can cite.
+    """
+    from sugar_lift_py_tests.floor import RaiseValue, StringValue
+
+    path = _corpus_root() / "tests/arithmetic/test_numeric.py"
+    source = path.read_text(encoding="utf-8")
+    assert source.count('obj < "a"') == 1
+    _compare_at(path, source, line=146)
+
+    twin = 'def f():\n    return 1.0 < "a"\n'
+    tree = SourceFile(
+        (twin, "number-lt-string-twin.py", blake3_512_of(twin.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(
+        n
+        for n in tree.nodes()
+        if isinstance(n, Compare) and n.line_col_span().start_line == 2
+    )
+    outcome = ComparisonOpSugar(
+        "Lt",
+        _ValueSugar(TermValue(1.0)),
+        _ValueSugar(StringValue("a")),
+        node.fragment,
+    ).desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.blame is not None
+
+
 @pytest.mark.parametrize(
     ("line", "op", "observed"),
     (

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
@@ -126,6 +126,14 @@ def test_two_floats_still_fold_on_the_number_floor() -> None:
     assert outcome.value.value == 4.0
 
 
+class _FragmentSite:
+    filename = "complex-non-field-twin.py"
+    line = 1
+    col = 0
+    source = "1j + peer"
+    unit = type("_Unit", (), {"source": "1j + peer\n"})()
+
+
 @pytest.mark.parametrize(
     "off_field",
     (
@@ -136,16 +144,14 @@ def test_two_floats_still_fold_on_the_number_floor() -> None:
         StringValue("1"),
     ),
 )
-def test_a_non_member_operand_keeps_the_complex_floor_loud(off_field) -> None:
-    """`panic = gap`: the field law admits members, and refuses to invent for
-    anything else -- including values Python itself would reject."""
-    with pytest.raises(ConstructionPanic) as raised:
-        ComplexValue(0.0, 1.0).add(off_field, SITE)
+def test_a_non_member_operand_is_authenticated_type_error(off_field) -> None:
+    """Decided non-field peers are TypeError RaiseValue, never a complex coordinate."""
+    from sugar_lift_py_tests.floor import RaiseValue
 
-    info = raised.value.info
-    assert info.owner == "add"
-    assert info.observed == "ComplexValue"
-    assert type(off_field).__name__ in info.fix
+    outcome = ComplexValue(0.0, 1.0).add(off_field, _FragmentSite())
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
 
 
 def test_an_integer_too_large_for_the_float_field_stays_loud() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -183,3 +183,110 @@ def test_pandas_series_bitand_mixed_rights_stay_named_refusals(
         observed=observed,
         requested_contains="authenticated exceptional exit",
     )
+
+
+def test_source_decided_int_float_bitand_emits_type_error() -> None:
+    """Truthful twin of ``s_0123 & 3.14`` with both types source-decided.
+
+    Enrolled site: ``pandas/tests/series/test_logical_ops.py:98``.  With an
+    undecided Series left the producer refuses; with two TermValues the
+    bitwise floor constructs authenticated TypeError RaiseValue.  The twin is
+    built on a workspace-relative locus so the ground exit can cite source.
+    """
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.floor import RaiseValue, TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import BinOp
+    from sugar_source_tree.tree import SourceFile
+
+    # Pin the enrolled shape, then desugar a relative-locus twin with decided types.
+    path = _corpus_file()
+    source = path.read_text(encoding="utf-8")
+    assert source.count("s_0123 & 3.14") == 1
+    _binop_at(source, path, line=98, kind="BitAnd")
+
+    twin = "def f():\n    return 1 & 3.14\n"
+    tree = SourceFile(
+        (twin, "int-bitand-float-twin.py", blake3_512_of(twin.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(n for n in tree.nodes() if isinstance(n, BinOp))
+
+    @dataclass(frozen=True)
+    class _ValueSugar(Sugar):
+        value: object
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(self.value)
+
+    operation = type(node.sugar())(
+        "BitAnd",
+        _ValueSugar(TermValue(1)),
+        _ValueSugar(TermValue(3.14)),
+        node.fragment,
+    )
+    outcome = operation.desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_source_decided_list_plus_int_emits_type_error() -> None:
+    """``list + int`` is source-decided TypeError — the ground field law.
+
+    Companion to enrolled mixed-right BitAnd sites: when the left is a
+    constructed ListValue and the right a TermValue, BinOp publishes
+    RaiseValue rather than panicking or inventing a concat coordinate.
+    """
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.tree import SourceFile
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_source_tree.nodes import BinOp
+
+    source = "def f():\n    return [1] + 0\n"
+    tree = SourceFile(
+        (source, "list-plus-int.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(n for n in tree.nodes() if isinstance(n, BinOp))
+
+    @dataclass(frozen=True)
+    class _ValueSugar(Sugar):
+        value: object
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(self.value)
+
+    operation = type(node.sugar())(
+        "Add",
+        _ValueSugar(ListValue((TermValue(1),))),
+        _ValueSugar(TermValue(0)),
+        node.fragment,
+    )
+    outcome = operation.desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -235,19 +235,41 @@ def test_the_whole_function_refuses_undecided_native_dispatch(
 # -- discriminating arm: the law refuses, loudly, everywhere else -------------
 
 
+class _FragmentSite:
+    """Workspace-relative locus so ground TypeError can mint RaiseValue."""
+
+    filename = "ground-binop-twin.py"
+    line = 1
+    col = 0
+    source = "left + right"
+    unit = type("_Unit", (), {"source": "left + right\n"})()
+
+
+def _assert_ground_type_error(outcome) -> None:
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
 @pytest.mark.parametrize(
     ("left", "right", "method"),
     (
         # Two DECIDED types are a ground question, not an unknown:
-        # `list + bool` is Python's TypeError. Constructing a coordinate here
-        # would launder a ground exit into a value.
+        # `list + predicate` is Python's TypeError — authenticated RaiseValue.
         (ListValue((TermValue(1),)), _predicate(), "add"),
+        # Predicate does not own addition; still loud construction (not TypeError).
         (_predicate(), TermValue(1), "add"),
         (_predicate(), StringValue("x"), "add"),
         (_comprehension(), SetValue((TermValue(1),)), "subtract"),
     ),
 )
-def test_two_decided_operands_stay_loud(left, right, method) -> None:
+def test_two_decided_operands_do_not_invent_coordinates(left, right, method) -> None:
+    if type(left) is ListValue and method == "add":
+        _assert_ground_type_error(getattr(left, method)(right, _FragmentSite()))
+        return
     with pytest.raises(ConstructionPanic) as raised:
         getattr(left, method)(right, SITE)
 
@@ -339,16 +361,19 @@ def test_a_non_denoting_operand_stays_loud() -> None:
         (StringValue("x"), ComplexValue(0.0, 1.0)),
     ),
 )
-def test_a_ground_type_error_never_becomes_a_coordinate(left, right) -> None:
-    """``1j + "x"`` is Python's ``TypeError``.
+def test_a_ground_type_error_is_an_authenticated_raise(left, right) -> None:
+    """``1j + "x"`` is Python's ``TypeError`` as RaiseValue, never a coordinate.
 
     Both operands have decided runtime types, so the operation is not unknown
-    -- it is known to raise. A coordinate here would invent an operation that
-    never happens, which is the one way this law could launder a ground exit
-    into a value. It stays LOUD in both operand orders.
+    -- it is known to raise. A coordinate would invent an operation that never
+    happens; a RuntimeEffect would invent runtime dependence that is not there.
     """
-    with pytest.raises(ConstructionPanic):
-        left.add(right, SITE)
+    if type(left) is ComplexValue:
+        _assert_ground_type_error(left.add(right, _FragmentSite()))
+        return
+    # String + complex: StringValue.add routes undecided/symbolic peers; a
+    # decided ComplexValue right is TypeError on the string addition floor.
+    _assert_ground_type_error(left.add(right, _FragmentSite()))
 
 
 def test_the_field_law_is_consulted_before_the_base_law() -> None:
@@ -393,10 +418,12 @@ def test_the_field_law_is_consulted_before_the_base_law() -> None:
 
 
 def test_the_law_never_converts_a_panic_into_a_refusal() -> None:
-    """The loud arm is still a ConstructionPanic -- never an Incomplete, never
-    a refusal value that a caller could mistake for an answer."""
+    """A non-denoting right still panics; a decided list+peer is RaiseValue."""
     with pytest.raises(ConstructionPanic):
-        ListValue((TermValue(1),)).add(_predicate(), SITE)
+        BytesValue(b"x").add(_predicate(), SITE)
+    _assert_ground_type_error(
+        ListValue((TermValue(1),)).add(_predicate(), _FragmentSite())
+    )
 
 
 # -- the testimony is the value's own, never a lexical name ------------------


### PR DESCRIPTION
## Summary

Vertical slice for Owner 4 no-call expression effects: when operand types are **source-decided**, construct authenticated `RaiseValue`/`TypeError` partitions instead of panicking or minting `TypeErrorRuntimeEffect` (ground operands cannot carry RuntimeEffect authority).

Undecided native dispatch stays named-loud (SymbolicValue Series left, etc.).

### Floor mechanisms

| Family | Decided pair → auth exit |
|--------|--------------------------|
| **Compare** | `TermValue`/`StringValue`/`NoneValue` ordering vs unorderable ground peers |
| **BinOp** | `ListValue + decided non-list`, `StringValue ± decided non-string`, float bitwise, `number @ number`, `None` arithmetic, `ComplexValue` + non-field |
| **Unary** (pre-existing) | float `~` already RaiseValue; unchanged |

Shared door: `ground_type_error()` → `Complete(RaiseValue(TypeError))`.

### Enrolled pandas sites (twins gain auth exits)

| Site | Undecided bare desugar | Source-decided twin |
|------|------------------------|---------------------|
| `tests/arithmetic/test_numeric.py:146` `obj < "a"` | still refuse (Symbolic left) | `1.0 < "a"` → TypeError RaiseValue |
| `tests/series/test_logical_ops.py:98` `s_0123 & 3.14` | still refuse | `1 & 3.14` → TypeError RaiseValue |
| `list + int` (list concat field law) | n/a | `[1] + 0` → TypeError RaiseValue |

## Validation

```
pytest test_undecided_binary_operand_law.py \
       test_pandas_binary_operation_exception_floor.py \
       test_compare_exceptional_exit_producer.py \
       test_complex_field_arithmetic_floor.py \
       test_unary_boolop_exception_producers.py
# 151 passed
```

No attribution/report/denominator changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return ground TypeError RaiseValue for decided no-call pairs in arithmetic and comparison operations
> - Replaces `Incomplete` `TypeErrorRuntimeEffect` emissions with authenticated ground `TypeError` `RaiseValue` exits for decided operand pairs that cannot legally combine (e.g. `None + int`, `str < list`, `int & float`, `complex + str`).
> - Adds a `ground_type_error` helper in [`ground_exit.py`](https://github.com/TSavo/sugar/pull/6558/files#diff-a7f3cb4fd67eabedbf1a0720f9bcc32bcf2bc01ec14036c4dd92a52e68dd6bd9) that constructs the authenticated exit by delegating to `ground_exceptional_exit` with `exception_name='TypeError'`.
> - Each floor value type (`TermValue`, `NoneValue`, `StringValue`, `ListValue`, `ComplexValue`) gains one or more helper methods (e.g. `_decided_non_field_type_error`, `_none_arithmetic_type_error`, `_unorderable_ground_peer`) to detect decided non-compatible operands and return the ground exit before falling back to the base law.
> - Behavioral Change: operations on decided incompatible pairs that previously fell through to the base floor or emitted an `Incomplete` effect now return a `Complete` `RaiseValue`, changing downstream outcome classification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d47351b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->