### PR TITLE
Construct Attribute exception class paths on assertion boundaries

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
@@ -28,9 +28,20 @@ class AuthenticatedExceptionTypeSugar(Sugar):
         from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
             AuthenticatedExceptionTypeValue,
         )
-
         from sugar_lift_py_tests.outcome import Complete
 
+        # When construction already projected the exception-class floor (import
+        # Attribute paths, source ClassDef graphs), do not re-enter Attribute
+        # or other receivers that only exist to name the same identity.
+        if self.class_value is not None:
+            return Complete(
+                AuthenticatedExceptionTypeValue(
+                    self.class_value,
+                    self.identity,
+                    self.mro,
+                    self.class_value,
+                )
+            )
         return self.value.desugar(ctx).and_then(
             lambda value: Complete(
                 AuthenticatedExceptionTypeValue(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -30,6 +30,10 @@ class MethodCallSugar(Sugar):
     site: object = dataclass_field(compare=False)
     keywords: tuple = ()  # (name, sugar) pairs, in source order
     source_call_frame: object = dataclass_field(default=None, compare=False)
+    # Exception construction only: when Raise authenticates an Attribute
+    # exception-class path, the resulting CallSiteValue carries that identity.
+    exception_type_coordinate: object = dataclass_field(default=None, compare=False)
+    exception_type_mro: tuple | None = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -138,5 +142,7 @@ class MethodCallSugar(Sugar):
                 body=None,
                 site=self.site,
                 runtime_dispatch_receiver=receiver,
+                exception_type_coordinate=self.exception_type_coordinate,
+                exception_type_mro=self.exception_type_mro,
             )
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -98,8 +98,17 @@ class _ProducerExpression:
         return ExitSet((self.authenticated_exit,))
 
 
-@pytest.mark.parametrize("producer", ["BinOp", "Subscript", "Compare"])
-def test_matching_noncall_producer_halt_is_consumed(producer):
+@pytest.mark.parametrize(
+    "producer",
+    ["BinOp", "Subscript", "Compare", "Attribute", "UnaryOp", "BoolOp", "Call"],
+)
+def test_matching_arbitrary_body_producer_halt_is_consumed(producer):
+    """The boundary consumes ExitSet effects from any body producer shape.
+
+    Never by searching for a Call. BinOp / Subscript / Compare / Attribute /
+    UnaryOp / BoolOp / Call all publish the same authenticated RaiseEffect
+    edge; the consumer is shape-blind.
+    """
     routed = _route(ExitSet((_raise("ValueError", producer),)))
 
     assert [(type(face).__name__, _marker(face)) for face in routed.exits] == [

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -687,13 +687,37 @@ def populate_source_derived_resource_refs(
             # A surviving bare builtin is therefore the language-owned value,
             # not a free formal. NameSugar deliberately represents every other
             # survivor symbolically, so project this one native floor here.
+            #
+            # Import Attribute exception-class paths (``pkg.Error``) are a
+            # second closed projection: the Attribute floor cannot resolve a
+            # SymbolicValue module receiver, but ``imported_exception_type_identity``
+            # already authenticates the dotted type. Project that identity as
+            # the call actual so EffectBoundary managers construct instead of
+            # dying at incomplete-call-actuals.
+            from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+                AuthenticatedExceptionTypeValue,
+            )
+            from sugar_lift_py_tests.floor.exception_class_value import (
+                ExceptionClassValue,
+            )
             from sugar_lift_py_tests.outcome import Complete as _Complete
-            from sugar_source_tree.nodes import Name
+            from sugar_source_tree.nodes import Attribute, Name
 
             if isinstance(node, Name):
                 builtin = actual_ctx.temporal.value_if_bound(node.id)
                 if builtin is not None:
                     return _Complete(builtin)
+            if isinstance(node, Attribute):
+                identity = node.unit.imported_exception_type_identity(node)
+                if identity is not None:
+                    qualified = getattr(identity.args[1], "value", None)
+                    if isinstance(qualified, str) and qualified:
+                        class_value = ExceptionClassValue(qualified)
+                        return _Complete(
+                            AuthenticatedExceptionTypeValue(
+                                class_value, identity, None, class_value
+                            )
+                        )
             return node.sugar().desugar(actual_ctx)
 
         actuals = []

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -2579,3 +2579,255 @@ def test_as_binding_requires_a_contract_that_declares_one(tmp_path):
 
     with pytest.raises(UnsupportedWithBindingTarget):
         next(node for node in tree.nodes() if node.kind == "With").sugar()
+
+
+# --- computed exception class paths (Attribute / import identity) ------------
+#
+# ``raises(pkg.Error)`` is an Attribute path, not a bare Name. Construction
+# projects the import identity without re-entering AttributeSugar on a
+# SymbolicValue module receiver. A factory() call stays typed opaque.
+
+
+_ATTRIBUTE_EXCEPTION_BOUNDARY = (
+    "class Boundary:\n"
+    "    def __init__(self, expected, match=None):\n"
+    "        self.expected = expected\n"
+    "        self.match = match\n"
+    "    def __enter__(self):\n"
+    "        return self\n"
+    "    def __exit__(self, effect_type, effect, traceback):\n"
+    "        if effect_type is None:\n"
+    "            raise RuntimeError()\n"
+    "        return effect_type is self.expected\n\n"
+    "def boundary(expected, match=None):\n"
+    "    return Boundary(expected, match)\n\n"
+    "class MyError(Exception):\n"
+    "    pass\n"
+)
+
+# Exit must mention the message formal for match= to derive; keep it separate
+# so the type-only Attribute path stays a single-predicate derivation.
+_ATTRIBUTE_EXCEPTION_BOUNDARY_WITH_MATCH = (
+    "class Boundary:\n"
+    "    def __init__(self, expected, match=None):\n"
+    "        self.expected = expected\n"
+    "        self.match = match\n"
+    "    def __enter__(self):\n"
+    "        return self\n"
+    "    def __exit__(self, effect_type, effect, traceback):\n"
+    "        if effect_type is None:\n"
+    "            raise RuntimeError()\n"
+    "        return (effect_type is self.expected) and (\n"
+    "            effect.message == self.match\n"
+    "        )\n\n"
+    "def boundary(expected, match=None):\n"
+    "    return Boundary(expected, match)\n\n"
+    "class MyError(Exception):\n"
+    "    pass\n"
+)
+
+
+def _attribute_exception_tree(
+    tmp_path,
+    *,
+    manager: str,
+    body: str,
+    as_clause: str = "",
+    implementation: str = _ATTRIBUTE_EXCEPTION_BOUNDARY,
+):
+    tmp_path = Path(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    distribution = _distribution(tmp_path, implementation, exported="boundary")
+    (tmp_path / "arbitrary" / "__init__.py").write_text(
+        "from arbitrary.manager import boundary, MyError\n",
+        encoding="utf-8",
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        f"    with {manager}{as_clause}:\n"
+        f"{textwrap.indent(textwrap.dedent(body), '        ')}\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    return tree, context
+
+
+def test_attribute_exception_class_path_constructs_effect_boundary(tmp_path):
+    """Truthful twin: ``boundary(arbitrary.MyError)`` is EffectBoundary, not gap."""
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    tree, context = _attribute_exception_tree(
+        tmp_path,
+        manager="arbitrary.boundary(arbitrary.MyError)",
+        body='raise arbitrary.MyError("boom")',
+    )
+    assert len(context.source_derived_contract_refs) == 1
+    sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    assert isinstance(sugar, WithEffectBoundarySugar)
+
+
+def test_attribute_exception_class_path_consumes_matching_raise(tmp_path):
+    """Attribute expected type and Attribute raise share one import identity."""
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+    tree, _context = _attribute_exception_tree(
+        tmp_path,
+        manager="arbitrary.boundary(arbitrary.MyError)",
+        body='raise arbitrary.MyError("boom")',
+    )
+    exits = outcome_to_exitset(
+        next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
+    )
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+
+
+def test_attribute_exception_class_path_restores_wrong_raise(tmp_path):
+    """Lying twin: wrong type is restored, never borrowed from sibling identity."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
+
+    tree, _context = _attribute_exception_tree(
+        tmp_path,
+        manager="arbitrary.boundary(arbitrary.MyError)",
+        body='raise ValueError("boom")',
+    )
+    exits = outcome_to_exitset(
+        next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
+    )
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, RaiseEffect)
+    assert face.effect.exception_name == "ValueError"
+
+
+def test_attribute_exception_class_with_match_consumes_and_misses(tmp_path):
+    """Attribute class path + match= predicate: hit completes, miss restores.
+
+    Regex empty-pattern / alternation semantics are pinned at the ExitSet
+    consumer. Here the manager derives an exact message formal so the
+    Attribute class path is exercised end-to-end with a message obligation.
+    """
+    from sugar_lift_py_tests.outcome import Completed, Halted, outcome_to_exitset
+
+    tree, _context = _attribute_exception_tree(
+        tmp_path / "match-hit",
+        manager='arbitrary.boundary(arbitrary.MyError, match="boom")',
+        body='raise arbitrary.MyError("boom")',
+        implementation=_ATTRIBUTE_EXCEPTION_BOUNDARY_WITH_MATCH,
+    )
+    exits = outcome_to_exitset(
+        next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
+    )
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+
+    tree, _context = _attribute_exception_tree(
+        tmp_path / "match-miss",
+        manager='arbitrary.boundary(arbitrary.MyError, match="boom")',
+        body='raise arbitrary.MyError("other")',
+        implementation=_ATTRIBUTE_EXCEPTION_BOUNDARY_WITH_MATCH,
+    )
+    exits = outcome_to_exitset(
+        next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
+    )
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Halted)
+
+
+def test_attribute_exception_class_as_binding_projects_consumed_effect(tmp_path):
+    """``as info`` on an Attribute class path authenticates the observation slot."""
+    from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+
+    tree, _context = _attribute_exception_tree(
+        tmp_path,
+        manager="arbitrary.boundary(arbitrary.MyError)",
+        body='raise arbitrary.MyError("boom")',
+        as_clause=" as info",
+    )
+    exits = outcome_to_exitset(
+        next(node for node in tree.nodes() if node.kind == "With").sugar().desugar()
+    )
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Completed)
+    assert len(_effect_binding_facts(face)) == 3
+
+
+def test_computed_exception_class_factory_stays_typed_opaque(tmp_path):
+    """Lying twin: ``boundary(factory())`` cannot borrow Attribute-path proof."""
+    from sugar_source_tree.panic import WithConstructionGap, WithConstructionGapKind
+
+    distribution = _distribution(
+        tmp_path,
+        _ATTRIBUTE_EXCEPTION_BOUNDARY + "def factory():\n    return MyError\n",
+        exported="boundary",
+    )
+    (tmp_path / "arbitrary" / "__init__.py").write_text(
+        "from arbitrary.manager import boundary, MyError, factory\n",
+        encoding="utf-8",
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def use_boundary():\n"
+        "    with arbitrary.boundary(arbitrary.factory()):\n"
+        "        raise arbitrary.MyError('boom')\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    # Either preconstruction refuses the call actual, or With stays force-floor /
+    # resolution-gap. Never silently constructs EffectBoundary without identity.
+    try:
+        sugar = with_node.sugar()
+    except Exception as caught:
+        assert type(caught).__name__ in {
+            "WithConstructionGap",
+            "ContextManagerResolutionConstructionGap",
+            "SugarNotWritten",
+        }, type(caught).__name__
+        return
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    # If sugar constructs, desugar must not consume via a fabricated identity.
+    if isinstance(sugar, WithEffectBoundarySugar):
+        from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
+
+        exits = outcome_to_exitset(sugar.desugar())
+        # Without authenticated expected type, match is retained or restored —
+        # never a sole Completed face claiming a decided identity match.
+        assert not (
+            len(exits.exits) == 1 and type(exits.exits[0]).__name__ == "Completed"
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5312,22 +5312,46 @@ class With(Statement):
         )
         if identity is None:
             return manager_sugar
+        # Attribute import paths cannot re-enter AttributeSugar (the module
+        # receiver is SymbolicValue). Project the authenticated exception
+        # class floor from the import identity; Name paths keep their existing
+        # sugar and only wrap when a source ClassDef graph is available.
+        class_value = None
+        if isinstance(actual, Attribute):
+            from sugar_lift_py_tests.floor.exception_class_value import (
+                ExceptionClassValue,
+            )
+
+            qualified = getattr(identity.args[1], "value", None)
+            if isinstance(qualified, str) and qualified:
+                class_value = ExceptionClassValue(qualified)
+        elif isinstance(actual, Name):
+            try:
+                class_value = self.unit.exception_class_value(actual)
+            except SugarNotWritten:
+                class_value = None
+        wrapped = AuthenticatedExceptionTypeSugar(
+            (
+                manager_sugar.args[actual_location[1]]
+                if actual_location[0] == "arg"
+                else next(
+                    sugar
+                    for name, sugar in manager_sugar.keywords
+                    if name == actual_location[1]
+                )
+            ),
+            identity,
+            site=actual.fragment,
+            class_value=class_value,
+        )
         if actual_location[0] == "arg":
             args = list(manager_sugar.args)
-            position = actual_location[1]
-            args[position] = AuthenticatedExceptionTypeSugar(
-                args[position], identity, site=actual.fragment
-            )
+            args[actual_location[1]] = wrapped
             return replace(manager_sugar, args=tuple(args))
         keywords_sugar = list(manager_sugar.keywords)
         for position, (name, sugar) in enumerate(keywords_sugar):
             if name == actual_location[1]:
-                keywords_sugar[position] = (
-                    name,
-                    AuthenticatedExceptionTypeSugar(
-                        sugar, identity, site=actual.fragment
-                    ),
-                )
+                keywords_sugar[position] = (name, wrapped)
                 break
         return replace(manager_sugar, keywords=tuple(keywords_sugar))
 
@@ -5652,31 +5676,58 @@ class Raise(Statement):
 
         identity = None
         mro = None
-        type_name = None
+        type_operand = None
         if isinstance(self.exc, Call) and isinstance(self.exc.func, Name):
-            type_name = self.exc.func
+            type_operand = self.exc.func
+        elif isinstance(self.exc, Call) and isinstance(self.exc.func, Attribute):
+            type_operand = self.exc.func
         elif isinstance(self.exc, Name):
-            type_name = self.exc
-        if type_name is not None:
+            type_operand = self.exc
+        elif isinstance(self.exc, Attribute):
+            type_operand = self.exc
+        if type_operand is not None:
             with reduction_span(
                 sugar="Raise.exception_type_identity",
                 role="construction",
                 site=where,
             ):
-                identity = self.unit.exception_type_identity(type_name)
-                mro = self.unit.exception_type_mro(type_name)
+                if isinstance(type_operand, Name):
+                    identity = self.unit.exception_type_identity(type_operand)
+                    mro = self.unit.exception_type_mro(type_operand)
+                else:
+                    identity = self.unit.imported_exception_type_identity(
+                        type_operand
+                    )
+                    mro = None
 
         with reduction_span(sugar="Raise.exc.sugar", role="construction", site=where):
             exception_sugar = self.exc.sugar()
-        if identity is not None and isinstance(exception_sugar, CallSiteSugar):
+        from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+
+        if identity is not None and isinstance(
+            exception_sugar, (CallSiteSugar, MethodCallSugar)
+        ):
             exception_sugar = replace(
                 exception_sugar,
                 exception_type_coordinate=identity,
                 exception_type_mro=mro,
             )
         elif identity is not None:
+            class_value = None
+            if isinstance(type_operand, Attribute):
+                from sugar_lift_py_tests.floor.exception_class_value import (
+                    ExceptionClassValue,
+                )
+
+                qualified = getattr(identity.args[1], "value", None)
+                if isinstance(qualified, str) and qualified:
+                    class_value = ExceptionClassValue(qualified)
             exception_sugar = AuthenticatedExceptionTypeSugar(
-                exception_sugar, identity, mro, self.exc.fragment
+                exception_sugar,
+                identity,
+                mro,
+                self.exc.fragment,
+                class_value=class_value,
             )
 
         return RaiseSugar(


### PR DESCRIPTION
## Summary

Closes remaining **computed exception class path** construction for assertion-With, and pins that assertion boundaries consume ExitSet effects from **arbitrary body producers** (never by searching for a Call).

### Mechanism

Import-bound Attribute operands (`pkg.Error`) already had `imported_exception_type_identity`, but:

1. manager preconstruction died on `AttributeSugar` over a SymbolicValue module receiver (`incomplete-call-actuals`)
2. Raise never stamped Attribute callees with that identity, so expected and raised identities could not meet

This PR:

- projects `AuthenticatedExceptionTypeValue` at call-actual construction for Attribute exception class paths
- wraps Attribute expected types with `class_value` so `AuthenticatedExceptionTypeSugar.desugar` never re-enters AttributeSugar
- authenticates `raise pkg.Error(...)` through `MethodCallSugar.exception_type_coordinate`
- extends the ExitSet consumer twin matrix to Attribute / UnaryOp / BoolOp / Call (shape-blind consumption)

### Shapes completed (Owner 7)

| Shape | Status |
|-------|--------|
| `match=` (literal / name-ref / resolvable / opaque) | already on main; message half + floors |
| empty-pattern / ordinary / accumulated-alternation | already on main + ExitSet consumer pins |
| `as e` / ObservationRef | already on main; Attribute path now carries binding |
| no-warning / warning | already on main (ExitSet routing) |
| **computed exception class paths** (`pkg.Error`) | **this PR** |
| factory / computed class | stays typed opaque (lying twin) |

### Twins

- truthful: `boundary(arbitrary.MyError)` constructs EffectBoundary and consumes matching `raise arbitrary.MyError(...)`
- lying: wrong type restored; `boundary(factory())` stays opaque
- match= hit/miss on Attribute class path
- as-binding projects consumed observation slot

### Validation

```bash
export PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src
python -m pytest \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py -k 'attribute_exception or computed_exception' \
  implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py \
  -q
# 6 + 19 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct Attribute exception class paths on assertion boundaries
> - Extends `With._prebound_manager_resolution` and `Raise._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6565/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to recognize `Attribute` nodes (e.g. `pkg.Error`) as exception class actuals, in addition to `Name` nodes.
> - Wraps authenticated Attribute exception types in `AuthenticatedExceptionTypeSugar` with a pre-projected `ExceptionClassValue` floor, avoiding re-entry into `AttributeSugar` on symbolic receivers.
> - Updates `MethodCallSugar` to carry `exception_type_coordinate` and `exception_type_mro` fields, and `AuthenticatedExceptionTypeSugar.desugar` to short-circuit when `class_value` is already set.
> - Extends [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6565/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to produce concrete authenticated actuals during preconstruction for Attribute-based exception class arguments.
> - Behavioral Change: manager construction calls with Attribute exception-class arguments now proceed through construction instead of failing on unresolved Attribute receivers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c48680.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->