### PR TITLE
Construct import-bound exception type coordinates source-visibly

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -1,0 +1,35 @@
+"""A closed import-bound module member coordinate.
+
+The lexical import pass authenticates the head; the static Attribute chain
+names the export path.  This floor carries that joined coordinate without
+re-asking an opaque module receiver for a member and without inventing
+AttributeError.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ImportMemberValue(FloorValue):
+    """Source-authenticated ``module.attr[.attr…]`` export coordinate."""
+
+    qualified_name: str
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:import_member", [str_const(self.qualified_name)])
+
+    def exception_type_identity(self):
+        """The same import coordinate the exception authenticator mints."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:exception_type_identity",
+            [str_const("import"), str_const(self.qualified_name)],
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -255,6 +255,35 @@ def _import_from_module(current: str, node: Node) -> str | None:
     return ".".join(base) or None
 
 
+def _importorskip_module(value: Node | None) -> str | None:
+    """Module name of ``pytest.importorskip("mod")`` / ``importorskip("mod")``.
+
+    Source-visible only: Attribute or Name head, one positional string
+    Constant, no keywords/stars.  Spelling of the module is the Constant's
+    own value, never a vendor table.
+    """
+    if value is None or value.kind != "Call":
+        return None
+    if value.keywords or any(arg.kind == "Starred" for arg in value.args):
+        return None
+    if len(value.args) != 1 or value.args[0].kind != "Constant":
+        return None
+    module = value.args[0].value
+    if not isinstance(module, str) or not module:
+        return None
+    func = value.func
+    if func.kind == "Name" and func.id == "importorskip":
+        return module
+    if (
+        func.kind == "Attribute"
+        and func.attr == "importorskip"
+        and func.value.kind == "Name"
+        and func.value.id == "pytest"
+    ):
+        return module
+    return None
+
+
 class _Pass:
     def __init__(
         self,
@@ -314,18 +343,20 @@ class _Pass:
         if node is None:
             return
         if node.kind == "Name":
-            # A name USE whose sole reaching definition is an import statement
-            # is lexically bound to that import's target coordinate.  Recorded
-            # here, by the same reaching-definition state the call rows use --
-            # never by a second resolver and never by spelling.
+            # A name USE whose sole concrete reaching definition is an import
+            # statement is lexically bound to that import's target coordinate.
+            # Optional try/import joins ImportDef with unbound on the except
+            # path; the ImportDef is still the only source-visible binding.
+            # Recorded here by the same reaching-definition state the call rows
+            # use -- never by a second resolver and never by spelling.
             reaching = state.get(node.id, frozenset({_UNBOUND}))
-            if len(reaching) == 1:
-                definition = next(iter(reaching))
-                if isinstance(definition, _ImportDef):
-                    span = node.line_col_span()
-                    self.name_targets[
-                        (span.start_line, span.start_col, span.end_line, span.end_col)
-                    ] = definition.target_symbol
+            imports = {value for value in reaching if isinstance(value, _ImportDef)}
+            if len(imports) == 1 and not (reaching - imports - {_UNBOUND}):
+                definition = next(iter(imports))
+                span = node.line_col_span()
+                self.name_targets[
+                    (span.start_line, span.start_col, span.end_line, span.end_col)
+                ] = definition.target_symbol
             return
         if node.kind == "Call":
             self.expression(node.func, state, scope)
@@ -544,8 +575,49 @@ class _Pass:
             value = getattr(node, "value", None)
             self.expression(value, state, scope)
             targets = node.targets if node.kind == "Assign" else [node.target]
+            importorskip = (
+                _importorskip_module(value)
+                if node.kind == "Assign" and len(targets) == 1
+                else None
+            )
             for target in targets:
-                for name in _bound_names(target):
+                names = _bound_names(target)
+                if (
+                    importorskip is not None
+                    and len(names) == 1
+                    and target.kind == "Name"
+                ):
+                    local = next(iter(names))
+                    module = importorskip
+                    payload = {
+                        "kind": "python-import-binding",
+                        "schemaVersion": "1",
+                        "sourceCid": self.source_cid,
+                        "scope": _site(self.source_cid, scope),
+                        "definitionSite": _site(self.source_cid, node),
+                        "localSlot": local,
+                        "target": {
+                            "moduleIdentity": self.module_identities.get(
+                                module,
+                                {
+                                    "kind": "unavailable-python-module",
+                                    "name": module,
+                                },
+                            ),
+                            "exportedPath": [],
+                        },
+                    }
+                    state[local] = frozenset(
+                        {
+                            _ImportDef(
+                                _hash(payload),
+                                f"python:{module}",
+                                encode_jcs(_json_value(payload)),
+                            )
+                        }
+                    )
+                    continue
+                for name in names:
                     state[name] = frozenset({_NON_IMPORT})
             return state
         if node.kind == "If":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
@@ -25,6 +25,17 @@ class AuthenticatedExceptionTypeSugar(Sugar):
         )
 
     def desugar(self, ctx=None):
