### PR TITLE
Construct assigned returned resource With through single-Name projection

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -84,13 +84,13 @@ class WithSourceResourceSugar(Sugar):
         if not parts:
             from sugar_source_tree.panic import SugarNotWritten
 
-        raise SugarNotWritten(
-            blame=self.site,
-            owner="WithSourceResourceSugar.desugar",
-            observed="constructed manager protocol produced no face",
-            requested="one completed or halted source-derived manager face",
-            fix="keep empty protocol testimony loud",
-        )
+            raise SugarNotWritten(
+                blame=self.site,
+                owner="WithSourceResourceSugar.desugar",
+                observed="constructed manager protocol produced no face",
+                requested="one completed or halted source-derived manager face",
+                fix="keep empty protocol testimony loud",
+            )
         result = parts[0]
         for part in parts[1:]:
             result = result.union(part)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -842,13 +842,16 @@ def _projected_manager_call_uses(source_file):
     # Preserve the original direct-call route exactly.
     collect(source_file.root, projected_names=False)
 
-    # Project only frames that actually contain the new bare-Name shape.  A
-    # module-wide substitution would enter unrelated functions and demand
-    # contracts for sites outside this population pass.
+    # Project frames that contain a bare-Name manager — single-item
+    # ``with m:`` and multi-item ``with m, n:`` alike.  The multi-item
+    # shape was the first enrolled reproducer (#6489); a returned resource
+    # assigned once and consumed as a single Name is the same projection,
+    # not a second binding mechanism.  Module-wide substitution is still
+    # avoided: only functions that actually write a bare-Name manager are
+    # projected, so unrelated frames do not demand contracts.
     for function in source_file.functions():
         if not any(
             isinstance(node, With)
-            and len(node.items) > 1
             and any(item.context_expr.kind == "Name" for item in node.items)
             for node in function.walk()
         ):

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -110,6 +110,50 @@ def test_pandas_303_two_name_managers_project_their_assignment_calls() -> None:
     assert rows == [(21, 32, 13), (30, 32, 18)]
 
 
