### PR TITLE
Follow bare manager bindings into provider construction

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1235,7 +1235,28 @@ def _resolve_source_visible_frame_uncached(
                 if nested is None:
                     nested = external_frames.get(call.func.id)
                 if nested is not None:
-                    _install_source_call_frame(context, call, nested)
+                    from sugar_lift_py_tests.source_call_resolution import (
+                        SourceCallPreconstructionGapV1,
+                    )
+
+                    try:
+                        nested.bind_node_actuals(
+                            call.args,
+                            tuple(
+                                (keyword.arg, keyword.value)
+                                for keyword in call.keywords
+                                if keyword.arg is not None
+                            ),
+                        )
+                    except SourceCallBindingGap as exc:
+                        coordinate = _call_coordinate(call)
+                        context.source_call_resolutions[coordinate] = (
+                            SourceCallPreconstructionGapV1(
+                                "call-binding", coordinate, str(exc)
+                            )
+                        )
+                    else:
+                        _install_source_call_frame(context, call, nested)
             frames[function.name] = function.source_visible_call_frame()
             pending.remove(function)
             progressed = True

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -30,7 +30,9 @@ def _pandas_root() -> Path:
         PANDAS_MANIFEST_CID,
         1421,
     )
-    return corpus.root
+    # Construction loci use the distribution-recorded seat, which is rooted at
+    # site-packages even though corpus identity is over the pandas package root.
+    return corpus.root.parent
 
 
 def _real_tree():
@@ -112,18 +114,37 @@ def test_projection_is_a_transaction_and_does_not_mutate_the_source_tree() -> No
     assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
 
 
-def test_pandas_303_assigned_manager_keeps_provider_refusal_loud() -> None:
-    """Projection reaches the provider but never invents a resource value."""
-    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
-
+def test_pandas_303_assigned_managers_construct_at_both_binding_calls() -> None:
+    """Each bare item follows its assignment to an authenticated generator frame."""
     tree = _real_tree()
     root = _pandas_root()