+        """Project the authenticated type floor without re-asking Attribute.
+
+        Import-bound dotted operands already carry a closed
+        ``python:exception_type_identity(import, …)`` coordinate from the
+        lexical import pass.  That coordinate *is* the source-visible floor:
+        re-desugaring the Attribute sugar would ask an opaque module receiver
+        for a member it has no testimony for, inventing either a
+        ``py.getattr`` projection or a spelling-table arm.  Neither is
+        admitted.  Builtins and source-class leaves still reduce their
+        constructed value (or the projected ``class_value``) as before.
+        """
         from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
             AuthenticatedExceptionTypeValue,
         )
@@ -42,6 +53,15 @@ class AuthenticatedExceptionTypeSugar(Sugar):
                     self.class_value,
                 )
             )
+
+        import_floor = _import_bound_exception_floor(self.identity)
+        if import_floor is not None:
+            return Complete(
+                AuthenticatedExceptionTypeValue(
+                    import_floor, self.identity, self.mro, import_floor
+                )
+            )
+
         return self.value.desugar(ctx).and_then(
             lambda value: Complete(
                 AuthenticatedExceptionTypeValue(
@@ -49,3 +69,24 @@ class AuthenticatedExceptionTypeSugar(Sugar):
                 )
             )
         )
+
+
+def _import_bound_exception_floor(identity):
+    """The ExceptionClassValue named by an import identity, or None.
+
+    Only the ``import`` kind of ``python:exception_type_identity`` is closed
+    without further floor projection: its second argument is the qualified
+    export coordinate already joined from the authenticated import target and
+    the static Attribute chain.  Builtins and source-class identities keep
+    their existing leaf floors.
+    """
+    from sugar_lift_py_tests.floor.exception_class_value import ExceptionClassValue
+
+    args = getattr(identity, "args", None)
+    if args is None or len(args) != 2:
+        return None
+    kind = getattr(args[0], "value", None)
+    qualified = getattr(args[1], "value", None)
+    if kind != "import" or not isinstance(qualified, str) or not qualified:
+        return None
+    return ExceptionClassValue(qualified)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
@@ -1,0 +1,32 @@
+"""Sugar for a closed import-bound Attribute chain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ImportMemberSugar(Sugar):
+    """``import M as h; h.a.b`` as the closed coordinate ``M.a.b``."""
+
+    qualified_name: str
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ImportMemberValue",
+            reason="projects one import-bound export coordinate from lexical authority",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+
+        return Complete(ImportMemberValue(self.qualified_name))

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -19,13 +19,16 @@ import subprocess
 import tempfile
 from functools import cache
 from pathlib import Path
+from types import MappingProxyType
 
 import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerResolutionGapV1,
+    ResolvedContractRefsV1,
     SourceDerivedContextManagerRefV1,
+    SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
@@ -36,7 +39,6 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     summarize_attribution_outcomes,
 )
 from sugar_lift_python_source.canonical import blake3_512_of
-
 
 _SOURCE_CID = (
     "blake3-512:3a71aa9c523d26a6a541cb6fdc124d37c364245b959d41873619701b421fbe370"
@@ -51,6 +53,21 @@ _CORPUS_MANIFEST_CID = (
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 )
 _EXTERNAL_ERROR_TARGET = "pandas._testing.external_error_raised"
+_CATALOG_CID = "blake3-512:" + "c" * 128
+_TABLE_CID = "blake3-512:" + "t" * 128
+
+# Owner 3 residual: import-bound pyarrow exception coordinates on external_error
+# With heads.  Before source-visible construction they panicked on
+# SymbolicValue.attribute; after, the type operand is an authenticated import
+# identity and any remaining residual is a later stage (never the exception
+# Attribute projection).
+_ARROW_EXCEPTION_SITES = (
+    "tests/extension/test_arrow.py:1715",
+    "tests/io/test_parquet.py:799",
+    "tests/series/accessors/test_list_accessor.py:100",
+    "tests/series/accessors/test_list_accessor.py:132",
+    "tests/series/accessors/test_list_accessor.py:134",
+)
 
 
 @cache
@@ -233,9 +250,7 @@ def _external_error_attributions():
                 (),
             )
         context = TreeConstructionContextV1(
-            ResolvedContractRefsV1(
-                _CATALOG_CID, _TABLE_CID, MappingProxyType(refs)
-            ),
+            ResolvedContractRefsV1(_CATALOG_CID, _TABLE_CID, MappingProxyType(refs)),
             workspace_root=str(corpus.root.parent),
         )
         tree = SourceFile(
@@ -293,20 +308,29 @@ def test_external_error_raised_47_site_outcome_partition() -> None:
     summary = summarize_attribution_outcomes(_external_error_attributions())
 
     assert summary.enrolled == 47
-    assert summary.authenticated_exceptional_exits == 0
-    assert summary.named_refusals == 42
-    assert summary.construction_panics == 5
+    # ArrowInvalid/ArrowException heads construct through import-bound export
+    # coordinates; residual is named (exit-face), never ConstructionPanic on
+    # SymbolicValue.attribute for the exception-type operand.
+    assert summary.construction_panics == 0
+    assert (
+        summary.authenticated_exceptional_exits + summary.named_refusals
+        == summary.enrolled
+    )
 
 
 def test_external_error_raised_refusal_and_gap_twins_are_concrete_sites() -> None:
     by_id = {body.body_id: body for body in _external_error_attributions()}
 
     refusal = by_id["tests/io/test_feather.py:40"]
-    gap = by_id["tests/extension/test_arrow.py:1715"]
     assert refusal.outcome is AttributionOutcome.NAMED_REFUSAL
     assert refusal.detail == "With._construct_sugar"
-    assert gap.outcome is AttributionOutcome.CONSTRUCTION_PANIC
-    assert gap.detail == "SymbolicValue.attribute"
+
+    for site_id in _ARROW_EXCEPTION_SITES:
+        site = by_id[site_id]
+        # Before: SymbolicValue.attribute on ArrowInvalid/ArrowException.
+        # After: import-bound export coordinate; residual is a later stage.
+        assert site.outcome is AttributionOutcome.NAMED_REFUSAL, site
+        assert site.detail == "With._construct_sugar", site
 
 
 def test_external_error_raised_emits_complete_consumer_testimony() -> None:
@@ -340,9 +364,7 @@ def test_external_error_raised_emits_complete_consumer_testimony() -> None:
 
     assert len(report.lines()) == 8
     assert report.lines()[4].endswith("pandas/tests/io/test_feather.py:40:13")
-    assert report.lines()[-1].startswith(
-        "survivingTypedGapsOrReattributions reported"
-    )
+    assert report.lines()[-1].startswith("survivingTypedGapsOrReattributions reported")
 
 
 def test_adjacent_computed_class_raises_stays_typed_opaque() -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8544,15 +8544,48 @@ class Attribute(Expression):
         """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
         The attr name is a static identifier carried onto the coordinate.
 
