### PR TITLE
Carry native operation exits through caller discharge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field as dataclass_field, replace
 import json
 from typing import Any
 
@@ -8,7 +8,15 @@ from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.context_manager_contract import _json_value
 from sugar_lift_py_tests.floor import FloorValue
-from sugar_lift_py_tests.ir import Formula, Term, formula_to_value, term_to_value
+from sugar_lift_py_tests.ir import (
+    Formula,
+    Term,
+    atomic,
+    ctor,
+    formula_to_value,
+    str_const,
+    term_to_value,
+)
 
 
 def _json(value) -> Any:
@@ -28,6 +36,188 @@ def source_coordinate(site) -> SourceFragmentCoordinateV1:
         span.end_line,
         span.end_col,
     )
+
+
+def native_operator_demand(operator: str, operands: tuple[Term, ...]) -> Formula:
+    """The unresolved caller obligation for one ordered native operation.
+
+    This formula records a question.  It does not choose a result, an exception
+    type, or a runtime coordinate; caller discharge supplies authenticated
+    actual operands and the ordinary Floor answers the question later.
+    """
+    return atomic(
+        "python:native_operator_demand",
+        [str_const(operator), *operands],
+    )
+
+
+@dataclass(frozen=True)
+class NativeOperationDemandV1:
+    """Content identity for an ordered native-operation occurrence."""
+
+    source_node: SourceFragmentCoordinateV1
+    operator: str
+    operand_terms: tuple[Term, ...]
+    operand_coordinate_cids: tuple[str | None, ...]
+    candidate: Term
+    candidate_cid: str
+    demanded_formula: Formula
+    demand_cid: str
+
+    @classmethod
+    def mint(cls, *, site, operator, operands, coordinates):
+        if not isinstance(operator, str) or not operator:
+            raise ValueError("native operation requires a nonempty operator")
+        operands = tuple(operands)
+        coordinates = tuple(coordinates)
+        if len(operands) != 2 or len(coordinates) != len(operands):
+            raise ValueError(
+                "native operation requires two ordered operands and aligned coordinates"
+            )
+
+        source_node = source_coordinate(site)
+        operand_terms = tuple(
+            operand.to_term(owner=f"native operation {operator} operand")
+            for operand in operands
+        )
+        coordinate_cids = tuple(
+            None if coordinate is None else coordinate.coordinate_cid
+            for coordinate in coordinates
+        )
+        candidate = ctor(
+            "python:native_operation",
+            [str_const(operator), *operand_terms],
+        )
+        candidate_preimage = {
+            "kind": "native-operation-candidate",
+            "schemaVersion": "1",
+            "sourceNode": source_node.wire(),
+            "operator": operator,
+            "operands": [_json(term_to_value(term)) for term in operand_terms],
+            "formalCoordinates": list(coordinate_cids),
+            "candidate": _json(term_to_value(candidate)),
+        }
+        candidate_cid = _cid(candidate_preimage)
+        demanded_formula = native_operator_demand(operator, operand_terms)
+        demand_preimage = {
+            "kind": "native-operation-demand",
+            "schemaVersion": "1",
+            "sourceNode": source_node.wire(),
+            "operator": operator,
+            "operands": [_json(term_to_value(term)) for term in operand_terms],
+            "formalCoordinates": list(coordinate_cids),
+            "candidateCid": candidate_cid,
+            "demandedFormula": _json(formula_to_value(demanded_formula)),
+        }
+        return cls(
+            source_node=source_node,
+            operator=operator,
+            operand_terms=operand_terms,
+            operand_coordinate_cids=coordinate_cids,
+            candidate=candidate,
+            candidate_cid=candidate_cid,
+            demanded_formula=demanded_formula,
+            demand_cid=_cid(demand_preimage),
+        )
+
+
+@dataclass(frozen=True)
+class NativeOperationExitCarrierV1:
+    """Deferred native operation whose discharge codomain is an ``ExitSet``.
+
+    The same recorded operation can complete or raise after its formal operands
+    are replaced by authenticated caller actuals.  Keeping that codomain here,
+    rather than retaining a ``FloorValue``, is what preserves the exceptional
+    arm until an enclosing effect boundary consumes it.
+    """
+
+    demand: NativeOperationDemandV1
+    operands: tuple[FloorValue, ...]
+    coordinates: tuple[object | None, ...]
+    site: object = dataclass_field(compare=False, repr=False)
+    continuations: tuple = dataclass_field(default=(), compare=False, repr=False)
+
+    @classmethod
+    def mint(cls, *, site, operator, operands, coordinates):
+        operands = tuple(operands)
+        coordinates = tuple(coordinates)
+        return cls(
+            demand=NativeOperationDemandV1.mint(
+                site=site,
+                operator=operator,
+                operands=operands,
+                coordinates=coordinates,
+            ),
+            operands=operands,
+            coordinates=coordinates,
+            site=site,
+        )
+
+    def and_then(self, step):
+        """Retain enclosing expression work until the operation discharges."""
+        return replace(self, continuations=(*self.continuations, step))
+
+    def discharge(self, actuals_by_formal_coordinate):
+        """Evaluate against authenticated actual operands and project exits."""
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.gap.info import GapKind
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
+        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        actual_operands = []
+        for original, coordinate_cid in zip(
+            self.operands, self.demand.operand_coordinate_cids, strict=True
+        ):
+            if coordinate_cid is None:
+                actual_operands.append(original)
+                continue
+            if coordinate_cid not in actuals_by_formal_coordinate:
+                construction_panic_gap(
+                    owner="NativeOperationExitCarrierV1.discharge",
+                    blame=self.demand.source_node,
+                    observed=(
+                        "native operation discharge omitted authenticated actual "
+                        f"for {coordinate_cid}"
+                    ),
+                    requested="one authenticated actual for every formal operand",
+                    fix=(
+                        "preserve the operation demand until caller discharge can "
+                        "supply the missing formal-to-actual binding"
+                    ),
+                    gap_kind=GapKind.FLOOR,
+                )
+            actual_operands.append(actuals_by_formal_coordinate[coordinate_cid])
+
+        left, right = actual_operands
+        operation = getattr(left, self.demand.operator, None)
+        if not callable(operation):
+            construction_panic_gap(
+                owner="NativeOperationExitCarrierV1.discharge",
+                blame=self.demand.source_node,
+                observed=(
+                    f"{type(left).__name__} has no native Floor operation "
+                    f"{self.demand.operator}"
+                ),
+                requested="an operator named by the authenticated producer Floor",
+                fix="wire the producer's existing Floor method into the carrier",
+                gap_kind=GapKind.FLOOR,
+            )
+
+        projected = operation(right, self.site)
+        if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
+            exits = ExitSet.halted(projected.value.effect)
+        elif isinstance(projected, (Complete, Incomplete, ExitSet)):
+            exits = outcome_to_exitset(projected)
+        else:
+            # Other Outcome variants must pass through the exit algebra's loud
+            # door.  In particular, never reinterpret an unresolved carrier as
+            # a normal completion.
+            exits = outcome_to_exitset(projected)
+
+        for continuation in self.continuations:
+            exits = exits.and_then(continuation)
+        return exits
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
@@ -7,6 +7,9 @@ from .incomplete import Incomplete
 from .outcome import Outcome
 from sugar_lift_py_tests.caller_parameter_contract import (
     ContractConditionalConstructionV1,
+    NativeOperationDemandV1,
+    NativeOperationExitCarrierV1,
+    native_operator_demand,
 )
 
 __all__ = [
@@ -16,8 +19,11 @@ __all__ = [
     "ExitSet",
     "Halted",
     "Incomplete",
+    "NativeOperationDemandV1",
+    "NativeOperationExitCarrierV1",
     "Outcome",
     "complete_value",
     "outcome_to_exitset",
+    "native_operator_demand",
     "true_guard",
 ]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -1274,6 +1274,7 @@ def outcome_to_exitset(outcome) -> ExitSet:
     # back through `collapse` returns the carrier.
     from sugar_lift_py_tests.caller_parameter_contract import (
         ContractConditionalConstructionV1,
+        NativeOperationExitCarrierV1,
     )
     from sugar_lift_py_tests.gap.info import GapKind
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
@@ -1288,6 +1289,21 @@ def outcome_to_exitset(outcome) -> ExitSet:
                 ),
             )
         ).normalize()
