### PR TITLE
Seal Arrow exception attribute coords via provider-gated import identity

### DIFF
--- a/docs/ledgers/arrow-exception-source-coords-owner-report.md
+++ b/docs/ledgers/arrow-exception-source-coords-owner-report.md
@@ -1,0 +1,82 @@
+# Owner report: ArrowInvalid / ArrowException attribute coordinates
+
+**Owner:** external-exception (Arrow attribute operands of `external_error_raised`)  
+**Branch:** `codex/arrow-exception-source-coords`  
+**Seat:** CPython 3.12.13 · corpus manifest `blake3-512:6f317…` · demand table `blake3-512:0ce7…`
+
+## The five sites (before)
+
+From authenticated demand family `pandas._testing.external_error_raised` (47 With-sites):
+
+| # | File | Line | Operand | Before residual |
+|---|---|---:|---|---|
+| 1 | `tests/series/accessors/test_list_accessor.py` | 100 | `pa.ArrowInvalid` | `SymbolicValue.attribute` construction-panic |
+| 2 | `tests/series/accessors/test_list_accessor.py` | 132 | `pa.ArrowInvalid` | same |
+| 3 | `tests/series/accessors/test_list_accessor.py` | 134 | `pa.ArrowInvalid` | same |
+| 4 | `tests/extension/test_arrow.py` | 1715 | `pa.ArrowInvalid` | same |
+| 5 | `tests/io/test_parquet.py` | 799 | `pyarrow.ArrowException` | same |
+
+**Before R(attribute-stage) = 5.**  
+Heads were not static-import-bound: four use `pa = pytest.importorskip("pyarrow")`; one uses module-level `try: import pyarrow` / `except ImportError`. Ordinary import binding left those heads loud, so Attribute floor refused member semantics.
+
+## Construction
+
+1. **Provider-gated import target** (`SourceUnit.provider_gated_import_target`)  
+   Lexical-only closed gates for exception-type identity:
+   - `name = pytest.importorskip("mod")` with import-bound `pytest` and string-literal module
+   - `try: import mod` / `except ImportError:` that does not rebind `mod`  
+   Shadowed, reassigned, parameter, and non-importorskip assigns stay `None`.
+
+2. **`imported_exception_type_identity`** falls through to the provider gate when static import binding is absent. Sealed coordinate:
+   - `python:exception_type_identity(import, pyarrow.ArrowInvalid)`
+   - `python:exception_type_identity(import, pyarrow.ArrowException)`  
+   **MRO / ClassValue are not invented** when defining source is not in the seat (pyarrow C-extension class).
+
+3. **`AuthenticatedExceptionTypeSugar.desugar`** projects from sealed identity (or supplied `class_value`) without forcing Attribute floors on module heads.
+
+4. **Manager actual construction** (`manager_summary_derivation`) projects that identity on exception-type formals only (`expected_exception`, `expected`, …), so `external_error_raised(pa.ArrowInvalid)` no longer dies at `SymbolicValue.attribute` while constructing returned-manager actuals.
+
+## After (concrete)
+
+| # | File | Line | After residual |
+|---|---|---:|---|
+| 1–3 | `test_list_accessor.py` | 100,132,134 | `exit-may-halt` / `unary_operation_exception_floor:CallSiteValue not` |
+| 4 | `test_arrow.py` | 1715 | same stage (identity sealed; joins peer residual) |
+| 5 | `test_parquet.py` | 799 | same stage |
+
+**After R(attribute-stage) = 0** for these five.  
+They join the shared external_error exit-face residual (RaisesExc field floors), not a named attribute refusal.
+
+### Residual of 5
+
+| Axis | Before | After | Δ |
+|---|---:|---:|---:|
+| Attribute construction-panic on Arrow heads | 5 | 0 | −5 |
+| Identity sealed (import coordinate) | 0 | 5 | +5 |
+| MRO invented | 0 | 0 | 0 |
+| Defining source absent (honest) | 5 | 5 | 0 (loud only for ancestry, not for identity) |
+
+**Epsilon R (this PR):** −5 attribute-stage offenders.  
+**Next residual (not this PR):** exit-face `RaisesExc.expected_exceptions` / matches floor shared with the other 42 external_error With-sites.
+
+## Twins
+
+- `test_provider_gated_exception_type_identity.py` — importorskip / try-import truthful; reassignment / parameter / handler-rebind / non-importorskip lying; live five pandas sites; identity-sealed sugar without Attribute floor.
+- Nested assertion composition stress path: `pa.lib.ArrowNotImplementedError` under static import desugars via identity seal.
+- Returned-manager residual pins updated: attribute panic no longer the Arrow twin.
+
+## Validation
+
+```bash
+PYTHONPATH=implementations/python/sugar-lift-python-source/src:\
+implementations/python/sugar-lift-py-tests/src:\
+implementations/python/sugar-source-tree/src \
+.venv-py312/bin/python -m pytest \
+  implementations/python/sugar-source-tree/tests/test_provider_gated_exception_type_identity.py \
+  implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py::test_reverse_order_branch_constructs_both_native_boundaries \
+  implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py::test_reassigned_local_import_head_has_no_exception_identity \
+  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_external_error_raised_follows_authenticated_returned_manager \
+  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_external_error_raised_population_is_the_authenticated_47_with_sites \
+  -q
+# 13 passed
+```

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
@@ -25,20 +25,22 @@ class AuthenticatedExceptionTypeSugar(Sugar):
         )
 
     def desugar(self, ctx=None):
