### PR TITLE
Refuse undecided Symbolic==Symbolic equality invents

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -45,7 +45,7 @@ _OPERATOR_COORDINATE = {
 
 
 def refuse_undecided_comparison(left, right, site, op_kind: str) -> None:
-    """Keep undecided native comparison/containment dispatch at the producer.
+    """Keep undecided native comparison/containment/equality dispatch loud.
 
     Ordering and membership are not total over undecided runtime types:
     Python may select a rich method that completes or raises (``Series`` vs
@@ -53,11 +53,15 @@ def refuse_undecided_comparison(left, right, site, op_kind: str) -> None:
     ``__contains__``). Emitting ``py.lt`` / ``py.in`` invents completion;
     inventing ``TypeError`` invents an exception identity. Both stay refused
     until native operand types are source-authenticated — the same producer
-    law BinOp/BoolOp already own.
+    law BinOp already owns.
 
-    Equality is different: ``==`` / ``!=`` remain total solver coordinates for
-    symbolic and ground pairs (``py.eq``), so equality only refuses an
-    unexecuted call result whose ``__eq__`` body is itself undecided.
+    Equality keeps a narrower carve-out: ``==`` / ``!=`` remain total solver
+    ``py.eq`` coordinates when at least one operand's runtime type is decided
+    (symbolic/ground and ground/ground pairs). They refuse when **both**
+    operand types are undecided — misaligned Index/Series/DataFrame/Categorical
+    equality raises at runtime, and inventing ``py.eq`` under ``pytest.raises``
+    is the residual silent Complete. Unexecuted ``CallSiteValue`` equality also
+    stays refused: the call result's ``__eq__`` body is itself a third value.
     """
     denotes_left = getattr(left, "denotes_value", None)
     denotes_right = getattr(right, "denotes_value", None)
@@ -66,16 +70,23 @@ def refuse_undecided_comparison(left, right, site, op_kind: str) -> None:
     if not (denotes_left() and denotes_right()):
         return
 
+    decided_left = getattr(left, "runtime_type_is_decided", None)
+    decided_right = getattr(right, "runtime_type_is_decided", None)
+    if not callable(decided_left) or not callable(decided_right):
+        return
+
     if op_kind in {"Eq", "NotEq"}:
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 
-        if not isinstance(left, CallSiteValue) and not isinstance(right, CallSiteValue):
+        # Solver-owned arm: at least one decided type, and neither side is an
+        # unexecuted call result whose __eq__ body is itself undecided.
+        if (
+            (decided_left() or decided_right())
+            and not isinstance(left, CallSiteValue)
+            and not isinstance(right, CallSiteValue)
+        ):
             return
     else:
-        decided_left = getattr(left, "runtime_type_is_decided", None)
-        decided_right = getattr(right, "runtime_type_is_decided", None)
-        if not callable(decided_left) or not callable(decided_right):
-            return
         if decided_left() and decided_right():
             return
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -44,6 +44,12 @@ COL_SOURCE_CID = (
 )
 NUMERIC_SITE_SHA256 = "ad382bdf9178c34fffa4762b4014a8ef64d02e548433adaa8aba414398d6e5d8"
 COMMON_SITE_SHA256 = "442441f4ea11ec95e361c54ddf5c599a49769928970af3daee3b9a482dce7754"
+CATEGORICAL_EQ_SITE_SHA256 = (
+    "b831a0a2339aaa702fc962a23f23b53e7f1eb08b45c6a93abddb42ee7e76690d"
+)
+MULTI_EQ_SITE_SHA256 = (
+    "45fafbc8cd4dcc9bfcabd8f807e44e15377d729cfd7cf517c2b7ff72560aa343"
+)
 
 
 @dataclass(frozen=True)
@@ -251,13 +257,47 @@ def test_undecided_symbolic_operands_refuse_invented_ordering(
     assert "TypeError" not in str(info)
 
 
-def test_symbolic_equality_remains_solver_owned() -> None:
-    """Equality stays a total ``py.eq`` coordinate for symbolic/ground pairs."""
+def test_undecided_symbolic_equality_refuses_invented_py_eq() -> None:
+    """``left == right`` cannot invent ``py.eq`` when both operand types are undecided.
+
+    Misaligned pandas Index/Series/DataFrame/Categorical equality raises
+    ValueError/TypeError at runtime. Emitting a total solver coordinate
+    invents completion under ``pytest.raises``; inventing the exception
+    invents an identity. Both stay refused until types are source-decided.
+    """
+    left = _ValueSugar(SymbolicValue(make_var("left")))
+    right = _ValueSugar(SymbolicValue(make_var("right")))
+    with pytest.raises(ConstructionPanic) as raised:
+        EqualityOpSugar(left, right, "compare-site").desugar(None)
+
+    info = raised.value.info
+    assert info.owner == "comparison_operation_exception_floor"
+    assert info.observed == "SymbolicValue == SymbolicValue"
+    assert "authenticated exceptional exit" in info.requested
+    assert "TypeError" not in str(info)
+    assert "ValueError" not in str(info)
+
+
+def test_symbolic_equality_with_ground_remains_solver_owned() -> None:
+    """Symbolic/ground equality stays a total ``py.eq`` coordinate."""
     from sugar_lift_py_tests.floor.predicate_value import PredicateValue
 
     outcome = EqualityOpSugar(
         _ValueSugar(SymbolicValue(make_var("left"))),
         _ValueSugar(TermValue(1)),
+        "compare-site",
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, PredicateValue)
+
+
+def test_ground_decided_equality_still_completes() -> None:
+    """Lying twin: two decided ground scalars are not an undecided third value."""
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+    outcome = EqualityOpSugar(
+        _ValueSugar(TermValue(1)),
+        _ValueSugar(TermValue(2)),
         "compare-site",
     ).desugar(None)
     assert isinstance(outcome, Complete)
@@ -291,6 +331,43 @@ def test_ground_decided_membership_still_completes() -> None:
     ).desugar(None)
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_pandas_categorical_equality_stays_source_undecided() -> None:
+    """``c1 == c2`` under TypeError: both Categorical types are source-undecided.
+
+    Site: ``pandas/tests/arrays/categorical/test_operators.py:335``. Emitting
+    ``py.eq`` invented the residual silent Complete; refuse without minting
+    TypeError.
+    """
+    path = _corpus_root() / "tests/arrays/categorical/test_operators.py"
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == CATEGORICAL_EQ_SITE_SHA256
+    assert source.count("c1 == c2") >= 1
+
+    from pandas import Categorical
+
+    c1 = Categorical(["a", "b"], categories=["a", "b"], ordered=False)
+    c2 = Categorical(["a", "c"], categories=["c", "a"], ordered=False)
+    with pytest.raises(TypeError, match="Categoricals can only be compared"):
+        c1 == c2  # noqa: B015
+
+    _assert_named_compare_panic(
+        _compare_at(path, source, line=335),
+        observed="SymbolicValue == SymbolicValue",
+    )
+
+
+def test_pandas_index_length_equality_stays_source_undecided() -> None:
+    """``index_a == index_b`` under ValueError: length mismatch is not ``py.eq``."""
+    path = _corpus_root() / "tests/indexes/multi/test_equivalence.py"
+    source = path.read_text(encoding="utf-8")
+    assert hashlib.sha256(source.encode()).hexdigest() == MULTI_EQ_SITE_SHA256
+
+    _assert_named_compare_panic(
+        _compare_at(path, source, line=43),
+        observed="SymbolicValue == SymbolicValue",
+    )
 
 
 def test_pandas_series_string_ordering_stays_source_undecided() -> None:


### PR DESCRIPTION
## What changed

- Extend Compare producer `refuse_undecided_comparison` so `==` / `!=` refuse when **both** operand runtime types are undecided (SymbolicValue == SymbolicValue).
- Keep solver-owned `py.eq` for symbolic/ground and ground/ground pairs; keep CallSiteValue equality refused.
- Do **not** invent TypeError/ValueError exception identities.
- Pin production sites (`c1 == c2`, `index_a == index_b`) and unit twins for the residual pattern.

## Why

PR #6540 / #6528 left **R_silent (equality invent) = 34**: enrolled no-call Compare bodies under `pytest.raises` completed as `Complete(PredicateValue(py.eq))` without an auth exit, named refusal, or construction panic. That is an AttributionInvariant discrepancy, not a finish.

These sites are misaligned Index/Series/DataFrame/Categorical equality that raises at runtime. Emitting total `py.eq` invents completion; inventing the exception invents an identity. Correct arm: named construction refusal at the producer (`comparison_operation_exception_floor`).

## Authenticated measurement (CPython 3.12.13, shared demand table)

| Axis | Before (#6540) | After this fix |
|---|---:|---:|
| enrolled | 1008 | 1008 |
| unaccounted | **34** | **0** |
| Compare enrolled | 181 | 181 |
| Compare three-outcome total | 147 | **181** |

Full instrument (this branch, authenticated pandas 3.0.3 / demand table `0ce7c645…`):

```
family=Subscript enrolled=392 … namedRefusal=390 constructionPanic=2
family=BinOp enrolled=367 … namedRefusal=27 constructionPanic=340
family=Compare enrolled=181 … namedRefusal=20 constructionPanic=161
family=Attribute enrolled=53 … namedRefusal=53 constructionPanic=0
family=UnaryOp enrolled=13 … namedRefusal=13 constructionPanic=0
family=BoolOp enrolled=2 … namedRefusal=2 constructionPanic=0
unaccounted=0
```

Exit remains red on construction panics (expected accounted arm; not remeasured into invent exits). Residual unaccounted count: **0**.

## Closed cases (34)

All former unaccounted Compare bodies, now `constructionPanic owner=comparison_operation_exception_floor`:

- `tests/arrays/categorical/test_operators.py:335,343` (`c1 == c2`)
- `tests/frame/test_arithmetic.py:1221,1227,1679,1682,1692,1704,1707`
- `tests/frame/test_nonunique_indexes.py:204`
- `tests/indexes/categorical/test_equals.py:39`
- `tests/indexes/datetimes/test_date_range.py:348,351`
- `tests/indexes/multi/test_equivalence.py:43,55,65,72,74,76,79,81`
- `tests/indexes/test_old_base.py:540,552,562,569,571,573,576,578`
- `tests/series/test_arithmetic.py:544,785,787,790,792`

(32× `Eq` Name/Name + 2× `NotEq` Name/Name)

## Validation

- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py -q -k 'not shared_table'` — 55 passed
- authenticated `no_call_body_attribution.py` (Compare-only + full 1008) — unaccounted 0
- black reformatted the two touched files

## Course correction note

Does **not** convert correct source-undecidable refusals into invent exits. Does **not** expand report schemas. "Measure/Keep loud" remains measurement; this closes the actual unaccounted completions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse equality invention when both operands have undecided runtime types
> - Updates `refuse_undecided_comparison` in [comparison_op_sugar.py](https://github.com/TSavo/sugar/pull/6559/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) so that `Eq`/`NotEq` between two `SymbolicValue` operands (both runtime-type-undecided) produces a `construction_panic_gap` instead of emitting a solver-owned `py.eq`.
> - Equality still completes normally when at least one operand's runtime type is decided and neither side is a `CallSiteValue`; `CallSiteValue` equality always refuses.
> - Adds tests covering: undecided symbolic vs. symbolic (panic), symbolic vs. ground (completes), ground vs. ground (completes), and pandas `Categorical`/`MultiIndex` equality sites that raise at runtime (panic).
> - Behavioral Change: `Symbolic == Symbolic` no longer produces a `py.eq` predicate — it now raises a `ConstructionPanic`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fa896f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->