### PR TITLE
Construct bare-name multi-manager With through reaching bindings

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -189,6 +189,11 @@ class TreeConstructionContextV1:
     # construction consumes the testimony only when execution reaches the call.
     opaque_source_call_obligations: dict = field(default_factory=dict)
     source_derived_contract_refs: dict = field(default_factory=dict)
+    # Reaching provider Calls for bare-Name manager uses, keyed by the immutable
+    # manager-use coordinate.  Binding coordinates own identity: the Name at the
+    # With head is not the provider; this table seats the authenticated Call
+    # that the Name reaches so With construction never re-resolves by spelling.
+    source_manager_provider_calls: dict = field(default_factory=dict)
     # Runtime-only, prebound class-base Sugar children keyed by the exact
     # subclass definition coordinate.  These are never serialized; the class
     # definition projects their sealed CIDs into its own preimage.

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -674,6 +674,12 @@ def populate_source_derived_resource_refs(
             frame, _ = frame_result
             if frame.generator_steps is not None:
                 _install_source_call_frame(context, call, frame)
+                # Seat the provider Call at the manager-use coordinate so a
+                # bare-Name With head resolves through its reaching binding
+                # rather than by spelling.  Direct Call heads already key the
+                # frame by their own span; the use-site seat is what carries
+                # assigned multi-manager projection.
+                context.source_manager_provider_calls[coordinate] = call
                 continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
         from sugar_lift_py_tests.temporal import builtin_name_temporal

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+import csv
+import importlib.metadata
 from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     _projected_manager_call_uses,
     populate_source_derived_resource_refs,
 )
+from sugar_source_tree.nodes import With
+from sugar_source_tree.tree import SourceFile
 
 PANDAS_SOURCE_CID = (
     "blake3-512:60e7b5ba2c971960e4d8edcaa85e916704dc8bfb977bc15dafb2f2b3e87458ff"
@@ -23,21 +29,28 @@ PANDAS_MANIFEST_CID = (
 )
 
 
-def _pandas_root() -> Path:
+def _pandas_construction_root() -> Path:
+    """Distribution seat is site-packages; corpus identity is the package root."""
     corpus = authenticated_pandas_corpus()
     assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
         "3.0.3",
         PANDAS_MANIFEST_CID,
         1421,
     )
-    return corpus.root
+    return corpus.root.parent
+
+
+def _pandas_consumer_path() -> Path:
+    corpus = authenticated_pandas_corpus()
+    path = corpus.root / "tests/io/formats/test_ipython_compat.py"
+    assert path.is_file()
+    assert blake3_512_of(path.read_bytes()) == PANDAS_SOURCE_CID
+    return path
 
 
 def _real_tree():
-    root = _pandas_root()
-    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
-    assert path.is_file()
-    assert blake3_512_of(path.read_bytes()) == PANDAS_SOURCE_CID
+    root = _pandas_construction_root()
+    path = _pandas_consumer_path()
     return open_source_file_for_construction(
         path,
         root=root,
@@ -52,6 +65,32 @@ def _line_32_with(tree):
         for node in tree.nodes()
         if node.kind == "With" and node.line_col_span().start_line == 32
     )
+
+
+def _generator_distribution(root: Path, source: str, *, exported: str = "acquire"):
+    package = root / "arbitrary"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        f"from arbitrary.manager import {exported}\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
 
 
 def test_local_two_name_managers_project_both_reaching_calls(tmp_path: Path) -> None:
@@ -112,18 +151,120 @@ def test_projection_is_a_transaction_and_does_not_mutate_the_source_tree() -> No
     assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
 
 
-def test_pandas_303_assigned_manager_keeps_provider_refusal_loud() -> None:
-    """Projection reaches the provider but never invents a resource value."""
-    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+def test_pandas_303_both_bare_managers_construct_independent_provider_frames() -> None:
+    """Pinned multi-manager With: each Name constructs through its reaching call.
 
+    Before: populate raised SourceCallBindingGap("unconsumed call actual") while
+    resolving option_context helpers that raise OptionError(msg). After: both
+    manager-use coordinates seat distinct generator frames, and With sugar is
+    GeneratorWithSugar without any SourceCallBindingGap.
+    """
     tree = _real_tree()