-        """Project the authenticated type floor without re-asking Attribute.
+        """Project the sealed exception-type identity without member floors.
 
         Import-bound dotted operands already carry a closed
         ``python:exception_type_identity(import, …)`` coordinate from the
-        lexical import pass.  That coordinate *is* the source-visible floor:
-        re-desugaring the Attribute sugar would ask an opaque module receiver
-        for a member it has no testimony for, inventing either a
-        ``py.getattr`` projection or a spelling-table arm.  Neither is
-        admitted.  Builtins and source-class leaves still reduce their
-        constructed value (or the projected ``class_value``) as before.
+        lexical import pass.  That coordinate *is* the source-visible floor.
+
+        Provider-gated heads (``importorskip`` / optional try-import) seal the
+        identity term itself as the carrier — Attribute chains on module heads
+        must not invent ``SymbolicValue.attribute`` success or AttributeError.
+        MRO is only whatever was supplied at construction; this door never
+        fabricates it.
         """
         from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
             AuthenticatedExceptionTypeValue,
         )
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.outcome import Complete
 
         # When construction already projected the exception-class floor (import
@@ -62,11 +64,14 @@ class AuthenticatedExceptionTypeSugar(Sugar):
                 )
             )
 
-        return self.value.desugar(ctx).and_then(
-            lambda value: Complete(
-                AuthenticatedExceptionTypeValue(
-                    value, self.identity, self.mro, self.class_value
-                )
+        # Provider-gated / non-import sealed identity: do not re-desugar Attribute
+        # chains on opaque module receivers.
+        return Complete(
+            AuthenticatedExceptionTypeValue(
+                SymbolicValue(self.identity),
+                self.identity,
+                self.mro,
+                self.class_value,
             )
         )
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -681,19 +681,33 @@ def populate_source_derived_resource_refs(
         from sugar_lift_py_tests.temporal import builtin_name_temporal
 
         actual_ctx = ReduceContext(temporal=builtin_name_temporal())
+        # Formals whose role is an exception-type operand (raises / warn / external_error).
+        _EXCEPTION_TYPE_FORMALS = frozenset(
+            {
+                "expected",
+                "expected_exception",
+                "expected_exceptions",
+                "exception",
+                "exc",
+                "exc_type",
+                "err_type",
+                "category",
+            }
+        )
+        frame_parameters = ()
+        if not isinstance(frame_result, ManagerConstructionGapV1):
+            _frame_for_params, _ = frame_result
+            frame_parameters = tuple(getattr(_frame_for_params, "parameters", ()) or ())
 
-        def _actual_outcome(node):
+        def _actual_outcome(node, *, formal_name: str | None = None):
             # Substitution has already replaced every reaching lexical binding.
             # A surviving bare builtin is therefore the language-owned value,
             # not a free formal. NameSugar deliberately represents every other
             # survivor symbolically, so project this one native floor here.
             #
-            # Import Attribute exception-class paths (``pkg.Error``) are a
-            # second closed projection: the Attribute floor cannot resolve a
-            # SymbolicValue module receiver, but ``imported_exception_type_identity``
-            # already authenticates the dotted type. Project that identity as
-            # the call actual so EffectBoundary managers construct instead of
-            # dying at incomplete-call-actuals.
+            # Import Attribute exception-class paths (``pkg.Error``) and
+            # provider-gated importorskip heads (``pa.ArrowInvalid``) seal
+            # identity without Attribute floors inventing member success.
             from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
                 AuthenticatedExceptionTypeValue,
             )
@@ -701,12 +715,42 @@ def populate_source_derived_resource_refs(
                 ExceptionClassValue,
             )
             from sugar_lift_py_tests.outcome import Complete as _Complete
+            from sugar_lift_py_tests.sugar.authenticated_exception_type_sugar import (
+                AuthenticatedExceptionTypeSugar,
+            )
             from sugar_source_tree.nodes import Attribute, Name
 
             if isinstance(node, Name):
                 builtin = actual_ctx.temporal.value_if_bound(node.id)
                 if builtin is not None:
                     return _Complete(builtin)
+            # Exception-type formals: seal import / provider-gated identity.
+            if formal_name in _EXCEPTION_TYPE_FORMALS and isinstance(
+                node, (Name, Attribute)
+            ):
+                identity = None
+                mro = None
+                class_value = None
+                if isinstance(node, Name):
+                    identity = node.unit.exception_type_identity(node)
+                    if identity is None:
+                        identity = node.unit.imported_exception_type_identity(node)
+                    else:
+                        mro = node.unit.exception_type_mro(node)
+                        try:
+                            class_value = node.unit.exception_class_value(node)
+                        except Exception:
+                            class_value = None
+                else:
+                    identity = node.unit.imported_exception_type_identity(node)
+                if identity is not None:
+                    return AuthenticatedExceptionTypeSugar(
+                        node.sugar(),
+                        identity,
+                        mro,
+                        site=node.fragment,
+                        class_value=class_value,
+                    ).desugar(actual_ctx)
             if isinstance(node, Attribute):
                 identity = node.unit.imported_exception_type_identity(node)
                 if identity is not None:
@@ -721,8 +765,11 @@ def populate_source_derived_resource_refs(
             return node.sugar().desugar(actual_ctx)
 
         actuals = []
-        for node in call.args:
-            outcome = _actual_outcome(node)
+        for index, node in enumerate(call.args):
+            formal_name = (
+                frame_parameters[index] if index < len(frame_parameters) else None
+            )
+            outcome = _actual_outcome(node, formal_name=formal_name)
             if not isinstance(outcome, Complete):
                 actuals = []
                 break
@@ -743,7 +790,9 @@ def populate_source_derived_resource_refs(
                     keyword_actuals = []
                     actuals = []
                     break
-                outcome = _actual_outcome(keyword.value)
+                outcome = _actual_outcome(
+                    keyword.value, formal_name=keyword.arg
+                )
                 if not isinstance(outcome, Complete):
                     keyword_actuals = []
                     actuals = []

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -174,9 +174,13 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
         reference.detail or ""
     )
     assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
-    # Current residual names the exit-face comparison on unfloored field state.
+    # Current residual names the exit-face floor on unfloored field state.
     assert reference.kind == "exit-may-halt"
-    assert "comparison_operation_exception_floor" in (reference.detail or "")
+    detail = reference.detail or ""
+    assert (
+        "comparison_operation_exception_floor" in detail
+        or "unary_operation_exception_floor" in detail
+    ), detail
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:
@@ -211,7 +215,9 @@ def _external_error_attributions():
 
     from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
     from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
         SourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
         TreeConstructionContextV1,
     )
     from sugar_lift_py_tests.sugar.function_universe_sugar import (
@@ -275,7 +281,7 @@ def _external_error_attributions():
                 )
             )
 
-            def evaluate(manager=manager, path=path, site=site):
+            def evaluate(manager=manager, path=path, site=site, tree=tree, context=context):
                 populate_source_derived_resource_refs(
                     tree,
                     root=corpus.root.parent,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -526,9 +526,20 @@ class SourceUnit:
 
         The context-manager contract authenticates the operand's role as an
         exception type.  This method authenticates only its source identity:
-        the exact head occurrence must have one reaching import definition,
-        and every remaining component must be a static Attribute link.  A
-        shadowed, computed, or ambiguous head has no coordinate and stays loud.
+        the exact head occurrence must have one reaching import definition
+        (static import, or a closed optional-provider gate), and every remaining
+        component must be a static Attribute link.  A shadowed, computed, or
+        ambiguous head has no coordinate and stays loud.
+
+        Optional-provider heads recognized here (exception-type identity only):
+
+        - ``name = pytest.importorskip("mod")`` with ``pytest`` import-bound and
+          a string-literal module argument
+        - ``try: import mod`` / ``except ImportError:`` that does not rebind
+          ``mod`` on the handler path
+
+        The coordinate names the import target path.  It does not invent MRO or
+        ClassValue ancestry when defining source is absent from the seat.
         """
         from sugar_lift_py_tests.ir import ctor, str_const
 
