### PR TITLE
Construct more source-decided no-call TypeError RaiseValue partitions

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -194,6 +194,21 @@ class ListValue(FloorValue):
             self, other, site, elements=self.elements, rebuild=ListValue
         )
 
+    def subtract(self, other, site):
+        """Lists never subtract: decided peers are TypeError."""
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="ListValue.subtract")
+        return super().subtract(other, site)
+
+    def floor_divide(self, other, site):
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="ListValue.floor_divide")
+        return super().floor_divide(other, site)
+
     def matrix_multiply(self, other, site):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -52,24 +52,55 @@ class NoneValue(FloorValue):
     def less_than(self, other, site):
         # None orders against nothing: any ground comparison is authenticated
         # TypeError. Symbolic falls to super() emit.
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="NoneValue.less_than")
+        return super().less_than(other, site)
+
+    def _unorderable_ground_peer(self, other) -> bool:
         from sugar_lift_py_tests.floor.list_value import ListValue
         from sugar_lift_py_tests.floor.set_value import SetValue
         from sugar_lift_py_tests.floor.string_value import StringValue
         from sugar_lift_py_tests.floor.term_value import TermValue
         from sugar_lift_py_tests.floor.tuple_value import TupleValue
 
-        if type(other) in (
+        return type(other) in (
             NoneValue,
             TermValue,
             StringValue,
             ListValue,
             TupleValue,
             SetValue,
-        ):
+        )
+
+    def less_equal(self, other, site):
+        if self._unorderable_ground_peer(other):
             from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
-            return ground_type_error(site=site, owner="NoneValue.less_than")
-        return super().less_than(other, site)
+            return ground_type_error(site=site, owner="NoneValue.less_equal")
+        return super().less_equal(other, site)
+
+    def greater_than(self, other, site):
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="NoneValue.greater_than")
+        return super().greater_than(other, site)
+
+    def greater_equal(self, other, site):
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="NoneValue.greater_equal")
+        return super().greater_equal(other, site)
+
+    def contains(self, item, site):
+        """``x in None`` is exact TypeError — None is never a container."""
+        del item
+        from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+        return ground_type_error(site=site, owner="NoneValue.contains")
 
     def equals(self, other, site):
         # None stands on the equals floor only against itself. Cross-type is the

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py
@@ -69,28 +69,16 @@ def is_known_invalid_repetition_count(value) -> bool:
 
 
 def known_invalid_repetition_type_error(sequence, count, site):
-    """Construct Python's typed exceptional boundary for ``sequence * count``."""
-    from sugar_lift_py_tests.effect import (
-        TypeErrorRuntimeEffect,
-        runtime_effect_evidence,
-    )
-    from sugar_lift_py_tests.ir import ctor
-    from sugar_lift_py_tests.outcome import Incomplete
+    """Authenticated TypeError for a source-decided non-``__index__`` count.
 
-    operation = ctor(
-        "call:python.sequence_repeat",
-        [
-            sequence.to_term(owner=str(site)),
-            _known_ground_term(count, owner=str(site)),
-        ],
-    )
-    return Incomplete(
-        TypeErrorRuntimeEffect(
-            "sequence repetition count is a known ground value without "
-            f"__index__; count={type(count).__name__} site={site}",
-            **runtime_effect_evidence("python:sequence_repeat", operation, site),
-        )
-    )
+    ``[1] * 1.5`` / ``[1] * "a"`` / ``[1] * None`` are lift-time decided:
+    Python never selects ``__mul__`` successfully.  That is RaiseValue, not a
+    RuntimeEffect (the count is not runtime-dependent).
+    """
+    del sequence, count
+    from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+    return ground_type_error(site=site, owner="sequence_repetition")
 
 
 def _known_ground_term(value, *, owner: str):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -361,12 +361,16 @@ class StringValue(GuardStableValue):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.floor.term_value import TermValue
 