-    root = _pandas_root()
-    with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
-        populate_source_derived_resource_refs(
-            tree,
-            root=root,
-            path=root / "pandas/tests/io/formats/test_ipython_compat.py",
-        )
+    root = _pandas_construction_root()
+    path = _pandas_consumer_path()
+    site = _line_32_with(tree)
+
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+
+    context = tree.root.unit.construction_context
+    seats = sorted(
+        (coordinate.start_col, call.line_col_span().start_line)
+        for coordinate, call in context.source_manager_provider_calls.items()
+        if coordinate.start_line == 32
+    )
+    assert seats == [(13, 21), (18, 30)]
+
+    frames = []
+    for item in site.items:
+        frame = site._generator_manager_frame(item)
+        assert frame is not None
+        assert frame.generator_steps is not None
+        assert frame.parameter_kinds == ("vararg",)
+        frames.append(frame.frame_cid)
+    # Independent manager coordinates: two seats, same provider identity is fine,
+    # but each item must resolve its own use-site seat (cols 13 and 18).
+    assert len(frames) == 2
+    assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
+
+    sugar = site.sugar()
+    assert isinstance(sugar, GeneratorWithSugar)
+
+
+def test_truthful_local_two_assigned_generators_construct_and_desugar(
+    tmp_path: Path,
+) -> None:
+    """Truthful twin: two bare Names that reach generator calls both construct."""
+    distribution = _generator_distribution(
+        tmp_path, "def acquire():\n    yield\n", exported="acquire"
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def exercise():\n"
+        "    first = arbitrary.acquire()\n"
+        "    second = arbitrary.acquire()\n"
+        "    with first, second:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    site = next(node for node in tree.nodes() if isinstance(node, With))
+    assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
+    seats = sorted(
+        (coordinate.start_col, call.line_col_span().start_line)
+        for coordinate, call in context.source_manager_provider_calls.items()
+        if coordinate.start_line == 5
+    )
+    assert seats == [(9, 3), (16, 4)]
+    assert all(site._generator_manager_frame(item) is not None for item in site.items)
+
+    sugar = site.sugar()
+    assert isinstance(sugar, GeneratorWithSugar)
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+
+
+def test_lying_same_spelling_without_reaching_call_does_not_construct(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: bare Names with no reaching Call never mint provider seats."""
+    source = tmp_path / "lying.py"
+    source.write_text(
+        "def exercise(opt_value, latex_value):\n"
+        "    opt = opt_value\n"
+        "    with_latex = latex_value\n"
+        "    with opt, with_latex:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=context,
+        populate_derived=False,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=source)
+
+    site = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, With) and node.line_col_span().start_line == 4
+    )
+    assert context.source_manager_provider_calls == {}
+    assert all(site._generator_manager_frame(item) is None for item in site.items)
+    assert _projected_manager_call_uses(tree) == {}
 
 
 def test_undecided_rebinding_does_not_invent_a_second_manager_call(
@@ -154,3 +295,71 @@ def test_undecided_rebinding_does_not_invent_a_second_manager_call(
         if coordinate.start_line == 5
     ]
     assert rows == [(5, 9, 2)]
+
+
+def test_independent_manager_coordinates_survive_shared_provider_spelling(
+    tmp_path: Path,
+) -> None:
+    """Two uses of the same provider function keep independent use coordinates."""
+    distribution = _generator_distribution(
+        tmp_path, "def acquire():\n    yield\n", exported="acquire"
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def exercise():\n"
+        "    left = arbitrary.acquire()\n"
+        "    right = arbitrary.acquire()\n"
+        "    with left, right:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    site = next(node for node in tree.nodes() if isinstance(node, With))
+    use_coords = [
+        item._manager_use_site_span()
+        for item in site.items
+    ]
+    assert use_coords[0] != use_coords[1]
+    provider_calls = [
+        site._provider_manager_call(item) for item in site.items
+    ]
+    assert all(call is not None for call in provider_calls)
+    assert provider_calls[0].line_col_span() != provider_calls[1].line_col_span()
+
+
+def test_mechanism_modules_contain_no_vendor_name_literals() -> None:
+    """Provider construction cannot admit this site by manager spelling."""
+    import ast
+    import inspect
+    import textwrap
+
+    import sugar_lift_python_source.manager_summary_derivation as derivation
+    import sugar_source_tree.nodes as nodes
+
+    for module in (derivation, nodes):
+        tree = ast.parse(textwrap.dedent(inspect.getsource(module)))
+        literals = {
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        assert literals.isdisjoint(
+            {
+                "opt",
+                "with_latex",
+                "option_context",
+                "pytest.raises",
+                "external_error_raised",
+            }
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2831,12 +2831,7 @@ class ClassDef(Statement):
             ),
             None,
         )
-        params = () if initializer is None else initializer.params[1:]
         owner_cid = self.fragment.seal().cid
-        coordinates = tuple(
-            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
-            for index, param in enumerate(params)
-        )
         span = self.line_col_span()
         site = SourceFragmentCoordinateV1(
             self.unit.source_cid,
@@ -2844,6 +2839,37 @@ class ClassDef(Statement):
             span.start_col,
             span.end_line,
             span.end_col,
+        )
+        # A source class without ``__init__`` that is an exception type inherits
+        # BaseException's constructor law: ``(*args)``.  Ordinary new-style
+        # classes inherit ``object.__init__`` (zero formals).  Installing the
+        # empty frame at ``raise OptionError(msg)`` was minting
+        # SourceCallBindingGap("unconsumed call actual") for every argumented
+        # exception construction during module-wide frame resolution — and that
+        # silence blocked authenticated generator managers whose helpers only
+        # *mention* those raises.
+        if initializer is None and self._inherits_default_exception_constructor():
+            args_coordinate = BindingCoordinateV1.mint(
+                owner_cid, self.fragment, ("inherited-exception-args", 0)
+            )
+            return SourceVisibleCallFrameV1(
+                source_identity_cid=self.unit.source_cid,
+                definition_site=site,
+                definition_fragment_cid=owner_cid,
+                parameters=("args",),
+                formal_coordinates=(args_coordinate,),
+                parameter_kinds=("vararg",),
+                default_sugars=(None,),
+                default_nodes=(None,),
+                default_fragments=(None,),
+                default_fragment_cids=(None,),
+                body=self._source_visible_body({}),
+                owner=self,
+            )
+        params = () if initializer is None else initializer.params[1:]
+        coordinates = tuple(
+            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
+            for index, param in enumerate(params)
         )
         formal_scope = {
             param.name: self._make_constructor_coordinate_ref(param, coordinate)
@@ -2872,6 +2898,47 @@ class ClassDef(Statement):
             body=self._source_visible_body(formal_scope),
             owner=self,
         )
+
+    def _inherits_default_exception_constructor(self) -> bool:
+        """Whether this class inherits BaseException's ``(*args)`` constructor.
+
+        Identity is the authenticated base graph, never the class spelling.
+        A non-exception class without ``__init__`` still takes zero arguments
+        (object construction); only exception ancestry opens ``*args``.
+        """
+        from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+            BUILTIN_EXCEPTION_NAMES,
+        )
+
+        module = self.unit._require_typed_module(
+            "ClassDef._inherits_default_exception_constructor",
+            blame=self.fragment,
+        )
+        visiting: set[str] = set()
+
+        def base_is_exception(base) -> bool:
+            if not isinstance(base, Name):
+                return False
+            if base.id in BUILTIN_EXCEPTION_NAMES:
+                return True
+            if base.id in visiting:
+                return False
+            # Walk the same lexical ClassDef graph SourceUnit.exception_type_mro
+            # authenticates: one unique same-module definition, no guessed imports.
+            definitions = [
+                item
+                for item in module.body
+                if isinstance(item, ClassDef) and item.name == base.id
+            ]
+            if len(definitions) != 1:
+                return False
+            visiting.add(base.id)
+            try:
+                return any(base_is_exception(item) for item in definitions[0].bases)
+            finally:
+                visiting.remove(base.id)
+
+        return any(base_is_exception(base) for base in self.bases)
 
     def _make_constructor_coordinate_ref(self, param: "Param", coordinate) -> "Node":
         from .backend import Leaf, materialize
@@ -4775,8 +4842,38 @@ class With(Statement):
         self.reporter.report_gap(self, panic)
         raise panic
 
+    def _provider_manager_call(self, item: WithItem):
+        """The Call that authenticates this manager item, by binding not spelling.
+
+        A direct Call head is already the provider.  A bare Name head reaches
+        its provider only through the seat populate installed at the immutable
+        manager-use coordinate when projecting ordinary assignment testimony.
+        Same spelling elsewhere never authorizes a manager.
+        """
+        if isinstance(item.context_expr, Call):
+            return item.context_expr
+        context = self.unit.construction_context
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+
+        if not isinstance(context, TreeConstructionContextV1):
+            return None
+        start_line, start_col, end_line, end_col = item._manager_use_site_span()
+        coordinate = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        )
+        call = context.source_manager_provider_calls.get(coordinate)
+        return call if isinstance(call, Call) else None
+
     def _generator_manager_frame(self, item: WithItem):
-        if not isinstance(item.context_expr, Call):
+        call = self._provider_manager_call(item)
+        if call is None:
             return None
         context = self.unit.construction_context
         from sugar_lift_py_tests.context_manager_resolution import (
@@ -4786,7 +4883,7 @@ class With(Statement):
 
         if not isinstance(context, TreeConstructionContextV1):
             return None
-        span = item.context_expr.line_col_span()
+        span = call.line_col_span()
         coordinate = SourceFragmentCoordinateV1(
             self.unit.source_cid,
             span.start_line,
@@ -4802,7 +4899,12 @@ class With(Statement):
     def _generator_manager_sugar(self, item: WithItem):
         if self._generator_manager_frame(item) is None:
             return None
-        return item.context_expr.sugar()
+        call = self._provider_manager_call(item)
+        if call is None:
+            return None
+        # Always sugar the provider Call (with its installed frame), never the
+        # bare Name spelling at the With head.
+        return call.sugar()
 
     def _require_narrow_cm_ref(self, item: WithItem):
         resolution = self._prebound_manager_resolution(item)

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
@@ -335,3 +337,56 @@ def test_census_door_refuses_both_yield_constructors_with_no_call_site() -> None
             assert refusal.owner == owner
         else:
             raise AssertionError(f"{owner} must refuse under the census door")
+
+
+def test_exception_subclass_without_init_accepts_message_actuals() -> None:
+    """Truthful twin: inherited BaseException law is ``(*args)``.
+
+    ``raise OptionError(msg)`` is ordinary Python. An empty constructor frame
+    refused the message as SourceCallBindingGap and blocked every manager whose
+    helpers only mentioned those raises (pandas option_context).
+    """
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedOptionError(AttributeError, KeyError):\n"
+        "    pass\n\n"
+        "def helper(pat):\n"
+        "    raise RenamedOptionError(f'no such key {pat!r}')\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    frame = class_node.source_visible_constructor_frame()
+    assert frame.parameters == ("args",)
+    assert frame.parameter_kinds == ("vararg",)
+
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = frame
+    bound = frame.bind_node_actuals(call.args, ())
+    assert bound.runtime_entries  # message consumed by *args
+    # Constructing the raise expression must not raise SourceCallBindingGap.
+    try:
+        call.sugar()
+    except SourceCallBindingGap as exc:  # pragma: no cover - regression guard
+        raise AssertionError(f"exception construction refused: {exc}") from exc
+
+
+def test_plain_class_without_init_still_refuses_constructor_actuals() -> None:
+    """Lying twin: non-exception classes keep object.__init__ (zero formals)."""
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedPlain:\n"
+        "    pass\n\n"
+        "RenamedPlain(1)\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    frame = class_node.source_visible_constructor_frame()
+    assert frame.parameters == ()
+    assert frame.parameter_kinds == ()
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
+        frame.bind_node_actuals(call.args, ())


### PR DESCRIPTION
## What changed

Supersedes reporting-only #6547. The two bare-name managers at the pinned pandas multi-item With now **construct** through their reaching bindings — no `SourceCallBindingGap`.

### Mechanism

1. **Exception constructor law** — A source class without `__init__` that inherits exception ancestry projects BaseException's `(*args)` constructor. Empty frames at `raise OptionError(msg)` were minting `SourceCallBindingGap("unconsumed call actual")` during module-wide frame resolution and blocked authenticated generator managers (including `option_context`) whose helpers only *mention* those raises. Non-exception classes keep zero formals (`object.__init__`).

2. **Provider seating** — `populate_source_derived_resource_refs` seats each reaching provider `Call` at the immutable manager-use coordinate (`source_manager_provider_calls`) when installing a generator frame.

3. **With resolves by binding** — Bare-Name manager items look up their provider Call and generator frame by use-site coordinate, never by Name spelling. Direct Call heads remain self-authoritative.

### Verified corpus site

Pinned pandas **3.0.3** `pandas/tests/io/formats/test_ipython_compat.py:32`:

```python
with opt, with_latex:
```

- `opt` reaches `cf.option_context(...)` at line 21  
- `with_latex` reaches `cf.option_context(...)` at line 30  

### Before / after (both managers)

| Manager | Use coordinate | Before | After |
|---|---|---|---|
| `opt` | line 32, col 13–16 | `provider=None`, `frame=None`; populate raises `SourceCallBindingGap("unconsumed call actual")` | provider Call @ line 21; generator frame `(*args)` with 11 steps; `GeneratorWithSugar` |
| `with_latex` | line 32, col 18–28 | same refusal | provider Call @ line 30; same generator frame identity; independent use-site seat |

Independent manager coordinates are preserved: seats `(13, 21)` and `(18, 30)`.

### PR gate

- Real pinned pandas reproducer (`test_pandas_303_both_bare_managers_construct_independent_provider_frames`)
- Truthful twin: two assigned local generator managers construct and desugar (`Complete`)
- Lying twin: same spelling without a reaching Call does not seat providers
- Rebinding twin: undecided rebind does not invent a second manager call
- Independent coordinates under shared provider spelling
- Exception constructor truthful/lying twins
- No vendor-name literals in the mechanism modules

### Validation

Authenticated interpreter: **CPython 3.12.13**; NumPy/pandas from the authenticated corpus (pandas 3.0.3).

```
export PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py \
  implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py::test_exception_subclass_without_init_accepts_message_actuals \
  implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py::test_plain_class_without_init_still_refuses_constructor_actuals \
  -q
# 11 passed
```

Closes the construction path that #6547 only reported.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct bare-name multi-manager `With` nodes by resolving through reaching provider `Call` bindings
> - Adds `source_manager_provider_calls` to `TreeConstructionContextV1` to map each bare-Name `With`-site coordinate to its authenticated provider `Call`, populated in `populate_source_derived_resource_refs`.
> - Adds `With._provider_manager_call` to look up the provider `Call` for bare-Name manager heads via the construction context, enabling `_generator_manager_frame` and `_generator_manager_sugar` to work correctly without requiring the manager head to be a direct `Call`.
> - Fixes `ClassDef.source_visible_constructor_frame` so exception subclasses without `__init__` expose a vararg constructor frame, preventing 'unconsumed call actual' gaps at raise-site analysis.
> - Adds tests covering independent provider frame seating for two bare-Name managers, desugaring, same-spelling/distinct-coordinate scenarios, and a guard that mechanism modules contain no vendor name literals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4704a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->