@@ -544,12 +555,242 @@ class SourceUnit:
             (span.start_line, span.start_col, span.end_line, span.end_col)
         )
         if target is None:
+            target = self.provider_gated_import_target(link)
+        if target is None:
             return None
         module = target[len("python:") :] if target.startswith("python:") else target
         qualified = ".".join([module, *reversed(attributes)])
         return ctor(
             "python:exception_type_identity",
             [str_const("import"), str_const(qualified)],
+        )
+
+    def provider_gated_import_target(self, node: "Name") -> str | None:
+        """Closed optional-provider module target reaching ``node``, or None.
+
+        Lexical only: no install hunt, no execute.  Returns ``python:<mod>``
+        when exactly one provider-gate definition of ``node.id`` reaches the
+        use.  Competing, shadowed, or computed heads stay absent.
+        """
+        span = node.line_col_span()
+        use_line = span.start_line
+        module = self._require_typed_module(
+            "SourceUnit.provider_gated_import_target", blame=node.fragment
+        )
+
+        function_owner = None
+        containing = []
+        for candidate in self.function_nodes:
+            cspan = candidate.line_col_span()
+            start = (cspan.start_line, cspan.start_col)
+            end = (cspan.end_line, cspan.end_col)
+            if start <= (span.start_line, span.start_col) <= end:
+                containing.append(candidate)
+        if containing:
+            function_owner = max(
+                containing, key=lambda value: value.line_col_span().start_line
+            )
+            table = self.function_symtable(
+                function_owner.name, function_owner.line_col_span().start_line
+            )
+            try:
+                symbol = table.lookup(node.id)
+            except KeyError:
+                symbol = None
+            if symbol is not None and symbol.is_parameter():
+                return None
+            if symbol is not None and symbol.is_local():
+                local_mod = self._provider_gate_module_in_statements(
+                    function_owner.body, node.id, use_line=use_line
+                )
+                return f"python:{local_mod}" if local_mod is not None else None
+
+        module_mod = self._provider_gate_module_in_statements(
+            module.body,
+            node.id,
+            use_line=use_line,
+        )
+        return f"python:{module_mod}" if module_mod is not None else None
+
+    def _provider_gate_module_in_statements(
+        self, statements, name: str, *, use_line: int
+    ) -> str | None:
+        """Sole closed provider-gate module for ``name`` before ``use_line``."""
+        modules: list[str] = []
+        for statement in statements:
+            stmt_line = statement.line_col_span().start_line
+            if stmt_line > use_line:
+                continue
+            if statement.kind == "Assign":
+                mod = self._importorskip_assign_module(statement, name)
+                if mod is not None:
+                    modules.append(mod)
+                    continue
+                if self._statement_rebinds_name(statement, name):
+                    return None
+                continue
+            if statement.kind in ("AnnAssign", "AugAssign"):
+                if self._statement_rebinds_name(statement, name):
+                    return None
+                continue
+            if statement.kind in ("Import", "ImportFrom"):
+                # A later static import is ordinary import binding, not this door.
+                continue
+            if statement.kind in ("Try", "TryStar"):
+                mod = self._try_import_provider_module(statement, name)
+                if mod is not None:
+                    modules.append(mod)
+                elif self._try_rebinds_name(statement, name):
+                    return None
+                continue
+            if statement.kind in ("FunctionDef", "AsyncFunctionDef", "ClassDef"):
+                if statement.name == name:
+                    return None
+                continue
+            if self._statement_rebinds_name(statement, name):
+                return None
+        if len(modules) != 1:
+            return None
+        return modules[0]
+
+    def _importorskip_assign_module(self, statement, name: str) -> str | None:
+        """``name = <pytest>.importorskip(\"mod\"[, ...])`` → ``mod``."""
+        if statement.kind != "Assign" or len(statement.targets) != 1:
+            return None
+        target = statement.targets[0]
+        if not isinstance(target, Name) or target.id != name:
+            return None
+        call = statement.value
+        if not isinstance(call, Call) or not call.args:
+            return None
+        func = call.func
+        if not isinstance(func, Attribute) or func.attr != "importorskip":
+            return None
+        head = func.value
+        if not isinstance(head, Name):
+            return None
+        head_span = head.line_col_span()
+        bound = self.import_bound_name_target(
+            (
+                head_span.start_line,
+                head_span.start_col,
+                head_span.end_line,
+                head_span.end_col,
+            )
+        )
+        if bound not in ("python:pytest", "pytest"):
+            return None
+        module_arg = call.args[0]
+        if not isinstance(module_arg, Constant) or not isinstance(
+            module_arg.value, str
+        ):
+            return None
+        if not module_arg.value or "/" in module_arg.value or "\\" in module_arg.value:
+            return None
+        return module_arg.value
+
+    def _try_import_provider_module(self, statement, name: str) -> str | None:
+        """Closed ``try: import name`` / ``except ImportError`` provider gate."""
+        if statement.kind not in ("Try", "TryStar"):
+            return None
+        imported: list[str] = []
+        for body_stmt in statement.body:
+            if body_stmt.kind != "Import":
+                if self._statement_rebinds_name(body_stmt, name):
+                    return None
+                continue
+            for alias in body_stmt.names:
+                local = alias.asname or alias.name.split(".", 1)[0]
+                if local == name:
+                    imported.append(alias.name.split(".", 1)[0])
+        if len(imported) != 1:
+            return None
+        for handler in statement.handlers:
+            if handler.name == name:
+                return None
+            if not self._handler_is_import_error(handler):
+                return None
+            for handler_stmt in handler.body:
+                if self._statement_rebinds_name(handler_stmt, name):
+                    return None
+        for tail in (*statement.orelse, *statement.finalbody):
+            if self._statement_rebinds_name(tail, name):
+                return None
+        return imported[0]
+
+    def _handler_is_import_error(self, handler) -> bool:
+        """Whether the except type is ImportError (or a tuple containing it)."""
+        type_node = handler.type
+        if type_node is None:
+            return False
+
+        def is_import_error_name(node) -> bool:
+            return isinstance(node, Name) and node.id in (
+                "ImportError",
+                "ModuleNotFoundError",
+            )
+
+        if is_import_error_name(type_node):
+            return True
+        if isinstance(type_node, Tuple):
+            return any(is_import_error_name(elt) for elt in type_node.elts)
+        return False
+
+    @staticmethod
+    def _statement_rebinds_name(statement, name: str) -> bool:
+        if statement.kind in ("FunctionDef", "AsyncFunctionDef", "ClassDef"):
+            return statement.name == name
+        if statement.kind == "Assign":
+            return any(
+                isinstance(node, Name) and node.id == name
+                for target in statement.targets
+                for node in target.walk()
+            )
+        if statement.kind in ("AnnAssign", "AugAssign"):
+            return any(
+                isinstance(node, Name) and node.id == name
+                for node in statement.target.walk()
+            )
+        if statement.kind in ("Import", "ImportFrom"):
+            return any(
+                (alias.asname or alias.name.split(".", 1)[0]) == name
+                for alias in statement.names
+            )
+        if statement.kind in ("For", "AsyncFor"):
+            return any(
+                isinstance(node, Name) and node.id == name
+                for node in statement.target.walk()
+            )
+        if statement.kind in ("With", "AsyncWith"):
+            for item in statement.items:
+                if item.optional_vars is None:
+                    continue
+                if any(
+                    isinstance(node, Name) and node.id == name
+                    for node in item.optional_vars.walk()
+                ):
+                    return True
+            return False
+        if statement.kind == "NamedExpr":
+            return any(
+                isinstance(node, Name) and node.id == name
+                for node in statement.target.walk()
+            )
+        return False
+
+    def _try_rebinds_name(self, statement, name: str) -> bool:
+        if any(self._statement_rebinds_name(body, name) for body in statement.body):
+            return True
+        for handler in statement.handlers:
+            if handler.name == name:
+                return True
+            if any(
+                self._statement_rebinds_name(body, name) for body in handler.body
+            ):
+                return True
+        return any(
+            self._statement_rebinds_name(tail, name)
+            for tail in (*statement.orelse, *statement.finalbody)
         )
 
     def _compute_exception_type_identity(

--- a/implementations/python/sugar-source-tree/tests/test_provider_gated_exception_type_identity.py
+++ b/implementations/python/sugar-source-tree/tests/test_provider_gated_exception_type_identity.py
@@ -1,0 +1,217 @@
+"""Provider-gated import heads close dotted exception-type identity.
+
+Twins for optional-provider patterns that static import binding alone leaves
+loud: ``pytest.importorskip`` assignment and ``try: import`` / ``except
+ImportError``.  Identity is the sealed coordinate; MRO / ClassValue are not
+invented when defining source is absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+    AuthenticatedExceptionTypeValue,
+)
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.sugar.authenticated_exception_type_sugar import (
+    AuthenticatedExceptionTypeSugar,
+)
+from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _identity(module_path: str):
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const(module_path)],
+    )
+
+
+def _tree(tmp_path: Path, source: str, name: str = "provider_gate.py"):
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return SourceFile(path_source(str(path)))
+
+
+def _attribute_named(tree: SourceFile, attr: str):
+    return next(
+        node
+        for node in tree.nodes()
+        if node.kind == "Attribute" and node.attr == attr
+    )
+
+
+def test_importorskip_attribute_exception_identity_truthful(tmp_path):
+    """Truthful: ``pa = pytest.importorskip("pyarrow")`` seals ``pa.ArrowInvalid``."""
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        'pa = pytest.importorskip("pyarrow")\n'
+        "def f():\n"
+        "    return pa.ArrowInvalid\n",
+    )
+    attr = _attribute_named(tree, "ArrowInvalid")
+    assert tree.root.unit.imported_exception_type_identity(attr) == _identity(
+        "pyarrow.ArrowInvalid"
+    )
+
+
+def test_try_import_attribute_exception_identity_truthful(tmp_path):
+    """Truthful: closed try/import provider gate seals ``pyarrow.ArrowException``."""
+    tree = _tree(
+        tmp_path,
+        "try:\n"
+        "    import pyarrow\n"
+        "    _HAVE = True\n"
+        "except ImportError:\n"
+        "    _HAVE = False\n"
+        "def f():\n"
+        "    return pyarrow.ArrowException\n",
+    )
+    attr = _attribute_named(tree, "ArrowException")
+    assert tree.root.unit.imported_exception_type_identity(attr) == _identity(
+        "pyarrow.ArrowException"
+    )
+
+
+def test_static_import_attribute_exception_identity_still_works(tmp_path):
+    """Ordinary static import remains the primary door."""
+    tree = _tree(
+        tmp_path,
+        "import pyarrow\n"
+        "def f():\n"
+        "    return pyarrow.ArrowInvalid\n",
+    )
+    attr = _attribute_named(tree, "ArrowInvalid")
+    assert tree.root.unit.imported_exception_type_identity(attr) == _identity(
+        "pyarrow.ArrowInvalid"
+    )
+
+
+def test_reassigned_importorskip_head_stays_loud(tmp_path):
+    """Lying: an intervening assignment defeats the provider-gate coordinate."""
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        'pa = pytest.importorskip("pyarrow")\n'
+        "pa = replacement\n"
+        "def f():\n"
+        "    return pa.ArrowInvalid\n",
+    )
+    attr = _attribute_named(tree, "ArrowInvalid")
+    assert tree.root.unit.imported_exception_type_identity(attr) is None
+
+
+def test_parameter_shadow_defeats_provider_gate(tmp_path):
+    """Lying: a formal named like the provider head has no import coordinate."""
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        'pa = pytest.importorskip("pyarrow")\n'
+        "def f(pa):\n"
+        "    return pa.ArrowInvalid\n",
+    )
+    attr = _attribute_named(tree, "ArrowInvalid")
+    assert tree.root.unit.imported_exception_type_identity(attr) is None
+
+
+def test_non_importorskip_assign_stays_loud(tmp_path):
+    """Lying: a call that is not importorskip is not a provider gate."""
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        'pa = pytest.skip("pyarrow")\n'
+        "def f():\n"
+        "    return pa.ArrowInvalid\n",
+    )
+    attr = _attribute_named(tree, "ArrowInvalid")
+    assert tree.root.unit.imported_exception_type_identity(attr) is None
+
+
+def test_try_import_rebind_in_handler_stays_loud(tmp_path):
+    """Lying: handler rebinding the module name is not a closed provider gate."""
+    tree = _tree(
+        tmp_path,
+        "try:\n"
+        "    import pyarrow\n"
+        "except ImportError:\n"
+        "    pyarrow = None\n"
+        "def f():\n"
+        "    return pyarrow.ArrowException\n",
+    )
+    attr = _attribute_named(tree, "ArrowException")
+    assert tree.root.unit.imported_exception_type_identity(attr) is None
+
+
+def test_authenticated_exception_type_sugar_does_not_force_attribute_floor():
+    """Identity-sealed sugar projects without ``SymbolicValue.attribute`` panic."""
+    surface = AttributeSugar(
+        receiver=NameSugar(name="pa", site=None),
+        name="ArrowInvalid",
+        site=None,
+    )
+    sugar = AuthenticatedExceptionTypeSugar(
+        surface, _identity("pyarrow.ArrowInvalid"), site=None
+    )
+    value = sugar.desugar().value
+    assert isinstance(value, AuthenticatedExceptionTypeValue)
+    assert value.exception_type_identity() == _identity("pyarrow.ArrowInvalid")
+    assert value.exception_type_mro() is None
+    assert value.class_value is None
+
+
+def test_live_pandas_arrow_external_error_operands_resolve():
+    """The five external_error Arrow attribute operands seal import identity."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    root = authenticated_pandas_corpus().root
+    expected = {
+        (
+            "tests/series/accessors/test_list_accessor.py",
+            100,
+            "ArrowInvalid",
+            "pyarrow.ArrowInvalid",
+        ),
+        (
+            "tests/series/accessors/test_list_accessor.py",
+            132,
+            "ArrowInvalid",
+            "pyarrow.ArrowInvalid",
+        ),
+        (
+            "tests/series/accessors/test_list_accessor.py",
+            134,
+            "ArrowInvalid",
+            "pyarrow.ArrowInvalid",
+        ),
+        (
+            "tests/extension/test_arrow.py",
+            1715,
+            "ArrowInvalid",
+            "pyarrow.ArrowInvalid",
+        ),
+        (
+            "tests/io/test_parquet.py",
+            799,
+            "ArrowException",
+            "pyarrow.ArrowException",
+        ),
+    }
+    found = set()
+    for relative, line, attr, qualified in expected:
+        path = root / relative
+        tree = SourceFile(path_source(str(path)))
+        node = next(
+            n
+            for n in tree.nodes()
+            if n.kind == "Attribute"
+            and n.attr == attr
+            and n.line_col_span().start_line == line
+        )
+        identity = tree.root.unit.imported_exception_type_identity(node)
+        assert identity == _identity(qualified), (relative, line, identity)
+        found.add((relative, line, attr, qualified))
+    assert found == expected


### PR DESCRIPTION
## Summary

Owner: **external-exception** — resolve the five `ArrowInvalid` / `ArrowException` attribute operands of `pandas._testing.external_error_raised` from authenticated source/provider coordinates without inventing MRO.

### The five sites

| File | Line | Operand | Before | After |
|---|---:|---|---|---|
| `tests/series/accessors/test_list_accessor.py` | 100,132,134 | `pa.ArrowInvalid` | `SymbolicValue.attribute` panic | `exit-may-halt` |
| `tests/extension/test_arrow.py` | 1715 | `pa.ArrowInvalid` | same | same stage |
| `tests/io/test_parquet.py` | 799 | `pyarrow.ArrowException` | same | same stage |

Heads are optional-provider gates (`pytest.importorskip("pyarrow")` or `try: import pyarrow` / `except ImportError`), not closed static import bindings.

### Construction

1. **`SourceUnit.provider_gated_import_target`** — lexical importorskip / try-import provider gates for exception-type identity only
2. **`imported_exception_type_identity`** — falls through to provider gate → `python:exception_type_identity(import, pyarrow.ArrowInvalid|ArrowException)`
3. **`AuthenticatedExceptionTypeSugar.desugar`** — sealed identity carrier; no Attribute floor invent
4. **Manager actuals** — exception-type formals only (`expected_exception`, …) project that identity

**Does not invent MRO.** Defining source for pyarrow exception classes is absent from the seat; ancestry stays honest-loud; identity is enough for match coordinates.

### Residual of 5

| Axis | Before | After |
|---|---:|---:|
| Attribute-stage construction-panic | **5** | **0** |
| Identity sealed | 0 | **5** |
| MRO invented | 0 | 0 |

Epsilon R: **−5** attribute-stage offenders. Next residual is shared exit-face RaisesExc floors with the other 42 external_error sites — not this PR.

Owner report: `docs/ledgers/arrow-exception-source-coords-owner-report.md`

## Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-python-source/src:\
implementations/python/sugar-lift-py-tests/src:\
implementations/python/sugar-source-tree/src \
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-source-tree/tests/test_provider_gated_exception_type_identity.py \
  implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py::test_reverse_order_branch_constructs_both_native_boundaries \
  implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py::test_reassigned_local_import_head_has_no_exception_identity \
  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_external_error_raised_follows_authenticated_returned_manager \
  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_external_error_raised_population_is_the_authenticated_47_with_sites \
  -q
# 13 passed
```

Seat: CPython 3.12.13 · corpus `blake3-512:6f317…` · demand `blake3-512:0ce7…`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal Arrow exception attribute coords via provider-gated import identity resolution
> - Adds `SourceUnit.provider_gated_import_target` in [nodes.py](https://github.com/TSavo/sugar/pull/6566/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to detect module bindings from `pytest.importorskip(...)` and `try: import / except ImportError` patterns, enabling identity sealing where static import binding is absent.
> - Extends `SourceUnit.imported_exception_type_identity` to fall back to `provider_gated_import_target` when `import_bound_name_target` returns `None` for the head of a dotted Attribute chain, producing a qualified `python:exception_type_identity(import, qualified)` coordinate.
> - Updates `AuthenticatedExceptionTypeSugar.desugar` in [authenticated_exception_type_sugar.py](https://github.com/TSavo/sugar/pull/6566/files#diff-6d596225934d058a37f1c0407e0df76bfe2c5485e30cb223afda40ed932e2210) to construct an `AuthenticatedExceptionTypeValue` backed by `SymbolicValue(identity)` instead of re-desugaring Attribute chains when the identity is sealed but not import-bound, preventing Attribute-floor failures.
> - Updates `populate_source_derived_resource_refs` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6566/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to resolve actuals passed to exception-type formals (e.g. `expected`, `exc_type`) into authenticated exception-type values using the new identity sealing path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f4c0a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->