-        if type(other) is TermValue and type(other.value) is int:
+        if type(other) is TermValue and isinstance(other.value, int):
             from sugar_lift_py_tests.outcome import Complete
 
             return Complete(StringValue(self.value * other.value))
         if type(other) in (CallSiteValue, ImportAliasValue, SymbolicValue):
             return SymbolicValue(self.to_term(owner=str(site))).multiply(other, site)
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.multiply")
         return super().multiply(other, site)
 
     def divide(self, other, site):
@@ -375,6 +379,10 @@ class StringValue(GuardStableValue):
 
         if type(other) is CallSiteValue:
             return SymbolicValue(self.to_term(owner=str(site))).divide(other, site)
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.divide")
         return super().divide(other, site)
 
     def modulo(self, other, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -99,6 +99,20 @@ class TermValue(FloorValue):
 
         return ground_type_error(site=site, owner=owner)
 
+    def _decided_binary_type_error(self, other, site, *, owner: str):
+        """Decided non-numeric right → authenticated TypeError; else super gap.
+
+        After the numeric tower and sequence-repetition arms have run, a
+        source-decided peer that still has no arm is Python's TypeError
+        (``1 + "a"``, ``3 % []``).  Undecided rights stay on the shared
+        third-value law via ``super()``.
+        """
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner=owner)
+        return getattr(super(), owner.rsplit(".", 1)[-1])(other, site)
+
     def less_than(self, other, site):
         # A number stands on the ordering floor: two numbers are ordered or not, and
         # it gives back the True or False literal -- the boolean IS the type.
@@ -234,7 +248,13 @@ class TermValue(FloorValue):
         folded = complex_add(self, other, site)
         if folded is not None:
             return folded
-        return super().add(other, site)
+        from sugar_lift_py_tests.floor.complex_value import ComplexValue
+
+        # Overflow / non-finite complex field results stay loud construction
+        # gaps — not TypeError.
+        if type(other) is ComplexValue:
+            return super().add(other, site)
+        return self._decided_binary_type_error(other, site, owner="TermValue.add")
 
     def subtract(self, other, site):
         # A number stands on the subtraction floor: two numbers subtract to a number.
@@ -256,7 +276,13 @@ class TermValue(FloorValue):
         folded = complex_subtract(self, other, site)
         if folded is not None:
             return folded
-        return super().subtract(other, site)
+        from sugar_lift_py_tests.floor.complex_value import ComplexValue
+
+        if type(other) is ComplexValue:
+            return super().subtract(other, site)
+        return self._decided_binary_type_error(
+            other, site, owner="TermValue.subtract"
+        )
 
     def multiply(self, other, site):
         # A number stands on the multiplication floor: two numbers multiply, and the
@@ -281,14 +307,24 @@ class TermValue(FloorValue):
         if type(other) is OpaqueOpCallsite and other.callee == "len":
             return SymbolicValue(self.to_term(owner=str(site))).multiply(other, site)
         if type(other) in (ListValue, StringValue, TupleValue):
-            if type(self.value) is int:
+            # int/bool * sequence is repetition; float * sequence is TypeError.
+            if isinstance(self.value, int):
                 return other.multiply(self, site)
+            return self._decided_binary_type_error(
+                other, site, owner="TermValue.multiply"
+            )
         from sugar_lift_py_tests.floor.complex_arithmetic import complex_multiply
 
         folded = complex_multiply(self, other, site)
         if folded is not None:
             return folded
-        return super().multiply(other, site)
+        from sugar_lift_py_tests.floor.complex_value import ComplexValue
+
+        if type(other) is ComplexValue:
+            return super().multiply(other, site)
+        return self._decided_binary_type_error(
+            other, site, owner="TermValue.multiply"
+        )
 
     def power(self, other, site):
         if type(other) is TermValue:
@@ -377,7 +413,7 @@ class TermValue(FloorValue):
 
         if type(other) in (CallSiteValue, SymbolicValue):
             return SymbolicValue(self.to_term(owner=str(site))).divide(other, site)
