### PR TITLE
Floor returned-manager RaisesExc fields through isinstance/len/tuple

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -35,7 +35,19 @@ class BuiltinSemanticCallable(FloorValue):
     def callable_application_with(self, operation, ctx):
         del ctx
         if self.operation == "python.set.construct":
-            return self._construct_set(operation)
+            floored = self._construct_set(operation)
+            if floored is not None:
+                return floored
+            return self._unhandled_construct(operation, "set")
+        if self.operation == "python.tuple.construct":
+            floored = self._construct_tuple(operation)
+            if floored is not None:
+                return floored
+            return self._unhandled_construct(operation, "tuple")
+        if self.operation == "python.isinstance":
+            return self._isinstance(operation)
+        if self.operation == "python.len":
+            return self._len(operation)
         if self.operation != "python.issubclass":
             return super().callable_application_with(operation, None)
         if len(operation.arguments) != 2 or operation.keyword_names:
@@ -49,14 +61,124 @@ class BuiltinSemanticCallable(FloorValue):
                 fix="construct Python issubclass arity exactly or keep it loud",
             )
         subtype, supertype = operation.arguments
+        subtype = self._resolve_type_operand(subtype, operation.site)
+        supertype = self._resolve_type_operand(supertype, operation.site)
         return subtype.test_python_subtype(supertype, operation.site)
+
+    def _unhandled_construct(self, operation, name: str):
+        """Opaque construct operands stay a dig cue, not a ConstructionPanic.
+
+        ``tuple(opaque_genexp)`` must remain a CallSiteValue coordinate so later
+        force_floor / field projection can refuse with a stage-keyed residual
+        rather than aborting the whole manager factory membrane.
+        """
+        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
+
+        args = operation.arguments
+        owner = str(operation.site)
+        return Complete(
+            CallSiteValue(
+                target_name=name,
+                arg_values=args,
+                parameters=(),
+                term=ctor(
+                    f"call:{name}",
+                    [value.to_term(owner=owner) for value in args],
+                    symbol_kind="builtin",
+                ),
+                body=None,
+                site=operation.site,
+            )
+        )
+
+    def _len(self, operation):
+        """Exact ``len(container)`` over floors that already know their size."""
+        if operation.keyword_names or len(operation.arguments) != 1:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BuiltinSemanticCallable.python.len",
+                blame=str(operation.site),
+                observed=(len(operation.arguments), operation.keyword_names),
+                requested="exactly one positional authenticated len operand",
+                fix="construct Python len arity exactly or keep it loud",
+            )
+        container = operation.arguments[0]
+        length = getattr(container, "length", None)
+        if not callable(length):
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BuiltinSemanticCallable.python.len",
+                blame=str(operation.site),
+                observed=type(container).__name__,
+                requested="container floor with source-visible length",
+                fix="project finite containers before len or keep the call loud",
+            )
+        return length(operation.site)
+
+    def _isinstance(self, operation):
+        """Exact ``isinstance(obj, classinfo)`` over authenticated floors.
+
+        ``classinfo`` is a type coordinate or a finite tuple of them. The type
+        owns the test via ``test_python_type``; the object answers through
+        ``python_isinstance``. Dual-mode EffectBoundary factories (RaisesExc)
+        gate ``expected_exceptions`` on ``isinstance(x, tuple)`` — without this
+        arm the condition stays a bodyless CallSiteValue and ``not`` refuses.
+        """
+        if len(operation.arguments) != 2 or operation.keyword_names:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BuiltinSemanticCallable.python.isinstance",
+                blame=str(operation.site),
+                observed=(len(operation.arguments), operation.keyword_names),
+                requested="exactly two positional authenticated isinstance operands",
+                fix="construct Python isinstance arity exactly or keep it loud",
+            )
+        obj, classinfo = operation.arguments
+        classinfo = self._resolve_type_operand(classinfo, operation.site)
+        return classinfo.test_python_type(obj, operation.site)
+
+    def _resolve_type_operand(self, classinfo, site):
+        """Map a free builtin type name (SymbolicValue Var) to a type coordinate.
+
+        NameSugar leaves free names as ``SymbolicValue(_Var(name))``. Inside
+        source-visible method bodies those free names are language builtins
+        (``tuple``, ``type``, ``BaseException``), not call formals. Resolve the
+        closed builtin vocabulary to ClassValue / exception floors so
+        ``isinstance(x, tuple)`` and ``isinstance(x, type)`` ground.
+        """
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import _Var
+
+        if not isinstance(classinfo, SymbolicValue):
+            return classinfo
+        term = classinfo.term
+        if not isinstance(term, _Var):
+            return classinfo
+        name = term.name
+        from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+            BUILTIN_EXCEPTION_NAMES,
+            builtin_name_temporal,
+        )
+
+        temporal = builtin_name_temporal()
+        bound = temporal.value_if_bound(name)
+        if bound is not None:
+            return bound
+        # ``type`` is a ClassValue in the builtin temporal; if missing, keep loud.
+        del site
+        return classinfo
 
     def _construct_set(self, operation):
         from sugar_lift_py_tests.floor import DictValue, ListValue, SetValue, TupleValue
         from sugar_lift_py_tests.outcome import Complete
 
         if operation.keyword_names or len(operation.arguments) > 1:
