### PR TITLE
Publish both undecided comparison dispatch edges

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -32,85 +32,92 @@ COMPARE_METHODS: dict[str, str] = {
 # operand: `x in xs` is `xs.contains(x)`).
 COMPARISON_KINDS = frozenset(COMPARE_METHODS) | {"NotEq", "Is", "IsNot", "In", "NotIn"}
 
-_OPERATOR_COORDINATE = {
-    "Eq": "==",
-    "NotEq": "!=",
-    "Lt": "<",
-    "LtE": "<=",
-    "Gt": ">",
-    "GtE": ">=",
-    "In": "in",
-    "NotIn": "not in",
+_DISPATCH_RAISE_COORDINATE = {
+    "Eq": "python.eq_dispatch_raises",
+    "NotEq": "python.eq_dispatch_raises",
+    "Lt": "python.lt_dispatch_raises",
+    "LtE": "python.le_dispatch_raises",
+    "Gt": "python.gt_dispatch_raises",
+    "GtE": "python.ge_dispatch_raises",
+    "In": "python.contains_dispatch_raises",
+    "NotIn": "python.contains_dispatch_raises",
 }
 
 
-def refuse_undecided_comparison(left, right, site, op_kind: str) -> None:
-    """Keep undecided native comparison/containment/equality dispatch loud.
+def publish_undecided_comparison_edges(left, right, site, op_kind: str, outcome):
+    """Retain both native-dispatch faces when operand types are undecided.
 
-    Ordering and membership are not total over undecided runtime types:
+    Ordering, membership, and equality are not total over undecided runtime types:
     Python may select a rich method that completes or raises (``Series`` vs
     ``str`` raises ``TypeError``; unknown containers may raise from
     ``__contains__``). Emitting ``py.lt`` / ``py.in`` invents completion;
     inventing ``TypeError`` invents an exception identity. Both stay refused
     until native operand types are source-authenticated — the same producer
-    law BinOp already owns.
+    law BinOp/BoolOp already own.
 
-    Equality keeps a narrower carve-out: ``==`` / ``!=`` remain total solver
-    ``py.eq`` coordinates when at least one operand's runtime type is decided
-    (symbolic/ground and ground/ground pairs). They refuse when **both**
-    operand types are undecided — misaligned Index/Series/DataFrame/Categorical
-    equality raises at runtime, and inventing ``py.eq`` under ``pytest.raises``
-    is the residual silent Complete. Unexecuted ``CallSiteValue`` equality also
-    stays refused: the call result's ``__eq__`` body is itself a third value.
+    Equality is total only after both native operand types are decided.  An
+    undecided value may dispatch ``__eq__`` / ``__ne__`` that completes or
+    raises.  The producer owns that two-way split: the completed face retains
+    the operator's solver atom and the halted face retains a source-cited raise
+    occurrence whose exception identity remains undecided.  Identity is not
+    routed here because Python ``is`` / ``is not`` cannot invoke user code.
     """
     denotes_left = getattr(left, "denotes_value", None)
     denotes_right = getattr(right, "denotes_value", None)
     if not callable(denotes_left) or not callable(denotes_right):
-        return
+        return outcome
     if not (denotes_left() and denotes_right()):
-        return
+        return outcome
 
     decided_left = getattr(left, "runtime_type_is_decided", None)
     decided_right = getattr(right, "runtime_type_is_decided", None)
     if not callable(decided_left) or not callable(decided_right):
-        return
+        return outcome
+    if decided_left() and decided_right():
+        return outcome
 
-    if op_kind in {"Eq", "NotEq"}:
-        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-
-        # Solver-owned arm: at least one decided type, and neither side is an
-        # unexecuted call result whose __eq__ body is itself undecided.
-        if (
-            (decided_left() or decided_right())
-            and not isinstance(left, CallSiteValue)
-            and not isinstance(right, CallSiteValue)
-        ):
-            return
-    else:
-        if decided_left() and decided_right():
-            return
-
-    from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-    operator = _OPERATOR_COORDINATE[op_kind]
-    construction_panic_gap(
-        owner="comparison_operation_exception_floor",
-        blame=site,
-        observed=(f"{type(left).__name__} {operator} {type(right).__name__}"),
-        requested=(
-            "source-visible native comparison testimony selecting completion "
-            "or an authenticated exceptional exit"
-        ),
-        fix=(
-            "preserve the undecided third value at the Compare producer; "
-            "resolve native operand types and their comparison/containment "
-            "bodies from source, or retain this named refusal without "
-            "inventing an exception identity"
-        ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
+    from sugar_lift_py_tests.floor import PredicateValue
+    from sugar_lift_py_tests.outcome import Complete, ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import (
+        Completed,
+        Halted,
+        complement_guard,
+        partition,
     )
+
+    if not isinstance(outcome, Complete) or not isinstance(
+        outcome.value, PredicateValue
+    ):
+        return outcome
+
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.ir import atomic
+
+    dispatch_raises = atomic(
+        _DISPATCH_RAISE_COORDINATE[op_kind],
+        [
+            left.to_term(owner=f"{op_kind} left operand"),
+            right.to_term(owner=f"{op_kind} right operand"),
+        ],
+    )
+    halted_face, completed_face = partition(
+        ("comparison-native-dispatch", str(site), op_kind)
+    )
+    effect = RaiseEffect(
+        blame=str(site),
+        occurrence=str(site),
+        producer_node_owner="Compare",
+    )
+    return ExitSet(
+        (
+            Halted(dispatch_raises, effect, faces=frozenset({halted_face})),
+            Completed(
+                complement_guard(dispatch_raises),
+                outcome.value,
+                frozenset({completed_face}),
+            ),
+        )
+    ).normalize()
 
 
 @dataclass(frozen=True)
@@ -145,15 +152,21 @@ class ComparisonOpSugar(Sugar):
         inventing ``TypeError`` invents an exit. Keep that undecided dispatch
         loud at the Compare producer.
         """
-        refuse_undecided_comparison(item, container, self.site, self.op_kind)
-        return container.contains(item, self.site)
+        outcome = container.contains(item, self.site)
+        return publish_undecided_comparison_edges(
+            item, container, self.site, self.op_kind, outcome
+        )
 
     def _apply(self, left, right):
-        if self.op_kind not in {"Is", "IsNot", "In", "NotIn"}:
-            refuse_undecided_comparison(left, right, self.site, self.op_kind)
         if self.op_kind == "NotEq":
             # a != b is not (a == b): stand on the equals floor, negate.
-            return left.equals(right, self.site).and_then(
+            return publish_undecided_comparison_edges(
+                left,
+                right,
+                self.site,
+                self.op_kind,
+                left.equals(right, self.site),
+            ).and_then(
                 lambda predicate: predicate.negate()
             )
         if self.op_kind == "Is":
@@ -173,4 +186,10 @@ class ComparisonOpSugar(Sugar):
                 lambda predicate: predicate.negate()
             )
         method = COMPARE_METHODS[self.op_kind]
-        return getattr(left, method)(right, self.site)
+        return publish_undecided_comparison_edges(
+            left,
+            right,
+            self.site,
+            self.op_kind,
+            getattr(left, method)(right, self.site),
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -99,25 +99,30 @@ def _equals_and_refine(left, right, site, ctx, left_coordinate):
 
 def _equals_with_derived_residue(left, right, site, ctx):
     from sugar_lift_py_tests.sugar.comparison_op_sugar import (
-        refuse_undecided_comparison,
+        publish_undecided_comparison_edges,
     )
 
-    refuse_undecided_comparison(left, right, site, "Eq")
     outcome = left.equals(right, site)
 
     from sugar_lift_py_tests.floor import CallSiteValue, PredicateValue
     from sugar_lift_py_tests.outcome import Complete
 
-    if not isinstance(left, CallSiteValue):
-        return outcome
-    residue = left.derived_equality_residue(ctx)
-    if residue is None or not (
-        isinstance(outcome, Complete) and isinstance(outcome.value, PredicateValue)
-    ):
-        return outcome
-    return Complete(
-        replace(
-            outcome.value,
-            derived_formulas=(*outcome.value.derived_formulas, residue),
-        )
+    if isinstance(left, CallSiteValue):
+        residue = left.derived_equality_residue(ctx)
+        if residue is not None and (
+            isinstance(outcome, Complete)
+            and isinstance(outcome.value, PredicateValue)
+        ):
+            outcome = Complete(
+                replace(
+                    outcome.value,
+                    derived_formulas=(*outcome.value.derived_formulas, residue),
+                )
+            )
+    return publish_undecided_comparison_edges(
+        left,
+        right,
+        site,
+        "Eq",
+        outcome,
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -13,7 +13,6 @@ import pytest
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import CallSiteValue, SymbolicValue, TermValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
@@ -94,16 +93,46 @@ def _compare_at(path: Path, source: str, *, line: int) -> Compare:
     return matches[0]
 
 
-def _assert_named_compare_panic(node, *, observed: str) -> None:
-    with pytest.raises(ConstructionPanic) as raised:
-        node.sugar().desugar(None)
-    info = raised.value.info
-    assert info.owner == "comparison_operation_exception_floor"
-    assert info.observed == observed
-    assert "source-visible native comparison testimony" in info.requested
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "RuntimeEffect" not in str(info)
+def _synthetic_compare(expression: str) -> Compare:
+    source = f"def f(left, container):\n    return {expression}\n"
+    tree = SourceFile(
+        (source, "compare-dual-edge.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(node for node in tree.nodes() if isinstance(node, Compare))
+
+
+def _assert_dual_dispatch(outcome, *, atom: str, blame: str) -> None:
+    from sugar_lift_py_tests.floor import PredicateValue
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, complement_guard
+
+    assert isinstance(outcome, ExitSet)
+    completed = next(exit_ for exit_ in outcome.exits if isinstance(exit_, Completed))
+    halted = next(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert isinstance(completed.value, PredicateValue)
+
+    def atom_names(formula) -> set[str]:
+        name = getattr(formula, "name", None)
+        if isinstance(name, str):
+            return {name}
+        return {
+            nested
+            for operand in getattr(formula, "operands", ())
+            for nested in atom_names(operand)
+        }
+
+    assert atom in atom_names(completed.value.formula)
+    assert halted.effect.exception_name is None
+    assert halted.effect.blame == blame
+    assert halted.effect.producer_node_owner == "Compare"
+    assert completed.guard == complement_guard(halted.guard)
+
+
+def _assert_compare_dual(node, *, atom: str) -> None:
+    _assert_dual_dispatch(
+        node.sugar().desugar(None), atom=atom, blame=str(node.fragment)
+    )
 
 
 def test_launcher_authenticates_content_manifest_not_path_shape() -> None:
@@ -169,16 +198,13 @@ def test_shared_table_authenticates_the_exact_compare_site(tmp_path: Path) -> No
     assert len(rows) == 1
 
 
-def test_pandas_col_membership_refuses_to_invent_type_error() -> None:
+def test_pandas_col_membership_retains_both_source_visible_faces() -> None:
     path = _corpus_root() / "tests/test_col.py"
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == COL_SITE_SHA256
     assert blake3_512_of(source.encode()) == COL_SOURCE_CID
 
-    _assert_named_compare_panic(
-        _compare_at(path, source, line=365),
-        observed="TermValue in CallSiteValue",
-    )
+    _assert_compare_dual(_compare_at(path, source, line=365), atom="py.in")
 
 
 def test_literal_container_lying_twin_does_not_inherit_the_refusal() -> None:
@@ -227,73 +253,77 @@ def test_every_nonidentity_comparison_keeps_undecided_call_dispatch_loud(
         )
     )
 
+    expression_by_kind = {
+        "Lt": "left < 1",
+        "NotEq": "left != 1",
+        "In": "1 in container",
+        "NotIn": "1 not in container",
+        "Eq": "left == 1",
+    }
+    site = _synthetic_compare(expression_by_kind[op_kind]).fragment
     sugar = (
-        EqualityOpSugar(left, right, "compare-site")
+        EqualityOpSugar(left, right, site)
         if op_kind == "Eq"
-        else ComparisonOpSugar(op_kind, left, right, "compare-site")
+        else ComparisonOpSugar(op_kind, left, right, site)
     )
-    with pytest.raises(ConstructionPanic) as raised:
-        sugar.desugar(None)
+    _assert_dual_dispatch(
+        sugar.desugar(None),
+        atom={
+            "Lt": "py.lt",
+            "NotEq": "py.eq",
+            "Eq": "py.eq",
+            "In": "py.in",
+            "NotIn": "py.in",
+        }[op_kind],
+        blame=str(site),
+    )
 
-    assert raised.value.info.owner == "comparison_operation_exception_floor"
-    assert "TypeError" not in str(raised.value.info)
 
-
-@pytest.mark.parametrize("op_kind", ["Lt", "Gt", "LtE", "GtE"])
-def test_undecided_symbolic_operands_refuse_invented_ordering(
-    op_kind: str,
+@pytest.mark.parametrize(
+    ("op_kind", "operator", "atom"),
+    (
+        ("Lt", "<", "py.lt"),
+        ("Gt", ">", "py.gt"),
+        ("LtE", "<=", "py.le"),
+        ("GtE", ">=", "py.ge"),
+    ),
+)
+def test_undecided_symbolic_ordering_emits_completed_and_exceptional_edges(
+    op_kind: str, operator: str, atom: str
 ) -> None:
-    """``left < right`` cannot invent ``py.lt`` when operand types are undecided."""
+    """Ordering keeps its solver atom and the native dispatch halt together."""
+    node = _synthetic_compare(f"left {operator} 1")
     left = _ValueSugar(SymbolicValue(make_var("left")))
-    right = _ValueSugar(SymbolicValue(make_var("right")))
-    with pytest.raises(ConstructionPanic) as raised:
-        ComparisonOpSugar(op_kind, left, right, "compare-site").desugar(None)
-
-    info = raised.value.info
-    assert info.owner == "comparison_operation_exception_floor"
-    operator = {"Lt": "<", "Gt": ">", "LtE": "<=", "GtE": ">="}[op_kind]
-    assert info.observed == f"SymbolicValue {operator} SymbolicValue"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
+    right = _ValueSugar(TermValue(1))
+    outcome = ComparisonOpSugar(op_kind, left, right, node.fragment).desugar(None)
+    _assert_dual_dispatch(outcome, atom=atom, blame=str(node.fragment))
 
 
-def test_undecided_symbolic_equality_refuses_invented_py_eq() -> None:
-    """``left == right`` cannot invent ``py.eq`` when both operand types are undecided.
-
-    Misaligned pandas Index/Series/DataFrame/Categorical equality raises
-    ValueError/TypeError at runtime. Emitting a total solver coordinate
-    invents completion under ``pytest.raises``; inventing the exception
-    invents an identity. Both stay refused until types are source-decided.
-    """
-    left = _ValueSugar(SymbolicValue(make_var("left")))
-    right = _ValueSugar(SymbolicValue(make_var("right")))
-    with pytest.raises(ConstructionPanic) as raised:
-        EqualityOpSugar(left, right, "compare-site").desugar(None)
-
-    info = raised.value.info
-    assert info.owner == "comparison_operation_exception_floor"
-    assert info.observed == "SymbolicValue == SymbolicValue"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "ValueError" not in str(info)
-
-
-def test_symbolic_equality_with_ground_remains_solver_owned() -> None:
-    """Symbolic/ground equality stays a total ``py.eq`` coordinate."""
-    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-
+def test_symbolic_equality_keeps_solver_atom_and_exceptional_edge() -> None:
+    """The landed ``py.eq`` atom survives beside possible native ``__eq__`` halt."""
+    node = _synthetic_compare("left == 1")
     outcome = EqualityOpSugar(
         _ValueSugar(SymbolicValue(make_var("left"))),
         _ValueSugar(TermValue(1)),
-        "compare-site",
+        node.fragment,
     ).desugar(None)
-    assert isinstance(outcome, Complete)
-    assert isinstance(outcome.value, PredicateValue)
+    _assert_dual_dispatch(outcome, atom="py.eq", blame=str(node.fragment))
+
+
+def test_two_symbolic_equality_operands_keep_both_dispatch_faces() -> None:
+    """Two undecided operands neither fabricate totality nor refuse dispatch."""
+    node = _synthetic_compare("left == container")
+    outcome = EqualityOpSugar(
+        _ValueSugar(SymbolicValue(make_var("left"))),
+        _ValueSugar(SymbolicValue(make_var("right"))),
+        node.fragment,
+    ).desugar(None)
+    _assert_dual_dispatch(outcome, atom="py.eq", blame=str(node.fragment))
 
 
 def test_ground_decided_equality_still_completes() -> None:
-    """Lying twin: two decided ground scalars are not an undecided third value."""
-    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    """Lying twin: two decided scalars do not gain a dispatch split."""
+    from sugar_lift_py_tests.floor import PredicateValue
 
     outcome = EqualityOpSugar(
         _ValueSugar(TermValue(1)),
@@ -304,19 +334,27 @@ def test_ground_decided_equality_still_completes() -> None:
     assert isinstance(outcome.value, PredicateValue)
 
 
-def test_undecided_symbolic_membership_refuses_invented_py_in() -> None:
-    with pytest.raises(ConstructionPanic) as raised:
-        ComparisonOpSugar(
-            "In",
-            _ValueSugar(TermValue(1)),
-            _ValueSugar(SymbolicValue(make_var("container"))),
-            "compare-site",
-        ).desugar(None)
+def test_undecided_symbolic_membership_emits_completed_and_exceptional_edges() -> None:
+    node = _synthetic_compare("1 in container")
+    outcome = ComparisonOpSugar(
+        "In",
+        _ValueSugar(TermValue(1)),
+        _ValueSugar(SymbolicValue(make_var("container"))),
+        node.fragment,
+    ).desugar(None)
+    _assert_dual_dispatch(outcome, atom="py.in", blame=str(node.fragment))
 
-    info = raised.value.info
-    assert info.owner == "comparison_operation_exception_floor"
-    assert info.observed == "TermValue in SymbolicValue"
-    assert "TypeError" not in str(info)
+
+def test_identity_never_gains_an_exceptional_dispatch_edge() -> None:
+    """LYING TWIN: ``is`` is total and must not inherit rich-operation edges."""
+    node = _synthetic_compare("left is 1")
+    outcome = ComparisonOpSugar(
+        "Is",
+        _ValueSugar(SymbolicValue(make_var("left"))),
+        _ValueSugar(TermValue(1)),
+        node.fragment,
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
 
 
 def test_ground_decided_membership_still_completes() -> None:
@@ -333,50 +371,22 @@ def test_ground_decided_membership_still_completes() -> None:
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
 
-def test_pandas_categorical_equality_stays_source_undecided() -> None:
-    """``c1 == c2`` under TypeError: both Categorical types are source-undecided.
-
-    Site: ``pandas/tests/arrays/categorical/test_operators.py:335``. Emitting
-    ``py.eq`` invented the residual silent Complete; refuse without minting
-    TypeError.
-    """
+def test_pandas_categorical_equality_retains_both_dispatch_faces() -> None:
     path = _corpus_root() / "tests/arrays/categorical/test_operators.py"
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == CATEGORICAL_EQ_SITE_SHA256
     assert source.count("c1 == c2") >= 1
-
-    from pandas import Categorical
-
-    c1 = Categorical(["a", "b"], categories=["a", "b"], ordered=False)
-    c2 = Categorical(["a", "c"], categories=["c", "a"], ordered=False)
-    with pytest.raises(TypeError, match="Categoricals can only be compared"):
-        c1 == c2  # noqa: B015
-
-    _assert_named_compare_panic(
-        _compare_at(path, source, line=335),
-        observed="SymbolicValue == SymbolicValue",
-    )
+    _assert_compare_dual(_compare_at(path, source, line=335), atom="py.eq")
 
 
-def test_pandas_index_length_equality_stays_source_undecided() -> None:
-    """``index_a == index_b`` under ValueError: length mismatch is not ``py.eq``."""
+def test_pandas_index_length_equality_retains_both_dispatch_faces() -> None:
     path = _corpus_root() / "tests/indexes/multi/test_equivalence.py"
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == MULTI_EQ_SITE_SHA256
-
-    _assert_named_compare_panic(
-        _compare_at(path, source, line=43),
-        observed="SymbolicValue == SymbolicValue",
-    )
+    _assert_compare_dual(_compare_at(path, source, line=43), atom="py.eq")
 
 
 def test_source_decided_membership_in_number_emits_type_error() -> None:
-    """``1 in 2`` is TypeError — numbers are never containers.
-
-    Companion to enrolled membership under pytest.raises: when the container
-    is a decided TermValue, Compare constructs RaiseValue rather than panicking
-    on the contains floor.
-    """
     from sugar_lift_py_tests.floor import RaiseValue
 
     twin = "def f():\n    return 1 in 2\n"
@@ -401,7 +411,6 @@ def test_source_decided_membership_in_number_emits_type_error() -> None:
 
 
 def test_source_decided_none_greater_than_emits_type_error() -> None:
-    """``None > 1`` is TypeError on every ordering face, not a py.gt emit."""
     from sugar_lift_py_tests.floor import NoneValue, RaiseValue
 
     twin = "def f():\n    return None > 1\n"
@@ -425,7 +434,7 @@ def test_source_decided_none_greater_than_emits_type_error() -> None:
     assert outcome.value.effect.exception_name == "TypeError"
 
 
-def test_pandas_series_string_ordering_stays_source_undecided() -> None:
+def test_pandas_series_string_ordering_retains_both_faces() -> None:
     """``obj < "a"``: string right is decided; left Series type is not.
 
     Site: ``pandas/tests/arithmetic/test_numeric.py:146`` under
@@ -443,10 +452,7 @@ def test_pandas_series_string_ordering_stays_source_undecided() -> None:
     with pytest.raises(TypeError, match="Invalid comparison"):
         series < "a"  # noqa: B015
 
-    _assert_named_compare_panic(
-        _compare_at(path, source, line=146),
-        observed="SymbolicValue < StringValue",
-    )
+    _assert_compare_dual(_compare_at(path, source, line=146), atom="py.lt")
 
 
 def test_source_decided_number_string_ordering_emits_type_error() -> None:
@@ -501,7 +507,7 @@ def test_source_decided_number_string_ordering_emits_type_error() -> None:
         (158, ">=", "SymbolicValue >= SymbolicValue"),
     ),
 )
-def test_pandas_left_right_ordering_faces_stay_source_undecided(
+def test_pandas_left_right_ordering_faces_retain_both_edges(
     line: int, op: str, observed: str
 ) -> None:
     """``left < right`` family in arithmetic/common.py: both sides undecided.
@@ -512,8 +518,8 @@ def test_pandas_left_right_ordering_faces_stay_source_undecided(
     path = _corpus_root() / "tests/arithmetic/common.py"
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == COMMON_SITE_SHA256
-    _assert_named_compare_panic(
+    _assert_compare_dual(
         _compare_at(path, source, line=line),
-        observed=observed,
+        atom={"<": "py.lt", "<=": "py.le", ">": "py.gt", ">=": "py.ge"}[op],
     )
-    del op  # documented in parametrize for human readers of the tooth list
+    del observed  # documents the source operand pair beside each coordinate

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_family_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_family_attribution.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.no_call_body_attribution import (
+    AttributionOutcome,
+    BodyProbe,
+    ProducerFamily,
+    attribute_body_probe,
+    run_authenticated_attribution,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, Compare, FunctionDef, Name
+from sugar_source_tree.tree import SourceFile
+
+
+def _coordinate(node: Call) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def test_call_operand_raise_is_owned_by_call_not_compare_root() -> None:
+    """LYING TWIN: root shape cannot steal a pre-comparison Call halt."""
+    source = (
+        "def fail():\n"
+        "    raise ValueError()\n"
+        "def check():\n"
+        "    with boundary(ValueError):\n"
+        "        fail() == 1\n"
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, "compare_call_owner.py", blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+    fail_definition = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "fail"
+    )
+    fail_call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "fail"
+    )
+    context.source_call_frames[_coordinate(fail_call)] = (
+        fail_definition.source_visible_call_frame()
+    )
+    compare = next(node for node in tree.nodes() if isinstance(node, Compare))
+
+    attributed = attribute_body_probe(
+        BodyProbe(
+            body_id="compare_call_owner.py:5:Compare",
+            family=ProducerFamily.COMPARE,
+            evaluator=lambda: compare.sugar().desugar(None),
+        )
+    )
+
+    assert attributed.outcome is AttributionOutcome.AUTHENTICATED_EXIT
+    assert attributed.detail == "Call"
+    assert attributed.body_id == "compare_call_owner.py:5:Compare"
+
+
+def test_authenticated_compare_population_has_closed_three_outcome_split() -> None:
+    repo_root = Path(__file__).resolve().parents[4]
+    report = run_authenticated_attribution(
+        repo_root, families=frozenset({ProducerFamily.COMPARE})
+    )
+    row = report.by_family[ProducerFamily.COMPARE]
+
+    print(report.render())
+    assert row.enrolled == 181
+    assert (
+        row.authenticated_exceptional_exits
+        + row.named_refusals
+        + row.construction_panics
+        == 181
+    )
+    assert report.discrepancies == ()
+    assert row.construction_panics == 0


### PR DESCRIPTION
## What changed

Supersedes held PR #6550. GitHub refuses to reopen #6550 after its required rebase and force-push (`state cannot be changed. The fleet/compare-outcome-coverage branch was force-pushed or recreated`).

- publish both native-dispatch faces for undecided equality, ordering, and membership operands: the existing solver completion and a source-cited exceptional edge with undecided exception identity
- keep decided operand pairs on their existing construction path and keep identity comparisons completion-only
- preserve `py.eq` solver ownership, including call-site equality residue, while attaching real Compare blame coordinates to the exceptional face
- retain the authenticated 181-body Compare attribution gate and the failing-node ownership twin

## Laws

Undecided rich comparison is neither total nor refused: source-visible Python dispatch supports both completion and a raise from `__eq__`, ordering methods, or `__contains__`. The producer therefore emits complementary completed and halted edges without inventing an exception type. `is` and `is not` remain total because they do not dispatch user code. A Call operand that raises before Compare executes remains owned by Call.

## Authenticated outcome

Battleaxe used CPython 3.12.13, pandas 3.0.3, NumPy 2.5.1, and canonical corpus manifest `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`.

The unchanged Compare denominator partitions exactly:

- enrolled: 181
- authenticated exceptional exits: 161
- named producer refusals: 20 (`SymbolicValue.subscript` or `SymbolicValue.attribute`)
- construction panics: 0

The former `comparison_operation_exception_floor` block moved together; no row was converted into a named refusal by this repair.

## Validation

- `bin/bpytest -q implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py implementations/python/sugar-lift-py-tests/tests/test_compare_family_attribution.py implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py` — 41 passed
- mutation transaction: clean diff hash recorded; exceptional face removed; equality twin failed on `Complete` versus required `ExitSet`; mutation reverted; identical diff hash restored; twin passed
- `git diff --check` — clean

The shared demand table was consumed, not rebuilt. This PR does not touch assertion-With, `exit_set.py`, `outcome/`, generator construction, shared floor/binding files, or the BinOp floor.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish both undecided comparison dispatch edges instead of refusing construction
> - Replaces `refuse_undecided_comparison` with `publish_undecided_comparison_edges` in [comparison_op_sugar.py](https://github.com/TSavo/sugar/pull/6564/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) and [equality_op_sugar.py](https://github.com/TSavo/sugar/pull/6564/files#diff-e84076b87cd75964f4dd373e3c1424c63e64ad01c466910cf516b2f408a9ff38), so undecided operand types yield a dual `ExitSet` instead of a `ConstructionPanic`.
> - The dual `ExitSet` contains a `Completed` face with the solver atom and a `Halted` face with a `RaiseEffect` whose `exception_name` is `None` and `producer_node_owner` is `'Compare'`; identity comparisons (`Is`/`IsNot`) are excluded and remain `Completed`-only.
> - Tests in [test_compare_exceptional_exit_producer.py](https://github.com/TSavo/sugar/pull/6564/files#diff-fa2b8d1cb82b05e4512ec1bae4c7a4d961547ff92ac23924a9abf1ad25c75388) are reworked to assert dual edges, and a new [test_compare_family_attribution.py](https://github.com/TSavo/sugar/pull/6564/files#diff-54e9850f2cf7c2808b8ffe16a55ed8d973316531a55e9ccfe02a5743ba2d3b0c) validates attribution across 181 enrolled compares.
> - Behavioral Change: callers that previously caught `ConstructionPanic` for undecided comparisons will now receive a dual `ExitSet` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d25cd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->