+        When the whole chain is a closed import-bound export
+        (``import M as h; h.a.b``), the coordinate is the joined export
+        ``M.a.b`` — the same authority Call uses for import-bound callees.
+        No module receiver is projected, so no AttributeError is invented and
+        no vendor member table is consulted.
+
         An opaque receiver still constructs this native operation. Its floor
         decides whether source testimony supplies a value or exceptional exit;
         when neither is known, the producer refuses instead of inventing a
         completed ``py.getattr`` projection or guessing ``AttributeError``."""
+        export = self._import_bound_export_symbol()
+        if export is not None:
+            from sugar_lift_py_tests.sugar.import_member_sugar import ImportMemberSugar
+
+            return ImportMemberSugar(qualified_name=export, site=self.fragment)
         from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 
         return AttributeSugar(
             receiver=self.value.sugar(), name=self.attr, site=self.fragment
         )
+
+    def _import_bound_export_symbol(self) -> Optional[str]:
+        """Closed ``module.attr…`` coordinate when the head is uniquely import-bound.
+
+        Mirrors ``Call._import_bound_callee_symbol`` for non-call Attribute
+        expressions (exception types, dtype constructors used as values).
+        """
+        link = self
+        attributes: list[str] = []
+        while isinstance(link, Attribute):
+            attributes.append(link.attr)
+            link = link.value
+        if not isinstance(link, Name):
+            return None
+        span = link.line_col_span()
+        target = self.unit.import_bound_name_target(
+            (span.start_line, span.start_col, span.end_line, span.end_col)
+        )
+        if target is None:
+            return None
+        module = target[len("python:") :] if target.startswith("python:") else target
+        return ".".join([module, *reversed(attributes)])
 
     def substitute(self, scope):
         """Project only from a construction-authenticated object place."""

--- a/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
@@ -1,0 +1,368 @@
+"""Import-bound dotted exception types construct without Attribute projection.
+
+Mechanism: ``imported_exception_type_identity`` joins the authenticated import
+target with the static Attribute chain into one
+``python:exception_type_identity(import, qualified)`` coordinate.  The CM
+contract authenticates the operand's *role* as an exception type; this module
+authenticates only the identity.  ``AuthenticatedExceptionTypeSugar`` projects
+that coordinate as ``ExceptionClassValue`` and never re-asks the opaque module
+receiver for a member (no spelling table, no ``py.getattr`` invent).
+
+Pinned pandas residual (Owner 3 — external exception coordinates):
+
+- four ``pa.ArrowInvalid`` With heads
+- one ``pyarrow.ArrowException`` With head
+
+Each site either routes with a matching authenticated type operand, or keeps a
+later residual that is *not* ``SymbolicValue.attribute`` on the exception name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExceptionInfoBindingV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    KeywordOnlyV1,
+    LiteralDefaultV1,
+    NoDefaultV1,
+    OptionalFormalArgumentProjectionV1,
+    PositionalOrKeywordV1,
+    RaiseEffectKindV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ImportSignatureV2,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+    AuthenticatedExceptionTypeValue,
+)
+from sugar_lift_py_tests.floor.exception_class_value import ExceptionClassValue
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+SIGNATURE = ImportSignatureV2(
+    (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("String"),
+            KeywordOnlyV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+)
+
+
+def _cid(char: str) -> str:
+    return "blake3-512:" + char * 128
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _raise_semantics():
+    return EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+
+
+def _ref(use_site, salt: str) -> ContextManagerContractRefV1:
+    return ContextManagerContractRefV1(
+        resolution_cid=_cid(salt),
+        demand_cid=_cid("d"),
+        use_site=use_site,
+        use_site_cid=_hash_json(use_site.wire()),
+        authenticated_import_use_cid=_cid("u"),
+        import_binding_cid=_cid("i"),
+        construction_context_generation_cid=_cid("g"),
+        contract_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        provenance_cid=_cid("v"),
+        distribution_artifact_cid=_cid("a"),
+        dependency_artifact_graph_cid=_cid("b"),
+        module_source_cid=_cid("s"),
+        resolved_definition_cid=_cid("f"),
+        manager_construction_cid=_cid("n"),
+        enter_testimony_cid=_cid("1"),
+        exit_testimony_cid=_cid("2"),
+        import_signature=SIGNATURE,
+        semantics=_raise_semantics(),
+    )
+
+
+def _boundary(tmp_path: Path, source: str) -> WithEffectBoundarySugar:
+    path = tmp_path / "site.py"
+    path.write_text(source, encoding="utf-8")
+    identity = path_source(str(path))
+    probe = SourceFile(identity)
+    with_node = next(node for node in probe.nodes() if node.kind == "With")
+    coordinate = _coordinate(with_node.items[0].context_expr)
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(
+            _cid("c"), _cid("t"), MappingProxyType({coordinate: _ref(coordinate, "r")})
+        )
+    )
+    function = next(SourceFile(identity, construction_context=context).functions())
+    sugar = function.sugar()
+    boundaries: list[WithEffectBoundarySugar] = []
+
+    def walk(node) -> None:
+        if isinstance(node, WithEffectBoundarySugar):
+            boundaries.append(node)
+        for field in ("body", "statements", "entries", "then_body", "else_body"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+        manager = getattr(node, "manager", None)
+        if manager is not None:
+            walk(manager)
+
+    walk(sugar)
+    assert len(boundaries) == 1
+    return boundaries[0]
+
+
+def _attribute(tree: SourceFile, attr: str):
+    return next(
+        node for node in tree.nodes() if node.kind == "Attribute" and node.attr == attr
+    )
+
+
+def test_import_alias_arrow_invalid_identity_is_import_coordinate(tmp_path):
+    """Truthful: ``import pyarrow as pa`` + ``pa.ArrowInvalid`` is one import identity."""
+    path = tmp_path / "alias.py"
+    path.write_text(
+        "import pyarrow as pa\n"
+        "def f():\n"
+        "    with expect(pa.ArrowInvalid):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    identity = tree.unit.imported_exception_type_identity(
+        _attribute(tree, "ArrowInvalid")
+    )
+    assert identity == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowInvalid")],
+    )
+
+
+def test_module_name_arrow_exception_identity_is_import_coordinate(tmp_path):
+    """Truthful: bare ``import pyarrow`` + ``pyarrow.ArrowException`` is closed."""
+    path = tmp_path / "mod.py"
+    path.write_text(
+        "import pyarrow\n"
+        "def f():\n"
+        "    with expect(pyarrow.ArrowException):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    identity = tree.unit.imported_exception_type_identity(
+        _attribute(tree, "ArrowException")
+    )
+    assert identity == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowException")],
+    )
+
+
+def test_import_bound_exception_desugars_to_authenticated_type(tmp_path):
+    """Truthful twin: manager arg is AuthenticatedExceptionTypeValue, not Attribute."""
+    boundary = _boundary(
+        tmp_path,
+        "import pyarrow as pa\n"
+        "def f():\n"
+        "    with expect(pa.ArrowInvalid):\n"
+        "        raise ValueError('x')\n",
+    )
+    call = boundary.manager.desugar().value
+    expected = call.arg_values[0]
+    assert isinstance(expected, AuthenticatedExceptionTypeValue)
+    assert expected.exception_type_identity() == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowInvalid")],
+    )
+    assert isinstance(expected.value, ExceptionClassValue)
+    assert expected.value.qualified_name == "pyarrow.ArrowInvalid"
+
+
+def test_arrow_exception_module_attr_desugars_to_authenticated_type(tmp_path):
+    """Truthful twin for the parquet residual spelling ``pyarrow.ArrowException``."""
+    boundary = _boundary(
+        tmp_path,
+        "import pyarrow\n"
+        "def f():\n"
+        "    with expect(pyarrow.ArrowException):\n"
+        "        raise ValueError('x')\n",
+    )
+    expected = boundary.manager.desugar().value.arg_values[0]
+    assert isinstance(expected, AuthenticatedExceptionTypeValue)
+    assert expected.exception_type_identity() == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowException")],
+    )
+    assert isinstance(expected.value, ExceptionClassValue)
+    assert expected.value.qualified_name == "pyarrow.ArrowException"
+
+
+def test_nested_lib_export_uses_full_import_chain(tmp_path):
+    """Mechanism: every static Attribute link joins the import coordinate."""
+    path = tmp_path / "nested.py"
+    path.write_text(
+        "import pyarrow as pa\n"
+        "def f():\n"
+        "    with expect(pa.lib.ArrowInvalid):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    identity = tree.unit.imported_exception_type_identity(
+        _attribute(tree, "ArrowInvalid")
+    )
+    assert identity == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.lib.ArrowInvalid")],
+    )
+
+
+def test_reassigned_import_head_has_no_exception_identity(tmp_path):
+    """Lying twin: an intervening assignment defeats the import coordinate."""
+    path = tmp_path / "shadowed.py"
+    path.write_text(
+        "import pyarrow as pa\n"
+        "def f(replacement):\n"
+        "    pa = replacement\n"
+        "    with expect(pa.ArrowInvalid):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    assert (
+        tree.unit.imported_exception_type_identity(_attribute(tree, "ArrowInvalid"))
+        is None
+    )
+
+
+def test_no_pyarrow_spelling_arm_in_authenticator():
+    """Guard: the desugar path never branches on vendor exception spellings."""
+    from pathlib import Path
+
+    sugar_path = (
+        Path(__file__).resolve().parents[2]
+        / "sugar-lift-py-tests"
+        / "src"
+        / "sugar_lift_py_tests"
+        / "sugar"
+        / "authenticated_exception_type_sugar.py"
+    )
+    text = sugar_path.read_text(encoding="utf-8")
+    for forbidden in (
+        "ArrowInvalid",
+        "ArrowException",
+        "pyarrow",
+        "ArrowNotImplemented",
+    ):
+        assert forbidden not in text, forbidden
+
+
+def test_importorskip_binding_authenticates_arrow_invalid(tmp_path):
+    """Truthful: ``pa = pytest.importorskip("pyarrow")`` is an import binding."""
+    path = tmp_path / "skip.py"
+    path.write_text(
+        "import pytest\n"
+        'pa = pytest.importorskip("pyarrow")\n'
+        "def f():\n"
+        "    with expect(pa.ArrowInvalid):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    identity = tree.unit.imported_exception_type_identity(
+        _attribute(tree, "ArrowInvalid")
+    )
+    assert identity == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowInvalid")],
+    )
+    sugar = _attribute(tree, "ArrowInvalid").sugar()
+    from sugar_lift_py_tests.sugar.import_member_sugar import ImportMemberSugar
+
+    assert isinstance(sugar, ImportMemberSugar)
+    assert sugar.qualified_name == "pyarrow.ArrowInvalid"
+    floor = sugar.desugar().value
+    assert floor.exception_type_identity() == identity
+
+
+def test_try_import_optional_binding_authenticates_module_attr(tmp_path):
+    """Truthful: try/import with unbound except path keeps the ImportDef alone."""
+    path = tmp_path / "tryimp.py"
+    path.write_text(
+        "try:\n"
+        "    import pyarrow\n"
+        "except ImportError:\n"
+        "    pass\n"
+        "def f():\n"
+        "    with expect(pyarrow.ArrowException):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    identity = tree.unit.imported_exception_type_identity(
+        _attribute(tree, "ArrowException")
+    )
+    assert identity == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowException")],
+    )
+
+
+def test_try_import_with_except_rebind_stays_loud(tmp_path):
+    """Lying: except rebinding the name defeats unique import identity."""
+    path = tmp_path / "try_rebind.py"
+    path.write_text(
+        "try:\n"
+        "    import pyarrow\n"
+        "except ImportError:\n"
+        "    pyarrow = None\n"
+        "def f():\n"
+        "    with expect(pyarrow.ArrowException):\n"
+        "        raise ValueError('x')\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    assert (
+        tree.unit.imported_exception_type_identity(_attribute(tree, "ArrowException"))
+        is None
+    )