+def test_local_single_name_manager_projects_reaching_call(tmp_path: Path) -> None:
+    """Single-item ``with m:`` projects the same way multi-item does."""
+    source = tmp_path / "single.py"
+    source.write_text(
+        "def exercise(make_manager):\n"
+        "    opt = make_manager()\n"
+        "    with opt:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    tree = open_source_file_for_construction(
+        source,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+    projected = _projected_manager_call_uses(tree)
+    rows = sorted(
+        (call.line_col_span().start_line, coordinate.start_line, coordinate.start_col)
+        for coordinate, call, _exit_face in projected.values()
+    )
+    assert rows == [(2, 3, 9)]
+
+
+def test_pandas_303_single_assigned_manager_projects_reaching_call() -> None:
+    """Same corpus file, single-item ``with opt:`` — general single-Name projection."""
+    tree = _real_tree()
+    site = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 53
+    )
+    assert len(site.items) == 1
+    assert site.items[0].context_expr.kind == "Name"
+
+    projected = _projected_manager_call_uses(tree)
+    rows = sorted(
+        (call.line_col_span().start_line, coordinate.start_line, coordinate.start_col)
+        for coordinate, call, _exit_face in projected.values()
+        if coordinate.start_line == 53
+    )
+    assert rows == [(51, 53, 13)]
+
+
 def test_projection_is_a_transaction_and_does_not_mutate_the_source_tree() -> None:
     tree = _real_tree()
     site = _line_32_with(tree)

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -1,0 +1,473 @@
+"""Returned / assigned resource managers construct through the one With algebra.
+
+A returned resource is a factory call that yields an object with source-visible
+``__enter__`` / ``__exit__``.  The consumer may write that call directly
+(``with make_guard(x):``) or assign once and consume the Name
+(``m = make_guard(x); with m:``).  Both spellings must project to the same
+reaching call, install a ``SourceDerivedContextManagerRefV1`` with
+``ProtocolResourceSemanticsV1``, and construct ``WithSourceResourceSugar`` so
+``ExitSet.and_exit`` runs ``__exit__`` over every outgoing body edge.
+
+Fixture-supplied formals (``def use(resource): with resource:``) have no local
+acquisition call.  Their obligation is the formal coordinate
+(``FixtureSuppliedResourceObligationV1``); without sealed actual-value
+testimony the With stays a typed resolution gap — never a silent dissolve and
+never a second algebra.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import ProtocolResourceSemanticsV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedContextManagerRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.fixture_resource_obligation import (
+    FixtureSuppliedResourceObligationV1,
+)
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_summary_derivation import (
+    _projected_manager_call_uses,
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+_GUARD_SOURCE = (
+    "class Guard:\n"
+    "    def __init__(self, marker):\n"
+    "        self.marker = marker\n"
+    "    def __enter__(self):\n"
+    "        return self.marker\n"
+    "    def __exit__(self, effect_type, effect, traceback):\n"
+    "        return False\n"
+    "\n"
+    "def make_guard(marker):\n"
+    "    return Guard(marker)\n"
+)
+
+
+def _distribution(root: Path, source: str, *, exported: str = "make_guard"):
+    package = root / "arbitrary"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        f"from arbitrary.manager import {exported}\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _tree(root: Path, consumer: str, *, dist):
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        distribution_index={"arbitrary": dist},
+    )
+    return tree, context, path
+
+
+def _with_chain(sugar):
+    chain = []
+
+    def walk(node):
+        if isinstance(node, (WithSourceResourceSugar, WithResourceSugar, WithEffectBoundarySugar)):
+            chain.append(node)
+            for child in getattr(node, "body", ()) or ():
+                walk(child)
+            return
+        for field in ("body", "statements", "entries"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return chain
+
+
+class _FixedSugar(Sugar):
+    def __init__(self, outcome, *, probe=None):
+        self._outcome = outcome
+        self._probe = probe
+
+    def desugar(self, ctx=None):
+        del ctx
+        if self._probe is not None:
+            self._probe.append(1)
+        return self._outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _FloorValue:
+    def __init__(self, label: str):
+        self.label = label
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import str_const
+
+        return str_const(self.label)
+
+
+def test_single_assigned_returned_resource_projects_reaching_call(tmp_path: Path):
+    """LAW: ``m = make_guard(x); with m:`` projects the Name to the assignment call."""
+    dist = _distribution(tmp_path, _GUARD_SOURCE)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    m = make_guard(x)\n"
+        "    with m:\n"
+        "        pass\n"
+        "    return x\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    projected = _projected_manager_call_uses(tree)
+    rows = sorted(
+        (call.line_col_span().start_line, coordinate.start_line, coordinate.start_col)
+        for coordinate, call, _exit in projected.values()
+    )
+    assert rows == [(3, 4, 9)]
+
+
+def test_discrimination_single_assigned_is_not_vacuous_empty(tmp_path: Path):
+    """BITE: a projection that still ignored single-item Names would yield []."""
+    dist = _distribution(tmp_path, _GUARD_SOURCE)
+    del dist
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    m = make_guard(x)\n"
+        "    with m:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    with pytest.raises(AssertionError):
+        assert _projected_manager_call_uses(tree) == {}
+
+
+def test_single_assigned_returned_resource_constructs_with_source_resource(
+    tmp_path: Path,
+):
+    """Truthful: assigned returned resource installs ProtocolResource and constructs."""
+    dist = _distribution(tmp_path, _GUARD_SOURCE)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    m = make_guard(x)\n"
+        "    with m:\n"
+        "        raise ValueError('boom')\n"
+        "    return x\n"
+    )
+    tree, context, _ = _tree(tmp_path, consumer, dist=dist)
+    refs = list(context.source_derived_contract_refs.values())
+    assert len(refs) == 1
+    assert isinstance(refs[0], SourceDerivedContextManagerRefV1)
+    assert isinstance(refs[0].semantics, ProtocolResourceSemanticsV1)
+
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    sugar = with_node.sugar()
+    assert isinstance(sugar, WithSourceResourceSugar)
+
+    faces = sugar.desugar().exits
+    assert any(
+        isinstance(face, Halted)
+        and getattr(face.effect, "exception_name", None) == "ValueError"
+        for face in faces
+    ), faces
+
+
+def test_direct_call_returned_resource_still_constructs(tmp_path: Path):
+    """Direct ``with make_guard(x):`` remains the authoritative non-assigned twin."""
+    dist = _distribution(tmp_path, _GUARD_SOURCE)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    with make_guard(x):\n"
+        "        raise ValueError('boom')\n"
+        "    return x\n"
+    )
+    tree, context, _ = _tree(tmp_path, consumer, dist=dist)
+    assert any(
+        isinstance(ref, SourceDerivedContextManagerRefV1)
+        and isinstance(ref.semantics, ProtocolResourceSemanticsV1)
+        for ref in context.source_derived_contract_refs.values()
+    )
+    sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    assert isinstance(sugar, WithSourceResourceSugar)
+
+
+def test_nested_assigned_resources_compose_through_one_algebra(tmp_path: Path):
+    """LAW: ``with m, n:`` nests two source-derived resources; halt runs both exits.
+
+    Nesting IS Python's multi-manager law.  Each level owns ``and_exit`` over
+    every outgoing body edge, so a body halt exits the inner manager then the
+    outer under NeverSuppresses without a second control model.
+    """
+    dist = _distribution(tmp_path, _GUARD_SOURCE)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    m = make_guard(x)\n"
+        "    n = make_guard(x)\n"
+        "    with m, n:\n"
+        "        raise ValueError('boom')\n"
+        "    return x\n"
+    )
+    tree, context, _ = _tree(tmp_path, consumer, dist=dist)
+    refs = [
+        ref
+        for ref in context.source_derived_contract_refs.values()
+        if isinstance(ref, SourceDerivedContextManagerRefV1)
+    ]
+    assert len(refs) == 2
+    assert all(isinstance(ref.semantics, ProtocolResourceSemanticsV1) for ref in refs)
+
+    sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    chain = _with_chain(sugar)
+    assert len(chain) == 2
+    assert all(isinstance(node, WithSourceResourceSugar) for node in chain)
+    assert chain[1] in chain[0].body
+
+    faces = sugar.desugar().exits
+    assert any(
+        isinstance(face, Halted)
+        and getattr(face.effect, "exception_name", None) == "ValueError"
+        for face in faces
+    ), faces
+
+
+def test_discrimination_nested_assigned_does_not_collapse_to_one(tmp_path: Path):
+    """BITE: collapsing multi-item nesting into one resource would hide exit order."""
+    dist = _distribution(tmp_path, _GUARD_SOURCE)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    m = make_guard(x)\n"
+        "    n = make_guard(x)\n"
+        "    with m, n:\n"
+        "        pass\n"
+    )
+    tree, _, _ = _tree(tmp_path, consumer, dist=dist)
+    sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    with pytest.raises(AssertionError):
+        assert len(_with_chain(sugar)) == 1
+
+
+def test_failure_entering_inner_assigned_resource_still_exits_outer():
+    """LAW: enter-halt of the inner With is an outgoing body edge of the outer.
+
+    Shared algebra only: outer ``and_exit`` must run; inner ``__exit__`` must not
+    (the inner manager was never entered).
+    """
+    outer_exit, inner_exit = [], []
+    halt = RaiseEffect(exception_name="OSError", occurrence="inner.py:1:0")
+    inner = WithSourceResourceSugar(
+        manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
+        protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),
+        summary=_never_suppresses_summary(),
+        body=(),
+        manager_slot_id="B",
+        enter_slot_id=None,
+        exit_face_id="B#exit_face",
+        site=None,
+    )
+    outer = WithSourceResourceSugar(
+        manager=_FixedSugar(Complete(_FloorValue("outer-mgr"))),
+        protocol=_ProbeProtocol(
+            enter=Complete(_Entered(_FloorValue("entered"))),
+            exit_probe=outer_exit,
+        ),
+        summary=_never_suppresses_summary(),
+        body=(inner,),
+        manager_slot_id="A",
+        enter_slot_id=None,
+        exit_face_id="A#exit_face",
+        site=None,
+    )
+    out = outer.desugar()
+    assert inner_exit == [], "inner was never entered"
+    assert outer_exit == [1], "outer __exit__ must run on inner enter-halt"
+    assert any(
+        isinstance(face, Halted) and face.effect == halt for face in out.exits
+    ), out.exits
+
+
+def test_discrimination_outer_exit_is_not_skipped_on_enter_halt():
+    """BITE: completion-only exit would leave the outer exit probe empty."""
+    outer_exit, inner_exit = [], []
+    halt = RaiseEffect(exception_name="OSError", occurrence="inner.py:1:0")
+    inner = WithSourceResourceSugar(
+        manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
+        protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),
+        summary=_never_suppresses_summary(),
+        body=(),
+        manager_slot_id="B",
+        enter_slot_id=None,
+        exit_face_id="B#exit_face",
+        site=None,
+    )
+    outer = WithSourceResourceSugar(
+        manager=_FixedSugar(Complete(_FloorValue("outer-mgr"))),
+        protocol=_ProbeProtocol(
+            enter=Complete(_Entered(_FloorValue("entered"))),
+            exit_probe=outer_exit,
+        ),
+        summary=_never_suppresses_summary(),
+        body=(inner,),
+        manager_slot_id="A",
+        enter_slot_id=None,
+        exit_face_id="A#exit_face",
+        site=None,
+    )
+    outer.desugar()
+    with pytest.raises(AssertionError):
+        assert outer_exit == []
+
+
+def test_fixture_supplied_formal_manager_stays_typed_loud_without_actual(
+    tmp_path: Path,
+):
+    """Fixture formal as manager: no local acquisition call → typed gap.
+
+    The formal coordinate still mints a fixture-supplied obligation.  Construction
+    of enter/exit requires sealed actual-value testimony the frame does not
+    contain, so With refuses rather than inventing a local manager.
+    """
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import SourceTreePanic
+
+    # Obligation minting uses a body-free formal frame (no With construction).
+    obligation_src = tmp_path / "formal_only.py"
+    obligation_src.write_text(
+        "def use(resource):\n    return resource\n", encoding="utf-8"
+    )
+    frame = next(SourceFile(path_source(str(obligation_src))).functions()).source_visible_call_frame()
+    obligation = FixtureSuppliedResourceObligationV1.mint(frame.formal_coordinates[0])
+    assert obligation.kind == "fixture-supplied-resource-obligation"
+    assert obligation.formal_coordinate_cid == frame.formal_coordinates[0].cid
+
+    consumer = (
+        "def use(resource):\n"
+        "    with resource:\n"
+        "        raise ValueError('boom')\n"
+        "    return resource\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    assert context.source_derived_contract_refs == {}
+    assert _projected_manager_call_uses(tree) == {}
+
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    with pytest.raises(SourceTreePanic):
+        with_node.sugar()
+
+
+def test_undecided_rebinding_blocks_single_assigned_resource(tmp_path: Path):
+    """Lying twin: rebinding the Name away from the acquired call stays unprojected."""
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x, undecided):\n"
+        "    m = make_guard(x)\n"
+        "    m = undecided\n"
+        "    with m:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    assert _projected_manager_call_uses(tree) == {}
+
+
+# ---------------------------------------------------------------------------
+# Probe protocol / summaries for the pure ExitSet algebra twins above
+# ---------------------------------------------------------------------------
+
+
+class _Entered:
+    def __init__(self, enter_value):
+        self.enter_value = enter_value
+
+
+class _ProbeProtocol:
+    def __init__(self, *, enter, exit_probe=None):
+        self._enter = enter
+        self._exit_probe = exit_probe
+
+    def enter_resource_outcome(self, ctx=None):
+        del ctx
+        return self._enter
+
+    def exit_outcome_for(self, entered, ctx=None):
+        del entered, ctx
+        if self._exit_probe is not None:
+            self._exit_probe.append(1)
+        from sugar_lift_py_tests.floor import BlockValue
+
+        return Complete(BlockValue((), can_fall_through=True))
+
+
+def _never_suppresses_summary():
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import NeverSuppresses
+
+    return SimpleNamespace(
+        semantics=SimpleNamespace(exit=SimpleNamespace(disposition=NeverSuppresses()))
+    )


### PR DESCRIPTION
## What changed

- extend bare-Name manager projection from multi-item only to **single-item** `with m:` (same reaching-assignment projection, not a second binding mechanism)
- fix `WithSourceResourceSugar.desugar`: #6553’s `blame=` edit left `raise SugarNotWritten` outside the empty-parts guard so every source-resource desugar always panicked
- twins for assigned returned resource construction, nested multi-item composition, enter-halt exit algebra, fixture-formal loudness, and pandas 3.0.3 single `with opt:`

## Why

Owner 6 — nested/resource With. Assigned returned resources (`m = make_guard(x); with m:`) did not project, so populate never installed a ProtocolResource ref. Multi-item projection already worked (#6489 / #6557). Single-item is the same law.

The #6553 indent bug made every constructed `WithSourceResourceSugar` fail at desugar even when the ref was correct.

## Sites constructed

| Site | Result |
|------|--------|
| local `m = make_guard(x); with m:` | `WithSourceResourceSugar` + halt preserved under NeverSuppresses |
| local `with m, n:` nested assigned | two nested `WithSourceResourceSugar`; body halt runs both exits |
| enter-halt of inner | outer `__exit__` runs; inner does not (shared `and_exit`) |
| pandas 3.0.3 `test_ipython_compat.py:53` `with opt:` | projects to provider Call at line 51 |
| fixture formal `with resource:` | no local acquisition → typed gap + `FixtureSuppliedResourceObligation` mint |

No vendor/name admission arms. Fixture formals without sealed actual-value testimony stay loud (obligation at formal coordinate; no invented enter/exit).

## Validation

```text
cd implementations/python/sugar-lift-python-source
PYTHONPATH=src:../sugar-lift-py-tests/src:../sugar-source-tree/src \
  python -m pytest tests/test_returned_resource_with_construction.py \
  tests/test_assigned_multi_manager_with.py -q
# 21 passed (CPython 3.12.13)
```

Mutation: re-indent `raise SugarNotWritten` outside the guard → construction twins fail with UnboundLocalError / always-raise; fix restores green.

## Epsilon R

`Epsilon R_construction`: single bare-Name assigned returned resource managers that previously had no projection now construct when the factory is source-derived ProtocolResource. Fixture formals remain correctly loud until sealed actual testimony exists (named obligation, not silent dissolve).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct assigned returned resource `With` through single-Name projection
> - Extends `_projected_manager_call_uses` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6562/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to project single-item bare-Name context managers (e.g., `with m:`) to their reaching call sites, in addition to the previously handled multi-item cases.
> - Fixes `WithSourceResourceSugar.desugar` in [with_source_resource_sugar.py](https://github.com/TSavo/sugar/pull/6562/files#diff-019cb1219f11d2a8455045d2a46e8e9550f902ff5fabf32c95a098bd46143923) to only raise `SugarNotWritten` when no faces are produced, rather than unconditionally.
> - Adds tests for single-Name projection, `WithSourceResourceSugar` construction, nested resource composition, exit ordering, and blocking on undecided rebinding in [test_returned_resource_with_construction.py](https://github.com/TSavo/sugar/pull/6562/files#diff-516e8891dc248d2149005b9dfa3dfc5e559fe9652a9f705bca9ebd9c97741685).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c6933d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->