-        return super().divide(other, site)
+        return self._decided_binary_type_error(other, site, owner="TermValue.divide")
 
     def modulo(self, other, site):
         # A number stands on the modulo floor: the remainder. A concrete zero
@@ -399,7 +435,7 @@ class TermValue(FloorValue):
             from sugar_lift_py_tests.effect import runtime_modulo
 
             return runtime_modulo(self, other, site)
-        return super().modulo(other, site)
+        return self._decided_binary_type_error(other, site, owner="TermValue.modulo")
 
     def floor_divide(self, other, site):
         if type(other) is TermValue:
@@ -419,7 +455,16 @@ class TermValue(FloorValue):
             return SymbolicValue(self.to_term(owner=str(site))).floor_divide(
                 other, site
             )
-        return super().floor_divide(other, site)
+        return self._decided_binary_type_error(
+            other, site, owner="TermValue.floor_divide"
+        )
+
+    def contains(self, item, site):
+        """Numbers are never containers: ``x in 1`` is exact TypeError."""
+        del item
+        from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+        return ground_type_error(site=site, owner="TermValue.contains")
 
     def _bitwise_int_pair(self, other):
         """Python bitwise ops accept int/bool; float is decided TypeError."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -154,6 +154,10 @@ class TupleValue(FloorValue):
 
         if type(other) in (CallSiteValue, ImportAliasValue, SymbolicValue):
             return SymbolicValue(self.to_term(owner=str(site))).add(other, site)
+        if other.denotes_value() and other.runtime_type_is_decided():
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="TupleValue.add")
         return super().add(other, site)
 
     def test_python_type(self, value, site):

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -370,6 +370,61 @@ def test_pandas_index_length_equality_stays_source_undecided() -> None:
     )
 
 
+def test_source_decided_membership_in_number_emits_type_error() -> None:
+    """``1 in 2`` is TypeError — numbers are never containers.
+
+    Companion to enrolled membership under pytest.raises: when the container
+    is a decided TermValue, Compare constructs RaiseValue rather than panicking
+    on the contains floor.
+    """
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    twin = "def f():\n    return 1 in 2\n"
+    tree = SourceFile(
+        (twin, "in-number-twin.py", blake3_512_of(twin.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(
+        n
+        for n in tree.nodes()
+        if isinstance(n, Compare) and n.line_col_span().start_line == 2
+    )
+    outcome = ComparisonOpSugar(
+        "In",
+        _ValueSugar(TermValue(1)),
+        _ValueSugar(TermValue(2)),
+        node.fragment,
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_source_decided_none_greater_than_emits_type_error() -> None:
+    """``None > 1`` is TypeError on every ordering face, not a py.gt emit."""
+    from sugar_lift_py_tests.floor import NoneValue, RaiseValue
+
+    twin = "def f():\n    return None > 1\n"
+    tree = SourceFile(
+        (twin, "none-gt-twin.py", blake3_512_of(twin.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(
+        n
+        for n in tree.nodes()
+        if isinstance(n, Compare) and n.line_col_span().start_line == 2
+    )
+    outcome = ComparisonOpSugar(
+        "Gt",
+        _ValueSugar(NoneValue()),
+        _ValueSugar(TermValue(1)),
+        node.fragment,
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
 def test_pandas_series_string_ordering_stays_source_undecided() -> None:
     """``obj < "a"``: string right is decided; left Series type is not.
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -242,6 +242,103 @@ def test_source_decided_int_float_bitand_emits_type_error() -> None:
     assert outcome.value.effect.exception_name == "TypeError"
 
 