### PR DESCRIPTION
## Summary

Owner 3 — external exception coordinates. Drain four `ArrowInvalid` + one `ArrowException` `external_error_raised` construction sites by constructing category identity through authenticated imports/source exports (no spelling-based PyArrow arm).

### Before (5 sites)
| Site | Outcome |
|------|---------|
| `tests/extension/test_arrow.py:1715` | `SymbolicValue.attribute` / ArrowInvalid |
| `tests/io/test_parquet.py:799` | `SymbolicValue.attribute` / ArrowException |
| `tests/series/accessors/test_list_accessor.py:100` | `SymbolicValue.attribute` / ArrowInvalid |
| `tests/series/accessors/test_list_accessor.py:132` | `SymbolicValue.attribute` / ArrowInvalid |
| `tests/series/accessors/test_list_accessor.py:134` | `SymbolicValue.attribute` / ArrowInvalid |

### After (5 sites)
| Site | Outcome |
|------|---------|
| all five | `named-refusal` `With._construct_sugar` residual `exit-may-halt [unary_operation_exception_floor:…]` |

Exception-type operand constructs as closed import-bound export (`ImportMemberSugar` / authenticated identity). Later residual is exit-face, never Attribute projection on the exception name.

### Mechanism
1. **`pytest.importorskip("mod")`** is a lexical import binding (source-visible call shape; Constant module name).
2. **Optional try/import**: reaching `{ImportDef, unbound}` still authenticates the ImportDef.
3. **Import-bound Attribute chains** construct `ImportMemberSugar` (same authority as import-bound Call callees).
4. **`AuthenticatedExceptionTypeSugar`** projects `python:exception_type_identity(import, …)` without re-desugaring Attribute.

No vendor spelling table. Reassigned heads / except-rebind stay loud (lying twins).

### Validation
```
pytest implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
pytest implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
# 5-site remeasure: all detail != SymbolicValue.attribute
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct import-bound exception type coordinates source-visibly via `ImportMemberSugar` and `ImportMemberValue`
> - Adds `ImportMemberValue`, a floor value for import-bound attribute chains, serializing to `python:import_member` terms and `python:exception_type_identity` identities.
> - Adds `ImportMemberSugar` that desugars import-rooted attribute chains directly into `ImportMemberValue` floors, bypassing generic `AttributeSugar`.
> - `Attribute._construct_sugar` now detects import-bound names by walking the attribute chain and querying `import_bound_name_target`, returning `ImportMemberSugar` when matched.
> - `AuthenticatedExceptionTypeSugar.desugar` gains an early-return path for import-bound identities, resolving them to `AuthenticatedExceptionTypeValue` with an `ExceptionClassValue` floor without evaluating the receiver chain.
> - Extends import binding analysis to handle `pytest.importorskip` assignments and to preserve unique import definitions across try/except joins with unbound paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ace7c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->