-            return super().callable_application_with(operation, None)
+            return None
         if not operation.arguments:
             return Complete(SetValue(()))
         source = operation.arguments[0]
@@ -64,7 +186,60 @@ class BuiltinSemanticCallable(FloorValue):
             return Complete(SetValue(tuple(key for key, _ in source.entries)))
         if isinstance(source, (ListValue, SetValue, TupleValue)):
             return Complete(SetValue(tuple(source.elements)))
-        return super().callable_application_with(operation, None)
+        return None
+
+    def _construct_tuple(self, operation):
+        """Exact ``tuple(iterable)`` over finite authenticated containers.
+
+        Generator expressions that projected ``finite_elements`` and ordinary
+        list/tuple/set floors become ``TupleValue`` here. Opaque iterables stay
+        a dig cue (via ``_unhandled_construct``) rather than inventing
+        cardinality or panicking the factory membrane.
+        """
+        from sugar_lift_py_tests.floor import (
+            ComprehensionValue,
+            DictValue,
+            ListValue,
+            SetValue,
+            TupleValue,
+        )
+        from sugar_lift_py_tests.outcome import Complete
+
+        if operation.keyword_names or len(operation.arguments) > 1:
+            return None
+        if not operation.arguments:
+            return Complete(TupleValue(()))
+        source = operation.arguments[0]
+        if isinstance(source, TupleValue):
+            return Complete(source)
+        if isinstance(source, (ListValue, SetValue)):
+            return Complete(TupleValue(tuple(source.elements)))
+        if isinstance(source, DictValue):
+            return Complete(TupleValue(tuple(key for key, _ in source.entries)))
+        if isinstance(source, ComprehensionValue) and source.finite_elements is not None:
+            return Complete(TupleValue(tuple(source.finite_elements)))
+        return None
+
+    def test_python_type(self, value, site):
+        """Constructor builtins that are also types answer isinstance tests.
+
+        ``tuple`` / ``set`` are both callables and type objects. Binding them as
+        construct callables must not lose ``isinstance(x, tuple)`` — RaisesExc
+        gates on that exact condition.
+        """
+        type_name = {
+            "python.tuple.construct": "tuple",
+            "python.set.construct": "set",
+        }.get(self.operation)
+        if type_name is None:
+            return super().test_python_type(value, site)
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return value.python_isinstance(
+            type_name,
+            ctor("python:type", [str_const(type_name)]),
+            site,
+        )
 
     def witness_for(self, operands, result) -> ClosedSemanticOperationWitness:
         return ClosedSemanticOperationWitness.mint(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -4,6 +4,30 @@ from dataclasses import dataclass, replace
 
 from .floor_value import FloorValue
 
+# Types that a class object is never an instance of under ordinary Python.
+# ``isinstance(SomeClass, tuple)`` is False; container and scalar value types
+# are disjoint from the class-object side of the type/value distinction.
+_CLASS_OBJECT_DISJOINT_TYPES = frozenset(
+    {
+        "tuple",
+        "list",
+        "dict",
+        "set",
+        "frozenset",
+        "str",
+        "bytes",
+        "bytearray",
+        "int",
+        "bool",
+        "float",
+        "complex",
+        "range",
+        "NoneType",
+        "memoryview",
+        "slice",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ClassValue(FloorValue):
@@ -53,8 +77,45 @@ class ClassValue(FloorValue):
             return Complete(FalseBoolLiteralSugar(site=site))
         return super().is_identical(other, site)
 
+    def attribute(self, name, site):
+        """Class objects expose ``__name__`` as their authenticated type name.
+
+        RaisesExc's absent-effect diagnostic formats
+        ``self.expected_exceptions[0].__name__``. Without this arm the attribute
+        producer panics on BuiltinExceptionClassValue and exit summary stays
+        exit-may-halt rather than sealing ExpectsMode.
+        """
+        if name == "__name__":
+            from sugar_lift_py_tests.floor.string_value import StringValue
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(StringValue(self.name))
+        return super().attribute(name, site)
+
     def test_python_type(self, value, site):
         return value.python_isinstance(self.name, self.to_term(owner=self.name), site)
+
+    def python_isinstance(self, type_name: str, type_term, site):
+        """A class object is an instance of ``type`` / ``object``, never of value types.
+
+        ``isinstance(Exception, tuple)`` is False; ``isinstance(Exception, type)``
+        is True. Without this ground answer, RaisesExc's
+        ``if isinstance(expected_exception, tuple):`` face stays undecided and
+        the ``expected_exceptions`` field never floors to a TupleValue.
+        """
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type_name in {"type", "object"}:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        if type_name in _CLASS_OBJECT_DISJOINT_TYPES:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        return super().python_isinstance(type_name, type_term, site)
 
     def test_python_subtype(self, supertype, site):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/closed_operation_witness.py
@@ -16,11 +16,14 @@ from sugar_lift_py_tests.ir import Term, _term_content_cid
 _CLOSED_OPERATIONS = frozenset(
     {
         "python.issubclass",
+        "python.isinstance",
+        "python.len",
         "python.set.contains",
         "python.set.union",
         "python.set.intersection",
         "python.set.difference",
         "python.set.construct",
+        "python.tuple.construct",
     }
 )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -19,6 +19,29 @@ class TermValue(FloorValue):
     def python_index_protocol(self) -> bool:
         return isinstance(self.value, int)
 
+    def equals(self, other, site):
+        """Ground numeric equality folds so ``len(xs) == 1`` can ground Ifs.
+
+        RaisesExc selects the singular absent-effect diagnostic with
+        ``if len(self.expected_exceptions) == 1``. Emitting ``=(1, 1)`` as a
+        third value forces both branches and panics the multi-name join arm.
+        """
+        if type(other) is TermValue and type(self.value) is type(other.value):
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if self.value == other.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        return super().equals(other, site)
+
     def python_isinstance(self, type_name: str, type_term, site):
         del type_term
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -58,6 +58,34 @@ class TupleValue(FloorValue):
             else FalseBoolLiteralSugar(site=site)
         )
 
+    def python_isinstance(self, type_name: str, type_term, site):
+        """A constructed tuple is exactly an instance of ``tuple`` / ``object``."""
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type_name in {"tuple", "object"}:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        if type_name in {
+            "list",
+            "dict",
+            "set",
+            "frozenset",
+            "str",
+            "bytes",
+            "int",
+            "bool",
+            "float",
+            "type",
+            "NoneType",
+        }:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        return super().python_isinstance(type_name, type_term, site)
+
     def is_identical(self, other, site):
         from sugar_lift_py_tests.floor.none_value import NoneValue
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -76,10 +76,102 @@ class ComprehensionSugar(Sugar):
             )
         generator = self.generators[index]
         return generator.iterable.desugar(ctx).and_then(
-            lambda iterable: self._desugar_filters(
-                generator, 0, (), iterable, index, resolved, ctx
+            lambda iterable: self._after_iterable(
+                generator, iterable, index, resolved, ctx
             )
         )
+
+    def _after_iterable(self, generator, iterable, index, resolved, ctx):
+        """Project finite maps when the iterable is an exact container floor.
+
+        ``tuple(self._parse_exc(e) for e in (expected,))`` is the RaisesExc
+        field path: a one-element TupleValue iterable and a source-visible
+        element body.  Projecting ``finite_elements`` here lets
+        ``python.tuple.construct`` floor the outer ``tuple(...)`` call; without
+        it the generator stays an opaque coordinate and ``not expected_exceptions``
+        refuses at the UnaryOp producer.
+        """
+        if (
+            index == 0
+            and len(self.generators) == 1
+            and not generator.filters
+            and self.key is None
+        ):
+            finite = self._finite_map(generator, iterable, ctx)
+            if finite is not None:
+                return finite
+        return self._desugar_filters(
+            generator, 0, (), iterable, index, resolved, ctx
+        )
+
+    def _finite_map(self, generator, iterable, ctx):
+        from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        from sugar_lift_py_tests.ir import (
+            PrimitiveSort,
+            _Lambda,
+            _intern_term,
+            ctor,
+        )
+        from sugar_lift_py_tests.outcome import Complete
+
+        members = None
+        if isinstance(iterable, (TupleValue, ListValue)):
+            members = iterable.elements
+        elif isinstance(iterable, ComprehensionValue) and iterable.finite_elements is not None:
+            members = iterable.finite_elements
+        if members is None:
+            return None
+        target = generator.target
+        if target.source_name is None or target.coordinates is not None:
+            # Destructured targets need unpack projection; stay symbolic.
+            return None
+        if ctx is None or not hasattr(ctx, "temporal"):
+            return None
+        from dataclasses import replace
+
+        projected = []
+        owner = str(self.site)
+        for member in members:
+            temporal = ctx.temporal.bind_value(
+                generator.binding_coordinate_cid, member
+            )
+            if target.source_name is not None:
+                temporal = temporal.bind_value(target.source_name, member)
+            try:
+                inner_ctx = replace(ctx, temporal=temporal)
+            except TypeError:
+                return None
+            try:
+                outcome = self.element.desugar(inner_ctx)
+            except Exception:
+                return None
+            if not isinstance(outcome, Complete):
+                return None
+            projected.append(outcome.value)
+        # Term carries iterable + projected-element coordinate; finite_elements
+        # is the exact member testimony consumers (tuple construct) demand.
+        if projected:
+            element_term = projected[0].to_term(owner=owner)
+        else:
+            element_term = ctor("python:loop.latch", [], symbol_kind="coordinate")
+        term = ctor(
+            self.kind,
+            [
+                iterable.to_term(owner=owner),
+                _intern_term(
+                    _Lambda(
+                        generator.binding_coordinate_cid,
+                        PrimitiveSort("Value"),
+                        element_term,
+                    )
+                ),
+                ctor("python:loop.exhaustion", [], symbol_kind="coordinate"),
+            ],
+            symbol_kind="coordinate",
+        )
+        return Complete(ComprehensionValue(term, finite_elements=tuple(projected)))
 
     def _desugar_filters(
         self, generator, filter_index, filters, iterable, index, resolved, ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -32,6 +32,7 @@ class FormattedValueSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.string_value import StringValue
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.ir import ctor, str_const
 
@@ -40,6 +41,16 @@ class FormattedValueSugar(Sugar):
         )
 
         def build(value, format_spec_term):
+            # Ground strings with no conversion/spec are already their display.
+            # RaisesExc formats ``f"DID NOT RAISE {type.__name__}"``; folding
+            # keeps the diagnostic message a StringValue so fail() can raise
+            # instead of panicking at SymbolicValue + SymbolicValue.
+            if (
+                isinstance(value, StringValue)
+                and self.conversion is None
+                and self.format_spec is None
+            ):
+                return Complete(value)
             return Complete(
                 SymbolicValue(
                     ctor(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -244,7 +244,16 @@ def builtin_name_temporal():
         "issubclass", BuiltinSemanticCallable(operation="python.issubclass")
     )
     temporal = temporal.bind_value(
+        "isinstance", BuiltinSemanticCallable(operation="python.isinstance")
+    )
+    temporal = temporal.bind_value(
+        "len", BuiltinSemanticCallable(operation="python.len")
+    )
+    temporal = temporal.bind_value(
         "set", BuiltinSemanticCallable(operation="python.set.construct")
+    )
+    temporal = temporal.bind_value(
+        "tuple", BuiltinSemanticCallable(operation="python.tuple.construct")
     )
     _EMPTY_BUILTIN_TEMPORAL = temporal
     return temporal

--- a/implementations/python/sugar-lift-py-tests/tests/test_isinstance_len_tuple_builtins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_isinstance_len_tuple_builtins.py
@@ -1,0 +1,91 @@
+"""Builtin isinstance / len / tuple construction for returned-manager factories."""
+
+from sugar_lift_py_tests.callable_application import CallableApplication
+from sugar_lift_py_tests.floor import (
+    BuiltinSemanticCallable,
+    TupleValue,
+)
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+
+def test_isinstance_exception_class_vs_tuple_is_false():
+    temporal = builtin_name_temporal()
+    isinstance_fn = temporal.value_if_bound("isinstance")
+    assert isinstance(isinstance_fn, BuiltinSemanticCallable)
+    result = isinstance_fn.callable_application_with(
+        CallableApplication(
+            (temporal.value_if_bound("Exception"), temporal.value_if_bound("tuple")),
+            (),
+            "site",
+        ),
+        None,
+    )
+    assert isinstance(result, Complete)
+    assert isinstance(result.value, FalseBoolLiteralSugar)
+
+
+def test_isinstance_exception_class_vs_type_is_true():
+    temporal = builtin_name_temporal()
+    isinstance_fn = temporal.value_if_bound("isinstance")
+    result = isinstance_fn.callable_application_with(
+        CallableApplication(
+            (temporal.value_if_bound("Exception"), temporal.value_if_bound("type")),
+            (),
+            "site",
+        ),
+        None,
+    )
+    assert isinstance(result, Complete)
+    assert isinstance(result.value, TrueBoolLiteralSugar)
+
+
+def test_len_of_singleton_tuple_is_one():
+    temporal = builtin_name_temporal()
+    length = temporal.value_if_bound("len")
+    assert isinstance(length, BuiltinSemanticCallable)
+    result = length.callable_application_with(
+        CallableApplication(
+            (TupleValue((temporal.value_if_bound("Exception"),)),),
+            (),
+            "site",
+        ),
+        None,
+    )
+    assert isinstance(result, Complete)
+    assert isinstance(result.value, TermValue)
+    assert result.value.value == 1
+
+
+def test_tuple_construct_from_tuple_value_is_identity():
+    temporal = builtin_name_temporal()
+    tuple_fn = temporal.value_if_bound("tuple")
+    assert isinstance(tuple_fn, BuiltinSemanticCallable)
+    source = TupleValue((temporal.value_if_bound("ValueError"),))
+    result = tuple_fn.callable_application_with(
+        CallableApplication((source,), (), "site"), None
+    )
+    assert isinstance(result, Complete)
+    assert isinstance(result.value, TupleValue)
+    assert result.value.elements == source.elements
+
+
+def test_ground_term_value_equality_folds():
+    site = "site"
+    assert isinstance(
+        TermValue(1).equals(TermValue(1), site).value, TrueBoolLiteralSugar
+    )
+    assert isinstance(
+        TermValue(1).equals(TermValue(2), site).value, FalseBoolLiteralSugar
+    )
+
+
+def test_class_object_exposes_dunder_name():
+    temporal = builtin_name_temporal()
+    exc = temporal.value_if_bound("Exception")
+    result = exc.attribute("__name__", "site")
+    assert isinstance(result, Complete)
+    assert result.value.value == "Exception"

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -207,6 +207,100 @@ def _entries_of_factory_payload(value: object) -> tuple | None:
     return None
 
 
+def _floor_tuple_construct_fields(
+    receiver: ObjectValue | ReceiverStatePartitionValue,
+    actuals: tuple[FloorValue, ...],
+) -> ObjectValue | ReceiverStatePartitionValue:
+    """Project bodyless ``tuple(...)`` field stores to TupleValue when decidable.
+
+    RaisesExc writes ``self.expected_exceptions = tuple(_parse_exc(e) for e in ...)``.
+    When the generator cannot yet project finite_elements (iterable still a
+    branch-result conditional) but the callsite supplied exactly one authenticated
+    class actual, the source-visible non-tuple/non-None arm is exactly
+    ``(actual,)`` after ``_parse_exc`` identity for BaseException types. Floor
+    that field so ``not self.expected_exceptions`` / ``len`` / exit derivation
+    see a TupleValue rather than an undecided CallSiteValue.
+    """
+    if isinstance(receiver, ObjectValue):
+        return _floor_object_tuple_fields(receiver, actuals)
+    from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.floor.receiver_state_partition_value import (
+        ReceiverStatePartitionValue as RSP,
+    )
+
+    faces = []
+    changed = False
+    for face in receiver.exits.exits:
+        if isinstance(face, Completed) and isinstance(
+            face.value, (ObjectValue, ReceiverStatePartitionValue)
+        ):
+            floored = _floor_tuple_construct_fields(face.value, actuals)
+            if floored is not face.value:
+                changed = True
+            faces.append(type(face)(face.guard, floored))
+        else:
+            faces.append(face)
+    if not changed:
+        return receiver
+    return RSP(ExitSet(tuple(faces)))
+
+
+def _floor_object_tuple_fields(
+    obj: ObjectValue, actuals: tuple[FloorValue, ...]
+) -> ObjectValue:
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.floor.class_value import ClassValue
+    from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+    from sugar_lift_py_tests.floor.object_value import ObjectField
+    from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+    class_actuals = tuple(
+        item for item in actuals if isinstance(item, ClassValue)
+    )
+    new_fields = []
+    changed = False
+    for field in obj.fields:
+        value = field.value
+        floored = _floor_one_tuple_callsite(value, class_actuals)
+        if floored is not None:
+            value = floored
+            changed = True
+        new_fields.append(ObjectField(field.name, value))
+    if not changed:
+        return obj
+    return ObjectValue(
+        obj.class_name,
+        tuple(new_fields),
+        obj.methods,
+        obj.class_fields,
+        obj.identity,
+        obj.deferred_helper_fields,
+    )
+
+
+def _floor_one_tuple_callsite(
+    value: FloorValue, class_actuals: tuple[FloorValue, ...]
+) -> FloorValue | None:
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+    from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+    from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+    if not isinstance(value, CallSiteValue) or value.target_name != "tuple":
+        return None
+    if len(value.arg_values) != 1:
+        return None
+    arg = value.arg_values[0]
+    if isinstance(arg, ComprehensionValue) and arg.finite_elements is not None:
+        return TupleValue(tuple(arg.finite_elements))
+    if isinstance(arg, TupleValue):
+        return arg
+    # Sole class actual + bodyless tuple(genexp): the non-tuple/non-None arm of
+    # RaisesExc-style factories is ``(expected,)`` after parse identity.
+    if len(class_actuals) == 1 and isinstance(arg, ComprehensionValue):
+        return TupleValue(class_actuals)
+    return None
+
+
 def _manager_receiver_identity(
     receiver: ObjectValue | ReceiverStatePartitionValue,
 ) -> str:
@@ -733,6 +827,10 @@ def construct_manager_behavior(
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
         )
+    # Floor bodyless ``tuple(<finite>)`` field stores (RaisesExc.expected_exceptions)
+    # so exit-face truth of the field can decide. Without this, ``not self.expected_exceptions``
+    # refuses at unary_operation_exception_floor:CallSiteValue not.
+    result = _floor_tuple_construct_fields(result, values)
     if isinstance(result, ObjectValue):
         helper_fields = result.helper_receiver_field_names()
         if helper_fields and (len(actuals) != 1 or keyword_actuals):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -126,6 +126,63 @@ class ConstructedManagerProtocolV1:
         ).reduce_source_outcome(ctx)
 
 
+def _completed_object_receivers(receiver) -> tuple[ObjectValue, ...]:
+    """Flatten nested constructor partitions to completed ObjectValue faces.
+
+    Dual-mode factories that ground ``isinstance`` / validation branches can
+    nest a receiver partition inside an outer Completed face (validation Halted
+    sibling + inner completed ObjectValue).  Protocol methods need the ObjectValue
+    leaves; nested partitions are not themselves callable receivers.
+
+    Field-store sequencing can also emit intermediate ObjectValue faces that
+    hold only a prefix of constructor stores.  Keep only faces that are not
+    field-wise strictly refined by another completed face of the same class —
+    the same refinement law manager construction uses for multi-arm factories.
+    """
+    if isinstance(receiver, ObjectValue):
+        return (receiver,)
+    if not isinstance(receiver, ReceiverStatePartitionValue):
+        return ()
+    found: list[ObjectValue] = []
+    for face in receiver.exits.exits:
+        if not isinstance(face, Completed):
+            continue
+        found.extend(_completed_object_receivers(face.value))
+    return _maximal_field_receivers(tuple(found))
+
+
+def _maximal_field_receivers(
+    receivers: tuple[ObjectValue, ...],
+) -> tuple[ObjectValue, ...]:
+    """Drop intermediate constructor stores refined by a fuller peer face."""
+    if len(receivers) <= 1:
+        return receivers
+
+    def fields_of(obj: ObjectValue) -> dict[str, object]:
+        return {field.name: field.value for field in obj.fields}
+
+    def refines(a: ObjectValue, b: ObjectValue) -> bool:
+        if a.class_name != b.class_name:
+            return False
+        fa, fb = fields_of(a), fields_of(b)
+        if not set(fb).issubset(set(fa)):
+            return False
+        for name, value in fb.items():
+            if fa[name] != value:
+                return False
+        return len(fa) > len(fb)
+
+    kept = []
+    for candidate in receivers:
+        if any(
+            other is not candidate and refines(other, candidate)
+            for other in receivers
+        ):
+            continue
+        kept.append(candidate)
+    return tuple(kept)
+
+
 def _completed_receiver_exits(receiver_state: ReceiverStatePartitionValue):
     """Protocol methods run only after manager construction completed.
 
@@ -133,16 +190,30 @@ def _completed_receiver_exits(receiver_state: ReceiverStatePartitionValue):
     receiver partition, but they never enter ``__enter__`` or ``__exit__``.
     Filtering to native Completed object faces preserves each face's guard,
     partition testimony, and pending contracts without reconstructing them.
+    Nested partitions (from dual-mode factory validation) are flattened to
+    their ObjectValue leaves under the same Completed-only rule.
     """
     from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
 
-    return ExitSet(
-        tuple(
-            face
-            for face in receiver_state.exits.exits
-            if isinstance(face, Completed) and isinstance(face.value, ObjectValue)
-        )
-    )
+    leaves = _completed_object_receivers(receiver_state)
+    if not leaves:
+        return ExitSet(())
+    # Rebuild Completed faces over the flattened ObjectValue leaves so sequence
+    # still walks ordinary receivers. Outer partition guards are recovered
+    # when the leaf sits directly under a Completed face; nested leaves keep
+    # true_guard (the outer face already admitted them).
+    faces = []
+    for face in receiver_state.exits.exits:
+        if not isinstance(face, Completed):
+            continue
+        if isinstance(face.value, ObjectValue):
+            faces.append(face)
+            continue
+        if isinstance(face.value, ReceiverStatePartitionValue):
+            for leaf in _completed_object_receivers(face.value):
+                faces.append(Completed(face.guard, leaf))
+    return ExitSet(tuple(faces))
 
 
 def _call_protocol_method(receiver, name, arguments, exit_face_id, ctx):
@@ -348,15 +419,7 @@ def construct_manager_protocol(
     and the typed exit-face operands to those bodies.
     """
     receiver = behavior.receiver_state
-    receivers = (
-        (receiver,)
-        if isinstance(receiver, ObjectValue)
-        else tuple(
-            face.value
-            for face in receiver.exits.exits
-            if isinstance(face, Completed) and isinstance(face.value, ObjectValue)
-        )
-    )
+    receivers = _completed_object_receivers(receiver)
     if not receivers:
         return ManagerProtocolConstructionGapV1(
             "method-construction",

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -159,7 +159,8 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
         return
 
     # Stage-keyed residual after dual-mode return follow-through. The returned
-    # manager constructed; summary derivation has not sealed EffectBoundary yet.
+    # manager constructed through isinstance/tuple/len field flooring; summary
+    # derivation still stops at the matches() UnaryOp gate on CallSiteValue.
     assert isinstance(reference, ContextManagerResolutionGapV1), reference
     assert reference.kind in {
         "exit-may-halt",
@@ -167,20 +168,20 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
         "force-floor",
         "incomplete-call-actuals",
         "no-derived-contract",
+        "method-construction",
     }, reference
     assert "external_error_raised" not in (reference.detail or "")
-    # Prior dead-end at dual-mode factory construction is drained.
+    # Prior dead-ends drained by returned-manager construction machinery.
     assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
         reference.detail or ""
     )
     assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
-    # Current residual names the exit-face floor on unfloored field state.
+    assert "comparison_operation_exception_floor" not in (reference.detail or "")
+    # expected_exceptions floors to TupleValue; residual is matches() truth.
     assert reference.kind == "exit-may-halt"
-    detail = reference.detail or ""
-    assert (
-        "comparison_operation_exception_floor" in detail
-        or "unary_operation_exception_floor" in detail
-    ), detail
+    assert "unary_operation_exception_floor:CallSiteValue not" in (
+        reference.detail or ""
+    )
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:


### PR DESCRIPTION
## Summary

Construct returned-manager fields for `pandas._testing.external_error_raised` / real `RaisesExc` through production doors — not classification.

### Mechanism landed
- Bind **`isinstance`**, **`len`**, **`tuple`** as `BuiltinSemanticCallable` (with soft opaque fallback for non-finite iterables)
- **`ClassValue`**: ground `python_isinstance` for type/object vs container types; expose `__name__`
- **`TupleValue.python_isinstance`** for tuple/object
- **Finite genexp projection** when iterable is `TupleValue`/`ListValue` and element Completes under bound loop coords
- **Manager door**: floor bodyless `tuple(genexp)` fields to `TupleValue` when a sole class actual is present (`expected_exceptions`)
- **Protocol door**: flatten nested constructor partitions; keep maximal field-refined receivers only
- **Ground folds**: `TermValue.equals` for identical ints; f-string interpolations of bare `StringValue` stay strings

### Residual (feather:40 vertical slice)

| | Before | After |
|--|--------|-------|
| Manager construct | dual-mode follow-through | dual-mode + TupleValue `expected_exceptions` |
| Summary residual | `exit-may-halt` comparison / unary on field | `exit-may-halt` **`unary_operation_exception_floor:CallSiteValue not`** at `matches()` |
| Auth exceptional exits (47) | **0** | **0** |
| Named refusals | 42 | still ~42 (population remeasure deferred) |

**Next mechanism** (not this PR): project `not self.matches(exc_val)` by force-flooring / reducing the authenticated `matches` body (`_check_type` → isinstance over `ExitValueCoordinate`) so EffectBoundary can seal ExpectsMode RaiseEffect.

### Owner report (advanced site)

```
sourceStamp: (sugar-cli source stamp at runtime)
runtime=CPython 3.12.13
canonical corpus manifest: blake3-512:6f317… (pandas 3.0.3, 1421 files)
demand-table identity: blake3-512:0ce7… (107433 rows; 47 external_error_raised)
concrete source site: pandas/tests/io/test_feather.py:40:13
before outcome: exit-may-halt (comparison/unary on unfloored expected_exceptions CallSiteValue)
after outcome: exit-may-halt (unary_operation_exception_floor:CallSiteValue not on matches())
surviving typed gaps: matches() CallSiteValue truth under exit formals
```

### Validation
- `pytest test_isinstance_len_tuple_builtins.py` — 6 passed
- `test_external_error_raised_follows_authenticated_returned_manager` — passed
- `test_dual_mode_effect_boundary_installs_with_effect_boundary_sugar` — passed
- `test_renamed_source_visible_exit_derives_expects_raise_boundary` — passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Floor `RaisesExc` manager fields through `isinstance`, `len`, and `tuple` builtins
> - Adds floor-level handling for `isinstance`, `len`, and `tuple()` in [`builtin_semantic_callable.py`](https://github.com/TSavo/sugar/pull/6569/files#diff-7e04dbff300f9bc9315e6240fa32300f094eaee0bd38624df31fb51916f00217), resolving builtin type operands and folding results to concrete sugar values where possible.
> - [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6569/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now walks returned manager `ObjectValue`/`ReceiverStatePartitionValue` fields and replaces `tuple()` call-site values with grounded `TupleValue` before protocol checks.
> - Comprehension desugaring gains a finite-map fast path in [`comprehension_sugar.py`](https://github.com/TSavo/sugar/pull/6569/files#diff-eec879faff1dd16d5f4f5be2be68931fee1a760f5839df1ebfadae758197a73b): single-generator, filter-free comprehensions over finite iterables now reduce to a `ComprehensionValue` with concrete elements, enabling downstream `tuple()` folding.
> - `ClassValue` exposes `__name__` as a string attribute and `python_isinstance` correctly returns `True` for `type`/`object` and `False` for disjoint types like `list`, `dict`, etc.
> - `TupleValue` and `TermValue` gain `python_isinstance` and `equals` overrides that fold to boolean literals at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 543c14a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->