+def test_source_decided_int_plus_str_emits_type_error() -> None:
+    """Reverse of string-add sites: ``1 + "foo"`` is decided TypeError.
+
+    Enrolled shapes like ``"foo_" + ser`` refuse on undecided right; the
+    dual ``TermValue + StringValue`` publishes RaiseValue.
+    """
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.floor import RaiseValue, StringValue, TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import BinOp
+    from sugar_source_tree.tree import SourceFile
+
+    twin = 'def f():\n    return 1 + "foo"\n'
+    tree = SourceFile(
+        (twin, "int-plus-str-twin.py", blake3_512_of(twin.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(n for n in tree.nodes() if isinstance(n, BinOp))
+
+    @dataclass(frozen=True)
+    class _ValueSugar(Sugar):
+        value: object
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(self.value)
+
+    operation = type(node.sugar())(
+        "Add",
+        _ValueSugar(TermValue(1)),
+        _ValueSugar(StringValue("foo")),
+        node.fragment,
+    )
+    outcome = operation.desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_source_decided_int_mod_list_emits_type_error() -> None:
+    """Twin of enrolled ``td % []`` / ``2 % tdarr`` with decided ground types.
+
+    ``TermValue % ListValue`` is Python TypeError when both sides are decided.
+    """
+    from dataclasses import dataclass
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import BinOp
+    from sugar_source_tree.tree import SourceFile
+
+    twin = "def f():\n    return 2 % []\n"
+    tree = SourceFile(
+        (twin, "int-mod-list-twin.py", blake3_512_of(twin.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(n for n in tree.nodes() if isinstance(n, BinOp))
+
+    @dataclass(frozen=True)
+    class _ValueSugar(Sugar):
+        value: object
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(self.value)
+
+    operation = type(node.sugar())(
+        "Mod",
+        _ValueSugar(TermValue(2)),
+        _ValueSugar(ListValue(())),
+        node.fragment,
+    )
+    outcome = operation.desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
 def test_source_decided_list_plus_int_emits_type_error() -> None:
     """``list + int`` is source-decided TypeError — the ground field law.
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
@@ -4,25 +4,31 @@ import importlib
 
 import pytest
 
-from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
     CallSiteValue,
     ImportAliasValue,
     ListValue,
+    RaiseValue,
     SymbolicValue,
     TermValue,
     TupleValue,
 )
 from sugar_lift_py_tests.ir import _Ctor, ctor
 from sugar_lift_py_tests.outcome import Complete, Incomplete
-from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.tree import SourceFile
 
 
 def _site(tmp_path):
-    source = tmp_path / "sequence_repeat.py"
-    source.write_text("def witness():\n    return [1] * 1.5\n", encoding="utf-8")
-    return next(SourceFile(path_source(str(source))).functions()).fragment
+    """Workspace-relative fragment so ground TypeError can cite source."""
+    del tmp_path
+    source = "def witness():\n    return [1] * 1.5\n"
+    tree = SourceFile(
+        (source, "sequence_repeat.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(tree.functions()).fragment
 
 
 def _symbolic_result(sequence, multiplier):
@@ -58,21 +64,23 @@ def test_exact_constructed_bool_is_a_valid_repetition_count(sequence_type) -> No
     assert outcome.value.elements == (element,)
 
 
-def test_list_times_known_ground_float_is_loud_type_error(tmp_path) -> None:
+def test_list_times_known_ground_float_is_authenticated_type_error(tmp_path) -> None:
     outcome = ListValue((TermValue(1),)).multiply(TermValue(1.5), _site(tmp_path))
 
-    assert isinstance(outcome, Incomplete)
-    assert isinstance(outcome.effect, TypeErrorRuntimeEffect)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
 
 
-def test_tuple_times_known_ground_string_is_loud_type_error(tmp_path) -> None:
+def test_tuple_times_known_ground_string_is_authenticated_type_error(tmp_path) -> None:
     outcome = TupleValue((TermValue(1),)).multiply(
         TermValue("x"),  # type: ignore[arg-type] - planted invalid ground payload
         _site(tmp_path),
     )
 
-    assert isinstance(outcome, Incomplete)
-    assert isinstance(outcome.effect, TypeErrorRuntimeEffect)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
 
 
 @pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_repetition_has_no_cardinality_cap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_repetition_has_no_cardinality_cap.py
@@ -127,22 +127,31 @@ def test_a_known_invalid_count_does_not_reach_either_repetition_arm(
 ) -> None:
     """Removing the cap must not have widened the door to non-index counts.
 
-    The typed TypeError exit carries a genuine runtime locus, so this arm needs
-    a real fragment -- not the prose site the folding arms accept.
+    A source-decided non-``__index__`` count is authenticated TypeError
+    RaiseValue on a workspace-relative fragment.
     """
-    from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
-    from sugar_lift_py_tests.outcome import Incomplete
-    from sugar_lift_python_source.source_oracle import path_source
+    del tmp_path
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source.canonical import blake3_512_of
     from sugar_source_tree.tree import SourceFile
 
-    source = tmp_path / "sequence_repeat.py"
-    source.write_text("def witness():\n    return [1] * 1.5\n", encoding="utf-8")
-    fragment = next(SourceFile(path_source(str(source))).functions()).fragment
+    source = "def witness():\n    return [1] * 1.5\n"
+    fragment = next(
+        SourceFile(
+            (source, "sequence_repeat.py", blake3_512_of(source.encode())),
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        ).functions()
+    ).fragment
 
     outcome = sequence_type((TermValue(1),)).multiply(TermValue(1.5), fragment)
 
-    assert isinstance(outcome, Incomplete)
-    assert isinstance(outcome.effect, TypeErrorRuntimeEffect)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
 
 
 # -- discriminating arm: each category rebuilds ITSELF ------------------------


### PR DESCRIPTION
## Summary

Owner 4 vertical slice after #6558. More source-decided no-call pairs construct authenticated `TypeError` RaiseValue partitions.

### Floor mechanisms

| Area | Decided pair → auth exit |
|------|--------------------------|
| **TermValue** reverse arithmetic | `1+"a"`, `1-str`, `1%[]`, `1.5*list`, … |
| **TermValue.contains** | `x in 1` → TypeError |
| **TupleValue.add** | `tuple + int` → TypeError |
| **ListValue.subtract / floor_divide** | decided peers → TypeError |
| **StringValue multiply/divide** | `str * 1.5`, `str / 1` → TypeError |
| **sequence_repetition** | `[1] * 1.5` → RaiseValue (was TypeErrorRuntimeEffect) |
| **NoneValue** full ordering + contains | `None > 1`, `x in None` → TypeError |

Complex overflow stays a loud construction gap (not TypeError). Undecided rights stay third-valued.

### Twins that gain auth exits

- `1 + "foo"` (reverse of enrolled `"foo_" + ser` shapes)
- `2 % []` (decided twin of `td % []` / mixed-right BinOp)
- `1 in 2` (non-container membership)
- `None > 1` (full None ordering face)
- `[1] * 1.5` sequence repetition

## Validation

```
pytest test_compare_exceptional_exit_producer.py \
       test_pandas_binary_operation_exception_floor.py \
       test_sequence_multiply_value_driven.py \
       test_undecided_binary_operand_law.py
# 120 passed (plus related suites green earlier)
```

No attribution/report/denominator changes. Rebased on origin/main including #6558 and #6559.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit ground TypeError RaiseValues for source-decided invalid binary operations at lift time
> - Arithmetic operators (`+`, `-`, `*`, `/`, `//`, `%`) on `TermValue`, `ListValue`, `TupleValue`, and `StringValue` now return a complete ground `TypeError` `RaiseValue` when the right operand has a decided runtime type that is incompatible, instead of falling through to generic handling.
> - `NoneValue` comparison operators (`<`, `<=`, `>`, `>=`) and `contains` now emit ground `TypeError` for unorderable decided peers.
> - `TermValue.contains` and `NoneValue.contains` unconditionally emit ground `TypeError` since numbers and `None` are never containers.
> - `known_invalid_repetition_type_error` is refactored to use the common `ground_exit` path, replacing an incomplete `TypeErrorRuntimeEffect`.
> - Tests updated to assert `Complete RaiseValue` with `TypeError` where they previously expected `Incomplete TypeErrorRuntimeEffect`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97a3f8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->