-    with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
-        populate_source_derived_resource_refs(
-            tree,
-            root=root,
-            path=root / "pandas/tests/io/formats/test_ipython_compat.py",
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=root / "pandas/tests/io/formats/test_ipython_compat.py",
+    )
+
+    context = tree.root.unit.construction_context
+    assert context is not None
+    projected = _projected_manager_call_uses(tree)
+    binding_coordinates = sorted(
+        (
+            call.line_col_span().start_line,
+            next(
+                coordinate
+                for coordinate in context.source_call_frames
+                if coordinate.start_line == call.line_col_span().start_line
+                and coordinate.start_col == call.line_col_span().start_col
+            ),
         )
+        for coordinate, call, _exit_face in projected.values()
+        if coordinate.start_line == 32
+    )
+    assert [line for line, _coordinate in binding_coordinates] == [21, 30]
+    assert all(
+        context.source_call_frames[coordinate].generator_steps is not None
+        for _line, coordinate in binding_coordinates
+    )
 
 
 def test_undecided_rebinding_does_not_invent_a_second_manager_call(
@@ -154,3 +175,58 @@ def test_undecided_rebinding_does_not_invent_a_second_manager_call(
         if coordinate.start_line == 5
     ]
     assert rows == [(5, 9, 2)]
+
+
+def test_same_spelled_names_bound_elsewhere_do_not_authenticate(tmp_path: Path) -> None:
+    """Lying twin: names cannot authorize managers independently of bindings."""
+    source = tmp_path / "lying.py"
+    source.write_text(
+        "def exercise(opt_value, latex_value):\n"
+        "    opt = opt_value\n"
+        "    with_latex = latex_value\n"
+        "    with opt, with_latex:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+
+    projected = _projected_manager_call_uses(tree)
+    assert [
+        coordinate
+        for coordinate, _call, _exit_face in projected.values()
+        if coordinate.start_line == 4
+    ] == []
+
+
+def test_bare_name_resolution_path_contains_no_vendor_name_literals() -> None:
+    """The structural resolver cannot admit this site by manager spelling."""
+    import ast
+    import inspect
+    import textwrap
+
+    import sugar_lift_python_source.manager_construction as construction
+    import sugar_lift_python_source.manager_summary_derivation as derivation
+
+    module = ast.parse(
+        textwrap.dedent(inspect.getsource(construction))
+        + textwrap.dedent(inspect.getsource(derivation))
+    )
+    literals = {
+        node.value
+        for node in ast.walk(module)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert literals.isdisjoint(
+        {
+            "opt",
+            "with_latex",
+            "option_context",
+            "pytest.raises",
+            "external_error_raised",
+        }
+    )


### PR DESCRIPTION
## What changed

- follow each bare `Name` manager through its reaching assignment call at the authenticated binding coordinate
- validate nested source-call actuals while preparing frames; an incompatible nested call is parked as the existing exact-site `call-binding` obligation instead of aborting construction of an unrelated provider
- construct both `option_context` assignments at pandas 3.0.3 `pandas/tests/io/formats/test_ipython_compat.py:32` as authenticated generator frames
- preserve the same-spelling/different-binding lying twin and assert zero vendor-name literals across the production resolution modules

## Reversed ruling

#6547 previously stopped at two `SourceCallBindingGap` refusals. That was wrong: the assignment coordinates are authenticated source and are followable. This revision removes the added refusal-report API entirely and carries construction through those bindings. A refusal remains only at the exact nested call whose actuals do not match its authenticated source frame; no provider contract is fabricated and no refusal schema fields are added.

## Root cause

Preparing the pandas config module encountered guarded `OptionError(...)` at `pandas/_config/config.py:131`. Its source-visible zero-actual constructor frame rejected the rendered message actual with `unconsumed call actual`, aborting preparation before either `option_context` generator frame could be installed. The source-call preconstruction vocabulary already owns this condition as `call-binding`; the mechanism now parks it at that exact call coordinate and continues constructing independent definitions.

## Verified site

Pinned pandas 3.0.3 line 32 is exactly `with opt, with_latex:` and both context expressions are bare `Name` nodes. `opt` reaches the assignment call at line 21; `with_latex` reaches the assignment call at line 30. Both independently install authenticated source-visible frames with generator steps.

## Validation

Authenticated interpreter: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3.

```
PYTHON312=/usr/local/opt/python@3.12/bin/python3.12 bash scripts/bootstrap-venv-py312.sh
PYTHONUNBUFFERED=1 .venv-py312/bin/python -m pytest implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_unresolved_source_call_is_parked_at_its_exact_coordinate implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_imported_renamed_generator_manager_installs_native_frame implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_imported_ordinary_factory_cannot_lie_as_generator_manager -q
# 10 passed, exit 0
```

Mutation transaction: replacing exact-site `call-binding` parking with re-raise restored the concrete pandas `unconsumed call actual` failure; restoration returned the focused suite to green.

No venv files are tracked. macOS does not authenticate Battleaxe Linux binary cells, so this PR makes no crash/timeout-zero or corpus-wide delta claim.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind call actuals before installing source call frames for bare manager bindings
> - In `_resolve_source_visible_frame_uncached` ([manager_construction.py](https://github.com/TSavo/sugar/pull/6561/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1)), call actuals are now bound via `bind_node_actuals` before installing a source call frame for nested callable targets.
> - If binding fails with `SourceCallBindingGap`, a `SourceCallPreconstructionGapV1("call-binding", ...)` is recorded in `context.source_call_resolutions` instead of raising or installing a frame.
> - Tests updated to verify that two binding coordinates are found and both have non-None `generator_steps`, that bare names bound to non-manager values produce no projected manager call coordinates, and that resolution logic contains no vendor-specific string literals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8bea7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->