+
+    if isinstance(outcome, NativeOperationExitCarrierV1):
+        construction_panic_gap(
+            owner="outcome_to_exitset",
+            blame=outcome.demand.source_node,
+            observed="undischarged native operation demand",
+            requested=(
+                "an ExitSet projected from authenticated caller actual operands"
+            ),
+            fix=(
+                "retain the carrier through caller discharge; do not treat the "
+                "absence of a halted edge as normal completion"
+            ),
+            gap_kind=GapKind.FLOOR,
+        )
 
     construction_panic_gap(
         owner="outcome_to_exitset",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/outcome.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/outcome.py
@@ -5,6 +5,13 @@ from .incomplete import Incomplete
 from .exit_set import ExitSet
 from sugar_lift_py_tests.caller_parameter_contract import (
     ContractConditionalConstructionV1,
+    NativeOperationExitCarrierV1,
 )
 
-Outcome = Complete | Incomplete | ExitSet | ContractConditionalConstructionV1
+Outcome = (
+    Complete
+    | Incomplete
+    | ExitSet
+    | ContractConditionalConstructionV1
+    | NativeOperationExitCarrierV1
+)

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+)
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.floor import NoneValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
+from sugar_lift_py_tests.outcome import Completed, Halted, outcome_to_exitset
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _site():
+    source = "def operation(left, right):\n    return left + right\n"
+    tree = SourceFile(
+        (source, "native_operation.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(tree.functions()).fragment
+
+
+def _coordinate(name: str, ordinal: int) -> FormalParameterCoordinateV1:
+    source_cid = "blake3-512:" + "a" * 128
+    owner = SourceFragmentCoordinateV1(source_cid, 1, 0, 2, 23)
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=source_cid,
+        owner_definition_locus=owner,
+        declaration_locus=SourceFragmentCoordinateV1(
+            source_cid, 1, 14 + ordinal * 6, 1, 18 + ordinal * 6
+        ),
+        ordinal=ordinal,
+        parameter_kind="positional-or-keyword",
+        declared_name=name,
+        sort=PrimitiveSort("Value"),
+    )
+
+
+def _carrier(operator: str = "add"):
+    left_coordinate = _coordinate("left", 0)
+    right_coordinate = _coordinate("right", 1)
+    carrier = NativeOperationExitCarrierV1.mint(
+        site=_site(),
+        operator=operator,
+        operands=(
+            SymbolicValue(make_var("left"), left_coordinate),
+            SymbolicValue(make_var("right"), right_coordinate),
+        ),
+        coordinates=(left_coordinate, right_coordinate),
+    )
+    return carrier, left_coordinate, right_coordinate
+
+
+def test_same_native_operation_demand_can_complete_for_authenticated_actuals():
+    carrier, left, right = _carrier()
+
+    exits = carrier.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert exits.exits == (Completed(exits.exits[0].guard, TermValue(3)),)
+
+
+def test_same_native_operation_demand_can_halt_for_authenticated_actuals():
+    carrier, left, right = _carrier()
+
+    exits = carrier.discharge(
+        {
+            left.coordinate_cid: NoneValue(),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_name == "TypeError"
+
+
+def test_undischarged_native_operation_is_typed_loud_not_completed():
+    carrier, _, _ = _carrier()
+
+    with pytest.raises(ConstructionPanic, match="native operation"):
+        outcome_to_exitset(carrier)
+
+
+def test_missing_authenticated_actual_remains_typed_loud():
+    carrier, left, _ = _carrier()
+
+    with pytest.raises(ConstructionPanic, match="authenticated actual"):
+        carrier.discharge({left.coordinate_cid: TermValue(1)})
+
+
+def test_swapped_operands_retain_distinct_demand_coordinates():
+    carrier, left, right = _carrier()
+    swapped = NativeOperationExitCarrierV1.mint(
+        site=_site(),
+        operator="add",
+        operands=tuple(reversed(carrier.operands)),
+        coordinates=(right, left),
+    )
+
+    assert carrier.demand.operand_coordinate_cids == (
+        left.coordinate_cid,
+        right.coordinate_cid,
+    )
+    assert swapped.demand.operand_coordinate_cids == (
+        right.coordinate_cid,
+        left.coordinate_cid,
+    )
+    assert carrier.demand.demand_cid != swapped.demand.demand_cid
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(name)],
+        )
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def test_lying_exception_type_is_rejected_without_inventing_identity():
+    carrier, left, right = _carrier()
+    exits = carrier.discharge(
+        {
+            left.coordinate_cid: NoneValue(),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+    with pytest.raises(SugarNotWritten, match="no term to state the test over"):
+        exits.and_exit(
+            type(exits).completed(object()),
+            disposition=EffectBoundaryDisposition(
+                matcher=AuthenticatedRaiseMatcher(expected=_Expected("ValueError")),
+                unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+            ),
+        )
+
+
+def test_identity_operation_never_acquires_a_fabricated_exceptional_edge():
+    carrier, left, right = _carrier("is_identical")
+
+    exits = carrier.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(1),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)


### PR DESCRIPTION
## What changed

- add a content-addressed `NativeOperationDemandV1` recording the source occurrence, operator, ordered operand terms, and aligned formal coordinates
- add `NativeOperationExitCarrierV1`, whose caller discharge result is an `ExitSet`
- project source-authenticated normal results to `Completed` and authenticated `RaiseValue` results to `Halted(RaiseEffect)`
- keep undischarged or incompletely bound operations construction-loud
- admit the carrier to `Outcome` without allowing `outcome_to_exitset` to reinterpret it as a normal completion

## Why

The existing parameter-contract carrier retains only a `FloorValue`. A native operation can complete or raise after caller actuals are known, so a value-only codomain loses the exceptional arm before an assertion boundary can consume it. This PR provides the shared deferred carrier that binary and comparison producers can wire into without moving exception knowledge into the boundary.

## Assumption for downstream wiring

Caller discharge supplies authenticated actual `FloorValue` operands keyed by formal-coordinate CID. The carrier invokes the producer-selected existing Floor method at that point. It does not manufacture a result, exception type, runtime coordinate, or boundary verdict. Missing actuals and still-undecidable Floor behavior remain loud.

The ground TypeError twin intentionally does not invent exception-identity testimony. A lying ValueError matcher therefore remains typed-loud where the existing ground `RaiseEffect` lacks an authenticated identity coordinate.

## Validation

- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_value_correctness.py implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py` — 61 passed on CPython 3.12.13, NumPy 2.5.1
- `.venv-py312/bin/python -m pyright implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py` — 0 errors


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry native operation exits through caller discharge with `NativeOperationExitCarrierV1`
> - Adds `NativeOperationExitCarrierV1` in [`caller_parameter_contract.py`](https://github.com/TSavo/sugar/pull/6570/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57), a carrier that wraps a native operation demand, authenticates operands by coordinate, invokes the operation, and projects the result as an `ExitSet` with queued continuations applied.
> - Adds `NativeOperationDemandV1` to mint a stable, deterministic identity (candidate term + CID, demand formula + CID) for a native operation occurrence.
> - Extends `outcome_to_exitset` to raise a typed `construction_panic_gap` when an undischarged `NativeOperationExitCarrierV1` is passed directly, guiding callers to use `discharge` instead.
> - Re-exports the new types and `native_operator_demand` helper from the `outcome` package.
> - Risk: code that passes carrier objects to `outcome_to_exitset` without discharging will now panic instead of silently converting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4174e6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->